### PR TITLE
Fix HTTP routing issues

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
 * Fixed bug in Firestore emulator where some FieldTransforms were sending back incorrect results.
 * Fixed bug where read-only transactions would cause errors in the Firestore emulator.
 * Fixed bug where collection group query listeners would cause errors in the Firestore emulator.
+* Fixed bug where query parameters were not sent to HTTP functions.
+* Fixed bug where some HTTP methods (like DELETE) were not allowed.

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -27,7 +27,7 @@ import {
 import { EmulatorRegistry } from "./registry";
 import { EventEmitter } from "events";
 import * as stream from "stream";
-import { removePathSegments } from "./functionsEmulatorUtils";
+import { trimFunctionPath } from "./functionsEmulatorUtils";
 import { EmulatorLogger, Verbosity } from "./emulatorLogger";
 
 const EVENT_INVOKE = "functions:invoke";
@@ -176,15 +176,13 @@ export class FunctionsEmulator implements EmulatorInstance {
         `[functions] Runtime ready! Sending request! ${JSON.stringify(runtime.metadata)}`
       );
 
-      /*
-          We do this instead of just 302'ing because many HTTP clients don't respect 302s so it may cause unexpected
-          situations - not to mention CORS troubles and this enables us to use a socketPath (IPC socket) instead of
-          consuming yet another port which is probably faster as well.
-         */
+      // We do this instead of just 302'ing because many HTTP clients don't respect 302s so it may cause unexpected
+      // situations - not to mention CORS troubles and this enables us to use a socketPath (IPC socket) instead of
+      // consuming yet another port which is probably faster as well.
       const runtimeReq = http.request(
         {
           method,
-          path: "/" + removePathSegments(req.url, 3), // Remove the first 4 url paths like /X/X/X/a/b/c/
+          path: "/" + trimFunctionPath(req.url),
           headers: req.headers,
           socketPath: runtime.metadata.socketPath,
         },

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -244,9 +244,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     // need to be registered first otherwise the HTTP functions consume
     // all events.
     hub.post(backgroundFunctionRoute, backgroundHandler);
-    hub.post(httpsFunctionRoutes, httpsHandler);
-    hub.get(httpsFunctionRoutes, httpsHandler);
-
+    hub.all(httpsFunctionRoutes, httpsHandler);
     return hub;
   }
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -549,8 +549,7 @@ async function ProcessHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
     ephemeralServer.use(bodyParser.urlencoded({ extended: true }));
     ephemeralServer.use(bodyParser.raw({ type: "*/*" }));
 
-    ephemeralServer.get("/*", handler);
-    ephemeralServer.post("/*", handler);
+    ephemeralServer.all("/*", handler);
 
     const instance = ephemeralServer.listen(socketPath, () => {
       new EmulatorLog("SYSTEM", "runtime-status", "ready", { socketPath }).log();

--- a/src/emulator/functionsEmulatorUtils.ts
+++ b/src/emulator/functionsEmulatorUtils.ts
@@ -2,6 +2,10 @@
 Please be careful when adding require/imports to this file, it is pulled into functionsEmulatorRuntime
 which is ran in a separate node process, so it is likely to have unintended side-effects for you.
  */
+
+// Safe import because it's standard in Node
+import * as url from "url";
+
 const wildcardRegex = new RegExp("{[^/{}]*}");
 const wildcardKeyRegex = new RegExp("^{(.+)}$");
 
@@ -61,4 +65,14 @@ export function removePathSegments(path: string, count: number): string {
     .split("/")
     .slice(count)
     .join("/");
+}
+
+/**
+ * The full URL to an emulated function is /project/region/path(/subpath)?params but the function
+ * does not need to know about anything before the subpath.
+ */
+export function trimFunctionPath(path: string): string {
+  // Use the URL library to separate query params for later reconstruction.
+  const fakeURL = new url.URL(path, "https://example.com");
+  return removePathSegments(fakeURL.pathname, 3) + fakeURL.search;
 }

--- a/src/test/emulators/functionsEmulatorUtils.spec.ts
+++ b/src/test/emulators/functionsEmulatorUtils.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import {
   extractParamsFromPath,
   isValidWildcardMatch,
+  trimFunctionPath,
   trimSlashes,
 } from "../../emulator/functionsEmulatorUtils";
 
@@ -91,6 +92,26 @@ describe("FunctionsEmulatorUtils", () => {
     });
     it("should do both", () => {
       expect(trimSlashes("///a////b//c/")).to.equal("a/b/c");
+    });
+  });
+
+  describe("trimFunctionPath", () => {
+    it("should remove the beginning of a function URL", () => {
+      expect(trimFunctionPath("/projectid/us-central1/functionPath")).to.equal("");
+    });
+    it("should not care about leading slashes", () => {
+      expect(trimFunctionPath("projectid/us-central1/functionPath")).to.equal("");
+    });
+    it("should preserve query parameters", () => {
+      expect(trimFunctionPath("/projectid/us-central1/functionPath?foo=bar")).to.equal("?foo=bar");
+    });
+    it("should preserve subpaths", () => {
+      expect(trimFunctionPath("/projectid/us-central1/functionPath/x/y")).to.equal("x/y");
+    });
+    it("should preserve subpaths with query parameters", () => {
+      expect(trimFunctionPath("/projectid/us-central1/functionPath/x/y?foo=bar")).to.equal(
+        "x/y?foo=bar"
+      );
     });
   });
 });


### PR DESCRIPTION
Fixes #1325  (some HTTP methods blocked)
Fixes #1314 (query params lost)

Tested with this simple function:
```js
exports.httpFn = functions.https.onRequest((request, response) => {
    response.send({
        method: request.method,
        path: request.path, 
        query: request.query 
    });
});
```

Simple GET request
```bash
$ http -b GET http://localhost:5001/fir-dumpster/us-central1/httpFn
{
    "method": "GET",
    "path": "/",
    "query": {}
}
```

Simple DELETE request:
```bash
$ http -b DELETE http://localhost:5001/fir-dumpster/us-central1/httpFn
{
    "method": "DELETE",
    "path": "/",
    "query": {}
}
```

GET with query params:
```bash
$ http -b GET "http://localhost:5001/fir-dumpster/us-central1/httpFn?foo=bar&baz=qux"
{
    "method": "GET",
    "path": "/",
    "query": {
        "baz": "qux",
        "foo": "bar"
    }
}
```

GET with query params at subpath:
```bash
$ http -b GET "http://localhost:5001/fir-dumpster/us-central1/httpFn/subpath?foo=bar&baz=qux"
{
    "method": "GET",
    "path": "/subpath",
    "query": {
        "baz": "qux",
        "foo": "bar"
    }
}
```