### PR TITLE
Allow runtime function to handle CORS

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,3 +3,4 @@
 * Fixed bug where collection group query listeners would cause errors in the Firestore emulator.
 * Fixed bug where query parameters were not sent to HTTP functions.
 * Fixed bug where some HTTP methods (like DELETE) were not allowed.
+* Fixed bug where CORS headers were too restrictive.

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -69,19 +69,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     const hub = express();
 
     hub.use((req, res, next) => {
-      // Allow CORS to facilitate easier testing.
-      // Sources:
-      //  * https://enable-cors.org/server_expressjCannot understand what targets to deploys.html
-      //  * https://stackoverflow.com/a/37228330/324977
-      res.header("Access-Control-Allow-Origin", "*");
-
-      // Callable functions send "Authorization" and "Content-Type".
-      res.header(
-        "Access-Control-Allow-Headers",
-        "Origin, X-Requested-With, Content-Type, Authorization, Accept"
-      );
-      res.header("Access-Control-Allow-Methods", "GET,OPTIONS,POST");
-
       let data = "";
       req.on("data", (chunk: any) => {
         data += chunk;


### PR DESCRIPTION
Fixes #1275 ONCE AND FOR ALL

https://www.youtube.com/watch?v=LpOIPb1_aCU

You can see here the functions SDK handles CORS itself:
https://github.com/firebase/firebase-functions/blob/9e3bda13565454543b4c7b2fd10fb627a6a3ab97/src/providers/https.ts#L419

So we just need to get out of the way.  Tested this using callable functions and it still works.