### PR TITLE
Inherit env and disable noop piping for emulators:exec.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,5 @@
 * Fixed bug where query parameters were not sent to HTTP functions.
 * Fixed bug where some HTTP methods (like DELETE) were not allowed.
 * Fixed bug where CORS headers were too restrictive.
+* Fixed bug where environment variables are unset for script in `emulators:exec`.
+* `emulators:exec` script now inherits stdout and stderr.

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -16,7 +16,7 @@ import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 async function runScript(script: string): Promise<void> {
   utils.logBullet(`Running script: ${clc.bold(script)}`);
 
-  const env: NodeJS.ProcessEnv = {...process.env};
+  const env: NodeJS.ProcessEnv = { ...process.env };
 
   const firestoreInstance = EmulatorRegistry.get(Emulators.FIRESTORE);
   if (firestoreInstance) {

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -16,7 +16,7 @@ import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 async function runScript(script: string): Promise<void> {
   utils.logBullet(`Running script: ${clc.bold(script)}`);
 
-  const env: NodeJS.ProcessEnv = {};
+  const env: NodeJS.ProcessEnv = {...process.env};
 
   const firestoreInstance = EmulatorRegistry.get(Emulators.FIRESTORE);
   if (firestoreInstance) {
@@ -26,21 +26,13 @@ async function runScript(script: string): Promise<void> {
   }
 
   const proc = childProcess.spawn(script, {
-    stdio: ["inherit", "pipe", "pipe"] as StdioOptions,
+    stdio: ["inherit", "inherit", "inherit"] as StdioOptions,
     shell: true,
     windowsHide: true,
     env,
   });
 
   logger.debug(`Running ${script} with environment ${JSON.stringify(env)}`);
-
-  proc.stdout.on("data", (data) => {
-    process.stdout.write(data.toString());
-  });
-
-  proc.stderr.on("data", (data) => {
-    process.stderr.write(data.toString());
-  });
 
   return new Promise((resolve, reject) => {
     proc.on("error", (err: any) => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This change makes the script of `firestore emulators:exec` inherit the environment variables (e.g. `PATH`). This should make sure `firestore emulators:exec "npm test"` always uses the local npm as expected.

It also disables piping of `stdout` and `stderr` since we're not changing them in anyway. As a nice side benefit, most CLI tools will now detect stdout as a terminal and turn on nice coloring, etc.

### Scenarios Tested

Manually: `firestore emulators:exec "env"` to make sure environment variables are inherited. (As opposed to before where it only has the firestore emulator env var.) Also, manually `firestore emulators:exec "which node"` now correctly shows my local nvm node.

Manually `firestore emulators:exec "npm test"` in `quickstart-nodejs/firestore-emulator/typescript-quickstart` to make sure mocha prints nice colored output, as opposed to no colors before.

