### PR TITLE
Throttle in-memory buffer stream to not block event queue

### DIFF
--- a/lib/upload.js
+++ b/lib/upload.js
@@ -64,7 +64,7 @@ module.exports = {
       ThrottledBufferStream.prototype._read = function() {
         // Populating this stream requires no I/O, given that all of the required data to stream is
         // already in memory. Due to a bug affecting Node v0.10 through v0.11.0, this synchronous
-        // streaming has the potential to block the event loop and lead to a recursive nextTime()
+        // streaming has the potential to block the event loop and lead to a recursive nextTick()
         // call resulting in a crash. As a workaround, temporarily pause streaming periodically
         // so as to not plug the event queue.
         // See https://github.com/joyent/node/issues/6065

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -67,6 +67,7 @@ module.exports = {
         // streaming has the potential to block the event loop and lead to a recursive nextTime()
         // call resulting in a crash. As a workaround, temporarily pause streaming periodically
         // so as to not plug the event queue.
+        // See https://github.com/joyent/node/issues/6065
         if (this.buffers.length > 0) {
           this.push(this.buffers.pop());
         } else {

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -53,23 +53,33 @@ module.exports = {
     });
 
     zipStream.on('end', function() {
-      var BufferStream = function(buffers, options) {
+      var ThrottledBufferStream = function(buffers, options) {
         this.buffers = buffers.reverse();
 
         stream.Readable.call(this, options);
       };
 
-      util.inherits(BufferStream, stream.Readable);
+      util.inherits(ThrottledBufferStream, stream.Readable);
 
-      BufferStream.prototype._read = function() {
+      ThrottledBufferStream.prototype._read = function() {
+        // Populating this stream requires no I/O, given that all of the required data to stream is
+        // already in memory. Due to a bug affecting Node v0.10 through v0.11.0, this synchronous
+        // streaming has the potential to block the event loop and lead to a recursive nextTime()
+        // call resulting in a crash. As a workaround, temporarily pause streaming periodically
+        // so as to not plug the event queue.
         if (this.buffers.length > 0) {
           this.push(this.buffers.pop());
         } else {
           this.push(null);
         }
+        var this_ = this;
+        this_.pause();
+        setTimeout(function() {
+          this_.resume();
+        }, 0);
       };
 
-      var bufferStream = new BufferStream(buffers);
+      var bufferStream = new ThrottledBufferStream(buffers);
 
       if (fileCount === 0) {
         console.log(chalk.yellow('Public Directory Warning') + ' - Public ' +

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -53,15 +53,15 @@ module.exports = {
     });
 
     zipStream.on('end', function() {
-      var ThrottledBufferStream = function(buffers, options) {
+      var BufferStream = function(buffers, options) {
         this.buffers = buffers.reverse();
 
         stream.Readable.call(this, options);
       };
 
-      util.inherits(ThrottledBufferStream, stream.Readable);
+      util.inherits(BufferStream, stream.Readable);
 
-      ThrottledBufferStream.prototype._read = function() {
+      BufferStream.prototype._read = function() {
         // Populating this stream requires no I/O, given that all of the required data to stream is
         // already in memory. Due to a bug affecting Node v0.10 through v0.11.0, this synchronous
         // streaming has the potential to block the event loop and lead to a recursive nextTick()
@@ -80,7 +80,7 @@ module.exports = {
         }, 0);
       };
 
-      var bufferStream = new ThrottledBufferStream(buffers);
+      var bufferStream = new BufferStream(buffers);
 
       if (fileCount === 0) {
         console.log(chalk.yellow('Public Directory Warning') + ' - Public ' +

--- a/lib/upload.js
+++ b/lib/upload.js
@@ -73,10 +73,10 @@ module.exports = {
         } else {
           this.push(null);
         }
-        var this_ = this;
-        this_.pause();
+        var self = this;
+        self.pause();
         setTimeout(function() {
-          this_.resume();
+          self.resume();
         }, 0);
       };
 


### PR DESCRIPTION
@TamalSaha @drtriumph For review. This is a temporary workaround fixing the call stack overflow while maintaining the same in-memory buffer behavior.