### PR TITLE
Firestore Emulator v1.6.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,3 +2,4 @@
 * Make `functions:shell` respect the `--port` argument.
 * Improve error message when `firebase serve` can't acquire the right port.
 * Allow running the Firestore and RTDB emulators without a configuration.
+* Allow the Firestore emulator to give more information about invalid rulesets.

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -39,10 +39,10 @@ const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
     stdout: null,
     cacheDir: CACHE_DIR,
     remoteUrl:
-      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.5.0.jar",
-    expectedSize: 57204418,
-    expectedChecksum: "774fb006fc96ebbddb3a020dc0bfd324",
-    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.5.0.jar"),
+      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.6.0.jar",
+    expectedSize: 57397358,
+    expectedChecksum: "58e9360b2abac579b2451c36c0cce147",
+    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.6.0.jar"),
   },
 };
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Releasing emulator v1.6.0
	 
### Scenarios Tested

Test download:
```
$ npx firebase emulators:start --only firestore
⚠  Could not find config (firebase.json) so using defaults.
i  Starting emulators: ["firestore"]
⚠  No Firestore rules file specified in firebase.json, using default rules.
i  firestore: downloading emulator...
Progress: ============================================================> (100% of 58MB)
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
```

Test running the JAR:
```
$ java -jar ~/.cache/firebase/emulators/cloud-firestore-emulator-v1.6.0.jar 
API endpoint: http://localhost:8080
If you are using a library that supports the FIRESTORE_EMULATOR_HOST environment variable, run:

   export FIRESTORE_EMULATOR_HOST=localhost:8080

Dev App Server is now running.
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
