### PR TITLE
removed ignored argument

### DIFF
--- a/src/deploy/hosting/uploader.js
+++ b/src/deploy/hosting/uploader.js
@@ -179,7 +179,7 @@ class Uploader {
 
   queuePopulate() {
     const pop = this.populateBatch;
-    this.populateQueue.add(pop, "batch" + (this.populateQueue.stats().total + 1));
+    this.populateQueue.add(pop);
     this.populateBatch = {};
     this.populateQueue.process();
   }


### PR DESCRIPTION
This was added in https://github.com/firebase/firebase-tools/commit/484e784777cb2ae770358444fa20292c13e5c4e6#diff-2041a1adf696cab777ab5e6e3670a9e9R176

Queue.add() only takes one argument, so this is being ignored the whole time.

I discovered this bug because the hosting integration test. https://travis-ci.org/firebase/firebase-tools/jobs/463079863.
Cheers to whoever added the integration test! It is actually catching some bugs.