### PR TITLE
Update templates to latest functions SDK

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,4 +5,4 @@
 * Allow the Firestore emulator to give more information about invalid rulesets.
 * Hot reload firestore rules on change.
 * Upgrade archiver dependency to 3.0.0.
-* Update functions init templates to v3.1.0
+* Update functions init templates to `v3.1.0`

--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,4 @@
 * Allow running the Firestore and RTDB emulators without a configuration.
 * Allow the Firestore emulator to give more information about invalid rulesets.
 * Hot reload firestore rules on change.
+* Update functions init templates to v3.1.0

--- a/scripts/triggers-end-to-end-tests/functions/package.json
+++ b/scripts/triggers-end-to-end-tests/functions/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "firebase-admin": "^8.0.0",
-    "firebase-functions": "^3.0.0"
+    "firebase-functions": "^3.1.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.1.6"

--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "firebase-admin": "^8.0.0",
-    "firebase-functions": "^3.0.0"
+    "firebase-functions": "^3.1.0"
   },
   "devDependencies": {
     "eslint": "^5.12.0",

--- a/templates/init/functions/javascript/package.nolint.json
+++ b/templates/init/functions/javascript/package.nolint.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "firebase-admin": "^8.0.0",
-    "firebase-functions": "^3.0.0"
+    "firebase-functions": "^3.1.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.1.6"

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^8.0.0",
-    "firebase-functions": "^3.0.0"
+    "firebase-functions": "^3.1.0"
   },
   "devDependencies": {
     "tslint": "^5.12.0",

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -14,7 +14,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^8.0.0",
-    "firebase-functions": "^3.0.0"
+    "firebase-functions": "^3.1.0"
   },
   "devDependencies": {
     "typescript": "^3.2.2"


### PR DESCRIPTION
We are releasing functions SDK v3.1.0, so updating the templates in the init portion of the functions to use latest version.