### PR TITLE
Properly suggest matching commands if the user mistypes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ function suggestCommands(cmd, cmdList) {
   if (suggestion) {
     logger.error();
     logger.error("Did you mean", clc.bold(suggestion) + "?");
-    process.exit(1);
+    return;
   }
 }
 
@@ -62,7 +62,6 @@ var RENAMED_COMMANDS = {
 };
 
 program.action(function(cmd, cmd2) {
-  suggestCommands(cmd, commandNames);
   logger.error(clc.bold.red("Error:"), clc.bold(cmd), "is not a Firebase command");
 
   if (RENAMED_COMMANDS[cmd]) {
@@ -76,9 +75,9 @@ program.action(function(cmd, cmd2) {
     if (!didYouMean(cmd, commandNames)) {
       cmd = [cmd, cmd2].join(":");
     }
-    suggestCommands(cmd, commandNames);
   }
 
+  suggestCommands(cmd, commandNames);
   process.exit(1);
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,11 +36,7 @@ client.getCommand = function(name) {
 require("./commands")(client);
 
 function suggestCommands(cmd, cmdList) {
-  var suggestion = didYouMean(cmd, cmdList);
-  if (suggestion) {
-    logger.error();
-    logger.error("Did you mean " + clc.bold(suggestion) + "?");
-  }
+  return didYouMean(cmd, cmdList);
 }
 
 var commandNames = program.commands.map(function(cmd) {
@@ -74,9 +70,14 @@ program.action(function(cmd, cmd2) {
     if (!suggestCommands(cmd, commandNames)) {
       cmd = [cmd, cmd2].join(":");
     }
+
+    var suggestion = suggestCommands(cmd, commandNames);
+    if (suggestion) {
+      logger.error();
+      logger.error("Did you mean " + clc.bold(suggestion) + "?");
+    }
   }
 
-  suggestCommands(cmd, commandNames);
   process.exit(1);
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,15 @@ client.getCommand = function(name) {
 
 require("./commands")(client);
 
+function suggestCommands(cmd, cmdList) {
+  var suggestion = didYouMean(cmd, cmdList);
+  if (suggestion) {
+    logger.error();
+    logger.error("Did you mean", clc.bold(suggestion) + "?");
+    process.exit(1);
+  }
+}
+
 var commandNames = program.commands.map(function(cmd) {
   return cmd._name;
 });
@@ -53,6 +62,7 @@ var RENAMED_COMMANDS = {
 };
 
 program.action(function(cmd, cmd2) {
+  suggestCommands(cmd, commandNames);
   logger.error(clc.bold.red("Error:"), clc.bold(cmd), "is not a Firebase command");
 
   if (RENAMED_COMMANDS[cmd]) {
@@ -63,12 +73,10 @@ program.action(function(cmd, cmd2) {
       "instead"
     );
   } else {
-    var suggestion = didYouMean(cmd, commandNames);
-    suggestion = suggestion || didYouMean([cmd, cmd2].join(":"), commandNames);
-    if (suggestion) {
-      logger.error();
-      logger.error("Did you mean", clc.bold(suggestion) + "?");
+    if (!didYouMean(cmd, commandNames)) {
+      cmd = [cmd, cmd2].join(":");
     }
+    suggestCommands(cmd, commandNames);
   }
 
   process.exit(1);

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function suggestCommands(cmd, cmdList) {
   var suggestion = didYouMean(cmd, cmdList);
   if (suggestion) {
     logger.error();
-    logger.error("Did you mean", clc.bold(suggestion) + "?");
+    logger.error("Did you mean "  + clc.bold(suggestion) + "?");
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function suggestCommands(cmd, cmdList) {
   var suggestion = didYouMean(cmd, cmdList);
   if (suggestion) {
     logger.error();
-    logger.error("Did you mean "  + clc.bold(suggestion) + "?");
+    logger.error("Did you mean " + clc.bold(suggestion) + "?");
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,6 @@ function suggestCommands(cmd, cmdList) {
   if (suggestion) {
     logger.error();
     logger.error("Did you mean", clc.bold(suggestion) + "?");
-    return;
   }
 }
 
@@ -72,7 +71,7 @@ program.action(function(cmd, cmd2) {
       "instead"
     );
   } else {
-    if (!didYouMean(cmd, commandNames)) {
+    if (!suggestCommands(cmd, commandNames)) {
       cmd = [cmd, cmd2].join(":");
     }
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

The code-base already comprised of `did-you-mean.js` library in-order to suggest matching commands in case if the user mistypes. But still the intended functionality was missing. Made it such that the warning shows up.

 
<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
	