### PR TITLE
Pass Cookie headers to functions emulator

### DIFF
--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -42,7 +42,8 @@ module.exports = function(options) {
           'X-Forwarded-Host': req.headers.host,
           'X-Original-Url': req.url,
           'Pragma': 'no-cache',
-          'Cache-Control': 'no-cache, no-store'
+          'Cache-Control': 'no-cache, no-store',
+          'Cookie': req.headers.cookie
         },
         followRedirect: false,
         timeout: 60000

--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var request = require('request');
 var RSVP = require('rsvp');
+var Cookie = require('cookie');
 
 var getProjectId = require('../getProjectId');
 
@@ -34,6 +35,9 @@ module.exports = function(options) {
       url = 'https://us-central1-' + getProjectId(options) + '.cloudfunctions.net/' + rewrite.function;
     }
     return RSVP.resolve(function(req, res, next) {
+      // extract the __session cookie from request headers
+      var sessionCookie = Cookie.parse(req.headers.cookie || '').__session;
+
       var proxied = request({
         method: req.method,
         qs: req.query,
@@ -43,7 +47,10 @@ module.exports = function(options) {
           'X-Original-Url': req.url,
           'Pragma': 'no-cache',
           'Cache-Control': 'no-cache, no-store',
-          'Cookie': req.headers.cookie
+          // forward the parsed __session cookie if any
+          'Cookie': sessionCookie ?
+            Cookie.serialize('__session', sessionCookie)
+            : undefined
         },
         followRedirect: false,
         timeout: 60000

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cli-table": "^0.3.1",
     "commander": "^2.8.1",
     "configstore": "^1.2.0",
+    "cookie": "^0.3.1",
     "cross-spawn": "^4.0.0",
     "csv-streamify": "^3.0.4",
     "didyoumean": "^1.2.1",


### PR DESCRIPTION
This PR fixes #404 by forwarding the `Cookie` header to the emulator.

This doesn't exactly follow the cloud functions convention described [here](https://firebase.google.com/docs/hosting/functions#using_cookies) since all cookies are forwarded, instead of only the one named `__session`.

Howerever, this makes authentication using cookies fully functional.