### PR TITLE
Print error and exit early with Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "6"
   - "8"
   - "10"
 after_script:
@@ -9,7 +8,7 @@ jobs:
   include:
     - stage: hosting functional test
       if: repo == head_repo OR type == push
-      node_js: "6"
+      node_js: "8"
       before_script: ./scripts/decrypt-app-credentials.sh
       script: ./scripts/test-hosting.sh
       after_script: skip

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
+* **BREAKING** The CLI no longer suppport being run in Node 6 environments.
 * Fixed bug in Firestore emulator where some FieldTransforms were sending back incorrect results.
 * Fixed bug where read-only transactions would cause errors in the Firestore emulator.
 * Fixed bug where collection group query listeners would cause errors in the Firestore emulator.
@@ -6,4 +7,3 @@
 * Fixed bug where CORS headers were too restrictive.
 * Fixed bug where environment variables are unset for script in `emulators:exec`.
 * `emulators:exec` script now inherits stdout and stderr.
-* **BREAKING** The CLI no longer suppport being run in Node 6 environments.

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,3 +6,4 @@
 * Fixed bug where CORS headers were too restrictive.
 * Fixed bug where environment variables are unset for script in `emulators:exec`.
 * `emulators:exec` script now inherits stdout and stderr.
+* **BREAKING** The CLI no longer suppport being run in Node 6 environments.

--- a/package.json
+++ b/package.json
@@ -40,9 +40,8 @@
   ],
   "preferGlobal": true,
   "engines": {
-    "node": ">= 6.0.0"
+    "node": ">= 8.0.0"
   },
-  "engineStrict": true,
   "author": "Firebase (https://firebase.google.com/)",
   "license": "MIT",
   "bugs": {

--- a/src/bin/firebase.js
+++ b/src/bin/firebase.js
@@ -7,10 +7,11 @@ var pkg = require("../../package.json");
 var nodeVersion = process.version;
 if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
   console.error(
-    "Node " +
+    "Firebase CLI v" +
+      pkg.version +
+      " is incompatible with Node.js " +
       nodeVersion +
-      " is not supported to run the CLI." +
-      " Please upgrade Node to satisfy " +
+      " Please upgrade Node.js to version " +
       pkg.engines.node
   );
   process.exit(1);

--- a/src/bin/firebase.js
+++ b/src/bin/firebase.js
@@ -1,7 +1,21 @@
 #!/usr/bin/env node
 "use strict";
 
+// Make check for Node 6, which is no longer supported by the CLI.
+var semver = require("semver");
 var pkg = require("../../package.json");
+var nodeVersion = process.version;
+if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
+  console.error(
+    "Node " +
+      nodeVersion +
+      " is not supported to run the CLI." +
+      " Please upgrade Node to satisfy " +
+      pkg.engines.node
+  );
+  process.exit(1);
+}
+
 var updateNotifier = require("update-notifier")({ pkg: pkg });
 updateNotifier.notify({ defer: true, isGlobal: true });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Node 6 is end of life. To make it clear that the CLI does not support Node 6, we can print a nice error message and exit early.
	 
### Scenarios Tested

`npm link`'d the CLI in a Node 6 environment and witnessed the error showing up!

### Sample Commands

Any command run with the CLI in a Node 6 environment will print the error message:

![image](https://user-images.githubusercontent.com/160236/58649775-d972f700-82c1-11e9-9d87-8ad20f72be09.png)

