### PR TITLE
Prevent trying to stringify DB rules when already a string

### DIFF
--- a/lib/init/features/database.js
+++ b/lib/init/features/database.js
@@ -13,7 +13,7 @@ var _getConsoleDBRules = function(instance) {
     auth: true,
     origin: utils.addSubdomain(api.realtimeOrigin, instance)
   }).then(function(response) {
-    return JSON.stringify(response.body, null, 2);
+    return response.body;
   });
 };
 


### PR DESCRIPTION
The response from the API is already a string.
Calling `JSON.stringify()` over it correctly inserts `\n` strings
to attempt to preserve the formatting.
Later, this stringification is not undone,
resulting in the final output also containing literal `\n` strings.

The database rules allow inline comments
which would break on JSON.parse(),
meaning we cannot convert directly to JSON first
then convert back to a string representation at write-to-disk time.

Passing the string response directly to the write-to-disk task
accomplishes the goal of retreiving DB rules
and saving them locally.

This may also fix #87.