### PR TITLE
Write errors from functions upload in debug logs

### DIFF
--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -13,6 +13,7 @@ var tmp = require('tmp');
 var FirebaseError = require('./error');
 var functionsConfig = require('./functionsConfig');
 var getProjectId = require('./getProjectId');
+var logger = require('/.logger');
 var utils = require('./utils');
 var parseTriggers = require('./parseTriggers');
 
@@ -24,6 +25,7 @@ var _prepareSource = function(context, options) {
   try {
     fs.copySync(options.config.path(options.config.get('functions.source')), tmpdir.name);
   } catch (err) {
+    logger.debug(err);
     throw new FirebaseError('Problem preparing functions directory for upload.', {exit: 1});
   }
   return functionsConfig.materializeAll(getProjectId(options)).then(function(output) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Currently errors from prepping functions source code doesn't get written in the debug logs.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->