### PR TITLE
Add live reload option to firebase serve

### DIFF
--- a/commands/serve.js
+++ b/commands/serve.js
@@ -11,6 +11,7 @@ module.exports = new Command('serve')
   .description('start a local server for your static assets')
   .option('-p, --port <port>', 'the port on which to listen (default: 5000)', 5000)
   .option('-o, --host <host>', 'the host on which to listen (default: localhost)', 'localhost')
+  .option('-l, --live', 'enable live reload (default: false)', false)
   .action(function(options) {
     var config = Config.load(options);
 
@@ -18,6 +19,7 @@ module.exports = new Command('serve')
       debug: true,
       port: options.port,
       host: options.host,
+      live: options.live,
       config: config.data.hosting
     }).listen();
 


### PR DESCRIPTION
Superstatic already supports live reload, which is awesome for development. This adds it as an option for firebase serve.