### PR TITLE
Add precheck for base64 strings in auth:import

### DIFF
--- a/lib/accountImporter.js
+++ b/lib/accountImporter.js
@@ -26,6 +26,13 @@ var ALLOWED_JSON_KEYS_RENAMING = {
 var ALLOWED_PROVIDER_USER_INFO_KEYS = ["providerId", "rawId", "email", "displayName", "photoUrl"];
 var ALLOWED_PROVIDER_IDS = ["google.com", "facebook.com", "twitter.com", "github.com"];
 
+var _isValidBase64 = function(str) {
+  var expected = Buffer.from(str, "base64").toString("base64");
+  // Buffer automatically pads with '=' character.
+  str = str.padEnd(expected.length, "=");
+  return expected === str;
+};
+
 var _toWebSafeBase64 = function(data) {
   return data
     .toString("base64")
@@ -115,6 +122,17 @@ var transArrayToUser = function(arr) {
   _addProviderUserInfo(user, "facebook.com", arr.slice(11, 15));
   _addProviderUserInfo(user, "twitter.com", arr.slice(15, 19));
   _addProviderUserInfo(user, "github.com", arr.slice(19, 23));
+
+  if (user.passwordHash && !_isValidBase64(user.passwordHash)) {
+    return {
+      error: "Password hash should be base64 encoded.",
+    };
+  }
+  if (user.salt && !_isValidBase64(user.salt)) {
+    return {
+      error: "Password salt should be base64 encoded.",
+    };
+  }
   return user;
 };
 
@@ -250,6 +268,17 @@ var validateUserJson = function(userJson) {
         return res;
       }
     }
+  }
+  var badFormat = JSON.stringify(userJson, null, 2) + " has invalid data format: ";
+  if (userJson.passwordHash && !_isValidBase64(userJson.passwordHash)) {
+    return {
+      error: badFormat + "Password hash should be base64 encoded.",
+    };
+  }
+  if (userJson.salt && !_isValidBase64(userJson.salt)) {
+    return {
+      error: badFormat + "Password salt should be base64 encoded.",
+    };
   }
   return {};
 };

--- a/lib/accountImporter.js
+++ b/lib/accountImporter.js
@@ -28,8 +28,11 @@ var ALLOWED_PROVIDER_IDS = ["google.com", "facebook.com", "twitter.com", "github
 
 var _isValidBase64 = function(str) {
   var expected = Buffer.from(str, "base64").toString("base64");
-  // Buffer automatically pads with '=' character.
-  str = str.padEnd(expected.length, "=");
+  // Buffer automatically pads with '=' character,
+  // but input string might not have padding.
+  if (str.length < expected.length && str.slice(-1) !== "=") {
+    str += "=".repeat(expected.length - str.length);
+  }
   return expected === str;
 };
 

--- a/test/lib/accountImporter.spec.js
+++ b/test/lib/accountImporter.spec.js
@@ -8,9 +8,24 @@ var helpers = require("../helpers");
 
 var expect = chai.expect;
 describe("accountImporter", function() {
+  var transArrayToUser = accountImporter.transArrayToUser;
   var validateOptions = accountImporter.validateOptions;
   var validateUserJson = accountImporter.validateUserJson;
   var serialImportUsers = accountImporter.serialImportUsers;
+
+  describe("transArrayToUser", function() {
+    it("should reject when passwordHash is invalid base64", function() {
+      return expect(transArrayToUser(["123", undefined, undefined, "false"])).to.have.property(
+        "error"
+      );
+    });
+
+    it("should not reject when passwordHash is valid base64", function() {
+      return expect(
+        transArrayToUser(["123", undefined, undefined, "Jlf7onfLbzqPNFP/1pqhx6fQF/w="])
+      ).to.not.have.property("error");
+    });
+  });
 
   describe("validateOptions", function() {
     it("should reject when unsupported hash algorithm provided", function() {
@@ -62,6 +77,24 @@ describe("accountImporter", function() {
           ],
         })
       ).to.have.property("error");
+    });
+
+    it("should reject when passwordHash is invalid base64", function() {
+      return expect(
+        validateUserJson({
+          localId: "123",
+          passwordHash: "false",
+        })
+      ).to.have.property("error");
+    });
+
+    it("should not reject when passwordHash is valid base64", function() {
+      return expect(
+        validateUserJson({
+          localId: "123",
+          passwordHash: "Jlf7onfLbzqPNFP/1pqhx6fQF/w=",
+        })
+      ).to.not.have.property("error");
     });
   });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Add basic client-side type checks for base64 fields in auth:import. This ensures that auth:import won't throw an opaque

`Error: 400, Invalid value at 'users[66].password' (TYPE_BYTES), Base64 decoding failed for "false"
`

from the server but instead throws a

`Error: Line 67 (67, testuser67@email.com, , false, , , , , , , , , , , , , , , , , , , , , , , ) has invalid data format: Password hash should be base64 encoded.`

error after validation. Furthermore, the invalid request won't even be sent to the server.

Also exposed error messages for auth:import for this fix. Previously they are shown as "Error: An unexpected error has occurred." regardless of the error.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
Tested for .json and .csv files, for multiple users, for blank fields, and different base64 hashes.
