### PR TITLE
Override firebase name from env.

### DIFF
--- a/lib/getFirebaseName.js
+++ b/lib/getFirebaseName.js
@@ -7,7 +7,8 @@ var logger = require('./logger');
 /**
  * Tries to determine the correct app name for commands that
  * only require an app name. Uses passed in firebase option
- * first, then falls back to firebase.json.
+ * first, then falls back to environment variable, then
+ * finally falls back to firebase.json.
  * @param {Object} options The command-line options object
  * @param {boolean} allowNull Whether or not the firebase flag
  * is required
@@ -16,6 +17,10 @@ var logger = require('./logger');
 module.exports = function(options, allowNull) {
   if (options.firebase) {
     return options.firebase;
+  }
+  var envFirebase = process.env.FIREBASE_NAME;
+  if (envFirebase) {
+    return envFirebase;
   }
   try {
     var config = options.config || Config.load(options, true);


### PR DESCRIPTION
Adds support for optional firebase name override from environment variable, rather than only from command line argument or firebase config JSON.

You might also consider adding [dotenv](https://www.npmjs.com/package/dotenv).
