### PR TITLE
Pour one out for the fire emoji banner. 

### DIFF
--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -53,9 +53,6 @@ module.exports = new Command("init [feature]")
         "\n";
     }
 
-    if (process.platform === "darwin") {
-      BANNER_TEXT = BANNER_TEXT.replace(/#/g, "🔥");
-    }
     logger.info(
       clc.yellow.bold(BANNER_TEXT) +
         "\nYou're about to initialize a Firebase project in this directory:\n\n  " +


### PR DESCRIPTION
Ever since `<insert version of macOS here, don't remember>` the beautiful **FIREBASE** emoji banner has been wrecked in the default OS X Terminal app due to UTF-8 character spacing changes. Other terminals like Hyper or iTerm work fine, but there's no way that I was able to determine to detect where it will and won't work. 😞

Since a yellow `FIREBASE` is better than a glitchy mess, it's time to say goodbye to the fire emoji.

💧💧💧💧🔥💧💧💧💧 