### PR TITLE
firebase deploy with option --public fails

### DIFF
--- a/lib/deploy/hosting/prepare.js
+++ b/lib/deploy/hosting/prepare.js
@@ -16,7 +16,7 @@ module.exports = function(context, options, payload) {
   // Allow the public directory to be overridden by the --public flag
   if (options.public) {
     // trigger legacy key import since public may not exist in firebase.json
-    options.config.importLegacyKeys();
+    options.config.importLegacyHostingKeys();
     options.config.set('hosting.public', options.public);
   }
 


### PR DESCRIPTION
There is apparently a typo in lib/deploy/hosting/prepare.js - it references a non-existing function ‘importLegacyKeys’.
Therefore firebase deploy fails when specifying the --public or -p option.