### PR TITLE
Improve memory performance of Queue implementation

### DIFF
--- a/src/test/queue.spec.ts
+++ b/src/test/queue.spec.ts
@@ -31,6 +31,20 @@ describe("Queue", () => {
     expect(q.taskName(0)).to.equal("index 0");
   });
 
+  it("should return 'finished task' as the task name", () => {
+    const handler = sinon.stub().resolves();
+    const q = new Queue({
+      handler,
+    });
+
+    q.add(2);
+    q.close();
+
+    return q.wait().then(() => {
+      expect(q.taskName(0)).to.equal("finished task");
+    });
+  });
+
   it("should handle function tasks", () => {
     const task = sinon.stub().resolves();
     const q = new Queue({});
@@ -44,6 +58,7 @@ describe("Queue", () => {
       expect(q.success).to.equal(1);
       expect(q.errored).to.equal(0);
       expect(q.retried).to.equal(0);
+      expect(q.total).to.equal(1);
     });
   });
 
@@ -62,6 +77,7 @@ describe("Queue", () => {
       expect(q.success).to.equal(1);
       expect(q.errored).to.equal(0);
       expect(q.retried).to.equal(0);
+      expect(q.total).to.equal(1);
     });
   });
 
@@ -89,6 +105,7 @@ describe("Queue", () => {
         expect(q.success).to.equal(0);
         expect(q.errored).to.equal(1);
         expect(q.retried).to.equal(0);
+        expect(q.total).to.equal(1);
       });
   });
 
@@ -117,6 +134,7 @@ describe("Queue", () => {
         expect(q.success).to.equal(0);
         expect(q.errored).to.equal(1);
         expect(q.retried).to.equal(3);
+        expect(q.total).to.equal(1);
       });
   });
 
@@ -157,6 +175,7 @@ describe("Queue", () => {
         expect(q.success).to.equal(3);
         expect(q.errored).to.equal(0);
         expect(q.retried).to.equal(6);
+        expect(q.total).to.equal(3);
       });
   });
 
@@ -194,6 +213,7 @@ describe("Queue", () => {
         expect(q.success).to.equal(3);
         expect(q.errored).to.equal(0);
         expect(q.retried).to.equal(6);
+        expect(q.total).to.equal(3);
       });
   });
 });


### PR DESCRIPTION
So right now `queue.ts` will save all the tasks submitted.
When I tested it on an extremely large testing database, the program run out of memory with `1773371` tasks.

I convert list 'tasks` to a map of unfinished tasks.

```
[2018-11-12T04:58:32.304Z] [database] Prefetching test at /p-100000000/15521604
[2018-11-12T04:58:32.311Z] [database] Sucessfully removed data at /p-100000000/15521584
[2018-11-12T04:58:32.311Z] [database] Prefetching test at /p-100000000/15521605
  complete: 192532,
  success: 192521,
  errored: 11,
  retried: 297,
  total: 1773371,
  elapsed: 4256988 }
tail: a: file truncated

<--- Last few GCs --->

[183951:0x24cd700] 256515676 ms: Mark-sweep 971.0 (1396.7) -> 971.0 (1396.7) MB, 778.0 / 0.0 ms  allocation failure GC in old space requested
[183951:0x24cd700] 256516481 ms: Mark-sweep 971.0 (1396.7) -> 971.0 (1362.7) MB, 804.5 / 0.0 ms  last resort GC in old space requested
[183951:0x24cd700] 256517275 ms: Mark-sweep 971.0 (1362.7) -> 971.0 (1345.2) MB, 794.5 / 0.0 ms  last resort GC in old space requested


<--- JS stacktrace --->

==== JS stack trace =========================================

Security context: 0x27667ca57c1 <JSObject>
    1: /* anonymous */(aka /* anonymous */) [/usr/local/google/home/fredzqm/dev/firebase-tools/lib/database/remove.js:~35] [pc=0x128dc6b4937c](this=0x1191e1b022d1 <undefined>,pathList=0x3fdba276e851 <JSArray[50000]>)
    2: /* anonymous */(aka /* anonymous */)(this=0x1191e1b022d1 <undefined>)
    6: _tickDomainCallback [internal/process/next_tick.js:~193] [pc=0x128dc6b0f3a1](this=0x3e9949b89cc1 <...
```
