### PR TITLE
FIX: hostname value on emulated rewrited function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,3 +9,4 @@
 * `emulators:exec` script now inherits stdout and stderr.
 * Improved reliability and performance of project listing for `firebase use` command.
 * Fixed bug where `firestore:delete` skips legacy documents with numeric IDs.
+* Fixed bug in Firestore emulator where it ignored `x-forwarded-host` header.

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -544,6 +544,7 @@ async function ProcessHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
       }
     };
 
+    ephemeralServer.enable("trust proxy");
     ephemeralServer.use(bodyParser.json({}));
     ephemeralServer.use(bodyParser.text({}));
     ephemeralServer.use(bodyParser.urlencoded({ extended: true }));


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

This PR fixes #1359 issue.

When running a function through a hosting rewrite the emulator behaves differently regarding the `req.hostname` value (ie`x-forwarded-host` header) from the deployed one.

The deployed function gets under `req.hostname` the original hostname (instead of the one the proxy used). In this case, the function uses the value under `x-forwarded-host` header to set the `req.hostname` value.

The emulator behaves differently. The emulated function ignores the `x-forwarded-host` header and you always get under `req.hostname` the value `localhost`.

This PR makes the emulator to be coherent with the deployed behavior. The `trust proxy` option is enabled, so the emulated function will use the value of the `x-forwarded-host` header to the set the `req.hostname` property. 

