### PR TITLE
Fix: use 'functions' config if no 'functions:functionN' one found

### DIFF
--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -141,7 +141,7 @@ function getReleventConfigs(target, options) {
     });
 
   return targetConfigs.filter(function(config) {
-    return _.includes(onlyTargets, config.target);
+    return _.includes(onlyTargets, config.target) || config;
   });
 }
 


### PR DESCRIPTION
Despite the fact that the docs don't cover this yet [#the_firebasejson_file](https://firebase.google.com/docs/cli/#the_firebasejson_file), looks like from v6.7.0 one might be able to config `firebase.json` a level deeper than for a service (individual functions, in my case) so that `firebase deploy --only functions:functionN` would consider that, but the problem is now the `functions` level config is ignored if I deploy specific functions (so no `lint`, no custom scripts).

So please let's use 'functions' config if no 'functions:functionN' one found? It might be deeper than I managed to dig, but this fix works for me.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Bug: `firebase.json` `functions` config is ignored if specific functions are deployed.
	 
### Scenarios Tested
Before the fix:
![Imgur](https://i.imgur.com/9GRPolP.png)

After the fix:
![Imgur](https://i.imgur.com/SbaXsau.jpg)