### PR TITLE
Properly set CORS headers for emulated functions

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Fixed issue with CORS rejecting some callable functions.

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -90,9 +90,16 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     hub.use((req, res, next) => {
       // Allow CORS to facilitate easier testing.
-      // Source: https://enable-cors.org/server_expressjCannot understand what targets to deploys.html
+      // Sources:
+      //  * https://enable-cors.org/server_expressjCannot understand what targets to deploys.html
+      //  * https://stackoverflow.com/a/37228330/324977
       res.header("Access-Control-Allow-Origin", "*");
-      res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+      res.header(
+        "Access-Control-Allow-Headers",
+        "Access-Control-Allow-Headers, Origin, X-Requested-With, Content-Type, Accept, Access-Control-Request-Method, Access-Control-Request-Headers"
+      );
+      res.header("Access-Control-Allow-Credentials", "true");
+      res.header("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS,POST,PUT");
 
       let data = "";
       req.on("data", (chunk: any) => {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -94,12 +94,11 @@ export class FunctionsEmulator implements EmulatorInstance {
       //  * https://enable-cors.org/server_expressjCannot understand what targets to deploys.html
       //  * https://stackoverflow.com/a/37228330/324977
       res.header("Access-Control-Allow-Origin", "*");
-      res.header(
-        "Access-Control-Allow-Headers",
-        "Access-Control-Allow-Headers, Origin, X-Requested-With, Content-Type, Accept, Access-Control-Request-Method, Access-Control-Request-Headers"
-      );
+
+      // For callable functions there are the default headers allowed.
+      res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
       res.header("Access-Control-Allow-Credentials", "true");
-      res.header("Access-Control-Allow-Methods", "GET,HEAD,OPTIONS,POST,PUT");
+      res.header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
 
       let data = "";
       req.on("data", (chunk: any) => {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -95,9 +95,11 @@ export class FunctionsEmulator implements EmulatorInstance {
       //  * https://stackoverflow.com/a/37228330/324977
       res.header("Access-Control-Allow-Origin", "*");
 
-      // For callable functions there are the default headers allowed.
-      res.header("Access-Control-Allow-Headers", "Content-Type, Authorization");
-      res.header("Access-Control-Allow-Credentials", "true");
+      // Callable functions send "Authorization" and "Content-Type".
+      res.header(
+        "Access-Control-Allow-Headers",
+        "Origin, X-Requested-With, Content-Type, Authorization, Accept"
+      );
       res.header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
 
       let data = "";


### PR DESCRIPTION
Fixes #1275 

The issue was that when authenticated, callable functions send an `Authorization` header which we were not accounting for.