### PR TITLE
Validate emulator download by checking file size

### DIFF
--- a/src/emulator/constants.js
+++ b/src/emulator/constants.js
@@ -16,6 +16,7 @@ const _emulators = {
     remoteUrl:
       "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v3.5.0.jar",
     expectedSize: 17013124,
+    expectedHash: "4bc8a67bc2a11d3e7ed226eda1b1a986",
     localPath: path.join(CACHE_DIR, "firebase-database-emulator-v3.5.0.jar"),
   },
   firestore: {
@@ -27,6 +28,7 @@ const _emulators = {
     remoteUrl:
       "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.3.0.jar",
     expectedSize: 67825938,
+    expectedHash: "4703fa3f15b00a6a3330ab2b10bfbb4b",
     localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.3.0.jar"),
   },
 };

--- a/src/emulator/constants.js
+++ b/src/emulator/constants.js
@@ -16,7 +16,7 @@ const _emulators = {
     remoteUrl:
       "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v3.5.0.jar",
     expectedSize: 17013124,
-    expectedHash: "4bc8a67bc2a11d3e7ed226eda1b1a986",
+    expectedChecksum: "4bc8a67bc2a11d3e7ed226eda1b1a986",
     localPath: path.join(CACHE_DIR, "firebase-database-emulator-v3.5.0.jar"),
   },
   firestore: {
@@ -28,7 +28,7 @@ const _emulators = {
     remoteUrl:
       "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.3.0.jar",
     expectedSize: 67825938,
-    expectedHash: "4703fa3f15b00a6a3330ab2b10bfbb4b",
+    expectedChecksum: "4703fa3f15b00a6a3330ab2b10bfbb4b",
     localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.3.0.jar"),
   },
 };

--- a/src/emulator/constants.js
+++ b/src/emulator/constants.js
@@ -15,6 +15,7 @@ const _emulators = {
     cacheDir: CACHE_DIR,
     remoteUrl:
       "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v3.5.0.jar",
+    expectedSize: 17013124,
     localPath: path.join(CACHE_DIR, "firebase-database-emulator-v3.5.0.jar"),
   },
   firestore: {
@@ -25,6 +26,7 @@ const _emulators = {
     cacheDir: CACHE_DIR,
     remoteUrl:
       "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.3.0.jar",
+    expectedSize: 67825938,
     localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.3.0.jar"),
   },
 };

--- a/src/emulator/download.js
+++ b/src/emulator/download.js
@@ -1,61 +1,87 @@
 "use strict";
 
 const FirebaseError = require("../error");
-const fs = require("fs-extra");
-const tmp = require("tmp");
-const request = require("request");
-const emulatorConstants = require("./constants");
-const utils = require("../utils");
 const crypto = require("crypto");
+const emulatorConstants = require("./constants");
+const fs = require("fs-extra");
+const request = require("request");
+const tmp = require("tmp");
+const utils = require("../utils");
 
 tmp.setGracefulCleanup();
 
 module.exports = (name) => {
-  return new Promise((resolve, reject) => {
-    utils.logLabeledBullet(name, "downloading emulator...");
-    let emulator = emulatorConstants.emulators[name];
-    fs.ensureDirSync(emulator.cacheDir);
+  const emulator = emulatorConstants.emulators[name];
+  utils.logLabeledBullet(name, "downloading emulator...");
+  fs.ensureDirSync(emulator.cacheDir);
+  return downloadToTmp(emulator.remoteUrl).then(tmpfile => {
+    return validateSize(tmpfile, emulator.expectedSize)
+      .then(() => validateChecksum(tmpfile, emulator.expectedChecksum))
+      .then(() => {
+          fs.copySync(tmpfile, emulator.localPath);
+          fs.chmodSync(emulator.localPath, 0o755);
+      });
+  });
+};
 
-    let tmpFile = tmp.fileSync();
-    let req = request.get(emulator.remoteUrl);
-    let writeStream = fs.createWriteStream(tmpFile.name);
+/**
+  * Downloads the resource at `remoteUrl` to a temporary file.
+  * Resolves to the temporary file's name, rejects if there's any error.
+  */
+function downloadToTmp(remoteUrl) {
+  return new Promise((resolve, reject) => {
+    let tmpfile = tmp.fileSync();
+    let req = request.get(remoteUrl);
+    let writeStream = fs.createWriteStream(tmpfile.name);
     req.on("error", (err) => reject(err));
     req.on("response", (response) => {
-      if (response.statusCode != 200) {
+      if (response.statusCode !== 200) {
         reject(new FirebaseError(`download failed, status ${response.statusCode}`, { exit: 1 }));
       }
     });
     req.on("end", () => {
       writeStream.close();
-      const stat = fs.statSync(tmpFile.name);
-      if (stat.size != emulator.expectedSize) {
-        reject(
-          new FirebaseError(
-            `download failed, expected ${emulator.expectedSize} bytes but got ${stat.size}`,
-            { exit: 1 }
-          )
-        );
-      } else {
-        const hash = crypto.createHash('md5'),
-        const stream = fs.createReadStream(tmpFile.name);
-        stream.on('data', data => hash.update(data));
-        stream.on('end', function() {
-          const checksum = hash.digest('hex');
-          if (checksum != emulator.expectedHash) {
-            reject(
-              new FirebaseError(
-                `download failed, expected checksum ${emulator.expectedHash} but got ${checksum}`,
-                { exit: 1 }
-              )
-            );
-          } else {
-            fs.copySync(tmpFile.name, emulator.localPath);
-            fs.chmodSync(emulator.localPath, 0o755);
-            resolve();
-          }
-        })
-      }
+      resolve(tmpfile.name);
     });
     req.pipe(writeStream);
   });
-};
+}
+
+/**
+  * Checks whether the file at `filepath` has the expected size.
+  */
+function validateSize(filepath, expectedSize) {
+  return new Promise((resolve, reject) => {
+    const stat = fs.statSync(filepath);
+    return stat.size === expectedSize
+      ? resolve()
+      : reject(
+          new FirebaseError(
+            `download failed, expected ${expectedSize} bytes but got ${stat.size}`,
+            { exit: 1 }
+          )
+        );
+  });
+}
+
+/**
+  * Checks whether the file at `filepath` has the expected checksum.
+  */
+function validateChecksum(filepath, expectedChecksum) {
+  return new Promise((resolve, reject) => {
+    const hash = crypto.createHash('md5'),
+    const stream = fs.createReadStream(filepath);
+    stream.on('data', data => hash.update(data));
+    stream.on('end', () => {
+      const checksum = hash.digest('hex');
+      return checksum === expectedChecksum
+        ? resolve()
+        : reject(
+            new FirebaseError(
+              `download failed, expected checksum ${expectedChecksum} but got ${checksum}`,
+              { exit: 1 }
+            )
+          );
+    });
+  });
+}

--- a/src/emulator/download.js
+++ b/src/emulator/download.js
@@ -14,14 +14,14 @@ module.exports = (name) => {
   const emulator = emulatorConstants.emulators[name];
   utils.logLabeledBullet(name, "downloading emulator...");
   fs.ensureDirSync(emulator.cacheDir);
-  return downloadToTmp(emulator.remoteUrl).then(tmpfile => {
-    return validateSize(tmpfile, emulator.expectedSize)
+  return downloadToTmp(emulator.remoteUrl).then((tmpfile) =>
+    validateSize(tmpfile, emulator.expectedSize)
       .then(() => validateChecksum(tmpfile, emulator.expectedChecksum))
       .then(() => {
         fs.copySync(tmpfile, emulator.localPath);
         fs.chmodSync(emulator.localPath, 0o755);
-      });
-  });
+      })
+  );
 };
 
 /**
@@ -71,7 +71,7 @@ function validateChecksum(filepath, expectedChecksum) {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash("md5");
     const stream = fs.createReadStream(filepath);
-    stream.on("data", data => hash.update(data));
+    stream.on("data", (data) => hash.update(data));
     stream.on("end", () => {
       const checksum = hash.digest("hex");
       return checksum === expectedChecksum

--- a/src/emulator/download.js
+++ b/src/emulator/download.js
@@ -18,7 +18,6 @@ module.exports = (name) => {
     let tmpFile = tmp.fileSync();
     let req = request.get(emulator.remoteUrl);
     let writeStream = fs.createWriteStream(tmpFile.name);
-    let bytesDownloaded = 0;
     req.on("error", (err) => reject(err));
     req.on("response", (response) => {
       if (response.statusCode != 200) {

--- a/src/emulator/download.js
+++ b/src/emulator/download.js
@@ -18,16 +18,16 @@ module.exports = (name) => {
     return validateSize(tmpfile, emulator.expectedSize)
       .then(() => validateChecksum(tmpfile, emulator.expectedChecksum))
       .then(() => {
-          fs.copySync(tmpfile, emulator.localPath);
-          fs.chmodSync(emulator.localPath, 0o755);
+        fs.copySync(tmpfile, emulator.localPath);
+        fs.chmodSync(emulator.localPath, 0o755);
       });
   });
 };
 
 /**
-  * Downloads the resource at `remoteUrl` to a temporary file.
-  * Resolves to the temporary file's name, rejects if there's any error.
-  */
+ * Downloads the resource at `remoteUrl` to a temporary file.
+ * Resolves to the temporary file's name, rejects if there's any error.
+ */
 function downloadToTmp(remoteUrl) {
   return new Promise((resolve, reject) => {
     let tmpfile = tmp.fileSync();
@@ -48,8 +48,8 @@ function downloadToTmp(remoteUrl) {
 }
 
 /**
-  * Checks whether the file at `filepath` has the expected size.
-  */
+ * Checks whether the file at `filepath` has the expected size.
+ */
 function validateSize(filepath, expectedSize) {
   return new Promise((resolve, reject) => {
     const stat = fs.statSync(filepath);
@@ -65,15 +65,15 @@ function validateSize(filepath, expectedSize) {
 }
 
 /**
-  * Checks whether the file at `filepath` has the expected checksum.
-  */
+ * Checks whether the file at `filepath` has the expected checksum.
+ */
 function validateChecksum(filepath, expectedChecksum) {
   return new Promise((resolve, reject) => {
-    const hash = crypto.createHash('md5'),
+    const hash = crypto.createHash("md5");
     const stream = fs.createReadStream(filepath);
-    stream.on('data', data => hash.update(data));
-    stream.on('end', () => {
-      const checksum = hash.digest('hex');
+    stream.on("data", data => hash.update(data));
+    stream.on("end", () => {
+      const checksum = hash.digest("hex");
       return checksum === expectedChecksum
         ? resolve()
         : reject(

--- a/src/emulator/download.js
+++ b/src/emulator/download.js
@@ -29,7 +29,12 @@ module.exports = (name) => {
       writeStream.close();
       const stat = fs.statSync(tmpFile.name);
       if (stat.size != emulator.expectedSize) {
-        reject(new FirebaseError(`download failed, expected ${emulator.expectedSize} bytes but got ${stat.size}`, { exit: 1 }));
+        reject(
+          new FirebaseError(
+            `download failed, expected ${emulator.expectedSize} bytes but got ${stat.size}`,
+            { exit: 1 }
+          )
+        );
       } else {
         fs.copySync(tmpFile.name, emulator.localPath);
         fs.chmodSync(emulator.localPath, 0o755);


### PR DESCRIPTION
There are still customer reports of corrupted downloads that finish successfully. This is a fairly blunt way of double-checking that the download is valid.