### PR TITLE
Recommend v6.11.1 for functions emulator

### DIFF
--- a/lib/serve/functions.js
+++ b/lib/serve/functions.js
@@ -74,8 +74,8 @@ function _startEmulator(options) {
     EmulatorController = require('@google-cloud/functions-emulator/src/cli/controller');
   } catch (err) {
     var msg = err;
-    if (process.version !== 'v6.9.1') {
-      msg = 'Please use Node version v6.9.1, you have ' + process.version + '\n';
+    if (process.version !== 'v6.11.1') {
+      msg = 'Please use Node version v6.11.1, you have ' + process.version + '\n';
     }
     utils.logWarning(chalk.yellow('functions:') + ' Cannot start emulator. ' + msg);
     return RSVP.reject();


### PR DESCRIPTION
The recommended Node version to be used for the emulator is now Node v6.11.1, since that's what the runtime has been updated to (due to Node vulnerabilities in 6.9.1) See https://github.com/GoogleCloudPlatform/cloud-functions-emulator/blob/master/package.json