### PR TITLE
Update progress module to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "open": "^0.0.5",
     "ora": "0.2.3",
     "portfinder": "^0.4.0",
-    "progress": "^1.1.8",
+    "progress": "^2.0.0",
     "request": "^2.58.0",
     "rsvp": "^3.0.18",
     "semver": "^5.0.3",


### PR DESCRIPTION
v2.0.0 contains as fix which otherwise can cause Windows machines to fail the firebase deploy command (https://github.com/visionmedia/node-progress/commit/8ef3972b5e29bd67bd1d55d21810ee4ac692d969).