### PR TITLE
fix tslint path to project config

### DIFF
--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "lint": "tslint -p tslint.json",
+    "lint": "tslint --project tsconfig.json",
     "build": "tsc",
     "serve": "npm run build && firebase serve --only functions",
     "shell": "npm run build && firebase experimental:functions:shell",


### PR DESCRIPTION
`-p` (or the long version `--project`) was incorrectly referencing the linting configuration in `tslint.json`. Fixing this to reference the `tsconfig.json` file to enable rules that work with the type checker.

Using the long version `--project` as it is more readable

Refer to: https://github.com/firebase/functions-samples/pull/319