### PR TITLE
Run tools on several versions of Node and use new Travis infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
 - '0.10'
+- '0.12'
+- stable
+sudo: false
 install:
 - npm install
 script:


### PR DESCRIPTION
See [here](http://docs.travis-ci.com/user/migrating-from-legacy) for details on the new Travis infrastructure.

We should run the CI tests against several versions of Node: 0.10, 0.12, and the latest stable version.