### PR TITLE
Convert RSVP to native Promise throughout codebase.

### DIFF
--- a/commands/auth-import.js
+++ b/commands/auth-import.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var RSVP = require("rsvp");
 var csv = require("csv-streamify");
 var chalk = require("chalk");
 var fs = require("fs");
@@ -58,7 +57,7 @@ module.exports = new Command("auth:import [dataFile]")
     var inStream = fs.createReadStream(dataFile);
     var batches = [];
     var currentBatch = [];
-    return new RSVP.Promise(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       var parser;
       var counter = 0;
       if (dataFile.endsWith(".csv")) {

--- a/commands/database-get.js
+++ b/commands/database-get.js
@@ -6,7 +6,7 @@ var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
 var FirebaseError = require("../lib/error");
-var RSVP = require("rsvp");
+
 var utils = require("../lib/utils");
 var querystring = require("querystring");
 var _ = require("lodash");
@@ -85,7 +85,7 @@ module.exports = new Command("database:get <path>")
     };
 
     return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
-      return new RSVP.Promise(function(resolve, reject) {
+      return new Promise(function(resolve, reject) {
         var fileOut = !!options.output;
         var outStream = fileOut ? fs.createWriteStream(options.output) : process.stdout;
         var erroring;

--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -6,7 +6,7 @@ var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
 var FirebaseError = require("../lib/error");
-var RSVP = require("rsvp");
+
 var utils = require("../lib/utils");
 var chalk = require("chalk");
 var logger = require("../lib/logger");
@@ -37,7 +37,7 @@ module.exports = new Command("database:push <path> [infile]")
     };
 
     return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
-      return new RSVP.Promise(function(resolve, reject) {
+      return new Promise(function(resolve, reject) {
         inStream.pipe(
           request.post(reqOptionsWithToken, function(err, res, body) {
             logger.info();

--- a/commands/database-remove.js
+++ b/commands/database-remove.js
@@ -6,7 +6,7 @@ var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
 var FirebaseError = require("../lib/error");
-var RSVP = require("rsvp");
+
 var utils = require("../lib/utils");
 var prompt = require("../lib/prompt");
 var chalk = require("chalk");
@@ -42,7 +42,7 @@ module.exports = new Command("database:remove <path>")
       };
 
       return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
-        return new RSVP.Promise(function(resolve, reject) {
+        return new Promise(function(resolve, reject) {
           request.del(reqOptionsWithToken, function(err, res, body) {
             if (err) {
               return reject(

--- a/commands/database-set.js
+++ b/commands/database-set.js
@@ -6,7 +6,7 @@ var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
 var FirebaseError = require("../lib/error");
-var RSVP = require("rsvp");
+
 var utils = require("../lib/utils");
 var chalk = require("chalk");
 var logger = require("../lib/logger");
@@ -54,7 +54,7 @@ module.exports = new Command("database:set <path> [infile]")
       };
 
       return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
-        return new RSVP.Promise(function(resolve, reject) {
+        return new Promise(function(resolve, reject) {
           inStream.pipe(
             request.put(reqOptionsWithToken, function(err, res, body) {
               logger.info();

--- a/commands/database-update.js
+++ b/commands/database-update.js
@@ -6,7 +6,7 @@ var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
 var FirebaseError = require("../lib/error");
-var RSVP = require("rsvp");
+
 var utils = require("../lib/utils");
 var chalk = require("chalk");
 var logger = require("../lib/logger");
@@ -54,7 +54,7 @@ module.exports = new Command("database:update <path> [infile]")
       };
 
       return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
-        return new RSVP.Promise(function(resolve, reject) {
+        return new Promise(function(resolve, reject) {
           inStream.pipe(
             request.patch(reqOptionsWithToken, function(err, res, body) {
               logger.info();

--- a/commands/firestore-delete.js
+++ b/commands/firestore-delete.js
@@ -5,7 +5,7 @@ var Command = require("../lib/command");
 var FirestoreDelete = require("../lib/firestore/delete");
 var prompt = require("../lib/prompt");
 var requireAccess = require("../lib/requireAccess");
-var RSVP = require("rsvp");
+
 var scopes = require("../lib/scopes");
 var utils = require("../lib/utils");
 
@@ -88,7 +88,7 @@ module.exports = new Command("firestore:delete [path]")
 
     var checkPrompt;
     if (options.yes) {
-      checkPrompt = RSVP.resolve({ confirm: true });
+      checkPrompt = Promise.resolve({ confirm: true });
     } else {
       checkPrompt = prompt(options, [
         {

--- a/commands/functions-config-legacy.js
+++ b/commands/functions-config-legacy.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var Command = require("../lib/command");
 var getProjectId = require("../lib/getProjectId");
 var requireAccess = require("../lib/requireAccess");
@@ -39,6 +39,6 @@ module.exports = new Command("functions:config:legacy")
           logger.info("You do not have any legacy config variables.");
           return null;
         }
-        return RSVP.reject(err);
+        return Promise.reject(err);
       });
   });

--- a/commands/functions-config-set.js
+++ b/commands/functions-config-set.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var chalk = require("chalk");
-var RSVP = require("rsvp");
+
 var Command = require("../lib/command");
 var getProjectId = require("../lib/getProjectId");
 var requireAccess = require("../lib/requireAccess");
@@ -30,7 +30,7 @@ module.exports = new Command("functions:config:set [values...]")
       );
     });
 
-    return RSVP.all(promises).then(function() {
+    return Promise.all(promises).then(function() {
       utils.logSuccess("Functions config updated.");
       logger.info(
         "\nPlease deploy your functions for the change to take effect by running " +

--- a/commands/functions-config-unset.js
+++ b/commands/functions-config-unset.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var chalk = require("chalk");
 var Command = require("../lib/command");
 var functionsConfig = require("../lib/functionsConfig");
@@ -22,7 +22,7 @@ module.exports = new Command("functions:config:unset [keys...]")
     }
     var projectId = getProjectId(options);
     var parsed = functionsConfig.parseUnsetArgs(args);
-    return RSVP.all(
+    return Promise.all(
       _.map(parsed, function(item) {
         if (item.varId === "") {
           return runtimeconfig.configs.delete(projectId, item.configId);

--- a/commands/functions-log.js
+++ b/commands/functions-log.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var Command = require("../lib/command");
 var FirebaseError = require("../lib/error");
 var gcp = require("../lib/gcp");
@@ -42,7 +42,7 @@ module.exports = new Command("functions:log")
         "&project=" +
         projectId;
       open(url);
-      return RSVP.resolve();
+      return Promise.resolve();
     }
     return gcp.cloudlogging
       .listEntries(projectId, apiFilter, options.lines || 35, "desc")
@@ -59,10 +59,10 @@ module.exports = new Command("functions:log")
         if (_.isEmpty(entries)) {
           logger.info("No log entries found.");
         }
-        return RSVP.resolve(entries);
+        return Promise.resolve(entries);
       })
       .catch(function(err) {
-        return RSVP.reject(
+        return Promise.reject(
           new FirebaseError("Failed to list log entries " + err.message, {
             exit: 1,
           })

--- a/commands/help.js
+++ b/commands/help.js
@@ -28,5 +28,5 @@ module.exports = new Command("help [command]")
       logger.info();
     }
 
-    Promise.resolve();
+    return Promise.resolve();
   });

--- a/commands/help.js
+++ b/commands/help.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var Command = require("../lib/command");
-var RSVP = require("rsvp");
+
 var chalk = require("chalk");
 var logger = require("../lib/logger");
 var utils = require("../lib/utils");
@@ -28,5 +28,5 @@ module.exports = new Command("help [command]")
       logger.info();
     }
 
-    RSVP.resolve();
+    Promise.resolve();
   });

--- a/commands/hosting-disable.js
+++ b/commands/hosting-disable.js
@@ -6,7 +6,6 @@ var api = require("../lib/api");
 var utils = require("../lib/utils");
 var prompt = require("../lib/prompt");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 module.exports = new Command("hosting:disable")
   .description("stop serving web traffic to your Firebase Hosting site")
@@ -24,7 +23,7 @@ module.exports = new Command("hosting:disable")
     ])
       .then(function() {
         if (!options.confirm) {
-          return RSVP.resolve();
+          return Promise.resolve();
         }
 
         return api.request(

--- a/commands/init.js
+++ b/commands/init.js
@@ -4,7 +4,6 @@ var chalk = require("chalk");
 var fs = require("fs");
 var homeDir = require("user-home");
 var path = require("path");
-var RSVP = require("rsvp");
 
 var Command = require("../lib/command");
 var Config = require("../lib/config");
@@ -107,7 +106,7 @@ module.exports = new Command("init [feature]")
         message: "Are you ready to proceed?",
       });
     } else {
-      next = RSVP.resolve(true);
+      next = Promise.resolve(true);
     }
 
     return next

--- a/commands/kits-uninstall.js
+++ b/commands/kits-uninstall.js
@@ -1,7 +1,6 @@
 "use strict";
 var chalk = require("chalk");
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var Command = require("../lib/command");
 var gcp = require("../lib/gcp");
@@ -70,7 +69,7 @@ function _promptForKitsUninstall(choices, dict) {
 }
 
 function _deleteKitFunctions(projectId, functions) {
-  return RSVP.all(
+  return Promise.all(
     _.map(functions, function(funcName) {
       return gcp.cloudfunctions.delete({
         projectId: projectId,

--- a/commands/login.js
+++ b/commands/login.js
@@ -6,7 +6,7 @@ var configstore = require("../lib/configstore");
 var chalk = require("chalk");
 var utils = require("../lib/utils");
 var prompt = require("../lib/prompt");
-var RSVP = require("rsvp");
+
 var auth = require("../lib/auth");
 
 module.exports = new Command("login")
@@ -31,7 +31,7 @@ module.exports = new Command("login")
 
     if (user && tokens && !options.reauth) {
       logger.info("Already logged in as", chalk.bold(user.email));
-      return RSVP.resolve(user);
+      return Promise.resolve(user);
     }
 
     return prompt(options, [

--- a/commands/logout.js
+++ b/commands/logout.js
@@ -4,7 +4,7 @@ var Command = require("../lib/command");
 var configstore = require("../lib/configstore");
 var logger = require("../lib/logger");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
+
 var utils = require("../lib/utils");
 var api = require("../lib/api");
 var auth = require("../lib/auth");
@@ -22,7 +22,7 @@ module.exports = new Command("logout")
     if (token) {
       next = auth.logout(token);
     } else {
-      next = RSVP.resolve();
+      next = Promise.resolve();
     }
 
     var cleanup = function() {

--- a/commands/open.js
+++ b/commands/open.js
@@ -3,7 +3,6 @@
 var _ = require("lodash");
 var chalk = require("chalk");
 var open = require("open");
-var RSVP = require("rsvp");
 
 var api = require("../lib/api");
 var Command = require("../lib/command");
@@ -70,7 +69,7 @@ module.exports = new Command("open [link]")
       );
     }
 
-    var next = RSVP.resolve(link);
+    var next = Promise.resolve(link);
     if (!link) {
       next = prompt
         .once({
@@ -111,6 +110,6 @@ module.exports = new Command("open [link]")
       logger.info(chalk.bold.underline(url));
 
       open(url);
-      return RSVP.resolve(url);
+      return Promise.resolve(url);
     });
   });

--- a/commands/setup-web.js
+++ b/commands/setup-web.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var fs = require("fs");
-var RSVP = require("rsvp");
 
 var Command = require("../lib/command");
 var fetchWebSetup = require("../lib/fetchWebSetup");
@@ -17,6 +16,6 @@ module.exports = new Command("setup:web")
   .action(function(options) {
     return fetchWebSetup(options).then(function(config) {
       logger.info(JS_TEMPLATE.replace("{/*--CONFIG--*/}", JSON.stringify(config, null, 2)));
-      return RSVP.resolve(config);
+      return Promise.resolve(config);
     });
   });

--- a/commands/target-clear.js
+++ b/commands/target-clear.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var Command = require("../lib/command");
 var requireConfig = require("../lib/requireConfig");
@@ -17,5 +16,5 @@ module.exports = new Command("target:clear <type> <target>")
     } else {
       utils.logWarning("No action taken. No " + type + " target found named " + chalk.bold(name));
     }
-    return RSVP.resolve(existed);
+    return Promise.resolve(existed);
   });

--- a/commands/target-remove.js
+++ b/commands/target-remove.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var Command = require("../lib/command");
 var requireConfig = require("../lib/requireConfig");
@@ -21,5 +20,5 @@ module.exports = new Command("target:remove <type> <resource>")
         "No action taken. No target found for " + type + " resource " + chalk.bold(resource)
       );
     }
-    return RSVP.resolve(name);
+    return Promise.resolve(name);
   });

--- a/commands/target.js
+++ b/commands/target.js
@@ -2,7 +2,6 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var Command = require("../lib/command");
 var logger = require("../lib/logger");
@@ -29,12 +28,12 @@ module.exports = new Command("target [type]")
     if (type) {
       var targets = options.rc.targets(options.project, type);
       _logTargets(type, targets);
-      return RSVP.resolve(targets);
+      return Promise.resolve(targets);
     }
 
     var allTargets = options.rc.get(["targets", options.project], {});
     _.forEach(allTargets, function(ts, tp) {
       _logTargets(tp, ts);
     });
-    return RSVP.resolve(allTargets);
+    return Promise.resolve(allTargets);
   });

--- a/commands/tools-migrate.js
+++ b/commands/tools-migrate.js
@@ -2,7 +2,6 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var Command = require("../lib/command");
 var Config = require("../lib/config");
@@ -65,7 +64,7 @@ module.exports = new Command("tools:migrate")
 
       changed = true;
     } else {
-      next = RSVP.resolve();
+      next = Promise.resolve();
     }
 
     return next.then(function() {
@@ -82,7 +81,7 @@ module.exports = new Command("tools:migrate")
       logger.info();
 
       if (options.confirm) {
-        next = RSVP.resolve(true);
+        next = Promise.resolve(true);
       } else {
         next = prompt.once({
           type: "confirm",

--- a/lib/RulesDeploy.js
+++ b/lib/RulesDeploy.js
@@ -3,7 +3,6 @@
 var _ = require("lodash");
 var chalk = require("chalk");
 var fs = require("fs");
-var RSVP = require("rsvp");
 
 var gcp = require("./gcp");
 var logger = require("./logger");
@@ -46,7 +45,7 @@ RulesDeploy.prototype = {
     _.forEach(this.rulesFiles, function(files, filename) {
       promises.push(self._compileRuleset(filename, files));
     });
-    return RSVP.all(promises);
+    return Promise.all(promises);
   },
 
   /**
@@ -66,7 +65,7 @@ RulesDeploy.prototype = {
         })
       );
     });
-    return RSVP.all(promises);
+    return Promise.all(promises);
   },
 
   release: function(filename, resourceName) {
@@ -117,7 +116,7 @@ RulesDeploy.prototype = {
           chalk.bold(filename) +
           " compiled successfully"
       );
-      return RSVP.resolve();
+      return Promise.resolve();
     });
   },
 };

--- a/lib/acquireRefs.js
+++ b/lib/acquireRefs.js
@@ -3,13 +3,13 @@
 var FirebaseError = require("./error");
 var api = require("./api");
 var Firebase = require("firebase");
-var RSVP = require("rsvp");
+
 var utils = require("./utils");
 var requireAccess = require("./requireAccess");
 
 module.exports = function(options, authScopes) {
   return requireAccess(options, authScopes).then(function() {
-    return new RSVP.Promise(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       if (process.env.FIREBASE_BYPASS_ADMIN_CALLS_FOR_TESTING === "true") {
         // requireAccess() hasn't set the metadataToken, so can't auth.
         resolve();

--- a/lib/api.js
+++ b/lib/api.js
@@ -3,7 +3,6 @@
 var _ = require("lodash");
 var querystring = require("querystring");
 var request = require("request");
-var RSVP = require("rsvp");
 
 var FirebaseError = require("./error");
 var logger = require("./logger");
@@ -29,7 +28,7 @@ var _request = function(options) {
     new Date().toString()
   );
 
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var req = request(options, function(err, response, body) {
       if (err) {
         return reject(
@@ -141,7 +140,7 @@ var api = {
   },
   getAccessToken: function() {
     return accessToken
-      ? RSVP.resolve({ access_token: accessToken })
+      ? Promise.resolve({ access_token: accessToken })
       : require("./auth").getAccessToken(refreshToken, commandScopes);
   },
   addRequestHeaders: function(reqOptions) {
@@ -213,7 +212,7 @@ var api = {
           return res.body;
         }
 
-        return RSVP.reject(
+        return Promise.reject(
           new FirebaseError("Server Error: Unexpected Response. Please try again", {
             context: res,
             exit: 2,
@@ -231,7 +230,7 @@ var api = {
           return res.body.projects;
         }
 
-        return RSVP.reject(
+        return Promise.reject(
           new FirebaseError("Server Error: Unexpected Response. Please try again", {
             context: res,
             exit: 2,

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -104,7 +104,7 @@ var _getTokensFromAuthorizationCode = function(code, callbackUrl) {
 };
 
 var _respondWithFile = function(req, res, statusCode, filename) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     fs.readFile(path.join(__dirname, filename), function(err, response) {
       if (err) {
         return reject(err);
@@ -151,7 +151,7 @@ var _loginWithoutLocalhost = function() {
 };
 
 var _loginWithLocalhost = function(port) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var callbackUrl = _getCallbackUrl(port);
     var authUrl = _getLoginUrl(callbackUrl);
 
@@ -284,7 +284,7 @@ var _refreshAccessToken = function(refreshToken, authScopes) {
 
 var getAccessToken = function(refreshToken, authScopes) {
   if (_haveValidAccessToken(refreshToken, authScopes)) {
-    return RSVP.resolve(lastAccessToken);
+    return Promise.resolve(lastAccessToken);
   }
   return _refreshAccessToken(refreshToken, authScopes);
 };

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -39,7 +39,7 @@ var SCOPES = [
 ];
 
 var _nonce = _.random(1, 2 << 29).toString();
-var _getPort = RSVP.denodeify(portfinder.getPort);
+var _getPort = portfinder.getPortPromise;
 
 // in-memory cache, so we have it for successive calls
 var lastAccessToken = {};

--- a/lib/checkDupHostingKeys.js
+++ b/lib/checkDupHostingKeys.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var utils = require("./utils");
 var chalk = require("chalk");
 var Config = require("./config");
@@ -9,7 +9,7 @@ var FirebaseError = require("./error");
 var logger = require("./logger");
 
 module.exports = function(options) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var src = options.config._src;
     var legacyKeys = Config.LEGACY_HOSTING_KEYS;
 

--- a/lib/checkFirebaseSDKVersion.js
+++ b/lib/checkFirebaseSDKVersion.js
@@ -2,7 +2,7 @@
 
 var chalk = require("chalk");
 var path = require("path");
-var RSVP = require("rsvp");
+
 var semver = require("semver");
 var spawn = require("cross-spawn");
 
@@ -10,7 +10,7 @@ var utils = require("./utils");
 var logger = require("./logger");
 
 module.exports = function(options) {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     if (!options.config.has("functions")) {
       return resolve();
     }

--- a/lib/checkValidTargetFilters.js
+++ b/lib/checkValidTargetFilters.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var FirebaseError = require("./error");
 
 module.exports = function(options) {
@@ -18,7 +18,7 @@ module.exports = function(options) {
     return numFilters(targetTypes) === 0;
   }
 
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     if (!options.only) {
       return resolve();
     }

--- a/lib/command.js
+++ b/lib/command.js
@@ -110,7 +110,7 @@ Command.prototype.register = function(client) {
         var projectId = getProjectId(options, true);
         var preppedMessage = chalk.stripColor(err.message || "").replace(projectId, "<namespace>");
 
-        Promise.all([
+        return Promise.all([
           track(self._name, "error", duration),
           track(errorEvent, preppedMessage, duration),
         ]).then(function() {

--- a/lib/command.js
+++ b/lib/command.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var RSVP = require("rsvp");
 var _ = require("lodash");
 var track = require("./track");
 var logger = require("./logger");
@@ -111,7 +110,7 @@ Command.prototype.register = function(client) {
         var projectId = getProjectId(options, true);
         var preppedMessage = chalk.stripColor(err.message || "").replace(projectId, "<namespace>");
 
-        RSVP.all([
+        Promise.all([
           track(self._name, "error", duration),
           track(errorEvent, preppedMessage, duration),
         ]).then(function() {
@@ -151,7 +150,7 @@ Command.prototype._prepare = function(options) {
 
   options.projectRoot = detectProjectRoot(options.cwd);
   this.applyRC(options);
-  return RSVP.resolve();
+  return Promise.resolve();
 };
 
 /**
@@ -201,7 +200,7 @@ Command.prototype.runner = function() {
         return self._action.apply(self, args);
       });
     } catch (e) {
-      return RSVP.reject(e);
+      return Promise.reject(e);
     }
   };
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,6 @@ var chalk = require("chalk");
 var cjson = require("cjson");
 var fs = require("fs-extra");
 var path = require("path");
-var RSVP = require("rsvp");
 
 var detectProjectRoot = require("./detectProjectRoot");
 var FirebaseError = require("./error");
@@ -206,7 +205,7 @@ Config.prototype.askWriteProjectFile = function(p, content) {
       default: false,
     });
   } else {
-    next = RSVP.resolve(true);
+    next = Promise.resolve(true);
   }
 
   var self = this;

--- a/lib/deploy/database/prepare.js
+++ b/lib/deploy/database/prepare.js
@@ -3,7 +3,6 @@
 var _ = require("lodash");
 var chalk = require("chalk");
 var path = require("path");
-var RSVP = require("rsvp");
 
 var FirebaseError = require("../../error");
 var parseBoltRules = require("../../parseBoltRules");
@@ -12,7 +11,7 @@ var utils = require("../../utils");
 
 module.exports = function(context, options) {
   var rulesConfig = options.config.get("database");
-  var next = RSVP.resolve();
+  var next = Promise.resolve();
 
   if (!rulesConfig) {
     return next;

--- a/lib/deploy/database/release.js
+++ b/lib/deploy/database/release.js
@@ -1,21 +1,20 @@
 "use strict";
 
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var rtdb = require("../../rtdb");
 var utils = require("../../utils");
 
 module.exports = function(context) {
   if (!context.database || !context.database.deploys || !context.database.ruleFiles) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   var deploys = context.database.deploys;
   var ruleFiles = context.database.ruleFiles;
 
   utils.logBullet(chalk.bold.cyan("database: ") + "releasing rules...");
-  return RSVP.all(
+  return Promise.all(
     deploys.map(function(deploy) {
       return rtdb
         .updateRules(deploy.instance, ruleFiles[deploy.rules], {

--- a/lib/deploy/firestore/deploy.js
+++ b/lib/deploy/firestore/deploy.js
@@ -4,7 +4,7 @@ var _ = require("lodash");
 var chalk = require("chalk");
 var firestoreIndexes = require("../../firestore/indexes");
 var logger = require("../../logger");
-var RSVP = require("rsvp");
+
 var utils = require("../../utils");
 
 /**
@@ -22,7 +22,7 @@ var _createIfMissing = function(projectId, index, existingIndexes) {
 
   if (exists) {
     logger.debug("Skipping existing index: " + JSON.stringify(index));
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   logger.debug("Creating new index: " + JSON.stringify(index));
@@ -40,7 +40,7 @@ var _createIfMissing = function(projectId, index, existingIndexes) {
  */
 var _createAllChained = function(projectId, indexes, existingIndexes) {
   if (indexes.length === 0) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   var index = indexes.shift();
@@ -84,20 +84,20 @@ var _logAllMissing = function(indexes, existingIndexes) {
 function _deployRules(context) {
   var rulesDeploy = _.get(context, "firestore.rulesDeploy");
   if (!context.firestoreRules || !rulesDeploy) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
   return rulesDeploy.createRulesets();
 }
 
 function _deployIndexes(context, options) {
   if (!context.firestoreIndexes) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   var indexesSrc = _.get(context, "firestore.indexes.content");
   if (!indexesSrc) {
     logger.debug("No Firestore indexes present.");
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   var indexes = indexesSrc.indexes;
@@ -115,5 +115,5 @@ function _deployIndexes(context, options) {
  * Deploy indexes.
  */
 module.exports = function(context, options) {
-  return RSVP.all([_deployRules(context), _deployIndexes(context, options)]);
+  return Promise.all([_deployRules(context), _deployIndexes(context, options)]);
 };

--- a/lib/deploy/firestore/prepare.js
+++ b/lib/deploy/firestore/prepare.js
@@ -1,13 +1,12 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var firestoreIndexes = require("../../firestore/indexes");
 var RulesDeploy = require("../../RulesDeploy");
 
 function _prepareRules(context, options) {
-  var prepare = RSVP.resolve();
+  var prepare = Promise.resolve();
   var rulesFile = options.config.get("firestore.rules");
 
   if (context.firestoreRules && rulesFile) {
@@ -22,7 +21,7 @@ function _prepareRules(context, options) {
 
 function _prepareIndexes(context, options) {
   if (!context.firestoreIndexes || !options.config.get("firestore.indexes")) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   return firestoreIndexes.prepare(context, options);
@@ -42,5 +41,5 @@ module.exports = function(context, options) {
     context.firestoreRules = true;
   }
 
-  return RSVP.all([_prepareRules(context, options), _prepareIndexes(context, options)]);
+  return Promise.all([_prepareRules(context, options), _prepareIndexes(context, options)]);
 };

--- a/lib/deploy/firestore/release.js
+++ b/lib/deploy/firestore/release.js
@@ -1,14 +1,13 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var FIRESTORE_RELEASE_NAME = "cloud.firestore";
 
 function _releaseRules(context, options) {
   var rulesDeploy = _.get(context, "firestore.rulesDeploy");
   if (!context.firestoreRules || !rulesDeploy) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
   return rulesDeploy.release(options.config.get("firestore.rules"), FIRESTORE_RELEASE_NAME);
 }

--- a/lib/deploy/functions/deploy.js
+++ b/lib/deploy/functions/deploy.js
@@ -2,7 +2,7 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
+
 var tmp = require("tmp");
 var utils = require("../../utils");
 var gcp = require("../../gcp");
@@ -49,9 +49,9 @@ module.exports = function(context, options, payload) {
         })
         .catch(function(err) {
           utils.logWarning(chalk.yellow("functions:") + " Upload Error: " + err.message);
-          return RSVP.reject(err);
+          return Promise.reject(err);
         });
     });
   }
-  return RSVP.resolve();
+  return Promise.resolve();
 };

--- a/lib/deploy/functions/prepare.js
+++ b/lib/deploy/functions/prepare.js
@@ -4,7 +4,6 @@ var _ = require("lodash");
 var cjson = require("cjson");
 var chalk = require("chalk");
 var path = require("path");
-var RSVP = require("rsvp");
 
 var ensureApiEnabled = require("../../ensureApiEnabled");
 var functionsConfig = require("../../functionsConfig");
@@ -18,7 +17,7 @@ var VALID_FUNCTION_NAME_REGEX = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
 
 module.exports = function(context, options, payload) {
   if (!options.config.has("functions")) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   var sourceDirName = options.config.get("functions.source");
@@ -73,7 +72,7 @@ module.exports = function(context, options, payload) {
     );
   }
   var projectId = getProjectId(options);
-  return RSVP.all([
+  return Promise.all([
     ensureApiEnabled.ensure(options.project, "cloudfunctions.googleapis.com", "functions"),
     ensureApiEnabled.check(projectId, "runtimeconfig.googleapis.com", "runtimeconfig", true),
   ])

--- a/lib/deploy/functions/release.js
+++ b/lib/deploy/functions/release.js
@@ -2,7 +2,6 @@
 
 var chalk = require("chalk");
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var FirebaseError = require("../../error");
 var gcp = require("../../gcp");
@@ -13,7 +12,7 @@ var pollOperation = require("../../pollOperations");
 
 module.exports = function(context, options, payload) {
   if (!options.config.has("functions")) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   var GCP_REGION = gcp.cloudfunctions.DEFAULT_REGION;
@@ -57,7 +56,7 @@ module.exports = function(context, options, payload) {
   function _fetchTriggerUrls(ops) {
     if (!_.find(ops, ["trigger.httpsTrigger", {}])) {
       // No HTTPS functions being deployed
-      return RSVP.resolve();
+      return Promise.resolve();
     }
     return gcp.cloudfunctions.list(projectId, GCP_REGION).then(function(functions) {
       var httpFunctions = _.chain(functions)
@@ -70,7 +69,7 @@ module.exports = function(context, options, payload) {
           .assign({ triggerUrl: httpFunc.httpsTrigger.url })
           .value();
       });
-      return RSVP.resolve();
+      return Promise.resolve();
     });
   }
 
@@ -170,7 +169,7 @@ module.exports = function(context, options, payload) {
         "You can use the --only flag to deploy only a portion of your functions in the future."
       );
       deployments = []; // prevents analytics tracking of deployments
-      return RSVP.resolve();
+      return Promise.resolve();
     } else if (_.size(operations) > 40) {
       interval = 10 * 1000;
     } else if (_.size(operations) > 15) {
@@ -388,7 +387,7 @@ module.exports = function(context, options, payload) {
         })
         .value();
 
-      return RSVP.allSettled(
+      return Promise.allSettled(
         _.map(deployments, function(op) {
           return op.retryFunction().then(function(res) {
             return _.merge(op, res);
@@ -417,7 +416,9 @@ module.exports = function(context, options, payload) {
               "You can check on their status at " +
                 utils.consoleUrl(options.project, "/functions/logs")
             );
-            return RSVP.reject(new FirebaseError("Failed to get status of functions deployments."));
+            return Promise.reject(
+              new FirebaseError("Failed to get status of functions deployments.")
+            );
           });
         })
         .then(function() {
@@ -431,7 +432,7 @@ module.exports = function(context, options, payload) {
               "\n\nFunctions deploy had errors. To continue deploying other features (such as database), run:"
             );
             logger.info("    " + chalk.bold("firebase deploy --except functions"));
-            return RSVP.reject(new FirebaseError("Functions did not deploy properly."));
+            return Promise.reject(new FirebaseError("Functions did not deploy properly."));
           }
         });
     });

--- a/lib/deploy/hosting/deploy.js
+++ b/lib/deploy/hosting/deploy.js
@@ -4,7 +4,6 @@ var _ = require("lodash");
 var chalk = require("chalk");
 var fs = require("fs-extra");
 var ProgressBar = require("progress");
-var RSVP = require("rsvp");
 
 var api = require("../../api");
 var logger = require("../../logger");
@@ -16,7 +15,7 @@ module.exports = function(context, options, payload) {
   var local = context.hosting;
 
   if (!payload.hosting) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   utils.logBullet(
@@ -46,7 +45,7 @@ module.exports = function(context, options, payload) {
       // })
     });
 
-    return new RSVP.Promise(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       var lastCount = 0;
       var lastPercent = 0;
       var bar;

--- a/lib/deploy/hosting/prepare.js
+++ b/lib/deploy/hosting/prepare.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var resolveProjectPath = require("../../resolveProjectPath");
 var fsutils = require("../../fsutils");
 var utils = require("../../utils");
@@ -35,5 +35,5 @@ module.exports = function(context, options, payload) {
     }
   }
 
-  return RSVP.resolve();
+  return Promise.resolve();
 };

--- a/lib/deploy/index.js
+++ b/lib/deploy/index.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var RSVP = require("rsvp");
 var logger = require("../logger");
 var api = require("../api");
 var chalk = require("chalk");
@@ -20,7 +19,7 @@ var TARGETS = {
 };
 
 var _chain = function(fns, context, options, payload) {
-  var latest = (fns.shift() || RSVP.resolve)(context, options, payload);
+  var latest = (fns.shift() || Promise.resolve)(context, options, payload);
   if (fns.length) {
     return latest.then(function() {
       return _chain(fns, context, options, payload);
@@ -51,7 +50,7 @@ var deploy = function(targetNames, options) {
     var target = TARGETS[targetName];
 
     if (!target) {
-      return RSVP.reject(
+      return Promise.reject(
         new FirebaseError(chalk.bold(targetName) + " is not a valid deploy target", { exit: 1 })
       );
     }

--- a/lib/deploy/lifecycleHooks.js
+++ b/lib/deploy/lifecycleHooks.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var utils = require("../utils");
 var chalk = require("chalk");
 var childProcess = require("child_process");
@@ -48,7 +48,7 @@ module.exports = function(target, hook) {
     var commands = options.config.get(target + "." + hook);
 
     if (!commands) {
-      return RSVP.resolve();
+      return Promise.resolve();
     }
     if (typeof commands === "string") {
       commands = [commands];

--- a/lib/deploy/storage/deploy.js
+++ b/lib/deploy/storage/deploy.js
@@ -1,12 +1,11 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 module.exports = function(context) {
   var rulesDeploy = _.get(context, "storage.rulesDeploy");
   if (!rulesDeploy) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   return rulesDeploy.createRulesets();

--- a/lib/deploy/storage/prepare.js
+++ b/lib/deploy/storage/prepare.js
@@ -1,14 +1,13 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var gcp = require("../../gcp");
 var RulesDeploy = require("../../RulesDeploy");
 
 module.exports = function(context, options) {
   var rulesConfig = options.config.get("storage");
-  var next = RSVP.resolve();
+  var next = Promise.resolve();
 
   if (!rulesConfig) {
     return next;

--- a/lib/deploy/storage/release.js
+++ b/lib/deploy/storage/release.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var STORAGE_RELEASE_NAME = "firebase.storage";
 
@@ -9,7 +8,7 @@ module.exports = function(context, options) {
   var rules = _.get(context, "storage.rules", []);
   var rulesDeploy = _.get(context, "storage.rulesDeploy");
   if (!rules.length || !rulesDeploy) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   var toRelease = [];
@@ -23,7 +22,7 @@ module.exports = function(context, options) {
     }
   });
 
-  return RSVP.all(
+  return Promise.all(
     toRelease.map(function(release) {
       return rulesDeploy.release(release.rules, [STORAGE_RELEASE_NAME, release.bucket].join("/"));
     })

--- a/lib/ensureApiEnabled.js
+++ b/lib/ensureApiEnabled.js
@@ -2,7 +2,6 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var api = require("./api");
 var utils = require("./utils");
@@ -50,7 +49,7 @@ var _pollCheckEnabled = function(projectId, apiName, prefix, enablementRetries, 
     return _enableApiWithRetries(projectId, apiName, prefix, enablementRetries + 1);
   }
 
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     setTimeout(function() {
       resolve();
     }, POLL_INTERVAL);

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -5,7 +5,7 @@ var chalk = require("chalk");
 var FirebaseError = require("../../lib/error");
 var logger = require("../../lib/logger");
 var ProgressBar = require("progress");
-var RSVP = require("rsvp");
+
 var utils = require("../../lib/utils");
 
 /**
@@ -282,7 +282,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var self = this;
   return this._getDescendantBatch(this.allDescendants, this.batchSize).then(function(docs) {
     if (docs.length <= 0) {
-      return RSVP.resolve();
+      return Promise.resolve();
     }
 
     return self._deleteDocuments(docs).then(function(numDeleted) {
@@ -312,14 +312,14 @@ FirestoreDelete.prototype._deletePath = function() {
       if (self.allDescendants) {
         // On a recursive delete, we are insensitive to
         // failures of the initial delete
-        return RSVP.resolve();
+        return Promise.resolve();
       }
 
       // For a shallow delete, this error is fatal.
       return utils.reject("Unable to delete " + chalk.cyan(this.path));
     });
   } else {
-    initialDelete = RSVP.resolve();
+    initialDelete = Promise.resolve();
   }
 
   return initialDelete.then(function() {
@@ -373,7 +373,7 @@ FirestoreDelete.prototype.deleteDatabase = function() {
         promises.push(deleteOp.execute());
       }
 
-      return RSVP.all(promises);
+      return Promise.all(promises);
     });
 };
 
@@ -402,7 +402,7 @@ FirestoreDelete.prototype.execute = function() {
       }
     });
   } else {
-    verifyRecurseSafe = RSVP.resolve();
+    verifyRecurseSafe = Promise.resolve();
   }
 
   var self = this;

--- a/lib/firestore/indexes.js
+++ b/lib/firestore/indexes.js
@@ -4,7 +4,6 @@ var api = require("../../lib/api");
 var chalk = require("chalk");
 var FirebaseError = require("../../lib/error");
 var loadCJSON = require("../../lib/loadCJSON");
-var RSVP = require("rsvp");
 
 var VALID_INDEX_MODES = ["ASCENDING", "DESCENDING"];
 
@@ -231,7 +230,7 @@ var prepare = function(context, options) {
     content: parsedSrc,
   };
 
-  return RSVP.resolve();
+  return Promise.resolve();
 };
 
 module.exports = {

--- a/lib/fsAsync.js
+++ b/lib/fsAsync.js
@@ -3,7 +3,6 @@
 var fs = require("fs");
 var _ = require("lodash");
 var path = require("path");
-var RSVP = require("rsvp");
 var minimatch = require("minimatch");
 
 // resolver creates a promise resolver for an errback
@@ -17,7 +16,7 @@ function resolver(resolve, reject) {
 }
 
 function readdir(location) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var done = resolver(resolve, reject);
     // In earlier versions of Node, fs.readdir was a two param function;
     // later versions of Node introduced an options parameter in between
@@ -31,19 +30,19 @@ function readdir(location) {
 }
 
 function stat(location) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     fs.stat(location, resolver(resolve, reject));
   });
 }
 
 function unlink(location) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     fs.unlink(location, resolver(resolve, reject));
   });
 }
 
 function rmdir(location) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     return fs.rmdir(location, resolver(resolve, reject));
   });
 }
@@ -77,7 +76,7 @@ function _readdirRecursive(options) {
 
       // Note: we cannot flatten in the chain because we have an array of Promises
       // which might themselves resolve into an array.
-      return RSVP.Promise.all(work).then(_.flatten);
+      return Promise.all(work).then(_.flatten);
     })
     .then(function(results) {
       // Special files were returned as null; cut them from results.
@@ -107,7 +106,7 @@ function readdirRecursive(options) {
 
 function rmdirRecursive(location) {
   return readdir(location).then(function(dirContents) {
-    var cleanThisDir = RSVP.Promise.all(
+    var cleanThisDir = Promise.all(
       _.map(dirContents, function(file) {
         file = path.join(location, file);
         return stat(file).then(function(fstat) {

--- a/lib/functionsConfig.js
+++ b/lib/functionsConfig.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var chalk = require("chalk");
 var api = require("./api");
 var FirebaseError = require("./error");
@@ -72,7 +72,7 @@ exports.setVariablesRecursive = function(projectId, configId, varPath, val) {
   }
   // If 'parsed' is object, call again
   if (_.isPlainObject(parsed)) {
-    return RSVP.all(
+    return Promise.all(
       _.map(parsed, function(item, key) {
         var newVarPath = varPath ? _.join([varPath, key], "/") : key;
         return exports.setVariablesRecursive(projectId, configId, newVarPath, item);
@@ -94,7 +94,7 @@ exports.materializeConfig = function(configName, output) {
   };
 
   var _traverseVariables = function(variables) {
-    return RSVP.all(
+    return Promise.all(
       _.map(variables, function(variable) {
         return _materializeVariable(variable.name);
       })
@@ -114,11 +114,11 @@ exports.materializeConfig = function(configName, output) {
 exports.materializeAll = function(projectId) {
   var output = {};
   return runtimeconfig.configs.list(projectId).then(function(configs) {
-    return RSVP.all(
+    return Promise.all(
       _.map(configs, function(config) {
         if (config.name.match(new RegExp("configs/firebase"))) {
           // ignore firebase config
-          return RSVP.resolve();
+          return Promise.resolve();
         }
         return exports.materializeConfig(config.name, output);
       })

--- a/lib/functionsConfigClone.js
+++ b/lib/functionsConfigClone.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var chalk = require("chalk");
 var FirebaseError = require("./error");
 var functionsConfig = require("./functionsConfig");
@@ -36,7 +36,7 @@ var _cloneVariable = function(varName, toProject) {
 
 var _cloneConfig = function(configName, toProject) {
   return runtimeconfig.variables.list(configName).then(function(variables) {
-    return RSVP.all(
+    return Promise.all(
       _.map(variables, function(variable) {
         return _cloneVariable(variable.name, toProject);
       })
@@ -62,7 +62,7 @@ var _cloneConfigOrVariable = function(key, fromProject, toProject) {
         promises.push(_cloneVariable(variable.name, toProject));
       }
     });
-    return RSVP.all(promises);
+    return Promise.all(promises);
   });
 };
 
@@ -70,7 +70,7 @@ module.exports = function(fromProject, toProject, only, except) {
   except = except || [];
 
   if (only) {
-    return RSVP.all(
+    return Promise.all(
       _.map(only, function(key) {
         return _cloneConfigOrVariable(key, fromProject, toProject);
       })
@@ -79,7 +79,7 @@ module.exports = function(fromProject, toProject, only, except) {
   return functionsConfig.materializeAll(fromProject).then(function(toClone) {
     _.unset(toClone, "firebase"); // Do not clone firebase config
     _applyExcept(toClone, except);
-    return RSVP.all(
+    return Promise.all(
       _.map(toClone, function(val, configId) {
         return functionsConfig.setVariablesRecursive(toProject, configId, "", val);
       })

--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -3,7 +3,7 @@
 var _ = require("lodash");
 var chalk = require("chalk");
 var path = require("path");
-var RSVP = require("rsvp");
+
 var getProjectId = require("./getProjectId");
 var utils = require("./utils");
 var parseTriggers = require("./parseTriggers");
@@ -23,7 +23,7 @@ var FunctionsEmulator = function(options) {
 };
 
 var _pollOperation = function(op, controller) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var poll = function() {
       controller.client
         .getOperation(op[0].name)
@@ -50,7 +50,7 @@ FunctionsEmulator.prototype.stop = function() {
   delete process.env.FIREBASE_PROJECT;
   delete process.env.GCLOUD_PROJECT;
   var controller = this.controller;
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     if (controller) {
       controller.stop().then(resolve);
       // Force-kill controller after 0.5 s
@@ -107,7 +107,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
   } catch (err) {
     var msg = err;
     utils.logWarning(chalk.yellow("functions:") + " Cannot start emulator. " + msg);
-    return RSVP.reject();
+    return Promise.reject();
   }
 
   this.controller = new EmulatorController(controllerConfig);
@@ -137,7 +137,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
             " inside the functions directory."
         );
         logger.debug("Error during trigger parsing: ", e.message);
-        return RSVP.reject(e.message);
+        return Promise.reject(e.message);
       });
     })
     .then(function(triggers) {
@@ -153,7 +153,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
             })
             .catch(function(e) {
               logger.debug("Error while deploying to emulator: " + e + "\n" + e.stack);
-              return RSVP.reject({ name: trigger.name });
+              return Promise.reject({ name: trigger.name });
             });
         }
         if (!shellMode) {
@@ -163,7 +163,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
               chalk.bold("firebase functions:shell") +
               " if you would like to emulate other types of functions."
           );
-          return RSVP.resolve(); // Don't emulate non-HTTPS functions if shell not running
+          return Promise.resolve(); // Don't emulate non-HTTPS functions if shell not running
         }
         logger.debug("Deploying functions locally");
         return controller
@@ -176,13 +176,13 @@ FunctionsEmulator.prototype.start = function(shellMode) {
           })
           .catch(function(e) {
             logger.debug("Error while deploying to emulator: " + e + "\n" + e.stack);
-            return RSVP.reject({ name: trigger.name });
+            return Promise.reject({ name: trigger.name });
           });
       });
-      return RSVP.allSettled(promises);
+      return Promise.allSettled(promises);
     })
     .then(function(operations) {
-      return RSVP.all(
+      return Promise.all(
         _.map(operations, function(operation) {
           if (operation.state === "rejected") {
             utils.logWarning(
@@ -190,10 +190,10 @@ FunctionsEmulator.prototype.start = function(shellMode) {
                 " Failed to emulate " +
                 _.get(operation, "reason.name", "")
             );
-            return RSVP.resolve();
+            return Promise.resolve();
           }
           if (!operation.value) {
-            return RSVP.resolve(); // Emulation was not attempted
+            return Promise.resolve(); // Emulation was not attempted
           }
           return _pollOperation(operation.value, controller).then(function(res) {
             var funcName = _.chain(res)

--- a/lib/functionsShellCommandAction.js
+++ b/lib/functionsShellCommandAction.js
@@ -2,7 +2,7 @@
 
 var repl = require("repl");
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var request = require("request");
 var util = require("util");
 
@@ -50,7 +50,7 @@ module.exports = function(options) {
         "https://firebase.google.com/docs/functions/local-emulator";
     })
     .then(function() {
-      return new RSVP.Promise(function(resolve) {
+      return new Promise(function(resolve) {
         process.on("SIGINT", function() {
           return emulator
             .stop()

--- a/lib/gcp/cloudfunctions.js
+++ b/lib/gcp/cloudfunctions.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var api = require("../api");
-var RSVP = require("rsvp");
+
 var utils = require("../utils");
 var _ = require("lodash");
 var logger = require("../logger");
@@ -20,7 +20,7 @@ function _functionsOpLogReject(func, type, err) {
   } else {
     logger.info(err.message);
   }
-  return RSVP.reject(err.message);
+  return Promise.reject(err.message);
 }
 
 function _generateUploadUrl(projectId, location) {
@@ -35,13 +35,13 @@ function _generateUploadUrl(projectId, location) {
     .then(
       function(result) {
         var responseBody = JSON.parse(result.body);
-        return RSVP.resolve(responseBody.uploadUrl);
+        return Promise.resolve(responseBody.uploadUrl);
       },
       function(err) {
         logger.info(
           "\n\nThere was an issue deploying your functions. Verify that your project has a Google App Engine instance setup at https://console.cloud.google.com/appengine and try again. If this issue persists, please contact support."
         );
-        return RSVP.reject(err);
+        return Promise.reject(err);
       }
     );
 }
@@ -70,7 +70,7 @@ function _createFunction(options) {
     })
     .then(
       function(resp) {
-        return RSVP.resolve({
+        return Promise.resolve({
           func: func,
           eventType: options.eventType,
           done: false,
@@ -120,7 +120,7 @@ function _updateFunction(options) {
     })
     .then(
       function(resp) {
-        return RSVP.resolve({
+        return Promise.resolve({
           func: func,
           done: false,
           name: resp.body.name,
@@ -144,7 +144,7 @@ function _deleteFunction(options) {
     })
     .then(
       function(resp) {
-        return RSVP.resolve({
+        return Promise.resolve({
           func: func,
           done: false,
           name: resp.body.name,
@@ -171,12 +171,12 @@ function _listFunctions(projectId, region) {
         _.forEach(functionsList, function(f) {
           f.functionName = f.name.substring(f.name.lastIndexOf("/") + 1);
         });
-        return RSVP.resolve(functionsList);
+        return Promise.resolve(functionsList);
       },
       function(err) {
         logger.debug("[functions] failed to list functions for " + projectId);
         logger.debug("[functions] " + err.message);
-        return RSVP.reject(err.message);
+        return Promise.reject(err.message);
       }
     );
 }
@@ -195,13 +195,13 @@ function _checkOperation(operation) {
         if (_.has(resp.body, "error")) {
           operation.error = resp.body.error;
         }
-        return RSVP.resolve(operation);
+        return Promise.resolve(operation);
       },
       function(err) {
         logger.debug("[functions] failed to get status of operation: " + operation.name);
         logger.debug("[functions] " + err.message);
         operation.error = err;
-        return RSVP.reject(err.message);
+        return Promise.reject(err.message);
       }
     );
 }

--- a/lib/gcp/cloudlogging.js
+++ b/lib/gcp/cloudlogging.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var RSVP = require("rsvp");
 var api = require("../api");
 
 var version = "v2beta1";
@@ -18,7 +17,7 @@ var _listEntries = function(projectId, filter, pageSize, order) {
       origin: api.cloudloggingOrigin,
     })
     .then(function(result) {
-      return RSVP.resolve(result.body.entries);
+      return Promise.resolve(result.body.entries);
     });
 };
 

--- a/lib/gcp/runtimeconfig.js
+++ b/lib/gcp/runtimeconfig.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var api = require("../api");
-var RSVP = require("rsvp");
+
 var utils = require("../utils");
 var logger = require("../logger");
 var _ = require("lodash");
@@ -15,7 +15,7 @@ function _retryOnServerError(requestFunction) {
         setTimeout(resolve, 1000);
       }).then(requestFunction);
     }
-    return RSVP.reject(err);
+    return Promise.reject(err);
   });
 }
 
@@ -26,7 +26,7 @@ function _listConfigs(projectId) {
       origin: api.runtimeconfigOrigin,
     });
   }).then(function(resp) {
-    return RSVP.resolve(resp.body.configs);
+    return Promise.resolve(resp.body.configs);
   });
 }
 
@@ -44,9 +44,9 @@ function _createConfig(projectId, configId) {
   }).catch(function(err) {
     if (_.get(err, "context.response.statusCode") === 409) {
       // Config has already been created as part of a parallel operation during firebase functions:config:set
-      return RSVP.resolve();
+      return Promise.resolve();
     }
-    return RSVP.reject(err);
+    return Promise.reject(err);
   });
 }
 
@@ -63,9 +63,9 @@ function _deleteConfig(projectId, configId) {
   }).catch(function(err) {
     if (_.get(err, "context.response.statusCode") === 404) {
       logger.debug("Config already deleted.");
-      return RSVP.resolve();
+      return Promise.resolve();
     }
-    return RSVP.reject(err);
+    return Promise.reject(err);
   });
 }
 
@@ -76,7 +76,7 @@ function _listVariables(configPath) {
       origin: api.runtimeconfigOrigin,
     });
   }).then(function(resp) {
-    return RSVP.resolve(resp.body.variables);
+    return Promise.resolve(resp.body.variables);
   });
 }
 
@@ -87,7 +87,7 @@ function _getVariable(varPath) {
       origin: api.runtimeconfigOrigin,
     });
   }).then(function(resp) {
-    return RSVP.resolve(resp.body);
+    return Promise.resolve(resp.body);
   });
 }
 
@@ -110,7 +110,7 @@ function _createVariable(projectId, configId, varId, value) {
         return _createVariable(projectId, configId, varId, value);
       });
     }
-    return RSVP.reject(err);
+    return Promise.reject(err);
   });
 }
 
@@ -139,7 +139,7 @@ function _setVariable(projectId, configId, varId, value) {
       if (_.get(err, "context.response.statusCode") === 404) {
         return _createVariable(projectId, configId, varId, value);
       }
-      return RSVP.reject(err);
+      return Promise.reject(err);
     });
 }
 
@@ -155,9 +155,9 @@ function _deleteVariable(projectId, configId, varId) {
   }).catch(function(err) {
     if (_.get(err, "context.response.statusCode") === 404) {
       logger.debug("Variable already deleted.");
-      return RSVP.resolve();
+      return Promise.resolve();
     }
-    return RSVP.reject(err);
+    return Promise.reject(err);
   });
 }
 

--- a/lib/gcp/storage.js
+++ b/lib/gcp/storage.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var RSVP = require("rsvp");
 var api = require("../api");
 var logger = require("../logger");
 var FirebaseError = require("../error");
@@ -15,19 +14,19 @@ function _getDefaultBucket(projectId) {
       function(resp) {
         if (resp.body.defaultBucket === "undefined") {
           logger.debug("Default storage bucket is undefined.");
-          return RSVP.reject(
+          return Promise.reject(
             new FirebaseError(
               "Your project is being set up. Please wait a minute before deploying again."
             )
           );
         }
-        return RSVP.resolve(resp.body.defaultBucket);
+        return Promise.resolve(resp.body.defaultBucket);
       },
       function(err) {
         logger.info(
           "\n\nThere was an issue deploying your functions. Verify that your project has a Google App Engine instance setup at https://console.cloud.google.com/appengine and try again. If this issue persists, please contact support."
         );
-        return RSVP.reject(err);
+        return Promise.reject(err);
       }
     );
 }

--- a/lib/getProjectNumber.js
+++ b/lib/getProjectNumber.js
@@ -2,11 +2,10 @@
 
 var getProjectId = require("./getProjectId");
 var api = require("./api");
-var RSVP = require("rsvp");
 
 module.exports = function(options) {
   if (options.projectNumber) {
-    return RSVP.resolve(options.projectNumber);
+    return Promise.resolve(options.projectNumber);
   }
   var projectId = getProjectId(options);
   return api

--- a/lib/handlePreviewToggles.js
+++ b/lib/handlePreviewToggles.js
@@ -2,7 +2,6 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var auth = require("./auth");
 var configstore = require("./configstore");
@@ -26,7 +25,7 @@ module.exports = function(args) {
       if (tokens && tokens.refresh_token) {
         next = auth.logout(tokens.refresh_token);
       } else {
-        next = RSVP.resolve();
+        next = Promise.resolve();
       }
       return next.then(function() {
         console.log("Preview feature enabled!");

--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -3,7 +3,6 @@
 var _ = require("lodash");
 var logger = require("../logger");
 var request = require("request");
-var RSVP = require("rsvp");
 
 var getProjectId = require("../getProjectId");
 
@@ -48,7 +47,7 @@ module.exports = function(options) {
       url =
         "https://us-central1-" + getProjectId(options) + ".cloudfunctions.net/" + rewrite.function;
     }
-    return RSVP.resolve(function(req, res, next) {
+    return Promise.resolve(function(req, res, next) {
       logger.info("[hosting] Rewriting", req.url, "to", destLabel, "function", rewrite.function);
       // Extract the __session cookie from headers to forward it to the functions
       var sessionCookie = (req.headers.cookie || "").split(/; ?/).find(function(c) {

--- a/lib/init/features/database.js
+++ b/lib/init/features/database.js
@@ -6,7 +6,6 @@ var prompt = require("../../prompt");
 var logger = require("../../logger");
 var utils = require("../../utils");
 var fsutils = require("../../fsutils");
-var RSVP = require("rsvp");
 
 var defaultRules = JSON.stringify(
   { rules: { ".read": "auth != null", ".write": "auth != null" } },
@@ -16,7 +15,7 @@ var defaultRules = JSON.stringify(
 
 var _getDBRules = function(instance) {
   if (!instance) {
-    return RSVP.resolve(defaultRules);
+    return Promise.resolve(defaultRules);
   }
   return api
     .request("GET", "/.settings/rules.json", {
@@ -85,7 +84,7 @@ module.exports = function(setup, config) {
           default: false,
         });
       }
-      return RSVP.resolve(true);
+      return Promise.resolve(true);
     })
     .then(function(overwrite) {
       if (overwrite) {
@@ -99,6 +98,6 @@ module.exports = function(setup, config) {
           chalk.bold("firebase deploy") +
           "."
       );
-      return RSVP.resolve();
+      return Promise.resolve();
     });
 };

--- a/lib/init/features/functions/index.js
+++ b/lib/init/features/functions/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var chalk = require("chalk");
-var RSVP = require("rsvp");
+
 var _ = require("lodash");
 
 var logger = require("../../../logger");
@@ -29,7 +29,7 @@ module.exports = function(setup, config) {
       enableApi(projectId, "runtimeconfig.googleapis.com");
     });
   } else {
-    enableApis = RSVP.resolve();
+    enableApis = Promise.resolve();
   }
   return enableApis.then(function() {
     return prompt(setup.functions, [

--- a/lib/init/features/functions/npm-dependencies.js
+++ b/lib/init/features/functions/npm-dependencies.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var RSVP = require("rsvp");
 var spawn = require("cross-spawn");
 
 var logger = require("../../../logger");
@@ -16,7 +15,7 @@ exports.askInstallDependencies = function(setup, config) {
     },
   ]).then(function() {
     if (setup.functions.npm) {
-      return new RSVP.Promise(function(resolve) {
+      return new Promise(function(resolve) {
         var installer = spawn("npm", ["install"], {
           cwd: config.projectDir + "/functions",
           stdio: "inherit",

--- a/lib/init/features/hosting.js
+++ b/lib/init/features/hosting.js
@@ -2,7 +2,6 @@
 
 var chalk = require("chalk");
 var fs = require("fs");
-var RSVP = require("rsvp");
 
 var api = require("../../api");
 var logger = require("../../logger");
@@ -55,7 +54,7 @@ module.exports = function(setup, config) {
     var next;
     if (setup.hosting.spa) {
       setup.config.hosting.rewrites = [{ source: "**", destination: "/index.html" }];
-      next = RSVP.resolve();
+      next = Promise.resolve();
     } else {
       // SPA doesn't need a 404 page since everything is index.html
       next = config.askWriteProjectFile(setup.hosting.public + "/404.html", MISSING_TEMPLATE);

--- a/lib/init/index.js
+++ b/lib/init/index.js
@@ -2,7 +2,6 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var logger = require("../logger");
 var features = require("./features");
@@ -11,11 +10,11 @@ var init = function(setup, config, options) {
   var nextFeature = setup.features.shift();
   if (nextFeature) {
     logger.info(chalk.bold("\n" + chalk.gray("=== ") + _.capitalize(nextFeature) + " Setup"));
-    return RSVP.resolve(features[nextFeature](setup, config, options)).then(function() {
+    return Promise.resolve(features[nextFeature](setup, config, options)).then(function() {
       return init(setup, config, options);
     });
   }
-  return RSVP.resolve();
+  return Promise.resolve();
 };
 
 module.exports = init;

--- a/lib/kits/deploy.js
+++ b/lib/kits/deploy.js
@@ -2,7 +2,6 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var FirebaseError = require("../error");
 var functionsConfig = require("../functionsConfig");
@@ -37,7 +36,7 @@ function _deployKitFunctions(functions, options, config, sourceUploadUrl) {
 
   return functionsConfig.getFirebaseConfig(options).then(function(firebaseconfig) {
     // TODO: Do we deal with nested functions? How would we deal with nested functions
-    return RSVP.all(
+    return Promise.all(
       _.map(functions, function(cloudfunction) {
         var functionTrigger = _getFunctionTrigger(cloudfunction, firebaseconfig, config);
         return gcp.cloudfunctions.create({

--- a/lib/kits/pollKits.js
+++ b/lib/kits/pollKits.js
@@ -5,7 +5,6 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var gcp = require("../gcp");
 var pollOperations = require("../pollOperations");
@@ -32,10 +31,10 @@ function _pollKitFunctions(operations) {
   };
 
   var success = function(op) {
-    return RSVP.resolve(_.last(op.func.split("/")).match(/[^-]*/)[0]);
+    return Promise.resolve(_.last(op.func.split("/")).match(/[^-]*/)[0]);
   };
   var fail = function(op) {
-    return RSVP.reject({
+    return Promise.reject({
       kit: _.last(op.func.split("/")).match(/[^-]*/)[0],
       reason: op.error.message,
     });
@@ -57,7 +56,7 @@ module.exports = function(operations, printSuccess, printFail) {
       return printSuccess(successes);
     })
     .catch(function(reason) {
-      // since poll operations uses RSVP.all, will catch immediately on first failure
+      // since poll operations uses Promise.all, will catch immediately on first failure
       return printFail(reason);
     });
 };

--- a/lib/kits/prepareKitsConfig.js
+++ b/lib/kits/prepareKitsConfig.js
@@ -1,7 +1,6 @@
 "use strict";
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var FirebaseError = require("../error");
 var prompt = require("../prompt");
@@ -48,9 +47,9 @@ function _promptForKitConfig(kitName, kitConfig) {
     })
     .then(function(configList) {
       // checking that all values that need to be set are set and of the correct type
-      return RSVP.allSettled(
+      return Promise.allSettled(
         _.map(kitConfig, function(question) {
-          return new RSVP.Promise(function(resolve, reject) {
+          return new Promise(function(resolve, reject) {
             var configValue = configList[question.name];
             // if value still isn't set
             if (!("default" in question) && !configValue) {
@@ -74,7 +73,7 @@ function _promptForKitConfig(kitName, kitConfig) {
       );
     })
     .then(function(allPrompts) {
-      return new RSVP.Promise(function(resolve, reject) {
+      return new Promise(function(resolve, reject) {
         var failed = _.chain(allPrompts)
           .filter({ state: "rejected" })
           .map("reason")

--- a/lib/kits/prepareKitsUpload.js
+++ b/lib/kits/prepareKitsUpload.js
@@ -9,7 +9,6 @@ var tar = require("tar");
 var path = require("path");
 var request = require("request");
 var tmp = require("tmp");
-var RSVP = require("rsvp");
 
 var fsAsync = require("../fsAsync");
 var api = require("../api");
@@ -21,7 +20,7 @@ var DEFAULT_REGION = gcp.cloudfunctions.DEFAULT_REGION;
 var CONFIG_DEST_FILE = ".runtimeconfig.json";
 
 var _pipeAsync = function(from, to) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     to.on("finish", resolve);
     to.on("error", reject);
     from.pipe(to);
@@ -47,17 +46,17 @@ function _retrieveFile(githubConfig) {
     })
     .then(function(result) {
       if (result.status !== 200) {
-        return RSVP.reject(
+        return Promise.reject(
           new FirebaseError(
             githubConfig.path + " could not be retrieved for kit at " + githubConfig.repo
           )
         );
       }
       var buf = Buffer.from(result.body.content, "base64");
-      return RSVP.resolve(buf);
+      return Promise.resolve(buf);
     })
     .catch(function(error) {
-      return RSVP.reject(error);
+      return Promise.reject(error);
     });
 }
 

--- a/lib/parseTriggers.js
+++ b/lib/parseTriggers.js
@@ -3,13 +3,13 @@
 var FirebaseError = require("./error");
 var fork = require("child_process").fork;
 var path = require("path");
-var RSVP = require("rsvp");
+
 var _ = require("lodash");
 
 var TRIGGER_PARSER = path.resolve(__dirname, "./triggerParser.js");
 
 module.exports = function(projectId, sourceDir, configValues, firebaseConfig) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var env = { GCLOUD_PROJECT: projectId };
     if (!_.isEmpty(configValues)) {
       env.CLOUD_RUNTIME_CONFIG = JSON.stringify(configValues);

--- a/lib/pollOperations.js
+++ b/lib/pollOperations.js
@@ -1,13 +1,12 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
 
 var MAX_POLL_RETRIES = 2;
 
 function pollOperation(op, pollFunction, interval, pollFailCount) {
   pollFailCount = pollFailCount || 0;
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     function poll() {
       pollFunction(op)
         .then(function(result) {
@@ -39,7 +38,7 @@ function pollAndRetryOperations(
   retryCondition
 ) {
   // This function assumes that a Google.LongRunning operation is being polled
-  return RSVP.all(
+  return Promise.all(
     _.map(operations, function(op) {
       return pollOperation(op, pollFunction, interval).then(function(result) {
         if (!result.error) {

--- a/lib/prepareFirebaseRules.js
+++ b/lib/prepareFirebaseRules.js
@@ -2,7 +2,6 @@
 
 var chalk = require("chalk");
 var fs = require("fs");
-var RSVP = require("rsvp");
 
 var api = require("./api");
 var utils = require("./utils");
@@ -57,11 +56,11 @@ var prepareFirebaseRules = function(component, options, payload) {
         payload[component] = {
           rules: [{ name: options.config.get(rulesFileName), content: src }],
         };
-        return RSVP.resolve();
+        return Promise.resolve();
       });
   }
 
-  return RSVP.resolve();
+  return Promise.resolve();
 };
 
 module.exports = prepareFirebaseRules;

--- a/lib/prepareFunctionsUpload.js
+++ b/lib/prepareFunctionsUpload.js
@@ -6,7 +6,7 @@ var chalk = require("chalk");
 var filesize = require("filesize");
 var fs = require("fs");
 var path = require("path");
-var RSVP = require("rsvp");
+
 var tmp = require("tmp");
 
 var FirebaseError = require("./error");
@@ -20,7 +20,7 @@ var fsAsync = require("./fsAsync");
 var CONFIG_DEST_FILE = ".runtimeconfig.json";
 
 var _getFunctionsConfig = function(context) {
-  var next = RSVP.resolve({});
+  var next = Promise.resolve({});
   if (context.runtimeConfigEnabled) {
     next = functionsConfig.materializeAll(context.firebaseConfig.projectId).catch(function(err) {
       logger.debug(err);
@@ -44,7 +44,7 @@ var _getFunctionsConfig = function(context) {
 };
 
 var _pipeAsync = function(from, to) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     to.on("finish", resolve);
     to.on("error", reject);
     from.pipe(to);
@@ -121,7 +121,7 @@ module.exports = function(context, options) {
     .then(function(triggers) {
       options.config.set("functions.triggers", triggers);
       if (options.config.get("functions.triggers").length === 0) {
-        return RSVP.resolve(null);
+        return Promise.resolve(null);
       }
       return _packageSource(options, sourceDir, configValues);
     });

--- a/lib/prepareUpload.js
+++ b/lib/prepareUpload.js
@@ -2,7 +2,7 @@
 
 var fs = require("fs");
 var path = require("path");
-var RSVP = require("rsvp");
+
 var tar = require("tar");
 var tmp = require("tmp");
 
@@ -45,7 +45,7 @@ module.exports = function(options) {
       };
     })
     .catch(function(err) {
-      return RSVP.reject(
+      return Promise.reject(
         new FirebaseError("There was an issue preparing Hosting files for upload.", {
           original: err,
           exit: 2,

--- a/lib/profileReport.js
+++ b/lib/profileReport.js
@@ -6,7 +6,6 @@ var Set = require("es6-set");
 var fs = require("fs");
 var _ = require("lodash");
 var readline = require("readline");
-var RSVP = require("rsvp");
 
 var FirebaseError = require("./error");
 var logger = require("./logger");
@@ -402,7 +401,7 @@ ProfileReport.prototype.parse = function(onLine, onClose) {
   var tmpFile = this.tempFile;
   var outStream = this.output;
   var isInput = this.options.isInput;
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var rl = readline.createInterface({
       input: fs.createReadStream(tmpFile),
     });

--- a/lib/profiler.js
+++ b/lib/profiler.js
@@ -5,7 +5,7 @@ var _ = require("lodash");
 var ora = require("ora");
 var readline = require("readline");
 var request = require("request");
-var RSVP = require("rsvp");
+
 var tmp = require("tmp");
 
 var api = require("./api");
@@ -29,7 +29,7 @@ module.exports = function(options) {
   };
 
   return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
-    return new RSVP.Promise(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       var fileOut = !!options.output;
       var tmpFile = tmp.tmpNameSync();
       var tmpStream = fs.createWriteStream(tmpFile);

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -3,10 +3,9 @@
 var inquirer = require("inquirer");
 var _ = require("lodash");
 var FirebaseError = require("./error");
-var RSVP = require("rsvp");
 
 var prompt = function(options, questions) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     var prompts = [];
     for (var i = 0; i < questions.length; i++) {
       if (!options[questions[i].name]) {

--- a/lib/requireAccess.js
+++ b/lib/requireAccess.js
@@ -2,7 +2,6 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
 
 var api = require("./api");
 var getInstanceId = require("./getInstanceId");
@@ -33,7 +32,7 @@ module.exports = function(options, authScopes) {
     })
     .catch(function(err) {
       if (err && err.exit && _.get(err, "context.body.error.code") !== "PROJECT_NOT_FOUND") {
-        return RSVP.reject(err);
+        return Promise.reject(err);
       }
 
       return identifierToProjectId(projectId).then(function(realProjectId) {
@@ -43,7 +42,7 @@ module.exports = function(options, authScopes) {
             fixCommand += " --alias " + options.projectAlias;
           }
 
-          return RSVP.reject(
+          return Promise.reject(
             new FirebaseError(
               "Tried to access unrecognized project " +
                 chalk.bold(projectId) +
@@ -59,7 +58,7 @@ module.exports = function(options, authScopes) {
           );
         }
 
-        return RSVP.reject(
+        return Promise.reject(
           new FirebaseError("Unable to authorize access to project " + chalk.bold(projectId), {
             exit: 1,
           })

--- a/lib/requireAuth.js
+++ b/lib/requireAuth.js
@@ -2,7 +2,7 @@
 
 var _ = require("lodash");
 var chalk = require("chalk");
-var RSVP = require("rsvp");
+
 var autoAuth = require("google-auto-auth");
 
 var api = require("./api");
@@ -16,7 +16,7 @@ var AUTH_ERROR = new FirebaseError(
 );
 
 function _autoAuth(options, authScopes) {
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     logger.debug("> attempting to authenticate via app default credentials");
     autoAuth({ scopes: authScopes }).getToken(function(err, token) {
       if (err) {
@@ -60,11 +60,11 @@ module.exports = function(options, authScopes) {
 
   if (tokenOpt) {
     api.setRefreshToken(tokenOpt);
-    return RSVP.resolve();
+    return Promise.resolve();
   }
 
   if (!user || !tokens) {
-    return new RSVP.Promise(function(resolve, reject) {
+    return new Promise(function(resolve, reject) {
       if (configstore.get("session")) {
         return reject(
           new FirebaseError(
@@ -81,5 +81,5 @@ module.exports = function(options, authScopes) {
   options.user = user;
   options.tokens = tokens;
   api.setRefreshToken(tokens.refresh_token);
-  return RSVP.resolve();
+  return Promise.resolve();
 };

--- a/lib/requireConfig.js
+++ b/lib/requireConfig.js
@@ -1,13 +1,12 @@
 "use strict";
 
-var RSVP = require("rsvp");
 var FirebaseError = require("./error");
 
 module.exports = function(options) {
   if (options.config) {
-    return RSVP.resolve();
+    return Promise.resolve();
   }
-  return RSVP.reject(
+  return Promise.reject(
     options.configError ||
       new FirebaseError("Not in a Firebase project directory (could not locate firebase.json)", {
         exit: 1,

--- a/lib/serve/hosting.js
+++ b/lib/serve/hosting.js
@@ -2,7 +2,7 @@
 
 var chalk = require("chalk");
 var FirebaseError = require("../error");
-var RSVP = require("rsvp");
+
 var superstatic = require("superstatic").server;
 var utils = require("../utils");
 var detectProjectRoot = require("../detectProjectRoot");
@@ -70,7 +70,7 @@ function _startServer(options) {
 }
 
 function _stopServer() {
-  return RSVP.resolve();
+  return Promise.resolve();
 }
 
 module.exports = {

--- a/lib/serve/index.js
+++ b/lib/serve/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var RSVP = require("rsvp");
+
 var logger = require("../logger");
 var TARGETS = {
   hosting: require("./hosting"),
@@ -11,16 +11,16 @@ var TARGETS = {
 var _serve = function(options) {
   var targetNames = options.targets;
   options.port = parseInt(options.port, 10);
-  return RSVP.all(
+  return Promise.all(
     _.map(targetNames, function(targetName) {
       var target = TARGETS[targetName];
       return target.start(options);
     })
   ).then(function() {
-    return new RSVP.Promise(function(resolve) {
+    return new Promise(function(resolve) {
       process.on("SIGINT", function() {
         logger.info("Shutting down...");
-        return RSVP.all(
+        return Promise.all(
           _.forEach(targetNames, function(targetName) {
             var target = TARGETS[targetName];
             return target.stop(options);

--- a/lib/track.js
+++ b/lib/track.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var ua = require("universal-analytics");
-var RSVP = require("rsvp");
 
 var _ = require("lodash");
 var configstore = require("./configstore");
@@ -21,7 +20,7 @@ var visitor = ua(process.env.FIREBASE_ANALYTICS_UA || "UA-29174744-3", anonId, {
 });
 
 module.exports = function(action, label, duration) {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     if (!_.isString(action) || !_.isString(label)) {
       logger.debug("track received non-string arguments:", action, label);
       resolve();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,7 +3,6 @@
 var _ = require("lodash");
 var chalk = require("chalk");
 var Readable = require("stream").Readable;
-var RSVP = require("rsvp");
 
 var configstore = require("./configstore");
 var FirebaseError = require("./error");
@@ -112,7 +111,7 @@ module.exports = {
    * @param {Object} options the error options
    */
   reject: function(message, options) {
-    return RSVP.reject(new FirebaseError(message, options));
+    return Promise.reject(new FirebaseError(message, options));
   },
   /**
    * Print out an explanatory message if a TTY is detected for how to manage STDIN

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -3,7 +3,7 @@
 var JSONSchema = require("jsonschema");
 var jsonschema = new JSONSchema.Validator();
 var request = require("request");
-var RSVP = require("rsvp");
+
 var FirebaseError = require("./error");
 
 var NAMED_SCHEMAS = {
@@ -25,7 +25,7 @@ var Validator = function(url) {
 
 Validator.prototype.validate = function(data) {
   var self = this;
-  return new RSVP.Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     self._validateQueue.push({
       data: data,
       resolve: resolve,

--- a/package.json
+++ b/package.json
@@ -37,13 +37,7 @@
   "bugs": {
     "url": "https://github.com/firebase/firebase-tools/issues"
   },
-  "files": [
-    "bin/**",
-    "lib/**",
-    "commands/**",
-    "templates/**",
-    "index.js"
-  ],
+  "files": ["bin/**", "lib/**", "commands/**", "templates/**", "index.js"],
   "homepage": "https://github.com/firebase/firebase-tools",
   "dependencies": {
     "JSONStream": "^1.2.1",
@@ -72,10 +66,9 @@
     "minimatch": "^3.0.4",
     "open": "^0.0.5",
     "ora": "0.2.3",
-    "portfinder": "^0.4.0",
+    "portfinder": "^1.0.13",
     "progress": "^2.0.0",
     "request": "^2.58.0",
-    "rsvp": "^3.0.18",
     "semver": "^5.0.3",
     "superstatic": "^5.0.1",
     "tar": "^4.3.0",

--- a/scripts/test-functions-config.js
+++ b/scripts/test-functions-config.js
@@ -6,7 +6,6 @@ var exec = require("child_process").exec;
 var expect = require("chai").expect;
 var fs = require("fs-extra");
 var tmp = require("tmp");
-var RSVP = require("rsvp");
 
 var api = require("../lib/api");
 var scopes = require("../lib/scopes");
@@ -31,7 +30,7 @@ var postTest = function() {
 };
 
 var set = function(expression) {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec(localFirebase + " functions:config:set " + expression, { cwd: tmpDir }, function(err) {
       expect(err).to.be.null;
       resolve();
@@ -40,7 +39,7 @@ var set = function(expression) {
 };
 
 var unset = function(key) {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec(localFirebase + " functions:config:unset " + key, { cwd: tmpDir }, function(err) {
       expect(err).to.be.null;
       resolve();
@@ -49,7 +48,7 @@ var unset = function(key) {
 };
 
 var getAndCompare = function(expected) {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec(localFirebase + " functions:config:get", { cwd: tmpDir }, function(err, stdout) {
       expect(JSON.parse(stdout)).to.deep.equal(expected);
       resolve();
@@ -110,7 +109,7 @@ var main = function() {
     })
     .catch(function(err) {
       console.log(chalk.red("Error while running tests: "), err);
-      return RSVP.resolve();
+      return Promise.resolve();
     })
     .then(postTest);
 };

--- a/scripts/test-functions-deploy.js
+++ b/scripts/test-functions-deploy.js
@@ -12,7 +12,7 @@ var api = require("../lib/api");
 var scopes = require("../lib/scopes");
 var configstore = require("../lib/configstore");
 var extractTriggers = require("../lib/extractTriggers");
-var RSVP = require("rsvp");
+
 var chalk = require("chalk");
 var firebase = require("firebase");
 var functions = require("firebase-functions");
@@ -87,7 +87,7 @@ var checkFunctionsListMatch = function(expectedFunctions) {
 
 var testCreateUpdate = function() {
   fs.copySync(functionsSource, tmpDir + "/functions/index.js");
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec(localFirebase + " deploy", { cwd: tmpDir }, function(err, stdout) {
       console.log(stdout);
       expect(err).to.be.null;
@@ -98,7 +98,7 @@ var testCreateUpdate = function() {
 
 var testCreateUpdateWithFilter = function() {
   fs.copySync(functionsSource, tmpDir + "/functions/index.js");
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec(
       localFirebase + " deploy --only functions:dbAction,functions:httpsAction",
       { cwd: tmpDir },
@@ -112,7 +112,7 @@ var testCreateUpdateWithFilter = function() {
 };
 
 var testDelete = function() {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec("> functions/index.js &&" + localFirebase + " deploy", { cwd: tmpDir }, function(
       err,
       stdout
@@ -125,7 +125,7 @@ var testDelete = function() {
 };
 
 var testDeleteWithFilter = function() {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec(
       "> functions/index.js &&" + localFirebase + " deploy --only functions:dbAction",
       { cwd: tmpDir },
@@ -139,7 +139,7 @@ var testDeleteWithFilter = function() {
 };
 
 var testUnknownFilter = function() {
-  return new RSVP.Promise(function(resolve) {
+  return new Promise(function(resolve) {
     exec(
       "> functions/index.js &&" + localFirebase + " deploy --only functions:unknownFilter",
       { cwd: tmpDir },
@@ -185,7 +185,7 @@ var writeToDB = function(path) {
     .child(uuid)
     .set({ foo: "bar" })
     .then(function() {
-      return RSVP.resolve(uuid);
+      return Promise.resolve(uuid);
     });
 };
 
@@ -214,7 +214,7 @@ var publishPubsub = function(topic) {
     })
     .then(function(resp) {
       expect(resp.status).to.equal(200);
-      return RSVP.resolve(uuid);
+      return Promise.resolve(uuid);
     });
 };
 
@@ -236,7 +236,7 @@ var saveToStorage = function() {
     })
     .then(function(resp) {
       expect(resp.status).to.equal(200);
-      return RSVP.resolve(uuid);
+      return Promise.resolve(uuid);
     });
 };
 
@@ -254,7 +254,7 @@ var testFunctionsTrigger = function() {
   var checkGcsAction = saveToStorage().then(function(uuid) {
     return waitForAck(uuid, "storage triggered function");
   });
-  return RSVP.all([
+  return Promise.all([
     checkDbAction,
     checkNestedDbAction,
     checkHttpsAction,
@@ -297,7 +297,7 @@ var main = function() {
     })
     .catch(function(err) {
       console.log(chalk.red("Error while running tests: "), err);
-      return RSVP.resolve();
+      return Promise.resolve();
     })
     .then(postTest);
 };

--- a/test/lib/command.spec.js
+++ b/test/lib/command.spec.js
@@ -4,7 +4,6 @@ var chai = require("chai");
 var expect = chai.expect;
 chai.use(require("chai-as-promised"));
 
-var RSVP = require("rsvp");
 var Command = require("../../lib/command");
 
 describe("Command", function() {
@@ -42,7 +41,7 @@ describe("Command", function() {
       var run = command
         .action(function(options) {
           options.foo = "bar";
-          return RSVP.resolve(options);
+          return Promise.resolve(options);
         })
         .runner();
 
@@ -53,7 +52,7 @@ describe("Command", function() {
       var run = command
         .before(function(options) {
           options.foo = true;
-          return RSVP.resolve();
+          return Promise.resolve();
         })
         .action(function(options) {
           if (options.foo) {


### PR DESCRIPTION
Now that we are Node 4 and up, we can stop relying on RSVP for basic Promise implementation. This replaces RSVP everywhere and removes it as a dependency. It also updates `portfinder` to a version that has a promise-based implementation.