### PR TITLE
Send empty manifest to save payload size.

### DIFF
--- a/lib/deploy/hosting/deploy.js
+++ b/lib/deploy/hosting/deploy.js
@@ -29,9 +29,11 @@ module.exports = function(context, options, payload) {
     _.assign(payload.hosting, {
       version: local.versionId,
       prefix: local.versionId + '/',
-      manifest: upload.manifest.map(function(file) {
-        return {path: file, object: file};
-      })
+      manifest: [] // manifest is currently unused, saving payload size
+
+      // manifest: upload.manifest.map(function(file) {
+      //   return {path: file, object: file};
+      // })
     });
 
     return new RSVP.Promise(function(resolve, reject) {


### PR DESCRIPTION
We're not using the manifest on the backend currently, let's keep the request size down.

@laurenzlong can you take a quick look? Grab me in person if you have any questions about this.