### PR TITLE
Adds deploy --force command. Fixes #877

### DIFF
--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -42,7 +42,10 @@ module.exports = new Command("deploy")
   .description("deploy code and assets to your Firebase project")
   .option("-p, --public <path>", "override the Hosting public directory specified in firebase.json")
   .option("-m, --message <message>", "an optional message describing this deploy")
-  .option("-f, --force", "delete Cloud Functions missing from the current working directory")
+  .option(
+    "-f, --force",
+    "delete Cloud Functions missing from the current working directory without confirmation"
+  )
   .option(
     "--only <targets>",
     'only deploy to specified, comma-separated targets (e.g. "hosting,storage"). For functions, ' +

--- a/commands/deploy.js
+++ b/commands/deploy.js
@@ -42,6 +42,7 @@ module.exports = new Command("deploy")
   .description("deploy code and assets to your Firebase project")
   .option("-p, --public <path>", "override the Hosting public directory specified in firebase.json")
   .option("-m, --message <message>", "an optional message describing this deploy")
+  .option("-f, --force", "delete Cloud Functions missing from the current working directory")
   .option(
     "--only <targets>",
     'only deploy to specified, comma-separated targets (e.g. "hosting,storage"). For functions, ' +

--- a/lib/deploy/functions/release.js
+++ b/lib/deploy/functions/release.js
@@ -280,7 +280,7 @@ module.exports = function(context, options, payload) {
         return "\t" + helper.getFunctionLabel(func);
       }).join("\n");
 
-      if (options.nonInteractive) {
+      if (options.nonInteractive && !options.force) {
         var deleteCommands = _.map(functionsToDelete, function(func) {
           return (
             "\tfirebase functions:delete " +
@@ -296,9 +296,7 @@ module.exports = function(context, options, payload) {
             "\n\nAborting because deletion cannot proceed in non-interactive mode. To fix, manually delete the functions by running:\n" +
             clc.bold(deleteCommands)
         );
-      }
-
-      if (!options.force) {
+      } else if (!options.force) {
         logger.info(
           "\nThe following functions are found in your project but do not exist in your local source code:\n" +
             deleteList +

--- a/lib/deploy/functions/release.js
+++ b/lib/deploy/functions/release.js
@@ -298,52 +298,58 @@ module.exports = function(context, options, payload) {
         );
       }
 
-      logger.info(
-        "\nThe following functions are found in your project but do not exist in your local source code:\n" +
-          deleteList +
-          "\n\nIf you are renaming a function or changing its region, it is recommended that you create the new " +
-          "function first before deleting the old one to prevent event loss. For more info, visit " +
-          clc.underline("https://firebase.google.com/docs/functions/manage-functions#modify" + "\n")
-      );
+      if (!options.force) {
+        logger.info(
+          "\nThe following functions are found in your project but do not exist in your local source code:\n" +
+            deleteList +
+            "\n\nIf you are renaming a function or changing its region, it is recommended that you create the new " +
+            "function first before deleting the old one to prevent event loss. For more info, visit " +
+            clc.underline(
+              "https://firebase.google.com/docs/functions/manage-functions#modify" + "\n"
+            )
+        );
+      }
 
-      return prompt
-        .once({
-          type: "confirm",
-          name: "confirm",
-          default: false,
-          message:
-            "Would you like to proceed with deletion? Selecting no will continue the rest of the deployments.",
-        })
-        .then(function(proceed) {
-          if (!proceed) {
-            if (deployments.length !== 0) {
-              utils.logBullet(clc.bold.cyan("functions: ") + "continuing with other deployments.");
-            }
-            return;
+      const next = options.force
+        ? Promise.resolve(true)
+        : prompt.once({
+            type: "confirm",
+            name: "confirm",
+            default: false,
+            message:
+              "Would you like to proceed with deletion? Selecting no will continue the rest of the deployments.",
+          });
+
+      next.then(function(proceed) {
+        if (!proceed) {
+          if (deployments.length !== 0) {
+            utils.logBullet(clc.bold.cyan("functions: ") + "continuing with other deployments.");
           }
-          functionsToDelete.forEach(function(name) {
-            var functionName = helper.getFunctionName(name);
-            var region = helper.getRegion(name);
+          return;
+        }
+        functionsToDelete.forEach(function(name) {
+          var functionName = helper.getFunctionName(name);
+          var region = helper.getRegion(name);
 
-            utils.logBullet(
-              clc.bold.cyan("functions: ") +
-                "deleting function " +
-                clc.bold(helper.getFunctionLabel(name)) +
-                "..."
-            );
-            _startTimer(name, "delete");
-            deployments.push({
-              name: name,
-              retryFunction: function() {
-                return gcp.cloudfunctions.delete({
-                  projectId: projectId,
-                  region: region,
-                  functionName: functionName,
-                });
-              },
-            });
+          utils.logBullet(
+            clc.bold.cyan("functions: ") +
+              "deleting function " +
+              clc.bold(helper.getFunctionLabel(name)) +
+              "..."
+          );
+          _startTimer(name, "delete");
+          deployments.push({
+            name: name,
+            retryFunction: function() {
+              return gcp.cloudfunctions.delete({
+                projectId: projectId,
+                region: region,
+                functionName: functionName,
+              });
+            },
           });
         });
+      });
     })
     .then(function() {
       return utils.promiseAllSettled(

--- a/lib/firebaseApi.js
+++ b/lib/firebaseApi.js
@@ -1,3 +1,5 @@
+const _ = require("lodash");
+
 const api = require("./api");
 
 const API_VERSION = "v1beta1";
@@ -16,7 +18,7 @@ function _list(nextPageToken, projects) {
       origin: api.firebaseApiOrigin,
     })
     .then(response => {
-      projects = projects.concat(projects, response.body.results);
+      projects = projects.concat(response.body.results);
       if (response.body.nextPageToken) {
         return _list(response.body.nextPageToken, projects);
       }

--- a/lib/firebaseApi.js
+++ b/lib/firebaseApi.js
@@ -1,5 +1,3 @@
-const _ = require("lodash");
-
 const api = require("./api");
 
 const API_VERSION = "v1beta1";


### PR DESCRIPTION
This adds a new `--force` flag to the deploy command which will cause Cloud Functions not detected in the current package to be deleted while deploying. This is meant to address the developer feedback in #877 who are running deploys in automated environments and delete functions regularly enough for this to have become a problem.