### PR TITLE
Don't crash if no home directory in ensureDefaultCredentials (Fixes #464)

### DIFF
--- a/lib/ensureDefaultCredentials.js
+++ b/lib/ensureDefaultCredentials.js
@@ -6,6 +6,7 @@ var path = require('path');
 var api = require('./api');
 var configstore = require('./configstore');
 var fsutils = require('./fsutils');
+var logger = require('./logger');
 
 var configDir = function() {
   // Windows has a dedicated low-rights location for apps at ~/Application Data
@@ -15,14 +16,19 @@ var configDir = function() {
   return process.env.HOME && path.resolve(process.env.HOME, '.config');
 };
 
-var GCLOUD_CREDENTIAL_DIR = path.resolve(configDir(), 'gcloud');
-var GCLOUD_CREDENTIAL_PATH = path.join(GCLOUD_CREDENTIAL_DIR, 'application_default_credentials.json');
-
 /*
 Ensures that default credentials are available on the local machine, as specified by:
 https://developers.google.com/identity/protocols/application-default-credentials
 */
 module.exports = function() {
+  if (!configDir()) {
+    logger.debug('Cannot ensure default credentials, no home directory found.');
+    return;
+  }
+
+  var GCLOUD_CREDENTIAL_DIR = path.resolve(configDir(), 'gcloud');
+  var GCLOUD_CREDENTIAL_PATH = path.join(GCLOUD_CREDENTIAL_DIR, 'application_default_credentials.json');
+
   if (fsutils.fileExistsSync(GCLOUD_CREDENTIAL_PATH)) { return; }
   var credentials = {
     client_id: api.clientId,


### PR DESCRIPTION
Fixes #464 by not crashing if no home directory in the runtime (i.e. in GCF runtime).