### PR TITLE
Move DB rules deploy to CLI

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -15,8 +15,6 @@ var parseBoltRules = require('./parseBoltRules');
 var prompt = require('./prompt');
 var resolveProjectPath = require('./resolveProjectPath');
 var utils = require('./utils');
-var validateJsonRules = require('./validateJsonRules');
-var logger = require('./logger');
 
 var Config = function(src, options) {
   this.options = options || {};
@@ -120,13 +118,8 @@ Config.prototype._parseFile = function(target, filePath) {
     if (target === 'database') {
       this.notes.databaseRules = 'json';
     } else if (target === 'database.rules') {
-      var rules = fs.readFileSync(fullPath, 'utf8');
-      if (validateJsonRules(rules)) {
-        return rules;
-      }
-      utils.logWarning(chalk.bold.yellow('database: ') + chalk.bold(filePath) + ' must have an outer ' + chalk.bold('rules') + ' key, for example:');
-      logger.warn('\n{\n\t"rules": {".read": false, ".write": false}\n}');
-      throw new FirebaseError('Database security rules are not correctly formatted', {exit: 1});
+      this.notes.databaseRulesFile = filePath;
+      return fs.readFileSync(fullPath, 'utf8');
     }
     return loadCJSON(fullPath);
   /* istanbul ignore-next */

--- a/lib/deploy/database/index.js
+++ b/lib/deploy/database/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = {
-  prepare: require('./prepare')
+  prepare: require('./prepare'),
+  release: require('./release')
 };

--- a/lib/deploy/database/prepare.js
+++ b/lib/deploy/database/prepare.js
@@ -1,11 +1,20 @@
 'use strict';
 
-var RSVP = require('rsvp');
-var utils = require('../../utils');
 var chalk = require('chalk');
+var RSVP = require('rsvp');
 
-module.exports = function(context, options, payload) {
-  payload.database = {rulesString: options.config.get('database.rulesString')};
-  utils.logSuccess(chalk.green.bold('database:') + ' rules ready to deploy.');
-  return RSVP.resolve();
+var rtdb = require('../../rtdb');
+var utils = require('../../utils');
+
+module.exports = function(context, options) {
+  var rulesString = options.config.get('database.rulesString');
+  if (!rulesString) {
+    return RSVP.resolve();
+  }
+
+  context.database = {rulesString: rulesString};
+  utils.logBullet(chalk.bold.cyan('database: ') + 'checking rules syntax...');
+  return rtdb.updateRules(options.instance, rulesString, {dryRun: true}).then(function() {
+    utils.logSuccess(chalk.bold.green('database: ') + 'rules syntax is valid');
+  });
 };

--- a/lib/deploy/database/release.js
+++ b/lib/deploy/database/release.js
@@ -1,0 +1,20 @@
+'use strict';
+
+var chalk = require('chalk');
+var RSVP = require('rsvp');
+
+var rtdb = require('../../rtdb');
+var utils = require('../../utils');
+
+module.exports = function(context, options) {
+  if (!context.database || !context.database.rulesString) {
+    return RSVP.resolve();
+  }
+
+  var rulesString = context.database.rulesString;
+
+  utils.logBullet(chalk.bold.cyan('database: ') + 'releasing rules...');
+  return rtdb.updateRules(options.instance, rulesString).then(function() {
+    utils.logSuccess(chalk.bold.green('database: ') + 'rules released successfully');
+  });
+};

--- a/lib/deploy/functions/release.js
+++ b/lib/deploy/functions/release.js
@@ -15,6 +15,8 @@ module.exports = function(context, options, payload) {
     return RSVP.resolve();
   }
 
+  utils.logBullet('starting release process (may take several minutes)...');
+
   var POLL_INTERVAL = 5000; // 5 sec
   var GCP_REGION = 'us-central1';
   var projectId = context.projectId;

--- a/lib/deploy/index.js
+++ b/lib/deploy/index.js
@@ -70,7 +70,6 @@ var deploy = function(targetNames, options) {
   return _chain(prepares, context, options, payload).then(function() {
     return _chain(deploys, context, options, payload);
   }).then(function() {
-    utils.logBullet('starting release process (may take several minutes)...');
     return _chain(releases, context, options, payload);
   }).then(function() {
     // skip talking to deploy server if only deploying functions

--- a/lib/rtdb.js
+++ b/lib/rtdb.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var api = require('./api');
+var FirebaseError = require('./error');
+var utils = require('./utils');
+
+exports.updateRules = function(instance, src, options) {
+  options = options || {};
+  var url = '/.settings/rules.json';
+  if (options.dryRun) {
+    url += '?dryRun=true';
+  }
+
+  return api.request('PUT', url, {
+    origin: utils.addSubdomain(api.realtimeOrigin, instance),
+    auth: true,
+    data: src,
+    json: false,
+    resolveOnHTTPError: true
+  }).then(function(response) {
+    if (response.status === 400) {
+      throw new FirebaseError('Syntax error in database rules:\n\n' + JSON.parse(response.body).error);
+    }
+  });
+};

--- a/lib/rtdb.js
+++ b/lib/rtdb.js
@@ -20,6 +20,8 @@ exports.updateRules = function(instance, src, options) {
   }).then(function(response) {
     if (response.status === 400) {
       throw new FirebaseError('Syntax error in database rules:\n\n' + JSON.parse(response.body).error);
+    } else if (response.status > 400) {
+      throw new FirebaseError('Unexpected error while deploying database rules.', {exit: 2});
     }
   });
 };


### PR DESCRIPTION
Similar to #461, this extracts logic formerly done by the backend server into the CLI. In addition, this makes use of a dry run to validate syntax before releasing DB rules, so syntax errors will be caught earlier.

This will also fix #308 