### PR TITLE
Remove outdated warning about functions delay

### DIFF
--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -100,7 +100,6 @@ var deploy = function(targetNames, options) {
       utils.logSuccess(clc.underline.bold("Deploy complete!"));
       logger.info();
       var deployedHosting = _.includes(targetNames, "hosting");
-      var deployedFunctions = _.includes(targetNames, "functions");
       logger.info(clc.bold("Project Console:"), utils.consoleUrl(options.project, "/overview"));
       if (deployedHosting) {
         _.each(context.hosting.deploys, function(deploy) {

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -101,11 +101,6 @@ var deploy = function(targetNames, options) {
       logger.info();
       var deployedHosting = _.includes(targetNames, "hosting");
       var deployedFunctions = _.includes(targetNames, "functions");
-      if (deployedFunctions) {
-        logger.info(
-          "Please note that it can take up to 30 seconds for your updated functions to propagate."
-        );
-      }
       logger.info(clc.bold("Project Console:"), utils.consoleUrl(options.project, "/overview"));
       if (deployedHosting) {
         _.each(context.hosting.deploys, function(deploy) {


### PR DESCRIPTION
As far as I know, functions deploys are now actually done when the endpoint returns.