### PR TITLE
Fix typo in demo code

### DIFF
--- a/templates/init/hosting/index.html
+++ b/templates/init/hosting/index.html
@@ -45,7 +45,7 @@
         // // The Firebase SDK is initialized and available here!
         //
         // firebase.auth().onAuthStateChanged(user => { });
-        // firebase.database().ref('/path/to/ref').on('data', snapshot => { });
+        // firebase.database().ref('/path/to/ref').on('value', snapshot => { });
         // firebase.messaging().requestPermission().then(() => { });
         // firebase.storage().ref('/path/to/ref').getDownloadURL().then(() => { });
         //


### PR DESCRIPTION
At commented code demo is parameter out ouf [valid variables](https://firebase.google.com/docs/reference/js/firebase.database.Reference#on):
```javascript
firebase.database().ref('/path/to/ref').on('data', snapshot => { });
//                                          ^ should be 'value'
```

This PR fix it for faster Firebase learning for newbies (like a me).