### PR TITLE
Error instead of warn when no features are selected.

### DIFF
--- a/commands/init.js
+++ b/commands/init.js
@@ -108,8 +108,7 @@ module.exports = new Command('init [feature]')
         });
       }
       if (setup.features.length === 0) {
-        utils.logWarning('You have not selected any features. Continuing will simply associate this folder ' +
-          'with a Firebase project. Press Ctrl + C if you want to start over.');
+        return utils.reject('Must select at least one feature. Use ' + chalk.bold.underline('SPACEBAR') + ' to select features, or provide a feature with ' + chalk.bold('firebase init [feature_name]'));
       }
       setup.features.unshift('project');
       return init(setup, config, options);


### PR DESCRIPTION
We have gotten questions on a regular basis to the effect of "I deployed, but nothing happened" that turned out to be confusion after initializing without selecting any features.

I think it will be a better beginner experience if we explicitly error out in this case rather than printing an easy-to-miss warning message and continuing with initialization.