### PR TITLE
Adds messaging that functions may take up to 30s to propagate

### DIFF
--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -103,7 +103,7 @@ var deploy = function(targetNames, options) {
       var deployedFunctions = _.includes(targetNames, "functions");
       if (deployedFunctions) {
         logger.info(
-          "Please note that it can take up to 30 seconds for your updated functions to propagate"
+          "Please note that it can take up to 30 seconds for your updated functions to propagate."
         );
       }
       logger.info(clc.bold("Project Console:"), utils.consoleUrl(options.project, "/overview"));

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -100,6 +100,12 @@ var deploy = function(targetNames, options) {
       utils.logSuccess(clc.underline.bold("Deploy complete!"));
       logger.info();
       var deployedHosting = _.includes(targetNames, "hosting");
+      var deployedFunctions = _.includes(targetNames, "functions");
+      if (deployedFunctions) {
+        logger.info(
+          "Please note that it can take up to 30 seconds for your updated functions to propagate"
+        );
+      }
       logger.info(clc.bold("Project Console:"), utils.consoleUrl(options.project, "/overview"));
       if (deployedHosting) {
         _.each(context.hosting.deploys, function(deploy) {

--- a/src/serve/javaEmulators.js
+++ b/src/serve/javaEmulators.js
@@ -7,7 +7,7 @@ var utils = require("../utils");
 var emulatorConstants = require("../emulator/constants");
 var logger = require("../logger");
 
-var EMULATOR_INSTANCE_KILL_TIMEOUT = 2000 /* ms */;
+var EMULATOR_INSTANCE_KILL_TIMEOUT = 2000; /* ms */
 
 function _fatal(emulator, errorMsg) {
   if (emulator.instance) {


### PR DESCRIPTION
### Description
Adds a message to firebase deploy indicating that functions take up to 30 seconds to propogate/go live once deployed. Addresses https://github.com/firebase/firebase-functions/issues/288#issuecomment-408377656 and other similar customer feedback
![screenshot from 2019-01-07 15-19-10](https://user-images.githubusercontent.com/4635763/50799113-9ae78c00-128f-11e9-82f3-1bf393e5a5cd.png)

### Scenarios Tested

firebase deploy
firebase deploy --only functions
