### PR TITLE
Warm users when functions/index.js contains non-functions exports

### DIFF
--- a/lib/triggerParser.js
+++ b/lib/triggerParser.js
@@ -31,15 +31,29 @@ var EXIT = function() {
         EXIT
       );
       return;
-    } else if (/Firebase config variables are not available/.test(e.message)) {
+    }
+    if (/Firebase config variables are not available/.test(e.message)) {
       process.send(
         {
           error:
-            'Error occurred while parsing your function triggers. Please ensure you have the latest firebase-functions SDK by running "npm i --save firebase-functions@latest" inside your functions folder.\n\n' +
+            "Error occurred while parsing your function triggers. " +
+            'Please ensure you have the latest firebase-functions SDK by running "npm i --save firebase-functions@latest" inside your functions folder.\n\n' +
             e.stack,
         },
         EXIT
       );
+      return;
+    }
+    if (/Maximum call stack size exceeded/.test(e.message)) {
+      process.send(
+        {
+          error:
+            "Error occurred while parsing your function triggers. Please ensure that index.js only " +
+            "exports cloud functions.\n\n",
+        },
+        EXIT
+      );
+      return;
     }
 
     process.send(
@@ -54,7 +68,7 @@ var EXIT = function() {
   try {
     extractTriggers(mod, triggers);
   } catch (err) {
-    process.send({ error: err.message }, EXIT);
+    process.send({ error: err.message + err.stack }, EXIT);
   }
 
   process.send({ triggers: triggers }, EXIT);

--- a/lib/triggerParser.js
+++ b/lib/triggerParser.js
@@ -44,17 +44,6 @@ var EXIT = function() {
       );
       return;
     }
-    if (/Maximum call stack size exceeded/.test(e.message)) {
-      process.send(
-        {
-          error:
-            "Error occurred while parsing your function triggers. Please ensure that index.js only " +
-            "exports cloud functions.\n\n",
-        },
-        EXIT
-      );
-      return;
-    }
 
     process.send(
       {
@@ -68,7 +57,18 @@ var EXIT = function() {
   try {
     extractTriggers(mod, triggers);
   } catch (err) {
-    process.send({ error: err.message + err.stack }, EXIT);
+    if (/Maximum call stack size exceeded/.test(err.message)) {
+      process.send(
+        {
+          error:
+            "Error occurred while parsing your function triggers. Please ensure that index.js only " +
+            "exports cloud functions.\n\n",
+        },
+        EXIT
+      );
+      return;
+    }
+    process.send({ error: err.message }, EXIT);
   }
 
   process.send({ triggers: triggers }, EXIT);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Ran into this issue myself, where I accidentally exported a Firebase app in my functions/index.js. This caused a stack overflow in extractTriggers.js, since though the Firebase app was a group of nested functions and then recursively tried to parse it. Getting the error message "Call stack size exceeded" was extremely difficult to debug. This PR ensures CLI gives a more instructive error message.

### Scenarios Tested

- Deploy functions that only had exports which were cloud functions -> successful deploy
- Deploy functions where index.js also exported a Firebase app -> appropriate warning message. 

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
