### PR TITLE
Speed up functions deployment by doing in-place trigger parsing

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -110,7 +110,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
   var controller = this.controller;
 
   utils.logBullet(chalk.cyan.bold('functions:') + ' Preparing to emulate functions.');
-  logger.debug('Fetching environmenmt');
+  logger.debug('Fetching environment');
   ensureDefaultCredentials();
   return functionsConfig.getFirebaseConfig(projectId, options.instance)
   .then(function(result) {

--- a/lib/parseTriggers.js
+++ b/lib/parseTriggers.js
@@ -7,11 +7,11 @@ var RSVP = require('rsvp');
 
 var TRIGGER_PARSER = path.resolve(__dirname, './triggerParser.js');
 
-module.exports = function(projectId, sourceDir, functionsConfig, firebaseConfig) {
+module.exports = function(projectId, sourceDir, configValues, firebaseConfig) {
   return new RSVP.Promise(function(resolve, reject) {
     var env = {
-      GCLOUD_PROJECT: projectId,
-      CLOUD_RUNTIME_CONFIG: JSON.stringify(functionsConfig)
+      CLOUD_RUNTIME_CONFIG: JSON.stringify(configValues),
+      GCLOUD_PROJECT: projectId
     };
     if (firebaseConfig) {
       env.FIREBASE_PROJECT = firebaseConfig;

--- a/lib/parseTriggers.js
+++ b/lib/parseTriggers.js
@@ -7,10 +7,11 @@ var RSVP = require('rsvp');
 
 var TRIGGER_PARSER = path.resolve(__dirname, './triggerParser.js');
 
-module.exports = function(projectId, sourceDir, firebaseConfig) {
+module.exports = function(projectId, sourceDir, functionsConfig, firebaseConfig) {
   return new RSVP.Promise(function(resolve, reject) {
     var env = {
-      GCLOUD_PROJECT: projectId
+      GCLOUD_PROJECT: projectId,
+      CLOUD_RUNTIME_CONFIG: JSON.stringify(functionsConfig)
     };
     if (firebaseConfig) {
       env.FIREBASE_PROJECT = firebaseConfig;

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -17,7 +17,7 @@ var logger = require('./logger');
 var utils = require('./utils');
 var parseTriggers = require('./parseTriggers');
 
-var _prepareSource = function(context) {
+var _getFunctionsConfig = function(context) {
   var next = RSVP.resolve({});
   if (context.runtimeConfigEnabled) {
     next = functionsConfig.materializeAll(context.firebaseConfig.projectId).catch(function(err) {
@@ -99,7 +99,7 @@ var _packageSource = function(options, sourceDir, configValues) {
 module.exports = function(context, options) {
   var configValues;
   var sourceDir = options.config.path(options.config.get('functions.source'));
-  return _prepareSource(context).then(function(result) {
+  return _getFunctionsConfig(context).then(function(result) {
     configValues = result;
     return parseTriggers(getProjectId(options), sourceDir, configValues);
   }).then(function(triggers) {

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -17,18 +17,7 @@ var logger = require('./logger');
 var utils = require('./utils');
 var parseTriggers = require('./parseTriggers');
 
-var CONFIG_DEST_FILE = '.runtimeconfig.json';
-
-var _prepareSource = function(context, options) {
-  var tmpdir = tmp.dirSync({prefix: 'fbfn_'});
-  var configDest = path.join(tmpdir.name, CONFIG_DEST_FILE);
-  try {
-    fs.copySync(options.config.path(options.config.get('functions.source')), tmpdir.name);
-  } catch (err) {
-    logger.debug(err);
-    throw new FirebaseError('Problem preparing functions directory for upload.', {exit: 1});
-  }
-
+var _prepareSource = function(context) {
   var next = RSVP.resolve({});
   if (context.runtimeConfigEnabled) {
     next = functionsConfig.materializeAll(context.firebaseConfig.projectId).catch(function(err) {
@@ -46,14 +35,11 @@ var _prepareSource = function(context, options) {
   return next.then(function(config) {
     var firebaseConfig = _.get(context, 'firebaseConfig');
     _.set(config, 'firebase', firebaseConfig);
-    fs.ensureFileSync(configDest);
-    fs.writeFileSync(configDest, JSON.stringify(config, null, 2));
-    return tmpdir;
+    return config;
   });
 };
 
-var _packageSource = function(options, tmpdir) {
-  var sourceDir = tmpdir.name;
+var _packageSource = function(options, sourceDir, configValues) {
   return new RSVP.Promise(function(resolve, reject) {
     var tmpFile = tmp.fileSync({prefix: 'firebase-functions-', postfix: '.zip'});
 
@@ -89,8 +75,6 @@ var _packageSource = function(options, tmpdir) {
     // you're in the public dir when you deploy
     reader.addIgnoreRules(['firebase-debug.log']);
     reader.addIgnoreRules(options.config.get('functions.ignore', ['**/node_modules/**']));
-    // We want to always upload the env file regardless of ignore rules
-    reader.addIgnoreRules(['!' + CONFIG_DEST_FILE]);
 
     reader.on('child', function(file) {
       if (file.type !== 'Directory') {
@@ -106,29 +90,23 @@ var _packageSource = function(options, tmpdir) {
     });
 
     reader.on('end', function() {
+      archive.append(JSON.stringify(configValues), { name: '.runtimeconfig.json' });
       archive.finalize();
-      try {
-        fs.removeSync(tmpdir.name);
-      } catch (e) {
-        utils.logWarning('Unable to delete temporary directory ' + tmpdir.name +
-          '. You may want to manually delete it to save disk space.');
-        logger.debug(e);
-      }
     });
   });
 };
 
 module.exports = function(context, options) {
-  var tmpdir;
-  return _prepareSource(context, options).then(function(result) {
-    tmpdir = result;
-
-    return parseTriggers(getProjectId(options), tmpdir.name);
+  var configValues;
+  var sourceDir = options.config.path(options.config.get('functions.source'));
+  return _prepareSource(context).then(function(result) {
+    configValues = result;
+    return parseTriggers(getProjectId(options), sourceDir, configValues);
   }).then(function(triggers) {
     options.config.set('functions.triggers', triggers);
     if (options.config.get('functions.triggers').length === 0) {
       return RSVP.resolve(null);
     }
-    return _packageSource(options, tmpdir);
+    return _packageSource(options, sourceDir, configValues);
   });
 };

--- a/lib/triggerParser.js
+++ b/lib/triggerParser.js
@@ -20,6 +20,8 @@ var EXIT = function() { process.exit(0); };
     if (e.code === 'MODULE_NOT_FOUND') {
       process.send({error: 'Error parsing triggers: ' + e.message + '\n\nTry running "npm install" in your functions directory before deploying.'}, EXIT);
       return;
+    } else if (/Firebase config variables are not available/.test(e.message)) {
+      process.send({error: 'Error occurred while parsing your function triggers. Please ensure you have the latest firebase-functions SDK by running "npm i --save firebase-functions@latest" inside your functions folder.\n\n' + e.stack}, EXIT);
     }
 
     process.send({error: 'Error occurred while parsing your function triggers.\n\n' + e.stack}, EXIT);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Addresses https://github.com/firebase/firebase-tools/issues/536.

Speeds up functions deployment:
- Stop copying functions source code to a temporary folder
- Stop writing `.runtimeconfig.json`. The config variables are put inside an environment variable so that trigger parsing will still work, and are stuffed into the archive right before uploading. (must be used with https://github.com/firebase/firebase-functions/pull/155 version of firebase-functions)

This has been manually tested, deploy works as expected, and the uploaded source zip contains .runtimeconfig.json with the correct config values.

### Sample Commands

No change to commands.
<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->