### PR TITLE
When a single multi-resource instance is specified only run its lifecycle hooks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
 fixed - Fixes a bug in Cloud Firestore emulator where rulesets with no-op writes would modify a document's updated_at timestamp.
 fixed - Reduced lock contention in Cloud Firestore emulator during concurrent writes to a document.
 feature - Serving Hosting locally can now proxy to the live Cloud Run service.
+fixed - Lifecycle hooks will respect a single multi-resource deploy.

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -133,11 +133,11 @@ function getReleventConfigs(target, options) {
   }
 
   onlyTargets = onlyTargets
-    .filter(function(anOnly) {
-      return anOnly.indexOf(`${target}:`) === 0;
+    .filter(function(individualOnly) {
+      return individualOnly.indexOf(`${target}:`) === 0;
     })
-    .map(function(anOnly) {
-      return anOnly.replace(`${target}:`, "");
+    .map(function(individualOnly) {
+      return individualOnly.replace(`${target}:`, "");
     });
 
   return targetConfigs.filter(function(config) {

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -113,18 +113,42 @@ function runTargetCommands(target, hook, overallOptions, config) {
     });
 }
 
+function getReleventConfigs(target, options) {
+  let targetConfigs = options.config.get(target);
+  if (!targetConfigs) {
+    return [];
+  }
+  if (!_.isArray(targetConfigs)) {
+    targetConfigs = [targetConfigs];
+  }
+
+  if (!options.only) {
+    return targetConfigs;
+  }
+
+  var onlyTargets = options.only.split(",");
+  if (_.includes(onlyTargets, target)) {
+    // If the target matches entirely then all instances should be included.
+    return targetConfigs;
+  }
+
+  onlyTargets = onlyTargets
+    .filter(function(anOnly) {
+      return anOnly.indexOf(`${target}:`) === 0;
+    })
+    .map(function(anOnly) {
+      return anOnly.replace(`${target}:`, "");
+    });
+
+  return targetConfigs.filter(function(config) {
+    return _.includes(onlyTargets, config.target);
+  });
+}
+
 module.exports = function(target, hook) {
   return function(context, options) {
-    let targetConfigs = options.config.get(target);
-    if (!targetConfigs) {
-      return Promise.resolve();
-    }
-    if (!_.isArray(targetConfigs)) {
-      targetConfigs = [targetConfigs];
-    }
-
     return _.reduce(
-      targetConfigs,
+      getReleventConfigs(target, options),
       function(previousCommands, individualConfig) {
         return previousCommands.then(function() {
           return runTargetCommands(target, hook, options, individualConfig);


### PR DESCRIPTION
Brought up in #1160 this was due to fixing the fact that multi-resource lifecycle hooks weren't working at all before #1130.  Now we check the `--only` flag when adding the lifecycle hooks for each target.