### PR TITLE
Turn on template validation in OSS Bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,10 @@ labels: bug
 assignees: ''
 
 ---
+<!-- DO NOT DELETE 
+validate_template=true
+template_path=.github/ISSUE_TEMPLATE/bug_report.md
+-->
 
 <!--
 Thank you for contributing to the Firebase community!

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,10 @@ labels: feature request
 assignees: ''
 
 ---
+<!-- DO NOT DELETE 
+validate_template=false
+template_path=.github/ISSUE_TEMPLATE/feature_request.md
+-->
 
 <!--
 Thank you for contributing to the Firebase community!


### PR DESCRIPTION
Modify issue templates so that the OSS Bot can validate templates on incoming issues. 