### PR TITLE
Remove prepublish script (and typo)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-* **BREAKING** The CLI no longer suppport being run in Node 6 environments.
+* **BREAKING** The CLI no longer support being run in Node 6 environments.
 * Fixed bug in Firestore emulator where some FieldTransforms were sending back incorrect results.
 * Fixed bug where read-only transactions would cause errors in the Firestore emulator.
 * Fixed bug where collection group query listeners would cause errors in the Firestore emulator.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-* **BREAKING** The CLI no longer support being run in Node 6 environments.
+* **BREAKING** The CLI no longer supports being run in Node 6 environments.
 * Fixed bug in Firestore emulator where some FieldTransforms were sending back incorrect results.
 * Fixed bug where read-only transactions would cause errors in the Firestore emulator.
 * Fixed bug where collection group query listeners would cause errors in the Firestore emulator.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "lint:js": "eslint 'src/**/*.js'",
     "lint:ts": "tslint --project tsconfig.json --config tslint.json",
     "mocha": "nyc mocha --opts mocha.opts",
-    "prepublish": "npm run clean && npm run build",
     "prepare": "npm run clean && npm run build",
     "test": "npm run lint && npm run mocha"
   },


### PR DESCRIPTION
`prepublish` is deprecated in `npm@5` - removing this reduces the number of times we compile in `link` or `publish` :)

also, I can't spell.