### PR TITLE
Don't do hosting deploy if no hosting config is present

### DIFF
--- a/lib/deploy/hosting/deploy.js
+++ b/lib/deploy/hosting/deploy.js
@@ -12,6 +12,10 @@ var FirebaseError = require('../../error');
 module.exports = function(context, options, payload) {
   var local = context.hosting;
 
+  if (!payload.hosting) {
+    return RSVP.resolve();
+  }
+
   utils.logBullet('preparing ' + chalk.bold(payload.hosting.public) + ' directory for upload...');
   return prepareUpload(options, payload.hosting).then(function(upload) {
     if (!upload.foundIndex) {

--- a/lib/deploy/hosting/prepare.js
+++ b/lib/deploy/hosting/prepare.js
@@ -21,10 +21,12 @@ module.exports = function(context, options, payload) {
 
   payload.hosting = options.config.get('hosting');
 
-  if (!_.has(payload, 'hosting.public')) {
-    return utils.reject('No public directory specified, can\'t deploy hosting', {exit: 1});
-  } else if (!fs.existsSync(resolveProjectPath(options.cwd, payload.hosting.public))) {
-    return utils.reject('Specified public directory does not exist, can\'t deploy hosting', {exit: 1});
+  if (payload.hosting) {
+    if (!_.has(payload, 'hosting.public')) {
+      return utils.reject('No public directory specified, can\'t deploy hosting', {exit: 1});
+    } else if (!fs.existsSync(resolveProjectPath(options.cwd, payload.hosting.public))) {
+      return utils.reject('Specified public directory does not exist, can\'t deploy hosting', {exit: 1});
+    }
   }
 
   return RSVP.resolve();


### PR DESCRIPTION
Presently if you wanted to, for instance, deploy only rules from a Firebase and *not* hosting. You have to do `firebase deploy:rules`. This makes `firebase deploy` skip hosting if no hosting config is present.