### PR TITLE
Proper fix for #669

### DIFF
--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -150,6 +150,9 @@ FunctionsEmulator.prototype.start = function(shellMode) {
               firebase: true,
               source: functionsDir,
               triggerHttp: true,
+              timeout: {
+                seconds: 540
+              }
             })
             .catch(function(e) {
               logger.debug("Error while deploying to emulator: " + e + "\n" + e.stack);

--- a/lib/functionsEmulator.js
+++ b/lib/functionsEmulator.js
@@ -151,8 +151,8 @@ FunctionsEmulator.prototype.start = function(shellMode) {
               source: functionsDir,
               triggerHttp: true,
               timeout: {
-                seconds: 540
-              }
+                seconds: 540,
+              },
             })
             .catch(function(e) {
               logger.debug("Error while deploying to emulator: " + e + "\n" + e.stack);

--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -67,7 +67,7 @@ module.exports = function(options) {
           Cookie: sessionCookie,
         },
         followRedirect: false,
-        timeout: 540000,
+        timeout: 60000,
       });
 
       req.pipe(proxied);

--- a/lib/hosting/functionsProxy.js
+++ b/lib/hosting/functionsProxy.js
@@ -67,7 +67,7 @@ module.exports = function(options) {
           Cookie: sessionCookie,
         },
         followRedirect: false,
-        timeout: 60000,
+        timeout: 540000,
       });
 
       req.pipe(proxied);


### PR DESCRIPTION
### Description

As described in #669 (specifically [this comment](https://github.com/firebase/firebase-tools/issues/669#issuecomment-374680621)), the goal was to fix timeout issues in the emulator. 

Unfortunately, setting the `maxIdle` setting is not good enough. The real fix was already provided by @dinvlad in his branch (see [this comment](https://github.com/dinvlad)). 

I would like to request that these changes are also accepted to the _firebase-tools_ project as they are vital in getting the firebase-tools implementation of the GCP emulator to support long-running operations.
	 
### Scenarios Tested

Write a function that takes longer than 60 seconds:

```
export const myLongRunningFunction = functions.https.onRequest((req, res) => {
  setTimeout(() => {
    res.status(200).send('We are done here');
  }, 8 * 60 * 1000);
});
```
