### PR TITLE
Cache for Hosting file hashes should be located at the project root

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Cached Hosting file hashes should be located at the project root.

--- a/lib/deploy/hosting/uploader.js
+++ b/lib/deploy/hosting/uploader.js
@@ -9,6 +9,7 @@ const zlib = require("zlib");
 const crypto = require("crypto");
 
 const hashcache = require("./hashcache");
+const detectProjectRoot = require("../../detectProjectRoot");
 const api = require("../../api");
 const logger = require("../../logger");
 const Queue = require("../../queue");
@@ -32,7 +33,8 @@ class Uploader {
     this.version = options.version;
     this.cwd = options.cwd || process.cwd();
 
-    this.cache = hashcache.load(this.cwd, "0");
+    this.projectRoot = detectProjectRoot(this.cwd);
+    this.cache = hashcache.load(this.projectRoot, "0");
     this.cacheNew = {};
 
     this.gzipLevel = options.gzipLevel || 9;
@@ -78,7 +80,7 @@ class Uploader {
       .wait()
       .then(self.queuePopulate.bind(self))
       .then(function() {
-        hashcache.dump(self.cwd, "0", self.cacheNew);
+        hashcache.dump(self.projectRoot, "0", self.cacheNew);
         logger.debug("[hosting][hash queue][FINAL]", self.hashQueue.stats());
         self.populateQueue.close();
         return self.populateQueue.wait();


### PR DESCRIPTION
### Description

Currently after a deploy to Hosting a file of cached file hashes is stored at `<cwd>/.firebase/hosting.0.cache`.  This can cause issues if a user happens to be in their public directory when they deploy.  This change causes the CLI to look for (and save) the cache at `<project_root>/.firebase/hosting.0.cache`.
	 
### Scenarios Tested

Tested the change out on both Linux and Windows deploying from the project root, inside of the specified public directory, and in an unrelated deeper directory (still within the project root).
