### PR TITLE
Auto-download emulators through emulators:start

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,3 @@
 * Fixes a bug where the functions emulator did not work with `firebase-functions` versions `3.x.x`.
 * Make the Functions emulator automatically point to the RTDB emulator when running.
+* Auto-download Firestore and RTDB emulators when using `emulators:start`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,6 +230,7 @@
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
           "integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -319,7 +320,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "retry-request": {
           "version": "4.0.0",
@@ -399,7 +401,8 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-0.4.0.tgz",
       "integrity": "sha512-4yAHDC52TEMCNcMzVC8WlqnKKKq+Ssi2lXoUg9zWWkZ6U6tq9ZBRYLHHCRdfU+EU9YJsVmivwGcKYCjRGjnf4Q==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@google-cloud/storage": {
       "version": "2.5.0",
@@ -515,31 +518,36 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "dev": true,
+      "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -549,31 +557,36 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@sinonjs/commons": {
       "version": "1.4.0",
@@ -774,7 +787,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -940,6 +954,7 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -970,6 +985,7 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1263,7 +1279,8 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -2253,6 +2270,7 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
+      "optional": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -2347,13 +2365,15 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
+      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -2573,7 +2593,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "execa": {
       "version": "0.7.0",
@@ -2809,7 +2830,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
       "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -3193,7 +3215,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3211,11 +3234,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3228,15 +3253,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3339,7 +3367,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3349,6 +3378,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3361,17 +3391,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3388,6 +3421,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3460,7 +3494,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3470,6 +3505,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3545,7 +3581,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3575,6 +3612,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3592,6 +3630,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3630,11 +3669,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -3649,6 +3690,7 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.0.1.tgz",
       "integrity": "sha512-c1NXovTxkgRJTIgB2FrFmOFg4YIV6N/bAa4f/FZ4jIw13Ql9ya/82x69CswvotJhbV3DiGnlTZwoq2NVXk2Irg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -3710,6 +3752,7 @@
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
           "integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -3722,6 +3765,7 @@
               "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
               "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
               "dev": true,
+              "optional": true,
               "requires": {
                 "event-target-shim": "^5.0.0"
               }
@@ -3810,7 +3854,8 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
@@ -4071,7 +4116,8 @@
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
           "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
@@ -4275,6 +4321,7 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -4285,6 +4332,7 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
+          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4293,7 +4341,8 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -4799,6 +4848,7 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
       "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "bignumber.js": "^7.0.0"
       }
@@ -5141,7 +5191,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -5609,7 +5660,8 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node-forge": {
       "version": "0.7.6",
@@ -6200,6 +6252,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
       "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -6240,6 +6293,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6250,6 +6304,7 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
+      "optional": true,
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -6967,6 +7022,7 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "dev": true,
+      "optional": true,
       "requires": {
         "stubs": "^3.0.0"
       }
@@ -6975,7 +7031,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "streamsearch": {
       "version": "0.1.2",
@@ -7068,7 +7125,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "superagent": {
       "version": "3.8.3",
@@ -7287,6 +7345,7 @@
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-3.11.3.tgz",
       "integrity": "sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==",
       "dev": true,
+      "optional": true,
       "requires": {
         "https-proxy-agent": "^2.2.1",
         "node-fetch": "^2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -230,7 +230,6 @@
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
           "integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -320,8 +319,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "retry-request": {
           "version": "4.0.0",
@@ -401,8 +399,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-0.4.0.tgz",
       "integrity": "sha512-4yAHDC52TEMCNcMzVC8WlqnKKKq+Ssi2lXoUg9zWWkZ6U6tq9ZBRYLHHCRdfU+EU9YJsVmivwGcKYCjRGjnf4Q==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@google-cloud/storage": {
       "version": "2.5.0",
@@ -518,36 +515,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/codegen": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
       "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/eventemitter": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
       "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/fetch": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
       "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
       "dev": true,
-      "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.1",
         "@protobufjs/inquire": "^1.1.0"
@@ -557,36 +549,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/inquire": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
       "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@protobufjs/utf8": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@sinonjs/commons": {
       "version": "1.4.0",
@@ -787,8 +774,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.1",
@@ -822,6 +808,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.9.tgz",
       "integrity": "sha512-NelG/dSahlXYtSoVPErrp06tYFrvzj8XLWmKA+X8x0W//4MqbUyZu++giUG/v0bjAT6/Qxa8IjodrfdACyb0Fg==",
       "dev": true
+    },
+    "@types/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-bPOsfCZ4tsTlKiBjBhKnM8jpY5nmIll166IPD58D92hR7G7kZDfx5iB9wGF4NfZrdKolebjeAr3GouYkSGoJ/A==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -945,7 +940,6 @@
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "event-target-shim": "^5.0.0"
       }
@@ -976,7 +970,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
       "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "es6-promisify": "^5.0.0"
       }
@@ -1270,8 +1263,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "binary-extensions": {
       "version": "1.13.1",
@@ -2261,7 +2253,6 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "dev": true,
-      "optional": true,
       "requires": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -2356,15 +2347,13 @@
       "version": "4.2.8",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "es6-promisify": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
-      "optional": true,
       "requires": {
         "es6-promise": "^4.0.3"
       }
@@ -2584,8 +2573,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "execa": {
       "version": "0.7.0",
@@ -2821,8 +2809,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
       "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "fast-url-parser": {
       "version": "1.1.3",
@@ -3206,8 +3193,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3225,13 +3211,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3244,18 +3228,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3358,8 +3339,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3369,7 +3349,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3382,20 +3361,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3412,7 +3388,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3485,8 +3460,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3496,7 +3470,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3572,8 +3545,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3603,7 +3575,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3621,7 +3592,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3660,13 +3630,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },
@@ -3681,7 +3649,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.0.1.tgz",
       "integrity": "sha512-c1NXovTxkgRJTIgB2FrFmOFg4YIV6N/bAa4f/FZ4jIw13Ql9ya/82x69CswvotJhbV3DiGnlTZwoq2NVXk2Irg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -3743,7 +3710,6 @@
           "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-1.8.4.tgz",
           "integrity": "sha512-BoENMnu1Gav18HcpV9IleMPZ9exM+AvUjrAOV4Mzs/vfz2Lu/ABv451iEXByKiMPn2M140uul1txXCg83sAENw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "abort-controller": "^3.0.0",
             "extend": "^3.0.2",
@@ -3756,7 +3722,6 @@
               "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
               "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "event-target-shim": "^5.0.0"
               }
@@ -3845,8 +3810,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "write-file-atomic": {
           "version": "2.4.3",
@@ -4107,8 +4071,7 @@
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.1.1.tgz",
           "integrity": "sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
@@ -4312,7 +4275,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
       "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "agent-base": "^4.1.0",
         "debug": "^3.1.0"
@@ -4323,7 +4285,6 @@
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -4332,8 +4293,7 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -4839,7 +4799,6 @@
       "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
       "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
       "dev": true,
-      "optional": true,
       "requires": {
         "bignumber.js": "^7.0.0"
       }
@@ -5182,8 +5141,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
       "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -5651,8 +5609,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node-forge": {
       "version": "0.7.6",
@@ -6243,7 +6200,6 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
       "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -6284,7 +6240,6 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
       "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -6295,7 +6250,6 @@
       "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
       "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
-      "optional": true,
       "requires": {
         "duplexify": "^3.6.0",
         "inherits": "^2.0.3",
@@ -7013,7 +6967,6 @@
       "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "stubs": "^3.0.0"
       }
@@ -7022,8 +6975,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "streamsearch": {
       "version": "0.1.2",
@@ -7116,8 +7068,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "superagent": {
       "version": "3.8.3",
@@ -7336,7 +7287,6 @@
       "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-3.11.3.tgz",
       "integrity": "sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "https-proxy-agent": "^2.2.1",
         "node-fetch": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@types/mocha": "^5.2.5",
     "@types/nock": "^9.3.0",
     "@types/node": "^10.12.0",
+    "@types/progress": "^2.0.3",
     "@types/request": "^2.48.1",
     "@types/semver": "^6.0.0",
     "@types/sinon": "^5.0.5",

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -128,6 +128,7 @@ export async function startAll(options: any): Promise<void> {
     const args: FirestoreEmulatorArgs = {
       host: firestoreAddr.host,
       port: firestoreAddr.port,
+      auto_download: true,
     };
 
     const rules: string = path.join(options.projectRoot, options.config.get("firestore.rules"));
@@ -162,6 +163,7 @@ export async function startAll(options: any): Promise<void> {
         port: databaseAddr.port,
         functions_emulator_host: functionsAddr.host,
         functions_emulator_port: functionsAddr.port,
+        auto_download: true,
       });
     } else {
       databaseEmulator = new DatabaseEmulator({

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -7,6 +7,7 @@ interface DatabaseEmulatorArgs {
   host?: string;
   functions_emulator_port?: number;
   functions_emulator_host?: string;
+  auto_download?: boolean;
 }
 
 export class DatabaseEmulator implements EmulatorInstance {

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -1,5 +1,6 @@
 import * as crypto from "crypto";
 import * as request from "request";
+import * as ProgressBar from "progress";
 
 import * as FirebaseError from "../error";
 import * as utils from "../utils";
@@ -36,11 +37,24 @@ function downloadToTmp(remoteUrl: string): Promise<string> {
     const req = request.get(remoteUrl);
     const writeStream = fs.createWriteStream(tmpfile.name);
     req.on("error", (err: any) => reject(err));
+
+    let bar: ProgressBar;
+
     req.on("response", (response) => {
       if (response.statusCode !== 200) {
         reject(new FirebaseError(`download failed, status ${response.statusCode}`, { exit: 1 }));
       }
+
+      const total = parseInt(response.headers["content-length"] || "0", 10);
+      bar = new ProgressBar("Progress: :bar (:percent)", { total, head: ">" });
     });
+
+    req.on("data", (chunk) => {
+      if (bar) {
+        bar.tick(chunk.length);
+      }
+    });
+
     writeStream.on("finish", () => {
       resolve(tmpfile.name);
     });

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -46,7 +46,8 @@ function downloadToTmp(remoteUrl: string): Promise<string> {
       }
 
       const total = parseInt(response.headers["content-length"] || "0", 10);
-      bar = new ProgressBar("Progress: :bar (:percent)", { total, head: ">" });
+      const totalMb = Math.ceil(total / 1000000);
+      bar = new ProgressBar(`Progress: :bar (:percent of ${totalMb}MB)`, { total, head: ">" });
     });
 
     req.on("data", (chunk) => {

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -8,6 +8,7 @@ export interface FirestoreEmulatorArgs {
   host?: string;
   rules?: string;
   functions_emulator?: string;
+  auto_download?: boolean;
 }
 
 export class FirestoreEmulator implements EmulatorInstance {

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -55,6 +55,7 @@ export interface EmulatorInfo {
 export interface JavaEmulatorCommand {
   binary: string;
   args: string[];
+  optionalArgs: string[];
 }
 
 export interface JavaEmulatorDetails {

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -50,7 +50,14 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
   database: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.database.localPath],
-    optionalArgs: ["port", "host", "rules", "functions_emulator", "functions_emulator_port", "functions_emulator_host"],
+    optionalArgs: [
+      "port",
+      "host",
+      "rules",
+      "functions_emulator",
+      "functions_emulator_port",
+      "functions_emulator_host",
+    ],
   },
   firestore: {
     binary: "java",

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -54,7 +54,6 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
       "port",
       "host",
       "rules",
-      "functions_emulator",
       "functions_emulator_port",
       "functions_emulator_host",
     ],

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -11,6 +11,7 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
 
+// tslint:disable-next-line
 const downloadEmulator = require("../emulator/download");
 
 const EMULATOR_INSTANCE_KILL_TIMEOUT = 2000; /* ms */

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -50,12 +50,12 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
   database: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.database.localPath],
-    optionalArgs: ["port", "host", "rules", "functions_emulator"],
+    optionalArgs: ["port", "host", "rules", "functions_emulator", "functions_emulator_port", "functions_emulator_host"],
   },
   firestore: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.firestore.localPath],
-    optionalArgs: ["port", "host", "rules", "functions_emulator_port", "functions_emulator_host"],
+    optionalArgs: ["port", "host", "rules", "functions_emulator"],
   },
 };
 

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -185,7 +185,7 @@ export async function start(targetName: JavaEmulators, args: any): Promise<void>
       await downloadEmulator(targetName);
     } else {
       utils.logWarning("Setup required, please run: firebase setup:emulators:" + emulator.name);
-      return Promise.reject("emulator not found");
+      throw new FirebaseError("emulator not found");
     }
   }
 

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -11,6 +11,8 @@ import * as fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
 
+const downloadEmulator = require("../emulator/download");
+
 const EMULATOR_INSTANCE_KILL_TIMEOUT = 2000; /* ms */
 
 type JavaEmulators = Emulators.FIRESTORE | Emulators.DATABASE;
@@ -47,10 +49,12 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
   database: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.database.localPath],
+    optionalArgs: ["port", "host", "rules", "functions_emulator"],
   },
   firestore: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.firestore.localPath],
+    optionalArgs: ["port", "host", "rules", "functions_emulator_port", "functions_emulator_host"],
   },
 };
 
@@ -73,6 +77,11 @@ function _getCommand(emulator: JavaEmulators, args: { [s: string]: any }): JavaE
 
   const cmdLineArgs = baseCmd.args.slice();
   Object.keys(args).forEach((key) => {
+    if (baseCmd.optionalArgs.indexOf(key) < 0) {
+      logger.debug(`Ignoring unsupported arg: ${key}`);
+      return;
+    }
+
     const argKey = "--" + key;
     const argVal = args[key];
 
@@ -82,6 +91,7 @@ function _getCommand(emulator: JavaEmulators, args: { [s: string]: any }): JavaE
   return {
     binary: baseCmd.binary,
     args: cmdLineArgs,
+    optionalArgs: baseCmd.optionalArgs,
   };
 }
 
@@ -167,12 +177,18 @@ export async function stop(targetName: JavaEmulators): Promise<void> {
 
 export async function start(targetName: JavaEmulators, args: any): Promise<void> {
   const emulator = EmulatorDetails[targetName];
-  const command = _getCommand(targetName, args);
-  if (!fs.existsSync(emulator.localPath)) {
-    utils.logWarning("Setup required, please run: firebase setup:emulators:" + emulator.name);
-    return Promise.reject("emulator not found");
+
+  const hasEmulator = fs.existsSync(emulator.localPath);
+  if (!hasEmulator) {
+    if (args.auto_download) {
+      await downloadEmulator(targetName);
+    } else {
+      utils.logWarning("Setup required, please run: firebase setup:emulators:" + emulator.name);
+      return Promise.reject("emulator not found");
+    }
   }
 
+  const command = _getCommand(targetName, args);
   logger.debug(`Starting emulator ${targetName} with args ${JSON.stringify(args)}`);
   return _runBinary(emulator, command);
 }

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -50,13 +50,7 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
   database: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.database.localPath],
-    optionalArgs: [
-      "port",
-      "host",
-      "rules",
-      "functions_emulator_port",
-      "functions_emulator_host",
-    ],
+    optionalArgs: ["port", "host", "rules", "functions_emulator_port", "functions_emulator_host"],
   },
   firestore: {
     binary: "java",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Changes:
  * When using `emulators:start` the Java emulators will download if necessary.
  * Downloads now show a visual progress bar.
	 
### Scenarios Tested

**Before**
```bash
$ npx firebase-tools@7.0.0 emulators:start
i  Starting emulators: ["functions","firestore","database"]
✔  functions: Using node@8 from host.
✔  functions: Emulator started at http://localhost:5001
⚠  Setup required, please run: firebase setup:emulators:firestore
i  Shutting down emulators.
i  Stopping functions emulator

Error: An unexpected error has occurred.
```

**After**
```bash
$ npx firebase emulators:start
i  Starting emulators: ["functions","firestore","database"]
✔  functions: Using node@8 from host.
✔  functions: Emulator started at http://localhost:5001
i  firestore: downloading emulator...
Progress: ====================================================================> (100%)
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  database: downloading emulator...
Progress: ====================================================================> (100%)
i  database: Logging to database-debug.log
✔  database: Emulator started at http://localhost:9000
```

```bash
$ npx firebase serve --only database
⚠  Setup required, please run: firebase setup:emulators:database

Error: An unexpected error has occurred.
```

### Sample Commands

N/A
