### PR TITLE
Prevent Functional Tests from running on a PR from a fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
   - "6"
   - "8"
   - "10"
-before_script:
-  - env
 after_script:
   - nyc report --reporter=text-lcov | coveralls
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,20 @@
 language: node_js
 node_js:
-- '6'
-- '8'
-- '10'
+  - "6"
+  - "8"
+  - "10"
+before_script:
+  - env
 after_script:
-- nyc report --reporter=text-lcov | coveralls
+  - nyc report --reporter=text-lcov | coveralls
 jobs:
   include:
     - stage: hosting functional test
-      node_js: '6'
+      if: repo == head_repo OR type == push
+      node_js: "6"
       before_script: ./scripts/decrypt-app-credentials.sh
       script: ./scripts/test-hosting.sh
       after_script: skip
 cache:
   directories:
-  - node_modules
+    - node_modules


### PR DESCRIPTION
### Description

This stops Travis from running the functional tests on a PR from a fork. Because `push` events can only happen on this repository, they are always safe. Checking that the PR repo (`head_repo`, when set) is the same as the repo (`repo`) will ensure that the functional test is run only when they are the same.

There's a more convoluted solution to making the functional tests work on PRs, but I don't believe we have the time to make it :)

Also, I ran `prettier` on the file

### Tested

By making this PR from a fork, and the functional test is not run (the `pr` test below from travis passed because the unit tests passed).