### PR TITLE
Removed limit for PBKDF2_SHA256 hash algorithm

### DIFF
--- a/lib/accountImporter.js
+++ b/lib/accountImporter.js
@@ -125,8 +125,8 @@ var validateOptions = function(options) {
   case 'PBKDF_SHA1':
   case 'PBKDF2_SHA256':
     var roundsNum = parseInt(options.rounds, 10);
-    if (isNaN(roundsNum) || roundsNum < 0 || roundsNum > 30000) {
-      return utils.reject('Must provide valid rounds(0..30000) for hash algorithm ' + options.hashAlgo, {exit: 1});
+    if (isNaN(roundsNum) || roundsNum < 0) {
+      return utils.reject('Must provide valid rounds( > 0 ) for hash algorithm ' + options.hashAlgo, {exit: 1});
     }
     return {hashAlgo: hashAlgo, rounds: options.rounds, valid: true};
   case 'SCRYPT':


### PR DESCRIPTION
Google confirmed that the limit on PBKDF2_SHA256 has been removed in the backend. Users are able to import with the number of rounds > 30000.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

I have an issue when trying to import users by using PBKDF2_SHA256 and the number of rounds > 30000. Firebase and Google backend has a limit on this one.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
	 
### Scenarios Tested
I try to run this command and get an error.
```
firebase auth:import users.json --project='project-id' --hash-algo=PBKDF2_SHA256 --rounds=110050
```

```
Error: Must provide valid rounds(0..30000) for hash algorithm pbkdf2_sha256
```

After contacting google support, the limit has been lifted. 

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

This command now works.
```
firebase auth:import users.json --project='project-id' --hash-algo=PBKDF2_SHA256 --rounds=110050
```
<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
