### PR TITLE
Fix functions config clone

### DIFF
--- a/lib/functionsConfig.js
+++ b/lib/functionsConfig.js
@@ -63,21 +63,23 @@ exports.getFirebaseConfig = function(projectId, instance) {
 // If you make changes to this function, run "node scripts/test-functions-config.js"
 // to ensure that nothing broke.
 exports.setVariablesRecursive = function(projectId, configId, varPath, val) {
-  try {
-    var parsed = JSON.parse(val);
-    if (!_.isPlainObject(parsed)) {
-      // val can be JSON parsed, but is not an object (is a number, quoted string, etc.)
-      return _setVariable(projectId, configId, varPath, val);
-    } else if (parsed === null) {
-      return _setVariable(projectId, configId, varPath, 'null');
+  var parsed = val;
+  if(_.isString(val)) {
+    try {
+      //Only attempt to parse 'val' if it is a String (takes care of unparsed JSON, numbers, quoted string, etc.)
+      parsed = JSON.parse(val)
+    } catch (e) {
+      //'val' is just a String
     }
-    // parsed is a JSON, need to recurse on its key-value pairs
+  }
+  //If 'parsed' is object, call again
+  if (_.isPlainObject(parsed)) {
     return RSVP.all(_.map(parsed, function(item, key) {
       var newVarPath = varPath ? _.join([varPath, key], '/') : key;
       return exports.setVariablesRecursive(projectId, configId, newVarPath, item);
     }));
-  } catch (e) {
-    // val is a string
+  } else {
+    // 'val' wasn't more JSON, i.e. is a leaf node; set and return
     return _setVariable(projectId, configId, varPath, val);
   }
 };
@@ -161,4 +163,3 @@ exports.parseUnsetArgs = function(args) {
   });
   return parsed;
 };
-

--- a/lib/functionsConfig.js
+++ b/lib/functionsConfig.js
@@ -64,24 +64,24 @@ exports.getFirebaseConfig = function(projectId, instance) {
 // to ensure that nothing broke.
 exports.setVariablesRecursive = function(projectId, configId, varPath, val) {
   var parsed = val;
-  if(_.isString(val)) {
+  if (_.isString(val)) {
     try {
-      //Only attempt to parse 'val' if it is a String (takes care of unparsed JSON, numbers, quoted string, etc.)
-      parsed = JSON.parse(val)
+      // Only attempt to parse 'val' if it is a String (takes care of unparsed JSON, numbers, quoted string, etc.)
+      parsed = JSON.parse(val);
     } catch (e) {
-      //'val' is just a String
+      // 'val' is just a String
     }
   }
-  //If 'parsed' is object, call again
+  // If 'parsed' is object, call again
   if (_.isPlainObject(parsed)) {
     return RSVP.all(_.map(parsed, function(item, key) {
       var newVarPath = varPath ? _.join([varPath, key], '/') : key;
       return exports.setVariablesRecursive(projectId, configId, newVarPath, item);
     }));
-  } else {
-    // 'val' wasn't more JSON, i.e. is a leaf node; set and return
-    return _setVariable(projectId, configId, varPath, val);
   }
+
+  // 'val' wasn't more JSON, i.e. is a leaf node; set and return
+  return _setVariable(projectId, configId, varPath, val);
 };
 
 exports.materializeConfig = function(configName, output) {

--- a/lib/functionsConfigClone.js
+++ b/lib/functionsConfigClone.js
@@ -72,7 +72,7 @@ module.exports = function(fromProject, toProject, only, except) {
     _.unset(toClone, 'firebase'); // Do not clone firebase config
     _applyExcept(toClone, except);
     return RSVP.all(_.map(toClone, function(val, configId) {
-      return functionsConfig.setVariablesRecursive(toProject, configId, '', JSON.stringify(val));
+      return functionsConfig.setVariablesRecursive(toProject, configId, '', val);
     }));
   });
 };


### PR DESCRIPTION
### Description

Functions Config cloning does not work on deeply nested configs. On 2 tiers or less, it displays the problem shown in #320. In more than 2 tiers, it does not work at all.

This is a solution that fixes both of the problems, however, it seems that the function `setVariablesRecursive` has special tests that I do not have access to.

ex.
```javascript
{ tier1: {
    key1: "anything",
    tier2: {
      key2: "string"
}}}

// result
{ tier1: {
    key1: "\"anything\""
}}
// Error: HTTP Error: 400, Invalid JSON payload received. Unknown name "key2" at 'variable.text': Cannot find field.
```

### Sample Commands

```
firebase functions:config:clone --from <project-id>
```