### PR TITLE
Fix firebase init when Rules never used on a project

### DIFF
--- a/lib/gcp/rules.js
+++ b/lib/gcp/rules.js
@@ -46,6 +46,9 @@ function getLatestRulesetName(projectId, service) {
           }
           return release.rulesetName;
         }
+
+        // In this case it's likely that Firestore has not been used on this project before.
+        return null;
       }
 
       return _handleErrorResponse(response);


### PR DESCRIPTION
The `releases` endpoint can sometimes return a 200 but no releases in the body.  This means that no Storage/Firestore rules have ever been deployed.  This should not be an error.