### PR TITLE
Remove warning about Node 8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-**We are aware of compatiblity issues with Node v8.0.0 and are working to resolve them. For now, please use Node v7.10.0 or lower.**
-
 # Firebase CLI [![Build Status](https://travis-ci.org/firebase/firebase-tools.svg?branch=master)](https://travis-ci.org/firebase/firebase-tools) [![Coverage Status](https://img.shields.io/coveralls/firebase/firebase-tools.svg?branch=master&style=flat)](https://coveralls.io/r/firebase/firebase-tools) [![NPM version](https://badge.fury.io/js/firebase-tools.svg)](http://badge.fury.io/js/firebase-tools)
 
 These are the Firebase Command Line Interface (CLI) Tools. They can be used to:

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "preferGlobal": true,
   "engines": {
-    "node": ">=0.10.0 <8.0.0"
+    "node": ">=0.10.0"
   },
   "engineStrict": true,
   "author": "Firebase (https://firebase.google.com/)",


### PR DESCRIPTION
Since latest version of Node now works with the CLI.