### PR TITLE
Emulator fixes for #1281, #1279, and #1277 

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "@types/sinon-chai": "^3.2.2",
     "@types/supertest": "^2.0.6",
     "@types/tmp": "^0.1.0",
+    "@types/winston": "^2.4.4",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "coveralls": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "dependencies": {
     "JSONStream": "^1.2.1",
     "archiver": "^2.1.1",
+    "body-parser": "^1.19.0",
     "chokidar": "^2.1.5",
     "cjson": "^0.3.1",
     "cli-color": "^1.2.0",
@@ -103,6 +104,7 @@
     "winston": "^1.0.1"
   },
   "devDependencies": {
+    "@types/body-parser": "^1.17.0",
     "@types/chai": "^4.1.6",
     "@types/chai-as-promised": "^7.1.0",
     "@types/cli-color": "^0.3.29",

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -233,7 +233,8 @@ export class FunctionsEmulator implements EmulatorInstance {
     bundleTemplate: FunctionsRuntimeBundle,
     triggerId: string,
     nodeBinary: string,
-    proto?: any
+    proto?: any,
+    runtimeOpts?: InvokeRuntimeOpts
   ): FunctionsRuntimeInstance {
     const runtimeBundle: FunctionsRuntimeBundle = {
       ...bundleTemplate,
@@ -244,7 +245,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       triggerId,
     };
 
-    const runtime = InvokeRuntime(nodeBinary, runtimeBundle);
+    const runtime = InvokeRuntime(nodeBinary, runtimeBundle, runtimeOpts || {});
     runtime.events.on("log", FunctionsEmulator.handleRuntimeLog.bind(this));
     return runtime;
   }
@@ -527,10 +528,11 @@ You can probably fix this by running "npm install ${
   }
 }
 
+export interface InvokeRuntimeOpts { serializedTriggers?: string; env?: { [key: string]: string } }
 export function InvokeRuntime(
   nodeBinary: string,
   frb: FunctionsRuntimeBundle,
-  opts?: { serializedTriggers?: string; env?: { [key: string]: string } }
+  opts?: InvokeRuntimeOpts
 ): FunctionsRuntimeInstance {
   opts = opts || {};
 

--- a/src/emulator/functionsEmulatorUtils.ts
+++ b/src/emulator/functionsEmulatorUtils.ts
@@ -55,3 +55,10 @@ export function trimSlashes(str: string): string {
     .filter((c) => c)
     .join("/");
 }
+
+export function removePathSegments(path: string, count: number): string {
+  return trimSlashes(path)
+    .split("/")
+    .slice(count)
+    .join("/");
+}

--- a/src/test/emulators/fixtures.ts
+++ b/src/test/emulators/fixtures.ts
@@ -1,7 +1,16 @@
 import { findModuleRoot, FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 
+export const TIMEOUT_LONG = 10000;
+export const TIMEOUT_MED = 5000;
+
 const cwd = findModuleRoot("firebase-tools", __dirname);
 export const FunctionRuntimeBundles = {
+  template: {
+    ports: {},
+    cwd,
+    triggerId: "function_id",
+    projectId: "fake-project-id",
+  } as FunctionsRuntimeBundle,
   onCreate: {
     ports: {
       firestore: 8080,

--- a/src/test/emulators/fixtures.ts
+++ b/src/test/emulators/fixtures.ts
@@ -1,0 +1,109 @@
+import { findModuleRoot, FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
+
+const cwd = findModuleRoot("firebase-tools", __dirname);
+export const FunctionRuntimeBundles = {
+  onCreate: {
+    ports: {
+      firestore: 8080,
+    },
+    cwd,
+    proto: {
+      data: {
+        value: {
+          name: "projects/fake-project-id/databases/(default)/documents/test/test",
+          fields: {
+            when: {
+              timestampValue: "2019-04-15T16:55:48.150Z",
+            },
+          },
+          createTime: "2019-04-15T16:56:13.737Z",
+          updateTime: "2019-04-15T16:56:13.737Z",
+        },
+        updateMask: {},
+      },
+      context: {
+        eventId: "7ebfb089-f549-4e1f-8312-fe843efc8be7",
+        timestamp: "2019-04-15T16:56:13.737Z",
+        eventType: "providers/cloud.firestore/eventTypes/document.create",
+        resource: {
+          name: "projects/fake-project-id/databases/(default)/documents/test/test",
+          service: "firestore.googleapis.com",
+        },
+      },
+    },
+    triggerId: "function_id",
+    projectId: "fake-project-id",
+  } as FunctionsRuntimeBundle,
+  onWrite: {
+    ports: {
+      firestore: 8080,
+    },
+    cwd,
+    proto: {
+      data: {
+        value: {
+          name: "projects/fake-project-id/databases/(default)/documents/test/test",
+          fields: {
+            when: {
+              timestampValue: "2019-04-15T16:55:48.150Z",
+            },
+          },
+          createTime: "2019-04-15T16:56:13.737Z",
+          updateTime: "2019-04-15T16:56:13.737Z",
+        },
+        updateMask: {},
+      },
+      context: {
+        eventId: "7ebfb089-f549-4e1f-8312-fe843efc8be7",
+        timestamp: "2019-04-15T16:56:13.737Z",
+        eventType: "providers/cloud.firestore/eventTypes/document.write",
+        resource: {
+          name: "projects/fake-project-id/databases/(default)/documents/test/test",
+          service: "firestore.googleapis.com",
+        },
+      },
+    },
+    triggerId: "function_id",
+    projectId: "fake-project-id",
+  } as FunctionsRuntimeBundle,
+  onDelete: {
+    ports: {
+      firestore: 8080,
+    },
+    cwd,
+    proto: {
+      data: {
+        oldValue: {
+          name: "projects/fake-project-id/databases/(default)/documents/test/test",
+          fields: {
+            when: {
+              timestampValue: "2019-04-15T16:55:48.150Z",
+            },
+          },
+          createTime: "2019-04-15T16:56:13.737Z",
+          updateTime: "2019-04-15T16:56:13.737Z",
+        },
+        updateMask: {},
+      },
+      context: {
+        eventId: "7ebfb089-f549-4e1f-8312-fe843efc8be7",
+        timestamp: "2019-04-15T16:56:13.737Z",
+        eventType: "providers/cloud.firestore/eventTypes/document.delete",
+        resource: {
+          name: "projects/fake-project-id/databases/(default)/documents/test/test",
+          service: "firestore.googleapis.com",
+        },
+      },
+    },
+    triggerId: "function_id",
+    projectId: "fake-project-id",
+  } as FunctionsRuntimeBundle,
+  onRequest: {
+    ports: {
+      firestore: 8080,
+    },
+    cwd,
+    triggerId: "function_id",
+    projectId: "fake-project-id",
+  } as FunctionsRuntimeBundle,
+};

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { FunctionsEmulator, FunctionsRuntimeInstance } from "../../emulator/functionsEmulator";
 import * as supertest from "supertest";
-import { FunctionRuntimeBundles, TIMEOUT_MED } from "./fixtures";
+import { FunctionRuntimeBundles, TIMEOUT_LONG, TIMEOUT_MED } from "./fixtures";
 import * as logger from "../../logger";
 import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import * as express from "express";

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -50,7 +50,7 @@ describe("FunctionsEmulator-Hub", () => {
       .then((res) => {
         expect(res.body).to.deep.equal({ hello: "world" });
       });
-  }).timeout(TIMEOUT_MED);
+  }).timeout(TIMEOUT_LONG);
 
   it("should rewrite req.path to hide /:project_id/:trigger_id", async () => {
     UseFunctions(() => {
@@ -72,7 +72,7 @@ describe("FunctionsEmulator-Hub", () => {
       .then((res) => {
         expect(res.body.path).to.eq("/sub/route/a");
       });
-  }).timeout(TIMEOUT_MED);
+  }).timeout(TIMEOUT_LONG);
 
   it("should route request body", async () => {
     UseFunctions(() => {
@@ -95,7 +95,7 @@ describe("FunctionsEmulator-Hub", () => {
       .then((res) => {
         expect(res.body).to.deep.equal({ hello: "world" });
       });
-  }).timeout(TIMEOUT_MED);
+  }).timeout(TIMEOUT_LONG);
 
   it("should route query parameters", async () => {
     UseFunctions(() => {
@@ -117,5 +117,5 @@ describe("FunctionsEmulator-Hub", () => {
       .then((res) => {
         expect(res.body).to.deep.equal({ hello: "world" });
       });
-  }).timeout(TIMEOUT_MED);
+  }).timeout(TIMEOUT_LONG);
 });

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -6,12 +6,13 @@ import * as logger from "../../logger";
 import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import * as express from "express";
 
-// Uncomment this to enable --debug logging!
-// logger.add(require("winston").transports.Console, {
-//   level: "debug",
-//   showLevel: false,
-//   colorize: true,
-// });
+if ((process.env.DEBUG || "").toLowerCase().indexOf("spec") >= 0) {
+  logger.add(require("winston").transports.Console, {
+    level: "debug",
+    showLevel: false,
+    colorize: true,
+  });
+}
 
 const startFunctionRuntime = FunctionsEmulator.startFunctionRuntime;
 function UseFunctions(triggers: () => {}): void {

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -1,0 +1,8 @@
+import { FunctionsEmulator } from "../../emulator/functionsEmulator";
+import * as supertest from "supertest";
+
+describe.only("Hub", () => {
+  it("should route requests to /:project_id/:trigger_id to HTTPS Function", async () => {
+    supertest(FunctionsEmulator.createHubServer())
+  });
+});

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -7,6 +7,7 @@ import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import * as express from "express";
 
 if ((process.env.DEBUG || "").toLowerCase().indexOf("spec") >= 0) {
+  // tslint:disable-next-line:no-var-requires
   logger.add(require("winston").transports.Console, {
     level: "debug",
     showLevel: false,

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -1,8 +1,76 @@
-import { FunctionsEmulator } from "../../emulator/functionsEmulator";
+import { expect } from "chai";
+import { FunctionsEmulator, FunctionsRuntimeInstance } from "../../emulator/functionsEmulator";
 import * as supertest from "supertest";
+import { FunctionRuntimeBundles, TIMEOUT_MED } from "./fixtures";
+import * as logger from "../../logger";
+import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
+import * as express from "express";
 
-describe.only("Hub", () => {
+// Uncomment this to enable --debug logging!
+logger.add(require("winston").transports.Console, {
+  level: "debug",
+  showLevel: false,
+  colorize: true,
+});
+
+const startFunctionRuntime = FunctionsEmulator.startFunctionRuntime;
+function UseFunctions(triggers: () => {}): void {
+  const serializedTriggers = triggers.toString();
+
+  FunctionsEmulator.startFunctionRuntime = (
+    bundleTemplate: FunctionsRuntimeBundle,
+    triggerId: string,
+    nodeBinary: string,
+    proto?: any
+  ): FunctionsRuntimeInstance => {
+    return startFunctionRuntime(bundleTemplate, triggerId, nodeBinary, proto, {
+      serializedTriggers,
+    });
+  };
+}
+
+describe.only("FunctionsEmulator-Hub", () => {
   it("should route requests to /:project_id/:trigger_id to HTTPS Function", async () => {
-    supertest(FunctionsEmulator.createHubServer())
-  });
+    UseFunctions(() => {
+      require("firebase-admin").initializeApp();
+      return {
+        function_id: require("firebase-functions").https.onRequest(
+          (req: express.Request, res: express.Response) => {
+            res.json({ hello: "world" });
+          }
+        ),
+      };
+    });
+
+    await supertest(
+      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+    )
+      .get("/fake-project-id/us-central-1f/function_id")
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.deep.equal({ hello: "world" });
+      });
+  }).timeout(TIMEOUT_MED);
+
+  it("should rewrite req.path to hide /:project_id/:trigger_id", async () => {
+    UseFunctions(() => {
+      require("firebase-admin").initializeApp();
+      return {
+        function_id: require("firebase-functions").https.onRequest(
+          (req: express.Request, res: express.Response) => {
+            res.json({ path: req.path });
+          }
+        ),
+      };
+    });
+
+    await supertest(
+      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+    )
+      .get("/fake-project-id/us-central-1f/function_id/sub/route/a")
+      .expect(200)
+      .then((res) => {
+        expect(res.body.path).to.eq("/sub/route/a");
+      });
+  }).timeout(TIMEOUT_MED);
 });

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -9,7 +9,7 @@ import { request } from "http";
 import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import { Change } from "firebase-functions";
 import { DocumentSnapshot } from "firebase-functions/lib/providers/firestore";
-import { FunctionRuntimeBundles } from "./fixtures";
+import { FunctionRuntimeBundles, TIMEOUT_LONG, TIMEOUT_MED } from "./fixtures";
 
 async function _countLogEntries(
   runtime: FunctionsRuntimeInstance
@@ -42,9 +42,6 @@ function _is_verbose(runtime: FunctionsRuntimeInstance): void {
     process.stdout.write(el.toPrettyString() + "\n");
   });
 }
-
-const TIMEOUT_LONG = 10000;
-const TIMEOUT_MED = 5000;
 
 describe("FunctionsEmulator-Runtime", () => {
   describe("Stubs, Mocks, and Helpers (aka Magic, Glee, and Awesomeness)", () => {

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -428,13 +428,12 @@ describe("FunctionsEmulatorRuntime", () => {
 
   describe("Runtime", () => {
     describe("HTTPS", () => {
-      it("should handle a single invocation", async () => {
+      it("should handle a GET request", async () => {
         const serializedTriggers = (() => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
               async (req: any, res: any) => {
-                /* tslint:disable:no-console */
                 res.json({ from_trigger: true });
               }
             ),
@@ -462,6 +461,191 @@ describe("FunctionsEmulatorRuntime", () => {
               });
             }
           ).end();
+        });
+
+        await runtime.exit;
+      }).timeout(TIMEOUT_MED);
+
+      it("should handle a POST request with form data", async () => {
+        const serializedTriggers = (() => {
+          require("firebase-admin").initializeApp();
+          return {
+            function_id: require("firebase-functions").https.onRequest(
+              async (req: any, res: any) => {
+                res.json(req.body);
+              }
+            ),
+          };
+        }).toString();
+
+        const runtime = InvokeRuntime(process.execPath, FunctionRuntimeBundles.onRequest, {
+          serializedTriggers,
+        });
+
+        await runtime.ready;
+
+        await new Promise((resolve) => {
+          const reqData = "name=sparky";
+          const req = request(
+            {
+              socketPath: runtime.metadata.socketPath,
+              path: "/",
+              method: "post",
+              headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Content-Length": reqData.length,
+              },
+            },
+            (res) => {
+              let data = "";
+              res.on("data", (chunk) => (data += chunk));
+              res.on("end", () => {
+                expect(JSON.parse(data)).to.deep.equal({ name: "sparky" });
+                resolve();
+              });
+            }
+          );
+          req.write(reqData);
+          req.end();
+        });
+
+        await runtime.exit;
+      }).timeout(TIMEOUT_MED);
+
+      it("should handle a POST request with JSON data", async () => {
+        const serializedTriggers = (() => {
+          require("firebase-admin").initializeApp();
+          return {
+            function_id: require("firebase-functions").https.onRequest(
+              async (req: any, res: any) => {
+                res.json(req.body);
+              }
+            ),
+          };
+        }).toString();
+
+        const runtime = InvokeRuntime(process.execPath, FunctionRuntimeBundles.onRequest, {
+          serializedTriggers,
+        });
+
+        await runtime.ready;
+
+        await new Promise((resolve) => {
+          const reqData = '{"name": "sparky"}';
+          const req = request(
+            {
+              socketPath: runtime.metadata.socketPath,
+              path: "/",
+              method: "post",
+              headers: {
+                "Content-Type": "application/json",
+                "Content-Length": reqData.length,
+              },
+            },
+            (res) => {
+              let data = "";
+              res.on("data", (chunk) => (data += chunk));
+              res.on("end", () => {
+                expect(JSON.parse(data)).to.deep.equal({ name: "sparky" });
+                resolve();
+              });
+            }
+          );
+          req.write(reqData);
+          req.end();
+        });
+
+        await runtime.exit;
+      }).timeout(TIMEOUT_MED);
+
+      it("should handle a POST request with text data", async () => {
+        const serializedTriggers = (() => {
+          require("firebase-admin").initializeApp();
+          return {
+            function_id: require("firebase-functions").https.onRequest(
+              async (req: any, res: any) => {
+                res.json(req.body);
+              }
+            ),
+          };
+        }).toString();
+
+        const runtime = InvokeRuntime(process.execPath, FunctionRuntimeBundles.onRequest, {
+          serializedTriggers,
+        });
+
+        await runtime.ready;
+
+        await new Promise((resolve) => {
+          const reqData = "name is sparky";
+          const req = request(
+            {
+              socketPath: runtime.metadata.socketPath,
+              path: "/",
+              method: "post",
+              headers: {
+                "Content-Type": "text/plain",
+                "Content-Length": reqData.length,
+              },
+            },
+            (res) => {
+              let data = "";
+              res.on("data", (chunk) => (data += chunk));
+              res.on("end", () => {
+                expect(JSON.parse(data)).to.deep.equal("name is sparky");
+                resolve();
+              });
+            }
+          );
+          req.write(reqData);
+          req.end();
+        });
+
+        await runtime.exit;
+      }).timeout(TIMEOUT_MED);
+
+      it("should handle a POST request with any other type", async () => {
+        const serializedTriggers = (() => {
+          require("firebase-admin").initializeApp();
+          return {
+            function_id: require("firebase-functions").https.onRequest(
+              async (req: any, res: any) => {
+                res.json(req.body);
+              }
+            ),
+          };
+        }).toString();
+
+        const runtime = InvokeRuntime(process.execPath, FunctionRuntimeBundles.onRequest, {
+          serializedTriggers,
+        });
+
+        await runtime.ready;
+
+        await new Promise((resolve) => {
+          const reqData = "name is sparky";
+          const req = request(
+            {
+              socketPath: runtime.metadata.socketPath,
+              path: "/",
+              method: "post",
+              headers: {
+                "Content-Type": "gibber/ish",
+                "Content-Length": reqData.length,
+              },
+            },
+            (res) => {
+              let data = "";
+              res.on("data", (chunk) => (data += chunk));
+              res.on("end", () => {
+                expect(JSON.parse(data).type).to.deep.equal("Buffer");
+                expect(JSON.parse(data).data.length).to.deep.equal(14);
+                resolve();
+              });
+            }
+          );
+          req.write(reqData);
+          req.end();
         });
 
         await runtime.exit;

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -5,6 +5,7 @@ import { request } from "http";
 import { findModuleRoot, FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import { Change } from "firebase-functions";
 import { DocumentSnapshot } from "firebase-functions/lib/providers/firestore";
+import * as supertest from "supertest";
 const cwd = findModuleRoot("firebase-tools", __dirname);
 
 const FunctionRuntimeBundles = {
@@ -423,6 +424,12 @@ describe("FunctionsEmulatorRuntime", () => {
         const logs = await _countLogEntries(runtime);
         expect(logs["functions-config-missing-value"]).to.eq(2);
       }).timeout(TIMEOUT_MED);
+    });
+  });
+
+  describe("Hub", () => {
+    it("should route requests to /:project_id/:trigger_id to HTTPS Function", async () => {
+      // supertest()
     });
   });
 

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -2,118 +2,10 @@ import { expect } from "chai";
 import { FunctionsRuntimeInstance, InvokeRuntime } from "../../emulator/functionsEmulator";
 import { EmulatorLog } from "../../emulator/types";
 import { request } from "http";
-import { findModuleRoot, FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
+import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import { Change } from "firebase-functions";
 import { DocumentSnapshot } from "firebase-functions/lib/providers/firestore";
-import * as supertest from "supertest";
-const cwd = findModuleRoot("firebase-tools", __dirname);
-
-const FunctionRuntimeBundles = {
-  onCreate: {
-    ports: {
-      firestore: 8080,
-    },
-    cwd,
-    proto: {
-      data: {
-        value: {
-          name: "projects/fake-project-id/databases/(default)/documents/test/test",
-          fields: {
-            when: {
-              timestampValue: "2019-04-15T16:55:48.150Z",
-            },
-          },
-          createTime: "2019-04-15T16:56:13.737Z",
-          updateTime: "2019-04-15T16:56:13.737Z",
-        },
-        updateMask: {},
-      },
-      context: {
-        eventId: "7ebfb089-f549-4e1f-8312-fe843efc8be7",
-        timestamp: "2019-04-15T16:56:13.737Z",
-        eventType: "providers/cloud.firestore/eventTypes/document.create",
-        resource: {
-          name: "projects/fake-project-id/databases/(default)/documents/test/test",
-          service: "firestore.googleapis.com",
-        },
-      },
-    },
-    triggerId: "function_id",
-    projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-  onWrite: {
-    ports: {
-      firestore: 8080,
-    },
-    cwd,
-    proto: {
-      data: {
-        value: {
-          name: "projects/fake-project-id/databases/(default)/documents/test/test",
-          fields: {
-            when: {
-              timestampValue: "2019-04-15T16:55:48.150Z",
-            },
-          },
-          createTime: "2019-04-15T16:56:13.737Z",
-          updateTime: "2019-04-15T16:56:13.737Z",
-        },
-        updateMask: {},
-      },
-      context: {
-        eventId: "7ebfb089-f549-4e1f-8312-fe843efc8be7",
-        timestamp: "2019-04-15T16:56:13.737Z",
-        eventType: "providers/cloud.firestore/eventTypes/document.write",
-        resource: {
-          name: "projects/fake-project-id/databases/(default)/documents/test/test",
-          service: "firestore.googleapis.com",
-        },
-      },
-    },
-    triggerId: "function_id",
-    projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-  onDelete: {
-    ports: {
-      firestore: 8080,
-    },
-    cwd,
-    proto: {
-      data: {
-        oldValue: {
-          name: "projects/fake-project-id/databases/(default)/documents/test/test",
-          fields: {
-            when: {
-              timestampValue: "2019-04-15T16:55:48.150Z",
-            },
-          },
-          createTime: "2019-04-15T16:56:13.737Z",
-          updateTime: "2019-04-15T16:56:13.737Z",
-        },
-        updateMask: {},
-      },
-      context: {
-        eventId: "7ebfb089-f549-4e1f-8312-fe843efc8be7",
-        timestamp: "2019-04-15T16:56:13.737Z",
-        eventType: "providers/cloud.firestore/eventTypes/document.delete",
-        resource: {
-          name: "projects/fake-project-id/databases/(default)/documents/test/test",
-          service: "firestore.googleapis.com",
-        },
-      },
-    },
-    triggerId: "function_id",
-    projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-  onRequest: {
-    ports: {
-      firestore: 8080,
-    },
-    cwd,
-    triggerId: "function_id",
-    projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-};
+import { FunctionRuntimeBundles } from "./fixtures";
 
 async function _countLogEntries(
   runtime: FunctionsRuntimeInstance
@@ -424,12 +316,6 @@ describe("FunctionsEmulatorRuntime", () => {
         const logs = await _countLogEntries(runtime);
         expect(logs["functions-config-missing-value"]).to.eq(2);
       }).timeout(TIMEOUT_MED);
-    });
-  });
-
-  describe("Hub", () => {
-    it("should route requests to /:project_id/:trigger_id to HTTPS Function", async () => {
-      // supertest()
     });
   });
 

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -519,7 +519,6 @@ describe("FunctionsEmulator-Runtime", () => {
 
         await runtime.ready;
         await new Promise((resolve) => {
-          const reqData = "name is sparky";
           const req = request(
             {
               socketPath: runtime.metadata.socketPath,
@@ -535,7 +534,6 @@ describe("FunctionsEmulator-Runtime", () => {
               });
             }
           );
-          req.write(reqData);
           req.end();
         });
 


### PR DESCRIPTION
In this I've done some work to clean up some of our tests and I've refactored `FunctionsEmulator` to use more static methods so it's easier to stub out calls for testing. 

We also see an introduction of tests for the core emulator "hub" which routes the requests.