### PR TITLE
Added release.sh script to simplify release process

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Get the version number that is being released
+while [[ -z $VERSION ]]
+do
+  read -p "What version of firebase-tools are we releasing? " VERSION
+done
+echo
+
+# Ensure the changelog has been updated for the newest version
+CHANGELOG_VERSION="$(head -1 CHANGELOG.md | awk -F 'v' '{print $2}')"
+if [[ $VERSION != $CHANGELOG_VERSION ]]; then
+  echo "Error: Most recent version in changelog (${CHANGELOG_VERSION}) does not match version you are releasing (${VERSION})."
+  exit 1
+fi
+
+# Ensure the version number in the package.json is correct
+NPM_VERSION=$(grep "version" package.json | head -1 | awk -F '"' '{print $4}')
+if [[ $VERSION != $NPM_VERSION ]]; then
+  echo "Error: npm version specified in package.json (${NPM_VERSION}) does not match version you are releasing (${VERSION})."
+  exit 1
+fi
+
+# Create a new git tag if they have not already done so
+LAST_GIT_TAG="$(git tag --list | tail -1 | awk -F 'v' '{print $2}')"
+if [[ $VERSION != $LAST_GIT_TAG ]]; then
+  git tag v$VERSION
+  git push --tags
+
+  echo "*** Last commit tagged as v${VERSION} ***"
+  echo
+else
+  echo "*** Git tag v${VERSION} already created ***"
+  echo
+fi
+
+# Publish the new version to npm
+npm publish
+if [[ $? -ne 0 ]]; then
+  echo "!!! Error publishing to npm! You must do this manually by running 'npm publish'. !!!"
+  exit 1
+else
+  echo "*** v${VERSION} published to npm ***"
+  echo
+fi
+
+echo "Manual steps remaining:"
+echo "  1) Update the release notes for firebase-tools version ${VERSION} on GitHub"
+echo "  2) Update all firebase-tools version numbers specified in firebase-website to ${VERSION}"
+echo "  3) Tweet @FirebaseRelease: 'v${VERSION} of @Firebase tools CLI is available: https://www.npmjs.org/package/firebase-tools Changelog: https://github.com/firebase/firebase-tools/blob/master/CHANGELOG.md'"
+echo
+echo "Done! Woot!"
+echo


### PR DESCRIPTION
@drtriumph - I've created `release.sh` scripts for a lot of other repos and it's simplified the whole process for me. It also prevents us from making any stupid mistakes, such as forgetting to update the changelog or the `package.json` file. I went ahead and created a `release.sh` script for the firebase-tools repo as well.

Another note: I think we should create a git tag for each release, as we do with other repos. Then people can easily look through our releases on GitHub and quickly see how the code looked during a particular release. We also can add the changelog info to each release on GitHub. I added this to the manual tasks list which get printed at the end of the `release.sh` script. Feel free to chat with me offline if you have concerns. Otherwise, can you go ahead and create a git tag for v1.1.0?
