### PR TITLE
Upgrade @google-cloud/functions-emulator 1.0.0-beta.5 -> 1.0.0-beta.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,6 @@
     "typescript": "^3.1.3"
   },
   "optionalDependencies": {
-    "@google-cloud/functions-emulator": "^1.0.0-beta.5"
+    "@google-cloud/functions-emulator": "^1.0.0-beta.6"
   }
 }


### PR DESCRIPTION
### Description

google-cloud/functions-emulator 1.0.0-beta.6 is released. 
https://github.com/GoogleCloudPlatform/cloud-functions-emulator/issues/302

1.0.0-beta.5 is including `lodash 4.17.5`, which has a known vulnerability https://nvd.nist.gov/vuln/detail/CVE-2018-16487, that is showing up in GitHub's security alerts.

And 1.0.0-beta.5 engine requirement is limited to node 6, so following INFO logs are always written:

```
info @google-cloud/functions-emulator@1.0.0-beta.5: The engine "node" is incompatible with this module.  Expected version "~6". Got "8.X.X"
info "@google-cloud/functions-emulator@1.0.0-beta.5" is an optional dependency and failed compatibility  check. Excluding it from installation.
```
