### PR TITLE
Modify functions emulator to invoke RTDB emulator triggers

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,4 @@
 * **BREAKING** The CLI no longer supports being run in Node 6 environments.
+* **BREAKING** RTDB Emulator comes up with open rules by default
+* Modify RTDB emulator to publish triggers to the functions emulator
+* Modify functions emulator to invoke RTDB emulator triggers

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -13,6 +13,7 @@ const DEFAULT_HOST = "localhost";
 
 export class Constants {
   static SERVICE_FIRESTORE = "firestore.googleapis.com";
+  static SERVICE_REALTIME_DATABASE = "firebaseio.com";
 
   static getDefaultHost(emulator: Emulators): string {
     return DEFAULT_HOST;

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -160,8 +160,8 @@ export async function startAll(options: any): Promise<void> {
       databaseEmulator = new DatabaseEmulator({
         host: databaseAddr.host,
         port: databaseAddr.port,
-        functionsEmulatorHost: functionsAddr.host,
-        functionsEmulatorPort: functionsAddr.port,
+        functions_emulator_host: functionsAddr.host,
+        functions_emulator_port: functionsAddr.port,
       });
     } else {
       databaseEmulator = new DatabaseEmulator({

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -154,17 +154,22 @@ export async function startAll(options: any): Promise<void> {
 
   if (targets.indexOf(Emulators.DATABASE) > -1) {
     const databaseAddr = Constants.getAddress(Emulators.DATABASE, options);
-    const databaseEmulator = new DatabaseEmulator({
-      host: databaseAddr.host,
-      port: databaseAddr.port,
-    });
+    let databaseEmulator;
+    if (targets.indexOf(Emulators.FUNCTIONS) > -1) {
+      const functionsAddr = Constants.getAddress(Emulators.FUNCTIONS, options);
+      databaseEmulator = new DatabaseEmulator({
+        host: databaseAddr.host,
+        port: databaseAddr.port,
+        functionsEmulatorHost: functionsAddr.host,
+        functionsEmulatorPort: functionsAddr.port,
+      });
+    } else {
+      databaseEmulator = new DatabaseEmulator({
+        host: databaseAddr.host,
+        port: databaseAddr.port,
+      });
+    }
     await startEmulator(databaseEmulator);
-
-    // TODO: When the database emulator is integrated with the Functions
-    //       emulator, we will need to pass the port in and remove this warning
-    utils.logWarning(
-      `Note: the database emulator is not currently integrated with the functions emulator.`
-    );
   }
 
   if (targets.indexOf(Emulators.HOSTING) > -1) {

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -5,6 +5,8 @@ import { Constants } from "./constants";
 interface DatabaseEmulatorArgs {
   port?: number;
   host?: string;
+  functionsEmulatorPort?: number;
+  functionsEmulatorHost?: string;
 }
 
 export class DatabaseEmulator implements EmulatorInstance {

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -5,8 +5,8 @@ import { Constants } from "./constants";
 interface DatabaseEmulatorArgs {
   port?: number;
   host?: string;
-  functionsEmulatorPort?: number;
-  functionsEmulatorHost?: string;
+  functions_emulator_port?: number;
+  functions_emulator_host?: string;
 }
 
 export class DatabaseEmulator implements EmulatorInstance {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -562,7 +562,7 @@ You can probably fix this by running "npm install ${
         name: `projects/${projectId}/locations/_/functions/${definition.name}`,
         path: result[1], // path stored in the first capture group
         event: definition.eventTrigger.eventType,
-        topic: `projects/${projectId}/topics/_`,
+        topic: `projects/${projectId}/topics/${definition.name}`,
       },
     ]);
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -32,6 +32,14 @@ import { EmulatorLogger, Verbosity } from "./emulatorLogger";
 
 const EVENT_INVOKE = "functions:invoke";
 
+/*
+ * The Realtime Database emulator expects the `path` field in its trigger
+ * definition to be relative to the database root. This regex is used to extract
+ * that path from the `resource` member in the trigger definition used by the
+ * functions emulator.
+ */
+const DATABASE_PATH_PATTERN = new RegExp("^projects/[^/]+/instances/[^/]+/refs(/.*)$");
+
 export interface FunctionsEmulatorArgs {
   port?: number;
   host?: string;
@@ -538,13 +546,8 @@ You can probably fix this by running "npm install ${
       );
       return Promise.reject();
     }
-    /*
-     * The Realtime Database emulator expects the `path` field in its trigger
-     * definition to be relative to the database root.
-     */
-    const pathPattern = new RegExp("^projects/[^/]*/instances/[^/]*/refs(/.*)$");
-    const result: string[] | null = pathPattern.exec(definition.eventTrigger.resource);
 
+    const result: string[] | null = DATABASE_PATH_PATTERN.exec(definition.eventTrigger.resource);
     if (result === null || result.length !== 2) {
       EmulatorLogger.log(
         "WARN",

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -521,11 +521,13 @@ You can probably fix this by running "npm install ${
     projectId: string,
     definition: EmulatedTriggerDefinition
   ): Promise<any> {
-    const databasePort = 9000; //EmulatorRegistry.getPort(Emulators.DATABASE);
+    const databasePort = EmulatorRegistry.getPort(Emulators.DATABASE);
     if (!databasePort) {
       EmulatorLogger.log(
         "INFO",
-        `Ignoring trigger "${definition.name}" because the Realtime Database emulator is not running`
+        `Ignoring trigger "${
+          definition.name
+        }" because the Realtime Database emulator is not running`
       );
       return Promise.resolve();
     }
@@ -536,12 +538,14 @@ You can probably fix this by running "npm install ${
       );
       return Promise.reject();
     }
-    const bundle = JSON.stringify([{
-      name: `projects/${projectId}/locations/_/functions/${definition.name}`,
-      path: definition.eventTrigger.resource.split("refs")[1],
-      event: definition.eventTrigger.eventType,
-      topic: `projects/${projectId}/topics/_`,
-    }]);
+    const bundle = JSON.stringify([
+      {
+        name: `projects/${projectId}/locations/_/functions/${definition.name}`,
+        path: definition.eventTrigger.resource.split("refs")[1],
+        event: definition.eventTrigger.eventType,
+        topic: `projects/${projectId}/topics/_`,
+      },
+    ]);
 
     EmulatorLogger.logLabeled(
       "BULLET",
@@ -550,12 +554,13 @@ You can probably fix this by running "npm install ${
     );
     logger.debug(`addDatabaseTrigger`, JSON.stringify(bundle));
     return new Promise((resolve, reject) => {
-      request.put(`http://localhost:${databasePort}/.settings/functionTriggers.json`,
+      request.put(
+        `http://localhost:${databasePort}/.settings/functionTriggers.json`,
         {
           auth: {
-            bearer: "owner"
+            bearer: "owner",
           },
-          body: bundle
+          body: bundle,
         },
         (err, res, body) => {
           if (err) {
@@ -565,7 +570,7 @@ You can probably fix this by running "npm install ${
           }
           resolve();
         }
-      )
+      );
     });
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -527,7 +527,7 @@ You can probably fix this by running "npm install ${
         "INFO",
         `Ignoring trigger "${
           definition.name
-        }" because the Realtime Database emulator is not running`
+        }" because the Realtime Database emulator is not running.`
       );
       return Promise.resolve();
     }
@@ -538,10 +538,26 @@ You can probably fix this by running "npm install ${
       );
       return Promise.reject();
     }
+    /*
+     * The Realtime Database emulator expects the `path` field in its trigger
+     * definition to be relative to the database root.
+     */
+    const pathPattern = new RegExp("^projects/[^/]*/instances/[^/]*/refs(/.*)$");
+    const result: string[] | null = pathPattern.exec(definition.eventTrigger.resource);
+
+    if (result === null || result.length !== 2) {
+      EmulatorLogger.log(
+        "WARN",
+        `Event trigger "${definition.name}" has malformed "resource" member. ` +
+          `${definition.eventTrigger.resource}`
+      );
+      return Promise.reject();
+    }
+
     const bundle = JSON.stringify([
       {
         name: `projects/${projectId}/locations/_/functions/${definition.name}`,
-        path: definition.eventTrigger.resource.split("refs")[1],
+        path: result[1], // path stored in the first capture group
         event: definition.eventTrigger.eventType,
         topic: `projects/${projectId}/topics/_`,
       },

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -25,10 +25,10 @@ const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
     stdout: null,
     cacheDir: CACHE_DIR,
     remoteUrl:
-      "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v3.5.0.jar",
-    expectedSize: 17013124,
-    expectedChecksum: "4bc8a67bc2a11d3e7ed226eda1b1a986",
-    localPath: path.join(CACHE_DIR, "firebase-database-emulator-v3.5.0.jar"),
+      "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.0.0.jar",
+    expectedSize: 17097803,
+    expectedChecksum: "102c8de422db81933a0f29fede5a80a0",
+    localPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.0.0.jar"),
   },
   firestore: {
     name: Emulators.FIRESTORE,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

This change is part of the effort to integrate the RTDB emulator with the functions emulator.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

I have tested starting up a local RTDB emulator and a functions emulator that registers a single function to be called `onWrite`. I then wrote to the corresponding location in the RTDB emulator an observed that the function is called.

