### PR TITLE
Add npm run-scripts to functions init template 

### DIFF
--- a/lib/init/features/functions.js
+++ b/lib/init/features/functions.js
@@ -35,6 +35,12 @@ module.exports = function(setup, config) {
     return config.askWriteProjectFile('functions/package.json', {
       name: 'functions',
       description: 'Cloud Functions for Firebase',
+      scripts: {
+        'serve': 'firebase serve --only functions',
+        'start': 'npm run serve',
+        'deploy': 'firebase deploy --only functions',
+        'logs': 'firebase functions:log'
+      },
       dependencies: {
         'firebase-admin': '~5.2.1',
         'firebase-functions': '^0.6.2'

--- a/lib/init/features/functions.js
+++ b/lib/init/features/functions.js
@@ -37,7 +37,8 @@ module.exports = function(setup, config) {
       description: 'Cloud Functions for Firebase',
       scripts: {
         'serve': 'firebase serve --only functions',
-        'start': 'npm run serve',
+        'shell': 'firebase experimental:functions:shell',
+        'start': 'npm run shell',
         'deploy': 'firebase deploy --only functions',
         'logs': 'firebase functions:log'
       },

--- a/templates/init/functions/index.js
+++ b/templates/init/functions/index.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 
-// // Create and Deploy Your First Cloud Functions
-// // https://firebase.google.com/docs/functions/write-firebase-functions
-//
-// exports.helloWorld = functions.https.onRequest((request, response) => {
-//  response.send("Hello from Firebase!");
-// });
+// Create and Deploy Your First Cloud Functions
+// https://firebase.google.com/docs/functions/write-firebase-functions
+
+exports.helloWorld = functions.https.onRequest((request, response) => {
+ response.send("Hello from Firebase!");
+});

--- a/templates/init/functions/index.js
+++ b/templates/init/functions/index.js
@@ -1,8 +1,8 @@
 const functions = require('firebase-functions');
 
-// Create and Deploy Your First Cloud Functions
-// https://firebase.google.com/docs/functions/write-firebase-functions
-
-exports.helloWorld = functions.https.onRequest((request, response) => {
- response.send("Hello from Firebase!");
-});
+// // Create and Deploy Your First Cloud Functions
+// // https://firebase.google.com/docs/functions/write-firebase-functions
+//
+// exports.helloWorld = functions.https.onRequest((request, response) => {
+//  response.send("Hello from Firebase!");
+// });


### PR DESCRIPTION
## Summary
This PR makes it easier for new developers to get started after running `firebase init functions` by adding standard commands like `npm start` and uncommenting the `Hello World` code in the template.

### Description

With example projects like [`apiai-facts-about-google-nodejs`](https://github.com/actions-on-google/apiai-facts-about-google-nodejs) and  [`actionssdk-smart-home-nodejs`](https://github.com/actions-on-google/actionssdk-smart-home-nodejs) it is common to see a few [`run-script`](https://docs.npmjs.com/cli/run-script) commands within the `package.json`.

This PR will reduce developer friction by providing some standard commands and a working Hello World via firebase functions.

### Changes
* Removed the double comments in the template `index.js`
* Added standard `npm run` commands

### Sample Commands

#### Run the standard init
```sh
[~ ]$ P=~/my-awesome-firebase-project; mkdir $P; cd $P 
[my-awesome-firebase-project ]$ firebase init functions
   ...
  ✔  Wrote functions/package.json
  ✔  Wrote functions/index.js
   ...
[my-awesome-firebase-project ]$ (cd functions; npm start;);
   ...
   > firebase serve --only functions
   ...
   i  functions: Preparing to emulate functions.
  ✔  functions: helloWorld: http://localhost:5000/${PROJECT}/${REGION}/helloWorld
``` 
#### Open a new shell to test the local endpoint
``` 
[~ ]$ curl http://localhost:5000/${PROJECT}/${REGION}/helloWorld
>> Hello from Firebase!
``` 
