### PR TITLE
Windows paths should use forward slash

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Windows path separator should use a forward slash.

--- a/lib/deploy/hosting/uploader.js
+++ b/lib/deploy/hosting/uploader.js
@@ -158,11 +158,10 @@ class Uploader {
   }
 
   addHash(filePath, hash) {
-    const npath = path.relative(this.public, path.resolve(this.public, filePath));
-    this.hashMap[hash] = npath;
-    this.pathMap[npath] = hash;
+    this.hashMap[hash] = filePath;
+    this.pathMap[filePath] = hash;
 
-    this.populateBatch["/" + npath] = hash;
+    this.populateBatch["/" + filePath] = hash;
     this.populateCount++;
 
     const curBatchSize = size(this.populateBatch);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-tools",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "Command-Line Interface for Firebase",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
### Description

Remove the code to make the file path relative to the public directory (because it was already relative to it).  That was also inadvertently using backslashes for directory separators in Windows.
	 
### Scenarios Tested

Tested deploys on on both Windows and Linux.

### Sample Commands

`firebase deploy --only hosting`