### PR TITLE
Fixes emulator rules and google-gax resolution

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,4 @@ fixed - Fixes issue where firebase serve does not properly start the Functions e
 fixed - Adds a devDependency on firebase-functions-test to the default functions init template to prevent emulator issues.
 fixed - Fixes issue where the Firestore + RTDB emulators were starting on ports 5002/3 instead of 8080/9000
 fixed - Adds a log message when emulators have successfully started.
+fixed - Fixes error when using multiple @google-cloud APIs

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -13,6 +13,7 @@ import { DatabaseEmulator } from "../emulator/databaseEmulator";
 import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 import { HostingEmulator } from "../emulator/hostingEmulator";
 import * as FirebaseError from "../error";
+import * as path from "path";
 
 export const VALID_EMULATOR_STRINGS: string[] = ALL_EMULATORS;
 
@@ -122,7 +123,7 @@ export async function startAll(options: any): Promise<void> {
 
   if (targets.indexOf(Emulators.FIRESTORE) > -1) {
     const firestoreAddr = Constants.getAddress(Emulators.FIRESTORE, options);
-    const rules = options.config.get("firestore.rules");
+    const rules = path.join(options.projectRoot, options.config.get("firestore.rules"));
 
     const firestoreEmulator = new FirestoreEmulator({
       host: firestoreAddr.host,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -515,7 +515,7 @@ export function InvokeRuntime(
       JSON.stringify(frb),
       opts.serializedTriggers || "",
     ],
-    { env: { node: nodeBinary, ...opts.env } }
+    { env: { node: nodeBinary, ...opts.env }, cwd: frb.cwd }
   );
 
   const buffers: {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -225,7 +225,11 @@ function InitializeNetworkFiltering(frb: FunctionsRuntimeBundle): void {
     networkingModules.push(gaxModule);
     new EmulatorLog("DEBUG", "runtime-status", `Found google-gax at ${gaxPath}`).log();
   } catch (err) {
-    new EmulatorLog("DEBUG", "runtime-status", `Couldn't find google-cloud/firestore or google-gax`).log();
+    new EmulatorLog(
+      "DEBUG",
+      "runtime-status",
+      `Couldn't find google-cloud/firestore or google-gax`
+    ).log();
   }
 
   const history: { [href: string]: boolean } = {};

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -225,7 +225,7 @@ function InitializeNetworkFiltering(frb: FunctionsRuntimeBundle): void {
     networkingModules.push(gaxModule);
     new EmulatorLog("DEBUG", "runtime-status", `Found google-gax at ${gaxPath}`).log();
   } catch (err) {
-    new EmulatorLog("DEBUG", "runtime-status", `Couldn't find google-cloud/firestore`).log();
+    new EmulatorLog("DEBUG", "runtime-status", `Couldn't find google-cloud/firestore or google-gax`).log();
   }
 
   const history: { [href: string]: boolean } = {};

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -41,6 +41,7 @@ export interface FunctionsRuntimeFeatures {
   network_filtering?: boolean;
   timeout?: boolean;
   memory_limiting?: boolean;
+  protect_env?: boolean;
 }
 
 const memoryLookup = {

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -136,7 +136,7 @@ function _is_verbose(runtime: FunctionsRuntimeInstance): void {
 const TIMEOUT_LONG = 10000;
 const TIMEOUT_MED = 5000;
 
-describe("FunctionsEmulatorRuntime", () => {
+describe.only("FunctionsEmulatorRuntime", () => {
   describe("Stubs, Mocks, and Helpers (aka Magic, Glee, and Awesomeness)", () => {
     describe("_InitializeNetworkFiltering(...)", () => {
       it("should log outgoing HTTPS requests", async () => {

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -181,7 +181,6 @@ describe("FunctionsEmulatorRuntime", () => {
               .firestore.document("test/test")
               .onCreate(async () => {
                 /* tslint:disable:no-console */
-                console.log((require as any).resolveOriginal("firebase-admin"));
                 require("firebase-admin").initializeApp();
               }),
           };

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -136,7 +136,7 @@ function _is_verbose(runtime: FunctionsRuntimeInstance): void {
 const TIMEOUT_LONG = 10000;
 const TIMEOUT_MED = 5000;
 
-describe.only("FunctionsEmulatorRuntime", () => {
+describe("FunctionsEmulatorRuntime", () => {
   describe("Stubs, Mocks, and Helpers (aka Magic, Glee, and Awesomeness)", () => {
     describe("_InitializeNetworkFiltering(...)", () => {
       it("should log outgoing HTTPS requests", async () => {


### PR DESCRIPTION
* Fixed Firestore rules not being found when running from the `functions` directory.
* Fixed google-gax resolution failing when multiple versions of gax are present.