### PR TITLE
Make sure emulator success log message always shows

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,3 +2,4 @@ fixed - Fixes issue where functions for unsupported services caused a ReferenceE
 fixed - Fixes issue where headers and response codes for HTTP functions were lost.
 fixed - Fixes issue where firebase serve does not properly start the Functions emulator.
 fixed - Adds a devDependency on firebase-functions-test to the default functions init template to prevent emulator issues.
+fixed - Adds a log message when emulators have successfully started.

--- a/src/emulator/emulatorServer.ts
+++ b/src/emulator/emulatorServer.ts
@@ -16,10 +16,6 @@ export class EmulatorServer {
 
     const name = this.instance.getName();
     const info = this.instance.getInfo();
-    utils.logLabeledSuccess(
-      name,
-      `Emulator running at ${clc.bold.underline("http://" + info.host + ":" + info.port)}`
-    );
   }
 
   async connect(): Promise<void> {

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -1,5 +1,8 @@
+import * as clc from "cli-color";
+
 import { ALL_EMULATORS, EmulatorInstance, Emulators } from "./types";
 import * as FirebaseError from "../error";
+import * as utils from "../utils";
 
 /**
  * Static registry for running emulators to discover each other.
@@ -15,6 +18,12 @@ export class EmulatorRegistry {
 
     await instance.start();
     this.set(instance.getName(), instance);
+
+    const info = instance.getInfo();
+    utils.logLabeledSuccess(
+      instance.getName(),
+      `Emulator started at ${clc.bold.underline(`http://${info.host}:${info.port}`)}`
+    );
   }
 
   static async stop(name: Emulators): Promise<void> {


### PR DESCRIPTION
When we moved emulator starting responsibilities to the `EmulatorRegistry` we lost the log message in some cases.  Namely the log would show up in `firebase serve` but not `firebase emulators:start`.  This fixes that.