### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/track.js
+++ b/lib/track.js
@@ -6,7 +6,7 @@ var RSVP = require('rsvp');
 var _ = require('lodash');
 var configstore = require('./configstore');
 var pkg = require('../package.json');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var logger = require('./logger');
 
 var anonId = configstore.get('analytics-uuid');

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "jsonschema": "^1.0.2",
     "jsonwebtoken": "^5.4.0",
     "lodash": "^4.6.1",
-    "node-uuid": "^1.4.3",
     "open": "^0.0.5",
     "portfinder": "^0.4.0",
     "progress": "^1.1.8",
@@ -75,7 +74,7 @@
     "universal-analytics": "^0.3.9",
     "update-notifier": "^0.5.0",
     "user-home": "^2.0.0",
-    "uuid": "^2.0.1",
+    "uuid": "^3.0.0",
     "winston": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.