### PR TITLE
Use argv for settings alongside JSON.

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -349,6 +349,7 @@ module.exports = {
                           'firebase.json settings file');
         process.exit(1);
       }
+      util._extend(settings, argv);
       if (typeof(settings.firebase) !== 'string') {
         console.log(chalk.red('Initialization Error') +' - Could not read ' +
                           'firebase.json settings file');


### PR DESCRIPTION
We're currently shelling out to `firebase` from our deploy script, and needed a way to pass in environmentally-specific arguments. Rather than render `firebase.json` each time, this change allows options like `--firebase` and `--public` to affect the deployment process.
