### PR TITLE
Update  Package.json

### DIFF
--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "build": "./node_modules/.bin/tslint -p tslint.json && ./node_modules/.bin/tsc",
+    "build": "./node_modules/.bin/tslint -p tslint.json && tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase experimental:functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
at least on my machine and settings. running the firebase deploy functions command will result in an error :
'.' is not recognized as an internal or external command,
the source of error was from line 4. the dot in "./node_modules/.bin/tsc"
after removing the path to tsc command , the deploy command completed without errors

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->