### PR TITLE
Verify downloads before installing emulators

### DIFF
--- a/src/emulator/download.js
+++ b/src/emulator/download.js
@@ -26,7 +26,7 @@ module.exports = (name) => {
     });
     req.on("end", () => {
       writeStream.close();
-      fs.moveSync(tmpFile.name, emulator.localPath);
+      fs.copySync(tmpFile.name, emulator.localPath);
       fs.chmodSync(emulator.localPath, 0o755);
       resolve();
     });


### PR DESCRIPTION
Current behavior:
Download into `~/.cache/firebase/emulators/<emulator_name>`, fail on error

Downside:
We use the existence of  `~/.cache/firebase/emulators/<emulator_name>` to determine whether to try and run the emulator. If it exists, but is malformed (i.e., if the download failed), we try to run it and fail. It's not clear to developers that they need to retry the download.

New behavior:
Download into `/tmp/<tmp_file>`. On success, copy to `~/.cache/firebase/emulators/<emulator_name>`. On failed downloads, there is no malformed file.

I believe this should help prevent issues like https://github.com/firebase/quickstart-nodejs/issues/48