### PR TITLE
Make emulators:exec exit with non-zero code when script fails

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -3,4 +3,4 @@
 * Fixes bug in Firestore emulator where property paths with special characters would cause errors due to ClassNotFound exceptions.
 * Fixes bug in Firestore emulator where auto-id allocation only worked once per collection.
 * Adds REST API to Firestore emulator for setting security rules.
-* Fixes bug where "emulators:exec" would succeed even if the script failed.
+* Fixes bug where `firebase emulators:exec` would succeed even if the script failed.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,3 +3,4 @@
 * Fixes bug in Firestore emulator where property paths with special characters would cause errors due to ClassNotFound exceptions.
 * Fixes bug in Firestore emulator where auto-id allocation only worked once per collection.
 * Adds REST API to Firestore emulator for setting security rules.
+* Fixes bug where "emulators:exec" would succeed even if the script failed.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1385

### Scenarios Tested

**Failing command**
```bash
$ npx firebase emulators:exec "exit 2" ; echo $?
i  Starting emulators: ["firestore"]
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  Running script: exit 2
⚠  Script exited unsuccessfully (code 2)
i  Shutting down emulators.
i  Stopping firestore emulator

Error: Script "exit 2" exited with code 2

Having trouble? Try again or contact support with contents of firebase-debug.log
2
```

**Successful command**
```bash
$ npx firebase emulators:exec "exit 0" ; echo $?
i  Starting emulators: ["firestore"]
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  Running script: exit 0
✔  Script exited successfully (code 0)
i  Shutting down emulators.
i  Stopping firestore emulator
0
```

### Sample Commands

N/A