### PR TITLE
Fix bug where location not set when .firebaserc exists

### DIFF
--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -1,6 +1,7 @@
 import * as clc from "cli-color";
 import * as _ from "lodash";
 
+import * as firebaseApi from "../../firebaseApi";
 import * as Config from "../../config";
 import * as FirebaseError from "../../error";
 import { FirebaseProject, getProject, listProjects } from "../../firebaseApi";
@@ -121,9 +122,14 @@ export async function doSetup(setup: any, config: Config, options: any): Promise
   logger.info(`but for now we'll just set up a default project.`);
   logger.info();
 
-  if (_.has(setup.rcfile, "projects.default")) {
-    utils.logBullet(`.firebaserc already has a default project, skipping`);
-    setup.projectId = _.get(setup.rcfile, "projects.default");
+  const projectFromRcFile = _.get(setup.rcfile, "projects.default");
+  if (projectFromRcFile) {
+    utils.logBullet(`.firebaserc already has a default project, using ${projectFromRcFile}.`);
+    // we still need to get project info in case user wants to init firestore or storage, which
+    // require a resource location:
+    const rcProject: FirebaseProject = await firebaseApi.getProject(projectFromRcFile);
+    setup.projectId = projectFromRcFile;
+    setup.projectLocation = _.get(rcProject, "resources.locationId");
     return;
   }
 

--- a/src/test/init/features/project.spec.ts
+++ b/src/test/init/features/project.spec.ts
@@ -141,5 +141,16 @@ describe("project", () => {
 
       expect(setup).to.deep.equal({ config: {}, rcfile: {}, project: {} });
     });
+
+    it("should set project location even if .firebaserc is already set up", async () => {
+      const options = {};
+      const setup = { config: {}, rcfile: { projects: { default: "my-project" } } };
+      getProjectStub.returns(TEST_FIREBASE_PROJECT);
+
+      await doSetup(setup, {}, options);
+
+      expect(_.get(setup, "projectId")).to.equal("my-project");
+      expect(_.get(setup, "projectLocation")).to.equal("us-central");
+    });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description
Fixes bug in deferred location for initializing firestore and storage when `.firebaserc` is present.

Previously, this would error out if you did two `firebase init`s in the same directory. Since the `.firebaserc` already existed, the setup skipped fetching resource location and so if you were initializing a feature that requires resource location (like storage or firestore) on the second init, it would incorrectly fail with "cloud resource location not set" error.
 
### Scenarios Tested
Two back to back inits in the same directory on a project that has cloud resource location:

```
firebase init --project <project_id> => // select any features
// select firestore or storage
firebase init --project <project_id> => // select feature requiring resource location and should still work
```

Additionally tested:
Init all features at once => works.
Init firestore and storage together => works
Init features not requiring resource location => works

Also tested all the following on a project without cloud resource location and saw expected results.

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
