### PR TITLE
remove resource directory dependency in predeploy script

### DIFF
--- a/lib/deploy/lifecycleHooks.js
+++ b/lib/deploy/lifecycleHooks.js
@@ -11,11 +11,14 @@ var logger = require('../logger');
 
 function runCommand(command, childOptions) {
   return new Promise(function(resolve, reject) {
-    // TODO: replace with regex (maybe) if this option wins /(\$\S+\s) ^([^\s]*)\s
-    if (process.env === 'win32') {
-      var n = command.search('$');
-      command.substring(n).replace(/^([^\s]*)\s/i, '%');
-      command.replace('$', '%');
+    // TODO: replace with regex if this option works
+    // string slice or substring?
+    if (process.platforms === 'win32') {
+      var wordStart = command.indexOf('$');
+      var wordEnd = command.substring(wordStart).indexOf(' ');
+      var wordLength = wordStart + wordEnd;
+      command = command.substring(0, wordLength) + '% ' + command.substring(wordLength + 1);
+      command = command.replace('$', '%');
     }
 
     logger.info('Running command: ' + command);

--- a/lib/deploy/lifecycleHooks.js
+++ b/lib/deploy/lifecycleHooks.js
@@ -11,6 +11,13 @@ var logger = require('../logger');
 
 function runCommand(command, childOptions) {
   return new Promise(function(resolve, reject) {
+    // TODO: replace with regex (maybe) if this option wins /(\$\S+\s) ^([^\s]*)\s
+    if (process.env === 'win32') {
+      var n = command.search('$');
+      command.substring(n).replace(/^([^\s]*)\s/i, '%');
+      command.replace('$', '%');
+    }
+
     logger.info('Running command: ' + command);
     if (command === '') {
       resolve();

--- a/lib/deploy/lifecycleHooks.js
+++ b/lib/deploy/lifecycleHooks.js
@@ -11,14 +11,14 @@ var logger = require('../logger');
 
 function runCommand(command, childOptions) {
   return new Promise(function(resolve, reject) {
-    // TODO: replace with regex if this option works
-    // string slice or substring?
     if (process.platforms === 'win32') {
       var wordStart = command.indexOf('$');
-      var wordEnd = command.substring(wordStart).indexOf(' ');
-      var wordLength = wordStart + wordEnd;
-      command = command.substring(0, wordLength) + '% ' + command.substring(wordLength + 1);
-      command = command.replace('$', '%');
+      if (wordStart > -1) {
+        var wordEnd = command.substring(wordStart).indexOf(' ');
+        var wordLength = wordStart + wordEnd;
+        command = command.substring(0, wordLength) + '% ' + command.substring(wordLength + 1);
+        command = command.replace('$', '%');
+      }
     }
 
     logger.info('Running command: ' + command);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

The predeploy hooks depend on environment variables supplied by the process to execute. The syntax for accessing these environment variables differ depending on the operating system the process is executing on. More clearly, windows operating systems have a different syntax than linux and macOS. Since one codebase can be used on multiple machines, the predeploy scripts must be universal to all machines. The predeploy flow now includes a check for the platform before running predeploy scripts.

In response to #610 

Tested:
Ran firebase init + javascript on macOS + firebase deploy
Ran firebase init + typescript on macOS + firebase deploy
Ran firebase init + javascript on windows + firebase deploy
Ran firebase init + typescript on windows + firebase deploy

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->