### PR TITLE
Speed up functions deployment

### DIFF
--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -21,9 +21,13 @@ var CONFIG_DEST_FILE = '.runtimeconfig.json';
 
 var _prepareSource = function(context, options) {
   var tmpdir = tmp.dirSync({prefix: 'fbfn_'});
+  console.log('Start copying source');
   var configDest = path.join(tmpdir.name, CONFIG_DEST_FILE);
+  var label = 'Copy source';
   try {
+    console.time(label);
     fs.copySync(options.config.path(options.config.get('functions.source')), tmpdir.name);
+    console.timeEnd(label);
   } catch (err) {
     logger.debug(err);
     throw new FirebaseError('Problem preparing functions directory for upload.', {exit: 1});
@@ -39,6 +43,7 @@ var _prepareSource = function(context, options) {
 
 var _packageSource = function(options, tmpdir) {
   var sourceDir = tmpdir.name;
+  console.log('Start packaging source');
   return new RSVP.Promise(function(resolve, reject) {
     var tmpFile = tmp.fileSync({prefix: 'firebase-functions-', postfix: '.zip'});
 
@@ -46,9 +51,11 @@ var _packageSource = function(options, tmpdir) {
       flags: 'w',
       defaultEncoding: 'binary'
     });
-
+    var label = 'Package source';
+    console.time(label);
     var archive = archiver('zip');
     fileStream.on('finish', function() {
+      console.timeEnd(label);
       utils.logBullet(chalk.cyan.bold('functions:') + ' packaged ' + chalk.bold(options.config.get('functions.source')) + ' (' + filesize(archive.pointer()) + ') for uploading');
       resolve({
         file: tmpFile.name,
@@ -77,8 +84,10 @@ var _packageSource = function(options, tmpdir) {
     // We want to always upload the env file regardless of ignore rules
     reader.addIgnoreRules(['!' + CONFIG_DEST_FILE]);
 
+    var fileCount = 0;
     reader.on('child', function(file) {
       if (file.type !== 'Directory') {
+        fileCount++;
         archive.append(file, { name: path.relative(sourceDir, file.path), mode: file.props.mode });
       }
     });
@@ -91,6 +100,7 @@ var _packageSource = function(options, tmpdir) {
     });
 
     reader.on('end', function() {
+      console.log('Reader listed', fileCount, 'files');
       archive.finalize();
       fs.removeSync(tmpdir.name);
     });

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -21,13 +21,9 @@ var CONFIG_DEST_FILE = '.runtimeconfig.json';
 
 var _prepareSource = function(context, options) {
   var tmpdir = tmp.dirSync({prefix: 'fbfn_'});
-  console.log('Start copying source');
   var configDest = path.join(tmpdir.name, CONFIG_DEST_FILE);
-  var label = 'Copy source';
   try {
-    console.time(label);
     fs.copySync(options.config.path(options.config.get('functions.source')), tmpdir.name);
-    console.timeEnd(label);
   } catch (err) {
     logger.debug(err);
     throw new FirebaseError('Problem preparing functions directory for upload.', {exit: 1});
@@ -43,7 +39,6 @@ var _prepareSource = function(context, options) {
 
 var _packageSource = function(options, tmpdir) {
   var sourceDir = tmpdir.name;
-  console.log('Start packaging source');
   return new RSVP.Promise(function(resolve, reject) {
     var tmpFile = tmp.fileSync({prefix: 'firebase-functions-', postfix: '.zip'});
 
@@ -51,11 +46,9 @@ var _packageSource = function(options, tmpdir) {
       flags: 'w',
       defaultEncoding: 'binary'
     });
-    var label = 'Package source';
-    console.time(label);
+
     var archive = archiver('zip');
     fileStream.on('finish', function() {
-      console.timeEnd(label);
       utils.logBullet(chalk.cyan.bold('functions:') + ' packaged ' + chalk.bold(options.config.get('functions.source')) + ' (' + filesize(archive.pointer()) + ') for uploading');
       resolve({
         file: tmpFile.name,
@@ -84,10 +77,8 @@ var _packageSource = function(options, tmpdir) {
     // We want to always upload the env file regardless of ignore rules
     reader.addIgnoreRules(['!' + CONFIG_DEST_FILE]);
 
-    var fileCount = 0;
     reader.on('child', function(file) {
       if (file.type !== 'Directory') {
-        fileCount++;
         archive.append(file, { name: path.relative(sourceDir, file.path), mode: file.props.mode });
       }
     });
@@ -100,7 +91,6 @@ var _packageSource = function(options, tmpdir) {
     });
 
     reader.on('end', function() {
-      console.log('Reader listed', fileCount, 'files');
       archive.finalize();
       fs.removeSync(tmpdir.name);
     });

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "homepage": "https://github.com/firebase/firebase-tools",
   "dependencies": {
     "JSONStream": "^1.2.1",
-    "archiver": "^0.16.0",
+    "archiver": "^2.1.0",
     "chalk": "^1.1.0",
     "cjson": "^0.3.1",
     "cli-table": "^0.3.1",


### PR DESCRIPTION
### Description

I've noticed that deploying firebase functions takes very long. The reason for this is that the package firebase-tools is using to archive the code into a zip archive is outdated. By upgrading the ```archiver``` package from ```^0.16.0``` to the newest version of ```^2.1.0``` the archive time can be drastically reduced.

Some stats:

Before:
```
i  functions: preparing ./ directory for uploading...
Start copying source
Copy source: 10521.333ms
Start packaging source
Reader listed 34638 files
Package source: 683353.692ms
i  functions: packaged ./ (177.87 MB) for uploading
```

After:
```
i  functions: preparing ./ directory for uploading...
Start copying source
Copy source: 9761.668ms
Start packaging source
Reader listed 34638 files
Package source: 41077.057ms
i  functions: packaged ./ (177.87 MB) for uploading
```

Archive time has been reduced from ```11.4 min``` to ```41 sec```
