### PR TITLE
Get rid of version warning in Functions Emulator

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -101,9 +101,6 @@ FunctionsEmulator.prototype.start = function(shellMode) {
     EmulatorController = require('@google-cloud/functions-emulator/src/cli/controller');
   } catch (err) {
     var msg = err;
-    if (process.version !== 'v6.9.1') {
-      msg = 'Please use Node version v6.9.1, you have ' + process.version + '\n';
-    }
     utils.logWarning(chalk.yellow('functions:') + ' Cannot start emulator. ' + msg);
     return RSVP.reject();
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

The GCF Emulator already prints out warnings if the user is on the wrong Node version. As well, other error messages were getting swallowed up. This PR fixes it, and leaves the GCF emulator to be the source of truth when it comes to the error message.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->