### PR TITLE
Deploy cloud functions to specified region.

### DIFF
--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -28,7 +28,7 @@ module.exports = new Command("deploy")
       '(e.g. "--only functions:group1.subgroup1,functions:group2)"'
   )
   .option("--except <targets>", 'deploy to all targets except specified (e.g. "database")')
-  .option("--region <region>", 'deploy to specified region (only works for functions)')
+  .option("--region <region>", "deploy to specified region (only works for functions)")
   .before(requireConfig)
   .before(function(options) {
     return acquireRefs(options, [scopes.CLOUD_PLATFORM]).catch(function(err) {

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -28,6 +28,7 @@ module.exports = new Command("deploy")
       '(e.g. "--only functions:group1.subgroup1,functions:group2)"'
   )
   .option("--except <targets>", 'deploy to all targets except specified (e.g. "database")')
+  .option("--region <region>", 'deploy to specified region (only works for functions)')
   .before(requireConfig)
   .before(function(options) {
     return acquireRefs(options, [scopes.CLOUD_PLATFORM]).catch(function(err) {

--- a/lib/deploy/functions/deploy.js
+++ b/lib/deploy/functions/deploy.js
@@ -8,11 +8,19 @@ var utils = require("../../utils");
 var gcp = require("../../gcp");
 var prepareFunctionsUpload = require("../../prepareFunctionsUpload");
 
-var GCP_REGION = gcp.cloudfunctions.DEFAULT_REGION;
-
 tmp.setGracefulCleanup();
 
 module.exports = function(context, options, payload) {
+  var GCP_REGION = gcp.cloudfunctions.DEFAULT_REGION;
+
+  if(options.region) {
+    if(!gcp.cloudfunctions.AVAILABLE_REGIONS.includes(options.region)) {
+      return Promise.reject(new FirebaseError("specified region is not available: " + options.region));
+    }
+
+    GCP_REGION = options.region;
+  }
+
   var _uploadSource = function(source) {
     return gcp.cloudfunctions
       .generateUploadUrl(context.projectId, GCP_REGION)

--- a/lib/deploy/functions/deploy.js
+++ b/lib/deploy/functions/deploy.js
@@ -13,9 +13,11 @@ tmp.setGracefulCleanup();
 module.exports = function(context, options, payload) {
   var GCP_REGION = gcp.cloudfunctions.DEFAULT_REGION;
 
-  if(options.region) {
-    if(!gcp.cloudfunctions.AVAILABLE_REGIONS.includes(options.region)) {
-      return Promise.reject(new FirebaseError("specified region is not available: " + options.region));
+  if (options.region) {
+    if (!gcp.cloudfunctions.AVAILABLE_REGIONS.includes(options.region)) {
+      return Promise.reject(
+        new FirebaseError("specified region is not available: " + options.region)
+      );
     }
 
     GCP_REGION = options.region;

--- a/lib/deploy/functions/release.js
+++ b/lib/deploy/functions/release.js
@@ -17,9 +17,11 @@ module.exports = function(context, options, payload) {
 
   var GCP_REGION = gcp.cloudfunctions.DEFAULT_REGION;
 
-  if(options.region) {
-    if(!gcp.cloudfunctions.AVAILABLE_REGIONS.includes(options.region)) {
-      return Promise.reject(new FirebaseError("specified region is not available: " + options.region));
+  if (options.region) {
+    if (!gcp.cloudfunctions.AVAILABLE_REGIONS.includes(options.region)) {
+      return Promise.reject(
+        new FirebaseError("specified region is not available: " + options.region)
+      );
     }
 
     GCP_REGION = options.region;

--- a/lib/deploy/functions/release.js
+++ b/lib/deploy/functions/release.js
@@ -16,6 +16,15 @@ module.exports = function(context, options, payload) {
   }
 
   var GCP_REGION = gcp.cloudfunctions.DEFAULT_REGION;
+
+  if(options.region) {
+    if(!gcp.cloudfunctions.AVAILABLE_REGIONS.includes(options.region)) {
+      return Promise.reject(new FirebaseError("specified region is not available: " + options.region));
+    }
+
+    GCP_REGION = options.region;
+  }
+
   var projectId = context.projectId;
   var sourceUrl = context.uploadUrl;
   // Used in CLI releases v3.4.0 to v3.17.6

--- a/lib/gcp/cloudfunctions.js
+++ b/lib/gcp/cloudfunctions.js
@@ -210,6 +210,7 @@ function _checkOperation(operation) {
 
 module.exports = {
   DEFAULT_REGION: "us-central1",
+  AVAILABLE_REGIONS: ["us-central1", "us-east1", "europe-west1", "asia-northeast1"],
   generateUploadUrl: _generateUploadUrl,
   create: _createFunction,
   update: _updateFunction,


### PR DESCRIPTION

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
Added a --region option for the deploy command which makes it possible to deploy functions to any available region.
 
### Scenarios Tested

Deploying to europe-west1 was tested.

### Sample Commands
```bash
firebase deploy --region europe-west1
```


### Notes
Functions deployed to a different region than us-central1 only show up in the google cloud console and not in the firebase console.

