### PR TITLE
Log warnings, fail on errors

### DIFF
--- a/lib/RulesDeploy.js
+++ b/lib/RulesDeploy.js
@@ -93,11 +93,11 @@ RulesDeploy.prototype = {
     var self = this;
     return gcp.rules.testRuleset(self.options.project, files).then(function(response) {
       if (response.body && response.body.issues && response.body.issues.length > 0) {
-        var add = response.body.issues.length === 1 ? "" : "s";
-        var message = "Compilation error" + add + " in " + chalk.bold(filename) + ":\n";
+        var warnings = [];
+        var errors = [];
         response.body.issues.forEach(function(issue) {
-          message +=
-            "\n[" +
+          var issueMessage =
+            "[" +
             issue.severity.substring(0, 1) +
             "] " +
             issue.sourcePosition.line +
@@ -105,9 +105,26 @@ RulesDeploy.prototype = {
             issue.sourcePosition.column +
             " - " +
             issue.description;
+
+          if (issue.severity === "ERROR") {
+            errors.push(issueMessage);
+          } else {
+            warnings.push(issueMessage);
+          }
         });
 
-        return utils.reject(message, { exit: 1 });
+        if (errors.length > 0) {
+          var add = errors.length === 1 ? "" : "s";
+          var message =
+            "Compilation error" + add + " in " + chalk.bold(filename) + ":\n" + errors.join("\n");
+          return utils.reject(message, { exit: 1 });
+        }
+
+        if (warnings.length > 0) {
+          warnings.forEach(function(warning) {
+            utils.logWarning(warning);
+          });
+        }
       }
 
       utils.logSuccess(

--- a/lib/RulesDeploy.js
+++ b/lib/RulesDeploy.js
@@ -113,17 +113,17 @@ RulesDeploy.prototype = {
           }
         });
 
+        if (warnings.length > 0) {
+          warnings.forEach(function(warning) {
+            utils.logWarning(warning);
+          });
+        }
+
         if (errors.length > 0) {
           var add = errors.length === 1 ? "" : "s";
           var message =
             "Compilation error" + add + " in " + chalk.bold(filename) + ":\n" + errors.join("\n");
           return utils.reject(message, { exit: 1 });
-        }
-
-        if (warnings.length > 0) {
-          warnings.forEach(function(warning) {
-            utils.logWarning(warning);
-          });
         }
       }
 


### PR DESCRIPTION
This makes warnings look like this:

```
$ ~/Projects/firebase-tools/bin/firebase deploy --only firestore:rules

=== Deploying to 'firestoresigelbaum'...

i  deploying firestore
i  firestore: checking firestore.rules for compilation errors...
⚠  [W] 3:5 - Overlapping recursive wildcard match statement.
✔  firestore: rules file firestore.rules compiled successfully
i  firestore: uploading rules firestore.rules...
✔  firestore: released rules firestore.rules to cloud.firestore

✔  Deploy complete!
```