### PR TITLE
Add users command.

### DIFF
--- a/commands/index.js
+++ b/commands/index.js
@@ -31,6 +31,7 @@ module.exports = function(client) {
   // client.prefs = loadCommand('prefs');
   client.prefs.token = loadCommand('prefs-token');
   client.serve = loadCommand('serve');
+  client.users = loadCommand('users');
 
   return client;
 };

--- a/commands/users.js
+++ b/commands/users.js
@@ -1,0 +1,63 @@
+'use strict';
+
+var Command = require('../lib/command');
+var requireDataAccess = require('../lib/requireDataAccess');
+var request = require('request');
+var api = require('../lib/api');
+var responseToError = require('../lib/responseToError');
+var FirebaseError = require('../lib/error');
+var RSVP = require('rsvp');
+var querystring = require('querystring');
+var fs = require('fs');
+
+module.exports = new Command('users')
+  .description('fetch and print users')
+  .option('-f, --firebase <app>', 'override the app specified in firebase.json')
+  .option('-o, --output <filename>', 'save output to the specified file')
+  // TODO: Do we need to require data access?
+  .before(requireDataAccess)
+  .action(function(options) {
+    return new RSVP.Promise(function(resolve, reject) {
+      var fileOut = !!options.output;
+      var outStream = fileOut ? fs.createWriteStream(options.output) : process.stdout;
+      var erroring;
+      var errorResponse = '';
+      var response;
+
+      var url = api.authOrigin + '/v2/' + options.firebase + '/users?';
+
+      var query = {token: options.session.token};
+
+      url += querystring.stringify(query);
+
+      request.get(url)
+        .on('response', function(res) {
+          response = res;
+          if (response.statusCode >= 400) {
+            erroring = true;
+          }
+        })
+        .on('data', function(chunk) {
+          if (erroring) {
+            errorResponse += chunk;
+          } else {
+            outStream.write(chunk);
+          }
+        })
+        .on('end', function() {
+          if (erroring) {
+            try {
+              var data = JSON.parse(errorResponse);
+              return reject(responseToError(response, data));
+            } catch (e) {
+              return reject(new FirebaseError('Malformed JSON response', {
+                exit: 2,
+                original: e
+              }));
+            }
+          }
+          return resolve();
+        })
+        .on('error', reject);
+    });
+  });

--- a/lib/api.js
+++ b/lib/api.js
@@ -68,6 +68,7 @@ var _appendQueryData = function(path, data) {
 var api = {
   realtimeOrigin: utils.envOverride('FIREBASE_REALTIME_URL', 'https://firebaseio.com'),
   adminOrigin: utils.envOverride('FIREBASE_ADMIN_URL', 'https://admin.firebase.com'),
+  authOrigin: utils.envOverride('FIREBASE_AUTH_URL', 'https://auth.firebase.com'),
   uploadOrigin: utils.envOverride('FIREBASE_DEPLOY_URL', utils.envOverride('FIREBASE_UPLOAD_URL', 'https://deploy.firebase.com')),
   hostingOrigin: utils.envOverride('FIREBASE_HOSTING_URL', 'https://firebaseapp.com'),
   websiteOrigin: utils.envOverride('FIREBASE_WEBSITE_URL', 'https://www.firebase.com'),


### PR DESCRIPTION
Adds a command to get list of users from `auth.firebase.com`.

Enables tooling around users, e.g. finding a user ID by email:

```
firebase users | json users | json -c "this.email=='user@example.com'" | json -a uid
```

(using https://github.com/trentm/json)
