### PR TITLE
fix bug which sets nested config variables to unparsed json

### DIFF
--- a/lib/functionsConfig.js
+++ b/lib/functionsConfig.js
@@ -64,7 +64,7 @@ exports.setVariablesRecursive = function(projectId, configId, varPath, val) {
   try {
     var parsed = JSON.parse(val);
     if (!_.isPlainObject(parsed)) { // could be a number, etc.
-      return _setVariable(projectId, configId, varPath, val);
+      return _setVariable(projectId, configId, varPath, parsed);
     } else if (parsed === null) {
       return _setVariable(projectId, configId, varPath, 'null');
     }


### PR DESCRIPTION
Primitive values were parsed but the result was not used to set the variable, causing variables to be wrapped in escaped quotes.