### PR TITLE
Make firestore delete all work for many collections

### DIFF
--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -340,6 +340,10 @@ FirestoreDelete.prototype._listCollectionIds = function() {
     .request("POST", url, {
       auth: true,
       origin: api.firestoreOrigin,
+      data: {
+        // Maximum 32-bit integer
+        pageSize: 2147483647
+      }
     })
     .then(function(res) {
       return res.body.collectionIds || [];

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -342,8 +342,8 @@ FirestoreDelete.prototype._listCollectionIds = function() {
       origin: api.firestoreOrigin,
       data: {
         // Maximum 32-bit integer
-        pageSize: 2147483647
-      }
+        pageSize: 2147483647,
+      },
     })
     .then(function(res) {
       return res.body.collectionIds || [];


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #782
	 
### Scenarios Tested

Tried 100 collections, worked great:

```shell
$ ./bin/firebase --project=fir-dumpster firestore:delete --all-collections
? You are about to delete YOUR ENTIRE DATABASE. Are you sure? Yes
Deleting the following collections: 0, 1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 2, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 3, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 4, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 5, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 6, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 7,70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 8, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 9, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99
Deleted 100 docs
```

### Sample Commands

N/A