### PR TITLE
Updating validation for Auth user import

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,3 @@
 fixed - Multi-Site predeploy and postdeploy hooks now trigger
 feature - Added support to set and get feature flag defaultWriteSizeLimit for RTDB.
+fixed - Importing Auth users with MD5 or SHAs now have correct validation

--- a/src/accountImporter.js
+++ b/src/accountImporter.js
@@ -178,6 +178,14 @@ var _validateRequiredParameters = function(options) {
     case "SHA1":
     case "SHA256":
     case "SHA512":
+      var roundsNum = parseInt(options.rounds, 10);
+      if (isNaN(roundsNum) || roundsNum < 0 || roundsNum > 8192) {
+        return utils.reject(
+          "Must provide valid rounds(0..8192) for hash algorithm " + options.hashAlgo,
+          { exit: 1 }
+        );
+      }
+      return { hashAlgo: hashAlgo, rounds: options.rounds, valid: true };
     case "PBKDF_SHA1":
     case "PBKDF2_SHA256":
       var roundsNum = parseInt(options.rounds, 10);


### PR DESCRIPTION
### Description

The MD5 and SHA rounds were grouped with the PBKDF algorithms but they actually have a different number of allowed rounds.  This would allow the request to go to the sever and it [would get rejected at that point](https://github.com/firebase/firebase-tools/issues/1146).