### PR TITLE
Fix hang on malformed firebase.json

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -69,14 +69,14 @@ Command.prototype.register = function(client) {
       }
       var duration = new Date().getTime() - start;
       track(self._name, 'success', duration).then(process.exit);
-    }, function(err) {
+    }).catch(function(err) {
       if (utils.getInheritedOption(options, 'json')) {
         console.log(JSON.stringify({
           status: 'error',
           error: err.message
         }, null, 2));
       }
-      var duration = new Date().getTime() - start;
+      var duration = Date.now() - start;
       var errorEvent = err.exit === 1 ? 'Error (User)' : 'Error (Unexpected)';
       var firebase = getFirebaseName(options, true);
       var preppedMessage = chalk.stripColor(err.message || '').replace(firebase, '<namespace>');

--- a/lib/getFirebaseName.js
+++ b/lib/getFirebaseName.js
@@ -2,6 +2,7 @@
 
 var Config = require('./config');
 var FirebaseError = require('./error');
+var logger = require('./logger');
 
 /**
  * Tries to determine the correct app name for commands that
@@ -16,9 +17,13 @@ module.exports = function(options, allowNull) {
   if (options.firebase) {
     return options.firebase;
   }
-  var config = Config.load(options, true);
-  if (config && config.defaults.project) {
-    return config.defaults.project;
+  try {
+    var config = Config.load(options, true);
+    if (config && config.defaults.project) {
+      return config.defaults.project;
+    }
+  } catch (e) {
+    logger.debug('Config.load Error: ' + e.stack);
   }
 
   if (!allowNull) {


### PR DESCRIPTION
There was an error being raised in a catch block that caused the process to hang if `firebase.json` was malformed. Works now, including a readable JSON parsing error.