### PR TITLE
Fix deletes for numeric IDs

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,3 +6,4 @@
 * Fixed bug where CORS headers were too restrictive.
 * Fixed bug where environment variables are unset for script in `emulators:exec`.
 * `emulators:exec` script now inherits stdout and stderr.
+* Fixed bug where `firestore:delete` skips Datastore documents with numeric IDs.

--- a/src/firestore/delete.js
+++ b/src/firestore/delete.js
@@ -9,6 +9,11 @@ var FirebaseError = require("../error");
 var logger = require("../logger");
 var utils = require("../utils");
 
+// Datastore allowed numeric IDs where Firestore only allows strings. Numeric IDs are
+// exposed to Firestore as __idNUM__, so this is the lowest possible negative numeric
+// value expressed in that format.
+var MIN_ID = "__id-9223372036854775808__";
+
 /**
  * Construct a new Firestore delete operation.
  *
@@ -119,8 +124,8 @@ FirestoreDelete.prototype._collectionDescendantsQuery = function(
 ) {
   var nullChar = String.fromCharCode(0);
 
-  var startAt = this.parent + "/" + this.path + "/" + nullChar;
-  var endAt = this.parent + "/" + this.path + nullChar + "/" + nullChar;
+  var startAt = this.parent + "/" + this.path + "/" + MIN_ID;
+  var endAt = this.parent + "/" + this.path + nullChar + "/" + MIN_ID;
 
   var where = {
     compositeFilter: {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

See internal b/133879885
	 
### Scenarios Tested

#### Normal delete

I created 200 docs each with a subcollection of 5 docs:

```bash
$ npx firebase --project=fir-dumpster firestore:delete -r random
? You are about to delete all documents in the collection at random and all of their subcollections. Are you sure? Yes
Deleted 1200 docs (11321 docs/s)
```

This confirms that we didn't break the existing behavior. 

#### Numeric IDs

Created a collection with two of these special docs. 

Old CLI - Nothing happens
```
$ firebase --project=fir-dumpster firestore:delete -r NumericIds
? You are about to delete all documents in the collection at NumericIds and all of their subcollections. Are you sure? Yes
```

New CLI - Works
```
$ npx firebase --project=fir-dumpster firestore:delete -r NumericIds
? You are about to delete all documents in the collection at NumericIds and all of their subcollections. Are you sure? Yes
Deleted 2 docs (Infinity docs/s)
```

### Sample Commands

N/A