### PR TITLE
Fix bugs with serve vs emulators:start

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,3 @@
 fixed - Fixes issue where functions for unsupported services caused a ReferenceError.
+fixed - Fixes an issue where firebase serve does not properly start the Functions emulator.
+fixed - Adds a devDependency on firebase-functions-test to the default functions init template to prevent emulator issues.

--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -13,8 +13,8 @@ var serve = require("../serve/index");
 var filterTargets = require("../filterTargets");
 var getProjectNumber = require("../getProjectNumber");
 
-var VALID_EMULATORS = ["functions", "database", "firestore"];
-var VALID_TARGETS = ["hosting"];
+var VALID_EMULATORS = ["database", "firestore", "functions", "hosting"];
+var VALID_TARGETS = ["hosting", "functions"];
 var REQUIRES_AUTH = ["hosting", "functions"];
 
 var filterOnly = (list, only) => {

--- a/src/emulator/emulatorServer.ts
+++ b/src/emulator/emulatorServer.ts
@@ -22,6 +22,10 @@ export class EmulatorServer {
     );
   }
 
+  async connect(): Promise<void> {
+    await this.instance.connect();
+  }
+
   async stop(): Promise<void> {
     await EmulatorRegistry.stop(this.instance.getName());
   }

--- a/src/functionsShellCommandAction.js
+++ b/src/functionsShellCommandAction.js
@@ -16,6 +16,9 @@ module.exports = function(options) {
   return serveFunctions
     .start(options)
     .then(function() {
+      return serveFunctions.connect();
+    })
+    .then(function() {
       const emulator = serveFunctions.get();
       if (emulator.emulatedFunctions && emulator.emulatedFunctions.length === 0) {
         logger.info("No functions emulated.");

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -11,8 +11,12 @@ module.exports = {
     await this.emulatorServer.start();
   },
 
+  async connect(): Promise<void> {
+    await this.emulatorServer.connect();
+  },
+
   async stop(): Promise<void> {
-    await this.emulatorServer().stop();
+    await this.emulatorServer.stop();
   },
 
   get(): FunctionsEmulator {

--- a/src/serve/hosting.js
+++ b/src/serve/hosting.js
@@ -86,7 +86,12 @@ function _start(options) {
   });
 }
 
+function _connect() {
+  return Promise.resolve();
+}
+
 module.exports = {
   start: _start,
+  connect: _connect,
   stop: _stop,
 };

--- a/src/serve/index.js
+++ b/src/serve/index.js
@@ -19,21 +19,30 @@ var _serve = function(options) {
       var target = TARGETS[targetName];
       return target.start(options);
     })
-  ).then(function() {
-    return new Promise(function(resolve) {
-      process.on("SIGINT", function() {
-        logger.info("Shutting down...");
-        return Promise.all(
-          _.map(targetNames, function(targetName) {
-            var target = TARGETS[targetName];
-            return target.stop(options);
-          })
-        )
-          .then(resolve)
-          .catch(resolve);
+  )
+    .then(function() {
+      return Promise.all(
+        _.map(targetNames, function(targetName) {
+          var target = TARGETS[targetName];
+          return target.connect();
+        })
+      );
+    })
+    .then(function() {
+      return new Promise(function(resolve) {
+        process.on("SIGINT", function() {
+          logger.info("Shutting down...");
+          return Promise.all(
+            _.map(targetNames, function(targetName) {
+              var target = TARGETS[targetName];
+              return target.stop(options);
+            })
+          )
+            .then(resolve)
+            .catch(resolve);
+        });
       });
     });
-  });
 };
 
 module.exports = _serve;

--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -18,7 +18,8 @@
   },
   "devDependencies": {
     "eslint": "^5.12.0",
-    "eslint-plugin-promise": "^4.0.1"
+    "eslint-plugin-promise": "^4.0.1",
+    "firebase-functions-test": "^0.1.6"
   },
   "private": true
 }

--- a/templates/init/functions/javascript/package.nolint.json
+++ b/templates/init/functions/javascript/package.nolint.json
@@ -15,5 +15,8 @@
     "firebase-admin": "~7.0.0",
     "firebase-functions": "^2.3.0"
   },
+  "devDependencies": {
+    "firebase-functions-test": "^0.1.6"
+  },
   "private": true
 }


### PR DESCRIPTION
Changes:
  * Fixes #1242 
  * Makes `firebase serve` start both `hosting` and `functions` if they've both been initialized.
  * Adds a `connect()` stage to `firebase serve` to make sure functions and other emulators get set up the same as in `firebase emulators:start`
  * Adds a `devDependency` on `firebase-functions-test` to the default template since it's required by the new functions emulator.