### PR TITLE
add firebase login --no-localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Command | Description
 **init** | Setup a new Firebase project in the current directory. This command will create a `firebase.json` configuration file in your current directory.
 **help** | Display help information about the CLI or specific commands.
 
+Append `--no-localhost` to login (i.e., `firebase login --no-localhost`) to copy and paste a code instead of starting a local server for authentication. A use case might be if you ssh into an instance somewhere and you need to authenticate to firebase on that machine. 
+
 ### Deployment and Local Development
 
 These commands let you deploy and interact with your Firebase Hosting site.


### PR DESCRIPTION
I think adding this information right in the readme is helpful for newcomers who might not think to `firebase login --help`