### PR TITLE
Download existing DB rules during firebase init. Fixes #134.

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -105,7 +105,7 @@ module.exports = new Command('init [feature]')
       setup.features = setup.features.map(function(feat) {
         return prompt.listLabelToValue(feat, choices);
       });
-      setup.features.push('project');
+      setup.features.unshift('project');
       return init(setup, config, options);
     }).then(function() {
       logger.info();

--- a/lib/init/features/database.js
+++ b/lib/init/features/database.js
@@ -1,17 +1,41 @@
 'use strict';
 
 var chalk = require('chalk');
-
+var api = require('../../api');
 var prompt = require('../../prompt');
 var logger = require('../../logger');
+var configstore = require('../../configstore');
+var utils = require('../../utils');
+var fsutils = require('../../fsutils');
+var RSVP = require('rsvp');
+
+var _getConsoleDBRules = function(projectId) {
+  return api.request('GET', '/.settings/rules.json', {
+    auth: true,
+    origin: utils.addSubdomain(api.realtimeOrigin, projectId)
+  }).then(function(response) {
+    return JSON.stringify(response.body, null, 2);
+  });
+};
+
+var _writeDBRules = function(projectId, fileName, config) {
+  return _getConsoleDBRules(projectId).then(function(rules) {
+    return config.writeProjectFile(fileName, rules);
+  }).then(function() {
+    utils.logSuccess('Database Rules for ' + projectId + ' have been downloaded to ' + fileName + ' .');
+    logger.info('Future modifications to ' + fileName + ' will update Database Rules when you do');
+    logger.info(chalk.bold('firebase deploy') + '.');
+  });
+};
 
 module.exports = function(setup, config) {
   setup.config.database = {};
+  var projectId = configstore.get('activeProjects')[config.projectDir];
+  var fileName = null;
 
   logger.info();
   logger.info('Firebase Realtime Database Rules allow you to define how your data should be');
-  logger.info('structured and when your data can be read from and written to. You can keep');
-  logger.info('these rules in your project directory and publish them with ' + chalk.bold('firebase deploy') + '.');
+  logger.info('structured and when your data can be read from and written to.');
   logger.info();
 
   return prompt(setup.config.database, [
@@ -22,9 +46,26 @@ module.exports = function(setup, config) {
       default: 'database.rules.json'
     }
   ]).then(function() {
-    return config.askWriteProjectFile(setup.config.database.rules, {
-      '.read': true,
-      '.write': true
-    });
+    fileName = setup.config.database.rules;
+
+    if (fsutils.fileExistsSync(fileName)) {
+      var msg = 'File ' + chalk.underline(fileName) + ' already exists.'
+        + ' Do you want to overwrite it with the Database Rules for ' + projectId
+        + ' from the Firebase Console?';
+      return prompt.once({
+        type: 'confirm',
+        message: msg,
+        default: false
+      });
+    }
+    return RSVP.resolve(true);
+  }).then(function(overwrite) {
+    if (overwrite) {
+      return _writeDBRules(projectId, fileName, config);
+    }
+    logger.info('Skipping overwrite of Database Rules.');
+    logger.info('The rules defined in ' + fileName + ' will be published when you do ' + chalk.bold('firebase deploy') + '.');
+    return RSVP.resolve();
   });
 };
+

--- a/lib/init/features/database.js
+++ b/lib/init/features/database.js
@@ -4,34 +4,33 @@ var chalk = require('chalk');
 var api = require('../../api');
 var prompt = require('../../prompt');
 var logger = require('../../logger');
-var configstore = require('../../configstore');
 var utils = require('../../utils');
 var fsutils = require('../../fsutils');
 var RSVP = require('rsvp');
 
-var _getConsoleDBRules = function(projectId) {
+var _getConsoleDBRules = function(instance) {
   return api.request('GET', '/.settings/rules.json', {
     auth: true,
-    origin: utils.addSubdomain(api.realtimeOrigin, projectId)
+    origin: utils.addSubdomain(api.realtimeOrigin, instance)
   }).then(function(response) {
     return JSON.stringify(response.body, null, 2);
   });
 };
 
-var _writeDBRules = function(projectId, fileName, config) {
-  return _getConsoleDBRules(projectId).then(function(rules) {
-    return config.writeProjectFile(fileName, rules);
+var _writeDBRules = function(instance, filename, config) {
+  return _getConsoleDBRules(instance).then(function(rules) {
+    return config.writeProjectFile(filename, rules);
   }).then(function() {
-    utils.logSuccess('Database Rules for ' + projectId + ' have been downloaded to ' + fileName + ' .');
-    logger.info('Future modifications to ' + fileName + ' will update Database Rules when you do');
+    utils.logSuccess('Database Rules for ' + chalk.bold(instance) + ' have been downloaded to ' + chalk.bold(filename) + '.');
+    logger.info('Future modifications to ' + chalk.bold(filename) + ' will update Database Rules when you run');
     logger.info(chalk.bold('firebase deploy') + '.');
   });
 };
 
 module.exports = function(setup, config) {
   setup.config.database = {};
-  var projectId = configstore.get('activeProjects')[config.projectDir];
-  var fileName = null;
+  var instance = setup.rcfile.projects.default_instance;
+  var filename = null;
 
   logger.info();
   logger.info('Firebase Realtime Database Rules allow you to define how your data should be');
@@ -46,11 +45,11 @@ module.exports = function(setup, config) {
       default: 'database.rules.json'
     }
   ]).then(function() {
-    fileName = setup.config.database.rules;
+    filename = setup.config.database.rules;
 
-    if (fsutils.fileExistsSync(fileName)) {
-      var msg = 'File ' + chalk.underline(fileName) + ' already exists.'
-        + ' Do you want to overwrite it with the Database Rules for ' + projectId
+    if (fsutils.fileExistsSync(filename)) {
+      var msg = 'File ' + chalk.bold(filename) + ' already exists.'
+        + ' Do you want to overwrite it with the Database Rules for ' + chalk.bold(instance)
         + ' from the Firebase Console?';
       return prompt.once({
         type: 'confirm',
@@ -61,10 +60,10 @@ module.exports = function(setup, config) {
     return RSVP.resolve(true);
   }).then(function(overwrite) {
     if (overwrite) {
-      return _writeDBRules(projectId, fileName, config);
+      return _writeDBRules(instance, filename, config);
     }
     logger.info('Skipping overwrite of Database Rules.');
-    logger.info('The rules defined in ' + fileName + ' will be published when you do ' + chalk.bold('firebase deploy') + '.');
+    logger.info('The rules defined in ' + chalk.bold(filename) + ' will be published when you do ' + chalk.bold('firebase deploy') + '.');
     return RSVP.resolve();
   });
 };

--- a/lib/init/features/database.js
+++ b/lib/init/features/database.js
@@ -29,7 +29,7 @@ var _writeDBRules = function(instance, filename, config) {
 
 module.exports = function(setup, config) {
   setup.config.database = {};
-  var instance = setup.rcfile.projects.default_instance;
+  var instance = setup.instance;
   var filename = null;
 
   logger.info();

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -15,9 +15,9 @@ module.exports = function(setup, config) {
   setup.project = {};
 
   logger.info();
-  logger.info('Now that your Firebase project directory is set up, it\'s time to associate');
-  logger.info('it with a project. You can create multiple project aliases by running');
-  logger.info(chalk.bold('firebase use --add') + ', but for now we\'ll just set up a default project.');
+  logger.info('Let\'s associate this Firebase project directory with a Firebase project.');
+  logger.info('You can create multiple project aliases by running ' + chalk.bold('firebase use --add') + ', ');
+  logger.info('but for now we\'ll just set up a default project.');
   logger.info();
 
   return api.getProjects().then(function(projects) {

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -57,7 +57,7 @@ module.exports = function(setup, config) {
 
       // write "default" alias and activate it immediately
       _.set(setup.rcfile, 'projects.default', projectId);
-      _.set(setup.rcfile, 'projects.default_instance', instance);
+      setup.instance = instance;
       utils.makeActiveProject(config.projectDir, projectId);
     });
   });

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -15,7 +15,7 @@ module.exports = function(setup, config) {
   setup.project = {};
 
   logger.info();
-  logger.info('Let\'s associate this Firebase project directory with a Firebase project.');
+  logger.info('First, let\'s associate this project directory with a Firebase project.');
   logger.info('You can create multiple project aliases by running ' + chalk.bold('firebase use --add') + ', ');
   logger.info('but for now we\'ll just set up a default project.');
   logger.info();
@@ -53,9 +53,11 @@ module.exports = function(setup, config) {
         return;
       }
       projectId = prompt.listLabelToValue(projectId, choices);
+      var instance = projects[projectId].instances.database[0];
 
       // write "default" alias and activate it immediately
       _.set(setup.rcfile, 'projects.default', projectId);
+      _.set(setup.rcfile, 'projects.default_instance', instance);
       utils.makeActiveProject(config.projectDir, projectId);
     });
   });


### PR DESCRIPTION
To address custom security rules from being wiped out during firebase init. 
When there aren't existing rules files, rules will be downloaded from the console. When there is an existing file, user will be asked which rules they would like to keep. 

Addresses concerns here: https://github.com/firebase/firebase-tools/issues/134
