### PR TITLE
fix lint issue for ThrottlerConstructor

### DIFF
--- a/src/test/throttler/throttler.spec.ts
+++ b/src/test/throttler/throttler.spec.ts
@@ -7,9 +7,7 @@ import { Throttler, ThrottlerOptions } from "../../throttler/throttler";
 
 const TEST_ERROR = new Error("foobar");
 
-interface ThrottlerConstructor {
-  new <T, R>(options: ThrottlerOptions<T, R>): Throttler<T, R>;
-}
+type ThrottlerConstructor = new <T, R>(options: ThrottlerOptions<T, R>) => Throttler<T, R>;
 
 const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
   it("should have no waiting task after creation", () => {


### PR DESCRIPTION
Lint doesn't like the interface way of doing this, so following lint's suggestion of defining this as a type. It's in a `.spec.ts` file, so I'm happy to follow the linter...