### PR TITLE
remove run build command in predeploy hooks

### DIFF
--- a/lib/init/features/functions/javascript.js
+++ b/lib/init/features/functions/javascript.js
@@ -28,7 +28,6 @@ module.exports = function(setup, config) {
         config.askWriteProjectFile('functions/.eslintrc.json', ESLINT_TEMPLATE);
       });
     }
-    _.set(setup, 'config.functions.predeploy', 'npm --prefix $RESOURCE_DIR run build');
     return config.askWriteProjectFile('functions/package.json', PACKAGE_NO_LINTING_TEMPLATE);
   }).then(function() {
     return config.askWriteProjectFile('functions/src/index.js', INDEX_TEMPLATE);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

removing command to run build script in javascript

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->