### PR TITLE
do not instantiate firebase-node

### DIFF
--- a/commands/database-push.js
+++ b/commands/database-push.js
@@ -12,7 +12,6 @@ var utils = require("../lib/utils");
 var clc = require("cli-color");
 var logger = require("../lib/logger");
 var fs = require("fs");
-var Firebase = require("firebase");
 var _ = require("lodash");
 
 module.exports = new Command("database:push <path> [infile]")
@@ -62,13 +61,11 @@ module.exports = new Command("database:push <path> [infile]")
             }
 
             var consoleUrl = utils.consoleUrl(options.project, "/database/data" + path + body.name);
-            var refurl =
-              utils.addSubdomain(api.realtimeOrigin, options.instance) + path + body.name;
 
             utils.logSuccess("Data pushed successfully");
             logger.info();
             logger.info(clc.bold("View data at:"), consoleUrl);
-            return resolve(new Firebase(refurl));
+            return resolve({ key: body.name });
           })
         );
       });


### PR DESCRIPTION
fixes #962

### Description

All commands simply end with `resolve()`. Only the database:push command ends with `resolve(new Firebase(url))`. This seems to start some background tasks which means that when using database.push from the firebase module (not the CLI) your node process never ends since there are background tasks,.

Instantiation Firebase seems a mistake as none of the other commands do this. Replacing it with `resolve()` doesn't seem to break anything.
