### PR TITLE
Upgrade archiver dependency

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,4 @@
 * Allow running the Firestore and RTDB emulators without a configuration.
 * Allow the Firestore emulator to give more information about invalid rulesets.
 * Hot reload firestore rules on change.
+* Upgrade archive dependency to 3.0.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,4 +4,4 @@
 * Allow running the Firestore and RTDB emulators without a configuration.
 * Allow the Firestore emulator to give more information about invalid rulesets.
 * Hot reload firestore rules on change.
-* Upgrade archive dependency to 3.0.0
+* Upgrade archiver dependency to 3.0.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,31 +1046,43 @@
       }
     },
     "archiver": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.1.1.tgz",
-      "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-3.0.0.tgz",
+      "integrity": "sha512-5QeR6Xc5hSA9X1rbQfcuQ6VZuUXOaEdB65Dhmk9duuRJHYif/ZyJfuyJqsQrj34PFjU5emv5/MmfgA8un06onw==",
       "requires": {
-        "archiver-utils": "^1.3.0",
+        "archiver-utils": "^2.0.0",
         "async": "^2.0.0",
         "buffer-crc32": "^0.2.1",
         "glob": "^7.0.0",
-        "lodash": "^4.8.0",
         "readable-stream": "^2.0.0",
         "tar-stream": "^1.5.0",
-        "zip-stream": "^1.2.0"
+        "zip-stream": "^2.0.1"
       }
     },
     "archiver-utils": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
-      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.0.0.tgz",
+      "integrity": "sha512-JRBgcVvDX4Mwu2RBF8bBaHcQCSxab7afsxAPYDQ5W+19quIPP5CfKE7Ql+UHs9wYvwsaNR8oDuhtf5iqrKmzww==",
       "requires": {
         "glob": "^7.0.0",
         "graceful-fs": "^4.1.0",
         "lazystream": "^1.0.0",
-        "lodash": "^4.8.0",
-        "normalize-path": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.toarray": "^4.4.0",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
         "readable-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+        }
       }
     },
     "archy": {
@@ -5071,6 +5083,11 @@
         "lodash._objecttypes": "~2.4.1"
       }
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
+    },
     "lodash.at": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.at/-/lodash.at-4.6.0.tgz",
@@ -5084,6 +5101,21 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true,
       "optional": true
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw="
+    },
+    "lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw="
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -5166,6 +5198,16 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
+    },
+    "lodash.toarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
+    },
+    "lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
     },
     "lodash.values": {
       "version": "2.4.1",
@@ -8153,13 +8195,12 @@
       "dev": true
     },
     "zip-stream": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
-      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-2.0.1.tgz",
+      "integrity": "sha512-c+eUhhkDpaK87G/py74wvWLtz2kzMPNCCkUApkun50ssE0oQliIQzWpTnwjB+MTKVIf2tGzIgHyqW/Y+W77ecQ==",
       "requires": {
-        "archiver-utils": "^1.3.0",
+        "archiver-utils": "^2.0.0",
         "compress-commons": "^1.2.0",
-        "lodash": "^4.8.0",
         "readable-stream": "^2.0.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   },
   "dependencies": {
     "JSONStream": "^1.2.1",
-    "archiver": "^2.1.1",
+    "archiver": "^3.0.0",
     "body-parser": "^1.19.0",
     "chokidar": "^2.1.5",
     "cjson": "^0.3.1",


### PR DESCRIPTION
### Description

Upgrades the [archiver](https://www.npmjs.com/package/archiver) dependency from 2.1.1 to 3.0.0, released last August. This dependency is responsible for archiving the code into a zip during the preparation for the deploy, and according to its [release notes](https://github.com/archiverjs/node-archiver/releases/tag/3.0.0), the new version comes with:

```
breaking: follow node LTS, remove support for versions under 6.
bugfix: use stats in tar.js and core.js
other: update to archiver-utils@2 and zip-stream@2
other: remove lodash npm module usage
other: Avoid using deprecated Buffer constructor
other: Remove unnecessary return and fix indentation
test: now targeting node v10
```

### Scenarios Tested

Deployed Cloud Functions with create, update and delete operations by running:

```
firebase deploy --only functions
```

### Sample Commands

No changes.