### PR TITLE
Use PATCH verb for rules update.

### DIFF
--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -71,11 +71,13 @@ function createRelease(projectId, rulesetName, releaseName) {
  */
 function updateRelease(projectId, rulesetName, releaseName) {
   var payload = {
-    name: 'projects/' + projectId + '/releases/' + releaseName,
-    rulesetName: rulesetName
+    release: {
+      name: 'projects/' + projectId + '/releases/' + releaseName,
+      rulesetName: rulesetName
+    }
   };
 
-  return api.request('PUT', '/' + API_VERSION + '/projects/' + projectId + '/releases/' + releaseName, {
+  return api.request('PATCH', '/' + API_VERSION + '/projects/' + projectId + '/releases/' + releaseName, {
     auth: true,
     data: payload,
     origin: api.rulesOrigin


### PR DESCRIPTION
Updated API endpoint requires slightly different payload and `PATCH` verb.