### PR TITLE
Fix deployment issues in v3.18.0

### DIFF
--- a/lib/checkFirebaseSDKVersion.js
+++ b/lib/checkFirebaseSDKVersion.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var _ = require('lodash');
 var chalk = require('chalk');
+var path = require('path');
 var RSVP = require('rsvp');
 var semver = require('semver');
 var spawn = require('cross-spawn');
@@ -10,49 +10,47 @@ var utils = require('./utils');
 var logger = require('./logger');
 
 module.exports = function(options) {
-  return new RSVP.Promise(function(resolve, reject) {
-    var src = options.config._src;
-    if (!_.has(src, ['functions'])) {
+  return new RSVP.Promise(function(resolve) {
+    if (!options.config.has('functions')) {
       return resolve();
     }
+    try {
+      var output;
+      var child = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['outdated', 'firebase-functions', '--json=true'], {
+        cwd: path.join(options.config.projectDir, options.config.get('functions.source')),
+        stdio: [0, 'pipe', 2]
+      });
 
-    var output;
-    var child = spawn('npm', ['outdated', 'firebase-functions', '--json=true'], {
-      cwd: options.config.projectDir + '/functions',
-      stdio: [0, 'pipe', 2]
-    });
-
-    child.on('error', function(err) {
-      logger.debug(err.stack);
-      return reject(err);
-    });
-
-    child.stdout.on('data', function(data) {
-      output = JSON.parse(data.toString('utf8'));
-    });
-
-    child.on('exit', function() {
-      return resolve(output);
-    });
-  }).then(function(output) {
-    return new RSVP.Promise(function(resolve) {
-      if (!output) {
+      child.on('error', function(err) {
+        logger.debug(err.stack);
         return resolve();
-      }
+      });
 
-      var current = output['firebase-functions'].current;
-      var latest = output['firebase-functions'].latest;
+      child.stdout.on('data', function(data) {
+        output = JSON.parse(data.toString('utf8'));
+      });
 
-      if (semver.lt(current, latest)) {
-        utils.logWarning(chalk.bold.yellow('functions: ') + 'You are running an outdated version of firebase-functions.\n Please upgrade using '
-                          + chalk.bold('npm install --save firebase-functions@latest') +  ' in your functions directory.');
-        if (semver.satisfies(current, '0.x') && semver.satisfies(latest, '1.x')) {
-          utils.logWarning(chalk.bold.yellow('functions: ') + 'Please note that there will be breaking changes when you upgrade.\n Go to '
-                            + chalk.bold('https://firebase.google.com/docs/functions/beta-v1-diff') + ' to learn more.');
-        }
+      child.on('exit', function() {
+        return resolve(output);
+      });
+    } catch (e) {
+      resolve();
+    }
+  }).then(function(output) {
+    if (!output) {
+      return;
+    }
+    var wanted = output['firebase-functions'].wanted;
+    var latest = output['firebase-functions'].latest;
+
+    if (semver.lt(wanted, latest)) {
+      utils.logWarning(chalk.bold.yellow('functions: ') + 'package.json indicates an outdated version of firebase-functions.\n Please upgrade using '
+        + chalk.bold('npm install --save firebase-functions@latest') +  ' in your functions directory.');
+      if (semver.satisfies(wanted, '0.x') && semver.satisfies(latest, '1.x')) {
+        utils.logWarning(chalk.bold.yellow('functions: ') + 'Please note that there will be breaking changes when you upgrade.\n Go to '
+          + chalk.bold('https://firebase.google.com/docs/functions/beta-v1-diff') + ' to learn more.');
       }
-      return resolve();
-    });
+    }
   });
 };
 

--- a/lib/checkFirebaseSDKVersion.js
+++ b/lib/checkFirebaseSDKVersion.js
@@ -16,7 +16,7 @@ module.exports = function(options) {
     }
     try {
       var output;
-      var child = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['outdated', 'firebase-functions', '--json=true'], {
+      var child = spawn('npm', ['outdated', 'firebase-functions', '--json=true'], {
         cwd: path.join(options.config.projectDir, options.config.get('functions.source')),
         stdio: [0, 'pipe', 2]
       });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes https://github.com/firebase/firebase-tools/issues/715.

Namely:
- Fix check for whether functions is configured
- Fix bug where functions directory was assumed to be "functions"
- npm outdated only has "current' in its return value if "npm install" was run, whereas "wanted" indicates the version in package.json, and that's the more appropriate check
- Put spawn code in try catch
	 
### Scenarios Tested

- deploying when there's no node_modules in the functions directory
- deploying when firebase-functions version is outdated
- deploying when firebase-functions is v1.0.0
- the above scenarios on Windows

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
