### PR TITLE
fix: functions:log --open: use protoPayload.serviceName in URL

### DIFF
--- a/src/commands/functions-log.js
+++ b/src/commands/functions-log.js
@@ -22,7 +22,7 @@ module.exports = new Command("functions:log")
   .action(function(options) {
     var projectId = getProjectId(options);
     var apiFilter = 'resource.type="cloud_function" ';
-    var consoleFilter = 'metadata.serviceName:"cloudfunctions.googleapis.com"';
+    var consoleFilter = 'protoPayload.serviceName:"cloudfunctions.googleapis.com"';
     if (options.only) {
       var funcNames = options.only.split(",");
       var apiFuncFilters = _.map(funcNames, function(funcName) {


### PR DESCRIPTION
Possible fix for #1100

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

`firebase functions:log --open` opens a URL with incorrect parameters.
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Ran `npm test` and ran:
```
node  ./lib/bin/firebase.js functions:log --open --project <projectId>
```
this now works!

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

Fixes:

```
firebase functions:log --open
```