### PR TITLE
Release Firestore Emulator v1.2.2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,2 @@
 fixed - Firestore Emulator bug when running in Java 10 + Java 11 environments (due to better system clock granularity)
-changed - Firestore Emulator now binds to IPv6 loopback address by default (previous behavior was to bind to "localhost", which was usually IPv4-only). This improves gRPC performance significantly due to grpc/grpc#17282.
+changed - Firestore Emulator now binds to IPv6 loopback address by default (previous behavior was to bind to "localhost", which was usually IPv4-only). This improves gRPC performance significantly due to https://github.com/grpc/grpc/issues/17282.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,2 @@
-Firestore Emulator:
-- Fix bug when running in Java 10 + Java 11 environments (due to better system clock granularity)
-- Add explicit IPv6 bindings by default (previous behavior was to bind to
-  "localhost", which was usually IPv4-only). This improves gRPC performance
-  significantly due to grpc/grpc#17282.
+fixed - Firestore Emulator bug when running in Java 10 + Java 11 environments (due to better system clock granularity)
+changed - Firestore Emulator now binds to IPv6 loopback address by default (previous behavior was to bind to "localhost", which was usually IPv4-only). This improves gRPC performance significantly due to grpc/grpc#17282.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,5 @@
+Firestore Emulator:
+- Fix bug when running in Java 10 + Java 11 environments (due to better system clock granularity)
+- Add explicit IPv6 bindings by default (previous behavior was to bind to
+  "localhost", which was usually IPv4-only). This improves gRPC performance
+  significantly due to grpc/grpc#17282.

--- a/src/emulator/constants.js
+++ b/src/emulator/constants.js
@@ -24,8 +24,8 @@ const _emulators = {
     stdout: null,
     cacheDir: CACHE_DIR,
     remoteUrl:
-      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.2.1.jar",
-    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.2.1.jar"),
+      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.2.2.jar",
+    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.2.2.jar"),
   },
 };
 


### PR DESCRIPTION
This release fixes https://github.com/firebase/firebase-tools/issues/1010 and https://github.com/firebase/firebase-tools/issues/1041

Changelog:
  - Fix bug with Java 10 + Java 11 runtimes (due to better system clock granularity)
  - Add explicit IPv6 bindings by default (previous behavior was to bind to "localhost", which was usually IPv4-only). This improves gRPC performance significantly due to https://github.com/grpc/grpc/issues/17282