### PR TITLE
Update profiler to new query format

### DIFF
--- a/lib/profileReport.js
+++ b/lib/profileReport.js
@@ -88,6 +88,9 @@ ProfileReport.formatBytes = function(bytes) {
 };
 
 ProfileReport.extractReadableIndex = function(query) {
+  if (_.has(query, "orderBy") {
+      return query.orderBy;
+  }
   var indexPath = _.get(query, "index.path");
   if (indexPath) {
     return ProfileReport.pathString(indexPath);

--- a/lib/profileReport.js
+++ b/lib/profileReport.js
@@ -88,7 +88,7 @@ ProfileReport.formatBytes = function(bytes) {
 };
 
 ProfileReport.extractReadableIndex = function(query) {
-  if (_.has(query, "orderBy") {
+  if (_.has(query, "orderBy")) {
     return query.orderBy;
   }
   var indexPath = _.get(query, "index.path");

--- a/lib/profileReport.js
+++ b/lib/profileReport.js
@@ -89,7 +89,7 @@ ProfileReport.formatBytes = function(bytes) {
 
 ProfileReport.extractReadableIndex = function(query) {
   if (_.has(query, "orderBy") {
-      return query.orderBy;
+    return query.orderBy;
   }
   var indexPath = _.get(query, "index.path");
   if (indexPath) {


### PR DESCRIPTION
Currently, profiler queries are a nasty output of our internal model, and we're changing this to use the REST API format, which is much cleaner, this PR updates the unindexed report to collect the path from correct location in the new json object (in a backwards compatible way).
