### PR TITLE
Fix index.js location for non-typescript init.

### DIFF
--- a/lib/init/features/functions/javascript.js
+++ b/lib/init/features/functions/javascript.js
@@ -30,7 +30,7 @@ module.exports = function(setup, config) {
     }
     return config.askWriteProjectFile('functions/package.json', PACKAGE_NO_LINTING_TEMPLATE);
   }).then(function() {
-    return config.askWriteProjectFile('functions/src/index.js', INDEX_TEMPLATE);
+    return config.askWriteProjectFile('functions/index.js', INDEX_TEMPLATE);
   }).then(function() {
     return npmDependencies.askInstallDependencies(setup, config);
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->