### PR TITLE
Update "tar" package dependency. Fixes #557

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "rsvp": "^3.0.18",
     "semver": "^5.0.3",
     "superstatic": "^5.0.1",
-    "tar": "^3.1.5",
+    "tar": "^4.3.0",
     "tmp": "0.0.33",
     "universal-analytics": "^0.3.9",
     "update-notifier": "^0.5.0",


### PR DESCRIPTION
This fixes #557 by updating the `tar` dependency to something compatible with Node 9.x. I've tested it in Node 9 and confirmed it works, and also confirmed it still works in Node 4.