### PR TITLE
Fix bug where admin.initializeApp() sometimes throws errors during trigger parsing

### DIFF
--- a/lib/parseTriggers.js
+++ b/lib/parseTriggers.js
@@ -13,9 +13,18 @@ module.exports = function(projectId, sourceDir, configValues, firebaseConfig) {
     var env = { GCLOUD_PROJECT: projectId };
     if (!_.isEmpty(configValues)) {
       env.CLOUD_RUNTIME_CONFIG = JSON.stringify(configValues);
+      if (configValues.firebase) {
+        // In case user has `admin.initalizeApp()` at the top of the file and it was executed before firebase-functions v1
+        // is loaded, which would normally set FIREBASE_CONFIG.
+        env.FIREBASE_CONFIG = configValues.firebase;
+      }
     }
-    if (firebaseConfig) {
+    if (firebaseConfig) { // This value will be populated during functions emulation
+      // Make legacy firbase-functions SDK work
       env.FIREBASE_PROJECT = firebaseConfig;
+      // In case user has `admin.initalizeApp()` at the top of the file and it was executed before firebase-functions v1
+      // is loaded, which would normally set FIREBASE_CONFIG.
+      env.FIREBASE_CONFIG = firebaseConfig;
     }
     var parser = fork(TRIGGER_PARSER, [sourceDir], {silent: true, env: env});
 


### PR DESCRIPTION

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes https://github.com/firebase/firebase-functions/issues/216. The problem is caused by the fact that firebase-admin is looking for process.env.FIREBASE_CONFIG. If the initializeApp call is at the top of index.js, then this happens during trigger parsing pre deployment. Normally, firebase-functions sets FIREBASE_CONFIG, but depending on module loading behavior, the initializeApp call could be executed before firebase-functions is fully loaded. This PR lets the CLI set the env variable prior to trigger parsing.
	 
### Scenarios Tested

Deployment of functions where admin.initializeApp is called at the top of the file, before `require('firebase-functions')`. (Caveat is that I wasn't able to reproduce the bug in the first place. I suspect because my machine is fast, all the modules get loaded right away)

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
