### PR TITLE
Speed up recursive deletes

### DIFF
--- a/commands/firestore-delete.js
+++ b/commands/firestore-delete.js
@@ -80,7 +80,7 @@ module.exports = new Command("firestore:delete [path]")
     var deleteOp = new FirestoreDelete(options.project, path, {
       recursive: options.recursive,
       shallow: options.shallow,
-      batchSize: 50,
+      batchSize: 200,
       allCollections: options.allCollections,
     });
 

--- a/commands/firestore-delete.js
+++ b/commands/firestore-delete.js
@@ -80,7 +80,6 @@ module.exports = new Command("firestore:delete [path]")
     var deleteOp = new FirestoreDelete(options.project, path, {
       recursive: options.recursive,
       shallow: options.shallow,
-      batchSize: 200,
       allCollections: options.allCollections,
     });
 

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var api = require("../../lib/api");
 var clc = require("cli-color");
+var ProgressBar = require("progress");
+
+var api = require("../../lib/api");
 var firestore = require("../../lib/gcp/firestore");
 var FirebaseError = require("../../lib/error");
 var logger = require("../../lib/logger");
-var ProgressBar = require("progress");
-
 var utils = require("../../lib/utils");
 
 /**

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -9,6 +9,63 @@ var ProgressBar = require("progress");
 var utils = require("../../lib/utils");
 
 /**
+ * @constructor
+ */
+function DeletionQueue() {
+  this.queue = [];
+  this.numProcessing = 0;
+  this.pagesRemaining = false;
+  this.pageIncoming = false;
+}
+
+DeletionQueue.prototype.take = function() {
+  if (this.queue.length < 0) {
+    throw "Can't take from empty queue";
+  }
+
+  return this.queue.shift();
+};
+
+DeletionQueue.prototype.insert = function(item) {
+  this.queue.push(item);
+};
+
+DeletionQueue.prototype.startProcessing = function() {
+  this.numProcessing++;
+};
+
+DeletionQueue.prototype.endProcessing = function() {
+  this.numProcessing--;
+  if (this.numProcessing < 0) {
+    throw "Error: numProcessing < 0";
+  }
+};
+
+DeletionQueue.prototype.done = function() {
+  return this.queue.length == 0 && this.numProcessing == 0 && this.pagesRemaining == false;
+};
+
+DeletionQueue.prototype.pending = function() {
+  return this.queue.length;
+};
+
+DeletionQueue.prototype.shouldLoadMore = function() {
+  return this.pagesRemaining && !this.pageIncoming;
+};
+
+/**
+ * In a loop:
+ *
+ * if queue not empty and queue #processing < x {
+ *   take and process 1;
+ * }
+ *
+ * if queue size < y {
+ *  load a new page and add to queue (await)
+ * }
+ */
+
+/**
  * Construct a new Firestore delete operation.
  *
  * @constructor
@@ -26,6 +83,8 @@ function FirestoreDelete(project, path, options) {
   this.shallow = Boolean(options.shallow);
   this.batchSize = options.batchSize || 50;
   this.allCollections = Boolean(options.allCollections);
+
+  this.queue = new DeletionQueue();
 
   // Remove any leading or trailing slashes from the path
   if (this.path) {
@@ -102,6 +161,8 @@ FirestoreDelete.prototype._isCollectionPath = function(path) {
   return !this._isDocumentPath(path);
 };
 
+// TODO: Docs for startAfter
+
 /**
  * Construct a StructuredQuery to find descendant documents of a collection.
  *
@@ -112,7 +173,11 @@ FirestoreDelete.prototype._isCollectionPath = function(path) {
  * @param {number} batchSize maximum number of documents to target (limit).
  * @return {object} a StructuredQuery.
  */
-FirestoreDelete.prototype._collectionDescendantsQuery = function(allDescendants, batchSize) {
+FirestoreDelete.prototype._collectionDescendantsQuery = function(
+  allDescendants,
+  batchSize,
+  startAfter
+) {
   var nullChar = String.fromCharCode(0);
 
   var startAt = this.parent + "/" + this.path + "/" + nullChar;
@@ -148,7 +213,7 @@ FirestoreDelete.prototype._collectionDescendantsQuery = function(allDescendants,
     },
   };
 
-  return {
+  var query = {
     structuredQuery: {
       where: where,
       limit: batchSize,
@@ -160,8 +225,18 @@ FirestoreDelete.prototype._collectionDescendantsQuery = function(allDescendants,
       select: {
         fields: [{ fieldPath: "__name__" }],
       },
+      orderBy: [{ field: { fieldPath: "__name__" } }],
     },
   };
+
+  if (startAfter) {
+    query.structuredQuery.startAt = {
+      values: [{ referenceValue: startAfter }],
+      before: false,
+    };
+  }
+
+  return query;
 };
 
 /**
@@ -176,8 +251,8 @@ FirestoreDelete.prototype._collectionDescendantsQuery = function(allDescendants,
  * @param {number} batchSize maximum number of documents to target (limit).
  * @return {object} a StructuredQuery.
  */
-FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchSize) {
-  return {
+FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchSize, startAfter) {
+  var query = {
     structuredQuery: {
       limit: batchSize,
       from: [
@@ -188,8 +263,18 @@ FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchS
       select: {
         fields: [{ fieldPath: "__name__" }],
       },
+      orderBy: [{ field: { fieldPath: "__name__" } }],
     },
   };
+
+  if (startAfter) {
+    query.structuredQuery.startAt = {
+      values: [{ referenceValue: startAfter }],
+      before: false,
+    };
+  }
+
+  return query;
 };
 
 /**
@@ -202,15 +287,15 @@ FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchS
  * @param {number} batchSize the maximum size of the batch.
  * @return {Promise<object[]>} a promise for an array of documents.
  */
-FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSize) {
+FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSize, startAfter) {
   var url;
   var body;
   if (this.isDocumentPath) {
     url = this.parent + "/" + this.path + ":runQuery";
-    body = this._docDescendantsQuery(allDescendants, batchSize);
+    body = this._docDescendantsQuery(allDescendants, batchSize, startAfter);
   } else {
     url = this.parent + ":runQuery";
-    body = this._collectionDescendantsQuery(allDescendants, batchSize);
+    body = this._collectionDescendantsQuery(allDescendants, batchSize, startAfter);
   }
 
   return api
@@ -266,6 +351,22 @@ FirestoreDelete.prototype._deleteDocuments = function(docs) {
 };
 
 /**
+ * Delete a single Firestore document.
+ *
+ * For document format see:
+ * https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Document
+ *
+ * @param {object} doc a Document object to delete.
+ * @return {Promise} a promise for the delete operation.
+ */
+FirestoreDelete.prototype._deleteDocument = function(doc) {
+  return api.request("DELETE", "/v1beta1/" + doc.name, {
+    auth: true,
+    origin: api.firestoreOrigin,
+  });
+};
+
+/**
  * Progress bar shared by the class.
  */
 FirestoreDelete.progressBar = new ProgressBar("Deleted :current docs (:rate docs/s)", {
@@ -280,18 +381,66 @@ FirestoreDelete.progressBar = new ProgressBar("Deleted :current docs (:rate docs
  */
 FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var self = this;
-  return this._getDescendantBatch(this.allDescendants, this.batchSize).then(function(docs) {
-    if (docs.length <= 0) {
-      return Promise.resolve();
-    }
+  var lastDocName = undefined;
 
-    return self._deleteDocuments(docs).then(function(numDeleted) {
-      // Tick the progress bar
-      FirestoreDelete.progressBar.tick(numDeleted);
+  this.queue.pagesRemaining = true;
+  return new Promise(function(resolve, reject) {
+    setInterval(function() {
+      if (self.queue.done()) {
+        resolve();
+      }
 
-      // Recurse to delete another batch
-      return self._recursiveBatchDelete();
-    });
+      // TODO: Query pagination, then eager loading (when < 100 remaining)
+      if (self.queue.pending() <= 150 && self.queue.shouldLoadMore()) {
+        self.queue.pageIncoming = true;
+        self
+          ._getDescendantBatch(self.allDescendants, self.batchSize, lastDocName)
+          .then(function(docs) {
+            self.queue.pageIncoming = false;
+
+            if (docs.length == 0) {
+              self.queue.pagesRemaining = false;
+              return;
+            }
+
+            docs.forEach(function(doc) {
+              self.queue.insert(doc);
+            });
+
+            lastDocName = docs[docs.length - 1].name;
+          })
+          .catch(function() {
+            self.queue.pageIncoming = false;
+          });
+      }
+
+      // Don't have more than {x} requests outstanding
+      if (self.queue.numProcessing > 150) {
+        return;
+      }
+
+      if (self.queue.pending() == 0) {
+        return;
+      }
+
+      const toDelete = self.queue.take();
+      if (!toDelete) {
+        console.log("Queue exhausted!");
+        return;
+      }
+
+      self.queue.startProcessing();
+      self
+        ._deleteDocument(toDelete)
+        .then(function() {
+          FirestoreDelete.progressBar.tick(1);
+          self.queue.endProcessing();
+        })
+        .catch(function() {
+          self.queue.insert(toDelete);
+          self.queue.endProcessing();
+        });
+    }, 2);
   });
 };
 

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -16,7 +16,6 @@ var utils = require("../../lib/utils");
  * @param {string} path path to a document or collection.
  * @param {boolean} options.recursive true if the delete should be recursive.
  * @param {boolean} options.shallow true if the delete should be shallow (non-recursive).
- * @param {number} options.batchSize the number of documents to delete in a batch.
  * @param {boolean} options.allCollections true if the delete should universally remove all collections and docs.
  */
 function FirestoreDelete(project, path, options) {
@@ -24,7 +23,6 @@ function FirestoreDelete(project, path, options) {
   this.path = path;
   this.recursive = Boolean(options.recursive);
   this.shallow = Boolean(options.shallow);
-  this.batchSize = options.batchSize || 50;
   this.allCollections = Boolean(options.allCollections);
 
   // Remove any leading or trailing slashes from the path
@@ -275,6 +273,39 @@ FirestoreDelete.prototype._deleteDocument = function(doc) {
 };
 
 /**
+ * Delete an array of Firestore documents.
+ *
+ * For document format see:
+ * https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Document
+ *
+ * @param {object[]} docs an array of Document objects to delete.
+ * @return {Promise<number>} a promise for the number of deleted documents.
+ */
+FirestoreDelete.prototype._deleteDocuments = function(docs) {
+  var url = this.parent + ":commit";
+
+  var writes = docs.map(function(doc) {
+    return {
+      delete: doc.name,
+    };
+  });
+
+  var body = {
+    writes: writes,
+  };
+
+  return api
+    .request("POST", "/v1beta1/" + url, {
+      auth: true,
+      data: body,
+      origin: api.firestoreOrigin,
+    })
+    .then(function(res) {
+      return res.body.writeResults.length;
+    });
+};
+
+/**
  * Progress bar shared by the class.
  */
 FirestoreDelete.progressBar = new ProgressBar("Deleted :current docs (:rate docs/s)", {
@@ -291,21 +322,23 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var self = this;
 
   // Tunable deletion parameters
-  var maxOutstanding = 150;
-  var minimumQueueSize = 150;
+  var readBatchSize = 5000;
+  var deleteBatchSize = 250;
+  var maxPendingDeletes = 25;
+  var minimumQueueSize = deleteBatchSize * 10;
 
   // All temporary variables for the deletion queue.
   var queue = [];
-  var numOutstanding = 0;
+  var numPendingDeletes = 0;
   var pagesRemaining = true;
   var pageIncoming = false;
-  var lastDocName = undefined;
+  var lastDocName;
 
   var retried = {};
   var failures = [];
 
   var queueLoop = function() {
-    if (queue.length == 0 && numOutstanding == 0 && !pagesRemaining) {
+    if (queue.length == 0 && numPendingDeletes == 0 && !pagesRemaining) {
       return true;
     }
 
@@ -313,7 +346,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
       pageIncoming = true;
 
       self
-        ._getDescendantBatch(self.allDescendants, self.batchSize, lastDocName)
+        ._getDescendantBatch(self.allDescendants, readBatchSize, lastDocName)
         .then(function(docs) {
           pageIncoming = false;
 
@@ -334,7 +367,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         });
     }
 
-    if (numOutstanding > maxOutstanding) {
+    if (numPendingDeletes > maxPendingDeletes) {
       return false;
     }
 
@@ -342,27 +375,36 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
       return false;
     }
 
-    const toDelete = queue.shift();
-    numOutstanding++;
+    var toDelete = [];
+    var numToDelete = Math.min(deleteBatchSize, queue.length);
 
+    for (var i = 0; i < numToDelete; i++) {
+      toDelete.push(queue.shift());
+    }
+
+    numPendingDeletes++;
     self
-      ._deleteDocument(toDelete)
-      .then(function() {
-        FirestoreDelete.progressBar.tick(1);
-        numOutstanding--;
+      ._deleteDocuments(toDelete)
+      .then(function(numDeleted) {
+        FirestoreDelete.progressBar.tick(numDeleted);
+        numPendingDeletes--;
       })
       .catch(function(e) {
         // For server errors, retry if the document has not yet been retried.
         if (e.status >= 500 && e.status < 600 && !retried[toDelete.name]) {
           logger.debug("Server error deleting doc " + toDelete.name, e);
-          queue.push(toDelete);
-          retried[toDelete.name] = true;
+
+          // TODO
+          // queue.push(toDelete);
+          // retried[toDelete.name] = true;
         } else {
           logger.debug("Fatal error deleting doc " + toDelete.name, e);
-          failures.push(toDelete);
+
+          // TODO
+          // failures.push(toDelete);
         }
 
-        numOutstanding--;
+        numPendingDeletes--;
       });
 
     return false;
@@ -464,7 +506,6 @@ FirestoreDelete.prototype.deleteDatabase = function() {
         var collectionId = collectionIds[i];
         var deleteOp = new FirestoreDelete(self.project, collectionId, {
           recursive: true,
-          batchSize: self.batchSize,
         });
 
         promises.push(deleteOp.execute());

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -2,6 +2,7 @@
 
 var api = require("../../lib/api");
 var clc = require("cli-color");
+var firestore = require("../../lib/gcp/firestore");
 var FirebaseError = require("../../lib/error");
 var logger = require("../../lib/logger");
 var ProgressBar = require("progress");
@@ -258,55 +259,6 @@ FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSi
 };
 
 /**
- * Delete a single Firestore document.
- *
- * For document format see:
- * https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Document
- *
- * @param {object} doc a Document object to delete.
- * @return {Promise} a promise for the delete operation.
- */
-FirestoreDelete.prototype._deleteDocument = function(doc) {
-  return api.request("DELETE", "/v1beta1/" + doc.name, {
-    auth: true,
-    origin: api.firestoreOrigin,
-  });
-};
-
-/**
- * Delete an array of Firestore documents.
- *
- * For document format see:
- * https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Document
- *
- * @param {object[]} docs an array of Document objects to delete.
- * @return {Promise<number>} a promise for the number of deleted documents.
- */
-FirestoreDelete.prototype._deleteDocuments = function(docs) {
-  var url = this.parent + ":commit";
-
-  var writes = docs.map(function(doc) {
-    return {
-      delete: doc.name,
-    };
-  });
-
-  var body = {
-    writes: writes,
-  };
-
-  return api
-    .request("POST", "/v1beta1/" + url, {
-      auth: true,
-      data: body,
-      origin: api.firestoreOrigin,
-    })
-    .then(function(res) {
-      return res.body.writeResults.length;
-    });
-};
-
-/**
  * Progress bar shared by the class.
  */
 FirestoreDelete.progressBar = new ProgressBar("Deleted :current docs (:rate docs/s)", {
@@ -335,11 +287,16 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var pageIncoming = false;
   var lastDocName;
 
-  var retried = {};
   var failures = [];
+  var retried = {};
 
   var queueLoop = function() {
     if (queue.length == 0 && numPendingDeletes == 0 && !pagesRemaining) {
+      return true;
+    }
+
+    if (failures.length > 0) {
+      logger.debug("Found " + failures.length + " failed deletes, failing.");
       return true;
     }
 
@@ -373,7 +330,6 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
     }
 
     if (queue.length == 0) {
-      logger.debug("Queue is exhaused!");
       return false;
     }
 
@@ -385,8 +341,8 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
     }
 
     numPendingDeletes++;
-    self
-      ._deleteDocuments(toDelete)
+    firestore
+      .deleteDocuments(self.project, toDelete)
       .then(function(numDeleted) {
         FirestoreDelete.progressBar.tick(numDeleted);
         numPendingDeletes--;
@@ -399,7 +355,8 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
           // Retry each doc up to one time
           toDelete.forEach(function(doc) {
             if (retried[doc.name]) {
-              failures.push(doc);
+              logger.debug("Failed to delete doc " + doc.name + " multiple times.");
+              failures.push(doc.name);
             } else {
               retried[doc.name] = true;
               queue.push(doc);
@@ -408,7 +365,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         } else {
           logger.debug("Fatal error deleting docs ", e);
           toDelete.forEach(function(doc) {
-            failures.push(doc);
+            failures.push(doc.name);
           });
         }
 
@@ -426,12 +383,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         if (failures.length == 0) {
           resolve();
         } else {
-          // Fail and indicate in the message which docs
-          // could not be deleted.
-          var failIds = failures.map(function(doc) {
-            return doc.name;
-          });
-          reject("Failed to delete docs: " + failIds);
+          reject("Failed to delete documents " + failures);
         }
       }
     }, 0);
@@ -450,7 +402,7 @@ FirestoreDelete.prototype._deletePath = function() {
   var initialDelete;
   if (this.isDocumentPath) {
     var doc = { name: this.parent + "/" + this.path };
-    initialDelete = this._deleteDocument(doc).catch(function(err) {
+    initialDelete = firestore.deleteDocument(doc).catch(function(err) {
       logger.debug("deletePath:initialDelete:error", err);
       if (self.allDescendants) {
         // On a recursive delete, we are insensitive to
@@ -471,36 +423,14 @@ FirestoreDelete.prototype._deletePath = function() {
 };
 
 /**
- * List all collection IDs.
- *
- * @return {Promise<string[]>} a promise for an array of collection IDs.
- */
-FirestoreDelete.prototype._listCollectionIds = function() {
-  var url =
-    "/v1beta1/projects/" + this.project + "/databases/(default)/documents:listCollectionIds";
-
-  return api
-    .request("POST", url, {
-      auth: true,
-      origin: api.firestoreOrigin,
-      data: {
-        // Maximum 32-bit integer
-        pageSize: 2147483647,
-      },
-    })
-    .then(function(res) {
-      return res.body.collectionIds || [];
-    });
-};
-
-/**
  * Delete an entire database by finding and deleting each collection.
  *
  * @return {Promise} a promise for all of the operations combined.
  */
 FirestoreDelete.prototype.deleteDatabase = function() {
   var self = this;
-  return this._listCollectionIds()
+  return firestore
+    .listCollectionIds(this.project)
     .catch(function(err) {
       logger.debug("deleteDatabase:listCollectionIds:error", err);
       return utils.reject("Unable to list collection IDs");

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -109,7 +109,7 @@ FirestoreDelete.prototype._isCollectionPath = function(path) {
  *
  * @param {boolean} allDescendants true if subcollections should be included.
  * @param {number} batchSize maximum number of documents to target (limit).
- * @param {string} startAfter document name to start after (optional).
+ * @param {string=} startAfter document name to start after (optional).
  * @return {object} a StructuredQuery.
  */
 FirestoreDelete.prototype._collectionDescendantsQuery = function(
@@ -188,7 +188,7 @@ FirestoreDelete.prototype._collectionDescendantsQuery = function(
  *
  * @param {boolean} allDescendants true if subcollections should be included.
  * @param {number} batchSize maximum number of documents to target (limit).
- * @param {string} startAfter document name to start after (optional).
+ * @param {string=} startAfter document name to start after (optional).
  * @return {object} a StructuredQuery.
  */
 FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchSize, startAfter) {
@@ -225,7 +225,7 @@ FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchS
  *
  * @param {boolean} allDescendants true if subcollections should be included,
  * @param {number} batchSize the maximum size of the batch.
- * @param {string} startAfter the name of the document to start after (optional).
+ * @param {string=} startAfter the name of the document to start after (optional).
  * @return {Promise<object[]>} a promise for an array of documents.
  */
 FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSize, startAfter) {
@@ -313,10 +313,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
             return;
           }
 
-          docs.forEach(function(doc) {
-            queue.push(doc);
-          });
-
+          queue = queue.concat(docs);
           lastDocName = docs[docs.length - 1].name;
         })
         .catch(function(e) {
@@ -364,9 +361,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
           });
         } else {
           logger.debug("Fatal error deleting docs ", e);
-          toDelete.forEach(function(doc) {
-            failures.push(doc.name);
-          });
+          failures = failures.concat(toDelete);
         }
 
         numPendingDeletes--;

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -224,6 +224,7 @@ FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchS
  *
  * @param {boolean} allDescendants true if subcollections should be included,
  * @param {number} batchSize the maximum size of the batch.
+ * @param {string} startAfter the name of the document to start after (optional).
  * @return {Promise<object[]>} a promise for an array of documents.
  */
 FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSize, startAfter) {
@@ -322,7 +323,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var self = this;
 
   // Tunable deletion parameters
-  var readBatchSize = 5000;
+  var readBatchSize = 7500;
   var deleteBatchSize = 250;
   var maxPendingDeletes = 15;
   var maxQueueSize = deleteBatchSize * maxPendingDeletes * 2;
@@ -372,6 +373,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
     }
 
     if (queue.length == 0) {
+      logger.debug("Queue is exhaused!");
       return false;
     }
 
@@ -391,8 +393,8 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
       })
       .catch(function(e) {
         // For server errors, retry if the document has not yet been retried.
-        if (e.status >= 500 && e.status < 600 && !retried[toDelete.name]) {
-          logger.debug("Server error deleting doc " + toDelete.name, e);
+        if (e.status >= 500 && e.status < 600) {
+          logger.debug("Server error deleting doc batch", e);
 
           // Retry each doc up to one time
           toDelete.forEach(function(doc) {

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -301,6 +301,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var pageIncoming = false;
   var lastDocName = undefined;
 
+  var retried = {};
   var failures = [];
 
   var queueLoop = function() {
@@ -351,10 +352,11 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         numOutstanding--;
       })
       .catch(function(e) {
-        // For server errors, just throw the document back into the queue.
-        if (e.status >= 500 && e.status < 600) {
+        // For server errors, retry if the document has not yet been retried.
+        if (e.status >= 500 && e.status < 600 && !retried[toDelete.name]) {
           logger.debug("Server error deleting doc " + toDelete.name, e);
           queue.push(toDelete);
+          retried[toDelete.name] = true;
         } else {
           logger.debug("Fatal error deleting doc " + toDelete.name, e);
           failures.push(toDelete);
@@ -366,7 +368,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
     return false;
   };
 
-  return new Promise(function(resolve) {
+  return new Promise(function(resolve, reject) {
     var intervalId = setInterval(function() {
       if (queueLoop()) {
         clearInterval(intervalId);

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -259,39 +259,6 @@ FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSi
 };
 
 /**
- * Delete an array of Firestore documents.
- *
- * For document format see:
- * https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Document
- *
- * @param {object[]} docs an array of Document objects to delete.
- * @return {Promise<number>} a promise for the number of deleted documents.
- */
-FirestoreDelete.prototype._deleteDocuments = function(docs) {
-  var url = this.parent + ":commit";
-
-  var writes = docs.map(function(doc) {
-    return {
-      delete: doc.name,
-    };
-  });
-
-  var body = {
-    writes: writes,
-  };
-
-  return api
-    .request("POST", "/v1beta1/" + url, {
-      auth: true,
-      data: body,
-      origin: api.firestoreOrigin,
-    })
-    .then(function(res) {
-      return res.body.writeResults.length;
-    });
-};
-
-/**
  * Delete a single Firestore document.
  *
  * For document format see:
@@ -334,6 +301,8 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var pageIncoming = false;
   var lastDocName = undefined;
 
+  var failures = [];
+
   var queueLoop = function() {
     if (queue.length == 0 && numOutstanding == 0 && !pagesRemaining) {
       return true;
@@ -358,8 +327,8 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
 
           lastDocName = docs[docs.length - 1].name;
         })
-        .catch(function() {
-          // TODO: Debug log error
+        .catch(function(e) {
+          logger.debug("Failed to fetch page after " + lastDocName, e);
           pageIncoming = false;
         });
     }
@@ -381,9 +350,16 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         FirestoreDelete.progressBar.tick(1);
         numOutstanding--;
       })
-      .catch(function() {
-        // TODO: Care about the error reason
-        queue.push(toDelete);
+      .catch(function(e) {
+        // For server errors, just throw the document back into the queue.
+        if (e.status >= 500 && e.status < 600) {
+          logger.debug("Server error deleting doc " + toDelete.name, e);
+          queue.push(toDelete);
+        } else {
+          logger.debug("Fatal error deleting doc " + toDelete.name, e);
+          failures.push(toDelete);
+        }
+
         numOutstanding--;
       });
 
@@ -394,7 +370,17 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
     var intervalId = setInterval(function() {
       if (queueLoop()) {
         clearInterval(intervalId);
-        resolve();
+
+        if (failures.length == 0) {
+          resolve();
+        } else {
+          // Fail and indicate in the message which docs
+          // could not be deleted.
+          var failIds = failures.map(function(doc) {
+            return doc.name;
+          });
+          reject("Failed to delete docs: " + failIds);
+        }
       }
     }, 0);
   });
@@ -412,7 +398,7 @@ FirestoreDelete.prototype._deletePath = function() {
   var initialDelete;
   if (this.isDocumentPath) {
     var doc = { name: this.parent + "/" + this.path };
-    initialDelete = this._deleteDocuments([doc]).catch(function(err) {
+    initialDelete = this._deleteDocument(doc).catch(function(err) {
       logger.debug("deletePath:initialDelete:error", err);
       if (self.allDescendants) {
         // On a recursive delete, we are insensitive to

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -324,8 +324,8 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   // Tunable deletion parameters
   var readBatchSize = 5000;
   var deleteBatchSize = 250;
-  var maxPendingDeletes = 25;
-  var minimumQueueSize = deleteBatchSize * 10;
+  var maxPendingDeletes = 15;
+  var maxQueueSize = deleteBatchSize * maxPendingDeletes * 2;
 
   // All temporary variables for the deletion queue.
   var queue = [];
@@ -342,7 +342,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
       return true;
     }
 
-    if (queue.length <= minimumQueueSize && pagesRemaining && !pageIncoming) {
+    if (queue.length <= maxQueueSize && pagesRemaining && !pageIncoming) {
       pageIncoming = true;
 
       self
@@ -394,14 +394,20 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         if (e.status >= 500 && e.status < 600 && !retried[toDelete.name]) {
           logger.debug("Server error deleting doc " + toDelete.name, e);
 
-          // TODO
-          // queue.push(toDelete);
-          // retried[toDelete.name] = true;
+          // Retry each doc up to one time
+          toDelete.forEach(function(doc) {
+            if (retried[doc.name]) {
+              failures.push(doc);
+            } else {
+              retried[doc.name] = true;
+              queue.push(doc);
+            }
+          });
         } else {
-          logger.debug("Fatal error deleting doc " + toDelete.name, e);
-
-          // TODO
-          // failures.push(toDelete);
+          logger.debug("Fatal error deleting docs ", e);
+          toDelete.forEach(function(doc) {
+            failures.push(doc);
+          });
         }
 
         numPendingDeletes--;

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -9,63 +9,6 @@ var ProgressBar = require("progress");
 var utils = require("../../lib/utils");
 
 /**
- * @constructor
- */
-function DeletionQueue() {
-  this.queue = [];
-  this.numProcessing = 0;
-  this.pagesRemaining = false;
-  this.pageIncoming = false;
-}
-
-DeletionQueue.prototype.take = function() {
-  if (this.queue.length < 0) {
-    throw "Can't take from empty queue";
-  }
-
-  return this.queue.shift();
-};
-
-DeletionQueue.prototype.insert = function(item) {
-  this.queue.push(item);
-};
-
-DeletionQueue.prototype.startProcessing = function() {
-  this.numProcessing++;
-};
-
-DeletionQueue.prototype.endProcessing = function() {
-  this.numProcessing--;
-  if (this.numProcessing < 0) {
-    throw "Error: numProcessing < 0";
-  }
-};
-
-DeletionQueue.prototype.done = function() {
-  return this.queue.length == 0 && this.numProcessing == 0 && this.pagesRemaining == false;
-};
-
-DeletionQueue.prototype.pending = function() {
-  return this.queue.length;
-};
-
-DeletionQueue.prototype.shouldLoadMore = function() {
-  return this.pagesRemaining && !this.pageIncoming;
-};
-
-/**
- * In a loop:
- *
- * if queue not empty and queue #processing < x {
- *   take and process 1;
- * }
- *
- * if queue size < y {
- *  load a new page and add to queue (await)
- * }
- */
-
-/**
  * Construct a new Firestore delete operation.
  *
  * @constructor
@@ -83,8 +26,6 @@ function FirestoreDelete(project, path, options) {
   this.shallow = Boolean(options.shallow);
   this.batchSize = options.batchSize || 50;
   this.allCollections = Boolean(options.allCollections);
-
-  this.queue = new DeletionQueue();
 
   // Remove any leading or trailing slashes from the path
   if (this.path) {
@@ -383,62 +324,69 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var self = this;
   var lastDocName = undefined;
 
-  this.queue.pagesRemaining = true;
+  var queue = [];
+  var numProcessing = 0;
+  var pagesRemaining = true;
+  var pageIncoming = false;
+
   return new Promise(function(resolve, reject) {
     setInterval(function() {
-      if (self.queue.done()) {
+      if (queue.length == 0 && numProcessing == 0 && !pagesRemaining) {
         resolve();
       }
 
-      // TODO: Query pagination, then eager loading (when < 100 remaining)
-      if (self.queue.pending() <= 150 && self.queue.shouldLoadMore()) {
-        self.queue.pageIncoming = true;
+      // TODO: Factor out these magic numbers
+      if (queue.length <= 150 && pagesRemaining && !pageIncoming) {
+        pageIncoming = true;
+
         self
           ._getDescendantBatch(self.allDescendants, self.batchSize, lastDocName)
           .then(function(docs) {
-            self.queue.pageIncoming = false;
+            pageIncoming = false;
 
             if (docs.length == 0) {
-              self.queue.pagesRemaining = false;
+              pagesRemaining = false;
               return;
             }
 
             docs.forEach(function(doc) {
-              self.queue.insert(doc);
+              queue.push(doc);
             });
 
             lastDocName = docs[docs.length - 1].name;
           })
           .catch(function() {
-            self.queue.pageIncoming = false;
+            // TODO: Debug log error
+            pageIncoming = false;
           });
       }
 
       // Don't have more than {x} requests outstanding
-      if (self.queue.numProcessing > 150) {
+      if (numProcessing > 150) {
         return;
       }
 
-      if (self.queue.pending() == 0) {
+      if (queue.length == 0) {
         return;
       }
 
-      const toDelete = self.queue.take();
+      const toDelete = queue.shift();
       if (!toDelete) {
         console.log("Queue exhausted!");
         return;
       }
 
-      self.queue.startProcessing();
+      numProcessing++;
       self
         ._deleteDocument(toDelete)
         .then(function() {
           FirestoreDelete.progressBar.tick(1);
-          self.queue.endProcessing();
+          numProcessing--;
         })
         .catch(function() {
-          self.queue.insert(toDelete);
-          self.queue.endProcessing();
+          // TODO: Care about the error reason
+          queue.push(toDelete);
+          numProcessing--;
         });
     }, 2);
   });

--- a/lib/firestore/delete.js
+++ b/lib/firestore/delete.js
@@ -102,8 +102,6 @@ FirestoreDelete.prototype._isCollectionPath = function(path) {
   return !this._isDocumentPath(path);
 };
 
-// TODO: Docs for startAfter
-
 /**
  * Construct a StructuredQuery to find descendant documents of a collection.
  *
@@ -112,6 +110,7 @@ FirestoreDelete.prototype._isCollectionPath = function(path) {
  *
  * @param {boolean} allDescendants true if subcollections should be included.
  * @param {number} batchSize maximum number of documents to target (limit).
+ * @param {string} startAfter document name to start after (optional).
  * @return {object} a StructuredQuery.
  */
 FirestoreDelete.prototype._collectionDescendantsQuery = function(
@@ -190,6 +189,7 @@ FirestoreDelete.prototype._collectionDescendantsQuery = function(
  *
  * @param {boolean} allDescendants true if subcollections should be included.
  * @param {number} batchSize maximum number of documents to target (limit).
+ * @param {string} startAfter document name to start after (optional).
  * @return {object} a StructuredQuery.
  */
 FirestoreDelete.prototype._docDescendantsQuery = function(allDescendants, batchSize, startAfter) {
@@ -322,73 +322,81 @@ FirestoreDelete.progressBar = new ProgressBar("Deleted :current docs (:rate docs
  */
 FirestoreDelete.prototype._recursiveBatchDelete = function() {
   var self = this;
-  var lastDocName = undefined;
 
+  // Tunable deletion parameters
+  var maxOutstanding = 150;
+  var minimumQueueSize = 150;
+
+  // All temporary variables for the deletion queue.
   var queue = [];
-  var numProcessing = 0;
+  var numOutstanding = 0;
   var pagesRemaining = true;
   var pageIncoming = false;
+  var lastDocName = undefined;
 
-  return new Promise(function(resolve, reject) {
-    setInterval(function() {
-      if (queue.length == 0 && numProcessing == 0 && !pagesRemaining) {
-        resolve();
-      }
+  var queueLoop = function() {
+    if (queue.length == 0 && numOutstanding == 0 && !pagesRemaining) {
+      return true;
+    }
 
-      // TODO: Factor out these magic numbers
-      if (queue.length <= 150 && pagesRemaining && !pageIncoming) {
-        pageIncoming = true;
+    if (queue.length <= minimumQueueSize && pagesRemaining && !pageIncoming) {
+      pageIncoming = true;
 
-        self
-          ._getDescendantBatch(self.allDescendants, self.batchSize, lastDocName)
-          .then(function(docs) {
-            pageIncoming = false;
-
-            if (docs.length == 0) {
-              pagesRemaining = false;
-              return;
-            }
-
-            docs.forEach(function(doc) {
-              queue.push(doc);
-            });
-
-            lastDocName = docs[docs.length - 1].name;
-          })
-          .catch(function() {
-            // TODO: Debug log error
-            pageIncoming = false;
-          });
-      }
-
-      // Don't have more than {x} requests outstanding
-      if (numProcessing > 150) {
-        return;
-      }
-
-      if (queue.length == 0) {
-        return;
-      }
-
-      const toDelete = queue.shift();
-      if (!toDelete) {
-        console.log("Queue exhausted!");
-        return;
-      }
-
-      numProcessing++;
       self
-        ._deleteDocument(toDelete)
-        .then(function() {
-          FirestoreDelete.progressBar.tick(1);
-          numProcessing--;
+        ._getDescendantBatch(self.allDescendants, self.batchSize, lastDocName)
+        .then(function(docs) {
+          pageIncoming = false;
+
+          if (docs.length == 0) {
+            pagesRemaining = false;
+            return;
+          }
+
+          docs.forEach(function(doc) {
+            queue.push(doc);
+          });
+
+          lastDocName = docs[docs.length - 1].name;
         })
         .catch(function() {
-          // TODO: Care about the error reason
-          queue.push(toDelete);
-          numProcessing--;
+          // TODO: Debug log error
+          pageIncoming = false;
         });
-    }, 2);
+    }
+
+    if (numOutstanding > maxOutstanding) {
+      return false;
+    }
+
+    if (queue.length == 0) {
+      return false;
+    }
+
+    const toDelete = queue.shift();
+    numOutstanding++;
+
+    self
+      ._deleteDocument(toDelete)
+      .then(function() {
+        FirestoreDelete.progressBar.tick(1);
+        numOutstanding--;
+      })
+      .catch(function() {
+        // TODO: Care about the error reason
+        queue.push(toDelete);
+        numOutstanding--;
+      });
+
+    return false;
+  };
+
+  return new Promise(function(resolve) {
+    var intervalId = setInterval(function() {
+      if (queueLoop()) {
+        clearInterval(intervalId);
+        resolve();
+      }
+    }, 0);
   });
 };
 

--- a/lib/gcp/firestore.js
+++ b/lib/gcp/firestore.js
@@ -2,6 +2,8 @@
 
 var api = require("../../lib/api");
 
+var _API_ROOT = "/v1beta1/";
+
 /**
  * List all collection IDs.
  *
@@ -9,7 +11,7 @@ var api = require("../../lib/api");
  * @return {Promise<string[]>} a promise for an array of collection IDs.
  */
 var _listCollectionIds = function(project) {
-  var url = "/v1beta1/projects/" + project + "/databases/(default)/documents:listCollectionIds";
+  var url = _API_ROOT + "projects/" + project + "/databases/(default)/documents:listCollectionIds";
 
   return api
     .request("POST", url, {
@@ -35,7 +37,7 @@ var _listCollectionIds = function(project) {
  * @return {Promise} a promise for the delete operation.
  */
 var _deleteDocument = function(doc) {
-  return api.request("DELETE", "/v1beta1/" + doc.name, {
+  return api.request("DELETE", _API_ROOT + doc.name, {
     auth: true,
     origin: api.firestoreOrigin,
   });
@@ -66,7 +68,7 @@ var _deleteDocuments = function(project, docs) {
   };
 
   return api
-    .request("POST", "/v1beta1/" + url, {
+    .request("POST", _API_ROOT + url, {
       auth: true,
       data: body,
       origin: api.firestoreOrigin,

--- a/lib/gcp/firestore.js
+++ b/lib/gcp/firestore.js
@@ -1,0 +1,83 @@
+"use strict";
+
+var api = require("../../lib/api");
+
+/**
+ * List all collection IDs.
+ *
+ * @param {string} project the Google Cloud project ID.
+ * @return {Promise<string[]>} a promise for an array of collection IDs.
+ */
+var _listCollectionIds = function(project) {
+  var url = "/v1beta1/projects/" + project + "/databases/(default)/documents:listCollectionIds";
+
+  return api
+    .request("POST", url, {
+      auth: true,
+      origin: api.firestoreOrigin,
+      data: {
+        // Maximum 32-bit integer
+        pageSize: 2147483647,
+      },
+    })
+    .then(function(res) {
+      return res.body.collectionIds || [];
+    });
+};
+
+/**
+ * Delete a single Firestore document.
+ *
+ * For document format see:
+ * https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Document
+ *
+ * @param {object} doc a Document object to delete.
+ * @return {Promise} a promise for the delete operation.
+ */
+var _deleteDocument = function(doc) {
+  return api.request("DELETE", "/v1beta1/" + doc.name, {
+    auth: true,
+    origin: api.firestoreOrigin,
+  });
+};
+
+/**
+ * Delete an array of Firestore documents.
+ *
+ * For document format see:
+ * https://firebase.google.com/docs/firestore/reference/rest/v1beta1/Document
+ *
+ * @param {string} project the Google Cloud project ID.
+ * @param {object[]} docs an array of Document objects to delete.
+ * @return {Promise<number>} a promise for the number of deleted documents.
+ */
+var _deleteDocuments = function(project, docs) {
+  var parent = "projects/" + project + "/databases/(default)/documents";
+  var url = parent + ":commit";
+
+  var writes = docs.map(function(doc) {
+    return {
+      delete: doc.name,
+    };
+  });
+
+  var body = {
+    writes: writes,
+  };
+
+  return api
+    .request("POST", "/v1beta1/" + url, {
+      auth: true,
+      data: body,
+      origin: api.firestoreOrigin,
+    })
+    .then(function(res) {
+      return res.body.writeResults.length;
+    });
+};
+
+module.exports = {
+  deleteDocument: _deleteDocument,
+  deleteDocuments: _deleteDocuments,
+  listCollectionIds: _listCollectionIds,
+};


### PR DESCRIPTION
See #667 

## Description

**Old Strategy** (about 75 ops/s)

  * Get the first 50 docs by `__name__`
  * Delete them in a batch
  * Repeat

**New Strategy** (5000+ ops/s)

In a loop:
  * Fetch 5000  docs by `__name__`, paginated
  * Delete in batches of 250, up to 15 batches at a time
  * If there are less than 7500 docs waiting for deletion, load another page

Error handling:
  * 500 errors are caused by going too fast, those docs are retried
  * Non-500 errors are fatal

## Manual Testing

**Single Doc (and subcollections)**
```
$ ./bin/firebase --project=firestorequickstarts firestore:delete -r rdl/key-1
? You are about to delete the document at rdl/key-1 and all of its subcollections. Are you sure? Yes
Deleted 100 docs (5882 docs/s)
```

**Many docs (and subcollections)**

I tried this test many times with 1000-13000 documents.  I never saw a fatal error. 

```
$ ./bin/firebase --project=firestorequickstarts firestore:delete -r rdl
? You are about to delete all documents in the collection at rdl and all of their subcollections. Are you sure? Yes
Deleted 12500 docs (6586 docs/s)
```