### PR TITLE
Convert RulesDeploy.js into TypeScript

### DIFF
--- a/src/RulesDeploy.ts
+++ b/src/RulesDeploy.ts
@@ -1,30 +1,35 @@
 "use strict";
 
-var _ = require("lodash");
-var clc = require("cli-color");
-var fs = require("fs");
+import _ = require("lodash");
+import clc = require("cli-color");
+import fs = require("fs");
 
-var gcp = require("./gcp");
-var logger = require("./logger");
-var FirebaseError = require("./error");
-var utils = require("./utils");
+import gcp = require("./gcp");
+import logger = require("./logger");
+import FirebaseError = require("./error");
+import utils = require("./utils");
 
-function RulesDeploy(options, type) {
-  this.type = type;
-  this.options = options;
-  this.project = options.project;
-  this.rulesFiles = {};
-  this.rulesetNames = {};
-}
+class RulesDeploy {
+  type: any;
+  options: any;
+  project: any;
+  rulesFiles: any;
+  rulesetNames: any;
 
-RulesDeploy.prototype = {
+  constructor(options: any, type: any) {
+    this.type = type;
+    this.options = options;
+    this.project = options.project;
+    this.rulesFiles = {};
+    this.rulesetNames = {};
+  }
   /**
    * Adds a new project-relative file to be included in compilation and
    * deployment for this RulesDeploy.
    */
-  addFile: function(path) {
-    var fullPath = this.options.config.path(path);
-    var src;
+  addFile(path: any): void {
+    const fullPath = this.options.config.path(path);
+    let src;
     try {
       src = fs.readFileSync(fullPath, "utf8");
     } catch (e) {
@@ -33,46 +38,46 @@ RulesDeploy.prototype = {
     }
 
     this.rulesFiles[path] = [{ name: path, content: src }];
-  },
+  }
 
   /**
    * Compile all rulesets tied to this deploy, rejecting on first
    * compilation error.
    */
-  compile: function() {
-    var self = this;
-    var promises = [];
-    _.forEach(this.rulesFiles, function(files, filename) {
+  compile(): Promise<any> {
+    const self = this;
+    const promises: any[] = [];
+    _.forEach(this.rulesFiles, (files: any, filename: any) => {
       promises.push(self._compileRuleset(filename, files));
     });
     return Promise.all(promises);
-  },
+  }
 
   /**
    * Create rulesets for each file added to this deploy, and record
    * the name for use in the release process later.
    */
-  createRulesets: function() {
-    var self = this;
-    var promises = [];
-    _.forEach(this.rulesFiles, function(files, filename) {
+  createRulesets(): Promise<any> {
+    const self = this;
+    const promises: any = [];
+    _.forEach(this.rulesFiles, (files: any, filename: any) => {
       utils.logBullet(
         clc.bold.cyan(self.type + ":") + " uploading rules " + clc.bold(filename) + "..."
       );
       promises.push(
-        gcp.rules.createRuleset(self.options.project, files).then(function(rulesetName) {
+        gcp.rules.createRuleset(self.options.project, files).then((rulesetName: any) => {
           self.rulesetNames[filename] = rulesetName;
         })
       );
     });
     return Promise.all(promises);
-  },
+  }
 
-  release: function(filename, resourceName) {
-    var self = this;
+  release(filename: any, resourceName: any): Promise<any> {
+    const self = this;
     return gcp.rules
       .updateOrCreateRelease(this.options.project, this.rulesetNames[filename], resourceName)
-      .then(function() {
+      .then(() => {
         utils.logSuccess(
           clc.bold.green(self.type + ": ") +
             "released rules " +
@@ -81,22 +86,22 @@ RulesDeploy.prototype = {
             clc.bold(resourceName)
         );
       });
-  },
+  }
 
-  _compileRuleset: function(filename, files) {
+  _compileRuleset(filename: any, files: any): Promise<any> {
     utils.logBullet(
       clc.bold.cyan(this.type + ":") +
         " checking " +
         clc.bold(filename) +
         " for compilation errors..."
     );
-    var self = this;
-    return gcp.rules.testRuleset(self.options.project, files).then(function(response) {
+    const self = this;
+    return gcp.rules.testRuleset(self.options.project, files).then((response: any) => {
       if (response.body && response.body.issues && response.body.issues.length > 0) {
-        var warnings = [];
-        var errors = [];
-        response.body.issues.forEach(function(issue) {
-          var issueMessage =
+        const warnings: any = [];
+        const errors: any = [];
+        response.body.issues.forEach((issue: any) => {
+          const issueMessage =
             "[" +
             issue.severity.substring(0, 1) +
             "] " +
@@ -114,14 +119,14 @@ RulesDeploy.prototype = {
         });
 
         if (warnings.length > 0) {
-          warnings.forEach(function(warning) {
+          warnings.forEach((warning: any) => {
             utils.logWarning(warning);
           });
         }
 
         if (errors.length > 0) {
-          var add = errors.length === 1 ? "" : "s";
-          var message =
+          const add = errors.length === 1 ? "" : "s";
+          const message =
             "Compilation error" + add + " in " + clc.bold(filename) + ":\n" + errors.join("\n");
           return utils.reject(message, { exit: 1 });
         }
@@ -135,7 +140,7 @@ RulesDeploy.prototype = {
       );
       return Promise.resolve();
     });
-  },
-};
+  }
+}
 
-module.exports = RulesDeploy;
+export = RulesDeploy;

--- a/src/RulesDeploy.ts
+++ b/src/RulesDeploy.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import _ = require("lodash");
 import clc = require("cli-color");
 import fs = require("fs");
@@ -9,7 +7,7 @@ import logger = require("./logger");
 import FirebaseError = require("./error");
 import utils = require("./utils");
 
-class RulesDeploy {
+export class RulesDeploy {
   type: any;
   options: any;
   project: any;
@@ -45,10 +43,9 @@ class RulesDeploy {
    * compilation error.
    */
   compile(): Promise<any> {
-    const self = this;
     const promises: any[] = [];
     _.forEach(this.rulesFiles, (files: any, filename: any) => {
-      promises.push(self._compileRuleset(filename, files));
+      promises.push(this._compileRuleset(filename, files));
     });
     return Promise.all(promises);
   }
@@ -58,15 +55,14 @@ class RulesDeploy {
    * the name for use in the release process later.
    */
   createRulesets(): Promise<any> {
-    const self = this;
-    const promises: any = [];
+    const promises: any[] = [];
     _.forEach(this.rulesFiles, (files: any, filename: any) => {
       utils.logBullet(
-        clc.bold.cyan(self.type + ":") + " uploading rules " + clc.bold(filename) + "..."
+        clc.bold.cyan(this.type + ":") + " uploading rules " + clc.bold(filename) + "..."
       );
       promises.push(
-        gcp.rules.createRuleset(self.options.project, files).then((rulesetName: any) => {
-          self.rulesetNames[filename] = rulesetName;
+        gcp.rules.createRuleset(this.options.project, files).then((rulesetName: any) => {
+          this.rulesetNames[filename] = rulesetName;
         })
       );
     });
@@ -74,12 +70,11 @@ class RulesDeploy {
   }
 
   release(filename: any, resourceName: any): Promise<any> {
-    const self = this;
     return gcp.rules
       .updateOrCreateRelease(this.options.project, this.rulesetNames[filename], resourceName)
       .then(() => {
         utils.logSuccess(
-          clc.bold.green(self.type + ": ") +
+          clc.bold.green(this.type + ": ") +
             "released rules " +
             clc.bold(filename) +
             " to " +
@@ -88,18 +83,17 @@ class RulesDeploy {
       });
   }
 
-  _compileRuleset(filename: any, files: any): Promise<any> {
+  private _compileRuleset(filename: any, files: any): Promise<any> {
     utils.logBullet(
       clc.bold.cyan(this.type + ":") +
         " checking " +
         clc.bold(filename) +
         " for compilation errors..."
     );
-    const self = this;
-    return gcp.rules.testRuleset(self.options.project, files).then((response: any) => {
+    return gcp.rules.testRuleset(this.options.project, files).then((response: any) => {
       if (response.body && response.body.issues && response.body.issues.length > 0) {
-        const warnings: any = [];
-        const errors: any = [];
+        const warnings: any[] = [];
+        const errors: any[] = [];
         response.body.issues.forEach((issue: any) => {
           const issueMessage =
             "[" +
@@ -133,7 +127,7 @@ class RulesDeploy {
       }
 
       utils.logSuccess(
-        clc.bold.green(self.type + ":") +
+        clc.bold.green(this.type + ":") +
           " rules file " +
           clc.bold(filename) +
           " compiled successfully"
@@ -142,5 +136,3 @@ class RulesDeploy {
     });
   }
 }
-
-export = RulesDeploy;

--- a/src/deploy/firestore/prepare.js
+++ b/src/deploy/firestore/prepare.js
@@ -4,7 +4,7 @@ var _ = require("lodash");
 var clc = require("cli-color");
 
 var loadCJSON = require("../../loadCJSON");
-var RulesDeploy = require("../../RulesDeploy").RulesDeploy;
+const { RulesDeploy } = require("../../RulesDeploy");
 var utils = require("../../utils");
 
 function _prepareRules(context, options) {

--- a/src/deploy/firestore/prepare.js
+++ b/src/deploy/firestore/prepare.js
@@ -4,7 +4,7 @@ var _ = require("lodash");
 var clc = require("cli-color");
 
 var loadCJSON = require("../../loadCJSON");
-var RulesDeploy = require("../../RulesDeploy");
+var RulesDeploy = require("../../RulesDeploy").RulesDeploy;
 var utils = require("../../utils");
 
 function _prepareRules(context, options) {

--- a/src/deploy/storage/prepare.js
+++ b/src/deploy/storage/prepare.js
@@ -3,7 +3,7 @@
 var _ = require("lodash");
 
 var gcp = require("../../gcp");
-var RulesDeploy = require("../../RulesDeploy");
+var RulesDeploy = require("../../RulesDeploy").RulesDeploy;
 
 module.exports = function(context, options) {
   var rulesConfig = options.config.get("storage");

--- a/src/deploy/storage/prepare.js
+++ b/src/deploy/storage/prepare.js
@@ -3,7 +3,7 @@
 var _ = require("lodash");
 
 var gcp = require("../../gcp");
-var RulesDeploy = require("../../RulesDeploy").RulesDeploy;
+const { RulesDeploy } = require("../../RulesDeploy");
 
 module.exports = function(context, options) {
   var rulesConfig = options.config.get("storage");


### PR DESCRIPTION
I tried to keep this as unobtrusive as possible. There's a lot of line-noise involved in converting JS to TypeScript just due to eslint, so my preference would be to merge this as-is and then "upgrade" the typescript to be more idiomatic in a separate PR, where the style changes can be inspected alone.