### PR TITLE
Need to fetch the instance before `open`

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - `firebase open hosting:site` might return an `undefined` Hosting Site

--- a/src/commands/open.js
+++ b/src/commands/open.js
@@ -61,6 +61,7 @@ var CHOICES = _.map(LINKS, "name");
 module.exports = new Command("open [link]")
   .description("quickly open a browser to relevant project resources")
   .before(requirePermissions)
+  .before(requireInstance)
   .action(function(linkName, options) {
     var link = _.find(LINKS, { arg: linkName });
     if (linkName && !link) {


### PR DESCRIPTION
`hosting:site` requires the instance (so that we can populate "<sitename>.firebaseapp.com") but we didn't actually make that requirement explicit, so in some rare cases the instance could be `undefined`.
