### PR TITLE
Automatically use alias if only one present.

### DIFF
--- a/commands/use.js
+++ b/commands/use.js
@@ -32,9 +32,9 @@ var listAliases = function(options) {
         logger.info('  ' + listing);
       }
     });
-  } else {
-    logger.info('Run', chalk.bold('firebase use --add'), 'to define a new project alias.');
+    logger.info();
   }
+  logger.info('Run', chalk.bold('firebase use --add'), 'to define a new project alias.');
 };
 
 var verifyMessage = function(name) {

--- a/lib/command.js
+++ b/lib/command.js
@@ -143,10 +143,14 @@ Command.prototype.applyRC = function(options) {
     options.project = options.config.defaults.project;
   }
 
-  var rcProject = _.get(rc, ['projects', options.project]);
+  var aliases = rc.projects || {};
+  var rcProject = _.get(aliases, options.project);
   if (rcProject) {
     options.projectAlias = options.project;
     options.project = rcProject;
+  } else if (_.size(aliases) === 1) {
+    options.projectAlias = _.head(_.keys(aliases));
+    options.project = _.head(_.values(aliases));
   }
 };
 

--- a/lib/getProjectId.js
+++ b/lib/getProjectId.js
@@ -23,9 +23,6 @@ module.exports = function(options, allowNull) {
       throw new FirebaseError('No project active. Run with ' + chalk.bold('--project <projectId>') + ' or define an alias by\nrunning ' + chalk.bold('firebase use --add'), {
         exit: 1
       });
-    } else if (aliasCount === 1) {
-      var name = _.head(_.keys(aliases));
-      throw new FirebaseError('No project active, but a project alias is available.\n\nRun ' + chalk.bold('firebase use ' + name) + ' to activate project ' + chalk.bold(aliases[name]));
     } else {
       var aliasList = _.map(aliases, function(projectId, aname) {
         return '  ' + aname + ' (' + projectId + ')';


### PR DESCRIPTION
As the new aliasing system met real users, it seems that there's too much confusion around requiring the explicit `use` of an alias if only one is available. This PR makes any single alias automatically active if no other alias has been set.

/cc @mckoss @mikelehen @inlined 