### PR TITLE
Sort indexes before output

### DIFF
--- a/src/firestore/indexes-sort.ts
+++ b/src/firestore/indexes-sort.ts
@@ -31,11 +31,15 @@ export function compareSpecIndex(a: Spec.Index, b: Spec.Index): number {
  *   3) The fields list.
  */
 export function compareApiIndex(a: API.Index, b: API.Index): number {
-  const aName = util.parseIndexName(a.name);
-  const bName = util.parseIndexName(b.name);
+  // When these indexes are used as part of a field override, the name is
+  // not always present or relevant.
+  if (a.name && b.name) {
+    const aName = util.parseIndexName(a.name);
+    const bName = util.parseIndexName(b.name);
 
-  if (aName.collectionGroupId !== bName.collectionGroupId) {
-    return aName.collectionGroupId.localeCompare(bName.collectionGroupId);
+    if (aName.collectionGroupId !== bName.collectionGroupId) {
+      return aName.collectionGroupId.localeCompare(bName.collectionGroupId);
+    }
   }
 
   if (a.queryScope !== b.queryScope) {

--- a/src/firestore/indexes-sort.ts
+++ b/src/firestore/indexes-sort.ts
@@ -1,0 +1,169 @@
+import * as API from "./indexes-api";
+import * as Spec from "./indexes-spec";
+import * as util from "./util";
+
+/**
+ * Compare two Index spec entries for sorting.
+ *
+ * Comparisons:
+ *   1) The collection group.
+ *   2) The query scope.
+ *   3) The fields list.
+ */
+export function compareSpecIndex(a: Spec.Index, b: Spec.Index): number {
+  if (a.collectionGroup !== b.collectionGroup) {
+    return a.collectionGroup.localeCompare(b.collectionGroup);
+  }
+
+  if (a.queryScope !== b.queryScope) {
+    return compareQueryScope(a.queryScope, b.queryScope);
+  }
+
+  return compareArrays(a.fields, b.fields, compareIndexField);
+}
+
+/**
+ * Compare two Index api entries for sorting.
+ *
+ * Comparisons:
+ *   1) The collection group.
+ *   2) The query scope.
+ *   3) The fields list.
+ */
+export function compareApiIndex(a: API.Index, b: API.Index): number {
+  const aName = util.parseIndexName(a.name);
+  const bName = util.parseIndexName(b.name);
+
+  if (aName.collectionGroupId !== bName.collectionGroupId) {
+    return aName.collectionGroupId.localeCompare(bName.collectionGroupId);
+  }
+
+  if (a.queryScope !== b.queryScope) {
+    return compareQueryScope(a.queryScope, b.queryScope);
+  }
+
+  return compareArrays(a.fields, b.fields, compareIndexField);
+}
+
+/**
+ * Compare two Field api entries for sorting.
+ *
+ * Comparisons:
+ *   1) The collection group.
+ *   2) The field path.
+ *   3) The indexes list in the config.
+ */
+export function compareApiField(a: API.Field, b: API.Field): number {
+  const aName = util.parseFieldName(a.name);
+  const bName = util.parseFieldName(b.name);
+
+  if (aName.collectionGroupId !== bName.collectionGroupId) {
+    return aName.collectionGroupId.localeCompare(bName.collectionGroupId);
+  }
+
+  if (aName.fieldPath !== bName.fieldPath) {
+    return aName.fieldPath.localeCompare(bName.fieldPath);
+  }
+
+  return compareArrays(a.indexConfig.indexes || [], b.indexConfig.indexes || [], compareApiIndex);
+}
+
+/**
+ * Compare two Field override specs for sorting.
+ *
+ * Comparisons:
+ *   1) The collection group.
+ *   2) The field path.
+ *   3) The list of indexes.
+ */
+export function compareFieldOverride(a: Spec.FieldOverride, b: Spec.FieldOverride): number {
+  if (a.collectionGroup !== b.collectionGroup) {
+    return a.collectionGroup.localeCompare(b.collectionGroup);
+  }
+
+  if (a.fieldPath !== b.fieldPath) {
+    return a.fieldPath.localeCompare(b.fieldPath);
+  }
+
+  return compareArrays(a.indexes, b.indexes, compareFieldIndex);
+}
+
+/**
+ * Compare two IndexField objects.
+ *
+ * Comparisons:
+ *   1) Field path.
+ *   2) Sort order (if it exists).
+ *   3) Array config (if it exists).
+ */
+function compareIndexField(a: API.IndexField, b: API.IndexField): number {
+  if (a.fieldPath !== b.fieldPath) {
+    return a.fieldPath.localeCompare(b.fieldPath);
+  }
+
+  if (a.order !== b.order) {
+    return compareOrder(a.order, b.order);
+  }
+
+  if (a.arrayConfig !== b.arrayConfig) {
+    return compareArrayConfig(a.arrayConfig, b.arrayConfig);
+  }
+
+  return 0;
+}
+
+function compareFieldIndex(a: Spec.FieldIndex, b: Spec.FieldIndex): number {
+  if (a.queryScope !== b.queryScope) {
+    return compareQueryScope(a.queryScope, b.queryScope);
+  }
+
+  if (a.order !== b.order) {
+    return compareOrder(a.order, b.order);
+  }
+
+  if (a.arrayConfig !== b.arrayConfig) {
+    return compareArrayConfig(a.arrayConfig, b.arrayConfig);
+  }
+
+  return 0;
+}
+
+function compareQueryScope(a: API.QueryScope, b: API.QueryScope): number {
+  const sequence = [API.QueryScope.COLLECTION_GROUP, API.QueryScope.COLLECTION, undefined];
+
+  return sequence.indexOf(a) - sequence.indexOf(b);
+}
+
+function compareOrder(a?: API.Order, b?: API.Order): number {
+  const sequence = [API.Order.ASCENDING, API.Order.DESCENDING, undefined];
+
+  return sequence.indexOf(a) - sequence.indexOf(b);
+}
+
+function compareArrayConfig(a?: API.ArrayConfig, b?: API.ArrayConfig): number {
+  const sequence = [API.ArrayConfig.CONTAINS, undefined];
+
+  return sequence.indexOf(a) - sequence.indexOf(b);
+}
+
+/**
+ * Compare two arrays of objects by first sorting each array, then
+ * looking for the first non-equal element and comparing them.
+ *
+ * If the shorter array is a perfect prefix of the longer array,
+ * then the shorter array is sorted first.
+ */
+function compareArrays<T>(a: T[], b: T[], fn: (x: T, y: T) => number): number {
+  const aSorted = a.sort(fn);
+  const bSorted = b.sort(fn);
+
+  const minFields = Math.min(aSorted.length, bSorted.length);
+  for (let i = 0; i < minFields; i++) {
+    const cmp = fn(aSorted[i], bSorted[i]);
+    if (cmp !== 0) {
+      return cmp;
+    }
+  }
+
+  return aSorted.length - bSorted.length;
+}

--- a/src/firestore/indexes-sort.ts
+++ b/src/firestore/indexes-sort.ts
@@ -2,6 +2,16 @@ import * as API from "./indexes-api";
 import * as Spec from "./indexes-spec";
 import * as util from "./util";
 
+const QUERY_SCOPE_SEQUENCE = [
+  API.QueryScope.COLLECTION_GROUP,
+  API.QueryScope.COLLECTION,
+  undefined,
+];
+
+const ORDER_SEQUENCE = [API.Order.ASCENDING, API.Order.DESCENDING, undefined];
+
+const ARRAY_CONFIG_SEQUENCE = [API.ArrayConfig.CONTAINS, undefined];
+
 /**
  * Compare two Index spec entries for sorting.
  *
@@ -133,21 +143,15 @@ function compareFieldIndex(a: Spec.FieldIndex, b: Spec.FieldIndex): number {
 }
 
 function compareQueryScope(a: API.QueryScope, b: API.QueryScope): number {
-  const sequence = [API.QueryScope.COLLECTION_GROUP, API.QueryScope.COLLECTION, undefined];
-
-  return sequence.indexOf(a) - sequence.indexOf(b);
+  return QUERY_SCOPE_SEQUENCE.indexOf(a) - QUERY_SCOPE_SEQUENCE.indexOf(b);
 }
 
 function compareOrder(a?: API.Order, b?: API.Order): number {
-  const sequence = [API.Order.ASCENDING, API.Order.DESCENDING, undefined];
-
-  return sequence.indexOf(a) - sequence.indexOf(b);
+  return ORDER_SEQUENCE.indexOf(a) - ORDER_SEQUENCE.indexOf(b);
 }
 
 function compareArrayConfig(a?: API.ArrayConfig, b?: API.ArrayConfig): number {
-  const sequence = [API.ArrayConfig.CONTAINS, undefined];
-
-  return sequence.indexOf(a) - sequence.indexOf(b);
+  return ARRAY_CONFIG_SEQUENCE.indexOf(a) - ARRAY_CONFIG_SEQUENCE.indexOf(b);
 }
 
 /**

--- a/src/firestore/indexes-spec.ts
+++ b/src/firestore/indexes-spec.ts
@@ -23,8 +23,8 @@ export interface FieldOverride {
  */
 export interface FieldIndex {
   queryScope: API.QueryScope;
-  order: API.Order | undefined;
-  arrayConfig: API.ArrayConfig | undefined;
+  order?: API.Order;
+  arrayConfig?: API.ArrayConfig;
 }
 
 /**
@@ -32,5 +32,5 @@ export interface FieldIndex {
  */
 export interface IndexFile {
   indexes: Index[];
-  fieldOverrides: FieldOverride[] | undefined;
+  fieldOverrides?: FieldOverride[];
 }

--- a/src/firestore/util.ts
+++ b/src/firestore/util.ts
@@ -1,0 +1,55 @@
+import * as FirebaseError from "../error";
+
+interface IndexName {
+  projectId: string;
+  collectionGroupId: string;
+  indexId: string;
+}
+
+interface FieldName {
+  projectId: string;
+  collectionGroupId: string;
+  fieldPath: string;
+}
+
+// projects/$PROJECT_ID/databases/(default)/collectionGroups/$COLLECTION_GROUP_ID/indexes/$INDEX_ID
+const INDEX_NAME_REGEX = /projects\/([^\/]+?)\/databases\/\(default\)\/collectionGroups\/([^\/]+?)\/indexes\/([^\/]*)/;
+
+// projects/$PROJECT_ID/databases/(default)/collectionGroups/$COLLECTION_GROUP_ID/fields/$FIELD_ID
+const FIELD_NAME_REGEX = /projects\/([^\/]+?)\/databases\/\(default\)\/collectionGroups\/([^\/]+?)\/fields\/([^\/]*)/;
+
+/**
+ * Parse an Index name into useful pieces.
+ */
+export function parseIndexName(name?: string): IndexName {
+  if (!name) {
+    throw new FirebaseError(`Cannot parse undefined index name.`);
+  }
+
+  const m = name.match(INDEX_NAME_REGEX);
+  if (!m || m.length < 4) {
+    throw new FirebaseError(`Error parsing index name: ${name}`);
+  }
+
+  return {
+    projectId: m[1],
+    collectionGroupId: m[2],
+    indexId: m[3],
+  };
+}
+
+/**
+ * Parse an Field name into useful pieces.
+ */
+export function parseFieldName(name: string): FieldName {
+  const m = name.match(FIELD_NAME_REGEX);
+  if (!m || m.length < 4) {
+    throw new FirebaseError(`Error parsing field name: ${name}`);
+  }
+
+  return {
+    projectId: m[1],
+    collectionGroupId: m[2],
+    fieldPath: m[3],
+  };
+}

--- a/src/test/firestore/indexes.spec.ts
+++ b/src/test/firestore/indexes.spec.ts
@@ -3,6 +3,7 @@ import { FirestoreIndexes } from "../../firestore/indexes";
 import * as FirebaseError from "../../error";
 import * as API from "../../firestore/indexes-api";
 import * as Spec from "../../firestore/indexes-spec";
+import * as sort from "../../firestore/indexes-sort";
 import * as util from "../../firestore/util";
 
 const idx = new FirestoreIndexes();
@@ -242,5 +243,200 @@ describe("IndexSpecMatching", () => {
 
     // The second spec contains "DESCENDING" where the first contains "ASCENDING"
     expect(idx.fieldMatchesSpec(apiField, specField)).to.eql(false);
+  });
+});
+
+describe("IndexSorting", () => {
+  it("should be able to handle empty arrays", () => {
+    expect(([] as Spec.Index[]).sort(sort.compareSpecIndex)).to.eql([]);
+    expect(([] as Spec.FieldOverride[]).sort(sort.compareFieldOverride)).to.eql([]);
+    expect(([] as API.Index[]).sort(sort.compareApiIndex)).to.eql([]);
+    expect(([] as API.Field[]).sort(sort.compareApiField)).to.eql([]);
+  });
+
+  it("should correctly sort an array of Spec indexes", () => {
+    // Sorts first because of collectionGroup
+    const a: Spec.Index = {
+      collectionGroup: "collectionA",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [],
+    };
+
+    // fieldA ASCENDING should sort before fieldA DESCENDING
+    const b: Spec.Index = {
+      collectionGroup: "collectionB",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "fieldA",
+          order: API.Order.ASCENDING,
+        },
+      ],
+    };
+
+    // This compound index sorts before the following simple
+    // index because the first element sorts first.
+    const c: Spec.Index = {
+      collectionGroup: "collectionB",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "fieldA",
+          order: API.Order.ASCENDING,
+        },
+        {
+          fieldPath: "fieldB",
+          order: API.Order.ASCENDING,
+        },
+      ],
+    };
+
+    const d: Spec.Index = {
+      collectionGroup: "collectionB",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "fieldA",
+          order: API.Order.DESCENDING,
+        },
+      ],
+    };
+
+    expect([b, a, d, c].sort(sort.compareSpecIndex)).to.eql([a, b, c, d]);
+  });
+
+  it("should correcty sort an array of Spec field overrides", () => {
+    // Sorts first because of collectionGroup
+    const a: Spec.FieldOverride = {
+      collectionGroup: "collectionA",
+      fieldPath: "fieldA",
+      indexes: [],
+    };
+
+    const b: Spec.FieldOverride = {
+      collectionGroup: "collectionB",
+      fieldPath: "fieldA",
+      indexes: [],
+    };
+
+    // Order indexes sort before Array indexes
+    const c: Spec.FieldOverride = {
+      collectionGroup: "collectionB",
+      fieldPath: "fieldB",
+      indexes: [
+        {
+          queryScope: API.QueryScope.COLLECTION,
+          order: API.Order.ASCENDING,
+        },
+      ],
+    };
+
+    const d: Spec.FieldOverride = {
+      collectionGroup: "collectionB",
+      fieldPath: "fieldB",
+      indexes: [
+        {
+          queryScope: API.QueryScope.COLLECTION,
+          arrayConfig: API.ArrayConfig.CONTAINS,
+        },
+      ],
+    };
+
+    expect([b, a, d, c].sort(sort.compareFieldOverride)).to.eql([a, b, c, d]);
+  });
+
+  it("should correctly sort an array of API indexes", () => {
+    // Sorts first because of collectionGroup
+    const a: API.Index = {
+      name: "/projects/project/databases/(default)/collectionGroups/collectionA/indexes/a",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [],
+    };
+
+    // fieldA ASCENDING should sort before fieldA DESCENDING
+    const b: API.Index = {
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/b",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "fieldA",
+          order: API.Order.ASCENDING,
+        },
+      ],
+    };
+
+    // This compound index sorts before the following simple
+    // index because the first element sorts first.
+    const c: API.Index = {
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/c",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "fieldA",
+          order: API.Order.ASCENDING,
+        },
+        {
+          fieldPath: "fieldB",
+          order: API.Order.ASCENDING,
+        },
+      ],
+    };
+
+    const d: API.Index = {
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/d",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "fieldA",
+          order: API.Order.DESCENDING,
+        },
+      ],
+    };
+
+    expect([b, a, d, c].sort(sort.compareApiIndex)).to.eql([a, b, c, d]);
+  });
+
+  it("should correctly sort an array of API field overrides", () => {
+    // Sorts first because of collectionGroup
+    const a: API.Field = {
+      name: "/projects/myproject/databases/(default)/collectionGroups/collectionA/fields/fieldA",
+      indexConfig: {
+        indexes: [],
+      },
+    };
+
+    const b: API.Field = {
+      name: "/projects/myproject/databases/(default)/collectionGroups/collectionB/fields/fieldA",
+      indexConfig: {
+        indexes: [],
+      },
+    };
+
+    // Order indexes sort before Array indexes
+    const c: API.Field = {
+      name: "/projects/myproject/databases/(default)/collectionGroups/collectionB/fields/fieldB",
+      indexConfig: {
+        indexes: [
+          {
+            queryScope: API.QueryScope.COLLECTION,
+            fields: [{ fieldPath: "fieldB", order: API.Order.DESCENDING }],
+          },
+        ],
+      },
+    };
+
+    const d: API.Field = {
+      name: "/projects/myproject/databases/(default)/collectionGroups/collectionB/fields/fieldB",
+      indexConfig: {
+        indexes: [
+          {
+            queryScope: API.QueryScope.COLLECTION,
+            fields: [{ fieldPath: "fieldB", arrayConfig: API.ArrayConfig.CONTAINS }],
+          },
+        ],
+      },
+    };
+
+    expect([b, a, d, c].sort(sort.compareApiField)).to.eql([a, b, c, d]);
   });
 });

--- a/src/test/firestore/indexes.spec.ts
+++ b/src/test/firestore/indexes.spec.ts
@@ -3,6 +3,7 @@ import { FirestoreIndexes } from "../../firestore/indexes";
 import * as FirebaseError from "../../error";
 import * as API from "../../firestore/indexes-api";
 import * as Spec from "../../firestore/indexes-spec";
+import * as util from "../../firestore/util";
 
 const idx = new FirestoreIndexes();
 
@@ -103,7 +104,7 @@ describe("IndexNameParsing", () => {
   it("should parse an index name correctly", () => {
     const name =
       "/projects/myproject/databases/(default)/collectionGroups/collection/indexes/abc123/";
-    expect(idx.parseIndexName(name)).to.eql({
+    expect(util.parseIndexName(name)).to.eql({
       projectId: "myproject",
       collectionGroupId: "collection",
       indexId: "abc123",
@@ -113,7 +114,7 @@ describe("IndexNameParsing", () => {
   it("should parse a field name correctly", () => {
     const name =
       "/projects/myproject/databases/(default)/collectionGroups/collection/fields/abc123/";
-    expect(idx.parseFieldName(name)).to.eql({
+    expect(util.parseFieldName(name)).to.eql({
       projectId: "myproject",
       collectionGroupId: "collection",
       fieldPath: "abc123",


### PR DESCRIPTION
### Description

Fixes #1023
	 
### Scenarios Tested

**Before (pretty)**
```
Compound Indexes
[READY] (manifs) -- (mandantIds,CONTAINS) (actif,DESCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (ville,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (pseudo,ASCENDING) 
[READY] (societes_contacts) -- (ownerId,ASCENDING) (nom,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (pseudo,ASCENDING) 
[READY] (taches) -- (ownerId,ASCENDING) (doneAt,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (lastCR,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (pseudo,DESCENDING) 
[READY] (replies) -- (topicId,ASCENDING) (createdAt,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (deptId,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (deptId,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (deptId,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (statut,ASCENDING) 
[READY] (manifs_cr) -- (ownerId,ASCENDING) (createdAt,DESCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (lastCR,DESCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (deptId,ASCENDING) 
[READY] (manifs_cr) -- (mandantId,ASCENDING) (createdAt,DESCENDING) 
[READY] (evts) -- (mandantId,ASCENDING) (endAt,DESCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (ville,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ownerId,ASCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (ville,ASCENDING) 
[READY] (taches) -- (mandantId,ASCENDING) (enabledAt,ASCENDING) 
[READY] (societes_cr) -- (ownerId,ASCENDING) (createdAt,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ville,DESCENDING) 
[READY] (taches) -- (done,ASCENDING) (enabledAt,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (deptId,ASCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (statut,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (deptId,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (actif,DESCENDING) 
[READY] (evts) -- (mandantId,ASCENDING) (alertAt,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ownerId,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ville,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (ville,DESCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (lastCR,ASCENDING) 
[READY] (societes_cr) -- (mandantId,ASCENDING) (createdAt,DESCENDING) 
[READY] (taches) -- (mandantId,ASCENDING) (doneAt,DESCENDING) 
[READY] (evts) -- (societeId,ASCENDING) (endAt,DESCENDING) 
[READY] (evts) -- (societeId,ASCENDING) (alertAt,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (statut,DESCENDING) 
[READY] (evts) -- (ownerId,ASCENDING) (alertAt,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (lastCR,ASCENDING) 
[READY] (incidents) -- (metro_id,ASCENDING) (added_time,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (lastCR,DESCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (ville,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (pseudo,ASCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (ville,DESCENDING) 
[READY] (societes_cr) -- (societeId,ASCENDING) (createdAt,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (pseudo,DESCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (actif,ASCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (deptId,DESCENDING) 
[READY] (societes_contacts) -- (mandantIds,CONTAINS) (nom,ASCENDING) 
[READY] (taches) -- (ownerId,ASCENDING) (enabledAt,ASCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (pseudo,ASCENDING) 
[READY] (taches) -- (societeId,ASCENDING) (doneAt,DESCENDING) 
[READY] (taches) -- (done,ASCENDING) (doneAt,DESCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (lastCR,DESCENDING) 
[READY] (manifs_cr) -- (manifId,ASCENDING) (createdAt,DESCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (pseudo,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (lastCR,DESCENDING) 
[READY] (evts) -- (ownerId,ASCENDING) (endAt,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (pseudo,DESCENDING) 
[READY] (taches) -- (societeId,ASCENDING) (enabledAt,ASCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (deptId,DESCENDING) 

Field Overrides
[widgets.thing] -- (no indexes)
```

**After (pretty)**
```
Compound Indexes
[READY] (evts) -- (alertAt,ASCENDING) (mandantId,ASCENDING) 
[READY] (evts) -- (alertAt,ASCENDING) (ownerId,ASCENDING) 
[READY] (evts) -- (alertAt,ASCENDING) (societeId,ASCENDING) 
[READY] (evts) -- (endAt,DESCENDING) (mandantId,ASCENDING) 
[READY] (evts) -- (endAt,DESCENDING) (ownerId,ASCENDING) 
[READY] (evts) -- (endAt,DESCENDING) (societeId,ASCENDING) 
[READY] (incidents) -- (metro_id,ASCENDING) (added_time,DESCENDING) 
[READY] (manifs) -- (actif,ASCENDING) (ownerId,ASCENDING) 
[READY] (manifs) -- (actif,DESCENDING) (mandantIds,CONTAINS) 
[READY] (manifs) -- (actif,DESCENDING) (ownerId,ASCENDING) 
[READY] (manifs) -- (deptId,ASCENDING) (mandantIds,CONTAINS) 
[READY] (manifs) -- (deptId,ASCENDING) (ownerId,ASCENDING) 
[READY] (manifs) -- (deptId,DESCENDING) (mandantIds,CONTAINS) 
[READY] (manifs) -- (deptId,DESCENDING) (ownerId,ASCENDING) 
[READY] (manifs) -- (lastCR,ASCENDING) (mandantIds,CONTAINS) 
[READY] (manifs) -- (lastCR,DESCENDING) (mandantIds,CONTAINS) 
[READY] (manifs) -- (lastCR,DESCENDING) (ownerId,ASCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (pseudo,ASCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (pseudo,DESCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (ville,ASCENDING) 
[READY] (manifs) -- (mandantIds,CONTAINS) (ville,DESCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (pseudo,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (pseudo,DESCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (ville,ASCENDING) 
[READY] (manifs) -- (ownerId,ASCENDING) (ville,DESCENDING) 
[READY] (manifs_cr) -- (createdAt,DESCENDING) (mandantId,ASCENDING) 
[READY] (manifs_cr) -- (createdAt,DESCENDING) (manifId,ASCENDING) 
[READY] (manifs_cr) -- (createdAt,DESCENDING) (ownerId,ASCENDING) 
[READY] (replies) -- (topicId,ASCENDING) (createdAt,DESCENDING) 
[READY] (societes) -- (deptId,ASCENDING) (mandantIds,CONTAINS) 
[READY] (societes) -- (deptId,ASCENDING) (ownerId,ASCENDING) 
[READY] (societes) -- (deptId,DESCENDING) (mandantIds,CONTAINS) 
[READY] (societes) -- (deptId,DESCENDING) (ownerId,ASCENDING) 
[READY] (societes) -- (lastCR,ASCENDING) (mandantIds,CONTAINS) 
[READY] (societes) -- (lastCR,ASCENDING) (ownerId,ASCENDING) 
[READY] (societes) -- (lastCR,DESCENDING) (mandantIds,CONTAINS) 
[READY] (societes) -- (lastCR,DESCENDING) (ownerId,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ownerId,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ownerId,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (pseudo,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (pseudo,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (statut,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (statut,DESCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ville,ASCENDING) 
[READY] (societes) -- (mandantIds,CONTAINS) (ville,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (pseudo,ASCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (pseudo,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (statut,DESCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (ville,ASCENDING) 
[READY] (societes) -- (ownerId,ASCENDING) (ville,DESCENDING) 
[READY] (societes_contacts) -- (mandantIds,CONTAINS) (nom,ASCENDING) 
[READY] (societes_contacts) -- (nom,ASCENDING) (ownerId,ASCENDING) 
[READY] (societes_cr) -- (createdAt,DESCENDING) (mandantId,ASCENDING) 
[READY] (societes_cr) -- (createdAt,DESCENDING) (ownerId,ASCENDING) 
[READY] (societes_cr) -- (createdAt,DESCENDING) (societeId,ASCENDING) 
[READY] (taches) -- (done,ASCENDING) (doneAt,DESCENDING) 
[READY] (taches) -- (done,ASCENDING) (enabledAt,ASCENDING) 
[READY] (taches) -- (doneAt,DESCENDING) (mandantId,ASCENDING) 
[READY] (taches) -- (doneAt,DESCENDING) (ownerId,ASCENDING) 
[READY] (taches) -- (doneAt,DESCENDING) (societeId,ASCENDING) 
[READY] (taches) -- (enabledAt,ASCENDING) (mandantId,ASCENDING) 
[READY] (taches) -- (enabledAt,ASCENDING) (ownerId,ASCENDING) 
[READY] (taches) -- (enabledAt,ASCENDING) (societeId,ASCENDING) 

Field Overrides
[widgets.thing] -- (no indexes)
```

### Sample Commands

N/A
