### PR TITLE
Adds --interactive flag for times when isTTY doesn't work.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ program.version(pkg.version);
 program.option('-j, --json', 'output JSON instead of text, also triggers non-interactive mode');
 program.option('--token <token>', 'supply an auth token for this command');
 program.option('--non-interactive', 'error out of the command instead of waiting for prompts');
+program.option('--interactive', 'force interactive shell treatment even when not detected');
 program.option('--debug', 'print verbose debug output and keep a debug log file');
 // program.option('-d, --debug', 'display debug information and keep firebase-debug.log');
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -97,6 +97,11 @@ Command.prototype._prepare = function(options) {
   if (!process.stdin.isTTY || utils.getInheritedOption(options, 'nonInteractive')) {
     options.nonInteractive = true;
   }
+  // allow override of detected non-interactive with --interactive flag
+  if (utils.getInheritedOption(options, 'interactive')) {
+    options.nonInteractive = false;
+  }
+
   if (utils.getInheritedOption(options, 'debug')) {
     logger.transports.console.level = 'debug';
   }


### PR DESCRIPTION
Allow manual override to address situations like #77 where the `isTTY` seems to be incorrect.