### PR TITLE
bootstrap mocha with chai-as-promised

### DIFF
--- a/mocha.opts
+++ b/mocha.opts
@@ -1,5 +1,6 @@
 --require ts-node/register
 --require source-map-support/register
+--require src/test/helpers/mocha-bootstrap.js
 --recursive
 --timeout=1000
 src/test/**/*.{ts,js}

--- a/src/test/command.spec.js
+++ b/src/test/command.spec.js
@@ -2,7 +2,6 @@
 
 var chai = require("chai");
 var expect = chai.expect;
-chai.use(require("chai-as-promised"));
 
 var Command = require("../command");
 

--- a/src/test/fsAsync.spec.js
+++ b/src/test/fsAsync.spec.js
@@ -8,11 +8,9 @@ var path = require("path");
 var fsAsync = require("../fsAsync");
 
 var chai = require("chai");
-var chaiAsPromised = require("chai-as-promised");
 var _ = require("lodash");
 
 var expect = chai.expect;
-chai.use(chaiAsPromised);
 
 // These tests work on the following directory structure:
 // <basedir>

--- a/src/test/helpers/mocha-bootstrap.js
+++ b/src/test/helpers/mocha-bootstrap.js
@@ -1,0 +1,8 @@
+const chai = require("chai");
+const chaiAsPromised = require("chai-as-promised");
+
+chai.use(chaiAsPromised);
+
+process.on("unhandledRejection", (error) => {
+  throw error;
+});

--- a/src/test/identifierToProjectId.spec.js
+++ b/src/test/identifierToProjectId.spec.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var chai = require("chai");
-chai.use(require("chai-as-promised"));
 var expect = chai.expect;
 var sinon = require("sinon");
 

--- a/src/test/profilerReport.spec.js
+++ b/src/test/profilerReport.spec.js
@@ -6,7 +6,6 @@ var path = require("path");
 var stream = require("stream");
 var ProfileReport = require("../profileReport");
 
-chai.use(require("chai-as-promised"));
 var expect = chai.expect;
 
 var combinerFunc = function(obj1, obj2) {


### PR DESCRIPTION
### Description

Bootstrap mocha with `chai-as-promised` and catch and rethrow any unhandled rejections (which will actually make the tests fail, as expected).

This allows us to not have to require and `.use` `chai-as-promised` everywhere, which will be much appreciated in the future as we write more async functions.

### Scenarios Tested

I made a promise-based test fail and succeed again.