### PR TITLE
[init functions] Wait for overwrite confirmation of tslint.json

### DIFF
--- a/src/init/features/functions/typescript.js
+++ b/src/init/features/functions/typescript.js
@@ -39,7 +39,7 @@ module.exports = function(setup, config) {
         return config
           .askWriteProjectFile("functions/package.json", PACKAGE_LINTING_TEMPLATE)
           .then(function() {
-            config.askWriteProjectFile("functions/tslint.json", TSLINT_TEMPLATE);
+            return config.askWriteProjectFile("functions/tslint.json", TSLINT_TEMPLATE);
           });
       }
       _.set(setup, "config.functions.predeploy", 'npm --prefix "$RESOURCE_DIR" run build');


### PR DESCRIPTION
### Description

When running `firebase init` for TypeScript functions, the CLI doesn't wait for confirmation to overwrite the existing `functions/tslint.json` file.

### Scenarios Tested

![functions-init-prompt](https://user-images.githubusercontent.com/2029586/50400837-36ee9f00-078a-11e9-9486-443e0632a981.png)

### Sample Commands

`firebase init` to initialize TypeScript functions in a folder where the file `functions/tslint.json` already exists.
