### PR TITLE
Fix predeploy hooks for directories with spaces in the name

### DIFF
--- a/lib/init/features/functions/javascript.js
+++ b/lib/init/features/functions/javascript.js
@@ -23,7 +23,7 @@ module.exports = function(setup, config) {
     }
   ]).then(function() {
     if (setup.functions.lint) {
-      _.set(setup, 'config.functions.predeploy', ['npm --prefix $RESOURCE_DIR run lint']);
+      _.set(setup, 'config.functions.predeploy', ['npm --prefix "$RESOURCE_DIR" run lint']);
       return config.askWriteProjectFile('functions/package.json', PACKAGE_LINTING_TEMPLATE).then(function() {
         config.askWriteProjectFile('functions/.eslintrc.json', ESLINT_TEMPLATE);
       });

--- a/lib/init/features/functions/typescript.js
+++ b/lib/init/features/functions/typescript.js
@@ -24,12 +24,12 @@ module.exports = function(setup, config) {
     }
   ]).then(function() {
     if (setup.functions.lint) {
-      _.set(setup, 'config.functions.predeploy', ['npm --prefix $RESOURCE_DIR run lint', 'npm --prefix $RESOURCE_DIR run build']);
+      _.set(setup, 'config.functions.predeploy', ['npm --prefix "$RESOURCE_DIR" run lint', 'npm --prefix "$RESOURCE_DIR" run build']);
       return config.askWriteProjectFile('functions/package.json', PACKAGE_LINTING_TEMPLATE).then(function() {
         config.askWriteProjectFile('functions/tslint.json', TSLINT_TEMPLATE);
       });
     }
-    _.set(setup, 'config.functions.predeploy', 'npm --prefix $RESOURCE_DIR run build');
+    _.set(setup, 'config.functions.predeploy', 'npm --prefix "$RESOURCE_DIR" run build');
     return config.askWriteProjectFile('functions/package.json', PACKAGE_NO_LINTING_TEMPLATE);
   }).then(function() {
     return config.askWriteProjectFile('functions/tsconfig.json', TSCONFIG_TEMPLATE);


### PR DESCRIPTION
### Description

Before this change, the predeploy commands fail with an unhelpful error if you try to run the command from a directory with spaces in the name. Using double quotes when expanding $RESOURCE_DIR guarantees that the variable expands to a single parameter, instead of being split on spaces.

This should fix #658.

### Scenarios Tested

All tests from "npm test" pass.

I can reproduce the error from #658 (predeploy error during `firebase deploy`) if I initialize the firebase directory in a directory that has a space anywhere in its full path. If I use these predeploy hooks instead, the deploy succeeds.

### Sample Commands

This PR does not change any commands, it just fixes the default predeploy hooks.