### PR TITLE
Remove outdated code for functions deployment for storage & database.

### DIFF
--- a/lib/deploy/functions/release.js
+++ b/lib/deploy/functions/release.js
@@ -235,10 +235,6 @@ module.exports = function(context, options, payload) {
       return RSVP.resolve(_.pick(functionInfo, 'httpsTrigger'));
     } else if (functionInfo.eventTrigger) {
       var trigger = functionInfo.eventTrigger;
-      if (trigger.eventType === 'providers/cloud.storage/eventTypes/object.change' && !trigger.resource) {
-        var bucket = _.get(context, 'firebaseConfig.storageBucket');
-        _.set(trigger, 'resource', 'projects/_/buckets/' + bucket);
-      }
       return RSVP.resolve({eventTrigger: trigger});
     }
     logger.debug('Unknown trigger type found in:', functionInfo);
@@ -293,34 +289,9 @@ module.exports = function(context, options, payload) {
           var existingFunction = _.find(existingFunctions, function(func) {
             return func.name.match(new RegExp('/' + functionName + '$'));
           });
-          var existingTriggerType = _.get(existingFunction, 'eventTrigger.eventType');
-          var newTriggerType = _.get(functionTrigger, 'eventTrigger.eventType');
-          var isNowDBTrigger = newTriggerType === 'providers/google.firebase.database/eventTypes/ref.write';
-          // Firebase Database triggers could be outdated in 2 ways: they are still a PubSub trigger, or their event
-          // type contains 'data.write' instead of 'ref.write'. GCF won't allow us to change the trigger type of an existing trigger
-          // so we have to delete functions that were based on the old prototype and create them as real database triggers.
-          if (isNowDBTrigger && newTriggerType !== existingTriggerType) {
-            var eventType = functionTrigger.eventTrigger ? functionTrigger.eventTrigger.eventType : 'https';
-            return gcp.cloudfunctions.delete(projectId, GCP_REGION, functionName)
-              .then(function(call) {
-                return _pollOperations([call]);
-              }).then(function() {
-                return gcp.cloudfunctions.create({
-                  projectId: projectId,
-                  region: GCP_REGION,
-                  eventType: eventType,
-                  functionName: functionName,
-                  entryPoint: functionInfo.entryPoint,
-                  trigger: functionTrigger,
-                  sourceArchiveUrl: sourceUrl,
-                  availableMemory: existingFunction.availableMemoryMb,
-                  functionTimeout: existingFunction.timeout
-                });
-              });
-          }
           _startTimer(functionName, 'update');
           // Also provide `availableMemory` and `timeout` retrieved from `gcp.cloudfunctions.list`
-          // This is a stop gap until GCF bug is fixed (https://buganizer.corp.google.com/issues/36844999)
+          // This is a stop gap until GCF bug is fixed BUG(36844999)
           return gcp.cloudfunctions.update({
             projectId: projectId,
             region: GCP_REGION,


### PR DESCRIPTION
- We no longer need to populate the storage bucket if it's not provided, since the SDK does it. 
- Its been > 3 months since we've changed the database event type to ref.write, so we can remove that shim now.