### PR TITLE
[README] Add Minimum Node Version Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firebase CLI [![Build Status](https://travis-ci.org/firebase/firebase-tools.svg?branch=master)](https://travis-ci.org/firebase/firebase-tools) [![Coverage Status](https://img.shields.io/coveralls/firebase/firebase-tools.svg?branch=master&style=flat)](https://coveralls.io/r/firebase/firebase-tools) [![NPM version](https://badge.fury.io/js/firebase-tools.svg)](http://badge.fury.io/js/firebase-tools)
+# Firebase CLI [![Build Status](https://travis-ci.org/firebase/firebase-tools.svg?branch=master)](https://travis-ci.org/firebase/firebase-tools) [![Coverage Status](https://img.shields.io/coveralls/firebase/firebase-tools.svg?branch=master&style=flat)](https://coveralls.io/r/firebase/firebase-tools) [![Node Version](https://img.shields.io/node/v/firebase-tools.svg)](https://www.npmjs.com/package/firebase-tools) [![NPM version](https://badge.fury.io/js/firebase-tools.svg)](http://badge.fury.io/js/firebase-tools)
 
 These are the Firebase Command Line Interface (CLI) Tools. They can be used to:
 
@@ -49,7 +49,7 @@ Command | Description
 **init** | Setup a new Firebase project in the current directory. This command will create a `firebase.json` configuration file in your current directory.
 **help** | Display help information about the CLI or specific commands.
 
-Append `--no-localhost` to login (i.e., `firebase login --no-localhost`) to copy and paste code instead of starting a local server for authentication. A use case might be if you SSH into an instance somewhere and you need to authenticate to Firebase on that machine. 
+Append `--no-localhost` to login (i.e., `firebase login --no-localhost`) to copy and paste code instead of starting a local server for authentication. A use case might be if you SSH into an instance somewhere and you need to authenticate to Firebase on that machine.
 
 ### Deployment and Local Development
 


### PR DESCRIPTION
##  Description
Show minimum node version at the top of the `README.md`

##  Background
I planned to submit a PR to address an issue with some unclear documentation on a [Google project](https://github.com/actions-on-google/apiai-facts-about-google-nodejs/issues/2) that requires Firebase CLI tools, and found that the node version [`~4.2`](https://github.com/actions-on-google/apiai-facts-about-google-nodejs/blob/master/functions/package.json#L9) specified by the project was [incompatible](https://github.com/actions-on-google/apiai-facts-about-google-nodejs/issues/17) with the latest Firebase CLI tools `3.12.0`.

This PR aims to reduce developer headache by broadcasting the minimum node version at the top of the page.

## Changes
* Adds Minimum Node Version Badge to `README.md`
* `i.e.` ![Node Version](https://img.shields.io/node/v/firebase-tools.svg)

