### PR TITLE
Add debug statements to functions emulation

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -10,6 +10,7 @@ var parseTriggers = require('./parseTriggers');
 var functionsConfig = require('./functionsConfig');
 var ensureDefaultCredentials = require('./ensureDefaultCredentials');
 var track = require('./track');
+var logger = require('./logger');
 
 var EmulatorController;
 
@@ -109,16 +110,19 @@ FunctionsEmulator.prototype.start = function(shellMode) {
   var controller = this.controller;
 
   utils.logBullet(chalk.cyan.bold('functions:') + ' Preparing to emulate functions.');
+  logger.debug('Fetching environmenmt');
   ensureDefaultCredentials();
   return functionsConfig.getFirebaseConfig(projectId, options.instance)
   .then(function(result) {
     firebaseConfig = JSON.stringify(result);
     process.env.FIREBASE_PROJECT = firebaseConfig;
     process.env.GCLOUD_PROJECT = projectId;
+    logger.debug('Starting @google-cloud/functions-emulator');
     return controller.start();
   }).then(function() {
+    logger.debug('Parsing function triggers');
     return parseTriggers(projectId, functionsDir, firebaseConfig);
-  }).catch(function(e) {
+  }, function(e) {
     utils.logWarning(chalk.yellow('functions:') + ' Failed to load functions source code. ' +
       'Ensure that you have the latest SDK by running ' + chalk.bold('npm i --save firebase-functions') +
       ' inside the functions directory.');
@@ -140,6 +144,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
       var parts = trigger.eventTrigger.eventType.split('/');
       var triggerProvider = parts[1];
       var triggerEvent = parts[3];
+      logger.debug('Deploying functions locally');
       return controller.deploy(trigger.name, {
         localPath: functionsDir,
         triggerProvider: triggerProvider,

--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -121,12 +121,12 @@ FunctionsEmulator.prototype.start = function(shellMode) {
     return controller.start();
   }).then(function() {
     logger.debug('Parsing function triggers');
-    return parseTriggers(projectId, functionsDir, firebaseConfig);
-  }, function(e) {
-    utils.logWarning(chalk.yellow('functions:') + ' Failed to load functions source code. ' +
-      'Ensure that you have the latest SDK by running ' + chalk.bold('npm i --save firebase-functions') +
-      ' inside the functions directory.');
-    return RSVP.reject(e);
+    return parseTriggers(projectId, functionsDir, firebaseConfig).catch(function(e) {
+      utils.logWarning(chalk.yellow('functions:') + ' Failed to load functions source code. ' +
+        'Ensure that you have the latest SDK by running ' + chalk.bold('npm i --save firebase-functions') +
+        ' inside the functions directory.');
+      return RSVP.reject(e);
+    });
   }).then(function(triggers) {
     instance.triggers = triggers;
     var promises = _.map(triggers, function(trigger) {


### PR DESCRIPTION
We've received a handful of public issues regarding the emulator freezing on startup. There are some heavyweight operations that might hang and it's not clear which is failing. This will add a bit more info to the verbose log about what the CLI is doing up to the point of failure.

Also, it was probably incorrect to use `.catch` in the main trigger flow since it would also catch errors starting the emulator and blame trigger parsing. Moved that error decoration to be inside the nested Promise.