### PR TITLE
[firebase-release] Removed change log and reset repo after 1.1.6 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,0 @@
-feature - Added ability to set `X-UA-Compatible`, `X-Content-Type-Options`, `X-Frame-Options`, and `X-XSS-Protection` headers to requests.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase-tools",
   "description": "Firebase command line tools",
-  "version": "1.1.6",
+  "version": "0.0.0",
   "author": "Firebase <support@firebase.com> (https://www.firebase.com/)",
   "homepage": "https://github.com/firebase/firebase-tools/",
   "repository": {


### PR DESCRIPTION
Manual cleanup after failed Catapult release.