### PR TITLE
Switches getFirebaseConfig to use new public api

### DIFF
--- a/src/functionsConfig.js
+++ b/src/functionsConfig.js
@@ -57,9 +57,9 @@ exports.getAppEngineLocation = function(config) {
 exports.getFirebaseConfig = function(options) {
   return getProjectNumber(options)
     .then(function(projectNumber) {
-      return api.request("GET", "/v1/projects/" + projectNumber + ":getServerAppConfig", {
+      return api.request("GET", "/v1beta1/projects/" + projectNumber + "/adminSdkConfig", {
         auth: true,
-        origin: api.firedataOrigin,
+        origin: api.firebaseApiOrigin,
       });
     })
     .then(function(response) {


### PR DESCRIPTION
### Description
Switches getFirebaseConfig to use the new public API instead of a private API, per b/133346721
### Scenarios Tested
Ran deploys before and after the change on a few different projects, and confirmed that the 2 apis return the same values.
