### PR TITLE
Fix functions proxy not working anymore since #395

### DIFF
--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -28,7 +28,7 @@ module.exports = function(options) {
   return function(rewrite) {
     var url;
     if (_.includes(options.targets, 'functions')) {
-      url = 'http://localhost:' + (options.port + 3) + '/' + getProjectId(options) + '/us-central1/' + rewrite.function;
+      url = 'http://localhost:' + (options.port + 1) + '/' + getProjectId(options) + '/us-central1/' + rewrite.function;
       console.log(url);
     } else {
       url = 'https://us-central1-' + getProjectId(options) + '.cloudfunctions.net/' + rewrite.function;

--- a/lib/serve/functions.js
+++ b/lib/serve/functions.js
@@ -51,9 +51,9 @@ function _stopEmulator() {
 
 function _getPorts(options) {
   var portsConfig = {
-    restPort: options.port,
+    restPort: options.port + 2,
     grpcPort: options.port + 1,
-    supervisorPort: options.port + 2
+    supervisorPort: options.port
   };
   if (_.includes(options.targets, 'hosting')) {
     return _.mapValues(portsConfig, function(port) {

--- a/lib/serve/functions.js
+++ b/lib/serve/functions.js
@@ -51,9 +51,9 @@ function _stopEmulator() {
 
 function _getPorts(options) {
   var portsConfig = {
-    restPort: options.port + 2,
+    restPort: options.port,
     grpcPort: options.port + 1,
-    supervisorPort: options.port
+    supervisorPort: options.port + 2
   };
   if (_.includes(options.targets, 'hosting')) {
     return _.mapValues(portsConfig, function(port) {


### PR DESCRIPTION
@jhuleatt posted an issue "firebase serve --only functions incorrect port" (#374), which was **not really** a bug, the option `--port` specifies the local port to run the equivalent of `<project>.firebaseapp.com`, this option is not designed to specify the port of the running cloud functions.

It looks like the user was confused because he was running firebase with `--only functions` and was expecting the server to strictly emulate the Google Cloud Functions and not the overall Firebase system.

@GabrielRivera21 posted the PR #395 to suggest a fix, the idea was to switch the ports of the Supervisor (`port +2 -> port`) and REST (`port -> port + 2`) so that when running with `--only functions` the supervisor was assigned to `--port` and when running with `--only hosting,functions` it was assigned to `--port + 1`

This quick PR fixes the functions proxy which was not configured correctly to use the new port (it was forwarding the requests to the REST server).

It may be good to refactor the port management to have only one source of truth instead of computing the port in `lib/hosting/functionsProxy.js` and `lib/serve/functions.js` 🙄.
