### PR TITLE
Fix use of undefined 'name' variable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,8 @@
   "plugins": ["prettier"],
   "rules": {
     "prettier/prettier": "error",
-    "no-unused-vars": "error"
+    "no-unused-vars": "error",
+    "no-restricted-globals": ["error", "name", "length"]
   },
   "parserOptions": {
     "ecmaVersion": 6

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Fixes issue where functions for unsupported services caused a ReferenceError.

--- a/package.json
+++ b/package.json
@@ -127,6 +127,9 @@
     "coveralls": "^3.0.1",
     "eslint": "^5.7.0",
     "eslint-plugin-prettier": "^3.0.0",
+    "firebase-admin": "^7.3.0",
+    "firebase-functions": "^2.2.1",
+    "firebase-functions-test": "^0.1.6",
     "mocha": "^5.0.5",
     "nock": "^9.3.3",
     "nyc": "^14.0.0",
@@ -136,12 +139,9 @@
     "source-map-support": "^0.5.9",
     "supertest": "^3.3.0",
     "ts-node": "^7.0.1",
-    "tslint": "^5.11.0",
+    "tslint": "^5.16.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "tslint-plugin-prettier": "^2.0.0",
-    "typescript": "^3.4.5",
-    "firebase-admin": "^7.3.0",
-    "firebase-functions": "^2.2.1",
-    "firebase-functions-test": "^0.1.6"
+    "typescript": "^3.4.5"
   }
 }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -404,7 +404,9 @@ You can probably fix this by running "npm install ${
             default:
               logger.debug(`Unsupported trigger: ${JSON.stringify(definition)}`);
               utils.logWarning(
-                `Ignoring trigger "${definition.name}" because the service "${service}" is not yet supported.`
+                `Ignoring trigger "${
+                  definition.name
+                }" because the service "${service}" is not yet supported.`
               );
               break;
           }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -404,7 +404,7 @@ You can probably fix this by running "npm install ${
             default:
               logger.debug(`Unsupported trigger: ${JSON.stringify(definition)}`);
               utils.logWarning(
-                `Ignoring trigger "${name}" because the service "${service}" is not yet supported.`
+                `Ignoring trigger "${definition.name}" because the service "${service}" is not yet supported.`
               );
               break;
           }

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
     "arrow-parens": true,
     "interface-name": false,
     "member-access": [true, "no-public"],
+    "no-restricted-globals": [true, "name", "length"],
     "object-literal-key-quotes": [true, "as-needed"],
     "object-literal-sort-keys": false,
     "ordered-imports": [true, { "import-sources-order": "any" }],


### PR DESCRIPTION
If you try to run `emulators:start` and you have defined a function with a trigger that's neither HTTPS nor Firestore you get:

```
[2019-05-07T05:23:43.831Z] ReferenceError: name is not defined
    at FunctionsEmulator.<anonymous> (/Users/samstern/Projects/firebase-tools/lib/emulator/functionsEmulator.js:263:71)
    at Generator.next (<anonymous>)
    at fulfilled (/Users/samstern/Projects/firebase-tools/lib/emulator/functionsEmulator.js:4:58)
    at <anonymous>
    at process._tickDomainCallback (internal/process/next_tick.js:229:7)
```

I can't figure out why `tsc` didn't catch this.  It seems there is some `declare const name: never;` in `lib.dom.d.ts` which means that `name` is technically defined but is good 4 nothing.

Would love to change something in `tsconfig` or `tslint` to catch this.

<hr />

Edit: upgrading `tslint` allows the `no-restricted-globals` fix.