### PR TITLE
Import top-level keys when --public flag used

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -41,7 +41,7 @@ Config.LEGACY_HOSTING_KEYS = ['public', 'rewrites', 'redirects', 'headers', 'ign
 
 Config.prototype.importLegacyKeys = function() {
   Config.LEGACY_HOSTING_KEYS.forEach(function(key) {
-    if (this._src[key]) {
+    if (_.has(this._src, key)) {
       this.set('hosting.' + key, this._src[key]);
     }
   }, this);

--- a/lib/config.js
+++ b/lib/config.js
@@ -31,18 +31,21 @@ var Config = function(src, options) {
 
   // use 'public' as signal for legacy hosting since it's a required key
   if (!this.data.hosting && this._src.public) {
-    this.data.hosting = {};
-    Config.LEGACY_HOSTING_KEYS.forEach(function(key) {
-      if (this._src[key]) {
-        this.data.hosting[key] = this._src[key];
-      }
-    }, this);
+    this.importLegacyKeys();
   }
 };
 
 Config.FILENAME = 'firebase.json';
 Config.TARGETS = ['hosting', 'rules'];
 Config.LEGACY_HOSTING_KEYS = ['public', 'rewrites', 'redirects', 'headers', 'ignore'];
+
+Config.prototype.importLegacyKeys = function() {
+  Config.LEGACY_HOSTING_KEYS.forEach(function(key) {
+    if (this._src[key]) {
+      this.set('hosting.' + key, this._src[key]);
+    }
+  }, this);
+};
 
 Config.prototype._materialize = function(target) {
   if (_.isString(this._src[target])) {

--- a/lib/deploy/hosting/prepare.js
+++ b/lib/deploy/hosting/prepare.js
@@ -14,6 +14,8 @@ module.exports = function(context, options, payload) {
 
   // Allow the public directory to be overridden by the --public flag
   if (options.public) {
+    // trigger legacy key import since public may not exist in firebase.json
+    options.config.importLegacyKeys();
     options.config.set('hosting.public', options.public);
   }
 

--- a/test/lib/config.spec.js
+++ b/test/lib/config.spec.js
@@ -41,6 +41,23 @@ describe('Config', function() {
     });
   });
 
+  describe('#importLegacyKeys', function() {
+    it('should respect non-overlapping keys in hosting', function() {
+      var redirects = [{source: '/foo', destination: '/bar.html', type: 301}];
+      var rewrites = [{source: '**', destination: '/index.html'}];
+      var config = new Config({
+        rewrites: rewrites,
+        hosting: {
+          redirects: redirects
+        }
+      }, {});
+
+      config.importLegacyKeys();
+      expect(config.get('hosting.redirects')).to.eq(redirects);
+      expect(config.get('hosting.rewrites')).to.eq(rewrites);
+    });
+  });
+
   describe('#_parseFile', function() {
     it('should load a cjson file', function() {
       var config = new Config({}, {cwd: _fixtureDir('config-imports')});


### PR DESCRIPTION
This solves a bug where if you *do not* specify a "public" in your `firebase.json` but *do* pass it as a flag, the deploy will proceed but without any of your rewrites, redirects, or headers.