### PR TITLE
adding local emulation for callable functions, no auth

### DIFF
--- a/lib/functionsShellCommandAction.js
+++ b/lib/functionsShellCommandAction.js
@@ -6,9 +6,7 @@ var _ = require("lodash");
 var request = require("request");
 var util = require("util");
 
-var getProjectId = require("./getProjectId");
 var FunctionsEmulator = require("../lib/functionsEmulator");
-var helper = require("./functionsDeployHelper");
 var LocalFunction = require("../lib/localFunction");
 var logger = require("../lib/logger");
 
@@ -39,21 +37,9 @@ module.exports = function(options) {
         writer: writer,
         useColors: true,
       });
-
-      var projectId = getProjectId(options);
-      var functionsInfo = helper.getFunctionsInfo(emulator.triggers, projectId);
-      _.forEach(functionsInfo, function(func) {
-        _.set(func, "name", helper.getFunctionName(func.name));
-      });
-
       _.forEach(emulator.triggers, function(trigger) {
         if (_.includes(emulator.emulatedFunctions, trigger.name)) {
-          var localFunction = new LocalFunction(
-            trigger,
-            functionsInfo,
-            emulator.urls,
-            emulator.controller
-          );
+          var localFunction = new LocalFunction(trigger, emulator.urls, emulator.controller);
           var triggerNameDotNotation = trigger.name.replace(/\-/g, ".");
           _.set(replServer.context, triggerNameDotNotation, localFunction.call);
         }

--- a/lib/localFunction.js
+++ b/lib/localFunction.js
@@ -6,9 +6,8 @@ var request = require("request");
 var encodeFirestoreValue = require("./firestore/encodeFirestoreValue");
 var utils = require("./utils");
 
-var LocalFunction = function(trigger, functionsInfo, urls, controller) {
-  const functionInfo = _.find(functionsInfo, { name: trigger.name });
-  const isCallable = _.get(functionInfo, ["labels", "deployment-callable"], "false");
+var LocalFunction = function(trigger, urls, controller) {
+  const isCallable = _.get(trigger, ["labels", "deployment-callable"], "false");
 
   this.name = trigger.name;
   this.eventTrigger = trigger.eventTrigger;

--- a/lib/localFunction.js
+++ b/lib/localFunction.js
@@ -10,8 +10,6 @@ var LocalFunction = function(trigger, functionsInfo, urls, controller) {
   const functionInfo = _.find(functionsInfo, { name: trigger.name });
   const isCallable = _.get(functionInfo, ["labels", "deployment-callable"], "false");
 
-
-
   this.name = trigger.name;
   this.eventTrigger = trigger.eventTrigger;
   this.httpsTrigger = trigger.httpsTrigger;

--- a/lib/localFunction.js
+++ b/lib/localFunction.js
@@ -7,17 +7,19 @@ var encodeFirestoreValue = require("./firestore/encodeFirestoreValue");
 var utils = require("./utils");
 
 var LocalFunction = function(trigger, functionsInfo, urls, controller) {
-  var functionInfo = _.find(functionsInfo, { name: trigger.name });
+  const functionInfo = _.find(functionsInfo, { name: trigger.name });
+  const isCallable = _.get(functionInfo, ["labels", "deployment-callable"], "false");
+
+
 
   this.name = trigger.name;
   this.eventTrigger = trigger.eventTrigger;
   this.httpsTrigger = trigger.httpsTrigger;
   this.controller = controller;
-  this.label = _.get(functionInfo, ["labels", "deployment-callable"], "false");
   this.url = _.get(urls, this.name);
 
   if (this.httpsTrigger) {
-    if (this.label == "true") {
+    if (isCallable == "true") {
       this.call = this._constructCallableFunc.bind(this);
     } else {
       this.call = request.defaults({


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Adds ability to locally emulate callable functions. 

Callable functions can be called using the following format in the functions shell:
callable(data, options)

where data is data to be passed in and options can be of format
{instanceIdToken: <string>} only. (the options are placed in the headers, and would be rejected if we allowed any other options).

No auth configuration is available.

	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

callable("string") 
callable() 
callable("string", {instanceIdToken: "string"})
=> returns 200 if valid
=> returns 400 if invalid (aka callable() because data field is required), but also prints out entire request being made. **Should we add a check to prevent this printout?**

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
