### PR TITLE
use total rather than tasks directly

### DIFF
--- a/src/deploy/hosting/uploader.js
+++ b/src/deploy/hosting/uploader.js
@@ -19,16 +19,8 @@ const MAX_UPLOAD_TIMEOUT = 7200000; // 2h
 
 function _progressMessage(message, current, total) {
   current = Math.min(current, total);
-  return (
-    message +
-    " [" +
-    current +
-    "/" +
-    total +
-    "] (" +
-    clc.bold.green(Math.floor(((current * 1.0) / total) * 100).toString() + "%") +
-    ")"
-  );
+  const percent = Math.floor(((current * 1.0) / total) * 100).toString();
+  return `${message} [${current}/${total}] (${clc.bold.green(`${percent}%`)})`;
 }
 
 class Uploader {
@@ -99,7 +91,7 @@ class Uploader {
       })
       .then(function() {
         logger.debug("[hosting][populate queue][FINAL]", self.populateQueue.stats());
-        logger.debug("[hosting] uploads queued:", self.uploadQueue.tasks.length);
+        logger.debug("[hosting] uploads queued:", self.uploadQueue.stats().total);
         self.uploadQueue.close();
       });
 
@@ -136,7 +128,7 @@ class Uploader {
       return _progressMessage(
         "uploading new files",
         this.uploadQueue.complete,
-        this.uploadQueue.tasks.length
+        this.uploadQueue.stats().total
       );
     } else {
       return "upload complete";
@@ -187,7 +179,7 @@ class Uploader {
 
   queuePopulate() {
     const pop = this.populateBatch;
-    this.populateQueue.add(pop, "batch" + (this.populateQueue.tasks.length + 1));
+    this.populateQueue.add(pop, "batch" + (this.populateQueue.stats().total + 1));
     this.populateBatch = {};
     this.populateQueue.process();
   }


### PR DESCRIPTION
fixes #1020

Uses `stats().total` rather than accessing the `tasks` directly (which no longer has `.length`)