### PR TITLE
Automatic emulator firebase-admin initialization, fixes #1278

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ fixed - Functions emulator fails to route HTTPS functions to user-provided Expre
 fixed - Functions emulator fails to provide correct req.path
 fixed - Functions emulator fails on various malformed body requests
 fixed - Functions emulator fails on Windows with EACCESS error
+fixed - Functions emulator can now automatically initialize "firebase-admin" for simple use-cases.
 fixed - Fixed race condition where downloading emulators would sometimes resolve too early and fail.
 fixed - Fixed a number of issues that broke functions:shell.
 fixed - Fixed an issue where Firestore emulator would not start if rules file can't be found.

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -306,7 +306,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         );
         break;
       case "default-admin-app-used":
-        EmulatorLogger.log("INFO", `Default "firebase-admin" instance created!`);
+        utils.logBullet(`Your code has been provided a "firebase-admin" instance.`);
         break;
       case "non-default-admin-app-used":
         EmulatorLogger.log(
@@ -358,10 +358,10 @@ You can probably fix this by running "npm install ${
           `The Cloud Functions directory you specified does not have a "package.json" file, so we can't load it.`
         );
         break;
-      case "admin-not-initialized":
-        utils.logWarning(
-          "The Firebase Admin module has not been initialized early enough. Make sure you run " +
-            '"admin.initializeApp()" outside of any function and at the top of your code'
+      case "admin-auto-initialized":
+        utils.logBullet(
+          "Your code does not appear to initialize the 'firebase-admin' module, so we've done it automatically.\n" +
+            "   - Learn more: https://firebase.google.com/docs/admin/setup"
         );
         break;
       default:

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -17,7 +17,6 @@ import * as path from "path";
 import * as admin from "firebase-admin";
 import * as bodyParser from "body-parser";
 import { EventUtils } from "./events/types";
-import * as fs from "fs";
 import { URL } from "url";
 
 let app: admin.app.App;
@@ -743,6 +742,7 @@ async function main(): Promise<void> {
   if (!app) {
     adminModuleProxy.initializeApp();
     new EmulatorLog("SYSTEM", "admin-auto-initialized", "").log();
+    throw new Error(JSON.stringify(frb.ports));
   }
 
   let seconds = 0;

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -537,12 +537,6 @@ async function ProcessHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
         res.on("finish", () => {
           instance.close();
           resolveEphemeralServer();
-
-          // If we're on a Unix platform, then the pipe is not cleaned up automatically so...
-          if (process.platform !== "win32") {
-            // We manually remove the pipe file
-            fs.unlinkSync(socketPath);
-          }
         });
 
         await RunHTTPS([req, res], func);
@@ -747,8 +741,8 @@ async function main(): Promise<void> {
   new EmulatorLog("DEBUG", "runtime-status", `Running ${frb.triggerId} in mode ${mode}`).log();
 
   if (!app) {
-    new EmulatorLog("SYSTEM", "admin-not-initialized", "").log();
-    return;
+    adminModuleProxy.initializeApp();
+    new EmulatorLog("SYSTEM", "admin-auto-initialized", "").log();
   }
 
   let seconds = 0;

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -742,7 +742,6 @@ async function main(): Promise<void> {
   if (!app) {
     adminModuleProxy.initializeApp();
     new EmulatorLog("SYSTEM", "admin-auto-initialized", "").log();
-    throw new Error(JSON.stringify(frb.ports));
   }
 
   let seconds = 0;

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -138,7 +138,11 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should auto-initialize admin when the app is not initialized by user code", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const onCreateCopy = JSON.parse(
+          JSON.stringify(FunctionRuntimeBundles.onRequest)
+        ) as FunctionsRuntimeBundle;
+        onCreateCopy.ports = {}; // Delete the ports so initialization doesn't try to connect to Firestore
+        const runtime = InvokeRuntimeWithFunctions(onCreateCopy, () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -137,7 +137,7 @@ describe("FunctionsEmulator-Runtime", () => {
         expect(logs["non-default-admin-app-used"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
-      it("should alert when the app is not initialized", async () => {
+      it("should auto-initialize admin when the app is not initialized by user code", async () => {
         const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           return {
             function_id: require("firebase-functions")
@@ -153,7 +153,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const logs = await _countLogEntries(runtime);
 
-        expect(logs["admin-not-initialized"]).to.eq(1);
+        expect(logs["admin-auto-initialized"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should route all sub-fields accordingly", async () => {

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -11,6 +11,7 @@ import { Change } from "firebase-functions";
 import { DocumentSnapshot } from "firebase-functions/lib/providers/firestore";
 import { FunctionRuntimeBundles, TIMEOUT_LONG, TIMEOUT_MED } from "./fixtures";
 import * as express from "express";
+import * as _ from "lodash";
 
 async function _countLogEntries(
   runtime: FunctionsRuntimeInstance

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -138,8 +138,8 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should auto-initialize admin when the app is not initialized by user code", async () => {
-        const onCreateCopy = JSON.parse(
-          JSON.stringify(FunctionRuntimeBundles.onRequest)
+        const onCreateCopy = _.cloneDeep(
+          FunctionRuntimeBundles.onRequest
         ) as FunctionsRuntimeBundle;
         onCreateCopy.ports = {}; // Delete the ports so initialization doesn't try to connect to Firestore
         const runtime = InvokeRuntimeWithFunctions(onCreateCopy, () => {
@@ -187,8 +187,8 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should redirect Firestore write to emulator", async () => {
-        const onRequestCopy = JSON.parse(
-          JSON.stringify(FunctionRuntimeBundles.onRequest)
+        const onRequestCopy = _.cloneDeep(
+          FunctionRuntimeBundles.onRequest
         ) as FunctionsRuntimeBundle;
 
         // Set the port to something crazy to avoid conflict with live emulator


### PR DESCRIPTION
A small change which enables the emulator to automatically initialize `firebase-admin` for the most basic use cases.