### PR TITLE
Fix non-200 response codes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,2 @@
 fixed - Fixes issue where functions for unsupported services caused a ReferenceError.
+fixed - Fixes issue where non-200 response codes for HTTP functions were lost.

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -188,15 +188,22 @@ export class FunctionsEmulator implements EmulatorInstance {
           socketPath: runtime.metadata.socketPath,
         },
         (runtimeRes: http.IncomingMessage) => {
+          function forwardStatus() {
+            return res.status(runtimeRes.statusCode || 200);
+          }
+
           runtimeRes.on("data", (buf) => {
+            forwardStatus();
             res.write(buf);
           });
 
           runtimeRes.on("close", () => {
+            forwardStatus();
             res.end();
           });
 
           runtimeRes.on("end", () => {
+            forwardStatus();
             res.end();
           });
         }


### PR DESCRIPTION
Testing:

**500**
```
$ npx firebase emulators:exec --only functions "http -h http://localhost:5001/fir-dumpster/us-central1/errorFunction"
i  Starting emulators: ["functions"]
✔  functions: Using node@8 from host.
i  functions: Watching "/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.2ZI0rsQx/functions" for Cloud Functions...
i  functions: HTTP trigger initialized at http://localhost:5001/fir-dumpster/us-central1/errorFunction
i  functions: HTTP trigger initialized at http://localhost:5001/fir-dumpster/us-central1/goodFunction
i  Running script: http -h http://localhost:5001/fir-dumpster/us-central1/errorFunction
i  functions: Beginning execution of "errorFunction"
i  functions: Finished "errorFunction" in ~1s
HTTP/1.1 500 Internal Server Error
X-Powered-By: Express
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
Date: Tue, 07 May 2019 15:46:37 GMT
Connection: keep-alive
Transfer-Encoding: chunked

✔  Script exited successfully (code 0)
i  Shutting down emulators.
i  Stopping functions emulator
```

**200**
```
$ npx firebase emulators:exec --only functions "http -h http://localhost:5001/fir-dumpster/us-central1/goodFunction"
i  Starting emulators: ["functions"]
✔  functions: Using node@8 from host.
i  functions: Watching "/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.2ZI0rsQx/functions" for Cloud Functions...
i  functions: HTTP trigger initialized at http://localhost:5001/fir-dumpster/us-central1/errorFunction
i  functions: HTTP trigger initialized at http://localhost:5001/fir-dumpster/us-central1/goodFunction
i  Running script: http -h http://localhost:5001/fir-dumpster/us-central1/goodFunction
i  functions: Beginning execution of "goodFunction"
i  functions: Finished "goodFunction" in ~1s
HTTP/1.1 200 OK
X-Powered-By: Express
Access-Control-Allow-Origin: *
Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept
Date: Tue, 07 May 2019 15:47:04 GMT
Connection: keep-alive
Transfer-Encoding: chunked

✔  Script exited successfully (code 0)
i  Shutting down emulators.
i  Stopping functions emulator
```