### PR TITLE
expose firestore.rules check independent from deploy

### DIFF
--- a/commands/firestore-rules-check.js
+++ b/commands/firestore-rules-check.js
@@ -10,17 +10,4 @@ module.exports = new Command("firestore:rules:check")
   .before(requireAccess, [scopes.CLOUD_PLATFORM])
   .action(function(options) {
     return PrepareRules({ firestoreRules: true, firestoreIndexes: false }, options);
-    /*
-    return firestoreIndexes.list(options.project).then(function(indexes) {
-      var jsonSpec = _makeJsonSpec(indexes);
-
-      if (options.pretty) {
-        _prettyPrint(indexes);
-      } else {
-        logger.info(JSON.stringify(jsonSpec, undefined, 2));
-      }
-
-      return jsonSpec;
-    });
-    */
   });

--- a/commands/firestore-rules-check.js
+++ b/commands/firestore-rules-check.js
@@ -1,0 +1,44 @@
+"use strict";
+
+var Command = require("../lib/command");
+var requireAccess = require("../lib/requireAccess");
+var scopes = require("../lib/scopes");
+// var logger = require("../lib/logger");
+// var _ = require("lodash");
+var PrepareRules = require("../lib/deploy/firestore/prepare.js");
+
+/*
+var _prettyPrint = function(indexes) {
+  indexes.forEach(function(index) {
+    logger.info(firestoreIndexes.toPrettyString(index));
+  });
+};
+
+var _makeJsonSpec = function(indexes) {
+  return {
+    indexes: indexes.map(function(index) {
+      return _.pick(index, ["collectionId", "fields"]);
+    }),
+  };
+};
+*/
+
+module.exports = new Command("firestore:rules:check")
+  .description("Checks if your firestore rules can compile.")
+  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .action(function(options) {
+    return PrepareRules({ firestoreRules: true, firestoreIndexes: false }, options);
+    /*
+    return firestoreIndexes.list(options.project).then(function(indexes) {
+      var jsonSpec = _makeJsonSpec(indexes);
+
+      if (options.pretty) {
+        _prettyPrint(indexes);
+      } else {
+        logger.info(JSON.stringify(jsonSpec, undefined, 2));
+      }
+
+      return jsonSpec;
+    });
+    */
+  });

--- a/commands/firestore-rules-check.js
+++ b/commands/firestore-rules-check.js
@@ -3,25 +3,7 @@
 var Command = require("../lib/command");
 var requireAccess = require("../lib/requireAccess");
 var scopes = require("../lib/scopes");
-// var logger = require("../lib/logger");
-// var _ = require("lodash");
 var PrepareRules = require("../lib/deploy/firestore/prepare.js");
-
-/*
-var _prettyPrint = function(indexes) {
-  indexes.forEach(function(index) {
-    logger.info(firestoreIndexes.toPrettyString(index));
-  });
-};
-
-var _makeJsonSpec = function(indexes) {
-  return {
-    indexes: indexes.map(function(index) {
-      return _.pick(index, ["collectionId", "fields"]);
-    }),
-  };
-};
-*/
 
 module.exports = new Command("firestore:rules:check")
   .description("Checks if your firestore rules can compile.")

--- a/commands/index.js
+++ b/commands/index.js
@@ -25,6 +25,9 @@ module.exports = function(client) {
   client.firestore = {
     delete: loadCommand("firestore-delete"),
     indexes: loadCommand("firestore-indexes-list"),
+    rules: {
+      check: loadCommand("firestore-rules-check"),
+    },
   };
 
   client.deploy = loadCommand("deploy");


### PR DESCRIPTION
### Description

this PR exposes the firestore.rules compilation check that is coupled with the deploy step.

by exposing this step, you can test that the rules are in good shape as a pre-hook, within your testing stage of your CI or just for fun.

such a command would prevent a "gotcha" where during deploy in a CI pipeline, you get a compilation failure. 
	 
### Scenarios Tested

ran the command on a working firestore.rules and exit with 0
ran the command on a malformed firestore.rules and did not exit with 0

### Sample Commands

firebase firestore:rules:check