### PR TITLE
Kill emulators properly

### DIFF
--- a/src/serve/index.js
+++ b/src/serve/index.js
@@ -24,7 +24,7 @@ var _serve = function(options) {
       process.on("SIGINT", function() {
         logger.info("Shutting down...");
         return Promise.all(
-          _.forEach(targetNames, function(targetName) {
+          _.map(targetNames, function(targetName) {
             var target = TARGETS[targetName];
             return target.stop(options);
           })

--- a/src/serve/javaEmulators.js
+++ b/src/serve/javaEmulators.js
@@ -64,9 +64,9 @@ function _stop(targetName) {
         var errorMsg = "Unable to terminate emulator process (PID=" + emulator.instance.pid + ")";
         console.warn(errorMsg);
         reject(new FirebaseError(emulator.name + ": " + errorMsg));
-      }, EMULATOR_INSTANCE_KILL_TIMEOUT)
+      }, EMULATOR_INSTANCE_KILL_TIMEOUT);
       emulator.instance.once("exit", function() {
-        clearTimeout(killTimeout)
+        clearTimeout(killTimeout);
         resolve();
       });
       emulator.instance.kill("SIGINT");

--- a/src/serve/javaEmulators.js
+++ b/src/serve/javaEmulators.js
@@ -5,6 +5,7 @@ var fs = require("fs-extra");
 var childProcess = require("child_process");
 var utils = require("../utils");
 var emulatorConstants = require("../emulator/constants");
+var logger = require("../logger");
 
 var EMULATOR_INSTANCE_KILL_TIMEOUT = 2000 /* ms */;
 
@@ -61,7 +62,12 @@ function _stop(targetName) {
     utils.logLabeledSuccess(emulator.name, "shutting down");
     if (emulator.instance) {
       var killTimeout = setTimeout(function() {
-        var errorMsg = "Unable to terminate emulator process (PID=" + emulator.instance.pid + ")";
+        var errorMsg =
+          emulator.name +
+          ": Unable to terminate emulator process (PID=" +
+          emulator.instance.pid +
+          ")";
+        logger.debug(errorMsg);
         console.warn(errorMsg);
         reject(new FirebaseError(emulator.name + ": " + errorMsg));
       }, EMULATOR_INSTANCE_KILL_TIMEOUT);

--- a/src/serve/javaEmulators.js
+++ b/src/serve/javaEmulators.js
@@ -58,9 +58,11 @@ function _stop(targetName) {
   return new Promise(function(resolve) {
     utils.logLabeledSuccess(emulator.name, "shutting down");
     if (emulator.instance) {
-      return emulator.instance.kill(0);
+      emulator.instance.once("exit", resolve);
+      emulator.instance.kill("SIGINT");
+    } else {
+      resolve();
     }
-    return resolve();
   });
 }
 


### PR DESCRIPTION
### Description
When using firebase-tools programmatically to serve the emulators, sending a SIGINT kill signal to the child process makes it exit immediately without actually killing the spawned emulators.
	 
### Use case
I want to launch the Firestore emulator via firebaseTools.serve() in a forked process, run some tests with @firebase/testing, and then kill the emulator once I'm done.

Here's a simplified version of what I'm trying to achieve:
```js
// demo.js

if (!process.send) {
  parent();
} else {
  child();
}

function parent() {
  const { fork } = require('child_process');

  console.log('Starting emulator.');
  const proc = fork('demo.js', [], {
    stdio: ['inherit', 'pipe', 'pipe', 'ipc']
  });

  proc.stdout.on('data', async data => {
    const stdout = data.toString();

    if (/^Dev App Server is now running/.test(stdout)) {
      console.log('Emulator is running.');

      /** Run tests with @firebase/testing using the emulator ... **/
      await runTests();

      /** ... and then kill it when we're done **/
      console.log('Done testing, closing the emulator.');
      proc.kill('SIGINT');
    }
  });

  proc.on('exit', message => {
    console.log('Emulator closed.');
  });
}

function child() {
  const firebaseTools = require('firebase-tools');
  const serving = firebaseTools.serve({
    only: 'firestore'
  });

  process.on('SIGINT', async () => {
    // Wait for serve to finish
    await serving;

    // And exit
    process.exit();
  });
}

async function runTests() {
  console.log('Testing 1, 2, 3.');
}
```

### Sample Commands
N/A