### PR TITLE
Firestore emulator warns when rules file not found

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,3 +6,4 @@ fixed - Functions emulator fails to provide correct req.path
 fixed - Functions emulator fails on various malformed body requests
 fixed - Fixed race condition where downloading emulators would sometimes resolve too early and fail.
 fixed - Fixed a number of issues that broke functions:shell.
+fixed - Fixed an issue where Firestore emulator would not start if rules file can't be found.

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -3,7 +3,7 @@ import { EmulatorInfo, EmulatorInstance, Emulators } from "../emulator/types";
 import { EmulatorRegistry } from "./registry";
 import { Constants } from "./constants";
 
-interface FirestoreEmulatorArgs {
+export interface FirestoreEmulatorArgs {
   port?: number;
   host?: string;
   rules?: string;


### PR DESCRIPTION
Fixes #1254

Here is the new behavior:
```
$ npx firebase emulators:start --only firestore
i  Starting emulators: ["firestore"]
⚠  Firestore rules file /tmp/tmp.a0CHDMOoRn/firestore.rules specified in firebase.json does not exist, starting Firestore emulator without rules.
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIREBASE_FIRESTORE_EMULATOR_ADDRESS=localhost:8080
```
