### PR TITLE
Adding functions/.gitignore when javascript is chosen in firebase init, updating typescript functions/.gitignore

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -7,3 +7,5 @@ feature - Firestore emulator now has the ability to produce rule-coverage report
 changed - Firestore emulator now exposes the v1 service definition
 changed - Firestore emulator has various runtime improvements
 changed - Clearer empty state when pretty-printing Firestore indexes
+changed - JavasSript functions template now includes gitignore
+changed - Added node_modules/ to TypeScript functions template gitignore

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,6 @@
+fixed - Fixed Firestore emulator bug related to https://github.com/firebase/firebase-tools/issues/1073
+fixed - Fixed Firestore emulator bug regarding array ordering during writing/reading
+fixed - Fixed Firestore emulator handling of query cursors using document names
+feature - Firestore emulator now has the ability to produce rule-coverage reports
+changed - Firestore emulator now exposes the v1 service definition
+changed - Firestore emulator has various runtime improvements

--- a/src/emulator/constants.js
+++ b/src/emulator/constants.js
@@ -24,8 +24,8 @@ const _emulators = {
     stdout: null,
     cacheDir: CACHE_DIR,
     remoteUrl:
-      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.2.2.jar",
-    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.2.2.jar"),
+      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.2.3.jar",
+    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.2.3.jar"),
   },
 };
 

--- a/src/init/features/functions/javascript.js
+++ b/src/init/features/functions/javascript.js
@@ -18,6 +18,7 @@ var PACKAGE_NO_LINTING_TEMPLATE = fs.readFileSync(
   "utf8"
 );
 var ESLINT_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "eslint.json"), "utf8");
+var GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
 
 module.exports = function(setup, config) {
   return prompt(setup.functions, [
@@ -41,6 +42,9 @@ module.exports = function(setup, config) {
     })
     .then(function() {
       return config.askWriteProjectFile("functions/index.js", INDEX_TEMPLATE);
+    })
+    .then(function() {
+      return config.askWriteProjectFile("functions/.gitignore", GITIGNORE_TEMPLATE);
     })
     .then(function() {
       return npmDependencies.askInstallDependencies(setup, config);

--- a/templates/init/functions/javascript/_gitignore
+++ b/templates/init/functions/javascript/_gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/templates/init/functions/typescript/_gitignore
+++ b/templates/init/functions/typescript/_gitignore
@@ -4,3 +4,7 @@
 
 # Typescript v1 declaration files
 typings/
+
+lib/
+
+node_modules/

--- a/templates/init/functions/typescript/_gitignore
+++ b/templates/init/functions/typescript/_gitignore
@@ -5,6 +5,4 @@
 # Typescript v1 declaration files
 typings/
 
-lib/
-
 node_modules/


### PR DESCRIPTION
### Description
Adding useful default .gitignore files for when the function directory is init - see bug # 72516785
	 
### Scenarios Tested
Created a new javascript functions project, functions/.gitignore exists
Created a new typescript functions project, functions/.gitignore includes the new additions

