### PR TITLE
Ensure we raise error when function code errors on load

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -347,16 +347,17 @@ You can probably fix this by running "npm install ${
         );
         break;
       case "function-code-resolution-failed":
-        const helper = ["Your code could not be loaded."];
-        if (systemLog.data.wrong_directory) {
+        EmulatorLogger.log("WARN", systemLog.data.error);
+        const helper = ["We were unable to load your functions code. (see above)"];
+        if (systemLog.data.isPotentially.wrong_directory) {
           helper.push(`   - There is no "package.json" file in your functions directory.`);
         }
-        if (systemLog.data.typescript) {
+        if (systemLog.data.isPotentially.typescript) {
           helper.push(
             "   - It appears your code is written in Typescript, which must be compiled before emulation."
           );
         }
-        if (systemLog.data.uncompiled) {
+        if (systemLog.data.isPotentially.uncompiled) {
           helper.push(
             `   - You may be able to run "npm run build" in your functions directory to resolve this.`
           );

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -678,7 +678,7 @@ async function RunHTTPS(
   This method attempts to help a developer whose code can't be loaded by suggesting
   possible fixes based on the files in their functions directory.
  */
-async function moduleResolutionDetective(frb: FunctionsRuntimeBundle): Promise<void> {
+async function moduleResolutionDetective(frb: FunctionsRuntimeBundle, error: Error): Promise<void> {
   /*
   These files could all potentially exist, if they don't then the value in the map will be
   falsey, so we just catch to keep from throwing.
@@ -698,7 +698,10 @@ async function moduleResolutionDetective(frb: FunctionsRuntimeBundle): Promise<v
   isPotentially.wrong_directory = !clues.packageJSON;
   isPotentially.uncompiled = !!_.get(clues.packageJSON, "scripts.build", false);
 
-  new EmulatorLog("SYSTEM", "function-code-resolution-failed", "", isPotentially).log();
+  new EmulatorLog("SYSTEM", "function-code-resolution-failed", "", {
+    isPotentially,
+    error: error.stack,
+  }).log();
 }
 
 async function main(): Promise<void> {
@@ -762,7 +765,7 @@ async function main(): Promise<void> {
     try {
       triggerModule = require(frb.cwd);
     } catch (err) {
-      await moduleResolutionDetective(frb);
+      await moduleResolutionDetective(frb, err);
       return;
     }
   }


### PR DESCRIPTION
Changes in my last PR resulted in unintentionally hiding user errors when the code can not be compiled. This fixes that.