### PR TITLE
Default options to an empty object.

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -158,6 +158,10 @@ Command.prototype.runner = function() {
   var self = this;
   return function() {
     var args = _.toArray(arguments);
+    // always provide at least an empty object for options
+    if (args.length === 0) {
+      args.push({});
+    }
     var options = _.last(args);
 
     try {


### PR DESCRIPTION
This allows commands that don't have any flags set to be called when requiring `firebase-tools`:

```js
const fbcli = require('firebase-tools');
fbcli.list().then(projects => { });
```

Previously you had to pass an empty object `{}` or it would crash.