### PR TITLE
Retry Runtime Config API calls when there is 500 or 503 error code

### DIFF
--- a/lib/gcp/runtimeconfig.js
+++ b/lib/gcp/runtimeconfig.js
@@ -8,10 +8,28 @@ var _ = require('lodash');
 
 var API_VERSION = 'v1beta1';
 
+function _retryOnServerError(requestFunction) {
+  var retryableCodes = [500, 503];
+  var waitTime = 1000;
+  var wait = function(t) {
+    return new Promise(function(resolve) {
+      setTimeout(resolve, t);
+    });
+  };
+  return requestFunction().catch(function(err) {
+    if (_.includes(retryableCodes, _.get(err, 'context.response.statusCode'))) {
+      return wait(waitTime).then(requestFunction);
+    }
+    return RSVP.reject(err);
+  });
+}
+
 function _listConfigs(projectId) {
-  return api.request('GET', utils.endpoint([API_VERSION, 'projects', projectId, 'configs']), {
-    auth: true,
-    origin: api.runtimeconfigOrigin
+  return _retryOnServerError(function() {
+    return api.request('GET', utils.endpoint([API_VERSION, 'projects', projectId, 'configs']), {
+      auth: true,
+      origin: api.runtimeconfigOrigin
+    });
   }).then(function(resp) {
     return RSVP.resolve(resp.body.configs);
   });
@@ -20,25 +38,29 @@ function _listConfigs(projectId) {
 function _createConfig(projectId, configId) {
   var path = _.join(['projects', projectId, 'configs'], '/');
   var endpoint = utils.endpoint([API_VERSION, path]);
-  return api.request('POST', endpoint, {
-    auth: true,
-    origin: api.runtimeconfigOrigin,
-    data: {
-      name: path + '/' + configId
-    }
+  return _retryOnServerError(function() {
+    return api.request('POST', endpoint, {
+      auth: true,
+      origin: api.runtimeconfigOrigin,
+      data: {
+        name: path + '/' + configId
+      }
+    });
   }).catch(function(err) {
     if (_.get(err, 'context.response.statusCode') === 409) {
     // Config has already been created as part of a parallel operation during firebase functions:config:set
       return RSVP.resolve();
     }
-    return RSVP.reject();
+    return RSVP.reject(err);
   });
 }
 
 function _deleteConfig(projectId, configId) {
-  return api.request('DELETE', utils.endpoint([API_VERSION, 'projects', projectId, 'configs', configId]), {
-    auth: true,
-    origin: api.runtimeconfigOrigin
+  return _retryOnServerError(function() {
+    return api.request('DELETE', utils.endpoint([API_VERSION, 'projects', projectId, 'configs', configId]), {
+      auth: true,
+      origin: api.runtimeconfigOrigin
+    });
   }).catch(function(err) {
     if (_.get(err, 'context.response.statusCode') === 404) {
       logger.debug('Config already deleted.');
@@ -49,18 +71,22 @@ function _deleteConfig(projectId, configId) {
 }
 
 function _listVariables(configPath) {
-  return api.request('GET', utils.endpoint([API_VERSION, configPath, 'variables']), {
-    auth: true,
-    origin: api.runtimeconfigOrigin
+  return _retryOnServerError(function() {
+    return api.request('GET', utils.endpoint([API_VERSION, configPath, 'variables']), {
+      auth: true,
+      origin: api.runtimeconfigOrigin
+    });
   }).then(function(resp) {
     return RSVP.resolve(resp.body.variables);
   });
 }
 
 function _getVariable(varPath) {
-  return api.request('GET', utils.endpoint([API_VERSION, varPath]), {
-    auth: true,
-    origin: api.runtimeconfigOrigin
+  return _retryOnServerError(function() {
+    return api.request('GET', utils.endpoint([API_VERSION, varPath]), {
+      auth: true,
+      origin: api.runtimeconfigOrigin
+    });
   }).then(function(resp) {
     return RSVP.resolve(resp.body);
   });
@@ -69,13 +95,15 @@ function _getVariable(varPath) {
 function _createVariable(projectId, configId, varId, value) {
   var path = _.join(['projects', projectId, 'configs', configId, 'variables'], '/');
   var endpoint = utils.endpoint([API_VERSION, path]);
-  return api.request('POST', endpoint, {
-    auth: true,
-    origin: api.runtimeconfigOrigin,
-    data: {
-      name: path + '/' + varId,
-      text: value
-    }
+  return _retryOnServerError(function() {
+    return api.request('POST', endpoint, {
+      auth: true,
+      origin: api.runtimeconfigOrigin,
+      data: {
+        name: path + '/' + varId,
+        text: value
+      }
+    });
   }).catch(function(err) {
     if (_.get(err, 'context.response.statusCode') === 404) { // parent config doesn't exist yet
       return _createConfig(projectId, configId).then(function() {
@@ -89,13 +117,15 @@ function _createVariable(projectId, configId, varId, value) {
 function _updateVariable(projectId, configId, varId, value) {
   var path = _.join(['projects', projectId, 'configs', configId, 'variables', varId], '/');
   var endpoint = utils.endpoint([API_VERSION, path]);
-  return api.request('PUT', endpoint, {
-    auth: true,
-    origin: api.runtimeconfigOrigin,
-    data: {
-      name: path,
-      text: value
-    }
+  return _retryOnServerError(function() {
+    return api.request('PUT', endpoint, {
+      auth: true,
+      origin: api.runtimeconfigOrigin,
+      data: {
+        name: path,
+        text: value
+      }
+    });
   });
 }
 
@@ -114,9 +144,11 @@ function _setVariable(projectId, configId, varId, value) {
 function _deleteVariable(projectId, configId, varId) {
   var endpoint = utils.endpoint([API_VERSION, 'projects', projectId, 'configs', configId, 'variables', varId])
     + '?recursive=true';
-  return api.request('DELETE', endpoint, {
-    auth: true,
-    origin: api.runtimeconfigOrigin
+  return _retryOnServerError(function() {
+    return api.request('DELETE', endpoint, {
+      auth: true,
+      origin: api.runtimeconfigOrigin
+    });
   }).catch(function(err) {
     if (_.get(err, 'context.response.statusCode') === 404) {
       logger.debug('Variable already deleted.');
@@ -125,7 +157,6 @@ function _deleteVariable(projectId, configId, varId) {
     return RSVP.reject(err);
   });
 }
-
 
 module.exports = {
   configs: {

--- a/lib/gcp/runtimeconfig.js
+++ b/lib/gcp/runtimeconfig.js
@@ -9,16 +9,12 @@ var _ = require('lodash');
 var API_VERSION = 'v1beta1';
 
 function _retryOnServerError(requestFunction) {
-  var retryableCodes = [500, 503];
-  var waitTime = 1000;
-  var wait = function(t) {
-    return new Promise(function(resolve) {
-      setTimeout(resolve, t);
-    });
-  };
   return requestFunction().catch(function(err) {
-    if (_.includes(retryableCodes, _.get(err, 'context.response.statusCode'))) {
-      return wait(waitTime).then(requestFunction);
+    if (_.includes([500, 503], _.get(err, 'context.response.statusCode'))) {
+      return new Promise(function(resolve) {
+        setTimeout(resolve, 1000);
+      })
+      .then(requestFunction);
     }
     return RSVP.reject(err);
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

500 or 503 error codes from Runtime Config are retryable. This PR modifies the behavior to retry once (waiting for 1 second) for these 2 error codes, and if it fails again, propagate the error.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->