### PR TITLE
Add check for package-lock.json on Travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: node_js
 node_js:
   - "8"
   - "10"
+before_install:
+  - npm i -g 'npm@>=6.9.0'
+before_script:
+  - git diff --exit-code -- package-lock.json || echo 'Error: package-lock.json is changed during `npm install`! Please make sure to use npm >= 6.9.0 and commit package-lock.json.'
 after_script:
   - nyc report --reporter=text-lcov | coveralls
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ node_js:
 before_install:
   - npm i -g 'npm@>=6.9.0'
 before_script:
-  - git diff --exit-code -- package-lock.json || echo 'Error: package-lock.json is changed during `npm install`! Please make sure to use npm >= 6.9.0 and commit package-lock.json.'
+  - npm install
+  - "git diff --exit-code -- package-lock.json || echo 'Error: package-lock.json is changed during npm install! Please make sure to use npm >= 6.9.0 and commit package-lock.json.'"
 after_script:
   - nyc report --reporter=text-lcov | coveralls
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - npm i -g 'npm@>=6.9.0'
 before_script:
   - npm install
-  - "git diff --exit-code -- package-lock.json || echo 'Error: package-lock.json is changed during npm install! Please make sure to use npm >= 6.9.0 and commit package-lock.json.' && false"
+  - "git diff --exit-code -- package-lock.json || (echo 'Error: package-lock.json is changed during npm install! Please make sure to use npm >= 6.9.0 and commit package-lock.json.' && false)"
 after_script:
   - nyc report --reporter=text-lcov | coveralls
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 before_install:
   - npm i -g 'npm@>=6.9.0'
 before_script:
-  - npm install
+  - npm install --package-lock-only
   - "git diff --exit-code -- package-lock.json || (echo 'Error: package-lock.json is changed during npm install! Please make sure to use npm >= 6.9.0 and commit package-lock.json.' && false)"
 after_script:
   - nyc report --reporter=text-lcov | coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - npm i -g 'npm@>=6.9.0'
 before_script:
   - npm install
-  - "git diff --exit-code -- package-lock.json || echo 'Error: package-lock.json is changed during npm install! Please make sure to use npm >= 6.9.0 and commit package-lock.json.'"
+  - "git diff --exit-code -- package-lock.json || echo 'Error: package-lock.json is changed during npm install! Please make sure to use npm >= 6.9.0 and commit package-lock.json.' && false"
 after_script:
   - nyc report --reporter=text-lcov | coveralls
 jobs:


### PR DESCRIPTION
This PR adds a check on Travis to ensure `package-lock.json` is not changed after `npm install`.

### Why does Travis yell at me for `package-lock.json`?

Just in case anyone wonders: Something is wrong if you merely run `npm install` without changing anything but you see diffs like below for `package-lock.json`. Usually, it's your `npm` version that is wrong -- please please please use `>= 6.9.0`. (Note that `node@8` by default comes with an older version -- use `npm i -g 'npm@>=6.9.0'` to fix that.)

```diff
-      "dev": true,
-      "optional": true
+      "dev": true
```

This can happen when a PR includes erroneous changes caused by an old `npm` version (which looks like above, as in #1433 ), or when someone actually made changes to dependencies but forgot to check in `package-lock.json`. Neither is a good thing so let's just block them, and hopefully `package-lock.json` on master will be always right. (Relying on reviewers to [catch that](https://github.com/firebase/firebase-tools/pull/1434#discussion_r297314677) won't scale, especially when [master is actually wrong](https://github.com/firebase/firebase-tools/pull/1358#discussion_r299128649) since the previous PR went through unnoticed.)

(Also, feel free to drop a link to redirect people here or to [dev setup](https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup) so you don't have to explain this all over again.)