### PR TITLE
Fix bug with functions deployment & emulation when .runtimeconfig.json exists

### DIFF
--- a/lib/parseTriggers.js
+++ b/lib/parseTriggers.js
@@ -4,15 +4,18 @@ var FirebaseError = require('./error');
 var fork = require('child_process').fork;
 var path = require('path');
 var RSVP = require('rsvp');
+var _ = require('lodash');
 
 var TRIGGER_PARSER = path.resolve(__dirname, './triggerParser.js');
 
 module.exports = function(projectId, sourceDir, configValues, firebaseConfig) {
   return new RSVP.Promise(function(resolve, reject) {
     var env = {
-      CLOUD_RUNTIME_CONFIG: JSON.stringify(configValues),
       GCLOUD_PROJECT: projectId
     };
+    if (!_.isEmpty(configValues)) {
+      env.CLOUD_RUNTIME_CONFIG = JSON.stringify(configValues);
+    }
     if (firebaseConfig) {
       env.FIREBASE_PROJECT = firebaseConfig;
     }

--- a/lib/parseTriggers.js
+++ b/lib/parseTriggers.js
@@ -10,9 +10,7 @@ var TRIGGER_PARSER = path.resolve(__dirname, './triggerParser.js');
 
 module.exports = function(projectId, sourceDir, configValues, firebaseConfig) {
   return new RSVP.Promise(function(resolve, reject) {
-    var env = {
-      GCLOUD_PROJECT: projectId
-    };
+    var env = { GCLOUD_PROJECT: projectId };
     if (!_.isEmpty(configValues)) {
       env.CLOUD_RUNTIME_CONFIG = JSON.stringify(configValues);
     }

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -17,6 +17,8 @@ var logger = require('./logger');
 var utils = require('./utils');
 var parseTriggers = require('./parseTriggers');
 
+var CONFIG_DEST_FILE = '.runtimeconfig.json';
+
 var _getFunctionsConfig = function(context) {
   var next = RSVP.resolve({});
   if (context.runtimeConfigEnabled) {
@@ -71,9 +73,11 @@ var _packageSource = function(options, sourceDir, configValues) {
       follow: true
     });
 
-    // we must ignore this or weird things happen if
-    // you're in the public dir when you deploy
-    reader.addIgnoreRules(['firebase-debug.log']);
+    // We must ignore firebase-debug.log or weird things happen if
+    // you're in the public dir when you deploy.
+    // We ignore any CONFIG_DEST_FILE that already exists, and write another one
+    // with current config values into the archive in the "end" handler for reader
+    reader.addIgnoreRules(['firebase-debug.log', CONFIG_DEST_FILE]);
     reader.addIgnoreRules(options.config.get('functions.ignore', ['**/node_modules/**']));
 
     reader.on('child', function(file) {
@@ -90,7 +94,7 @@ var _packageSource = function(options, sourceDir, configValues) {
     });
 
     reader.on('end', function() {
-      archive.append(JSON.stringify(configValues), { name: '.runtimeconfig.json' });
+      archive.append(JSON.stringify(configValues), { name: CONFIG_DEST_FILE });
       archive.finalize();
     });
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Fixes https://github.com/firebase/firebase-tools/issues/625 and https://github.com/firebase/firebase-tools/issues/629

### Scenarios Tested
- Deploying when there's .runtimeconfig.json (It gets ignored)
- Serving when there's .runtimeconfig.json 
- Deploying without .runtimeconfig.json
- Serving without .runtimeconfig.json

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->