### PR TITLE
Write functions emulator debug logs to cwd

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -76,6 +76,11 @@ FunctionsEmulator.prototype._getPorts = function() {
   return portsConfig;
 };
 
+FunctionsEmulator.prototype._getLogFile = function() {
+  var logFilename = path.join(process.cwd(), '/cloud-functions-emulator.log');
+  return {logFile: logFilename};
+}
+
 FunctionsEmulator.prototype.start = function(shellMode) {
   shellMode = shellMode || false;
   var options = this.options;
@@ -84,7 +89,8 @@ FunctionsEmulator.prototype.start = function(shellMode) {
   var instance = this;
   var functionsDir = path.join(options.config.projectDir, options.config.get('functions.source'));
   var ports = this._getPorts();
-  var controllerConfig = _.merge({tail: true, service: 'rest'}, ports, {maxIdle: 540000});
+  var logFile = this._getLogFile();
+  var controllerConfig = _.merge({tail: true, service: 'rest'}, ports, {maxIdle: 540000}, logFile);
   var firebaseConfig;
   var emulatedProviders = {};
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Sets the logFile option to current working directory. This writes the debug logs to a file named [cwd]/cloud-functions-emulator.log. 
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

ran `firebase:experimental:functions:shell --debug' and made sure the `cloud-functions-emulator.log` file showed up in my cwd. 

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
