### PR TITLE
Update the PBKDF2_SHA256 round limit to 120000

### DIFF
--- a/lib/accountImporter.js
+++ b/lib/accountImporter.js
@@ -125,8 +125,8 @@ var validateOptions = function(options) {
   case 'PBKDF_SHA1':
   case 'PBKDF2_SHA256':
     var roundsNum = parseInt(options.rounds, 10);
-    if (isNaN(roundsNum) || roundsNum < 0 || roundsNum > 30000) {
-      return utils.reject('Must provide valid rounds(0..30000) for hash algorithm ' + options.hashAlgo, {exit: 1});
+    if (isNaN(roundsNum) || roundsNum < 0 || roundsNum > 120000) {
+      return utils.reject('Must provide valid rounds(0..120000) for hash algorithm ' + options.hashAlgo, {exit: 1});
     }
     return {hashAlgo: hashAlgo, rounds: options.rounds, valid: true};
   case 'SCRYPT':


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Update the PBKDF2_SHA256 round limit to 120000 in order to match the new backend maximum.

### Sample Commands

firebase auth:import users_for_firebase.json  --hash-algo=PBKDF2_SHA256 --rounds=110050