### PR TITLE
Fix #837

### DIFF
--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -1,5 +1,7 @@
 "use strict";
 
+var _ = require("lodash");
+
 var api = require("../api");
 var FirebaseError = require("../error");
 var logger = require("../logger");
@@ -33,16 +35,18 @@ function getLatestRulesetName(projectId, service) {
     .then(function(response) {
       if (response.status == 200) {
         if (response.body.releases && response.body.releases.length > 0) {
-          var releases = response.body.releases;
+          var releases = _.orderBy(response.body.releases, ["updateTime"], ["desc"]);
+
           var prefix = "projects/" + projectId + "/releases/" + service;
-          for (var i = 0; i < releases.length; i++) {
-            var release = releases[i];
-            if (release.name.indexOf(prefix) == 0) {
-              return release.rulesetName;
-            }
+          var release = _.find(releases, function(r) {
+            return r.name.indexOf(prefix) == 0;
+          });
+
+          if (!release) {
+            throw new FirebaseError("Can't find rules release for service " + service);
           }
 
-          throw new FirebaseError("Can't find rules release for service " + service);
+          return release.rulesetName;
         }
       }
 

--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -3,7 +3,6 @@
 var _ = require("lodash");
 
 var api = require("../api");
-var FirebaseError = require("../error");
 var logger = require("../logger");
 var utils = require("../utils");
 
@@ -43,7 +42,7 @@ function getLatestRulesetName(projectId, service) {
           });
 
           if (!release) {
-            throw new FirebaseError("Can't find rules release for service " + service);
+            return undefined;
           }
 
           return release.rulesetName;

--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -42,9 +42,8 @@ function getLatestRulesetName(projectId, service) {
           });
 
           if (!release) {
-            return undefined;
+            return null;
           }
-
           return release.rulesetName;
         }
       }

--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var api = require("../api");
+var FirebaseError = require("../error");
 var logger = require("../logger");
 var utils = require("../utils");
 
@@ -20,24 +21,29 @@ function _handleErrorResponse(response) {
 /**
  * Gets the latest ruleset name on the project.
  * @param {String} projectId Project from which you want to get the ruleset.
+ * @param {String} service Service for the ruleset (ex: cloud.firestore or firebase.storage).
  * @returns {String} Name of the latest ruleset.
  */
-function getLatestRulesetName(projectId) {
+function getLatestRulesetName(projectId, service) {
   return api
-    .request("GET", "/" + API_VERSION + "/projects/" + projectId + "/rulesets", {
+    .request("GET", "/" + API_VERSION + "/projects/" + projectId + "/releases", {
       auth: true,
       origin: api.rulesOrigin,
-      data: {
-        pageSize: 1,
-      },
     })
     .then(function(response) {
       if (response.status == 200) {
-        if (response.body.rulesets && response.body.rulesets.length > 0) {
-          return response.body.rulesets[0].name;
-        }
+        if (response.body.releases && response.body.releases.length > 0) {
+          var releases = response.body.releases;
+          var prefix = "projects/" + projectId + "/releases/" + service;
+          for (var i = 0; i < releases.length; i++) {
+            var release = releases[i];
+            if (release.name.indexOf(prefix) == 0) {
+              return release.rulesetName;
+            }
+          }
 
-        return undefined;
+          throw new FirebaseError("Can't find rules release for service " + service);
+        }
       }
 
       return _handleErrorResponse(response);

--- a/lib/init/features/firestore.js
+++ b/lib/init/features/firestore.js
@@ -71,7 +71,7 @@ var _initRules = function(setup, config) {
 
 var _getRulesFromConsole = function(projectId) {
   return gcp.rules
-    .getLatestRulesetName(projectId)
+    .getLatestRulesetName(projectId, "cloud.firestore")
     .then(function(name) {
       if (!name) {
         logger.debug("No rulesets found, using default.");


### PR DESCRIPTION
Uses the `releases` API to tell which service we are getting the rules from.

Manual testing (to prove that I can now get either Storage or Firestore rules on demand):

```
samstern@samstern-macbookpro tmp.73XjfHwC
$ echo "Testing with service=firebase.storage"
Testing with service=firebase.storage
samstern@samstern-macbookpro tmp.73XjfHwC
$ ~/Projects/firebase-tools/bin/firebase init firestore

     🔥redacted

You're about to initialize a Firebase project in this directory:

  /private/var/folders/q_/sry2gzmj2tb8xsw3s5x_dz4h00643s/T/tmp.73XjfHwC

Before we get started, keep in mind:

  * You are currently outside your home directory
  * You are initializing in an existing Firebase project directory


=== Project Setup

First, let's associate this project directory with a Firebase project.
You can create multiple project aliases by running firebase use --add,
but for now we'll just set up a default project.

i  .firebaserc already has a default project, skipping

=== Firestore Setup

Firestore Security Rules allow you to define how and when to allow
requests. You can keep these rules in your project directory
and publish them with firebase deploy.

? What file should be used for Firestore Rules? firestore.rules

Firestore indexes allow you to perform complex queries while
maintaining performance that scales with the size of the result
set. You can keep index definitions in your project directory
and publish them with firebase deploy.

? What file should be used for Firestore indexes? firestore.indexes.json

i  Writing configuration info to firebase.json...
i  Writing project information to .firebaserc...

✔  Firebase initialization complete!
samstern@samstern-macbookpro tmp.73XjfHwC
$ cat firestore.rules
service firebase.storage {
  match /b/{bucket}/o {
    match /{allPaths=**} {
      allow read, write: if request.auth != null;
    }
  }
}
```

```
samstern@samstern-macbookpro tmp.73XjfHwC
$ echo "Testing with service=cloud.firestore"
Testing with service=cloud.firestore
samstern@samstern-macbookpro tmp.73XjfHwC
$ ~/Projects/firebase-tools/bin/firebase init firestore

     🔥redacted

You're about to initialize a Firebase project in this directory:

  /private/var/folders/q_/sry2gzmj2tb8xsw3s5x_dz4h00643s/T/tmp.73XjfHwC

Before we get started, keep in mind:

  * You are currently outside your home directory
  * You are initializing in an existing Firebase project directory


=== Project Setup

First, let's associate this project directory with a Firebase project.
You can create multiple project aliases by running firebase use --add,
but for now we'll just set up a default project.

i  .firebaserc already has a default project, skipping

=== Firestore Setup

Firestore Security Rules allow you to define how and when to allow
requests. You can keep these rules in your project directory
and publish them with firebase deploy.

? What file should be used for Firestore Rules? firestore.rules

Firestore indexes allow you to perform complex queries while
maintaining performance that scales with the size of the result
set. You can keep index definitions in your project directory
and publish them with firebase deploy.

? What file should be used for Firestore indexes? firestore.indexes.json

i  Writing configuration info to firebase.json...
i  Writing project information to .firebaserc...

✔  Firebase initialization complete!
samstern@samstern-macbookpro tmp.73XjfHwC
$ cat firestore.rules
service cloud.firestore {
  match /databases/{database}/documents {
                match /users/{uid} {
      // Transactions:
      //   read, write -> only the owning user
      match /transactions/{tid} {
        allow read, write: if request.auth.uid == uid;
      }

      // Bills:
      //   read -> only the owning user
      //   write -> only the server
      match /bills/{bid} {
        allow read: if request.auth.uid == uid;
        allow write: if false;
      }
    }
  }
}samstern@samstern-macbookpro tmp.73XjfHwC
$
```