### PR TITLE
Simplify initialization of specific project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '4'
 - '5.10'
 - '6'
 - '8'

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -11,6 +11,69 @@ var utils = require("../../utils");
 var NO_PROJECT = "[don't setup a default project]";
 var NEW_PROJECT = "[create a new project]";
 
+function getProject(options) {
+  // The user passed in a --project flag directly, so no need to
+  // load all projects.
+  if (options.project) {
+    return api
+      .request("GET", "/v1beta1/projects/" + options.project, {
+        auth: true,
+        origin: api.firebaseApiOrigin,
+      })
+      .then(function(response) {
+        // TODO: CATCH
+        return {
+          id: response.body.projectId,
+          name: response.body.displayName,
+          instance: response.body.resources.realtimeDatabaseInstance,
+        };
+      })
+      .catch(function(e) {
+        return utils.reject("Error getting project " + options.project, { original: e });
+      });
+  }
+
+  // Load all projects and prompt the user to choose
+  return api.getProjects().then(function(projects) {
+    var choices = _.map(projects, function(info, projectId) {
+      return {
+        name: projectId,
+        label: info.name + " (" + projectId + ")",
+      };
+    });
+    choices = _.orderBy(choices, ["name"], ["asc"]);
+    var nameOptions = [NO_PROJECT].concat(_.map(choices, "label")).concat([NEW_PROJECT]);
+
+    return prompt
+      .once({
+        type: "list",
+        name: "id",
+        message: "Select a default Firebase project for this directory:",
+        validate: function(answer) {
+          if (!_.includes(nameOptions, answer)) {
+            return "Must specify a Firebase to which you have access.";
+          }
+          return true;
+        },
+        choices: nameOptions,
+      })
+      .then(function(label) {
+        if (label === NEW_PROJECT || label === NO_PROJECT) {
+          return {
+            id: label,
+          };
+        }
+
+        var id = prompt.listLabelToValue(label, choices);
+        return {
+          id: prompt.listLabelToValue(label, choices),
+          name: label,
+          instance: projects[id].instances.database[0],
+        };
+      });
+  });
+}
+
 module.exports = function(setup, config, options) {
   setup.project = {};
 
@@ -22,62 +85,26 @@ module.exports = function(setup, config, options) {
   logger.info("but for now we'll just set up a default project.");
   logger.info();
 
-  return api.getProjects().then(function(projects) {
-    var choices = _.map(projects, function(info, projectId) {
-      return {
-        name: projectId,
-        label: info.name + " (" + projectId + ")",
-      };
-    });
-    choices = _.orderBy(choices, ["name"], ["asc"]);
-    var nameOptions = [NO_PROJECT].concat(_.map(choices, "label")).concat([NEW_PROJECT]);
+  if (_.has(setup.rcfile, "projects.default")) {
+    utils.logBullet(".firebaserc already has a default project, skipping");
+    setup.projectId = _.get(setup.rcfile, "projects.default");
+    return undefined;
+  }
 
-    if (_.has(setup.rcfile, "projects.default")) {
-      utils.logBullet(".firebaserc already has a default project, skipping");
-      setup.projectId = _.get(setup.rcfile, "projects.default");
-      return undefined;
+  return getProject(options).then(function(project) {
+    if (project.id === NEW_PROJECT) {
+      setup.createProject = true;
+      return;
+    } else if (project.id === NO_PROJECT) {
+      return;
     }
 
-    var getProjectId;
-    if (options.project) {
-      var projectIdLabel = prompt.valueToListLabel(options.project, choices);
-      if (!projectIdLabel) {
-        logger.info("No such project: " + options.project);
-        return;
-      }
+    logger.info("Using project " + project.name + " (" + project.id + ")");
 
-      logger.info("Using project " + projectIdLabel);
-      getProjectId = Promise.resolve(projectIdLabel);
-    } else {
-      getProjectId = prompt.once({
-        type: "list",
-        name: "id",
-        message: "Select a default Firebase project for this directory:",
-        validate: function(answer) {
-          if (!_.includes(nameOptions, answer)) {
-            return "Must specify a Firebase to which you have access.";
-          }
-          return true;
-        },
-        choices: nameOptions,
-      });
-    }
-
-    return getProjectId.then(function(projectId) {
-      if (projectId === NEW_PROJECT) {
-        setup.createProject = true;
-        return;
-      } else if (projectId === NO_PROJECT) {
-        return;
-      }
-      projectId = prompt.listLabelToValue(projectId, choices);
-      var instance = projects[projectId].instances.database[0];
-
-      // write "default" alias and activate it immediately
-      _.set(setup.rcfile, "projects.default", projectId);
-      setup.projectId = projectId;
-      setup.instance = instance;
-      utils.makeActiveProject(config.projectDir, projectId);
-    });
+    // write "default" alias and activate it immediately
+    _.set(setup.rcfile, "projects.default", project.id);
+    setup.projectId = project.id;
+    setup.instance = project.instance;
+    utils.makeActiveProject(config.projectDir, project.id);
   });
 };

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -11,7 +11,17 @@ var utils = require("../../utils");
 var NO_PROJECT = "[don't setup a default project]";
 var NEW_PROJECT = "[create a new project]";
 
-function getProject(options) {
+/**
+ * Get the user's desired project, prompting if necessary.
+ * Returns an object with three fields:
+ *
+ * {
+ *  id: project ID [required]
+ *  name: project display name [optional]
+ *  instance: project database instance [optional]
+ * }
+ */
+function _getProject(options) {
   // The user passed in a --project flag directly, so no need to
   // load all projects.
   if (options.project) {
@@ -33,7 +43,7 @@ function getProject(options) {
       });
   }
 
-  // Load all projects and prompt the user to choose
+  // Load all projects and prompt the user to choose.
   return api.getProjects().then(function(projects) {
     var choices = _.map(projects, function(info, projectId) {
       return {
@@ -91,7 +101,7 @@ module.exports = function(setup, config, options) {
     return undefined;
   }
 
-  return getProject(options).then(function(project) {
+  return _getProject(options).then(function(project) {
     if (project.id === NEW_PROJECT) {
       setup.createProject = true;
       return;

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -58,7 +58,9 @@ function _getProject(options) {
     if (choices.length >= 25) {
       utils.logBullet(
         "Don't want to scroll through all your projects? If you know your project ID, " +
-          "you can initialize it directly using 'firebase init --project=$PROJECT_ID.\n"
+          "you can initialize it directly using " +
+          clc.bold("firebase init --project <project_id>") +
+          ".\n"
       );
     }
 

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -11,7 +11,7 @@ var utils = require("../../utils");
 var NO_PROJECT = "[don't setup a default project]";
 var NEW_PROJECT = "[create a new project]";
 
-module.exports = function(setup, config) {
+module.exports = function(setup, config, options) {
   setup.project = {};
 
   logger.info();
@@ -29,6 +29,7 @@ module.exports = function(setup, config) {
         label: info.name + " (" + projectId + ")",
       };
     });
+    choices = _.orderBy(choices, ["name"], ["asc"]);
     var nameOptions = [NO_PROJECT].concat(_.map(choices, "label")).concat([NEW_PROJECT]);
 
     if (_.has(setup.rcfile, "projects.default")) {
@@ -37,8 +38,18 @@ module.exports = function(setup, config) {
       return undefined;
     }
 
-    return prompt
-      .once({
+    var getProjectId;
+    if (options.project) {
+      var projectIdLabel = prompt.valueToListLabel(options.project, choices);
+      if (!projectIdLabel) {
+        logger.info("No such project: " + options.project);
+        return;
+      }
+
+      logger.info("Using project " + projectIdLabel);
+      getProjectId = Promise.resolve(projectIdLabel);
+    } else {
+      getProjectId = prompt.once({
         type: "list",
         name: "id",
         message: "Select a default Firebase project for this directory:",
@@ -49,22 +60,24 @@ module.exports = function(setup, config) {
           return true;
         },
         choices: nameOptions,
-      })
-      .then(function(projectId) {
-        if (projectId === NEW_PROJECT) {
-          setup.createProject = true;
-          return;
-        } else if (projectId === NO_PROJECT) {
-          return;
-        }
-        projectId = prompt.listLabelToValue(projectId, choices);
-        var instance = projects[projectId].instances.database[0];
-
-        // write "default" alias and activate it immediately
-        _.set(setup.rcfile, "projects.default", projectId);
-        setup.projectId = projectId;
-        setup.instance = instance;
-        utils.makeActiveProject(config.projectDir, projectId);
       });
+    }
+
+    return getProjectId.then(function(projectId) {
+      if (projectId === NEW_PROJECT) {
+        setup.createProject = true;
+        return;
+      } else if (projectId === NO_PROJECT) {
+        return;
+      }
+      projectId = prompt.listLabelToValue(projectId, choices);
+      var instance = projects[projectId].instances.database[0];
+
+      // write "default" alias and activate it immediately
+      _.set(setup.rcfile, "projects.default", projectId);
+      setup.projectId = projectId;
+      setup.instance = instance;
+      utils.makeActiveProject(config.projectDir, projectId);
+    });
   });
 };

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -57,7 +57,7 @@ function _getProject(options) {
     if (choices.length >= 25) {
       utils.logBullet(
         "Don't want to scroll through all your projects? If you know your project ID, " +
-          "you can initialize it directly using 'firebase --project=$PROJECT_ID init.\n"
+          "you can initialize it directly using 'firebase init --project=$PROJECT_ID.\n"
       );
     }
 

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -17,7 +17,7 @@ var NEW_PROJECT = "[create a new project]";
  *
  * {
  *  id: project ID [required]
- *  name: project display name [optional]
+ *  label: project display label [optional]
  *  instance: project database instance [optional]
  * }
  */

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -54,6 +54,13 @@ function _getProject(options) {
     choices = _.orderBy(choices, ["name"], ["asc"]);
     var nameOptions = [NO_PROJECT].concat(_.map(choices, "label")).concat([NEW_PROJECT]);
 
+    if (choices.length >= 25) {
+      utils.logBullet(
+        "Don't want to scroll through all your projects? If you know your project ID, " +
+          "you can initialize it directly using 'firebase --project=$PROJECT_ID init.\n"
+      );
+    }
+
     return prompt
       .once({
         type: "list",
@@ -109,7 +116,7 @@ module.exports = function(setup, config, options) {
       return;
     }
 
-    logger.info("Using project " + project.name + " (" + project.id + ")");
+    utils.logBullet("Using project " + project.name + " (" + project.id + ")");
 
     // write "default" alias and activate it immediately
     _.set(setup.rcfile, "projects.default", project.id);

--- a/lib/init/features/project.js
+++ b/lib/init/features/project.js
@@ -31,10 +31,11 @@ function _getProject(options) {
         origin: api.firebaseApiOrigin,
       })
       .then(function(response) {
-        // TODO: CATCH
+        var id = response.body.projectId;
+        var name = response.body.displayName;
         return {
-          id: response.body.projectId,
-          name: response.body.displayName,
+          id: id,
+          label: id + " (" + name + ")",
           instance: response.body.resources.realtimeDatabaseInstance,
         };
       })
@@ -48,7 +49,7 @@ function _getProject(options) {
     var choices = _.map(projects, function(info, projectId) {
       return {
         name: projectId,
-        label: info.name + " (" + projectId + ")",
+        label: projectId + " (" + info.name + ")",
       };
     });
     choices = _.orderBy(choices, ["name"], ["asc"]);
@@ -83,8 +84,8 @@ function _getProject(options) {
 
         var id = prompt.listLabelToValue(label, choices);
         return {
-          id: prompt.listLabelToValue(label, choices),
-          name: label,
+          id: id,
+          label: label,
           instance: projects[id].instances.database[0],
         };
       });
@@ -116,7 +117,7 @@ module.exports = function(setup, config, options) {
       return;
     }
 
-    utils.logBullet("Using project " + project.name + " (" + project.id + ")");
+    utils.logBullet("Using project " + project.label);
 
     // write "default" alias and activate it immediately
     _.set(setup.rcfile, "projects.default", project.id);

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -60,4 +60,12 @@ prompt.listLabelToValue = function(label, choices) {
   }
 };
 
+prompt.valueToListLabel = function(value, choices) {
+  for (var i = 0; i < choices.length; i++) {
+    if (choices[i].name === value) {
+      return choices[i].label;
+    }
+  }
+};
+
 module.exports = prompt;

--- a/lib/prompt.js
+++ b/lib/prompt.js
@@ -60,12 +60,4 @@ prompt.listLabelToValue = function(label, choices) {
   }
 };
 
-prompt.valueToListLabel = function(value, choices) {
-  for (var i = 0; i < choices.length; i++) {
-    if (choices[i].name === value) {
-      return choices[i].label;
-    }
-  }
-};
-
 module.exports = prompt;


### PR DESCRIPTION
Fixes #847

Two changes to `firebase init`:
  * Allow passing `--project` to skip the prompt
  * When the prompt is shown, alphabetize by project ID

**Example 1: Valid Project ID**
```
$ ~/Projects/firebase/firebase-tools/bin/firebase --project="ossbot-test" init firestore

You're about to initialize a Firebase project in this directory:

  /usr/local/google/home/samstern/Projects/firebase/firebase-tools


=== Project Setup

First, let's associate this project directory with a Firebase project.
You can create multiple project aliases by running firebase use --add,
but for now we'll just set up a default project.

Using project OSSBot-test (ossbot-test)

=== Firestore Setup

Firestore Security Rules allow you to define how and when to allow
requests. You can keep these rules in your project directory
and publish them with firebase deploy.

? What file should be used for Firestore Rules? (firestore.rules)
```

**Example 2: Invalid Project ID**
```
$ ~/Projects/firebase/firebase-tools/bin/firebase --project="ossbot-testz" init firestore

You're about to initialize a Firebase project in this directory:

  /usr/local/google/home/samstern/Projects/firebase/firebase-tools


=== Project Setup

First, let's associate this project directory with a Firebase project.
You can create multiple project aliases by running firebase use --add,
but for now we'll just set up a default project.


Error: Error getting project firestorequickstartz
```