### PR TITLE
Updated deprecated fields in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,7 @@
   },
   "engine-strict": true,
   "author": "Firebase <support@firebase.com> (https://www.firebase.com/)",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://firebase.mit-license.org/"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/firebase/firebase-tools/issues"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "engines": {
     "node": ">=0.10.0"
   },
-  "engineStrict": true,
+  "engine-strict": true,
   "author": "Firebase <support@firebase.com> (https://www.firebase.com/)",
   "licenses": [
     {


### PR DESCRIPTION
The current `package.json` throws the following warnings:

```
$ npm install
npm WARN package.json firebase-tools@0.0.0 No license field.
# ...

$ npm link
npm WARN engineStrict Per-package engineStrict (found in this package's package.json) 
npm WARN engineStrict won't be used in npm 3+. Use the config setting `engine-strict` instead.
# ...
```

The `"licenses"` field has been replaced with [`"license"`](https://docs.npmjs.com/files/package.json#license) and the [`"engineStrict"`](https://docs.npmjs.com/files/package.json#enginestrict) field has been replaced with `"engine-strict"`.