### PR TITLE
Serve the functions on the specified port on Emulator

### DIFF
--- a/lib/serve/functions.js
+++ b/lib/serve/functions.js
@@ -51,9 +51,9 @@ function _stopEmulator() {
 
 function _getPorts(options) {
   var portsConfig = {
-    restPort: options.port,
+    restPort: options.port + 2,
     grpcPort: options.port + 1,
-    supervisorPort: options.port + 2
+    supervisorPort: options.port
   };
   if (_.includes(options.targets, 'hosting')) {
     return _.mapValues(portsConfig, function(port) {


### PR DESCRIPTION
This is in reference to issue #374 