### PR TITLE
Remove no-use-before-declare from tslint.json

### DIFF
--- a/templates/init/functions/typescript/tslint.json
+++ b/templates/init/functions/typescript/tslint.json
@@ -65,9 +65,6 @@
     // Disallow control flow statements, such as return, continue, break, and throw in finally blocks.
     "no-unsafe-finally": true,
 
-    // Do not allow variables to be used before they are declared.
-    "no-use-before-declare": true,
-
     // Expressions must always return a value. Avoids common errors like const myValue = functionReturningVoid();
     "no-void-expression": [true, "ignore-arrow-function-shorthand"],
 


### PR DESCRIPTION
no-use-before-declare is deprecated and triggers a warning when deploying to Firebase: "no-use-before-declare is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead."

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
