### PR TITLE
Fix function delete in interactive mode

### DIFF
--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -318,7 +318,7 @@ module.exports = function(context, options, payload) {
               "Would you like to proceed with deletion? Selecting no will continue the rest of the deployments.",
           });
 
-      next.then(function(proceed) {
+      return next.then(function(proceed) {
         if (!proceed) {
           if (deployments.length !== 0) {
             utils.logBullet(clc.bold.cyan("functions: ") + "continuing with other deployments.");


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes deleting functions without `--force`. The prompt wasn't being returned and was instead ignored.

### Scenarios Tested

1. Created a new function.
2. Ran deploy without `--force`, declined the prompt, checked function wasn't deleted.
3. Ran deploy without `--force`, confirmed the prompt, checked the function was deleted.
4. Ran deploy with `--force`, confirmed it still worked.

```
The following functions are found in your project but do not exist in your local source code:
	helloWorld(us-central1)

If you are renaming a function or changing its region, it is recommended that you create the new function first before deleting the old one to prevent event loss. For more info, visit https://firebase.google.com/docs/functions/manage-functions#modify

? Would you like to proceed with deletion? Selecting no will continue the rest of the deployments. Yes
i  functions: deleting function helloWorld(us-central1)...
✔  functions[helloWorld(us-central1)]: Successful delete operation.

✔  Deploy complete!
```