### PR TITLE
Adds optional FirepitVersion to UA Visitor definition

### DIFF
--- a/src/track.js
+++ b/src/track.js
@@ -19,8 +19,9 @@ var visitor = ua(process.env.FIREBASE_ANALYTICS_UA || "UA-29174744-3", anonId, {
   https: true,
 });
 
-visitor.set("cd1", process.platform);
-visitor.set("cd2", process.version);
+visitor.set("cd1", process.platform); # Platform
+visitor.set("cd2", process.version); # NodeVersion
+visitor.set("cd3", process.env.FIREPIT_VERSION || "none"); # FirepitVersion
 
 module.exports = function(action, label, duration) {
   return new Promise(function(resolve) {

--- a/src/track.js
+++ b/src/track.js
@@ -19,9 +19,9 @@ var visitor = ua(process.env.FIREBASE_ANALYTICS_UA || "UA-29174744-3", anonId, {
   https: true,
 });
 
-visitor.set("cd1", process.platform); # Platform
-visitor.set("cd2", process.version); # NodeVersion
-visitor.set("cd3", process.env.FIREPIT_VERSION || "none"); # FirepitVersion
+visitor.set("cd1", process.platform); // Platform
+visitor.set("cd2", process.version); // NodeVersion
+visitor.set("cd3", process.env.FIREPIT_VERSION || "none"); // FirepitVersion
 
 module.exports = function(action, label, duration) {
   return new Promise(function(resolve) {


### PR DESCRIPTION
No user facing changes, adds reporting of `FIREPIT_VERSION`  to Google Analytics if exists on `process.env` as exposed by top-level firepit shell. 