### PR TITLE
write default DB rules if firebase initing without project

### DIFF
--- a/lib/init/features/database.js
+++ b/lib/init/features/database.js
@@ -8,7 +8,12 @@ var utils = require('../../utils');
 var fsutils = require('../../fsutils');
 var RSVP = require('rsvp');
 
-var _getConsoleDBRules = function(instance) {
+var defaultRules = '{"rules":{".read":"auth != null",".write":"auth != null"}}';
+
+var _getDBRules = function(instance) {
+  if (!instance) {
+    return RSVP.resolve(defaultRules);
+  }
   return api.request('GET', '/.settings/rules.json', {
     auth: true,
     origin: utils.addSubdomain(api.realtimeOrigin, instance)
@@ -18,7 +23,7 @@ var _getConsoleDBRules = function(instance) {
 };
 
 var _writeDBRules = function(instance, filename, config) {
-  return _getConsoleDBRules(instance).then(function(rules) {
+  return _getDBRules(instance).then(function(rules) {
     return config.writeProjectFile(filename, rules);
   }).then(function() {
     utils.logSuccess('Database Rules for ' + chalk.bold(instance) + ' have been downloaded to ' + chalk.bold(filename) + '.');

--- a/lib/init/features/database.js
+++ b/lib/init/features/database.js
@@ -8,7 +8,7 @@ var utils = require('../../utils');
 var fsutils = require('../../fsutils');
 var RSVP = require('rsvp');
 
-var defaultRules = '{"rules":{".read":"auth != null",".write":"auth != null"}}';
+var defaultRules = JSON.stringify({rules: {'.read': 'auth != null', '.write': 'auth != null'}}, null, 2);
 
 var _getDBRules = function(instance) {
   if (!instance) {


### PR DESCRIPTION
Right now firebase init fails when there's no default project selected due to the fact that it is trying to fetch DB rules from the console. This PR fixes this by downloading default DB rules when there isn't a project specified. 