### PR TITLE
Ensure that Cookie header is not modified by functions proxy

### DIFF
--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -3,7 +3,6 @@
 var _ = require('lodash');
 var request = require('request');
 var RSVP = require('rsvp');
-var Cookie = require('cookie');
 
 var getProjectId = require('../getProjectId');
 
@@ -35,22 +34,12 @@ module.exports = function(options) {
       url = 'https://us-central1-' + getProjectId(options) + '.cloudfunctions.net/' + rewrite.function;
     }
     return RSVP.resolve(function(req, res, next) {
-      // read cookies from request
-      var cookies = Cookie.parse(req.headers.cookie || '', {
-        // the Cookie module will decode using decodeURIComponent() by default
-        // we prevent transforming the __session cookie by using the identity function
-        decode: function(cookie) {
-          return cookie;
-        }
-      });
-      // serialize the __session cookie if any
-      // we prevent transforming the __session cookie by using the identity function
-      var sessionCookie = cookies.__session ?
-        Cookie.serialize('__session', cookies.__session, {
-          encode: function(cookie) {
-            return cookie;
-          }
-        }) : undefined;
+      // Extract the __session cookie from headers to forward it to the functions
+      var sessionCookie = (req.headers.cookie || '')
+        .split(/; ?/)
+        .find(function(c) {
+          return c.trim().indexOf('__session=') === 0;
+        });
 
       var proxied = request({
         method: req.method,

--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -42,7 +42,8 @@ module.exports = function(options) {
           'X-Forwarded-Host': req.headers.host,
           'X-Original-Url': req.url,
           'Pragma': 'no-cache',
-          'Cache-Control': 'no-cache, no-store'
+          'Cache-Control': 'no-cache, no-store',
+          'Cookie': req.headers.cookie
         },
         followRedirect: false,
         timeout: 60000

--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -3,6 +3,7 @@
 var _ = require('lodash');
 var request = require('request');
 var RSVP = require('rsvp');
+var Cookie = require('cookie');
 
 var getProjectId = require('../getProjectId');
 
@@ -34,6 +35,9 @@ module.exports = function(options) {
       url = 'https://us-central1-' + getProjectId(options) + '.cloudfunctions.net/' + rewrite.function;
     }
     return RSVP.resolve(function(req, res, next) {
+      // extract the __session cookie from request headers
+      var sessionCookie = Cookie.parse(req.headers.cookie || '').__session;
+
       var proxied = request({
         method: req.method,
         qs: req.query,
@@ -43,7 +47,10 @@ module.exports = function(options) {
           'X-Original-Url': req.url,
           'Pragma': 'no-cache',
           'Cache-Control': 'no-cache, no-store',
-          'Cookie': req.headers.cookie
+          // forward the parsed __session cookie if any
+          'Cookie': sessionCookie ?
+            Cookie.serialize('__session', sessionCookie)
+            : undefined
         },
         followRedirect: false,
         timeout: 60000

--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -35,8 +35,22 @@ module.exports = function(options) {
       url = 'https://us-central1-' + getProjectId(options) + '.cloudfunctions.net/' + rewrite.function;
     }
     return RSVP.resolve(function(req, res, next) {
-      // extract the __session cookie from request headers
-      var sessionCookie = Cookie.parse(req.headers.cookie || '').__session;
+      // read cookies from request
+      var cookies = Cookie.parse(req.headers.cookie || '', {
+        // the Cookie module will decode using decodeURIComponent() by default
+        // we prevent transforming the __session cookie by using the identity function
+        decode: function(cookie) {
+          return cookie;
+        }
+      });
+      // serialize the __session cookie if any
+      // we prevent transforming the __session cookie by using the identity function
+      var sessionCookie = cookies.__session ?
+        Cookie.serialize('__session', cookies.__session, {
+          encode: function(cookie) {
+            return cookie;
+          }
+        }) : undefined;
 
       var proxied = request({
         method: req.method,
@@ -48,9 +62,7 @@ module.exports = function(options) {
           'Pragma': 'no-cache',
           'Cache-Control': 'no-cache, no-store',
           // forward the parsed __session cookie if any
-          'Cookie': sessionCookie ?
-            Cookie.serialize('__session', sessionCookie)
-            : undefined
+          'Cookie': sessionCookie
         },
         followRedirect: false,
         timeout: 60000

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "cli-table": "^0.3.1",
     "commander": "^2.8.1",
     "configstore": "^1.2.0",
+    "cookie": "^0.3.1",
     "cross-spawn": "^4.0.0",
     "csv-streamify": "^3.0.4",
     "didyoumean": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "cli-table": "^0.3.1",
     "commander": "^2.8.1",
     "configstore": "^1.2.0",
-    "cookie": "^0.3.1",
     "cross-spawn": "^4.0.0",
     "csv-streamify": "^3.0.4",
     "didyoumean": "^1.2.1",


### PR DESCRIPTION
This PR is a follow-up of #405.

After further testing, it turns out that the `cookie` module used to parse then serialize the proxied `__session` cookie from the request decodes and encodes the cookie using `decodeURIComponent` and `encodeURIComponent`.

Though this works well if the cookie header doesn't contain URI encodable characters, this can lead to hard-to-debug behaviors when it's the case, since the cookie is modified just before it is proxied to the cloud function.

As a reminder, the current workflow is:
- `Cookie.parse` parses the cookies from the request and extracts `__session`, calling `decodeURIComponent` (cookie unmodified)
- `Cookie.serialize` serializes `__session`, calling `encodeURIComponent` (cookie is modified is it contains special characters)
- modified cookie is proxied to the cloud function

To ensure that this doesn't happen, the calls to `Cookie.parse` and `Cookie.serialize` are now made using the identity function to encode/decode the cookies, which ensures that it is not modified during the proxy step.