### PR TITLE
Declare project and app metadata types

### DIFF
--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -1,18 +1,3 @@
-export interface FirebaseProjectMetadata {
-  name: string /* The fully qualified resource name of the Firebase project */;
-  projectId: string;
-  projectNumber: string;
-  displayName: string;
-  resources: DefaultResource;
-}
-
-export interface DefaultResource {
-  hostingSite: string;
-  realtimeDatabaseInstance: string;
-  storageBucket: string;
-  locationId: string;
-}
-
 export interface AppMetadata {
   name: string /* The fully qualified resource name of the Firebase App */;
   projectId: string;
@@ -44,3 +29,5 @@ export enum AppPlatform {
   ANDROID = "ANDROID",
   WEB = "WEB",
 }
+
+// TODO(caot): Add API methods related to app management into this file

--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -28,6 +28,7 @@ export enum AppPlatform {
   IOS = "IOS",
   ANDROID = "ANDROID",
   WEB = "WEB",
+  ANY = "ANY",
 }
 
 // TODO(caot): Add API methods related to app management into this file

--- a/src/management/metadata.ts
+++ b/src/management/metadata.ts
@@ -14,7 +14,7 @@ export interface DefaultResource {
 }
 
 export interface AppMetadata {
-  name: string /* The fully qualified resource name of the Firebase App*/;
+  name: string /* The fully qualified resource name of the Firebase App */;
   projectId: string;
   appId: string;
   platform: AppPlatform;

--- a/src/management/metadata.ts
+++ b/src/management/metadata.ts
@@ -1,4 +1,4 @@
-export interface ProjectMetadata {
+export interface FirebaseProjectMetadata {
   name: string /* The fully qualified resource name of the Firebase project */;
   projectId: string;
   projectNumber: string;

--- a/src/management/metadata.ts
+++ b/src/management/metadata.ts
@@ -39,7 +39,7 @@ export interface WebAppMetadata extends AppMetadata {
 }
 
 export enum AppPlatform {
-  PLATFORM_UNSPECIFIED = "PLATFORM UNSPECIFIED",
+  PLATFORM_UNSPECIFIED = "PLATFORM_UNSPECIFIED",
   IOS = "IOS",
   ANDROID = "ANDROID",
   WEB = "WEB",

--- a/src/management/metadata.ts
+++ b/src/management/metadata.ts
@@ -1,0 +1,46 @@
+export interface ProjectMetadata {
+  name: string /* The fully qualified resource name of the Firebase project */;
+  projectId: string;
+  projectNumber: string;
+  displayName: string;
+  resources: DefaultResource;
+}
+
+export interface DefaultResource {
+  hostingSite: string;
+  realtimeDatabaseInstance: string;
+  storageBucket: string;
+  locationId: string;
+}
+
+export interface AppMetadata {
+  name: string /* The fully qualified resource name of the Firebase App*/;
+  projectId: string;
+  appId: string;
+  platform: AppPlatform;
+  displayName?: string;
+}
+
+export interface IosAppMetadata extends AppMetadata {
+  bundleId: string;
+  appStoreId?: string;
+  platform: AppPlatform.IOS;
+}
+
+export interface AndroidAppMetadata extends AppMetadata {
+  packageName: string;
+  platform: AppPlatform.ANDROID;
+}
+
+export interface WebAppMetadata extends AppMetadata {
+  displayName: string;
+  appUrls?: string[];
+  platform: AppPlatform.WEB;
+}
+
+export enum AppPlatform {
+  PLATFORM_UNSPECIFIED = "PLATFORM UNSPECIFIED",
+  IOS = "IOS",
+  ANDROID = "ANDROID",
+  WEB = "WEB",
+}

--- a/src/management/projects.ts
+++ b/src/management/projects.ts
@@ -1,0 +1,16 @@
+export interface FirebaseProjectMetadata {
+  name: string /* The fully qualified resource name of the Firebase project */;
+  projectId: string;
+  projectNumber: string;
+  displayName: string;
+  resources: DefaultResource;
+}
+
+export interface DefaultResource {
+  hostingSite: string;
+  realtimeDatabaseInstance: string;
+  storageBucket: string;
+  locationId: string;
+}
+
+// TODO(caot): Add API methods related to project management into this file

--- a/src/management/projects.ts
+++ b/src/management/projects.ts
@@ -3,10 +3,10 @@ export interface FirebaseProjectMetadata {
   projectId: string;
   projectNumber: string;
   displayName: string;
-  resources: DefaultResource;
+  resources: DefaultProjectResources;
 }
 
-export interface DefaultResource {
+export interface DefaultProjectResources {
   hostingSite: string;
   realtimeDatabaseInstance: string;
   storageBucket: string;


### PR DESCRIPTION
### Summary
Declare interfaces which represent project and app metadata which are returned from project and app management api calls. The types are declared to match the REST resource: 
- [`ProjectMetadata`](https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects#FirebaseProject)
- [`AppMetadata`](https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects/searchApps#FirebaseAppInfo)
- [`IosAppMetadata`](https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects.iosApps)
- [`AndroidAppMetadata`](https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects.androidApps#AndroidApp)
- [`WebAppMetadata`](https://firebase.google.com/docs/projects/api/reference/rest/v1beta1/projects.webApps)

These types will be used to implement project and app management commands ([proposal](https://goto.google.com/firebase-cli-project-management))

### TODO
Update other PRs of the commands to use the new types