### PR TITLE
wait for write to complete

### DIFF
--- a/commands/database-get.js
+++ b/commands/database-get.js
@@ -114,7 +114,9 @@ module.exports = new Command("database:get <path>")
             }
           })
           .on("end", function() {
-            outStream.write("\n");
+            outStream.write("\n", function() {
+              resolve();
+            });
             if (erroring) {
               try {
                 var data = JSON.parse(errorResponse);
@@ -128,7 +130,6 @@ module.exports = new Command("database:get <path>")
                 );
               }
             }
-            return resolve();
           })
           .on("error", reject);
       });


### PR DESCRIPTION
fixes #706
fixes #675
fixes #267

Should fix three (duplicate) bugs that we also suffer from ourselves. When I dump a database of approx 6MB to a json file on disk with `database:get` it sometimes produces a truncated json file. On my machine (MacOS) it only fails about once every 20 times. Other machines seems to suffer much more or less from this issue.

With this change we wait for the last written chunk to complete before resolving the promise. At least that helps to keep the CLI process running while the last chunk has not completed yet.
