### PR TITLE
Change GCF emulator dependency from ^1.0.0-alpha.23 to 1.0.0-alpha.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "sinon-chai": "^2.8.0"
   },
   "optionalDependencies": {
-    "@google-cloud/functions-emulator": "^1.0.0-alpha.23"
+    "@google-cloud/functions-emulator": "1.0.0-alpha.23"
   }
 }


### PR DESCRIPTION
I forgot that '^' would still install 1.0.0-alpha.29, which is not what we want.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->