### PR TITLE
Add Bolt command line test.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,9 @@ gulp.task('lint', function() {
 
 // Runs the Mocha test suite
 gulp.task('test', function() {
+  // Set PATH to run installed command-line tools used in test.
+  process.env.PATH = process.cwd() + '/node_modules/.bin:' + process.env.PATH;
+
   return gulp.src(paths.js)
     .pipe(istanbul())
     .pipe(istanbul.hookRequire())

--- a/lib/config.js
+++ b/lib/config.js
@@ -72,7 +72,6 @@ Config.prototype._parseFile = function(target, filePath) {
       data = data[target];
     }
     return data;
-  /* istanbul ignore-next */
   case '.bolt':
     return parseBoltRules(fullPath);
   default:

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "chai-as-promised": "^5.1.0",
     "coveralls": "2.11.2",
     "eslint": "^1.4.1",
+    "firebase-bolt": "^0.3.0",
     "gulp": "^3.9.0",
     "gulp-eslint": "^1.0.0",
     "gulp-exit": "0.0.2",

--- a/test/fixtures/config-imports/rules.bolt
+++ b/test/fixtures/config-imports/rules.bolt
@@ -1,0 +1,1 @@
+path / is String;

--- a/test/lib/config.spec.js
+++ b/test/lib/config.spec.js
@@ -77,6 +77,16 @@ describe('Config', function() {
         config._parseFile('hosting', 'unsupported.txt');
       }).to.throw('unsupported.txt is not of a supported config file type');
     });
+
+    it('should load a bolt file', function() {
+      var config = new Config({}, {cwd: _fixtureDir('config-imports')});
+      expect(config._parseFile(undefined, 'rules.bolt'))
+        .to.deep.equal({
+          rules: {
+            '.validate': 'newData.isString()'
+          }
+        });
+    });
   });
 
   describe('#_materialize', function() {


### PR DESCRIPTION
This PR adds a test for loading a bolt file as a rules file.  This does not pass on node 0.10 at the moment.

@mbleigh 