### PR TITLE
Make RuntimeConfig optional in functions deployment

### DIFF
--- a/lib/deploy/functions/prepare.js
+++ b/lib/deploy/functions/prepare.js
@@ -6,7 +6,7 @@ var chalk = require('chalk');
 var path = require('path');
 var RSVP = require('rsvp');
 
-var ensureApiEnabled = require('../../ensureApiEnabled').ensure;
+var ensureApiEnabled = require('../../ensureApiEnabled');
 var functionsConfig = require('../../functionsConfig');
 var fsutils = require('../../fsutils');
 var getProjectId = require('../../getProjectId');
@@ -58,9 +58,10 @@ module.exports = function(context, options, payload) {
   var projectId = getProjectId(options);
   var instance = options.instance;
   return RSVP.all([
-    ensureApiEnabled(options.project, 'cloudfunctions.googleapis.com', 'functions'),
-    ensureApiEnabled(projectId, 'runtimeconfig.googleapis.com', 'runtimeconfig')
-  ]).then(function() {
+    ensureApiEnabled.ensure(options.project, 'cloudfunctions.googleapis.com', 'functions'),
+    ensureApiEnabled.check(projectId, 'runtimeconfig.googleapis.com', 'runtimeconfig', true)
+  ]).then(function(results) {
+    _.set(context, 'configEnabled', results[1]);
     return functionsConfig.getFirebaseConfig(projectId, instance);
   }).then(function(result) {
     _.set(context, 'firebaseConfig', result);

--- a/lib/deploy/functions/prepare.js
+++ b/lib/deploy/functions/prepare.js
@@ -61,7 +61,7 @@ module.exports = function(context, options, payload) {
     ensureApiEnabled.ensure(options.project, 'cloudfunctions.googleapis.com', 'functions'),
     ensureApiEnabled.check(projectId, 'runtimeconfig.googleapis.com', 'runtimeconfig', true)
   ]).then(function(results) {
-    _.set(context, 'configEnabled', results[1]);
+    _.set(context, 'runtimeConfigEnabled', results[1]);
     return functionsConfig.getFirebaseConfig(projectId, instance);
   }).then(function(result) {
     _.set(context, 'firebaseConfig', result);

--- a/lib/ensureApiEnabled.js
+++ b/lib/ensureApiEnabled.js
@@ -81,5 +81,6 @@ var _ensureApi = function(projectId, apiName, prefix, silent) {
 
 module.exports = {
   ensure: _ensureApi,
+  check: _checkEnabled,
   enable: _enableApi
 };

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -29,8 +29,8 @@ var _prepareSource = function(context, options) {
     throw new FirebaseError('Problem preparing functions directory for upload.', {exit: 1});
   }
 
-  var next;
-  if (context.configEnabled) {
+  var next = RSVP.resolve({});
+  if (context.runtimeConfigEnabled) {
     next = functionsConfig.materializeAll(context.firebaseConfig.projectId).catch(function(err) {
       logger.debug(err);
       var errorCode = _.get(err, 'context.response.statusCode');
@@ -41,8 +41,6 @@ var _prepareSource = function(context, options) {
           '\nRun `firebase deploy --except functions` if you want to continue deploying the rest of your project.');
       }
     });
-  } else {
-    next = RSVP.resolve({});
   }
 
   return next.then(function(config) {

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -28,11 +28,15 @@ var _prepareSource = function(context, options) {
     logger.debug(err);
     throw new FirebaseError('Problem preparing functions directory for upload.', {exit: 1});
   }
-  return functionsConfig.materializeAll(getProjectId(options)).then(function(output) {
+
+  var next = context.configEnabled ? functionsConfig.materializeAll(context.firebaseConfig.projectId)
+    : RSVP.resolve({});
+
+  return next.then(function(config) {
     var firebaseConfig = _.get(context, 'firebaseConfig');
-    _.set(output, 'firebase', firebaseConfig);
+    _.set(config, 'firebase', firebaseConfig);
     fs.ensureFileSync(configDest);
-    fs.writeFileSync(configDest, JSON.stringify(output, null, 2));
+    fs.writeFileSync(configDest, JSON.stringify(config, null, 2));
     return tmpdir;
   });
 };

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -35,9 +35,10 @@ var _prepareSource = function(context, options) {
       logger.debug(err);
       var errorCode = _.get(err, 'context.response.statusCode');
       if (errorCode === 500 || errorCode === 503) {
-        throw new FirebaseError('Runtime Config is currently experiencing issues, ' +
+        throw new FirebaseError('Cloud Runtime Config is currently experiencing issues, ' +
           'which is preventing your functions from being deployed. ' +
-          'Please wait a few minutes and then try to deploy your functions again.');
+          'Please wait a few minutes and then try to deploy your functions again.' +
+          '\nRun `firebase deploy --except functions` if you want to continue deploying the rest of your project.');
       }
     });
   } else {

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -29,8 +29,20 @@ var _prepareSource = function(context, options) {
     throw new FirebaseError('Problem preparing functions directory for upload.', {exit: 1});
   }
 
-  var next = context.configEnabled ? functionsConfig.materializeAll(context.firebaseConfig.projectId)
-    : RSVP.resolve({});
+  var next;
+  if (context.configEnabled) {
+    next = functionsConfig.materializeAll(context.firebaseConfig.projectId).catch(function(err) {
+      logger.debug(err);
+      var errorCode = _.get(err, 'context.response.statusCode');
+      if (errorCode === 500 || errorCode === 503) {
+        throw new FirebaseError('Runtime Config is currently experiencing issues, ' +
+          'which is preventing your functions from being deployed. ' +
+          'Please wait a few minutes and then try to deploy your functions again.');
+      }
+    });
+  } else {
+    next = RSVP.resolve({});
+  }
 
   return next.then(function(config) {
     var firebaseConfig = _.get(context, 'firebaseConfig');


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

- Runtime Config API is no longer automatically enabled when someone deploys functions
- Config values are only materialized if the API is already turned on, otherwise, only Firebase config values are fetched (and are accessible at functions.config().firebase inside functions source code)
- Issue error message when there's Runtime Config outage

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->