### PR TITLE
V1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase-tools",
   "preferGlobal": true,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The Firebase Command Line Tools",
   "keywords": [
     "firebase"


### PR DESCRIPTION
# v1.0.2
- Enforces node 0.10.x and above after shown not to work on previous versions
