### PR TITLE
Fix typo (CLoud -> Cloud)

### DIFF
--- a/commands/firestore-indexes-list.js
+++ b/commands/firestore-indexes-list.js
@@ -22,7 +22,7 @@ var _makeJsonSpec = function(indexes) {
 };
 
 module.exports = new Command('firestore:indexes')
-  .description('List indexes in your project\'s CLoud Firestore database.')
+  .description('List indexes in your project\'s Cloud Firestore database.')
   .option('--pretty', 'Pretty print. When not specified the indexes are printed in the '
       + 'JSON specification format.')
   .before(requireAccess, [scopes.CLOUD_PLATFORM])


### PR DESCRIPTION
### Description

Fixes typo shown in `firestore:indexes` command description.
	 
### Scenarios Tested

`firebase --help`

`firebase firestore:indexes --help`

`firebase`

### Sample Commands

`firebase --help`

`firebase firestore:indexes --help`

`firebase`
