### PR TITLE
Fix `firestore:delete --all-collections`

### DIFF
--- a/commands/firestore-delete.js
+++ b/commands/firestore-delete.js
@@ -60,7 +60,8 @@ module.exports = new Command('firestore:delete [path]')
     var deleteOp = new FirestoreDelete(options.project, path, {
       recursive: options.recursive,
       shallow: options.shallow,
-      batchSize: 50
+      batchSize: 50,
+      allCollections: options.allCollections
     });
 
     var checkPrompt;

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -295,13 +295,14 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
  * @return {Promise} a promise for the entire operation.
  */
 FirestoreDelete.prototype._deletePath = function() {
+  var self = this;
   var initialDelete;
   if (this._isDocumentPath) {
     var doc = { name: this.parent + '/' + this.path };
     initialDelete = this._deleteDocuments([doc])
       .catch(function(err) {
         logger.debug('deletePath:initialDelete:error', err);
-        if (this.allDescendants) {
+        if (self.allDescendants) {
           // On a recursive delete, we are insensitive to
           // failures of the initial delete
           return RSVP.resolve();
@@ -314,7 +315,6 @@ FirestoreDelete.prototype._deletePath = function() {
     initialDelete = RSVP.resolve();
   }
 
-  var self = this;
   return initialDelete.then(function() {
     return self._recursiveBatchDelete();
   });

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -332,7 +332,7 @@ FirestoreDelete.prototype._listCollectionIds = function() {
     auth: true,
     origin: api.firestoreOrigin
   }).then(function(res) {
-    return res.body.collectionIds;
+    return res.body.collectionIds || [];
   });
 };
 

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -24,6 +24,7 @@ function FirestoreDelete(project, path, options) {
   this.recursive = Boolean(options.recursive);
   this.shallow = Boolean(options.shallow);
   this.batchSize = options.batchSize || 50;
+  this.allCollections = Boolean(options.allCollections);
 
   this.isDocumentPath = this._isDocumentPath(this.path);
   this.isCollectionPath = this._isCollectionPath(this.path);
@@ -36,7 +37,10 @@ function FirestoreDelete(project, path, options) {
     path = path.replace(/(^\/+|\/+$)/g, '');
   }
 
-  this._validateOptions();
+  // When --all-collections is passed any other flags or arguments are ignored
+  if (!options.allCollections) {
+    this._validateOptions();
+  }
 }
 
 /**


### PR DESCRIPTION
This PR fixes `firebase firestore:delete --all-collections` command:

- Skip options validation when `--all-collections` is passed as `firebase firestore:delete --help` states:

  > --all-collections  Delete all. Deletes the entire Firestore database, including all collections and documents. Any other flags or arguments will be ignored.

- Fix `firestore:delete` ran against an empty DB.

- Fix incorrect usage of `this` in a callback.

  