### PR TITLE
Stop setting logFile when initializing functions emulator

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -77,10 +77,8 @@ FunctionsEmulator.prototype._getPorts = function() {
 };
 
 FunctionsEmulator.prototype._getConfigOptions = function() {
-  var logFilename = path.join(process.cwd(), "/cloud-functions-emulator.log");
   var ports = this._getPorts();
   return _.merge(ports, {
-    logFile: logFilename,
     maxIdle: 540000,
     tail: true,
   });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -198,9 +198,13 @@ module.exports = {
   promiseAllSettled: function(promises) {
     var wrappedPromises = _.map(promises, function(p) {
       return Promise.resolve(p)
-        .then(function(val) { return { state: "fulfilled", value: val }; })
-        .catch(function(err) { return { state: "rejected", reason: err }; });
+        .then(function(val) {
+          return { state: "fulfilled", value: val };
+        })
+        .catch(function(err) {
+          return { state: "rejected", reason: err };
+        });
     });
     return Promise.all(wrappedPromises);
-  }
+  },
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes https://github.com/firebase/firebase-tools/issues/720, and other scenarios where asynchronous operations inside emulated functions resulted in the error "socket hang up".
	 
### Scenarios Tested

Emulated this function with `firebase serve`, works with this branch, but gets 500 status and "socket hang up" on master:

```
exports.asyncTest1 = functions.https.onRequest((req, res) => {
  console.log("asyncTest1 start");
  setTimeout(function () {
    console.log("asyncTest1 send");
    res.send("All done... after 500ms...");
  }, 500);
});
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
