### PR TITLE
Lowercasing all 'firebase' settings in the firebase.json and arguments

### DIFF
--- a/lib/getFirebaseName.js
+++ b/lib/getFirebaseName.js
@@ -15,12 +15,12 @@ var logger = require('./logger');
  */
 module.exports = function(options, allowNull) {
   if (options.firebase) {
-    return options.firebase;
+    return options.firebase.toLowerCase();
   }
   try {
     var config = options.config || Config.load(options, true);
     if (config && config.defaults.project) {
-      return config.defaults.project;
+      return config.defaults.project.toLowerCase();
     }
   } catch (e) {
     logger.debug('Config.load Error: ' + e.stack);


### PR DESCRIPTION
Fix for namespaces entered with uppercase characters in them