### PR TITLE
Make serve functions respect the --port flag

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -32,14 +32,10 @@ const EVENT_INVOKE = "functions:invoke";
 
 const SERVICE_FIRESTORE = "firestore.googleapis.com";
 
-interface FunctionsEmulatorArgs {
+export interface FunctionsEmulatorArgs {
   port?: number;
   host?: string;
   disabledRuntimeFeatures?: FunctionsRuntimeFeatures;
-}
-
-interface RequestWithRawBody extends express.Request {
-  rawBody: string;
 }
 
 // FunctionsRuntimeInstance is the handler for a running function invocation
@@ -54,6 +50,10 @@ export interface FunctionsRuntimeInstance {
   exit: Promise<number>;
   // A function to manually kill the child process
   kill: (signal?: string) => void;
+}
+
+interface RequestWithRawBody extends express.Request {
+  rawBody: string;
 }
 
 export class FunctionsEmulator implements EmulatorInstance {

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -1,4 +1,4 @@
-import { FunctionsEmulator } from "../emulator/functionsEmulator";
+import { FunctionsEmulator, FunctionsEmulatorArgs } from "../emulator/functionsEmulator";
 import { EmulatorServer } from "../emulator/emulatorServer";
 
 // TODO(samstern): It would be better to convert this to an EmulatorServer
@@ -7,21 +7,32 @@ module.exports = {
   emulatorServer: undefined,
 
   async start(options: any): Promise<void> {
-    this.emulatorServer = new EmulatorServer(
-      new FunctionsEmulator(options, {
-        // When running the functions emulator through 'firebase serve' we disable some
-        // of the more adventurous features that could be breaking/unexpected behavior
-        // for those used to the legacy emulator.
-        disabledRuntimeFeatures: {
-          functions_config_helper: true,
-          network_filtering: true,
-          timeout: true,
-          memory_limiting: true,
-          protect_env: true,
-          admin_stubs: true,
-        },
-      })
-    );
+    const args: FunctionsEmulatorArgs = {
+      // When running the functions emulator through 'firebase serve' we disable some
+      // of the more adventurous features that could be breaking/unexpected behavior
+      // for those used to the legacy emulator.
+      disabledRuntimeFeatures: {
+        functions_config_helper: true,
+        network_filtering: true,
+        timeout: true,
+        memory_limiting: true,
+        protect_env: true,
+        admin_stubs: true,
+      },
+    };
+
+    // If hosting emulator is not being served but Functions is,
+    // we can use the port argument. Otherwise it goes to hosting and
+    // we use port + 1.
+    if (this.options.port) {
+      if (this.options.targets && this.options.targets.indexOf("hosting") < 0) {
+        args.port = this.options.port;
+      } else {
+        args.port = this.options.port + 1;
+      }
+    }
+
+    this.emulatorServer = new EmulatorServer(new FunctionsEmulator(options, args));
     await this.emulatorServer.start();
   },
 


### PR DESCRIPTION
Fixes #1265 

Test cases:

**firebase serve**
```
$ npx firebase serve

=== Serving from '/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.wuBSDpsc'...

i  functions: Preparing to emulate functions.
i  hosting: Serving hosting files from: public
✔  hosting: Local server: http://localhost:5000
✔  functions: httpToDbFn: http://localhost:5001/fir-dumpster/us-central1/httpToDbFn
✔  functions: callableFn: http://localhost:5001/fir-dumpster/us-central1/callableFn
✔  functions: httpToFirestoreFn: http://localhost:5001/fir-dumpster/us-central1/httpToFirestoreFn
✔  functions: httpFn: http://localhost:5001/fir-dumpster/us-central1/httpFn
```

**firebase serve --only hosting --port 9000**
```
$ npx firebase serve --only hosting --port 9000

=== Serving from '/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.wuBSDpsc'...

i  hosting: Serving hosting files from: public
✔  hosting: Local server: http://localhost:9000
```

**firebase serve --only functions --port 9000**
```
$ npx firebase serve --only functions --port 9000

=== Serving from '/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.wuBSDpsc'...

i  functions: Preparing to emulate functions.
✔  functions: httpFn: http://localhost:9000/fir-dumpster/us-central1/httpFn
✔  functions: httpToFirestoreFn: http://localhost:9000/fir-dumpster/us-central1/httpToFirestoreFn
✔  functions: httpToDbFn: http://localhost:9000/fir-dumpster/us-central1/httpToDbFn
✔  functions: callableFn: http://localhost:9000/fir-dumpster/us-central1/callableFn
```

**firebase serve --port 9000**
```
$ npx firebase serve --port 9000

=== Serving from '/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.wuBSDpsc'...

i  functions: Preparing to emulate functions.
i  hosting: Serving hosting files from: public
✔  hosting: Local server: http://localhost:9000
✔  functions: httpToFirestoreFn: http://localhost:9001/fir-dumpster/us-central1/httpToFirestoreFn
✔  functions: callableFn: http://localhost:9001/fir-dumpster/us-central1/callableFn
✔  functions: httpToDbFn: http://localhost:9001/fir-dumpster/us-central1/httpToDbFn
✔  functions: httpFn: http://localhost:9001/fir-dumpster/us-central1/httpFn
```