### PR TITLE
Add MultiDB support for database:* commands

### DIFF
--- a/commands/database-get.js
+++ b/commands/database-get.js
@@ -49,8 +49,8 @@ module.exports = new Command("database:get <path>")
   .option("--end-at <val>", "end results at <val> (based on specified ordering)")
   .option("--equal-to <val>", "restrict results to <val> (based on specified ordering)")
   .option(
-    "--instance <name>",
-    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+    "--instance <instance>",
+    "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
   .before(requireAccess)
   .action(function(path, options) {

--- a/commands/database-get.js
+++ b/commands/database-get.js
@@ -48,7 +48,10 @@ module.exports = new Command("database:get <path>")
   .option("--start-at <val>", "start results at <val> (based on specified ordering)")
   .option("--end-at <val>", "end results at <val> (based on specified ordering)")
   .option("--equal-to <val>", "restrict results to <val> (based on specified ordering)")
-  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
+  .option(
+    "--instance <name>",
+    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+  )
   .before(requireAccess)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-get.js
+++ b/commands/database-get.js
@@ -48,7 +48,7 @@ module.exports = new Command("database:get <path>")
   .option("--start-at <val>", "start results at <val> (based on specified ordering)")
   .option("--end-at <val>", "end results at <val> (based on specified ordering)")
   .option("--equal-to <val>", "restrict results to <val> (based on specified ordering)")
-  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
+  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-get.js
+++ b/commands/database-get.js
@@ -48,6 +48,7 @@ module.exports = new Command("database:get <path>")
   .option("--start-at <val>", "start results at <val> (based on specified ordering)")
   .option("--end-at <val>", "end results at <val> (based on specified ordering)")
   .option("--equal-to <val>", "restrict results to <val> (based on specified ordering)")
+  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-profile.js
+++ b/commands/database-profile.js
@@ -23,6 +23,7 @@ module.exports = new Command("database:profile")
     "generate the report based on the specified file instead " +
       "of streaming logs from the database"
   )
+  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(options) {
     // Validate options

--- a/commands/database-profile.js
+++ b/commands/database-profile.js
@@ -23,7 +23,7 @@ module.exports = new Command("database:profile")
     "generate the report based on the specified file instead " +
       "of streaming logs from the database"
   )
-  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
+  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(options) {
     // Validate options

--- a/commands/database-profile.js
+++ b/commands/database-profile.js
@@ -24,8 +24,8 @@ module.exports = new Command("database:profile")
       "of streaming logs from the database"
   )
   .option(
-    "--instance <name>",
-    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+    "--instance <instance>",
+    "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
   .before(requireAccess)
   .action(function(options) {

--- a/commands/database-profile.js
+++ b/commands/database-profile.js
@@ -23,7 +23,10 @@ module.exports = new Command("database:profile")
     "generate the report based on the specified file instead " +
       "of streaming logs from the database"
   )
-  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
+  .option(
+    "--instance <name>",
+    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+  )
   .before(requireAccess)
   .action(function(options) {
     // Validate options

--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -18,8 +18,8 @@ module.exports = new Command("database:push <path> [infile]")
   .description("add a new JSON object to a list of data in your Firebase")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option(
-    "--instance <name>",
-    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+    "--instance <instance>",
+    "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
   .before(requireAccess)
   .action(function(path, infile, options) {

--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -17,7 +17,10 @@ var _ = require("lodash");
 module.exports = new Command("database:push <path> [infile]")
   .description("add a new JSON object to a list of data in your Firebase")
   .option("-d, --data <data>", "specify escaped JSON directly")
-  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
+  .option(
+    "--instance <name>",
+    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+  )
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -17,6 +17,7 @@ var _ = require("lodash");
 module.exports = new Command("database:push <path> [infile]")
   .description("add a new JSON object to a list of data in your Firebase")
   .option("-d, --data <data>", "specify escaped JSON directly")
+  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -17,7 +17,7 @@ var _ = require("lodash");
 module.exports = new Command("database:push <path> [infile]")
   .description("add a new JSON object to a list of data in your Firebase")
   .option("-d, --data <data>", "specify escaped JSON directly")
-  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
+  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-remove.js
+++ b/commands/database-remove.js
@@ -15,6 +15,7 @@ var _ = require("lodash");
 module.exports = new Command("database:remove <path>")
   .description("remove data from your Firebase at the specified path")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
+  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-remove.js
+++ b/commands/database-remove.js
@@ -15,7 +15,10 @@ var _ = require("lodash");
 module.exports = new Command("database:remove <path>")
   .description("remove data from your Firebase at the specified path")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
-  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
+  .option(
+    "--instance <name>",
+    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+  )
   .before(requireAccess)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-remove.js
+++ b/commands/database-remove.js
@@ -16,8 +16,8 @@ module.exports = new Command("database:remove <path>")
   .description("remove data from your Firebase at the specified path")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
   .option(
-    "--instance <name>",
-    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+    "--instance <instance>",
+    "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
   .before(requireAccess)
   .action(function(path, options) {

--- a/commands/database-remove.js
+++ b/commands/database-remove.js
@@ -15,7 +15,7 @@ var _ = require("lodash");
 module.exports = new Command("database:remove <path>")
   .description("remove data from your Firebase at the specified path")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
-  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
+  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-set.js
+++ b/commands/database-set.js
@@ -18,7 +18,7 @@ module.exports = new Command("database:set <path> [infile]")
   .description("store JSON data at the specified path via STDIN, arg, or file")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
-  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
+  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-set.js
+++ b/commands/database-set.js
@@ -18,7 +18,10 @@ module.exports = new Command("database:set <path> [infile]")
   .description("store JSON data at the specified path via STDIN, arg, or file")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
-  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
+  .option(
+    "--instance <name>",
+    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+  )
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-set.js
+++ b/commands/database-set.js
@@ -18,6 +18,7 @@ module.exports = new Command("database:set <path> [infile]")
   .description("store JSON data at the specified path via STDIN, arg, or file")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
+  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-set.js
+++ b/commands/database-set.js
@@ -19,8 +19,8 @@ module.exports = new Command("database:set <path> [infile]")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
   .option(
-    "--instance <name>",
-    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+    "--instance <instance>",
+    "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
   .before(requireAccess)
   .action(function(path, infile, options) {

--- a/commands/database-update.js
+++ b/commands/database-update.js
@@ -18,6 +18,7 @@ module.exports = new Command("database:update <path> [infile]")
   .description("update some of the keys for the defined path in your Firebase")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
+  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-update.js
+++ b/commands/database-update.js
@@ -18,7 +18,10 @@ module.exports = new Command("database:update <path> [infile]")
   .description("update some of the keys for the defined path in your Firebase")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
-  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
+  .option(
+    "--instance <name>",
+    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+  )
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/commands/database-update.js
+++ b/commands/database-update.js
@@ -19,8 +19,8 @@ module.exports = new Command("database:update <path> [infile]")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
   .option(
-    "--instance <name>",
-    "use database <name>.firebaseio.com (otherwise, use the default instance)"
+    "--instance <instance>",
+    "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
   .before(requireAccess)
   .action(function(path, infile, options) {

--- a/commands/database-update.js
+++ b/commands/database-update.js
@@ -18,7 +18,7 @@ module.exports = new Command("database:update <path> [infile]")
   .description("update some of the keys for the defined path in your Firebase")
   .option("-d, --data <data>", "specify escaped JSON directly")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
-  .option("--instance <name>", "use database instance <name> (otherwise, use the default instance)")
+  .option("--instance <name>", "use database <name>.firebaseio.com (otherwise, use the default instance)")
   .before(requireAccess)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {

--- a/lib/getInstanceId.js
+++ b/lib/getInstanceId.js
@@ -1,8 +1,8 @@
-"use strict";
+'use strict';
 
-var _ = require("lodash");
-var api = require("./api");
-var FirebaseError = require("./error");
+var _ = require('lodash');
+var api = require('./api');
+var FirebaseError = require('./error');
 
 /**
  * Tries to determine the instance ID for the provided
@@ -12,11 +12,31 @@ var FirebaseError = require("./error");
  */
 module.exports = function(options) {
   return api.getProject(options.project).then(function(project) {
-    if (!_.has(project, ["instances", "database", 0])) {
-      throw new FirebaseError("No instance found for project. Please try a different project.", {
-        exit: 1,
-      });
+    if (!_.has(project, ['instances', 'database'])) {
+      throw new FirebaseError(
+          'No instance found for project. Please try a different project.', {
+            exit: 1,
+          });
     }
-    return project.instances.database[0];
+    if (!_.isArray(project.instances.database)) {
+      throw new FirebaseError(
+          'No instance found for project. Please try a different project.', {
+            exit: 1,
+          });
+    }
+    if (!_.has(options, ['instance'])) {
+      return project.instances.database[0];
+    } else if (_.includes(project.instances.database, options.instance)) {
+      return options.instance;
+    } else {
+      throw new FirebaseError(
+          'No instance named "' + options.instance +
+              '" found for project. Available options: [' +
+              project.instances.database.join(', ') +
+              '] Please try a different project.',
+          {
+            exit: 1,
+          });
+    }
   });
 };

--- a/lib/getInstanceId.js
+++ b/lib/getInstanceId.js
@@ -32,7 +32,7 @@ module.exports = function(options) {
           options.instance +
           "' found for project. Available options: " +
           project.instances.database.join(", ") +
-          ". Please try a different instance on this project, "
+          ". Please try a different instance on this project, " +
           "or switch to a different project using `firebase use`.",
         {
           exit: 1,

--- a/lib/getInstanceId.js
+++ b/lib/getInstanceId.js
@@ -1,8 +1,8 @@
-'use strict';
+"use strict";
 
-var _ = require('lodash');
-var api = require('./api');
-var FirebaseError = require('./error');
+var _ = require("lodash");
+var api = require("./api");
+var FirebaseError = require("./error");
 
 /**
  * Tries to determine the instance ID for the provided
@@ -12,31 +12,31 @@ var FirebaseError = require('./error');
  */
 module.exports = function(options) {
   return api.getProject(options.project).then(function(project) {
-    if (!_.has(project, ['instances', 'database'])) {
-      throw new FirebaseError(
-          'No instance found for project. Please try a different project.', {
-            exit: 1,
-          });
+    if (!_.has(project, ["instances", "database"])) {
+      throw new FirebaseError("No instance found for project. Please try a different project.", {
+        exit: 1,
+      });
     }
     if (!_.isArray(project.instances.database)) {
-      throw new FirebaseError(
-          'No instance found for project. Please try a different project.', {
-            exit: 1,
-          });
+      throw new FirebaseError("No instance found for project. Please try a different project.", {
+        exit: 1,
+      });
     }
-    if (!_.has(options, ['instance'])) {
+    if (!_.has(options, ["instance"])) {
       return project.instances.database[0];
     } else if (_.includes(project.instances.database, options.instance)) {
       return options.instance;
     } else {
       throw new FirebaseError(
-          'No instance named "' + options.instance +
-              '" found for project. Available options: [' +
-              project.instances.database.join(', ') +
-              '] Please try a different project.',
-          {
-            exit: 1,
-          });
+        "No instance named '" +
+          options.instance +
+          "' found for project. Available options: [" +
+          project.instances.database.join(", ") +
+          "] Please try a different project.",
+        {
+          exit: 1,
+        }
+      );
     }
   });
 };

--- a/lib/getInstanceId.js
+++ b/lib/getInstanceId.js
@@ -30,9 +30,10 @@ module.exports = function(options) {
       throw new FirebaseError(
         "No instance named '" +
           options.instance +
-          "' found for project. Available options: [" +
+          "' found for project. Available options: " +
           project.instances.database.join(", ") +
-          "] Please try a different project.",
+          ". Please try a different instance on this project, "
+          "or switch to a different project using `firebase use`.",
         {
           exit: 1,
         }


### PR DESCRIPTION
This change allows a `--instance` option that lets you change the
instance you're using. I went with `--instance` because it makes the
rest of the code a no-op change and fits in well :)

This also does validation against the databases for your project,
recommending others if an invalid one is selected.

Fixes #589 
