### PR TITLE
Enable firestore init with console rules

### DIFF
--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -33,7 +33,11 @@ function getLatestRulesetName(projectId) {
     })
     .then(function(response) {
       if (response.status == 200) {
-        return response.body.rulesets[0].name;
+        if (response.body.rulesets && response.body.rulesets.length > 0) {
+          return response.body.rulesets[0].name;
+        }
+
+        return undefined;
       }
 
       return _handleErrorResponse(response);

--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -12,9 +12,52 @@ function _handleErrorResponse(response) {
   }
 
   logger.debug("[rules] error:", response.status, response.body);
-  return utils.reject("Unexpected error encountered deploying rules.", {
+  return utils.reject("Unexpected error encountered with rules.", {
     code: 2,
   });
+}
+
+/**
+ * Gets the latest ruleset name on the project.
+ * @param {String} projectId Project from which you want to get the ruleset.
+ * @returns {String} Name of the latest ruleset.
+ */
+function getLatestRulesetName(projectId) {
+  return api
+    .request("GET", "/" + API_VERSION + "/projects/" + projectId + "/rulesets", {
+      auth: true,
+      origin: api.rulesOrigin,
+      data: {
+        pageSize: 1,
+      },
+    })
+    .then(function(response) {
+      if (response.status == 200) {
+        return response.body.rulesets[0].name;
+      }
+
+      return _handleErrorResponse(response);
+    });
+}
+
+/**
+ * Gets the full contents of a ruleset.
+ * @param {String} name Name of the ruleset.
+ * @return {Array<Object>} Array of files in the ruleset. Each entry has form { content, name }.
+ */
+function getRulesetContent(name) {
+  return api
+    .request("GET", "/" + API_VERSION + "/" + name, {
+      auth: true,
+      origin: api.rulesOrigin,
+    })
+    .then(function(response) {
+      if (response.status == 200) {
+        return response.body.source.files;
+      }
+
+      return _handleErrorResponse(response);
+    });
 }
 
 /**
@@ -127,4 +170,6 @@ module.exports = {
   updateRelease: updateRelease,
   updateOrCreateRelease: updateOrCreateRelease,
   testRuleset: testRuleset,
+  getLatestRulesetName: getLatestRulesetName,
+  getRulesetContent: getRulesetContent,
 };

--- a/lib/init/features/firestore.js
+++ b/lib/init/features/firestore.js
@@ -71,7 +71,13 @@ var _getRulesFromConsole = function(projectId) {
   return gcp.rules
     .getLatestRulesetName(projectId)
     .then(function(name) {
-      logger.debug('Found ruleset: ' + name);
+      if (!name) {
+        logger.debug("No rulesets found, using default.");
+        var defaultContent = [{ name: DEFAULT_RULES_FILE, content: RULES_TEMPLATE }];
+        return Promise.resolve(defaultContent);
+      }
+
+      logger.debug("Found ruleset: " + name);
       return gcp.rules.getRulesetContent(name);
     })
     .then(function(rules) {

--- a/lib/init/features/firestore.js
+++ b/lib/init/features/firestore.js
@@ -78,14 +78,18 @@ var _getRulesFromConsole = function(projectId) {
       return gcp.rules.getRulesetContent(name);
     })
     .then(function(rules) {
-      for (var i = 0; i < rules.length; i++) {
-        var entry = rules[i];
-        if (entry.name === DEFAULT_RULES_FILE) {
-          return entry.content;
-        }
-
-        return utils.reject("Could not find rules file " + DEFAULT_RULES_FILE, { exit: 1 });
+      if (rules.length <= 0) {
+        return utils.reject("Ruleset has no files", { exit: 1 });
       }
+
+      if (rules.length > 1) {
+        return utils.reject("Ruleset has too many files: " + rules.length, { exit: 1 });
+      }
+
+      // Even though the rules API allows for multi-file rulesets, right
+      // now both the console and the CLI are built on the single-file
+      // assumption.
+      return rules[0].content;
     });
 };
 

--- a/lib/init/features/firestore.js
+++ b/lib/init/features/firestore.js
@@ -3,13 +3,20 @@
 var chalk = require("chalk");
 var fs = require("fs");
 
+var gcp = require("../../gcp");
+
+var fsutils = require("../../fsutils");
 var prompt = require("../../prompt");
 var logger = require("../../logger");
+var utils = require("../../utils");
 
 var RULES_TEMPLATE = fs.readFileSync(
   __dirname + "/../../../templates/init/firestore/firestore.rules",
   "utf8"
 );
+
+var DEFAULT_RULES_FILE = "firestore.rules";
+
 var INDEXES_TEMPLATE = fs.readFileSync(
   __dirname + "/../../../templates/init/firestore/firestore.indexes.json",
   "utf8"
@@ -27,11 +34,56 @@ var _initRules = function(setup, config) {
       type: "input",
       name: "rules",
       message: "What file should be used for Firestore Rules?",
-      default: "firestore.rules",
+      default: DEFAULT_RULES_FILE,
     },
-  ]).then(function() {
-    return config.writeProjectFile(setup.config.firestore.rules, RULES_TEMPLATE);
-  });
+  ])
+    .then(function() {
+      var filename = setup.config.firestore.rules;
+
+      if (fsutils.fileExistsSync(filename)) {
+        var msg =
+          "File " +
+          chalk.bold(filename) +
+          " already exists." +
+          " Do you want to overwrite it with the Firestore Rules from the Firebase Console?";
+        return prompt.once({
+          type: "confirm",
+          message: msg,
+          default: false,
+        });
+      }
+
+      return Promise.resolve(true);
+    })
+    .then(function(overwrite) {
+      if (!overwrite) {
+        return Promise.resolve();
+      }
+
+      var projectId = setup.instance || setup.rcfile.projects.default;
+      return _getRulesFromConsole(projectId).then(function(contents) {
+        return config.writeProjectFile(setup.config.firestore.rules, contents);
+      });
+    });
+};
+
+var _getRulesFromConsole = function(projectId) {
+  return gcp.rules
+    .getLatestRulesetName(projectId)
+    .then(function(name) {
+      logger.debug('Found ruleset: ' + name);
+      return gcp.rules.getRulesetContent(name);
+    })
+    .then(function(rules) {
+      for (var i = 0; i < rules.length; i++) {
+        var entry = rules[i];
+        if (entry.name == DEFAULT_RULES_FILE) {
+          return entry.content;
+        }
+
+        return utils.reject("Could not find rules file " + DEFAULT_RULES_FILE, { exit: 1 });
+      }
+    });
 };
 
 var _initIndexes = function(setup, config) {

--- a/lib/init/features/firestore.js
+++ b/lib/init/features/firestore.js
@@ -4,7 +4,6 @@ var chalk = require("chalk");
 var fs = require("fs");
 
 var gcp = require("../../gcp");
-
 var fsutils = require("../../fsutils");
 var prompt = require("../../prompt");
 var logger = require("../../logger");
@@ -60,8 +59,7 @@ var _initRules = function(setup, config) {
         return Promise.resolve();
       }
 
-      var projectId = setup.instance || setup.rcfile.projects.default;
-      return _getRulesFromConsole(projectId).then(function(contents) {
+      return _getRulesFromConsole(setup.projectId).then(function(contents) {
         return config.writeProjectFile(setup.config.firestore.rules, contents);
       });
     });
@@ -73,8 +71,7 @@ var _getRulesFromConsole = function(projectId) {
     .then(function(name) {
       if (!name) {
         logger.debug("No rulesets found, using default.");
-        var defaultContent = [{ name: DEFAULT_RULES_FILE, content: RULES_TEMPLATE }];
-        return Promise.resolve(defaultContent);
+        return [{ name: DEFAULT_RULES_FILE, content: RULES_TEMPLATE }];
       }
 
       logger.debug("Found ruleset: " + name);
@@ -83,7 +80,7 @@ var _getRulesFromConsole = function(projectId) {
     .then(function(rules) {
       for (var i = 0; i < rules.length; i++) {
         var entry = rules[i];
-        if (entry.name == DEFAULT_RULES_FILE) {
+        if (entry.name === DEFAULT_RULES_FILE) {
           return entry.content;
         }
 

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -33,6 +33,7 @@ module.exports = function(setup, config) {
 
     if (_.has(setup.rcfile, "projects.default")) {
       utils.logBullet(".firebaserc already has a default project, skipping");
+      setup.projectId = _.get(setup.rcfile, "projects.default");
       return undefined;
     }
 
@@ -61,6 +62,7 @@ module.exports = function(setup, config) {
 
         // write "default" alias and activate it immediately
         _.set(setup.rcfile, "projects.default", projectId);
+        setup.projectId = projectId;
         setup.instance = instance;
         utils.makeActiveProject(config.projectDir, projectId);
       });


### PR DESCRIPTION
Partial fix for #562

When initializing Firestore, get rules from the console (rather than a default template).