### PR TITLE
process.send() is not synchronous

### DIFF
--- a/lib/triggerParser.js
+++ b/lib/triggerParser.js
@@ -3,27 +3,30 @@
 'use strict';
 
 var extractTriggers = require('./extractTriggers');
+var EXIT = function() { process.exit(0); };
 
-var packageDir = process.argv[2];
-if (!packageDir) {
-  process.send({error: 'Must supply package directory for functions trigger parsing.'});
-  process.exit(0);
-}
-
-var mod;
-var triggers = [];
-try {
-  mod = require(packageDir);
-} catch (e) {
-  if (e.code === 'MODULE_NOT_FOUND') {
-    process.send({error: 'Error parsing triggers: ' + e.message + '\n\nTry running "npm install" in your functions directory before deploying.'});
-  } else {
-    process.send({error: 'Error occurred while parsing your function triggers.\n\n' + e.stack});
+(function() { // wrap in function for flow control
+  var packageDir = process.argv[2];
+  if (!packageDir) {
+    process.send({error: 'Must supply package directory for functions trigger parsing.'}, EXIT);
+    return;
   }
-  process.exit(0);
-}
 
-extractTriggers(mod, triggers);
+  var mod;
+  var triggers = [];
+  try {
+    mod = require(packageDir);
+  } catch (e) {
+    if (e.code === 'MODULE_NOT_FOUND') {
+      process.send({error: 'Error parsing triggers: ' + e.message + '\n\nTry running "npm install" in your functions directory before deploying.'}, EXIT);
+      return;
+    }
 
-process.send({triggers: triggers});
-process.exit(0);
+    process.send({error: 'Error occurred while parsing your function triggers.\n\n' + e.stack}, EXIT);
+    return;
+  }
+
+  extractTriggers(mod, triggers);
+
+  process.send({triggers: triggers}, EXIT);
+})();

--- a/lib/triggerParser.js
+++ b/lib/triggerParser.js
@@ -5,7 +5,7 @@
 var extractTriggers = require('./extractTriggers');
 var EXIT = function() { process.exit(0); };
 
-(function() { // wrap in function for flow control
+(function() { // wrap in function to allow return without exiting process
   var packageDir = process.argv[2];
   if (!packageDir) {
     process.send({error: 'Must supply package directory for functions trigger parsing.'}, EXIT);


### PR DESCRIPTION
The Cloud Functions trigger parser was using a subprocess and `process.send()` to communicate back to the parent. This was mistakenly thought to be a synchronous call, but in fact is async. For some users, this would cause a deploy of functions (especially many functions) to fail.