### PR TITLE
Fixes --project and `firebase use <project_id>`

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -148,7 +148,7 @@ Command.prototype.applyRC = function(options) {
   if (rcProject) {
     options.projectAlias = options.project;
     options.project = rcProject;
-  } else if (_.size(aliases) === 1) {
+  } else if (!options.project && _.size(aliases) === 1) {
     options.projectAlias = _.head(_.keys(aliases));
     options.project = _.head(_.values(aliases));
   }


### PR DESCRIPTION
This fixes a bug where, when only a single project alias was defined in `.firebaserc`, the `firebase use <project_id>` and `--project <project_id>` flags weren't being respected.