### PR TITLE
feat(deploy): platform native notifications when deploy complete

### DIFF
--- a/lib/deploy/index.js
+++ b/lib/deploy/index.js
@@ -4,6 +4,7 @@ var logger = require("../logger");
 var api = require("../api");
 var clc = require("cli-color");
 var _ = require("lodash");
+var notifier = require("node-notifier");
 var getProjectId = require("../getProjectId");
 var utils = require("../utils");
 var FirebaseError = require("../error");
@@ -99,6 +100,11 @@ var deploy = function(targetNames, options) {
       logger.info();
       utils.logSuccess(clc.underline.bold("Deploy complete!"));
       logger.info();
+      notifier.notify({
+        title: "Firebase CLI 🔥",
+        message: "Deploy complete!",
+        sound: true
+      });
       var deployedHosting = _.includes(targetNames, "hosting");
       logger.info(clc.bold("Project Console:"), utils.consoleUrl(options.project, "/overview"));
       if (deployedHosting) {

--- a/lib/deploy/index.js
+++ b/lib/deploy/index.js
@@ -103,7 +103,7 @@ var deploy = function(targetNames, options) {
       notifier.notify({
         title: "Firebase CLI 🔥",
         message: "Deploy complete!",
-        sound: true
+        sound: true,
       });
       var deployedHosting = _.includes(targetNames, "hosting");
       logger.info(clc.bold("Project Console:"), utils.consoleUrl(options.project, "/overview"));

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "jsonwebtoken": "^8.2.1",
     "lodash": "^4.17.10",
     "minimatch": "^3.0.4",
+    "node-notifier": "^5.2.1",
     "opn": "^5.3.0",
     "ora": "0.2.3",
     "portfinder": "^1.0.13",


### PR DESCRIPTION
### Description

![ezgif-4-01cd2678f3](https://user-images.githubusercontent.com/7255298/44858647-bfdd4a00-ac72-11e8-8d40-001dfa805d11.gif)

I added a native notification to know when the deploy is finished without look to the terminal.
	 
### Scenarios Tested

I tested deploying some cloud functions and hosting changes on macOS, because macOS is my development platform and [node-notifier](https://www.npmjs.com/package/node-notifier) seems to work on all the platforms.
