### PR TITLE
throw nicer errors if the rules config file is not found. fixes #1153

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -133,7 +133,14 @@ Config.prototype._parseFile = function(target, filePath) {
         this.notes.databaseRules = "json";
       } else if (target === "database.rules") {
         this.notes.databaseRulesFile = filePath;
-        return fs.readFileSync(fullPath, "utf8");
+        try {
+          return fs.readFileSync(fullPath, "utf8");
+        } catch (e) {
+          if (e.code === "ENOENT") {
+            throw new FirebaseError(`Rules file not found: ${fullPath}`, { original: e });
+          }
+          throw e;
+        }
       }
       return loadCJSON(fullPath);
     /* istanbul ignore-next */
@@ -181,6 +188,9 @@ Config.prototype.readProjectFile = function(p, options) {
   } catch (e) {
     if (options.fallback) {
       return options.fallback;
+    }
+    if (e.code === "ENOENT") {
+      throw new FirebaseError(`Rules file not found: ${this.path(p)}`, { original: e });
     }
     throw e;
   }

--- a/src/config.js
+++ b/src/config.js
@@ -137,7 +137,7 @@ Config.prototype._parseFile = function(target, filePath) {
           return fs.readFileSync(fullPath, "utf8");
         } catch (e) {
           if (e.code === "ENOENT") {
-            throw new FirebaseError(`Rules file not found: ${fullPath}`, { original: e });
+            throw new FirebaseError(`File not found: ${fullPath}`, { original: e });
           }
           throw e;
         }
@@ -190,7 +190,7 @@ Config.prototype.readProjectFile = function(p, options) {
       return options.fallback;
     }
     if (e.code === "ENOENT") {
-      throw new FirebaseError(`Rules file not found: ${this.path(p)}`, { original: e });
+      throw new FirebaseError(`File not found: ${this.path(p)}`, { original: e });
     }
     throw e;
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixing #1153; printing better errors if the rules config file doesn't exist.
	 
### Scenarios Tested

When a rules file does not exist:
![image](https://user-images.githubusercontent.com/160236/53255944-962e3a00-367b-11e9-8bad-3829f828354c.png)

Happy Path still works as expected.