### PR TITLE
Adds support application default credentials.

### DIFF
--- a/commands/logout.js
+++ b/commands/logout.js
@@ -17,7 +17,7 @@ module.exports = new Command('logout')
     var tokens = configstore.get('tokens');
     var currentToken = _.get(tokens, 'refresh_token');
     var token = utils.getInheritedOption(options, 'token') || currentToken;
-    api.setToken(token);
+    api.setRefreshToken(token);
     var next;
     if (token) {
       next = auth.logout(token);

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,17 +1,21 @@
 'use strict';
 
-var request = require('request');
-var querystring = require('querystring');
-var FirebaseError = require('./error');
-var RSVP = require('rsvp');
 var _ = require('lodash');
+var querystring = require('querystring');
+var request = require('request');
+var RSVP = require('rsvp');
+
+var FirebaseError = require('./error');
 var logger = require('./logger');
-var utils = require('./utils');
 var responseToError = require('./responseToError');
+var scopes = require('./scopes');
+var utils = require('./utils');
+
+var CLI_VERSION = require('../package.json').version;
+
+var accessToken;
 var refreshToken;
 var commandScopes;
-var scopes = require('./scopes');
-var CLI_VERSION = require('../package.json').version;
 
 var _request = function(options) {
   logger.debug('>>> HTTP REQUEST',
@@ -89,8 +93,11 @@ var api = {
   rulesOrigin: utils.envOverride('FIREBASE_RULES_URL', 'https://firebaserules.googleapis.com'),
   runtimeconfigOrigin: utils.envOverride('FIREBASE_RUNTIMECONFIG_URL', 'https://runtimeconfig.googleapis.com'),
 
-  setToken: function(token) {
+  setRefreshToken: function(token) {
     refreshToken = token;
+  },
+  setAccessToken: function(token) {
+    accessToken = token;
   },
   setScopes: function(s) {
     commandScopes = _.uniq(_.flatten([
@@ -102,13 +109,12 @@ var api = {
     logger.debug('> command requires scopes:', JSON.stringify(commandScopes));
   },
   getAccessToken: function() {
-    return require('./auth').getAccessToken(refreshToken, commandScopes);
+    return accessToken ? RSVP.resolve({access_token: accessToken}) : require('./auth').getAccessToken(refreshToken, commandScopes);
   },
   addRequestHeaders: function(reqOptions) {
   // Runtime fetch of Auth singleton to prevent circular module dependencies
     _.set(reqOptions, ['headers', 'User-Agent'], 'FirebaseCLI/' + CLI_VERSION);
-    var auth = require('../lib/auth');
-    return auth.getAccessToken(refreshToken, commandScopes).then(function(result) {
+    return api.getAccessToken().then(function(result) {
       _.set(reqOptions, 'headers.authorization', 'Bearer ' + result.access_token);
       return reqOptions;
     });

--- a/lib/requireAuth.js
+++ b/lib/requireAuth.js
@@ -3,11 +3,33 @@
 var _ = require('lodash');
 var chalk = require('chalk');
 var RSVP = require('rsvp');
+var autoAuth = require('google-auto-auth');
 
 var api = require('./api');
 var configstore = require('./configstore');
-var utils = require('./utils');
+var FirebaseError = require('./error');
 var logger = require('./logger');
+var utils = require('./utils');
+
+var AUTH_ERROR = new FirebaseError('Command requires authentication, please run ' + chalk.bold('firebase login'));
+
+function _autoAuth(options, authScopes) {
+  return new RSVP.Promise(function(resolve, reject) {
+    logger.debug('> attempting to authenticate via app default credentials');
+    autoAuth({scopes: authScopes}).getToken(function(err, token) {
+      if (err) {
+        logger.debug('! auto-auth error:', err.message);
+        logger.debug('> no credentials could be found or automatically retrieved');
+        return reject(AUTH_ERROR);
+      }
+
+      logger.debug(token);
+      logger.debug('> retrieved access token via default credentials');
+      api.setAccessToken(token);
+      resolve();
+    });
+  });
+}
 
 module.exports = function(options, authScopes) {
   var inScopes = authScopes;
@@ -29,25 +51,28 @@ module.exports = function(options, authScopes) {
   } else if (user) {
     logger.debug('> authorizing via signed-in user');
   } else {
-    logger.debug('> no authorization credentials were supplied or found');
+    return _autoAuth(options, authScopes);
   }
 
   tokenOpt = tokenOpt || process.env.FIREBASE_TOKEN;
 
   if (tokenOpt) {
-    api.setToken(tokenOpt);
+    api.setRefreshToken(tokenOpt);
     return RSVP.resolve();
   }
 
+
   if (!user || !tokens) {
-    if (configstore.get('session')) {
-      return utils.reject('This version of Firebase CLI requires reauthentication.\n\nPlease run ' + chalk.bold('firebase login') + ' to regain access.');
-    }
-    return utils.reject('Command requires authentication, please run ' + chalk.bold('firebase login'));
+    return new RSVP.Promise(function(resolve, reject) {
+      if (configstore.get('session')) {
+        return reject(new FirebaseError('This version of Firebase CLI requires reauthentication.\n\nPlease run ' + chalk.bold('firebase login') + ' to regain access.'));
+      }
+      return reject(AUTH_ERROR);
+    });
   }
 
   options.user = user;
   options.tokens = tokens;
-  api.setToken(tokens.refresh_token);
+  api.setRefreshToken(tokens.refresh_token);
   return RSVP.resolve();
 };

--- a/scripts/test-functions-config.js
+++ b/scripts/test-functions-config.js
@@ -20,7 +20,7 @@ var preTest = function() {
   var dir = tmp.dirSync({prefix: 'cfgtest_'});
   tmpDir = dir.name;
   fs.copySync(projectDir, tmpDir);
-  api.setToken(configstore.get('tokens').refresh_token);
+  api.setRefreshToken(configstore.get('tokens').refresh_token);
   api.setScopes(scopes.CLOUD_PLATFORM);
   console.log('Done pretest prep.');
 };

--- a/scripts/test-functions-deploy.js
+++ b/scripts/test-functions-deploy.js
@@ -53,7 +53,7 @@ var preTest = function() {
   tmpDir = dir.name;
   fs.copySync(projectDir, tmpDir);
   execSync('npm install', {'cwd': tmpDir + '/functions'});
-  api.setToken(configstore.get('tokens').refresh_token);
+  api.setRefreshToken(configstore.get('tokens').refresh_token);
   api.setScopes(scopes.CLOUD_PLATFORM);
   var config = {
     apiKey: 'AIzaSyCLgng7Qgzf-2UKRPLz--LtLLxUsMK8oco',


### PR DESCRIPTION
This adds support for authenticating to the Firebase CLI via [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials). This should mean that if you're already authenticated via `gcloud auth application-default login` or running the CLI in a Google Cloud environment, you won't need to login to use the CLI.