### PR TITLE
Transition to cross-env-shell for lifecyle hooks

### DIFF
--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -11,13 +11,15 @@ var logger = require("../logger");
 var path = require("path");
 
 function runCommand(command, childOptions) {
+  var escapedCommand = command.replace(/\"/g, '\\"');
   var translatedCommand =
     '"' +
     process.execPath +
     '" "' +
-    path.resolve(require.resolve("cross-env"), "..", "bin", "cross-env.js") +
-    '" ' +
-    command;
+    path.resolve(require.resolve("cross-env"), "..", "bin", "cross-env-shell.js") +
+    '" "' +
+    escapedCommand +
+    '"';
 
   return new Promise(function(resolve, reject) {
     logger.info("Running command: " + command);


### PR DESCRIPTION
### Description

This is a change related to the standalone installer (firepit) initiative. In Firepit we use intermediary node processes which reroute core node/npm/sh back into the standalone installer. This multi-level process stacking results in loss of environmental variables if they're not passed via `cross-env-shell`. 

Changing to `cross-env-shell` requires escaping the quotes in the command to ensure it is passed properly.

I do not believe this will impact any developers and should add robustness to the cross-env invocation.
	 
### Scenarios Tested

Typescript lifecycle hooks on Windows & Linux with spaces in path and without.
