### PR TITLE
Support FIRESTORE_EMULATOR_HOST variable

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+* Set FIRESTORE_EMULATOR_HOST env var in "emulators:exec".

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -22,7 +22,9 @@ async function runScript(script: string): Promise<void> {
   if (firestoreInstance) {
     const info = firestoreInstance.getInfo();
     const hostString = `${info.host}:${info.port}`;
+
     env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV] = hostString;
+    env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV_ALT] = hostString;
   }
 
   const proc = childProcess.spawn(script, {

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -21,10 +21,10 @@ async function runScript(script: string): Promise<void> {
   const firestoreInstance = EmulatorRegistry.get(Emulators.FIRESTORE);
   if (firestoreInstance) {
     const info = firestoreInstance.getInfo();
-    const hostString = `${info.host}:${info.port}`;
+    const address = `${info.host}:${info.port}`;
 
-    env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV] = hostString;
-    env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV_ALT] = hostString;
+    env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV] = address;
+    env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV_ALT] = address;
   }
 
   const proc = childProcess.spawn(script, {

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -11,7 +11,8 @@ export interface FirestoreEmulatorArgs {
 }
 
 export class FirestoreEmulator implements EmulatorInstance {
-  static FIRESTORE_EMULATOR_ENV = "FIREBASE_FIRESTORE_EMULATOR_ADDRESS";
+  static FIRESTORE_EMULATOR_ENV = "FIRESTORE_EMULATOR_HOST";
+  static FIRESTORE_EMULATOR_ENV_ALT = "FIREBASE_FIRESTORE_EMULATOR_ADDRESS";
 
   constructor(private args: FirestoreEmulatorArgs) {}
 


### PR DESCRIPTION
The `@firebase/testing` SDK now supports both and all other SDKs now prefer `FIRESTORE_EMULATOR_HOST` so we should prefer that one (but still set both).