### PR TITLE
Add support for ARRAY_CONTAINS index mode

### DIFF
--- a/lib/firestore/indexes.js
+++ b/lib/firestore/indexes.js
@@ -5,7 +5,7 @@ var chalk = require("chalk");
 var FirebaseError = require("../../lib/error");
 var loadCJSON = require("../../lib/loadCJSON");
 
-var VALID_INDEX_MODES = ["ASCENDING", "DESCENDING"];
+var VALID_INDEX_MODES = ["ASCENDING", "DESCENDING", "ARRAY_CONTAINS"];
 
 /**
  * Validate an index is correctly formed, throws an exception for all


### PR DESCRIPTION
This makes `ARRAY_CONTAINS` a valid index mode.  Even though this works today, there is no SDK support for querying these indexes so it might not make sense to merge this yet.

Also: should we expand the command-line API to allow disabling of certain single-field indexes?