### PR TITLE
Generalize top-key deduping when loading files.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -50,7 +50,12 @@ Config.prototype.importLegacyKeys = function() {
 
 Config.prototype._materialize = function(target) {
   if (_.isString(this._src[target])) {
-    return this._parseFile(target, this._src[target]);
+    var out = this._parseFile(target, this._src[target]);
+    // if e.g. rules.json has {"rules": {}} use that
+    if (_.size(out) === 1 && _.has(out, target)) {
+      out = out[target];
+    }
+    return out;
   } else if (_.isObject(this._src[target])) {
     if (target === 'rules') {
       this.notes.rules = 'inline';
@@ -74,10 +79,6 @@ Config.prototype._parseFile = function(target, filePath) {
       this.notes.rules = 'json';
     }
     var data = loadCJSON(fullPath);
-    // if e.g. rules.json has {"rules": {}} use that
-    if (_.size(data) === 1 && data[target]) {
-      data = data[target];
-    }
     return data;
   /* istanbul ignore-next */
   case '.bolt':

--- a/test/fixtures/dup-top-level/firebase.json
+++ b/test/fixtures/dup-top-level/firebase.json
@@ -1,0 +1,4 @@
+{
+  "firebase":"random",
+  "rules":"rules.json"
+}

--- a/test/fixtures/dup-top-level/rules.json
+++ b/test/fixtures/dup-top-level/rules.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    ".read": true
+  }
+}

--- a/test/lib/config.spec.js
+++ b/test/lib/config.spec.js
@@ -84,5 +84,10 @@ describe('Config', function() {
       var config = new Config({example: {foo: 'bar'}}, {});
       expect(config._materialize('example').foo).to.equal('bar');
     });
+
+    it('should prevent top-level key duplication', function() {
+      var config = new Config({rules: 'rules.json'}, {cwd: _fixtureDir('dup-top-level')});
+      expect(config._materialize('rules')).to.deep.equal({'.read': true});
+    });
   });
 });


### PR DESCRIPTION
Should fix firebase/bolt#84 by moving the `rules.rules` checker to the general file loader case instead of the specific CJSON case.