### PR TITLE
Feature/typescript functions improvements

### DIFF
--- a/src/init/features/functions/typescript.js
+++ b/src/init/features/functions/typescript.js
@@ -36,6 +36,10 @@ module.exports = function(setup, config) {
           'npm --prefix "$RESOURCE_DIR" run lint',
           'npm --prefix "$RESOURCE_DIR" run build',
         ]);
+        _.set(setup, "config.functions.ignore", [
+          "node_modules", // the default
+          "src", // we also want to exclude the typescript sources
+        ]);
         return config
           .askWriteProjectFile("functions/package.json", PACKAGE_LINTING_TEMPLATE)
           .then(function() {

--- a/templates/init/functions/typescript/_gitignore
+++ b/templates/init/functions/typescript/_gitignore
@@ -1,6 +1,5 @@
-## Compiled JavaScript files
-**/*.js
-**/*.js.map
+# Compiled JavaScript files
+lib/
 
-# Typescript v1 declaration files
-typings/
+# Node Modules
+node_modules/

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -16,6 +16,7 @@
     "firebase-functions": "^2.1.0"
   },
   "devDependencies": {
+    "@firebase/app-types": "^0.3.2",
     "tslint": "^5.11.0",
     "typescript": "^3.1.4"
   },

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -1,5 +1,7 @@
 {
   "name": "functions",
+  "private": true,
+  "main": "lib/index.js",
   "scripts": {
     "lint": "tslint --project tsconfig.json",
     "build": "tsc",
@@ -9,7 +11,6 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
   },
-  "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "~6.0.0",
     "firebase-functions": "^2.1.0"
@@ -18,5 +19,7 @@
     "tslint": "~5.8.0",
     "typescript": "~2.8.3"
   },
-  "private": true
+  "engines": {
+    "node": "8"
+  }
 }

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -16,8 +16,8 @@
     "firebase-functions": "^2.1.0"
   },
   "devDependencies": {
-    "tslint": "~5.8.0",
-    "typescript": "~2.8.3"
+    "tslint": "^5.11.0",
+    "typescript": "^3.1.4"
   },
   "engines": {
     "node": "8"

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -1,5 +1,7 @@
 {
   "name": "functions",
+  "private": true,
+  "main": "lib/index.js",
   "scripts": {
     "build": "tsc",
     "serve": "npm run build && firebase serve --only functions",
@@ -8,7 +10,6 @@
     "deploy": "firebase deploy --only functions",
     "logs": "firebase functions:log"
   },
-  "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "~6.0.0",
     "firebase-functions": "^2.1.0"
@@ -16,5 +17,7 @@
   "devDependencies": {
     "typescript": "~2.8.3"
   },
-  "private": true
+  "engines": {
+    "node": "8"
+  }
 }

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -11,6 +11,7 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
+    "@firebase/app-types": "^0.3.2",
     "firebase-admin": "~6.0.0",
     "firebase-functions": "^2.1.0"
   },

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -15,7 +15,7 @@
     "firebase-functions": "^2.1.0"
   },
   "devDependencies": {
-    "typescript": "~2.8.3"
+    "typescript": "^3.1.4"
   },
   "engines": {
     "node": "8"

--- a/templates/init/functions/typescript/tsconfig.json
+++ b/templates/init/functions/typescript/tsconfig.json
@@ -1,11 +1,11 @@
 {
   "compilerOptions": {
-    "lib": ["es6"],
+    "lib": ["es2017"],
     "module": "commonjs",
-    "noImplicitReturns": true,
+    "strict": true,
     "outDir": "lib",
     "sourceMap": true,
-    "target": "es6"
+    "target": "es2017"
   },
   "compileOnSave": true,
   "include": [

--- a/templates/init/functions/typescript/tslint.json
+++ b/templates/init/functions/typescript/tslint.json
@@ -107,9 +107,6 @@
     // Warns if function overloads could be unified into a single function with optional or rest parameters.
     "unified-signatures": {"severity": "warning"},
 
-    // Warns if code has an import or variable that is unused.
-    "no-unused-variable": {"severity": "warning"},
-
     // Prefer const for values that will not change. This better documents code.
     "prefer-const": {"severity": "warning"},
 


### PR DESCRIPTION
### Description
Updates and improves the typescript templates
The default for typescript was outdated, and I thought it would be best to update to node 8 and typescript 3.

Let me know if you have any questions :)

### Commits

* add src to the functions.ignore settings on init
* include @firebase/app-types
* update typescript to version 3.1.4
* ignore node_modules/ and compiled lib/ directory
* set default of new functions project to node 8
	 
### Scenarios Tested

Tests run
Tested to link firebase-tools and init a firebase functions project and then compile and lint that.
