### PR TITLE
Cross-platform scripts

### DIFF
--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -2,7 +2,7 @@
   "name": "functions",
   "description": "Cloud Functions for Firebase",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint .",
+    "lint": "eslint .",
     "serve": "firebase serve --only functions",
     "shell": "firebase experimental:functions:shell",
     "start": "npm run shell",

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -1,8 +1,8 @@
 {
   "name": "functions",
   "scripts": {
-    "lint": "./node_modules/.bin/tslint -p tslint.json",
-    "build": "./node_modules/.bin/tsc",
+    "lint": "tslint -p tslint.json",
+    "build": "tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase experimental:functions:shell",
     "start": "npm run shell",

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "build": "./node_modules/.bin/tsc",
+    "build": "tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase experimental:functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
Scripts with `./node_modules/` will fail on Windows environments (`'.' is not recognized as an internal or external command, operable program or batch file.`). NPM scripts are already provided the context to find these scripts.