### PR TITLE
bugfix(cmd-use-clear) Removed automatic use of aliased firebase project

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -172,9 +172,6 @@ Command.prototype.applyRC = function(options) {
   if (rcProject) {
     options.projectAlias = options.project;
     options.project = rcProject;
-  } else if (!options.project && _.size(aliases) === 1) {
-    options.projectAlias = _.head(_.keys(aliases));
-    options.project = _.head(_.values(aliases));
   }
 };
 


### PR DESCRIPTION
@Memeriaj 

### Description
Before every command, `applyRc` runs. In `applyRc`, there exists a conditional check: 
```javascript
else if (!options.project && _.size(aliases) === 1) {
    options.projectAlias = _.head(_.keys(aliases));
    options.project = _.head(_.values(aliases));
  }
```

If there is **no active project** and there exists exactly **one project with an alias**, when running a command, the **one project with an alias** will be used.

This leads to some confusing logic. When a user runs `firebase use --clear`, they expect the active project to be cleared, but the current logic will lead to a false sense that the active project was never cleared.

### Scenarios Tested
Scenarios:
1. User is using the **one aliased project** as the active project
... User runs `firebase use --clear`. User runs `firebase use`. The same **one aliased project* shows up as the active project.
2. User has **one aliased project** and clears the active project
... Running a command will use the **one aliased project**
... Running `firebase use` will show the **one aliased project** as the active project
3. When user has **more than one aliased project**, and clears the active project
... Running a command will see a "No Active Project" error message.
... Running `firebase use` will show that there is no active project.
