### PR TITLE
Throw error when no valid deploy/serve target found.

### DIFF
--- a/lib/filterTargets.js
+++ b/lib/filterTargets.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var utils = require('../lib/utils');
+var FirebaseError = require('../lib/error');
 
 module.exports = function(options, validTargets) {
   var targets = validTargets.filter(function(t) {
@@ -16,7 +16,7 @@ module.exports = function(options, validTargets) {
   }
 
   if (targets.length === 0) {
-    return utils.reject('No targets found. Valid targets are: ' + validTargets.join(','), {exit: 1});
+    throw new FirebaseError('No targets found. Valid targets are: ' + validTargets.join(','), {exit: 1});
   }
   return targets;
 };


### PR DESCRIPTION
There was a bug where the error message wasn't actually getting shown properly, but leading to "unexpected error."  See https://github.com/firebase/firebase-tools/issues/340