### PR TITLE
added error catcher for server

### DIFF
--- a/commands/serve.js
+++ b/commands/serve.js
@@ -40,6 +40,8 @@ var startServer = function(options) {
         utils.logWarning(message);
         throw new FirebaseError('Could not find an open port for development server.', {exit: 1});
       }
+    } else {
+      logger.info(err);
     }
   });
 };


### PR DESCRIPTION
My local server (through `firebase serve`) was crashing without an error - this was due to there only being error handling for EADDRINUSE and nothing else. This change logs other errors.