### PR TITLE
Readme, coverage, testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '6'
 - '8'
-- stable
+- '10'
 sudo: false
 after_script:
 - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 - '10'
 sudo: false
 after_script:
-- cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+- nyc report --reporter=text-lcov | coveralls
 cache:
   directories:
   - node_modules

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Firebase CLI [![Build Status](https://travis-ci.org/firebase/firebase-tools.svg?branch=master)](https://travis-ci.org/firebase/firebase-tools) [![Coverage Status](https://img.shields.io/coveralls/firebase/firebase-tools.svg?branch=master&style=flat)](https://coveralls.io/r/firebase/firebase-tools) [![Node Version](https://img.shields.io/node/v/firebase-tools.svg)](https://www.npmjs.com/package/firebase-tools) [![NPM version](https://badge.fury.io/js/firebase-tools.svg)](http://badge.fury.io/js/firebase-tools)
+# Firebase CLI [![Build Status][travis-badge]][travis-ci] [![Coverage Status][coveralls-badge]][coveralls] [![Node Version][node-badge]][npm] [![NPM version][npm-badge]][npm]
 
 These are the Firebase Command Line Interface (CLI) Tools. They can be used to:
 
@@ -8,7 +8,6 @@ These are the Firebase Command Line Interface (CLI) Tools. They can be used to:
 * Import/Export users into/from Firebase Auth
 
 To get started with the Firebase CLI, read the full list of commands below or check out the [hosting-specific CLI documentation](https://firebase.google.com/docs/hosting/quickstart).
-
 
 ## Installation
 
@@ -24,7 +23,6 @@ npm install -g firebase-tools
 ```
 
 This will provide you with the globally accessible `firebase` command.
-
 
 ## Commands
 
@@ -148,3 +146,12 @@ client.deploy({
   // handle error
 });
 ```
+
+[travis-ci]: https://travis-ci.org/firebase/firebase-tools
+[coveralls]: https://coveralls.io/r/firebase/firebase-tools
+[npm]: https://www.npmjs.com/package/firebase-tools
+
+[travis-badge]: https://img.shields.io/travis/firebase/firebase-tools/master.svg
+[coveralls-badge]: https://img.shields.io/coveralls/firebase/firebase-tools.svg?branch=master&style=flat
+[node-badge]: https://img.shields.io/node/v/firebase-tools.svg
+[npm-badge]: https://img.shields.io/npm/v/firebase-tools.svg


### PR DESCRIPTION
### Description

A few bits of cleanup:
* travis doesn't need to test on node 11 (which is `stable` now)
* cleaned up and unified badges and links in the readme
* fix coverage reporting, which hasn't been running since April
	 
### Scenarios Tested

Tests pass, and coveralls works: https://coveralls.io/builds/19733366