### PR TITLE
Added Errors if a source directory is not defined.

### DIFF
--- a/lib/detectProjectRoot.js
+++ b/lib/detectProjectRoot.js
@@ -12,7 +12,7 @@ module.exports = function(cwd) {
   }
   if (!projectRootDir) {
     throw new Error(
-      'Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\"'
+      'Project Root Directory is undefined. Please add a directory to your firebase.json. Example: "source": "./functions"'
     );
   }
   while (!fsutils.fileExistsSync(path.resolve(projectRootDir, "./firebase.json"))) {

--- a/lib/detectProjectRoot.js
+++ b/lib/detectProjectRoot.js
@@ -6,10 +6,14 @@ var path = require("path");
 module.exports = function(cwd) {
   var projectRootDir = cwd || process.cwd();
   if (typeof projectRootDir !== "string") {
-    throw new Error("Project Root Directory is not a string. Please change your directory under firebase.json to be a valid string for the source paramter.");
+    throw new Error(
+      "Project Root Directory is not a string. Please change your directory under firebase.json to be a valid string for the source paramter."
+    );
   }
   if (!projectRootDir) {
-    throw new Error("Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\"");
+    throw new Error(
+      "Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\""
+    );
   }
   while (!fsutils.fileExistsSync(path.resolve(projectRootDir, "./firebase.json"))) {
     var parentDir = path.dirname(projectRootDir);

--- a/lib/detectProjectRoot.js
+++ b/lib/detectProjectRoot.js
@@ -5,15 +5,12 @@ var path = require("path");
 
 module.exports = function(cwd) {
   var projectRootDir = cwd || process.cwd();
-
-  if (typeof projectRootDir !== 'string') {
-    throw new Error('Project Root Directory is not a string. Please change your directory under firebase.json to be a valid string for the source paramter.');
+  if (typeof projectRootDir !== "string") {
+    throw new Error("Project Root Directory is not a string. Please change your directory under firebase.json to be a valid string for the source paramter.");
   }
-  
   if (!projectRootDir) {
-    throw new Error('Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\"');
+    throw new Error("Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\"");
   }
-
   while (!fsutils.fileExistsSync(path.resolve(projectRootDir, "./firebase.json"))) {
     var parentDir = path.dirname(projectRootDir);
     if (parentDir === projectRootDir) {
@@ -22,5 +19,4 @@ module.exports = function(cwd) {
     projectRootDir = parentDir;
   }
   return projectRootDir;
-
 };

--- a/lib/detectProjectRoot.js
+++ b/lib/detectProjectRoot.js
@@ -12,7 +12,7 @@ module.exports = function(cwd) {
   }
   if (!projectRootDir) {
     throw new Error(
-      "Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\""
+      'Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\"'
     );
   }
   while (!fsutils.fileExistsSync(path.resolve(projectRootDir, "./firebase.json"))) {

--- a/lib/detectProjectRoot.js
+++ b/lib/detectProjectRoot.js
@@ -5,6 +5,15 @@ var path = require("path");
 
 module.exports = function(cwd) {
   var projectRootDir = cwd || process.cwd();
+
+  if (typeof projectRootDir !== 'string') {
+    throw new Error('Project Root Directory is not a string. Please change your directory under firebase.json to be a valid string for the source paramter.');
+  }
+  
+  if (!projectRootDir) {
+    throw new Error('Project Root Directory is undefined. Please add a directory to your firebase.json. Example: \"source\":\"./functions\"');
+  }
+
   while (!fsutils.fileExistsSync(path.resolve(projectRootDir, "./firebase.json"))) {
     var parentDir = path.dirname(projectRootDir);
     if (parentDir === projectRootDir) {
@@ -13,4 +22,5 @@ module.exports = function(cwd) {
     projectRootDir = parentDir;
   }
   return projectRootDir;
+
 };


### PR DESCRIPTION
Referencing #833, I had an issue where I didn't specify a source directory and Node's `path.resolve()` was throwing an error, which was useless information.

For newbies to firebase like me, this should drastically help.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
