### PR TITLE
Refactor authz to check IAM permissions, reduce legacy infra dependence.

### DIFF
--- a/commands/auth-export.js
+++ b/commands/auth-export.js
@@ -8,7 +8,7 @@ var Command = require("../lib/command");
 var accountExporter = require("../lib/accountExporter");
 var getProjectId = require("../lib/getProjectId");
 var logger = require("../lib/logger");
-var requireAccess = require("../lib/requireAccess");
+var requirePermissions = require("../lib/requirePermissions");
 
 var MAX_BATCH_SIZE = 1000;
 
@@ -21,7 +21,7 @@ module.exports = new Command("auth:export [dataFile]")
     "--format <format>",
     "Format of exported data (csv, json). Ignored if [dataFile] has format extension."
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebaseauth.users.list"])
   .action(function(dataFile, options) {
     var projectId = getProjectId(options);
     var checkRes = validateOptions(options, dataFile);

--- a/commands/auth-import.js
+++ b/commands/auth-import.js
@@ -10,7 +10,7 @@ var Command = require("../lib/command");
 var accountImporter = require("../lib/accountImporter");
 var getProjectId = require("../lib/getProjectId");
 var logger = require("../lib/logger");
-var requireAccess = require("../lib/requireAccess");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 
 var MAX_BATCH_SIZE = 1000;
@@ -43,7 +43,7 @@ module.exports = new Command("auth:import [dataFile]")
     "specify the order of password and salt. Possible values are SALT_FIRST and PASSWORD_FIRST. " +
       "MD5, SHA1, SHA256, SHA512, HMAC_MD5, HMAC_SHA1, HMAC_SHA256, HMAC_SHA512 support this flag."
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebaseauth.users.create", "firebaseauth.users.update"])
   .action(function(dataFile, options) {
     var projectId = getProjectId(options);
     var checkRes = validateOptions(options);

--- a/commands/database-get.js
+++ b/commands/database-get.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
@@ -52,7 +53,8 @@ module.exports = new Command("database:get <path>")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebasedatabase.instances.get"])
+  .before(requireInstance)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/commands/database-profile.js
+++ b/commands/database-profile.js
@@ -3,7 +3,8 @@
 var _ = require("lodash");
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 var profiler = require("../lib/profiler");
 
@@ -27,7 +28,8 @@ module.exports = new Command("database:profile")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebasedatabase.instances.get"])
+  .before(requireInstance)
   .action(function(options) {
     // Validate options
     if (options.raw && options.input) {

--- a/commands/database-profile.js
+++ b/commands/database-profile.js
@@ -28,7 +28,7 @@ module.exports = new Command("database:profile")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
-  .before(requirePermissions, ["firebasedatabase.instances.get"])
+  .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
   .action(function(options) {
     // Validate options

--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
@@ -21,7 +22,8 @@ module.exports = new Command("database:push <path> [infile]")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebasedatabase.instances.update"])
+  .before(requireInstance)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/commands/database-remove.js
+++ b/commands/database-remove.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
@@ -19,7 +20,8 @@ module.exports = new Command("database:remove <path>")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebasedatabase.instances.update"])
+  .before(requireInstance)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/commands/database-set.js
+++ b/commands/database-set.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
@@ -22,7 +23,8 @@ module.exports = new Command("database:set <path> [infile]")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebasedatabase.instances.update"])
+  .before(requireInstance)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/commands/database-update.js
+++ b/commands/database-update.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var request = require("request");
 var api = require("../lib/api");
 var responseToError = require("../lib/responseToError");
@@ -22,7 +23,8 @@ module.exports = new Command("database:update <path> [infile]")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
-  .before(requireAccess)
+  .before(requirePermissions, ["firebasedatabase.instances.update"])
+  .before(requireInstance)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -1,20 +1,42 @@
 "use strict";
 
-var requireAccess = require("../lib/requireAccess");
-var clc = require("cli-color");
+var _ = require("lodash");
+
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var checkDupHostingKeys = require("../lib/checkDupHostingKeys");
 var checkValidTargetFilters = require("../lib/checkValidTargetFilters");
 var checkFirebaseSDKVersion = require("../lib/checkFirebaseSDKVersion");
 var Command = require("../lib/command");
 var deploy = require("../lib/deploy");
-var logger = require("../lib/logger");
 var requireConfig = require("../lib/requireConfig");
-var scopes = require("../lib/scopes");
-var utils = require("../lib/utils");
 var filterTargets = require("../lib/filterTargets");
 
 // in order of least time-consuming to most time-consuming
 var VALID_TARGETS = ["database", "storage", "firestore", "functions", "hosting"];
+var TARGET_PERMISSIONS = {
+  database: ["firebasedatabase.instances.update"],
+  hosting: ["firebasehosting.sites.update"],
+  functions: [
+    "cloudfunctions.functions.list",
+    "cloudfunctions.functions.create",
+    "cloudfunctions.functions.get",
+    "cloudfunctions.functions.update",
+    "cloudfunctions.functions.delete",
+    "cloudfunctions.operations.get",
+  ],
+  firestore: [
+    "datastore.indexes.list",
+    "datastore.indexes.create",
+    "datastore.indexes.update",
+    "datastore.indexes.delete",
+  ],
+  storage: [
+    "firebaserules.releases.create",
+    "firebaserules.rulesets.create",
+    "firebaserules.releases.update",
+  ],
+};
 
 module.exports = new Command("deploy")
   .description("deploy code and assets to your Firebase project")
@@ -30,25 +52,23 @@ module.exports = new Command("deploy")
   .option("--except <targets>", 'deploy to all targets except specified (e.g. "database")')
   .before(requireConfig)
   .before(function(options) {
-    return requireAccess(options, [scopes.CLOUD_PLATFORM]).catch(function(err) {
-      if (options.config.has("functions")) {
-        throw err;
-      }
-
-      logger.info();
-      utils.logWarning(
-        clc.bold("Your CLI authentication needs to be updated to take advantage of new features.")
-      );
-      utils.logWarning(clc.bold("Please run " + clc.underline("firebase login --reauth")));
-      logger.info();
-
-      return requireAccess(options, []);
+    options.filteredTargets = filterTargets(options, VALID_TARGETS);
+    var permissions = [];
+    options.filteredTargets.forEach(target => {
+      permissions = permissions.concat(TARGET_PERMISSIONS[target]);
     });
+
+    return requirePermissions(options, permissions);
+  })
+  .before(function(options) {
+    // only fetch the default instance for hosting or database deploys
+    if (_.find(options.filteredTargets, t => t == "hosting" || t == "database")) {
+      return requireInstance(options);
+    }
   })
   .before(checkDupHostingKeys)
   .before(checkValidTargetFilters)
   .before(checkFirebaseSDKVersion)
   .action(function(options) {
-    var targets = filterTargets(options, VALID_TARGETS);
-    return deploy(targets, options);
+    return deploy(options.filteredTargets, options);
   });

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -53,16 +53,14 @@ module.exports = new Command("deploy")
   .before(requireConfig)
   .before(function(options) {
     options.filteredTargets = filterTargets(options, VALID_TARGETS);
-    var permissions = [];
-    options.filteredTargets.forEach(target => {
-      permissions = permissions.concat(TARGET_PERMISSIONS[target]);
+    const permissions = options.filteredTargets.reduce((perms, target) => {
+      return perms.concat(TARGET_PERMISSIONS[target]);
     });
-
     return requirePermissions(options, permissions);
   })
   .before(function(options) {
     // only fetch the default instance for hosting or database deploys
-    if (_.find(options.filteredTargets, t => t == "hosting" || t == "database")) {
+    if (_.intersection(options.filteredTargets, ["hosting", "database"]).length > 0) {
       return requireInstance(options);
     }
   })

--- a/commands/experimental-functions-shell.js
+++ b/commands/experimental-functions-shell.js
@@ -1,9 +1,8 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requirePermissions = require("../lib/requirePermissions");
 var requireConfig = require("../lib/requireConfig");
-var scopes = require("../lib/scopes");
 var action = require("../lib/functionsShellCommandAction");
 
 module.exports = new Command("experimental:functions:shell")
@@ -12,5 +11,5 @@ module.exports = new Command("experimental:functions:shell")
   )
   .option("-p, --port <port>", "the port on which to emulate functions (default: 5000)", 5000)
   .before(requireConfig)
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions)
   .action(action);

--- a/commands/firestore-delete.js
+++ b/commands/firestore-delete.js
@@ -4,9 +4,7 @@ var clc = require("cli-color");
 var Command = require("../lib/command");
 var FirestoreDelete = require("../lib/firestore/delete");
 var prompt = require("../lib/prompt");
-var requireAccess = require("../lib/requireAccess");
-
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 
 var _getConfirmationMessage = function(deleteOp, options) {
@@ -70,7 +68,7 @@ module.exports = new Command("firestore:delete [path]")
       "including all collections and documents. Any other flags or arguments will be ignored."
   )
   .option("-y, --yes", "No confirmation. Otherwise, a confirmation prompt will appear.")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, ["datastore.entities.list", "datastore.entities.delete"])
   .action(function(path, options) {
     // Guarantee path
     if (!path && !options.allCollections) {

--- a/commands/firestore-indexes-list.js
+++ b/commands/firestore-indexes-list.js
@@ -2,8 +2,7 @@
 
 var Command = require("../lib/command");
 var firestoreIndexes = require("../lib/firestore/indexes.js");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var logger = require("../lib/logger");
 var _ = require("lodash");
 
@@ -28,7 +27,7 @@ module.exports = new Command("firestore:indexes")
     "Pretty print. When not specified the indexes are printed in the " +
       "JSON specification format."
   )
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, ["datastore.indexes.list"])
   .action(function(options) {
     return firestoreIndexes.list(options.project).then(function(indexes) {
       var jsonSpec = _makeJsonSpec(indexes);

--- a/commands/functions-config-clone.js
+++ b/commands/functions-config-clone.js
@@ -5,8 +5,7 @@ var Command = require("../lib/command");
 var functionsConfig = require("../lib/functionsConfig");
 var functionsConfigClone = require("../lib/functionsConfigClone");
 var getProjectId = require("../lib/getProjectId");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 var logger = require("../lib/logger");
 
@@ -15,7 +14,18 @@ module.exports = new Command("functions:config:clone")
   .option("--from <projectId>", "the project from which to clone configuration")
   .option("--only <keys>", "a comma-separated list of keys to clone")
   .option("--except <keys>", "a comma-separated list of keys to not clone")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [
+    "runtimeconfig.configs.list",
+    "runtimeconfig.configs.create",
+    "runtimeconfig.configs.get",
+    "runtimeconfig.configs.update",
+    "runtimeconfig.configs.delete",
+    "runtimeconfig.variables.list",
+    "runtimeconfig.variables.create",
+    "runtimeconfig.variables.get",
+    "runtimeconfig.variables.update",
+    "runtimeconfig.variables.delete",
+  ])
   .before(functionsConfig.ensureApi)
   .action(function(options) {
     var projectId = getProjectId(options);

--- a/commands/functions-config-get.js
+++ b/commands/functions-config-get.js
@@ -4,8 +4,7 @@ var _ = require("lodash");
 var Command = require("../lib/command");
 var getProjectId = require("../lib/getProjectId");
 var logger = require("../lib/logger");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var functionsConfig = require("../lib/functionsConfig");
 
 function _materialize(projectId, path) {
@@ -25,7 +24,12 @@ function _materialize(projectId, path) {
 
 module.exports = new Command("functions:config:get [path]")
   .description("fetch environment config stored at the given path")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [
+    "runtimeconfig.configs.list",
+    "runtimeconfig.configs.get",
+    "runtimeconfig.variables.list",
+    "runtimeconfig.variables.get",
+  ])
   .before(functionsConfig.ensureApi)
   .action(function(path, options) {
     return _materialize(getProjectId(options), path).then(function(result) {

--- a/commands/functions-config-legacy.js
+++ b/commands/functions-config-legacy.js
@@ -4,15 +4,19 @@ var _ = require("lodash");
 
 var Command = require("../lib/command");
 var getProjectId = require("../lib/getProjectId");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var runtimeconfig = require("../lib/gcp/runtimeconfig");
 var functionsConfig = require("../lib/functionsConfig");
 var logger = require("../lib/logger");
 
 module.exports = new Command("functions:config:legacy")
   .description("get legacy functions config variables")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [
+    "runtimeconfig.configs.list",
+    "runtimeconfig.configs.get",
+    "runtimeconfig.variables.list",
+    "runtimeconfig.variables.get",
+  ])
   .action(function(options) {
     var projectId = getProjectId(options);
     var metaPath = "projects/" + projectId + "/configs/firebase/variables/meta";

--- a/commands/functions-config-set.js
+++ b/commands/functions-config-set.js
@@ -4,15 +4,25 @@ var clc = require("cli-color");
 
 var Command = require("../lib/command");
 var getProjectId = require("../lib/getProjectId");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var logger = require("../lib/logger");
 var utils = require("../lib/utils");
 var functionsConfig = require("../lib/functionsConfig");
 
 module.exports = new Command("functions:config:set [values...]")
   .description("set environment config with key=value syntax")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [
+    "runtimeconfig.configs.list",
+    "runtimeconfig.configs.create",
+    "runtimeconfig.configs.get",
+    "runtimeconfig.configs.update",
+    "runtimeconfig.configs.delete",
+    "runtimeconfig.variables.list",
+    "runtimeconfig.variables.create",
+    "runtimeconfig.variables.get",
+    "runtimeconfig.variables.update",
+    "runtimeconfig.variables.delete",
+  ])
   .before(functionsConfig.ensureApi)
   .action(function(args, options) {
     if (!args.length) {

--- a/commands/functions-config-unset.js
+++ b/commands/functions-config-unset.js
@@ -7,14 +7,24 @@ var Command = require("../lib/command");
 var functionsConfig = require("../lib/functionsConfig");
 var getProjectId = require("../lib/getProjectId");
 var logger = require("../lib/logger");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 var runtimeconfig = require("../lib/gcp/runtimeconfig");
 
 module.exports = new Command("functions:config:unset [keys...]")
   .description("unset environment config at the specified path(s)")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [
+    "runtimeconfig.configs.list",
+    "runtimeconfig.configs.create",
+    "runtimeconfig.configs.get",
+    "runtimeconfig.configs.update",
+    "runtimeconfig.configs.delete",
+    "runtimeconfig.variables.list",
+    "runtimeconfig.variables.create",
+    "runtimeconfig.variables.get",
+    "runtimeconfig.variables.update",
+    "runtimeconfig.variables.delete",
+  ])
   .before(functionsConfig.ensureApi)
   .action(function(args, options) {
     if (!args.length) {

--- a/commands/functions-delete.js
+++ b/commands/functions-delete.js
@@ -9,8 +9,7 @@ var functionsDelete = require("../lib/functionsDelete");
 var getProjectId = require("../lib/getProjectId");
 var helper = require("../lib/functionsDeployHelper");
 var prompt = require("../lib/prompt");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 
 module.exports = new Command("functions:delete [filters...]")
@@ -21,7 +20,7 @@ module.exports = new Command("functions:delete [filters...]")
       "If omitted, functions from all regions whose names match the filters will be deleted. "
   )
   .option("-f, --force", "No confirmation. Otherwise, a confirmation prompt will appear.")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, ["cloudfunctions.functions.list", "cloudfunctions.functions.delete"])
   .action(function(filters, options) {
     if (!filters.length) {
       return utils.reject("Must supply at least function or group name.");

--- a/commands/functions-log.js
+++ b/commands/functions-log.js
@@ -7,8 +7,7 @@ var FirebaseError = require("../lib/error");
 var gcp = require("../lib/gcp");
 var getProjectId = require("../lib/getProjectId");
 var logger = require("../lib/logger");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var open = require("opn");
 
 module.exports = new Command("functions:log")
@@ -19,7 +18,7 @@ module.exports = new Command("functions:log")
   )
   .option("-n, --lines <num_lines>", "specify number of log lines to fetch")
   .option("--open", "open logs page in web browser")
-  .before(requireAccess, [scopes.OPENID, scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, ["logging.logEntries.list", "logging.logs.list"])
   .action(function(options) {
     var projectId = getProjectId(options);
     var apiFilter = 'resource.type="cloud_function" ';

--- a/commands/functions-shell.js
+++ b/commands/functions-shell.js
@@ -1,14 +1,13 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requirePermissions = require("../lib/requirePermissions");
 var requireConfig = require("../lib/requireConfig");
-var scopes = require("../lib/scopes");
 var action = require("../lib/functionsShellCommandAction");
 
 module.exports = new Command("functions:shell")
   .description("launch full Node shell with emulated functions")
   .option("-p, --port <port>", "the port on which to emulate functions (default: 5000)", 5000)
   .before(requireConfig)
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions)
   .action(action);

--- a/commands/hosting-disable.js
+++ b/commands/hosting-disable.js
@@ -1,7 +1,8 @@
 "use strict";
 
 var Command = require("../lib/command");
-var requireAccess = require("../lib/requireAccess");
+var requireInstance = require("../lib/requireInstance");
+var requirePermissions = require("../lib/requirePermissions");
 var api = require("../lib/api");
 var utils = require("../lib/utils");
 var prompt = require("../lib/prompt");
@@ -10,7 +11,8 @@ var clc = require("cli-color");
 module.exports = new Command("hosting:disable")
   .description("stop serving web traffic to your Firebase Hosting site")
   .option("-y, --confirm", "skip confirmation")
-  .before(requireAccess)
+  .before(requirePermissions, ["firebasehosting.sites.update"])
+  .before(requireInstance)
   .action(function(options) {
     return prompt(options, [
       {

--- a/commands/kits-install.js
+++ b/commands/kits-install.js
@@ -5,8 +5,7 @@ var clc = require("cli-color");
 var Command = require("../lib/command");
 var getProjectId = require("../lib/getProjectId");
 var logger = require("../lib/logger");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 var kits = require("../lib/kits");
 
@@ -15,7 +14,9 @@ module.exports = new Command("kits:install <githubRepo>")
   .option("-b, --branch <branch>", "repository branch to download from. Defaults to master")
   .option("-p, --path <path>", "custom path to kit configuration file. Defaults to kits.json")
   .option("--id <releaseId>", "release version to be installed. Defaults to latest")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [
+    /* TODO */
+  ])
   .action(function(githubRepo, options) {
     var projectId = getProjectId(options);
     var kit = githubRepo.split("/");

--- a/commands/kits-uninstall.js
+++ b/commands/kits-uninstall.js
@@ -7,8 +7,7 @@ var gcp = require("../lib/gcp");
 var pollKits = require("../lib/kits/pollKits");
 var getProjectId = require("../lib/getProjectId");
 var prompt = require("../lib/prompt");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 
 var DEFAULT_REGION = gcp.cloudfunctions.DEFAULT_REGION;
@@ -82,7 +81,9 @@ function _deleteKitFunctions(projectId, functions) {
 
 module.exports = new Command("kits:uninstall [kitName]")
   .description("Command to uninstall function kit")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [
+    /* TODO */
+  ])
   .action(function(kitName, options) {
     var projectId = getProjectId(options);
     return _listKits(projectId)

--- a/commands/open.js
+++ b/commands/open.js
@@ -8,7 +8,7 @@ var api = require("../lib/api");
 var Command = require("../lib/command");
 var logger = require("../lib/logger");
 var prompt = require("../lib/prompt");
-var requireAccess = require("../lib/requireAccess");
+var requirePermissions = require("../lib/requirePermissions");
 var utils = require("../lib/utils");
 
 var LINKS = [
@@ -60,7 +60,7 @@ var CHOICES = _.map(LINKS, "name");
 
 module.exports = new Command("open [link]")
   .description("quickly open a browser to relevant project resources")
-  .before(requireAccess)
+  .before(requirePermissions)
   .action(function(linkName, options) {
     var link = _.find(LINKS, { arg: linkName });
     if (linkName && !link) {

--- a/commands/serve.js
+++ b/commands/serve.js
@@ -5,11 +5,10 @@ var clc = require("cli-color");
 var Command = require("../lib/command");
 var logger = require("../lib/logger");
 var utils = require("../lib/utils");
-var requireAccess = require("../lib/requireAccess");
+var requirePermissions = require("../lib/requirePermissions");
 var requireConfig = require("../lib/requireConfig");
 var checkDupHostingKeys = require("../lib/checkDupHostingKeys");
 var serve = require("../lib/serve/index");
-var scopes = require("../lib/scopes");
 var filterTargets = require("../lib/filterTargets");
 var getProjectNumber = require("../lib/getProjectNumber");
 
@@ -28,7 +27,7 @@ module.exports = new Command("serve")
     "serve all except specified targets (valid targets are: functions, hosting)"
   )
   .before(requireConfig)
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions)
   .before(checkDupHostingKeys)
   .before(getProjectNumber)
   .action(function(options) {

--- a/commands/setup-web.js
+++ b/commands/setup-web.js
@@ -5,14 +5,13 @@ var fs = require("fs");
 var Command = require("../lib/command");
 var fetchWebSetup = require("../lib/fetchWebSetup");
 var logger = require("../lib/logger");
-var requireAccess = require("../lib/requireAccess");
-var scopes = require("../lib/scopes");
+var requirePermissions = require("../lib/requirePermissions");
 
 var JS_TEMPLATE = fs.readFileSync(__dirname + "/../templates/setup/web.js", "utf8");
 
 module.exports = new Command("setup:web")
   .description("display this project's setup information for the Firebase JS SDK")
-  .before(requireAccess, [scopes.CLOUD_PLATFORM])
+  .before(requirePermissions, [])
   .action(function(options) {
     return fetchWebSetup(options).then(function(config) {
       logger.info(JS_TEMPLATE.replace("{/*--CONFIG--*/}", JSON.stringify(config, null, 2)));

--- a/lib/api.js
+++ b/lib/api.js
@@ -18,14 +18,18 @@ var commandScopes;
 
 var _request = function(options, logOptions) {
   logOptions = logOptions || {};
-  logger.debug(
-    ">>> HTTP REQUEST",
-    options.method,
-    options.url,
-    options.qs ? "\nquery params: " + JSON.stringify(options.qs) : "",
-    "\n",
-    logOptions.skipRequestBody ? "<request body omitted>" : options.body || options.form || ""
-  );
+  var qsLog = "";
+  var bodyLog = "<request body omitted>";
+
+  if (options.qs && !logOptions.skipQueryParams) {
+    qsLog = JSON.stringify(options.qs);
+  }
+
+  if (!logOptions.skipRequestBody) {
+    bodyLog = options.body || options.form || "";
+  }
+
+  logger.debug(">>> HTTP REQUEST", options.method, options.url, qsLog, "\n", bodyLog);
 
   return new Promise(function(resolve, reject) {
     var req = request(options, function(err, response, body) {
@@ -198,7 +202,7 @@ var api = {
     reqOptions.headers = options.headers;
 
     var requestFunction = function() {
-      return _request(reqOptions);
+      return _request(reqOptions, options.logOptions);
     };
     if (options.auth === true) {
       requestFunction = function() {

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -239,23 +239,23 @@ var _logoutCurrentSession = function(refreshToken) {
 var _refreshAccessToken = function(refreshToken, authScopes) {
   logger.debug("> refreshing access token with scopes:", JSON.stringify(authScopes));
   return api
-    .request(
-      "POST",
-      "/oauth2/v3/token",
-      {
-        origin: api.googleOrigin,
-        form: {
-          refresh_token: refreshToken,
-          client_id: api.clientId,
-          client_secret: api.clientSecret,
-          grant_type: "refresh_token",
-          scope: (authScopes || []).join(" "),
-        },
+    .request("POST", "/oauth2/v3/token", {
+      origin: api.googleOrigin,
+      form: {
+        refresh_token: refreshToken,
+        client_id: api.clientId,
+        client_secret: api.clientSecret,
+        grant_type: "refresh_token",
+        scope: (authScopes || []).join(" "),
       },
-      { skipRequestBody: true }
-    )
+      logOptions: { skipRequestBody: true, skipQueryParams: true, skipResponseBody: true },
+    })
     .then(
       function(res) {
+        if (res.status === 401 || res.status === 400) {
+          return { access_token: refreshToken };
+        }
+
         if (!_.isString(res.body.access_token)) {
           throw INVALID_CREDENTIAL_ERROR;
         }
@@ -296,6 +296,7 @@ var getAccessToken = function(refreshToken, authScopes) {
   if (_haveValidAccessToken(refreshToken, authScopes)) {
     return Promise.resolve(lastAccessToken);
   }
+
   return _refreshAccessToken(refreshToken, authScopes);
 };
 

--- a/lib/requireAccess.js
+++ b/lib/requireAccess.js
@@ -9,15 +9,15 @@ var FirebaseError = require("./error");
 var identifierToProjectId = require("./identifierToProjectId");
 var requireAuth = require("./requireAuth");
 
-module.exports = function(options, authScopes) {
+module.exports = function(options) {
   var projectId = getProjectId(options);
   options.project = projectId;
 
   if (process.env.FIREBASE_BYPASS_ADMIN_CALLS_FOR_TESTING === "true") {
-    return requireAuth(options, authScopes);
+    return requireAuth(options);
   }
 
-  return requireAuth(options, authScopes)
+  return requireAuth(options)
     .then(function() {
       return getInstanceId(options);
     })

--- a/lib/requireAuth.js
+++ b/lib/requireAuth.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var _ = require("lodash");
 var clc = require("cli-color");
 
 var autoAuth = require("google-auto-auth");
@@ -10,6 +9,7 @@ var configstore = require("./configstore");
 var FirebaseError = require("./error");
 var logger = require("./logger");
 var utils = require("./utils");
+var scopes = require("./scopes");
 
 var AUTH_ERROR = new FirebaseError(
   "Command requires authentication, please run " + clc.bold("firebase login")
@@ -34,12 +34,7 @@ function _autoAuth(options, authScopes) {
 }
 
 module.exports = function(options, authScopes) {
-  var inScopes = authScopes;
-  if (_.isFunction(authScopes)) {
-    inScopes = authScopes(options);
-  }
-
-  api.setScopes(inScopes);
+  api.setScopes([scopes.CLOUD_PLATFORM, scopes.FIREBASE_PLATFORM]);
   options.authScopes = api.commandScopes;
 
   var tokens = configstore.get("tokens");

--- a/lib/requireInstance.js
+++ b/lib/requireInstance.js
@@ -1,0 +1,11 @@
+const getInstanceId = require("./getInstanceId");
+
+module.exports = function(options) {
+  if (options.instance) {
+    return Promise.resolve();
+  }
+
+  return getInstanceId(options).then(instance => {
+    options.instance = instance;
+  });
+};

--- a/lib/requirePermissions.js
+++ b/lib/requirePermissions.js
@@ -1,0 +1,48 @@
+const _ = require("lodash");
+const clc = require("cli-color");
+
+const api = require("./api");
+const getProjectId = require("./getProjectId");
+const requireAuth = require("./requireAuth");
+const utils = require("./utils");
+const logger = require("./logger");
+
+// Permissions required for all commands.
+const BASE_PERMISSIONS = ["firebase.projects.get"];
+
+module.exports = function(options, permissions) {
+  const projectId = getProjectId(options);
+  const requiredPermissions = BASE_PERMISSIONS.concat(permissions || []).sort();
+
+  return requireAuth(options)
+    .then(() => {
+      logger.debug(
+        "[iam] checking project",
+        projectId,
+        "for permissions",
+        JSON.stringify(requiredPermissions)
+      );
+      return api.request("POST", `/v1/projects/${projectId}:testIamPermissions`, {
+        auth: true,
+        data: {
+          permissions: requiredPermissions,
+        },
+        origin: api.resourceManagerOrigin,
+      });
+    })
+    .then(response => {
+      const allowedPermissions = (response.body.permissions || []).sort();
+      const missingPermissions = _.difference(requiredPermissions, allowedPermissions);
+
+      if (missingPermissions.length > 0) {
+        return utils.reject(
+          "Authorization failed. This account is missing the following required permissions on project " +
+            clc.bold(projectId) +
+            ":\n\n  " +
+            missingPermissions.join("\n  ")
+        );
+      }
+
+      return true;
+    });
+};


### PR DESCRIPTION
First, some context. The CLI currently uses some legacy Firebase infrastructure to do coarse-grained permission checking as a pre-flight for most commands (the `requireAccess` before filter). This causes a few issues, mainly that it doesn't work well with service-accounts that have been granted a more limited permission set. It also is legacy infrastructure that we'd like to turn down eventually.

This PR replaces `requireAccess` (in most but not 100% of cases) with a new `requirePermissions` filter that calls the Cloud [testIamPermissions](https://cloud.google.com/resource-manager/reference/rest/v1/projects/testIamPermissions) endpoint for the project. This has a few advantages:

1. No legacy dependency or coarse-grained weirdness.
2. We can provide specific information about which permissions the authorizing account lacks when crafting error messages.
3. It helps us prepare for a future state where Firebase users may not have access to the entire project.

To make this change, I manually mapped a list of permissions for each command. I believe these to be correct, but it's possible I missed some here and there. `deploy` in particular is a bit messy, since I selectively filter down which permissions are required based on which targets are being deployed (to minimize permission requirements for super-scoped service accounts).

The other change here is to start discarding the variable OAuth scopes and depend solely on `cloud-platform` and `firebase` scopes. This is in line with the general direction of Google APIs toward stronger reliance on IAM and less reliance on scopes for permission-setting in authz. With the removal of the legacy infra dependency, we also remove the reason we needed variable scopes in the first place. It's not 100% cleaned up here, so there's some follow-on work.

*Regarding Style:* I am fully using Node.js v4 features throughout this PR, and am comfortable doing so generally in CLI changes moving forward.

*One More Thing:* This also allows the `--token` flag to accept access tokens in addition to refresh tokens.