### PR TITLE
Refactor deploy/functions/prepare logic and add tests

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,7 @@ var fsutils = require("./fsutils");
 var loadCJSON = require("./loadCJSON");
 var parseBoltRules = require("./parseBoltRules");
 var prompt = require("./prompt");
-var projectPath = require("./projectPath");
+var { resolveProjectPath } = require("./projectPath");
 var utils = require("./utils");
 
 var Config = function(src, options) {
@@ -119,7 +119,7 @@ Config.prototype._materialize = function(target) {
 };
 
 Config.prototype._parseFile = function(target, filePath) {
-  var fullPath = projectPath.resolveProjectPath(this.options.cwd, filePath);
+  var fullPath = resolveProjectPath(this.options.cwd, filePath);
   var ext = path.extname(filePath);
   if (!fsutils.fileExistsSync(fullPath)) {
     throw new FirebaseError("Parse Error: Imported file " + filePath + " does not exist", {

--- a/src/config.js
+++ b/src/config.js
@@ -12,7 +12,7 @@ var fsutils = require("./fsutils");
 var loadCJSON = require("./loadCJSON");
 var parseBoltRules = require("./parseBoltRules");
 var prompt = require("./prompt");
-var resolveProjectPath = require("./resolveProjectPath");
+var projectPath = require("./projectPath");
 var utils = require("./utils");
 
 var Config = function(src, options) {
@@ -119,7 +119,7 @@ Config.prototype._materialize = function(target) {
 };
 
 Config.prototype._parseFile = function(target, filePath) {
-  var fullPath = resolveProjectPath(this.options.cwd, filePath);
+  var fullPath = projectPath.resolveProjectPath(this.options.cwd, filePath);
   var ext = path.extname(filePath);
   if (!fsutils.fileExistsSync(fullPath)) {
     throw new FirebaseError("Parse Error: Imported file " + filePath + " does not exist", {

--- a/src/deploy/functions/prepare.js
+++ b/src/deploy/functions/prepare.js
@@ -1,68 +1,9 @@
 "use strict";
-
 var _ = require("lodash");
-var cjson = require("cjson");
-var clc = require("cli-color");
-var path = require("path");
-
 var ensureApiEnabled = require("../../ensureApiEnabled");
 var functionsConfig = require("../../functionsConfig");
-var fsutils = require("../../fsutils");
 var getProjectId = require("../../getProjectId");
-var logger = require("../../logger");
-var resolveProjectPath = require("../../resolveProjectPath");
-var utils = require("../../utils");
-
-// Check that functions directory exists
-var _checkFunctionsDirectoryExists = function(cwd, sourceDirName) {
-  if (!fsutils.dirExistsSync(resolveProjectPath(cwd, sourceDirName))) {
-    var msg =
-      `could not deploy functions because the ${clc.bold('"' + sourceDirName + '"')} ` +
-      `directory was not found. Please create it or specify a different source directory in firebase.json`;
-    return utils.reject(msg, { exit: 1 });
-  }
-};
-
-// Validate function names only contain lower case letters, numbers, and dashes
-var _validateFunctionName = function(functionNames) {
-  var validFunctionNameRegex = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
-  var invalidNames = _.reject(_.keys(functionNames), function(name) {
-    return _.startsWith(name, ".") || validFunctionNameRegex.test(name);
-  });
-  if (!_.isEmpty(invalidNames)) {
-    var msg = `${invalidNames.join(
-      ", "
-    )} function name(s) must be a valid subdomain (lowercase letters, numbers and dashes)`;
-    return utils.reject(msg, { exit: 1 });
-  }
-};
-
-// Validate contents of package.json - main file present and engines specified
-var _validatePackageJsonFile = function(sourceDirName, sourceDir, projectDir) {
-  var packageJsonFile = path.join(sourceDir, "package.json");
-  if (fsutils.fileExistsSync(packageJsonFile)) {
-    try {
-      var data = cjson.load(packageJsonFile);
-      logger.debug("> [functions] package.json contents:", JSON.stringify(data, null, 2));
-      var indexJsFile = path.join(sourceDir, data.main || "index.js");
-      if (!fsutils.fileExistsSync(indexJsFile)) {
-        var msg = `${path.relative(
-          projectDir,
-          indexJsFile
-        )} does not exist, can't deploy Firebase Functions`;
-        return utils.reject(msg, { exit: 1 });
-      }
-    } catch (e) {
-      var msg = `There was an error reading ${sourceDirName}${path.sep}package.json:\n\n ${
-        e.message
-      }`;
-      return utils.reject(msg, { exit: 1 });
-    }
-  } else if (!fsutils.fileExistsSync(path.join(sourceDir, "function.js"))) {
-    var msg = `No npm package found in functions source directory. Please run 'npm init' inside ${sourceDirName}`;
-    return utils.reject(msg, { exit: 1 });
-  }
-};
+var validator = require("./validate");
 
 module.exports = function(context, options, payload) {
   if (!options.config.has("functions")) {
@@ -75,13 +16,15 @@ module.exports = function(context, options, payload) {
   var functionNames = payload.functions;
   var projectId = getProjectId(options);
 
-  var invalidOptions =
-    _checkFunctionsDirectoryExists(options.cwd, sourceDirName) ||
-    _validateFunctionName(functionNames) ||
-    _validatePackageJsonFile(sourceDirName, sourceDir, projectDir);
-
-  if (invalidOptions) {
-    return invalidOptions;
+  try {
+    validator.functionsDirectoryExists(options.cwd, sourceDirName);
+    validator.functionNamesAreValid(functionNames);
+    // it's annoying that we have to pass in both sourceDirName and sourceDir
+    // but they are two different methods on the config object, so cannot get
+    // sourceDir from sourceDirName without passing in config
+    validator.packageJsonIsValid(sourceDirName, sourceDir, projectDir);
+  } catch (e) {
+    return Promise.reject(e);
   }
 
   return Promise.all([

--- a/src/deploy/functions/prepare.js
+++ b/src/deploy/functions/prepare.js
@@ -13,38 +13,32 @@ var logger = require("../../logger");
 var resolveProjectPath = require("../../resolveProjectPath");
 var utils = require("../../utils");
 
-var VALID_FUNCTION_NAME_REGEX = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
-
-module.exports = function(context, options, payload) {
-  if (!options.config.has("functions")) {
-    return Promise.resolve();
-  }
-
-  var sourceDirName = options.config.get("functions.source");
-
-  if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, sourceDirName))) {
+// Check that functions directory exists
+var _checkFunctionsDirectoryExists = function(cwd, sourceDirName) {
+  if (!fsutils.dirExistsSync(resolveProjectPath(cwd, sourceDirName))) {
     var msg =
-      "could not deploy functions because the " +
-      clc.bold('"' + sourceDirName + '"') +
-      " directory was not found. Please create it or specify a different source directory in firebase.json";
-
+      `could not deploy functions because the ${clc.bold('"' + sourceDirName + '"')} ` +
+      `directory was not found. Please create it or specify a different source directory in firebase.json`;
     return utils.reject(msg, { exit: 1 });
   }
+};
 
-  // Function name validation
-  var invalidNames = _.reject(_.keys(payload.functions), function(name) {
-    return _.startsWith(name, ".") || VALID_FUNCTION_NAME_REGEX.test(name);
+// Validate function names only contain lower case letters, numbers, and dashes
+var _validateFunctionName = function(functionNames) {
+  var validFunctionNameRegex = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
+  var invalidNames = _.reject(_.keys(functionNames), function(name) {
+    return _.startsWith(name, ".") || validFunctionNameRegex.test(name);
   });
   if (!_.isEmpty(invalidNames)) {
-    return utils.reject(
-      invalidNames.join(", ") +
-        " function name(s) must be a valid subdomain (lowercase letters, numbers and dashes)",
-      { exit: 1 }
-    );
+    var msg = `${invalidNames.join(
+      ", "
+    )} function name(s) must be a valid subdomain (lowercase letters, numbers and dashes)`;
+    return utils.reject(msg, { exit: 1 });
   }
+};
 
-  // Check main file specified in package.json is present
-  var sourceDir = options.config.path(sourceDirName);
+// Validate contents of package.json - main file present and engines specified
+var _validatePackageJsonFile = function(sourceDirName, sourceDir, projectDir) {
   var packageJsonFile = path.join(sourceDir, "package.json");
   if (fsutils.fileExistsSync(packageJsonFile)) {
     try {
@@ -52,26 +46,44 @@ module.exports = function(context, options, payload) {
       logger.debug("> [functions] package.json contents:", JSON.stringify(data, null, 2));
       var indexJsFile = path.join(sourceDir, data.main || "index.js");
       if (!fsutils.fileExistsSync(indexJsFile)) {
-        return utils.reject(
-          path.relative(options.config.projectDir, indexJsFile) +
-            " does not exist, can't deploy Firebase Functions",
-          { exit: 1 }
-        );
+        var msg = `${path.relative(
+          projectDir,
+          indexJsFile
+        )} does not exist, can't deploy Firebase Functions`;
+        return utils.reject(msg, { exit: 1 });
       }
     } catch (e) {
-      return utils.reject(
-        "There was an error reading " + sourceDirName + path.sep + "package.json:\n\n" + e.message,
-        { exit: 1 }
-      );
+      var msg = `There was an error reading ${sourceDirName}${path.sep}package.json:\n\n ${
+        e.message
+      }`;
+      return utils.reject(msg, { exit: 1 });
     }
   } else if (!fsutils.fileExistsSync(path.join(sourceDir, "function.js"))) {
-    return utils.reject(
-      "No npm package found in functions source directory. Please run 'npm init' inside " +
-        sourceDirName,
-      { exit: 1 }
-    );
+    var msg = `No npm package found in functions source directory. Please run 'npm init' inside ${sourceDirName}`;
+    return utils.reject(msg, { exit: 1 });
   }
+};
+
+module.exports = function(context, options, payload) {
+  if (!options.config.has("functions")) {
+    return Promise.resolve();
+  }
+
+  var sourceDirName = options.config.get("functions.source");
+  var sourceDir = options.config.path(sourceDirName);
+  var projectDir = options.config.projectDir;
+  var functionNames = payload.functions;
   var projectId = getProjectId(options);
+
+  var invalidOptions =
+    _checkFunctionsDirectoryExists(options.cwd, sourceDirName) ||
+    _validateFunctionName(functionNames) ||
+    _validatePackageJsonFile(sourceDirName, sourceDir, projectDir);
+
+  if (invalidOptions) {
+    return invalidOptions;
+  }
+
   return Promise.all([
     ensureApiEnabled.ensure(options.project, "cloudfunctions.googleapis.com", "functions"),
     ensureApiEnabled.check(projectId, "runtimeconfig.googleapis.com", "runtimeconfig", true),

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -26,7 +26,8 @@ export function functionsDirectoryExists(cwd: string, sourceDirName: string): vo
 }
 
 /**
- * Validate function names only contain letters, numbers, underscores, and hyphens.
+ * Validate function names only contain letters, numbers, underscores, and hyphens
+ * and not exceed 62 characters in length.
  * @param functionNames Object containing function names as keys.
  * @throws { FirebaseError } Function names must be valid.
  */
@@ -39,9 +40,9 @@ export function functionNamesAreValid(functionNames: {}): void {
     }
   );
   if (!_.isEmpty(invalidNames)) {
-    const msg = `${invalidNames.join(
-      ", "
-    )} function name(s) must be a valid subdomain (letters, numbers, dashes, underscores)`;
+    const msg =
+      `${invalidNames.join(", ")} function name(s) can only contain letters, ` +
+      `numbers, hyphens, and not exceed 62 characters in length`;
     throw new FirebaseError(msg);
   }
 }

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -26,12 +26,12 @@ export function functionsDirectoryExists(cwd: string, sourceDirName: string): vo
 }
 
 /**
- * Validate function names only contain lower case letters, numbers, and dashes.
+ * Validate function names only contain letters, numbers, underscores, and hyphens.
  * @param functionNames Object containing function names as keys.
  * @throws { FirebaseError } Function names must be valid.
  */
 export function functionNamesAreValid(functionNames: {}): void {
-  const validFunctionNameRegex = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
+  const validFunctionNameRegex = /^[a-zA-Z0-9_-]{1,62}$/;
   const invalidNames = _.reject(
     _.keys(functionNames),
     (name: string): boolean => {
@@ -41,7 +41,7 @@ export function functionNamesAreValid(functionNames: {}): void {
   if (!_.isEmpty(invalidNames)) {
     const msg = `${invalidNames.join(
       ", "
-    )} function name(s) must be a valid subdomain (lowercase letters, numbers and dashes)`;
+    )} function name(s) must be a valid subdomain (letters, numbers, dashes, underscores)`;
     throw new FirebaseError(msg);
   }
 }

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -60,29 +60,26 @@ export function packageJsonIsValid(
   projectDir: string
 ): void {
   const packageJsonFile = path.join(sourceDir, "package.json");
-  if (fsutils.fileExistsSync(packageJsonFile)) {
-    try {
-      const data = cjson.load(packageJsonFile);
-      logger.debug("> [functions] package.json contents:", JSON.stringify(data, null, 2));
-      const indexJsFile = path.join(sourceDir, data.main || "index.js");
-      if (!fsutils.fileExistsSync(indexJsFile)) {
-        const msg = `${path.relative(
-          projectDir,
-          indexJsFile
-        )} does not exist, can't deploy Firebase Functions`;
-        throw new FirebaseError(msg);
-      }
-    } catch (e) {
-      const msg = `There was an error reading ${sourceDirName}${path.sep}package.json:\n\n ${
-        e.message
-      }`;
+  if (!fsutils.fileExistsSync(packageJsonFile)) {
+    const msg = `No npm package found in functions source directory. Please run 'npm init' inside ${sourceDirName}`;
+    throw new FirebaseError(msg);
+  }
+
+  try {
+    const data = cjson.load(packageJsonFile);
+    logger.debug("> [functions] package.json contents:", JSON.stringify(data, null, 2));
+    const indexJsFile = path.join(sourceDir, data.main || "index.js");
+    if (!fsutils.fileExistsSync(indexJsFile)) {
+      const msg = `${path.relative(
+        projectDir,
+        indexJsFile
+      )} does not exist, can't deploy Cloud Functions`;
       throw new FirebaseError(msg);
     }
-    // This else if block seems to be legacy behavior of Cloud Functions defaulting to functions.js if
-    // no package.json.
-    // TODO: verify if Cloud Functions no longer supports this behavior, then remove this block.
-  } else if (!fsutils.fileExistsSync(path.join(sourceDir, "function.js"))) {
-    const msg = `No npm package found in functions source directory. Please run 'npm init' inside ${sourceDirName}`;
+  } catch (e) {
+    const msg = `There was an error reading ${sourceDirName}${path.sep}package.json:\n\n ${
+      e.message
+    }`;
     throw new FirebaseError(msg);
   }
 }

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -27,10 +27,10 @@ export function functionsDirectoryExists(cwd: string, sourceDirName: string): vo
 
 /**
  * Validate function names only contain lower case letters, numbers, and dashes.
- * @param functionNames List of function names.
+ * @param functionNames Object containing function names as keys.
  * @throws { FirebaseError } Function names must be valid.
  */
-export function functionNamesAreValid(functionNames: string[]): void {
+export function functionNamesAreValid(functionNames: {}): void {
   const validFunctionNameRegex = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
   const invalidNames = _.reject(
     _.keys(functionNames),
@@ -79,6 +79,7 @@ export function packageJsonIsValid(
     }
     // This else if block seems to be legacy behavior of Cloud Functions defaulting to functions.js if
     // no package.json.
+    // TODO: verify if Cloud Functions no longer supports this behavior, then remove this block.
   } else if (!fsutils.fileExistsSync(path.join(sourceDir, "function.js"))) {
     const msg = `No npm package found in functions source directory. Please run 'npm init' inside ${sourceDirName}`;
     throw new FirebaseError(msg);

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -77,6 +77,8 @@ export function packageJsonIsValid(
       }`;
       throw new FirebaseError(msg);
     }
+    // This else if block seems to be legacy behavior of Cloud Functions defaulting to functions.js if
+    // no package.json.
   } else if (!fsutils.fileExistsSync(path.join(sourceDir, "function.js"))) {
     const msg = `No npm package found in functions source directory. Please run 'npm init' inside ${sourceDirName}`;
     throw new FirebaseError(msg);

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -1,0 +1,71 @@
+"use strict";
+
+import * as FirebaseError from "../../error";
+import * as _ from "lodash";
+import * as path from "path";
+import * as clc from "cli-color";
+import * as logger from "../../logger";
+import * as projectPath from "../../projectPath";
+import * as fsutils from "../../fsutils";
+
+// have to require this because no @types/cjson available
+// tslint:disable-next-line
+const cjson = require("cjson");
+
+// Check that functions directory exists
+export function functionsDirectoryExists(cwd: string, sourceDirName: string): void {
+  if (!fsutils.dirExistsSync(projectPath.resolveProjectPath(cwd, sourceDirName))) {
+    const msg =
+      `could not deploy functions because the ${clc.bold('"' + sourceDirName + '"')} ` +
+      `directory was not found. Please create it or specify a different source directory in firebase.json`;
+    throw new FirebaseError(msg);
+  }
+}
+
+// Validate function names only contain lower case letters, numbers, and dashes
+export function functionNamesAreValid(functionNames: string[]): void {
+  const validFunctionNameRegex = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
+  const invalidNames = _.reject(
+    _.keys(functionNames),
+    (name: string): boolean => {
+      return _.startsWith(name, ".") || validFunctionNameRegex.test(name);
+    }
+  );
+  if (!_.isEmpty(invalidNames)) {
+    const msg = `${invalidNames.join(
+      ", "
+    )} function name(s) must be a valid subdomain (lowercase letters, numbers and dashes)`;
+    throw new FirebaseError(msg);
+  }
+}
+
+// Validate contents of package.json - main file present and engines specified
+export function packageJsonIsValid(
+  sourceDirName: string,
+  sourceDir: any,
+  projectDir: string
+): void {
+  const packageJsonFile = path.join(sourceDir, "package.json");
+  if (fsutils.fileExistsSync(packageJsonFile)) {
+    try {
+      const data = cjson.load(packageJsonFile);
+      logger.debug("> [functions] package.json contents:", JSON.stringify(data, null, 2));
+      const indexJsFile = path.join(sourceDir, data.main || "index.js");
+      if (!fsutils.fileExistsSync(indexJsFile)) {
+        const msg = `${path.relative(
+          projectDir,
+          indexJsFile
+        )} does not exist, can't deploy Firebase Functions`;
+        throw new FirebaseError(msg);
+      }
+    } catch (e) {
+      const msg = `There was an error reading ${sourceDirName}${path.sep}package.json:\n\n ${
+        e.message
+      }`;
+      throw new FirebaseError(msg);
+    }
+  } else if (!fsutils.fileExistsSync(path.join(sourceDir, "function.js"))) {
+    const msg = `No npm package found in functions source directory. Please run 'npm init' inside ${sourceDirName}`;
+    throw new FirebaseError(msg);
+  }
+}

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as FirebaseError from "../../error";
 import * as _ from "lodash";
 import * as path from "path";
@@ -12,7 +10,12 @@ import * as fsutils from "../../fsutils";
 // tslint:disable-next-line
 const cjson = require("cjson");
 
-// Check that functions directory exists
+/**
+ * Check that functions directory exists.
+ * @param cwd Working directory.
+ * @param sourceDirName Relative path to source directory.
+ * @throws { FirebaseError } Functions directory must exist.
+ */
 export function functionsDirectoryExists(cwd: string, sourceDirName: string): void {
   if (!fsutils.dirExistsSync(projectPath.resolveProjectPath(cwd, sourceDirName))) {
     const msg =
@@ -22,7 +25,11 @@ export function functionsDirectoryExists(cwd: string, sourceDirName: string): vo
   }
 }
 
-// Validate function names only contain lower case letters, numbers, and dashes
+/**
+ * Validate function names only contain lower case letters, numbers, and dashes.
+ * @param functionNames List of function names.
+ * @throws { FirebaseError } Function names must be valid.
+ */
 export function functionNamesAreValid(functionNames: string[]): void {
   const validFunctionNameRegex = /^[a-z][a-zA-Z0-9_-]{1,62}$/i;
   const invalidNames = _.reject(
@@ -39,10 +46,17 @@ export function functionNamesAreValid(functionNames: string[]): void {
   }
 }
 
-// Validate contents of package.json - main file present and engines specified
+/**
+ * Validate contents of package.json to ensure main file is present.
+ * Throws an error if package.json is not found, main file not found, or
+ * @param sourceDirName Name of source directory.
+ * @param sourceDir Relative path of source directory.
+ * @param projectDir Relative path of project directory.
+ * @throws { FirebaseError } Package.json must be present and valid.
+ */
 export function packageJsonIsValid(
   sourceDirName: string,
-  sourceDir: any,
+  sourceDir: string,
   projectDir: string
 ): void {
   const packageJsonFile = path.join(sourceDir, "package.json");

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -48,7 +48,6 @@ export function functionNamesAreValid(functionNames: string[]): void {
 
 /**
  * Validate contents of package.json to ensure main file is present.
- * Throws an error if package.json is not found, main file not found, or
  * @param sourceDirName Name of source directory.
  * @param sourceDir Relative path of source directory.
  * @param projectDir Relative path of project directory.

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -9,7 +9,7 @@ const deploymentTool = require("../../deploymentTool");
 const FirebaseError = require("../../error");
 const fsutils = require("../../fsutils");
 const normalizedHostingConfigs = require("../../hosting/normalizedHostingConfigs");
-const projectPath = require("../../projectPath");
+const { resolveProjectPath } = require("../../projectPath");
 
 module.exports = function(context, options) {
   // Allow the public directory to be overridden by the --public flag
@@ -55,7 +55,7 @@ module.exports = function(context, options) {
       throw new FirebaseError('Must supply either "site" or "target" in each "hosting" config.');
     }
 
-    if (!fsutils.dirExistsSync(projectPath.resolveProjectPath(options.cwd, cfg.public))) {
+    if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, cfg.public))) {
       throw new FirebaseError(
         `Specified public directory '${cfg.public}' does not exist, ` +
           `can't deploy hosting to site ${deploy.site}`,

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -9,7 +9,7 @@ const deploymentTool = require("../../deploymentTool");
 const FirebaseError = require("../../error");
 const fsutils = require("../../fsutils");
 const normalizedHostingConfigs = require("../../hosting/normalizedHostingConfigs");
-const resolveProjectPath = require("../../resolveProjectPath");
+const projectPath = require("../../projectPath");
 
 module.exports = function(context, options) {
   // Allow the public directory to be overridden by the --public flag
@@ -55,7 +55,7 @@ module.exports = function(context, options) {
       throw new FirebaseError('Must supply either "site" or "target" in each "hosting" config.');
     }
 
-    if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, cfg.public))) {
+    if (!fsutils.dirExistsSync(projectPath.resolveProjectPath(options.cwd, cfg.public))) {
       throw new FirebaseError(
         `Specified public directory '${cfg.public}' does not exist, ` +
           `can't deploy hosting to site ${deploy.site}`,

--- a/src/projectPath.ts
+++ b/src/projectPath.ts
@@ -1,6 +1,11 @@
 import * as path from "path";
 import * as detectProjectRoot from "./detectProjectRoot";
 
+/**
+ * Returns a fully qualified path to the wanted file/directory inside the project.
+ * @param cwd current working directory.
+ * @param filePath the target file or directory in the project.
+ */
 export function resolveProjectPath(cwd: string, filePath: string): string {
   return path.resolve(detectProjectRoot(cwd), filePath);
 }

--- a/src/projectPath.ts
+++ b/src/projectPath.ts
@@ -1,10 +1,6 @@
-"use strict";
-
 import * as path from "path";
 import * as detectProjectRoot from "./detectProjectRoot";
 
-// export namespace projectPath {
 export function resolveProjectPath(cwd: string, filePath: string): string {
   return path.resolve(detectProjectRoot(cwd), filePath);
 }
-// }

--- a/src/projectPath.ts
+++ b/src/projectPath.ts
@@ -1,0 +1,10 @@
+"use strict";
+
+import * as path from "path";
+import * as detectProjectRoot from "./detectProjectRoot";
+
+// export namespace projectPath {
+export function resolveProjectPath(cwd: string, filePath: string): string {
+  return path.resolve(detectProjectRoot(cwd), filePath);
+}
+// }

--- a/src/resolveProjectPath.js
+++ b/src/resolveProjectPath.js
@@ -1,8 +1,0 @@
-"use strict";
-
-var path = require("path");
-var detectProjectRoot = require("./detectProjectRoot");
-
-module.exports = function(cwd, filePath) {
-  return path.resolve(detectProjectRoot(cwd), filePath);
-};

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -117,7 +117,7 @@ describe("validate", () => {
     it("should throw error if main is defined and that file is missing", () => {
       cjsonLoadStub.returns({ name: "my-project", main: "src/main.js" });
       fileExistsStub.withArgs("sourceDir/package.json").returns(true);
-      fileExistsStub.withArgs("sourceDir/srcmain.js").returns(false);
+      fileExistsStub.withArgs("sourceDir/src/main.js").returns(false);
 
       expect(() => {
         validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -11,12 +11,11 @@ const cjson = require("cjson");
 
 describe("validate", () => {
   describe("functionsDirectoryExists", () => {
-    let sandbox: sinon.SinonSandbox;
+    const sandbox: sinon.SinonSandbox = sinon.createSandbox();
     let resolvePpathStub: sinon.SinonStub;
     let dirExistsStub: sinon.SinonStub;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
       resolvePpathStub = sandbox.stub(projectPath, "resolveProjectPath");
       dirExistsStub = sandbox.stub(fsutils, "dirExistsSync");
     });
@@ -28,14 +27,16 @@ describe("validate", () => {
     it("should not throw error if functions directory is present", () => {
       resolvePpathStub.returns("some/path/to/project");
       dirExistsStub.returns(true);
+
       expect(() => {
         validate.functionsDirectoryExists("cwd", "sourceDirName");
-      }).to.not.throw;
+      }).to.not.throw();
     });
 
     it("should throw error if the functions directory does not exist", () => {
       resolvePpathStub.returns("some/path/to/project");
       dirExistsStub.returns(false);
+
       expect(() => {
         validate.functionsDirectoryExists("cwd", "sourceDirName");
       }).to.throw(FirebaseError);
@@ -44,28 +45,37 @@ describe("validate", () => {
 
   describe("functionNamesAreValid", () => {
     it("should allow properly formatted function names", () => {
-      const properNames = ["my-function-1", "my-function-2"];
+      const properNames = { "my-function-1": "some field", "my-function-2": "some field" };
+
       expect(() => {
         validate.functionNamesAreValid(properNames);
-      }).to.not.throw;
+      }).to.not.throw();
     });
 
     it("should throw error on improperly formatted function names", () => {
-      const properNames = ["my-function@#$%@#$", "my-function^#%#@"];
+      const properNames = {
+        "my-function-!@#$%": "some field",
+        "my-function-!@#$!@#": "some field",
+      };
+
       expect(() => {
         validate.functionNamesAreValid(properNames);
       }).to.throw(FirebaseError);
     });
 
     it("should throw error if some function names are improperly formatted", () => {
-      const properNames = ["my-function-1", "my-FUNCTION!@#$"];
+      const properNames = { "my-function$%#": "some field", "my-function-2": "some field" };
+
       expect(() => {
         validate.functionNamesAreValid(properNames);
       }).to.throw(FirebaseError);
     });
 
-    it("should throw error on empty function name", () => {
-      const properNames = [""];
+    // I think it should throw error here but it doesn't error on empty or even undefined functionNames.
+    // TODO(b/131331234): fix this test when validation code path is fixed.
+    it.skip("should throw error on empty function names", () => {
+      const properNames = {};
+
       expect(() => {
         validate.functionNamesAreValid(properNames);
       }).to.throw(FirebaseError);
@@ -73,12 +83,11 @@ describe("validate", () => {
   });
 
   describe("packageJsonIsValid", () => {
-    let sandbox: sinon.SinonSandbox;
+    const sandbox: sinon.SinonSandbox = sinon.createSandbox();
     let cjsonLoadStub: sinon.SinonStub;
     let fileExistsStub: sinon.SinonStub;
 
     beforeEach(() => {
-      sandbox = sinon.sandbox.create();
       fileExistsStub = sandbox.stub(fsutils, "fileExistsSync");
       cjsonLoadStub = sandbox.stub(cjson, "load");
     });
@@ -122,7 +131,7 @@ describe("validate", () => {
 
       expect(() => {
         validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
-      }).to.not.throw;
+      }).to.not.throw();
     });
   });
 });

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -111,7 +111,7 @@ describe("validate", () => {
 
       expect(() => {
         validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
-      }).to.throw(FirebaseError, "does not exist, can't deploy Firebase Functions");
+      }).to.throw(FirebaseError, "does not exist, can't deploy");
     });
 
     it("should throw error if main is defined and that file is missing", () => {
@@ -121,7 +121,7 @@ describe("validate", () => {
 
       expect(() => {
         validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
-      }).to.throw(FirebaseError, "does not exist, can't deploy Firebase Functions");
+      }).to.throw(FirebaseError, "does not exist, can't deploy");
     });
 
     it("should not throw error if package.json and functions file exist", () => {

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -1,0 +1,119 @@
+import { expect } from "chai";
+import * as fsutils from "../../../fsutils";
+import * as validate from "../../../deploy/functions/validate";
+import * as projectPath from "../../../projectPath";
+import * as FirebaseError from "../../../error";
+import * as sinon from "sinon";
+
+// have to require this because no @types/cjson available
+// tslint:disable-next-line
+const cjson = require("cjson");
+
+describe("validate", () => {
+  describe(".functionsDirectoryExists", () => {
+    it("should not throw error if functions directory is present", () => {
+      const ppath = sinon.stub(projectPath, "resolveProjectPath");
+      ppath.returns("some/path/to/project");
+      const listDir = sinon.stub(fsutils, "dirExistsSync");
+      listDir.returns(true);
+
+      expect(validate.functionsDirectoryExists("hi", "there")).to.not.throw;
+      sinon.restore();
+    });
+
+    it("should throw error if the functions directory does not exist", () => {
+      const ppath = sinon.stub(projectPath, "resolveProjectPath");
+      ppath.returns("some/path/to/project");
+      const listDir = sinon.stub(fsutils, "dirExistsSync");
+      listDir.returns(false);
+      expect(() => {
+        validate.functionsDirectoryExists("hi", "there");
+      }).to.throw(FirebaseError);
+      sinon.restore();
+    });
+  });
+
+  describe(".functionNamesAreValid", () => {
+    it("should allow properly formatted function names", () => {
+      const properNames = ["my-function-1", "my-function-2"];
+      expect(() => {
+        validate.functionNamesAreValid(properNames);
+      }).to.not.throw;
+    });
+
+    it("should throw error on improperly formatted function names", () => {
+      const properNames = ["my-function@#$%@#$", "my-function^#%#@"];
+      expect(() => {
+        validate.functionNamesAreValid(properNames);
+      }).to.throw(FirebaseError);
+    });
+
+    it("should throw if some function names are improperly formatted", () => {
+      const properNames = ["my-function-1", "my-FUNCTION!@#$"];
+      expect(() => {
+        validate.functionNamesAreValid(properNames);
+      }).to.throw(FirebaseError);
+    });
+
+    it("should throw on empty function name", () => {
+      const properNames = [""];
+      expect(() => {
+        validate.functionNamesAreValid(properNames);
+      }).to.throw(FirebaseError);
+    });
+  });
+
+  describe(".packageJsonIsValid", () => {
+    it("should throw error if package.json file is missing", () => {
+      const fileExists = sinon.stub(fsutils, "fileExistsSync");
+      fileExists.withArgs("sourceDir/package.json").returns(false);
+
+      expect(() => {
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+      }).to.throw(FirebaseError, "No npm package found");
+      sinon.restore();
+    });
+
+    it("should throw error if functions source file is missing", () => {
+      const cjsonStub = sinon.stub(cjson, "load");
+      cjsonStub.returns({ name: "my-project" });
+
+      const fileExists = sinon.stub(fsutils, "fileExistsSync");
+      fileExists.withArgs("sourceDir/package.json").returns(true);
+      fileExists.withArgs("sourceDir/index.js").returns(false);
+
+      expect(() => {
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+      }).to.throw(FirebaseError, "does not exist, can't deploy Firebase Functions");
+      sinon.restore();
+    });
+
+    it("should throw error if main is defined and that file is missing", () => {
+      const cjsonStub = sinon.stub(cjson, "load");
+      cjsonStub.returns({ name: "my-project", main: "src/main.js" });
+
+      const fileExists = sinon.stub(fsutils, "fileExistsSync");
+      fileExists.withArgs("sourceDir/package.json").returns(true);
+      fileExists.withArgs("sourceDir/srcmain.js").returns(false);
+
+      expect(() => {
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+      }).to.throw(FirebaseError, "does not exist, can't deploy Firebase Functions");
+      sinon.restore();
+    });
+
+    it("should not throw error if package.json and functions file exist", () => {
+      const cjsonStub = sinon.stub(cjson, "load");
+      cjsonStub.returns({ name: "my-project" });
+
+      const fileExists = sinon.stub(fsutils, "fileExistsSync");
+      fileExists.withArgs("sourceDir/package.json").returns(true);
+      fileExists.withArgs("sourceDir/index.js").returns(true);
+
+      expect(() => {
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+      }).to.not.throw;
+      sinon.restore();
+    });
+  });
+});

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -17,7 +17,7 @@ describe("validate", () => {
       const listDir = sinon.stub(fsutils, "dirExistsSync");
       listDir.returns(true);
 
-      expect(validate.functionsDirectoryExists("hi", "there")).to.not.throw;
+      expect(validate.functionsDirectoryExists("cwd", "sourceDirName")).to.not.throw;
       sinon.restore();
     });
 
@@ -27,7 +27,7 @@ describe("validate", () => {
       const listDir = sinon.stub(fsutils, "dirExistsSync");
       listDir.returns(false);
       expect(() => {
-        validate.functionsDirectoryExists("hi", "there");
+        validate.functionsDirectoryExists("cwd", "sourceDirName");
       }).to.throw(FirebaseError);
       sinon.restore();
     });
@@ -48,14 +48,14 @@ describe("validate", () => {
       }).to.throw(FirebaseError);
     });
 
-    it("should throw if some function names are improperly formatted", () => {
+    it("should throw error if some function names are improperly formatted", () => {
       const properNames = ["my-function-1", "my-FUNCTION!@#$"];
       expect(() => {
         validate.functionNamesAreValid(properNames);
       }).to.throw(FirebaseError);
     });
 
-    it("should throw on empty function name", () => {
+    it("should throw error on empty function name", () => {
       const properNames = [""];
       expect(() => {
         validate.functionNamesAreValid(properNames);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description
*This PR does not add any new functionality*
This is the first refactor needed to add the node engines check to the functions prepare logic as part of the Node upgrades work. 
	 
### Scenarios Tested
* several cases tested in the validation unit test `src/test/deploy/functions/validate.spec.ts`:
  * error out if functions source directory does not exist
  * error out if `package.json` cannot be found in the functions directory
  * error out if `main` file from `package.json` cannot be found
  * error out if function names are invalid
* tested manually by running `firebase deploy` in a test project with missing package.json, missing functions source file, invalid function names
* tested by running integration tests in `firebase-functions` by linking this branch of firebase-tools through `npm link`: `./integration_tests/run_tests.sh`
* tested by running the hosting integration test in the CLI: `scripts/test-hosting.sh`
* tested by running the functions integration test in the CLI: `scripts/test-functions-deploy.js` - however this test is currently broken on master, so will be fixing that in a separate PR. 

##### *Travis tests seem to be failing on type errors - I'm looking into the environment differences and why `tsc` on my machine is not failing.
