### PR TITLE
Changelog for v3.8.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,2 @@
-feature - Experimental: add ability to locally emulate HTTPS functions with "firebase serve --only functions". (Run "firebase serve --only functions,hosting" to emulate both functions and hosting.)
+feature - [Experimental] Add ability to locally emulate HTTPS functions with "firebase serve --only functions". Run "firebase serve --only functions,hosting" to serve both functions and hosting.
 feature - Add ability to target specific functions and export groups when deploying functions with "firebase deploy --only functions:function1,functions:groupA.function2".

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,2 @@
+feature - Experimental: add ability to locally emulate HTTPS functions with "firebase serve --only functions". (Run "firebase serve --only functions,hosting" to emulate both functions and hosting.)
+feature - Add ability to target specific functions and export groups when deploying functions with "firebase deploy --only functions:function1,functions:groupA.function2".


### PR DESCRIPTION
I realized that v3.7.0 did not actually contain new features, since we pulled single functions deploys out. So I thought maybe it makes more sense for this release to be 3.7.1 instead of going up one more minor version. But let me know if you think 3.8.0 is better.