### PR TITLE
Do null check before matching location, default to "us-central1". Fixes #1208

### DIFF
--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -117,7 +117,6 @@ module.exports = function(context, options, payload) {
   var projectId = context.projectId;
   var sourceUrl = context.uploadUrl;
   var appEngineLocation = getAppEngineLocation(context.firebaseConfig);
-  logger.debug(`appEngineLocation: ${appEngineLocation}`);
   // Used in CLI releases v3.4.0 to v3.17.6
   var legacySourceUrlTwo =
     "gs://" + "staging." + context.firebaseConfig.storageBucket + "/firebase-functions-source";

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -117,7 +117,7 @@ module.exports = function(context, options, payload) {
   var projectId = context.projectId;
   var sourceUrl = context.uploadUrl;
   var appEngineLocation = getAppEngineLocation(context.firebaseConfig);
-  utils.logWarning("appEngineLocation " + appEngineLocation);
+  logger.debug(`appEngineLocation: ${appEngineLocation}`);
   // Used in CLI releases v3.4.0 to v3.17.6
   var legacySourceUrlTwo =
     "gs://" + "staging." + context.firebaseConfig.storageBucket + "/firebase-functions-source";

--- a/src/functionsConfig.js
+++ b/src/functionsConfig.js
@@ -47,11 +47,11 @@ exports.idsToVarName = function(projectId, configId, varId) {
 
 exports.getAppEngineLocation = function(config) {
   var appEngineLocation = config.cloudResourceLocation;
-  if (appEngineLocation.match(/[^\d]$/)) {
+  if (appEngineLocation && appEngineLocation.match(/[^\d]$/)) {
     // For some regions, such as us-central1, the cloudResourceLocation has the trailing digit cut off
     appEngineLocation = appEngineLocation + "1";
   }
-  return appEngineLocation;
+  return appEngineLocation || "us-central1";
 };
 
 exports.getFirebaseConfig = function(options) {


### PR DESCRIPTION
This is a potential/probable fix for #1208. It seems that some customers do not have a default app engine location but still have functions. This covers the case when `config.cloudResourceLocation` is undefined and also defaults it to `us-central1` when that's the case.

I'm not 100% sure that this is the correct behavior as the interactions between the various bits here are a little hard to follow.