### PR TITLE
Fixes issue #364

### DIFF
--- a/lib/ensureDefaultCredentials.js
+++ b/lib/ensureDefaultCredentials.js
@@ -31,11 +31,13 @@ module.exports = function() {
     "application_default_credentials.json"
   );
 
+  var tokens = configstore.get("tokens") || {};
+  
   var credentials = {
     client_id: api.clientId,
     client_secret: api.clientSecret,
     type: "authorized_user",
-    refresh_token: configstore.get("tokens").refresh_token,
+    refresh_token: tokens.refresh_token || process.env.FIREBASE_TOKEN,
   };
   // Mimic the effects of running "gcloud auth application-default login"
   fs.ensureDirSync(GCLOUD_CREDENTIAL_DIR);

--- a/lib/ensureDefaultCredentials.js
+++ b/lib/ensureDefaultCredentials.js
@@ -32,7 +32,7 @@ module.exports = function() {
   );
 
   var tokens = configstore.get("tokens") || {};
-  
+
   var credentials = {
     client_id: api.clientId,
     client_secret: api.clientSecret,


### PR DESCRIPTION
### Description

As described in #364, it is not possible to run `firebase serve --only functions` in a dockerized environment because for some reason `configstore.get('tokens')` does not contain any values, regardless of whether you pass `--token` or set the `FIREBASE_TOKEN` environment variable.

What does work, is to actually switch to `process.env.FIREBASE_TOKEN` if there isn't a set of tokens available in the config store. This will also work with `--token`.
	 
### Scenarios Tested

Create a new Firebase Functions project with firebase-tools, Dockerize the application with `firebase serve --only functions --token $FIREBASE_TOKEN` as the command, or with `FIREBASE_TOKEN=<TOKEN> firebase serve --only functions` and watch it run smoothly. 

Sample Dockerfile

```Dockerfile
FROM node:8

ARG FIREBASE_TOKEN
ARG FB_PROJECTID
ENV FIREBASE_TOKEN ${FIREBASE_TOKEN}
ENV FB_PROJECTID ${FB_PROJECTID}

WORKDIR /opt/sample
COPY ./firebase.json firebase.json

WORKDIR /opt/sample/functions
COPY ./functions/package.json package.json
COPY ./functions/package-lock.json package-lock.json
RUN npm install; \
        npm install -g firebase-tools; \
	firebase use $FB_PROJECTID;

COPY ./functions/src src
COPY ./functions/tsconfig.json tsconfig.json
COPY ./functions/tslint.json tslint.json

CMD ["npm", "run", "serve"]
```