### PR TITLE
bump firebase major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "es6-set": "^0.1.4",
     "exit-code": "^1.0.2",
     "filesize": "^3.1.3",
-    "firebase": "2.x.x",
+    "firebase": "3.x.x",
     "fs-extra": "^0.23.1",
     "fstream-ignore": "^1.0.2",
     "inquirer": "^0.12.0",


### PR DESCRIPTION
Emberfire requires firebase 3, and when building ember apps the versions get clobbered. 