### PR TITLE
Handle 404 when deleting a config

### DIFF
--- a/lib/gcp/runtimeconfig.js
+++ b/lib/gcp/runtimeconfig.js
@@ -39,6 +39,12 @@ function _deleteConfig(projectId, configId) {
   return api.request('DELETE', utils.endpoint([API_VERSION, 'projects', projectId, 'configs', configId]), {
     auth: true,
     origin: api.runtimeconfigOrigin
+  }).catch(function(err) {
+    if (_.get(err, 'context.response.statusCode') === 404) {
+      logger.debug('Config already deleted.');
+      return RSVP.resolve();
+    }
+    return RSVP.reject(err);
   });
 }
 


### PR DESCRIPTION
This PR fixes an inconsistency with command `firebase functions:config:unset`, running the command on an non-existant variables fails or not depending the depth:

- `firebase functions:config:unset a.b` never fails
- `firebase functions:config:unset a`  fails with `Error: HTTP Error: 404, Requested entity was not found.`

This is because the command use two methods `runtimeconfig.variables.delete` and `runtimeconfig.configs.delete` (this one was not setup to handle 404).