### PR TITLE
Fixing multi resource lifecycle hooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Multi-Site predeploy and postdeploy hooks now trigger

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -1,18 +1,18 @@
 "use strict";
 
-var _ = require("lodash");
+const _ = require("lodash");
 
-var utils = require("../utils");
-var clc = require("cli-color");
-var childProcess = require("child_process");
-var FirebaseError = require("../error");
-var getProjectId = require("../getProjectId");
-var logger = require("../logger");
-var path = require("path");
+const utils = require("../utils");
+const clc = require("cli-color");
+const childProcess = require("child_process");
+const FirebaseError = require("../error");
+const getProjectId = require("../getProjectId");
+const logger = require("../logger");
+const path = require("path");
 
 function runCommand(command, childOptions) {
-  var escapedCommand = command.replace(/\"/g, '\\"');
-  var translatedCommand =
+  const escapedCommand = command.replace(/\"/g, '\\"');
+  const translatedCommand =
     '"' +
     process.execPath +
     '" "' +
@@ -26,7 +26,7 @@ function runCommand(command, childOptions) {
     if (translatedCommand === "") {
       resolve();
     }
-    var child = childProcess.spawn(translatedCommand, [], childOptions);
+    const child = childProcess.spawn(translatedCommand, [], childOptions);
     child.on("error", function(err) {
       reject(err);
     });
@@ -44,11 +44,11 @@ function runCommand(command, childOptions) {
 
 function getChildEnvironment(target, overallOptions, config) {
   // active project ID
-  var projectId = getProjectId(overallOptions);
+  const projectId = getProjectId(overallOptions);
   // root directory where firebase.json can be found
-  var projectDir = overallOptions.projectRoot;
+  const projectDir = overallOptions.projectRoot;
   // location of hosting site or functions deploy, defaults project directory
-  var resourceDir;
+  let resourceDir;
   switch (target) {
     case "hosting":
       resourceDir = overallOptions.config.path(config.public);
@@ -77,14 +77,14 @@ function runTargetCommands(target, hook, overallOptions, config) {
     commands = [commands];
   }
 
-  var childOptions = {
+  const childOptions = {
     cwd: overallOptions.config.projectDir,
     env: getChildEnvironment(target, overallOptions, config),
     shell: true,
     stdio: [0, 1, 2], // Inherit STDIN, STDOUT, and STDERR
   };
 
-  var runAllCommands = _.reduce(
+  const runAllCommands = _.reduce(
     commands,
     function(soFar, command) {
       return soFar.then(function() {

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -94,9 +94,6 @@ function runTargetCommands(target, hook, overallOptions, config) {
     Promise.resolve()
   );
 
-  // Errors in postdeploy script will not exit the process since it's too late to stop the deploy.
-  const exit = hook !== "postdeploy" ? undefined : { exit: 2 };
-
   // We currently use the resource name in info logs in the rest of the deploy.
   // However we don't have access to that here because predeploy hooks will
   // happen before we figure that out.  Internal bug tracking number: 123715324
@@ -112,7 +109,7 @@ function runTargetCommands(target, hook, overallOptions, config) {
       );
     })
     .catch(function(err) {
-      throw new FirebaseError(logIdentifier + " " + hook + " error: " + err.message, exit);
+      throw new FirebaseError(logIdentifier + " " + hook + " error: " + err.message);
     });
 }
 

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -105,14 +105,19 @@ module.exports = function(target, hook) {
           previousCommands
         );
     
+        let logIdentifier = target;
+        if (individualConfig.target) {
+          logIdentifier += `[${individualConfig.target}]`;
+        }
+
         return runAllCommands
           .then(function() {
             utils.logSuccess(
-              clc.green.bold(target + ":") + " Finished running " + clc.bold(hook) + " script."
+              clc.green.bold(logIdentifier + ":") + " Finished running " + clc.bold(hook) + " script."
             );
           })
           .catch(function(err) {
-            throw new FirebaseError(target + " " + hook + " error: " + err.message, exit);
+            throw new FirebaseError(logIdentifier + " " + hook + " error: " + err.message, exit);
           });
       }, 
       Promise.resolve());

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -51,10 +51,10 @@ function getChildEnvironment(target, overallOptions, config) {
   var resourceDir;
   switch (target) {
     case "hosting":
-      resourceDir = overallOptions.config.path(config["public"]);
+      resourceDir = overallOptions.config.path(config.public);
       break;
     case "functions":
-      resourceDir = overallOptions.config.path(config["source"]);
+      resourceDir = overallOptions.config.path(config.source);
       break;
     default:
       resourceDir = overallOptions.config.path(overallOptions.config.projectDir);

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -61,7 +61,7 @@ function getChildEnvironment(target, overallOptions, config) {
   }
 
   // Copying over environment variables
-  return_.assign({}, process.env, {
+  return _.assign({}, process.env, {
     GCLOUD_PROJECT: projectId,
     PROJECT_DIR: projectDir,
     RESOURCE_DIR: resourceDir,

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -97,6 +97,9 @@ function runTargetCommands(target, hook, overallOptions, config) {
   // Errors in postdeploy script will not exit the process since it's too late to stop the deploy.
   const exit = hook !== "postdeploy" ? undefined : { exit: 2 };
 
+  // We currently use the resource name in info logs in the rest of the deploy.
+  // However we don't have access to that here because predeploy hooks will
+  // happen before we figure that out.  Internal bug tracking number: 123715324
   let logIdentifier = target;
   if (config.target) {
     logIdentifier += `[${config.target}]`;


### PR DESCRIPTION
### Description

Fixing lifecycle hooks for Multi-Site deploys as found by [this issue](https://github.com/firebase/firebase-tools/issues/940).  Essentially the lifecycle hooks only deal with the top level object and were never changed to deal with an array of configs.  I tried to make this generic so that it'll be usable by other mutli resource deploys (which I don't think exist but RTDB could and we could _technically_ do it for individual functions).
	 
### Scenarios Tested

Verified both single Site deploy and Multi-Site deploys.  Also made sure that it worked if `predeploy` or `postdeploy` was an array or a single string.

### Sample Commands

Everything used `firebase deploy --only hosting` but single Site deploy had a `firebase.json` of:
```
{
  "hosting": {
    "public": "public",
    "predeploy": ["echo 'single predeploy 1'", "echo 'single predeploy 2'"],
    "postdeploy": "echo 'single postdeploy 1' && echo 'single postdeploy 2'",

...

  }
}
```
Multi-Site deploy had a `firebase.json` of:
```
{
  "hosting": [{
    "target": "first",
    "predeploy": ["echo 'multi first predeploy 1'", "echo 'multi first predeploy 2'"],
    "postdeploy": ["echo 'multi first postdeploy 1'", "echo 'multi first postdeploy 2'"],

...

  },
  {
    "target": "second",
    "predeploy": ["echo 'multi second predeploy 1'", "echo 'multi second predeploy 2'"],
    "postdeploy": "echo 'multi second postdeploy 1' && echo 'multi second postdeploy 2'",
    "public": "public"
  }]
}

```