### PR TITLE
Disable emulator features via CLI. Refs #595 and #1252

### DIFF
--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -18,6 +18,13 @@ module.exports = new Command("emulators:start")
       "Valid options are: " +
       JSON.stringify(controller.VALID_EMULATOR_STRINGS)
   )
+  .option(
+    "--disabled-features <list>",
+    "disable specific features. " +
+      "This is a comma separated list of functions features. " +
+      "Valid options are: " +
+      JSON.stringify(controller.VALID_FEATURE_STRINGS)
+  )
   .action(async (options: any) => {
     try {
       await controller.startAll(options);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -1,6 +1,7 @@
 import * as _ from "lodash";
 import * as clc from "cli-color";
 import * as fs from "fs";
+import * as path from "path";
 import * as pf from "portfinder";
 
 import * as utils from "../utils";
@@ -14,9 +15,10 @@ import { DatabaseEmulator } from "../emulator/databaseEmulator";
 import { FirestoreEmulator, FirestoreEmulatorArgs } from "../emulator/firestoreEmulator";
 import { HostingEmulator } from "../emulator/hostingEmulator";
 import * as FirebaseError from "../error";
-import * as path from "path";
+import { ALL_FEATURES } from "./functionsEmulatorShared";
 
 export const VALID_EMULATOR_STRINGS: string[] = ALL_EMULATORS;
+export const VALID_FEATURE_STRINGS: string[] = ALL_FEATURES;
 
 async function checkPortOpen(port: number): Promise<boolean> {
   try {
@@ -113,11 +115,17 @@ export async function startAll(options: any): Promise<void> {
     }
   }
 
+  const disabledRuntimeFeatures: any = {};
+  if (options.disabledFeatures) {
+    options.disabledFeatures.split(",").map((ft: string) => (disabledRuntimeFeatures[ft] = true));
+  }
+
   if (targets.indexOf(Emulators.FUNCTIONS) > -1) {
     const functionsAddr = Constants.getAddress(Emulators.FUNCTIONS, options);
     const functionsEmulator = new FunctionsEmulator(options, {
       host: functionsAddr.host,
       port: functionsAddr.port,
+      disabledRuntimeFeatures,
     });
     await startEmulator(functionsEmulator);
   }

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -49,6 +49,15 @@ export interface FunctionsRuntimeFeatures {
   admin_stubs?: boolean;
 }
 
+export const ALL_FEATURES = [
+  "functions_config_helper",
+  "network_filtering",
+  "timeout",
+  "memory_limiting",
+  "protect_env",
+  "admin_stubs",
+];
+
 const memoryLookup = {
   "128MB": 128,
   "256MB": 256,


### PR DESCRIPTION
### Description

Currently, there's no way to disable runtime features of the `FunctionsEmulator`, and the documentation mentions that you could set the `GOOGLE_APPLICATION_CREDENTIALS` env var, and run the `firebase emulators:start` command to allow the emulated functions to interact with the Google APIs or Firebase APIs, but that's not the case ATM because of the `protect_env` runtime feature, which needs to be disabled in order to work.

https://firebase.google.com/docs/functions/local-emulator#set_up_admin_credentials_optional
	 
### Scenarios Tested

I've used the resulting bundle of this PR in my local environment, with the latest npm packages for `firebase-functions` and `firebase-admin`, and I'm able to interact with the API successfully.

### Sample Commands

The new arg is properly documented in the help:
```
--disabled-features <list>  disable the specific features. This is a comma separated list of emulator features. Valid options are: ["functions_config_helper","network_filtering","timeout","memory_limiting","protect_env","admin_stubs"]
```
 and the documentation should be updated to use this command instead:
`firebase emulators:start --disabled-features protect_env`

### Note

`emulators:start` uses a different method to start the `FunctionsEmulator` than `serve`, as the last one disables all the runtime features to avoid conflicts with the legacy emulator, while the new one doesn't offer a way (setting or cli-arg) to disable them when it's required.