### PR TITLE
Functions Log: add better handling for unknown values

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+* Fixes bug in printing Function logs when the text payload was undefined.

--- a/src/commands/functions-log.ts
+++ b/src/commands/functions-log.ts
@@ -46,9 +46,9 @@ module.exports = new Command("functions:log")
         const entry = entries[i];
         logger.info(
           entry.timestamp,
-          entry.severity.substring(0, 1),
-          entry.resource.labels.function_name + ":",
-          entry.textPayload
+          _.get(entry, "severity", "?").substring(0, 1),
+          _.get(entry, "resource.labels.function_name") + ":",
+          _.get(entry, "textPayload", "")
         );
       }
       if (_.isEmpty(entries)) {


### PR DESCRIPTION
fixes #1343

### Description

It looks like sometimes the `textPayload` may have returned `undefined`, which caused `.substring` to fail. This adds slightly better handling with sensible fallbacks.

### Scenarios 

`firebase functions:log` continues to work and manually breaking things seemed to be handled okay.