### PR TITLE
Read .runtimeconfig.json when parsing function triggers

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -121,7 +121,13 @@ FunctionsEmulator.prototype.start = function(shellMode) {
     return controller.start();
   }).then(function() {
     logger.debug('Parsing function triggers');
-    return parseTriggers(projectId, functionsDir, {}, firebaseConfig).catch(function(e) {
+    var runtimeConfig = {};
+    try {
+      runtimeConfig = require(path.resolve(functionsDir, '.runtimeconfig.json'));
+    } catch (e) {
+      // do nothing
+    }
+    return parseTriggers(projectId, functionsDir, runtimeConfig, firebaseConfig).catch(function(e) {
       utils.logWarning(chalk.yellow('functions:') + ' Failed to load functions source code. ' +
         'Ensure that you have the latest SDK by running ' + chalk.bold('npm i --save firebase-functions') +
         ' inside the functions directory.');


### PR DESCRIPTION
### Description

This makes sure that .runtimeconfig.json is loaded when parsing triggers. If you e.g. use functions.config().api.key in your function index.js it will throw in serve but not in the real environment.
	 
### Scenarios Tested

Tested: .runtimeconfig.json present and not present.
