### PR TITLE
Revert addition of host option to functions emulator

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -89,7 +89,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
   var instance = this;
   var functionsDir = path.join(options.config.projectDir, options.config.get('functions.source'));
   var ports = this._getPorts();
-  var controllerConfig = _.merge({tail: true, service: 'rest'}, ports, {host: this.options.host}, {bindHost: this.options.host});
+  var controllerConfig = _.merge({tail: true, service: 'rest'}, ports);
   var firebaseConfig;
   var emulatedProviders = {};
 

--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "sinon-chai": "^2.8.0"
   },
   "optionalDependencies": {
-    "@google-cloud/functions-emulator": "^1.0.0-alpha.29"
+    "@google-cloud/functions-emulator": "^1.0.0-alpha.23"
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

This reverts https://github.com/firebase/firebase-tools/pull/564, which introduced a bug that prevented functions emulation. This is because the updated GCF emulator used processes differently than previously, so the way that the CLI set the FIREBASE_PROJECT env variable no longer worked. A future PR will fix this and bring this host flag back.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->