### PR TITLE
Modify use command to call new Public API when fetching projects

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,5 @@
 * Fixed bug where query parameters were not sent to HTTP functions.
 * Fixed bug where some HTTP methods (like DELETE) were not allowed.
 * Fixed bug where CORS headers were too restrictive.
+* Fixed bug where environment variables are unset for script in `emulators:exec`.
+* `emulators:exec` script now inherits stdout and stderr.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,3 +6,4 @@
 * Fixed bug where CORS headers were too restrictive.
 * Fixed bug where environment variables are unset for script in `emulators:exec`.
 * `emulators:exec` script now inherits stdout and stderr.
+* Improved reliability and performance of project listing for `firebase use` command.

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -16,7 +16,7 @@ import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 async function runScript(script: string): Promise<void> {
   utils.logBullet(`Running script: ${clc.bold(script)}`);
 
-  const env: NodeJS.ProcessEnv = {};
+  const env: NodeJS.ProcessEnv = { ...process.env };
 
   const firestoreInstance = EmulatorRegistry.get(Emulators.FIRESTORE);
   if (firestoreInstance) {
@@ -26,21 +26,13 @@ async function runScript(script: string): Promise<void> {
   }
 
   const proc = childProcess.spawn(script, {
-    stdio: ["inherit", "pipe", "pipe"] as StdioOptions,
+    stdio: ["inherit", "inherit", "inherit"] as StdioOptions,
     shell: true,
     windowsHide: true,
     env,
   });
 
   logger.debug(`Running ${script} with environment ${JSON.stringify(env)}`);
-
-  proc.stdout.on("data", (data) => {
-    process.stdout.write(data.toString());
-  });
-
-  proc.stderr.on("data", (data) => {
-    process.stderr.write(data.toString());
-  });
 
   return new Promise((resolve, reject) => {
     proc.on("error", (err: any) => {

--- a/src/commands/use.js
+++ b/src/commands/use.js
@@ -62,7 +62,7 @@ module.exports = new Command("use [alias_or_project_id]")
       const lookupProject = aliasedProject || newActive;
       return firebaseApi
         .getProject(lookupProject)
-        .then(function(foundProject) {
+        .then((foundProject) => {
           project = foundProject;
         })
         .catch(() => {

--- a/src/commands/use.js
+++ b/src/commands/use.js
@@ -3,18 +3,17 @@
 var Command = require("../command");
 var logger = require("../logger");
 var requireAuth = require("../requireAuth");
-var api = require("../api");
 var firebaseApi = require("../firebaseApi");
 var clc = require("cli-color");
 var utils = require("../utils");
 var _ = require("lodash");
 var prompt = require("../prompt");
 
-var listAliases = function (options) {
+var listAliases = function(options) {
   if (options.rc.hasProjects) {
     logger.info("Project aliases for", clc.bold(options.projectRoot) + ":");
     logger.info();
-    _.forEach(options.rc.projects, function (projectId, alias) {
+    _.forEach(options.rc.projects, function(projectId, alias) {
       var listing = alias + " (" + projectId + ")";
       if (options.project === projectId || options.projectAlias === alias) {
         logger.info(clc.cyan.bold("* " + listing));
@@ -27,7 +26,7 @@ var listAliases = function (options) {
   logger.info("Run", clc.bold("firebase use --add"), "to define a new project alias.");
 };
 
-var verifyMessage = function (name) {
+var verifyMessage = function(name) {
   return "please verify project " + clc.bold(name) + " exists and you have access.";
 };
 
@@ -38,7 +37,7 @@ module.exports = new Command("use [alias_or_project_id]")
   .option("--unalias <name>", "remove an already created project alias")
   .option("--clear", "clear the active project selection")
   .before(requireAuth)
-  .action(function (newActive, options) {
+  .action(function(newActive, options) {
     // HACK: Commander.js silently swallows an option called alias >_<
     var aliasOpt;
     var i = process.argv.indexOf("--alias");
@@ -50,16 +49,16 @@ module.exports = new Command("use [alias_or_project_id]")
       // not in project directory
       return utils.reject(
         clc.bold("firebase use") +
-        " must be run from a Firebase project directory.\n\nRun " +
-        clc.bold("firebase init") +
-        " to start a project directory in the current folder."
+          " must be run from a Firebase project directory.\n\nRun " +
+          clc.bold("firebase init") +
+          " to start a project directory in the current folder."
       );
     }
 
     if (newActive) {
       // firebase use [alias_or_project]
       var aliasedProject = options.rc.get(["projects", newActive]);
-      return firebaseApi.getProject(newActive).then(function (project) {
+      return firebaseApi.getProject(newActive).then(function(project) {
         if (aliasOpt) {
           // firebase use [project] --alias [alias]
           if (!project) {
@@ -105,13 +104,13 @@ module.exports = new Command("use [alias_or_project_id]")
       if (options.nonInteractive) {
         return utils.reject(
           "Cannot run " +
-          clc.bold("firebase use --add") +
-          " in non-interactive mode. Use " +
-          clc.bold("firebase use <project_id> --alias <alias>") +
-          " instead."
+            clc.bold("firebase use --add") +
+            " in non-interactive mode. Use " +
+            clc.bold("firebase use <project_id> --alias <alias>") +
+            " instead."
         );
       }
-      return firebaseApi.listProjects().then(function (projects) {
+      return firebaseApi.listProjects().then(function(projects) {
         var results = {};
 
         return prompt(results, [
@@ -119,17 +118,17 @@ module.exports = new Command("use [alias_or_project_id]")
             type: "list",
             name: "project",
             message: "Which project do you want to add?",
-            choices: projects.map(p => p.projectId).sort(),
+            choices: projects.map((p) => p.projectId).sort(),
           },
           {
             type: "input",
             name: "alias",
             message: "What alias do you want to use for this project? (e.g. staging)",
-            validate: function (input) {
+            validate: function(input) {
               return input && input.length > 0;
             },
           },
-        ]).then(function () {
+        ]).then(function() {
           options.rc.addProjectAlias(results.alias, results.project);
           utils.makeActiveProject(options.projectRoot, results.alias);
           logger.info();

--- a/src/commands/use.js
+++ b/src/commands/use.js
@@ -4,16 +4,17 @@ var Command = require("../command");
 var logger = require("../logger");
 var requireAuth = require("../requireAuth");
 var api = require("../api");
+var firebaseApi = require("../firebaseApi");
 var clc = require("cli-color");
 var utils = require("../utils");
 var _ = require("lodash");
 var prompt = require("../prompt");
 
-var listAliases = function(options) {
+var listAliases = function (options) {
   if (options.rc.hasProjects) {
     logger.info("Project aliases for", clc.bold(options.projectRoot) + ":");
     logger.info();
-    _.forEach(options.rc.projects, function(projectId, alias) {
+    _.forEach(options.rc.projects, function (projectId, alias) {
       var listing = alias + " (" + projectId + ")";
       if (options.project === projectId || options.projectAlias === alias) {
         logger.info(clc.cyan.bold("* " + listing));
@@ -26,7 +27,7 @@ var listAliases = function(options) {
   logger.info("Run", clc.bold("firebase use --add"), "to define a new project alias.");
 };
 
-var verifyMessage = function(name) {
+var verifyMessage = function (name) {
   return "please verify project " + clc.bold(name) + " exists and you have access.";
 };
 
@@ -37,7 +38,7 @@ module.exports = new Command("use [alias_or_project_id]")
   .option("--unalias <name>", "remove an already created project alias")
   .option("--clear", "clear the active project selection")
   .before(requireAuth)
-  .action(function(newActive, options) {
+  .action(function (newActive, options) {
     // HACK: Commander.js silently swallows an option called alias >_<
     var aliasOpt;
     var i = process.argv.indexOf("--alias");
@@ -49,19 +50,19 @@ module.exports = new Command("use [alias_or_project_id]")
       // not in project directory
       return utils.reject(
         clc.bold("firebase use") +
-          " must be run from a Firebase project directory.\n\nRun " +
-          clc.bold("firebase init") +
-          " to start a project directory in the current folder."
+        " must be run from a Firebase project directory.\n\nRun " +
+        clc.bold("firebase init") +
+        " to start a project directory in the current folder."
       );
     }
 
     if (newActive) {
       // firebase use [alias_or_project]
       var aliasedProject = options.rc.get(["projects", newActive]);
-      return api.getProjects().then(function(projects) {
+      return firebaseApi.getProject(newActive).then(function (project) {
         if (aliasOpt) {
           // firebase use [project] --alias [alias]
-          if (!projects[newActive]) {
+          if (!project) {
             return utils.reject(
               "Cannot create alias " + clc.bold(aliasOpt) + ", " + verifyMessage(newActive)
             );
@@ -73,7 +74,7 @@ module.exports = new Command("use [alias_or_project_id]")
 
         if (aliasedProject) {
           // found alias
-          if (!projects[aliasedProject]) {
+          if (!project) {
             // found alias, but not in project list
             return utils.reject(
               "Unable to use alias " + clc.bold(newActive) + ", " + verifyMessage(aliasedProject)
@@ -82,7 +83,7 @@ module.exports = new Command("use [alias_or_project_id]")
 
           utils.makeActiveProject(options.projectRoot, newActive);
           logger.info("Now using alias", clc.bold(newActive), "(" + aliasedProject + ")");
-        } else if (projects[newActive]) {
+        } else if (project) {
           // exact project id specified
           utils.makeActiveProject(options.projectRoot, newActive);
           logger.info("Now using project", clc.bold(newActive));
@@ -104,30 +105,31 @@ module.exports = new Command("use [alias_or_project_id]")
       if (options.nonInteractive) {
         return utils.reject(
           "Cannot run " +
-            clc.bold("firebase use --add") +
-            " in non-interactive mode. Use " +
-            clc.bold("firebase use <project_id> --alias <alias>") +
-            " instead."
+          clc.bold("firebase use --add") +
+          " in non-interactive mode. Use " +
+          clc.bold("firebase use <project_id> --alias <alias>") +
+          " instead."
         );
       }
-      return api.getProjects().then(function(projects) {
+      return firebaseApi.listProjects().then(function (projects) {
         var results = {};
+
         return prompt(results, [
           {
             type: "list",
             name: "project",
             message: "Which project do you want to add?",
-            choices: Object.keys(projects).sort(),
+            choices: projects.map(p => p.projectId).sort(),
           },
           {
             type: "input",
             name: "alias",
             message: "What alias do you want to use for this project? (e.g. staging)",
-            validate: function(input) {
+            validate: function (input) {
               return input && input.length > 0;
             },
           },
-        ]).then(function() {
+        ]).then(function () {
           options.rc.addProjectAlias(results.alias, results.project);
           utils.makeActiveProject(options.projectRoot, results.alias);
           logger.info();


### PR DESCRIPTION
### Description
Updating the code to switch over to the new Public API when calling the 'use' command. This change modifies two aspects of the code:
- When a user calls `firebase use project-name` this code will now try to fetch just the single project specificed by `project-name`. Prior to this change our code was grabbing all projects the user had access to and iterating through the list looking for `project-name`.
- The second change is to update the code when the user calls `firebase use --add` to use the new Public API to list the projects a user has access to. The code will now call the paged public API when displaying the list of users.
	 
### Scenarios Tested
`firebase use --add`
`firebase use valid-project`
`firebase use invalid-project`

### Sample Commands
`firebase use --add`
`firebase use project-name`
