### PR TITLE
Fix incorrect info message for no HTTPS functions emulated

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -157,12 +157,6 @@ FunctionsEmulator.prototype.start = function(shellMode) {
             });
         }
         if (!shellMode) {
-          utils.logBullet(
-            chalk.cyan.bold("functions:") +
-              " No HTTPS functions found. Use " +
-              chalk.bold("firebase functions:shell") +
-              " if you would like to emulate other types of functions."
-          );
           return Promise.resolve(); // Don't emulate non-HTTPS functions if shell not running
         }
         logger.debug("Deploying functions locally");
@@ -226,6 +220,16 @@ FunctionsEmulator.prototype.start = function(shellMode) {
       if (emulatedFunctions.length > 0) {
         track("Functions Emulation", providerList, emulatedFunctions.length);
       } else {
+        if (!shellMode) {
+          utils.logBullet(
+            chalk.cyan.bold("functions:") +
+              " No HTTPS functions found. Use " +
+              chalk.bold("firebase functions:shell") +
+              " if you would like to emulate other types of functions."
+          );
+        } else {
+          utils.logBullet(chalk.cyan.bold("functions:") + " No functions to emulate.");
+        }
         return instance.stop();
       }
     })


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fix issue where "No HTTPS functions found" was displayed even when there were HTTPS functions.
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
