### PR TITLE
remove es6-set

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2378,18 +2378,6 @@
         "es6-promise": "^4.0.3"
       }
     },
-    "es6-set": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "requires": {
-        "d": "1",
-        "es5-ext": "~0.10.14",
-        "es6-iterator": "~2.0.1",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "~0.3.5"
-      }
-    },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "cross-spawn": "^4.0.0",
     "csv-streamify": "^3.0.4",
     "didyoumean": "^1.2.1",
-    "es6-set": "^0.1.4",
     "exit-code": "^1.0.2",
     "express": "^4.16.4",
     "filesize": "^3.1.3",

--- a/src/profileReport.js
+++ b/src/profileReport.js
@@ -2,7 +2,6 @@
 
 var clc = require("cli-color");
 var Table = require("cli-table");
-var Set = require("es6-set");
 var fs = require("fs");
 var _ = require("lodash");
 var readline = require("readline");


### PR DESCRIPTION
### Description

`es6-set` isn't needed since we have `Set` now.