### PR TITLE
Locally serving Hosting proxies Cloud Run rewrites

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+feature - Serving Hosting locally can now proxy to the live Cloud Run service.

--- a/src/api.js
+++ b/src/api.js
@@ -129,6 +129,7 @@ var api = {
     "FIREBASE_HOSTING_API_URL",
     "https://firebasehosting.googleapis.com"
   ),
+  cloudRunApiOrigin: utils.envOverride("CLOUD_RUN_API_URL", "https://run.googleapis.com"),
 
   setRefreshToken: function(token) {
     refreshToken = token;

--- a/src/hosting/cloudRunProxy.ts
+++ b/src/hosting/cloudRunProxy.ts
@@ -27,12 +27,8 @@ function getCloudRunUrl(rewrite: CloudRunProxyRewrite, projectId: string): Promi
 
   const path = `/v1alpha1/projects/${projectId}/locations/${rewrite.run.region ||
     "us-central1"}/services/${rewrite.run.serviceId}`;
-  const requestOptions = {
-    origin: cloudRunApiOrigin,
-    auth: true,
-  };
   logger.info(`[hosting] Looking up Cloud Run service "${path}" for its URL`);
-  return apiRequest("GET", path, requestOptions)
+  return apiRequest("GET", path, { origin: cloudRunApiOrigin, auth: true })
     .then((res) => {
       const url = get(res, "body.status.address.hostname");
       if (!url) {

--- a/src/hosting/cloudRunProxy.ts
+++ b/src/hosting/cloudRunProxy.ts
@@ -1,7 +1,7 @@
-import { Request, RequestHandler, Response } from "express";
-import { capitalize, includes, get } from "lodash";
-import * as request from "request";
+import { RequestHandler } from "express";
+import { get } from "lodash";
 
+import { errorRequestHandler, proxyRequestHandler } from "./proxy";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
 import { request as apiRequest } from "../api";
@@ -12,29 +12,6 @@ export interface CloudRunProxyOptions {
 
 export interface CloudRunProxyRewrite {
   run: { serviceId: string; region?: string };
-}
-
-const REQUIRED_VARY_VALUES = ["Accept-Encoding", "Authorization", "Cookie"];
-
-function makeVary(vary?: string): string {
-  if (!vary) {
-    return "Accept-Encoding, Authorization, Cookie";
-  }
-
-  const varies = vary.split(/, ?/).map((v) => {
-    return v
-      .split("-")
-      .map((part) => capitalize(part))
-      .join("-");
-  });
-
-  REQUIRED_VARY_VALUES.forEach((requiredVary) => {
-    if (!includes(varies, requiredVary)) {
-      varies.push(requiredVary);
-    }
-  });
-
-  return varies.join(", ");
 }
 
 const cloudRunCache: { [s: string]: string } = {};
@@ -66,80 +43,6 @@ function getCloudRunUrl(rewrite: CloudRunProxyRewrite, projectId: string): Promi
       const errInfo = `error looking up URL for Cloud Run service: ${err}`;
       return Promise.reject(errInfo);
     });
-}
-
-function errorRequestHandler(error: string): RequestHandler {
-  return (req: Request, res: Response, next: () => void): any => {
-    res.statusCode = 500;
-    const out = `A problem occured while trying to handle a Cloud Run rewrite: ${error}`;
-    logger.error(out);
-    res.end(out);
-  };
-}
-
-function proxyRequestHandler(url: string, rewriteIdentifier: string): RequestHandler {
-  return (req: Request, res: Response, next: () => void): any => {
-    logger.info(`[hosting] Rewriting ${req.url} to ${url} for ${rewriteIdentifier}`);
-    // Extract the __session cookie from headers to forward it to the
-    // functions cookie is not a string[].
-    const cookie = (req.headers.cookie as string) || "";
-    const sessionCookie = cookie.split(/; ?/).find((c: string) => {
-      return c.trim().indexOf("__session=") === 0;
-    });
-
-    const proxied = request({
-      method: req.method,
-      qs: req.query,
-      url: url + req.url,
-      headers: {
-        "X-Forwarded-Host": req.headers.host,
-        "X-Original-Url": req.url,
-        Pragma: "no-cache",
-        "Cache-Control": "no-cache, no-store",
-        // forward the parsed __session cookie if any
-        Cookie: sessionCookie,
-      },
-      followRedirect: false,
-      timeout: 60000,
-    });
-
-    req.pipe(proxied);
-
-    // err here is `any` in order to check `.code`
-    proxied.on("error", (err: any) => {
-      if (err.code === "ETIMEDOUT" || err.code === "ESOCKETTIMEDOUT") {
-        res.statusCode = 504;
-        return res.end("Timed out waiting for function to respond.");
-      }
-
-      res.statusCode = 500;
-      res.end(`An internal error occurred while proxying for ${rewriteIdentifier}`);
-    });
-
-    proxied.on("response", (response) => {
-      if (response.statusCode === 404) {
-        // x-cascade is not a string[].
-        const cascade = response.headers["x-cascade"] as string;
-        if (cascade && cascade.toUpperCase() === "PASS") {
-          return next();
-        }
-      }
-
-      // default to private cache
-      if (!response.headers["cache-control"]) {
-        response.headers["cache-control"] = "private";
-      }
-
-      // don't allow cookies to be set on non-private cached responses
-      if (response.headers["cache-control"].indexOf("private") < 0) {
-        delete response.headers["set-cookie"];
-      }
-
-      response.headers.vary = makeVary(response.headers.vary);
-
-      proxied.pipe(res);
-    });
-  };
 }
 
 /**

--- a/src/hosting/cloudRunProxy.ts
+++ b/src/hosting/cloudRunProxy.ts
@@ -4,7 +4,7 @@ import { get } from "lodash";
 import { errorRequestHandler, proxyRequestHandler } from "./proxy";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
-import { request as apiRequest, cloudRunApiOrigin } from "../api";
+import { cloudRunApiOrigin, request as apiRequest } from "../api";
 
 export interface CloudRunProxyOptions {
   project?: string;

--- a/src/hosting/cloudRunProxy.ts
+++ b/src/hosting/cloudRunProxy.ts
@@ -1,0 +1,173 @@
+import { Request, RequestHandler, Response } from "express";
+import { capitalize, includes, get } from "lodash";
+import * as request from "request";
+
+import * as getProjectId from "../getProjectId";
+import * as logger from "../logger";
+import { request as apiRequest } from "../api";
+
+export interface CloudRunProxyOptions {
+  project?: string;
+}
+
+export interface CloudRunProxyRewrite {
+  run: { serviceId: string; region?: string };
+}
+
+const REQUIRED_VARY_VALUES = ["Accept-Encoding", "Authorization", "Cookie"];
+
+function makeVary(vary?: string): string {
+  if (!vary) {
+    return "Accept-Encoding, Authorization, Cookie";
+  }
+
+  const varies = vary.split(/, ?/).map((v) => {
+    return v
+      .split("-")
+      .map((part) => capitalize(part))
+      .join("-");
+  });
+
+  REQUIRED_VARY_VALUES.forEach((requiredVary) => {
+    if (!includes(varies, requiredVary)) {
+      varies.push(requiredVary);
+    }
+  });
+
+  return varies.join(", ");
+}
+
+const cloudRunCache: { [s: string]: string } = {};
+
+function getCloudRunUrl(rewrite: CloudRunProxyRewrite, projectId: string): Promise<string> {
+  const alreadyFetched = cloudRunCache[`${rewrite.run.region}/${rewrite.run.serviceId}`];
+  if (alreadyFetched) {
+    return Promise.resolve(alreadyFetched);
+  }
+
+  const path = `/v1alpha1/projects/${projectId}/locations/${rewrite.run.region ||
+    "us-central1"}/services/${rewrite.run.serviceId}`;
+  const requestOptions = {
+    origin: "https://run.googleapis.com",
+    auth: true,
+  };
+  logger.info(`[hosting] Looking up Cloud Run service "${path}" for its URL`);
+  return apiRequest("GET", path, requestOptions)
+    .then((res) => {
+      const url = get(res, "body.status.address.hostname");
+      if (!url) {
+        return Promise.reject("Cloud Run URL doesn't exist in response.");
+      }
+
+      cloudRunCache[`${rewrite.run.region}/${rewrite.run.serviceId}`] = url;
+      return url;
+    })
+    .catch((err) => {
+      const errInfo = `error looking up URL for Cloud Run service: ${err}`;
+      return Promise.reject(errInfo);
+    });
+}
+
+function errorRequestHandler(error: string): RequestHandler {
+  return (req: Request, res: Response, next: () => void): any => {
+    res.statusCode = 500;
+    const out = `A problem occured while trying to handle a Cloud Run rewrite: ${error}`;
+    logger.error(out);
+    res.end(out);
+  };
+}
+
+function proxyRequestHandler(url: string, rewriteIdentifier: string): RequestHandler {
+  return (req: Request, res: Response, next: () => void): any => {
+    logger.info(`[hosting] Rewriting ${req.url} to ${url} for ${rewriteIdentifier}`);
+    // Extract the __session cookie from headers to forward it to the
+    // functions cookie is not a string[].
+    const cookie = (req.headers.cookie as string) || "";
+    const sessionCookie = cookie.split(/; ?/).find((c: string) => {
+      return c.trim().indexOf("__session=") === 0;
+    });
+
+    const proxied = request({
+      method: req.method,
+      qs: req.query,
+      url: url + req.url,
+      headers: {
+        "X-Forwarded-Host": req.headers.host,
+        "X-Original-Url": req.url,
+        Pragma: "no-cache",
+        "Cache-Control": "no-cache, no-store",
+        // forward the parsed __session cookie if any
+        Cookie: sessionCookie,
+      },
+      followRedirect: false,
+      timeout: 60000,
+    });
+
+    req.pipe(proxied);
+
+    // err here is `any` in order to check `.code`
+    proxied.on("error", (err: any) => {
+      if (err.code === "ETIMEDOUT" || err.code === "ESOCKETTIMEDOUT") {
+        res.statusCode = 504;
+        return res.end("Timed out waiting for function to respond.");
+      }
+
+      res.statusCode = 500;
+      res.end(`An internal error occurred while proxying for ${rewriteIdentifier}`);
+    });
+
+    proxied.on("response", (response) => {
+      if (response.statusCode === 404) {
+        // x-cascade is not a string[].
+        const cascade = response.headers["x-cascade"] as string;
+        if (cascade && cascade.toUpperCase() === "PASS") {
+          return next();
+        }
+      }
+
+      // default to private cache
+      if (!response.headers["cache-control"]) {
+        response.headers["cache-control"] = "private";
+      }
+
+      // don't allow cookies to be set on non-private cached responses
+      if (response.headers["cache-control"].indexOf("private") < 0) {
+        delete response.headers["set-cookie"];
+      }
+
+      response.headers.vary = makeVary(response.headers.vary);
+
+      proxied.pipe(res);
+    });
+  };
+}
+
+/**
+ * Returns a function which, given a CloudRunProxyRewrite, returns a Promise
+ * that resolves with a middleware-like function that proxies the request to
+ * the live Cloud Run service running within the given project.
+ */
+export default function(
+  options: CloudRunProxyOptions
+): (r: CloudRunProxyRewrite) => Promise<RequestHandler> {
+  return async (rewrite: CloudRunProxyRewrite) => {
+    if (!rewrite.run) {
+      // SuperStatic wouldn't send it here, but we should check
+      return errorRequestHandler('Cloud Run rewrites must have a valid "run" field.');
+    }
+    if (!rewrite.run.serviceId) {
+      return errorRequestHandler("Cloud Run rewrites must supply a service ID.");
+    }
+    if (!rewrite.run.region) {
+      rewrite.run.region = "us-central1"; // Default region
+    }
+    logger.info(`[hosting] Cloud Run rewrite ${JSON.stringify(rewrite)} triggered`);
+
+    const textIdentifier = `Cloud Run service "${rewrite.run.serviceId}" for region "${
+      rewrite.run.region
+    }"`;
+    return getCloudRunUrl(rewrite, getProjectId(options, false))
+      .then((url) => proxyRequestHandler(url, textIdentifier))
+      .catch(errorRequestHandler);
+  };
+}

--- a/src/hosting/cloudRunProxy.ts
+++ b/src/hosting/cloudRunProxy.ts
@@ -4,7 +4,7 @@ import { get } from "lodash";
 import { errorRequestHandler, proxyRequestHandler } from "./proxy";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
-import { request as apiRequest } from "../api";
+import { request as apiRequest, cloudRunApiOrigin } from "../api";
 
 export interface CloudRunProxyOptions {
   project?: string;
@@ -28,7 +28,7 @@ function getCloudRunUrl(rewrite: CloudRunProxyRewrite, projectId: string): Promi
   const path = `/v1alpha1/projects/${projectId}/locations/${rewrite.run.region ||
     "us-central1"}/services/${rewrite.run.serviceId}`;
   const requestOptions = {
-    origin: "https://run.googleapis.com",
+    origin: cloudRunApiOrigin,
     auth: true,
   };
   logger.info(`[hosting] Looking up Cloud Run service "${path}" for its URL`);

--- a/src/hosting/cloudRunProxy.ts
+++ b/src/hosting/cloudRunProxy.ts
@@ -11,7 +11,10 @@ export interface CloudRunProxyOptions {
 }
 
 export interface CloudRunProxyRewrite {
-  run: { serviceId: string; region?: string };
+  run: {
+    serviceId: string;
+    region?: string;
+  };
 }
 
 const cloudRunCache: { [s: string]: string } = {};

--- a/src/hosting/functionsProxy.ts
+++ b/src/hosting/functionsProxy.ts
@@ -1,9 +1,8 @@
-import { capitalize, includes } from "lodash";
-import { Request, RequestHandler, Response } from "express";
-import * as request from "request";
+import { includes } from "lodash";
+import { RequestHandler } from "express";
 
+import { proxyRequestHandler } from "./proxy";
 import * as getProjectId from "../getProjectId";
-import * as logger from "../logger";
 
 export interface FunctionsProxyOptions {
   port: number;
@@ -13,29 +12,6 @@ export interface FunctionsProxyOptions {
 
 export interface FunctionProxyRewrite {
   function: string;
-}
-
-const REQUIRED_VARY_VALUES = ["Accept-Encoding", "Authorization", "Cookie"];
-
-function makeVary(vary?: string): string {
-  if (!vary) {
-    return "Accept-Encoding, Authorization, Cookie";
-  }
-
-  const varies = vary.split(/, ?/).map((v) => {
-    return v
-      .split("-")
-      .map((part) => capitalize(part))
-      .join("-");
-  });
-
-  REQUIRED_VARY_VALUES.forEach((requiredVary) => {
-    if (!includes(varies, requiredVary)) {
-      varies.push(requiredVary);
-    }
-  });
-
-  return varies.join(", ");
 }
 
 /**
@@ -58,71 +34,6 @@ export default function(
       }`;
     }
 
-    return await proxyRequestHandler(url, `Function ${rewrite.function}`);
-  };
-}
-
-function proxyRequestHandler(url: string, rewriteIdentifier: string): RequestHandler {
-  return (req: Request, res: Response, next: () => void): any => {
-    logger.info(`[hosting] Rewriting ${req.url} to ${url} for ${rewriteIdentifier}`);
-    // Extract the __session cookie from headers to forward it to the
-    // functions cookie is not a string[].
-    const cookie = (req.headers.cookie as string) || "";
-    const sessionCookie = cookie.split(/; ?/).find((c: string) => {
-      return c.trim().indexOf("__session=") === 0;
-    });
-
-    const proxied = request({
-      method: req.method,
-      qs: req.query,
-      url: url + req.url,
-      headers: {
-        "X-Forwarded-Host": req.headers.host,
-        "X-Original-Url": req.url,
-        Pragma: "no-cache",
-        "Cache-Control": "no-cache, no-store",
-        // forward the parsed __session cookie if any
-        Cookie: sessionCookie,
-      },
-      followRedirect: false,
-      timeout: 60000,
-    });
-
-    req.pipe(proxied);
-
-    // err here is `any` in order to check `.code`
-    proxied.on("error", (err: any) => {
-      if (err.code === "ETIMEDOUT" || err.code === "ESOCKETTIMEDOUT") {
-        res.statusCode = 504;
-        return res.end("Timed out waiting for function to respond.");
-      }
-
-      res.statusCode = 500;
-      res.end(`An internal error occurred while proxying for ${rewriteIdentifier}`);
-    });
-
-    proxied.on("response", (response) => {
-      if (response.statusCode === 404) {
-        // x-cascade is not a string[].
-        const cascade = response.headers["x-cascade"] as string;
-        if (cascade && cascade.toUpperCase() === "PASS") {
-          return next();
-        }
-      }
-
-      // default to private cache
-      if (!response.headers["cache-control"]) {
-        response.headers["cache-control"] = "private";
-      }
-
-      // don't allow cookies to be set on non-private cached responses
-      if (response.headers["cache-control"].indexOf("private") < 0) {
-        delete response.headers["set-cookie"];
-      }
-
-      response.headers.vary = makeVary(response.headers.vary);
-
-      proxied.pipe(res);
-    });
+    return await proxyRequestHandler(url, `${destLabel} Function ${rewrite.function}`);
   };
 }

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -98,3 +98,16 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
     });
   };
 }
+
+/**
+ * Returns an Express RequestHandler that will both log out the error and
+ * return an internal HTTP error response.
+ */
+export function errorRequestHandler(error: string): RequestHandler {
+  return (req: Request, res: Response, next: () => void): any => {
+    res.statusCode = 500;
+    const out = `A problem occured while trying to handle a Cloud Run rewrite: ${error}`;
+    logger.error(out);
+    res.end(out);
+  };
+}

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -1,0 +1,100 @@
+import { capitalize, includes } from "lodash";
+import { Request, RequestHandler, Response } from "express";
+import * as request from "request";
+
+import * as logger from "../logger";
+
+const REQUIRED_VARY_VALUES = ["Accept-Encoding", "Authorization", "Cookie"];
+
+function makeVary(vary?: string): string {
+  if (!vary) {
+    return "Accept-Encoding, Authorization, Cookie";
+  }
+
+  const varies = vary.split(/, ?/).map((v) => {
+    return v
+      .split("-")
+      .map((part) => capitalize(part))
+      .join("-");
+  });
+
+  REQUIRED_VARY_VALUES.forEach((requiredVary) => {
+    if (!includes(varies, requiredVary)) {
+      varies.push(requiredVary);
+    }
+  });
+
+  return varies.join(", ");
+}
+
+/**
+ * Returns an Express RequestHandler that will proxy the given request to a new
+ * URL. Provide a rewriteIdentifier to help identify what triggered the proxy
+ * when writing out logs or errors.  This makes some minor changes to headers,
+ * cookies, and caching similar to the behavior of the production version of
+ * the Firebase Hosting origin.
+ */
+export function proxyRequestHandler(url: string, rewriteIdentifier: string): RequestHandler {
+  return (req: Request, res: Response, next: () => void): any => {
+    logger.info(`[hosting] Rewriting ${req.url} to ${url} for ${rewriteIdentifier}`);
+    // Extract the __session cookie from headers to forward it to the
+    // functions cookie is not a string[].
+    const cookie = (req.headers.cookie as string) || "";
+    const sessionCookie = cookie.split(/; ?/).find((c: string) => {
+      return c.trim().indexOf("__session=") === 0;
+    });
+
+    const proxied = request({
+      method: req.method,
+      qs: req.query,
+      url: url + req.url,
+      headers: {
+        "X-Forwarded-Host": req.headers.host,
+        "X-Original-Url": req.url,
+        Pragma: "no-cache",
+        "Cache-Control": "no-cache, no-store",
+        // forward the parsed __session cookie if any
+        Cookie: sessionCookie,
+      },
+      followRedirect: false,
+      timeout: 60000,
+    });
+
+    req.pipe(proxied);
+
+    // err here is `any` in order to check `.code`
+    proxied.on("error", (err: any) => {
+      if (err.code === "ETIMEDOUT" || err.code === "ESOCKETTIMEDOUT") {
+        res.statusCode = 504;
+        return res.end("Timed out waiting for function to respond.");
+      }
+
+      res.statusCode = 500;
+      res.end(`An internal error occurred while proxying for ${rewriteIdentifier}`);
+    });
+
+    proxied.on("response", (response) => {
+      if (response.statusCode === 404) {
+        // x-cascade is not a string[].
+        const cascade = response.headers["x-cascade"] as string;
+        if (cascade && cascade.toUpperCase() === "PASS") {
+          return next();
+        }
+      }
+
+      // default to private cache
+      if (!response.headers["cache-control"]) {
+        response.headers["cache-control"] = "private";
+      }
+
+      // don't allow cookies to be set on non-private cached responses
+      if (response.headers["cache-control"].indexOf("private") < 0) {
+        delete response.headers["set-cookie"];
+      }
+
+      response.headers.vary = makeVary(response.headers.vary);
+
+      proxied.pipe(res);
+    });
+  };
+}

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -106,7 +106,7 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
 export function errorRequestHandler(error: string): RequestHandler {
   return (req: Request, res: Response, next: () => void): any => {
     res.statusCode = 500;
-    const out = `A problem occured while trying to handle a Cloud Run rewrite: ${error}`;
+    const out = `A problem occurred while trying to handle a proxied rewrite: ${error}`;
     logger.error(out);
     res.end(out);
   };

--- a/src/serve/hosting.js
+++ b/src/serve/hosting.js
@@ -9,6 +9,7 @@ var detectProjectRoot = require("../detectProjectRoot");
 var implicitInit = require("../hosting/implicitInit");
 var initMiddleware = require("../hosting/initMiddleware");
 var functionsProxy = require("../hosting/functionsProxy").default;
+var cloudRunProxy = require("../hosting/cloudRunProxy").default;
 var normalizedHostingConfigs = require("../hosting/normalizedHostingConfigs");
 
 var MAX_PORT_ATTEMPTS = 10;
@@ -28,6 +29,7 @@ function _startServer(options, config, port, init) {
     },
     rewriters: {
       function: functionsProxy(options),
+      run: cloudRunProxy(options),
     },
   }).listen(function() {
     var siteName = config.target || config.site;

--- a/src/test/hosting/cloudRunProxy.spec.ts
+++ b/src/test/hosting/cloudRunProxy.spec.ts
@@ -1,0 +1,176 @@
+import { expect } from "chai";
+import * as express from "express";
+import * as nock from "nock";
+import * as sinon from "sinon";
+import * as supertest from "supertest";
+
+import { cloudRunApiOrigin } from "../../api";
+import cloudRunProxy, {
+  CloudRunProxyOptions,
+  CloudRunProxyRewrite,
+} from "../../hosting/cloudRunProxy";
+
+describe("cloudRunProxy", () => {
+  const fakeOptions: CloudRunProxyOptions = {
+    project: "project-foo",
+  };
+
+  const fakeRewrite: CloudRunProxyRewrite = { run: { serviceId: "helloworld" } };
+
+  const cloudRunServiceOrigin = "https://helloworld-hash-uc.a.run.app";
+
+  before(() => {
+    nock(cloudRunApiOrigin)
+      .get("/v1alpha1/projects/project-foo/locations/us-central1/services/helloworld")
+      .reply(200, { status: { address: { hostname: cloudRunServiceOrigin } } });
+
+    nock(cloudRunServiceOrigin)
+      .get("/")
+      .reply(200, "live version");
+
+    nock(cloudRunServiceOrigin)
+      .get("/vary")
+      .reply(200, "live vary version", { vary: "Other, Authorization" });
+
+    nock(cloudRunServiceOrigin)
+      .get("/cached")
+      .reply(200, "cached page", { "cache-control": "custom", "set-cookie": "nom" });
+
+    nock(cloudRunServiceOrigin)
+      .get("/404.html")
+      .reply(404, "normal 404");
+
+    nock(cloudRunServiceOrigin)
+      .get("/404-cascade.html")
+      .reply(404, "normal 404 with cascade", { "x-cascade": "pass" });
+
+    nock(cloudRunServiceOrigin)
+      .get("/500")
+      .replyWithError({ message: "normal error" });
+
+    nock(cloudRunServiceOrigin)
+      .get("/timeout")
+      .replyWithError({ message: "ahh", code: "ETIMEDOUT" });
+
+    nock(cloudRunServiceOrigin)
+      .get("/sockettimeout")
+      .replyWithError({ message: "ahh", code: "ESOCKETTIMEDOUT" });
+  });
+
+  after(() => {
+    nock.cleanAll();
+  });
+
+  it("should resolve a function returns middleware that proxies to the live version", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/")
+      .expect(200, "live version")
+      .then(() => {
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+
+  it("should pass through normal 404 errors", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/404.html")
+      .expect(404, "normal 404")
+      .then(() => {
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+
+  it("should do nothing on 404 errors with x-cascade", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+    const finalMw = sinon.stub().callsFake((_, res) => {
+      res.status(404).send("unknown response");
+    });
+
+    const app = express();
+    app.use(spyMw);
+    app.use(finalMw);
+
+    return supertest(app)
+      .get("/404-cascade.html")
+      .expect(404, "unknown response")
+      .then(() => {
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+
+  it("should remove cookies on non-private cached responses", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/cached")
+      .expect(200, "cached page")
+      .then((res) => {
+        expect(spyMw.calledOnce).to.be.true;
+        expect(res.header["set-cookie"]).to.be.undefined;
+      });
+  });
+
+  it("should add required Vary headers to the response", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/vary")
+      .expect(200, "live vary version")
+      .then((res) => {
+        expect(spyMw.calledOnce).to.be.true;
+        expect(res.header.vary).to.equal("Other, Authorization, Accept-Encoding, Cookie");
+      });
+  });
+
+  it("should respond with a 500 error if an error occurs calling the Cloud Run service", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/500")
+      .expect(500)
+      .then(() => {
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+
+  it("should respond with a 504 error if a timeout error occurs calling the Cloud Run service", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/timeout")
+      .expect(504)
+      .then(() => {
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+
+  it("should respond with a 504 error if a sockettimeout error occurs calling the Cloud Run service", async () => {
+    const mwGenerator = await cloudRunProxy(fakeOptions);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/sockettimeout")
+      .expect(504)
+      .then(() => {
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+});


### PR DESCRIPTION
When running `firebase serve` the local Hosting instance will proxy Cloud Run rewrites configured in the `firebase.json` file to the Cloud Run service that is running in the current project.  In the process I refactored out the "proxy" code from locally serving Functions into a shared file.