### PR TITLE
register rtdb triggers per-namespace in functions emulator

### DIFF
--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -14,6 +14,7 @@ const DEFAULT_HOST = "localhost";
 export class Constants {
   static SERVICE_FIRESTORE = "firestore.googleapis.com";
   static SERVICE_REALTIME_DATABASE = "firebaseio.com";
+  static DEFAULT_DATABASE_EMULATOR_NAMESPACE = "fake-server";
 
   static getDefaultHost(emulator: Emulators): string {
     return DEFAULT_HOST;

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -588,8 +588,19 @@ You can probably fix this by running "npm install ${
     );
     logger.debug(`addDatabaseTrigger`, JSON.stringify(bundle));
     return new Promise((resolve, reject) => {
+      let setTriggersPath = `http://localhost:${databasePort}/.settings/functionTriggers.json`;
+      if (projectId !== "") {
+        setTriggersPath += `?ns=${projectId}`;
+      } else {
+        EmulatorLogger.log(
+          "WARN",
+          `No project in use. Registering function trigger for sentinel namespace '${
+            Constants.DEFAULT_DATABASE_EMULATOR_NAMESPACE
+          }'`
+        );
+      }
       request.put(
-        `http://localhost:${databasePort}/.settings/functionTriggers.json`,
+        setTriggersPath,
         {
           auth: {
             bearer: "owner",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

In the original commit used to wire together the functions emulator with the database emulator, we did not register function triggers per-namespace. Without a namespace query paramter (`ns`), the RTDB emulator assumes the request is for a special fake sentinel namespace called 'fake-server'. This is confusing because developers may expect that the function emulator registers triggers with a namespace whose name matches the project id of their currently active firebase project.

In the current state of things, writes to a namespace whose name matches the active firebase project id would not trigger RTDB functions because those triggers are always registered with the sentinel namespace.
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

I tested triggering an RTDB function for a specified namespace, something like:

```
curl -X PUT -d '{"data": true}' http://localhost:9000/rtdbReact.json?ns=my-namespace
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
