### PR TITLE
Bring back ability to configure host of emulated functions

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -76,11 +76,13 @@ FunctionsEmulator.prototype._getPorts = function() {
   return portsConfig;
 };
 
-FunctionsEmulator.prototype._getConfigOptions = function() {
+FunctionsEmulator.prototype._getConfigOptions = function(options) {
   var ports = this._getPorts();
   return _.merge(ports, {
     maxIdle: 540000,
     tail: true,
+    host: options.host,
+    bindHost: options.host,
   });
 };
 
@@ -91,7 +93,7 @@ FunctionsEmulator.prototype.start = function(shellMode) {
   var emulatedFunctions = this.emulatedFunctions;
   var instance = this;
   var functionsDir = path.join(options.config.projectDir, options.config.get("functions.source"));
-  var controllerConfig = this._getConfigOptions();
+  var controllerConfig = this._getConfigOptions(options);
   var firebaseConfig;
   var emulatedProviders = {};
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Reverts https://github.com/firebase/firebase-tools/pull/614 
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
