### PR TITLE
Fix typeError in lib/responseToError.js

### DIFF
--- a/lib/responseToError.js
+++ b/lib/responseToError.js
@@ -7,9 +7,19 @@ module.exports = function(response, body) {
   if (response.statusCode < 400) {
     return null;
   }
+
+  if (typeof body !== "object") {
+    try {
+      body = JSON.parse(body);
+    } catch (e) {
+      body = {};
+    }
+  }
+
   if (!body.error) {
+    var message = response.statusCode === 404 ? "Not Found" : "Unknown Error";
     body.error = {
-      message: "Unknown Error",
+      message: message,
     };
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Certain API calls (such as ones to cloudfunctions) return response bodies which are a JSON string. This change attempts to parse the string to retrieve error message and prevents type errors such as: 

> [2018-07-03T16:58:35.452Z] TypeError: Cannot create property 'error' on string '{
>   "error": {
>     "code": 503,
>     "message": "The service is currently unavailable.",
>     "status": "UNAVAILABLE",
>     "details": [
>       {
>         "@type": "type.googleapis.com/google.rpc.DebugInfo",
>         "detail": "[ORIGINAL ERROR] RPC::DEADLINE_EXCEEDED: "
>       }
>     ]
>   }
> }
> '
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
