### PR TITLE
Add tests for queue; allow custom backoff

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.5",
     "@types/node": "^10.12.0",
+    "@types/sinon": "^5.0.5",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.1",

--- a/src/queue.js
+++ b/src/queue.js
@@ -29,7 +29,7 @@ class Queue {
     this.max = 0;
     this.avg = 0;
     this.retries = options.retries || 0;
-    this.backoff = 200;
+    this.backoff = typeof options.backoff == "number" ? options.backoff : 200;
     this.retryCounts = {};
     this.closed = false;
     this.finished = false;

--- a/src/test/queue.spec.ts
+++ b/src/test/queue.spec.ts
@@ -1,0 +1,74 @@
+import * as sinon from "sinon";
+import * as chai from "chai";
+
+chai.use(require("chai-as-promised"));
+const { expect } = chai;
+
+const Queue = require("../queue");
+
+const TEST_ERROR = new Error("foobar");
+
+describe("Queue", () => {
+  it("should handle tasks", () => {
+    const handler = sinon.stub().resolves();
+    const q = new Queue({
+      handler,
+    });
+
+    q.add(4);
+    q.close();
+    q.process();
+
+    return q.wait()
+      .then(() => {
+        expect(handler.callCount).to.equal(1);
+      });
+  });
+
+  it("should not retry", () => {
+    const handler = sinon.stub().rejects(TEST_ERROR);
+    const q = new Queue({
+      handler,
+      retries: 0,
+    });
+
+    q.add(4);
+    q.close();
+    q.process();
+
+    return q.wait()
+      .then(() => {
+        throw new Error("handler should have rejected");
+      })
+      .catch((err: Error) => {
+        expect(err).to.equal(TEST_ERROR);
+      })
+      .then(() => {
+        expect(handler.callCount).to.equal(1);
+      });
+  });
+
+  it("should retry the number of retries, plus one", () => {
+    const handler = sinon.stub().rejects(TEST_ERROR);
+    const q = new Queue({
+      backoff: 0,
+      handler,
+      retries: 3,
+    });
+
+    q.add(4);
+    q.close();
+    q.process();
+
+    return q.wait()
+      .then(() => {
+        throw new Error("handler should have rejected");
+      })
+      .catch((err: Error) => {
+        expect(err).to.equal(TEST_ERROR);
+      })
+      .then(() => {
+        expect(handler.callCount).to.equal(4);
+      });
+  });
+});


### PR DESCRIPTION
Since you're changing the behavior of `queue.js`, we should be making sure tests still pass. Since there's no tests, we really should be adding them.

Here's a few tests to get you started. They're not comprehensive, but it's a start. If you could merge this into your branch and extend these tests to test the new behavior you're adding, it would do _a lot_ to build more confidence in the code we're writing 😄 