### PR TITLE
Tweak the bandwidth warning text in the profiler

### DIFF
--- a/lib/profileReport.js
+++ b/lib/profileReport.js
@@ -14,8 +14,8 @@ var utils = require('./utils');
 
 var DATA_LINE_REGEX = /^data: /;
 
-var BANDWIDTH_NOTE = 'NOTE: Bandwidth is an estimate and' +
-' not a valid measure of your bandwidth bill.';
+var BANDWIDTH_NOTE = 'NOTE: The numbers reported here are only estimates of the data' +
+' payloads from read operations. They are NOT a valid measure of your bandwidth bill.';
 
 var SPEED_NOTE = 'NOTE: Speeds are reported at millisecond resolution and' +
 ' are not the latencies that clients will see.';

--- a/test/fixtures/profiler-data/sample-output.json
+++ b/test/fixtures/profiler-data/sample-output.json
@@ -231,7 +231,7 @@
         "0 B"
       ]
     ],
-    "note": "NOTE: Bandwidth is an estimate and not a valid measure of your bandwidth bill."
+    "note": "The numbers reported here are only estimates of the data payloads from read operations. They are NOT a valid measure of your bandwidth bill."
   },
   "uploadedBytes": {
     "legend": [
@@ -296,7 +296,7 @@
         "15 B"
       ]
     ],
-    "note": "NOTE: Bandwidth is an estimate and not a valid measure of your bandwidth bill."
+    "note": "The numbers reported here are only estimates of the data payloads from read operations. They are NOT a valid measure of your bandwidth bill."
   },
   "unindexedQueries": {
     "legend": [


### PR DESCRIPTION
A few questions have come up about this, the bandwidth numbers in the profiler are estimates of the data in read operations and don't account for the protocol and encryption, which is all billed for.

This text has been approved by our technical writer.