### PR TITLE
Catch Hosting Cache Write Errors

### DIFF
--- a/lib/deploy/hosting/hashcache.js
+++ b/lib/deploy/hosting/hashcache.js
@@ -36,6 +36,10 @@ exports.dump = function(cwd, name, data) {
     count++;
     st += path + "," + data[path].mtime + "," + data[path].hash + "\n";
   }
-  fs.outputFileSync(cachePath(cwd, name), st, { encoding: "utf8" });
-  logger.debug("[hosting] hash cache [" + name + "] stored for", count, "files");
+  try {
+    fs.outputFileSync(cachePath(cwd, name), st, { encoding: "utf8" });
+    logger.debug("[hosting] hash cache [" + name + "] stored for", count, "files");
+  } catch (e) {
+    logger.debug("[hosting] unable to store hash cache [" + name + "]");
+  }
 };

--- a/lib/deploy/hosting/hashcache.js
+++ b/lib/deploy/hosting/hashcache.js
@@ -40,6 +40,6 @@ exports.dump = function(cwd, name, data) {
     fs.outputFileSync(cachePath(cwd, name), st, { encoding: "utf8" });
     logger.debug("[hosting] hash cache [" + name + "] stored for", count, "files");
   } catch (e) {
-    logger.debug("[hosting] unable to store hash cache [" + name + "]");
+    logger.debug("[hosting] unable to store hash cache [" + name + "]", e.stack);
   }
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixing #906. Catch errors thrown by writing the Hosting Cache so they don't surface for the user. Log them to the debugger.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

```bash
chmod u-w .firebase
firebase deploy --only hosting
```

w/o the change, you see the issue described in #906. Writing the cache shouldn't prevent the CLI from deploying, but we shouldn't not handle the promise.
