### PR TITLE
Disable functions emulator advanced features when 'served'

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,4 @@ fixed - Fixes issue where firebase serve does not properly start the Functions e
 fixed - Adds a devDependency on firebase-functions-test to the default functions init template to prevent emulator issues.
 fixed - Fixes issue where the Firestore + RTDB emulators were starting on ports 5002/3 instead of 8080/9000
 fixed - Adds a log message when emulators have successfully started.
+fixed - Disable some advanced Functions emulator features when run through "firebase serve".

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -20,6 +20,7 @@ import {
   EmulatedTriggerDefinition,
   EmulatedTriggerMap,
   FunctionsRuntimeBundle,
+  FunctionsRuntimeFeatures,
   getFunctionRegion,
   getTriggersFromDirectory,
 } from "./functionsEmulatorShared";
@@ -34,6 +35,7 @@ const SERVICE_FIRESTORE = "firestore.googleapis.com";
 interface FunctionsEmulatorArgs {
   port?: number;
   host?: string;
+  disabledRuntimeFeatures?: FunctionsRuntimeFeatures;
 }
 
 interface RequestWithRawBody extends express.Request {
@@ -256,6 +258,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       cwd: this.functionsDir,
       triggerId: triggerName,
       projectId: this.projectId,
+      disabled_features: this.args.disabledRuntimeFeatures,
     };
 
     const runtime = InvokeRuntime(this.nodeBinary, runtimeBundle);
@@ -380,6 +383,7 @@ You can probably fix this by running "npm install ${
       projectId: this.projectId,
       triggerId: "",
       ports: {},
+      disabled_features: this.args.disabledRuntimeFeatures,
     };
 
     // TODO(abehaskins): Gracefully handle removal of deleted function definitions

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -16,7 +16,6 @@ import { extractParamsFromPath } from "./functionsEmulatorUtils";
 import { spawnSync } from "child_process";
 import * as path from "path";
 import * as admin from "firebase-admin";
-import { logger } from "..";
 
 (require as any).resolveOriginal = require.resolve;
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -16,6 +16,7 @@ import { extractParamsFromPath } from "./functionsEmulatorUtils";
 import { spawnSync } from "child_process";
 import * as path from "path";
 import * as admin from "firebase-admin";
+import { logger } from "..";
 
 (require as any).resolveOriginal = require.resolve;
 
@@ -660,6 +661,12 @@ async function main(): Promise<void> {
       frb,
     }).log();
   }
+
+  new EmulatorLog(
+    "DEBUG",
+    "runtime-status",
+    `Disabled runtime features: ${JSON.stringify(frb.disabled_features)}`
+  ).log();
 
   const verified = verifyDeveloperNodeModules(frb.cwd);
   if (!verified) {

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -7,7 +7,19 @@ module.exports = {
   emulatorServer: undefined,
 
   async start(options: any): Promise<void> {
-    this.emulatorServer = new EmulatorServer(new FunctionsEmulator(options, {}));
+    this.emulatorServer = new EmulatorServer(
+      new FunctionsEmulator(options, {
+        // When running the functions emulator through 'firebase serve' we disable some
+        // of the more adventurous features that could be breaking/unexpected behavior
+        // for those used to the legacy emulator.
+        disabledRuntimeFeatures: {
+          functions_config_helper: true,
+          network_filtering: true,
+          timeout: true,
+          memory_limiting: true,
+        },
+      })
+    );
     await this.emulatorServer.start();
   },
 


### PR DESCRIPTION
@abehaskins had this idea, that way some of the really cool things the new emulator does won't freak people out who have been using `serve` with Functions for a while.