### PR TITLE
Add `force: true` when using firebase-tools as module

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ client.list().then(function(data) {
 client.deploy({
   project: 'myfirebase',
   token: process.env.FIREBASE_TOKEN,
+  force: true,
   cwd: '/path/to/project/folder'
 }).then(function() {
   console.log('Rules have been deployed!')


### PR DESCRIPTION
Add `force: true` to ensure that library usage of the CLI does not go into interactive mode. https://github.com/firebase/firebase-tools/issues/1031#issuecomment-441860984. Internal bug reference: 120046123.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description
Update README to provide correct usage of firebase-tools as module. 
	 
### Scenarios Tested
This was brought up and tested in https://github.com/firebase/firebase-tools/issues/1031
