### PR TITLE
Allow some emulators to start without config

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
 * Fixes a bug where the functions emulator did not work with `firebase-functions` versions `3.x.x`.
 * Make the Functions emulator automatically point to the RTDB emulator when running.
 * Fixes issue where the functions runtime would not always exit on success (#1346).
+* Allow running the Firestore and RTDB emulators without a configuration.

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -3,9 +3,6 @@ import { StdioOptions } from "child_process";
 import * as clc from "cli-color";
 
 import * as Command from "../command";
-import getProjectNumber = require("../getProjectNumber");
-import requireAuth = require("../requireAuth");
-import requireConfig = require("../requireConfig");
 import { Emulators } from "../emulator/types";
 import * as FirebaseError from "../error";
 import * as utils from "../utils";
@@ -13,6 +10,7 @@ import * as logger from "../logger";
 import * as controller from "../emulator/controller";
 import { EmulatorRegistry } from "../emulator/registry";
 import { FirestoreEmulator } from "../emulator/firestoreEmulator";
+import { beforeEmulatorCommand } from "../emulator/commandUtils";
 
 async function runScript(script: string): Promise<number> {
   utils.logBullet(`Running script: ${clc.bold(script)}`);
@@ -71,11 +69,7 @@ async function runScript(script: string): Promise<number> {
 }
 
 module.exports = new Command("emulators:exec <script>")
-  .before(async (options: any) => {
-    await requireConfig(options);
-    await requireAuth(options);
-    await getProjectNumber(options);
-  })
+  .before(beforeEmulatorCommand)
   .description(
     "start the local Firebase emulators, " + "run a test script, then shut down the emulators"
   )

--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -1,15 +1,9 @@
 import * as Command from "../command";
 import * as controller from "../emulator/controller";
-import getProjectNumber = require("../getProjectNumber");
-import requireAuth = require("../requireAuth");
-import requireConfig = require("../requireConfig");
+import { beforeEmulatorCommand } from "../emulator/commandUtils";
 
 module.exports = new Command("emulators:start")
-  .before(async (options: any) => {
-    await requireConfig(options);
-    await requireAuth(options);
-    await getProjectNumber(options);
-  })
+  .before(beforeEmulatorCommand)
   .description("start the local Firebase emulators")
   .option(
     "--only <list>",

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -12,7 +12,7 @@ import { Emulators } from "../emulator/types";
  */
 const DEFAULT_CONFIG = new Config({ database: {}, firestore: {}, functions: {}, hosting: {} }, {});
 
-export async function beforeEmulatorCommand(options: any) {
+export async function beforeEmulatorCommand(options: any): Promise<any> {
   const optionsWithDefaultConfig = {
     ...options,
     config: DEFAULT_CONFIG,

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -1,5 +1,6 @@
 import * as controller from "../emulator/controller";
 import * as Config from "../config";
+import * as utils from "../utils";
 import getProjectNumber = require("../getProjectNumber");
 import requireAuth = require("../requireAuth");
 import requireConfig = require("../requireConfig");
@@ -25,6 +26,7 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
     !controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
 
   if (canStartWithoutConfig && !options.config) {
+    utils.logWarning("Could not find config (firebase.json) so using defaults.");
     options.config = DEFAULT_CONFIG;
   } else {
     await requireConfig(options);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -84,6 +84,11 @@ export async function cleanShutdown(): Promise<boolean> {
   return true;
 }
 
+export function shouldStart(options: any, name: Emulators): boolean {
+  const targets: string[] = filterTargets(options, VALID_EMULATOR_STRINGS);
+  return targets.indexOf(name) >= 0;
+}
+
 export async function startAll(options: any): Promise<void> {
   // Emulators config is specified in firebase.json as:
   // "emulators": {
@@ -113,7 +118,7 @@ export async function startAll(options: any): Promise<void> {
     }
   }
 
-  if (targets.indexOf(Emulators.FUNCTIONS) > -1) {
+  if (shouldStart(options, Emulators.FUNCTIONS)) {
     const functionsAddr = Constants.getAddress(Emulators.FUNCTIONS, options);
     const functionsEmulator = new FunctionsEmulator(options, {
       host: functionsAddr.host,
@@ -122,7 +127,7 @@ export async function startAll(options: any): Promise<void> {
     await startEmulator(functionsEmulator);
   }
 
-  if (targets.indexOf(Emulators.FIRESTORE) > -1) {
+  if (shouldStart(options, Emulators.FIRESTORE)) {
     const firestoreAddr = Constants.getAddress(Emulators.FIRESTORE, options);
 
     const args: FirestoreEmulatorArgs = {
@@ -130,15 +135,18 @@ export async function startAll(options: any): Promise<void> {
       port: firestoreAddr.port,
     };
 
-    const rules: string = path.join(options.projectRoot, options.config.get("firestore.rules"));
-    if (fs.existsSync(rules)) {
-      args.rules = rules;
-    } else {
-      utils.logWarning(
-        `Firestore rules file ${clc.bold(
-          rules
-        )} specified in firebase.json does not exist, starting Firestore emulator without rules.`
-      );
+    const rulesLocalPath = options.config.get("firestore.rules");
+    if (rulesLocalPath) {
+      const rules: string = path.join(options.projectRoot, rulesLocalPath);
+      if (fs.existsSync(rules)) {
+        args.rules = rules;
+      } else {
+        utils.logWarning(
+          `Firestore rules file ${clc.bold(
+            rules
+          )} specified in firebase.json does not exist, starting Firestore emulator without rules.`
+        );
+      }
     }
 
     const firestoreEmulator = new FirestoreEmulator(args);
@@ -152,10 +160,10 @@ export async function startAll(options: any): Promise<void> {
     );
   }
 
-  if (targets.indexOf(Emulators.DATABASE) > -1) {
+  if (shouldStart(options, Emulators.DATABASE)) {
     const databaseAddr = Constants.getAddress(Emulators.DATABASE, options);
     let databaseEmulator;
-    if (targets.indexOf(Emulators.FUNCTIONS) > -1) {
+    if (shouldStart(options, Emulators.FUNCTIONS)) {
       const functionsAddr = Constants.getAddress(Emulators.FUNCTIONS, options);
       databaseEmulator = new DatabaseEmulator({
         host: databaseAddr.host,
@@ -172,7 +180,7 @@ export async function startAll(options: any): Promise<void> {
     await startEmulator(databaseEmulator);
   }
 
-  if (targets.indexOf(Emulators.HOSTING) > -1) {
+  if (shouldStart(options, Emulators.HOSTING)) {
     const hostingAddr = Constants.getAddress(Emulators.HOSTING, options);
     const hostingEmulator = new HostingEmulator({
       host: hostingAddr.host,

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -147,6 +147,8 @@ export async function startAll(options: any): Promise<void> {
           )} specified in firebase.json does not exist, starting Firestore emulator without rules.`
         );
       }
+    } else {
+      utils.logWarning(`No Firestore rules file specified in firebase.json, using default rules.`);
     }
 
     const firestoreEmulator = new FirestoreEmulator(args);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Right now if you don't have `firebase.json` you can't start any emulators through `emulators:start` or `emulators:exec`.  However with `firebase serve` this requirement is not as strict.

With this PR you can start Firestore or RTDB without a config.
	 
### Scenarios Tested

All of these tests are run in a directory without a `firebase.json` file.

**emulators:start**
```bash
$ npx firebase emulators:start

Error: Not in a Firebase app directory (could not locate firebase.json)
```

**emulators:start --only firestore**
```bash
$ npx firebase emulators:start --only firestore
i  Starting emulators: ["firestore"]
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
```

**emulators:start --only database**
```bash
$ npx firebase emulators:start --only database
i  Starting emulators: ["database"]
i  database: Logging to database-debug.log
✔  database: Emulator started at http://localhost:
```

**emulators:start --only firestore,database**
```bash
$ npx firebase emulators:start --only firestore,database
i  Starting emulators: ["firestore","database"]
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  database: Logging to database-debug.log
✔  database: Emulator started at http://localhost:9000
```

**emulators:start --only firestore,functions**
```bash
$ npx firebase emulators:start --only firestore,functions

Error: Not in a Firebase app directory (could not locate firebase.js
```

### Sample Commands

N/A
