### PR TITLE
Fix a name of an internal _onRequestWithOptions property

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,3 +6,4 @@
 * Hot reload firestore rules on change.
 * Upgrade archiver dependency to 3.0.0.
 * Update functions init templates to `v3.1.0`
+* Fix emulation of https functions

--- a/changelog.txt
+++ b/changelog.txt
@@ -6,4 +6,4 @@
 * Hot reload firestore rules on change.
 * Upgrade archiver dependency to 3.0.0.
 * Update functions init templates to `v3.1.0`
-* Fix emulation of https functions
+* Fix emulation of https functions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3052,19 +3052,27 @@
       }
     },
     "firebase-functions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.0.1.tgz",
-      "integrity": "sha512-ByVuJXQcV6dvOlbNWdPq9JfIuAiwJgQwevFkuRf1OepUqH1eIMtu16bXl5s/gTODvUSHyiYEIMYeCG4hekOmtg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.1.0.tgz",
+      "integrity": "sha512-cv2waFVZiiwPSa1lnuBpRZT1kBRJmGqFDOIbvd8GHGHYEwGUFNrHq3naqYtydWa6f6re57LKLzVa+o9Muf7ysA==",
       "dev": true,
       "requires": {
         "@types/cors": "^2.8.5",
-        "@types/express": "^4.11.1",
+        "@types/express": "^4.17.0",
         "@types/jsonwebtoken": "^8.3.2",
-        "@types/lodash": "^4.14.133",
-        "cors": "^2.8.4",
+        "@types/lodash": "^4.14.135",
+        "cors": "^2.8.5",
         "express": "^4.17.1",
-        "jsonwebtoken": "^8.3.2",
-        "lodash": "^4.6.1"
+        "jsonwebtoken": "^8.5.1",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "@types/lodash": {
+          "version": "4.14.136",
+          "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+          "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
+          "dev": true
+        }
       }
     },
     "flat-arguments": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "eslint-plugin-prettier": "^3.0.0",
     "firebase": "^2.4.2",
     "firebase-admin": "^8.1.0",
-    "firebase-functions": "^3.0.1",
+    "firebase-functions": "^3.1.0",
     "mocha": "^5.0.5",
     "nock": "^9.3.3",
     "nyc": "^14.0.0",

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -416,26 +416,26 @@ async function InitializeFirebaseFunctionsStubs(functionsDir: string): Promise<v
   const httpsProviderResolution = path.join(firebaseFunctionsRoot, "lib/providers/https");
 
   const httpsProvider = require(httpsProviderResolution);
-  const _onRequestWithOpts = httpsProvider._onRequestWithOpts;
+  const _onRequestWithOptions = httpsProvider._onRequestWithOptions;
 
-  httpsProvider._onRequestWithOpts = (
+  httpsProvider._onRequestWithOptions = (
     handler: (req: Request, resp: Response) => void,
     opts: DeploymentOptions
   ) => {
-    const cf = _onRequestWithOpts(handler, opts);
+    const cf = _onRequestWithOptions(handler, opts);
     cf.__emulator_func = handler;
     return cf;
   };
 
   /*
-    If you take a look at the link above, you'll see that onRequest relies on _onRequestWithOpts
-    so in theory, we should only need to mock _onRequestWithOpts, however that is not the case
-    because onRequest is defined in the same scope as _onRequestWithOpts, so replacing
-    the definition of _onRequestWithOpts does not replace the link to the original function
+    If you take a look at the link above, you'll see that onRequest relies on _onRequestWithOptions
+    so in theory, we should only need to mock _onRequestWithOptions, however that is not the case
+    because onRequest is defined in the same scope as _onRequestWithOptions, so replacing
+    the definition of _onRequestWithOptions does not replace the link to the original function
     which onRequest uses, so we need to manually force it to use our error-handle-able version.
      */
   httpsProvider.onRequest = (handler: (req: Request, resp: Response) => void) => {
-    return httpsProvider._onRequestWithOpts(handler, {});
+    return httpsProvider._onRequestWithOptions(handler, {});
   };
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Resolves #1480 

Apparently this repository relies on a private method defined in `firebase-functions`, which was renamed as part of https://github.com/firebase/firebase-functions/pull/495. This PR updates the name of the method.
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Unfortunately I was not able to run tests locally by simply doing `npm install && npm run test`, even on the master branch. I'll keep trying, but I thought that this PR might be simple enough to create it already, without 

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

Not relevant.