### PR TITLE
Allow log messages over 8192 bytes

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -8,3 +8,4 @@
 * Upgrade archiver dependency to 3.0.0.
 * Update functions init templates to `v3.1.0`
 * Fix emulation of https functions.
+* Fix bug where too many functions would hang the emulator.

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -778,7 +778,6 @@ export function InvokeRuntime(
   const metadata: { [key: string]: any } = {};
 
   const args = [
-    // "--no-warnings",
     path.join(__dirname, "functionsEmulatorRuntime"),
     JSON.stringify(frb),
     opts.serializedTriggers || "",
@@ -821,9 +820,7 @@ export function InvokeRuntime(
 
   return {
     exit: new Promise<number>((resolve) => {
-      runtime.on("exit", (code: number) => {
-        resolve(code);
-      });
+      runtime.on("exit", resolve);
     }),
     ready,
     metadata,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -836,7 +836,7 @@ function onData(
   emitter: EventEmitter,
   buffer: { value: string },
   buf: Buffer
-) {
+): void {
   let bufString = buf.toString();
 
   // Remove all chunk markings from the message

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -765,6 +765,7 @@ You can probably fix this by running "npm install ${
 export interface InvokeRuntimeOpts {
   serializedTriggers?: string;
   env?: { [key: string]: string };
+  ignore_warnings?: boolean;
 }
 export function InvokeRuntime(
   nodeBinary: string,
@@ -775,20 +776,23 @@ export function InvokeRuntime(
 
   const emitter = new EventEmitter();
   const metadata: { [key: string]: any } = {};
-  const runtime = spawn(
-    nodeBinary,
-    [
-      // "--no-warnings",
-      path.join(__dirname, "functionsEmulatorRuntime"),
-      JSON.stringify(frb),
-      opts.serializedTriggers || "",
-    ],
-    {
-      env: { node: nodeBinary, ...opts.env, ...process.env },
-      cwd: frb.cwd,
-      stdio: ["pipe", "pipe", "pipe", "ipc"],
-    }
-  );
+
+  const args = [
+    // "--no-warnings",
+    path.join(__dirname, "functionsEmulatorRuntime"),
+    JSON.stringify(frb),
+    opts.serializedTriggers || "",
+  ];
+
+  if (opts.ignore_warnings) {
+    args.unshift("--no-warnings");
+  }
+
+  const runtime = spawn(nodeBinary, args, {
+    env: { node: nodeBinary, ...opts.env, ...process.env },
+    cwd: frb.cwd,
+    stdio: ["pipe", "pipe", "pipe", "ipc"],
+  });
 
   const buffers: {
     [pipe: string]: {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -898,7 +898,9 @@ async function main(): Promise<void> {
 
   require("../extractTriggers")(triggerModule, triggerDefinitions);
   triggers = await getEmulatedTriggersFromDefinitions(triggerDefinitions, triggerModule);
-  new EmulatorLog("SYSTEM", "triggers-parsed", "", { triggers, triggerDefinitions }).log();
+
+  const triggerLogData = { triggers, triggerDefinitions };
+  new EmulatorLog("SYSTEM", "triggers-parsed", "", triggerLogData).log();
 
   if (!frb.triggerId) {
     /*

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -978,6 +978,9 @@ async function main(): Promise<void> {
 if (require.main === module) {
   main()
     .then(() => {
+      return EmulatorLog.waitForFlush();
+    })
+    .then(() => {
       process.exit(0);
     })
     .catch((err) => {

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -156,15 +156,15 @@ export class EmulatorLog {
    * between the emulator runtime and the emulator itself. We were falsely making the assumption
    * that we could pass messages of any length over stdout and the stream reader would always get
    * a whole message in a single "data" callback.
-   * 
+   *
    * Now we chunk the messages into 8000B pieces and then add a signal (CHUNK_DIVIDER) to the
    * end of partial messages that instructs the receiver to wait for the whole message to
    * appear.
-   * 
+   *
    * We use a global boolean to know if all of our messages have been flushed, and the functions
    * emulator can wait on this variable to flip before exiting. This ensures that we never
    * miss a log message that has been queued but has not yet flushed from stdout.
-   * 
+   *
    * Note: it would be better to use ipc via process.send() since that is faster and has
    * extremely large message limits but in some experiments the IPC channel seemed to get
    * full and not flush, so stdout remains.

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -151,6 +151,24 @@ export class EmulatorLog {
     return this.toStringCore(true);
   }
 
+  /**
+   * As discovered in #1486, some very large log messages (>8192B) were not being properly passed
+   * between the emulator runtime and the emulator itself. We were falsely making the assumption
+   * that we could pass messages of any length over stdout and the stream reader would always get
+   * a whole message in a single "data" callback.
+   * 
+   * Now we chunk the messages into 8000B pieces and then add a signal (CHUNK_DIVIDER) to the
+   * end of partial messages that instructs the receiver to wait for the whole message to
+   * appear.
+   * 
+   * We use a global boolean to know if all of our messages have been flushed, and the functions
+   * emulator can wait on this variable to flip before exiting. This ensures that we never
+   * miss a log message that has been queued but has not yet flushed from stdout.
+   * 
+   * Note: it would be better to use ipc via process.send() since that is faster and has
+   * extremely large message limits but in some experiments the IPC channel seemed to get
+   * full and not flush, so stdout remains.
+   */
   log(): void {
     const msg = `${this.toString()}\n`;
     const chunks = this.chunkString(msg);

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -180,7 +180,7 @@ export class EmulatorLog {
 
     EmulatorLog.WAITING_FOR_FLUSH = true;
     process.stdout.write(nextMsg, () => {
-      EmulatorLog.WAITING_FOR_FLUSH = EmulatorLog.LOG_BUFFER.length === 0;
+      EmulatorLog.WAITING_FOR_FLUSH = EmulatorLog.LOG_BUFFER.length > 0;
       this.flush();
     });
   }

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -33,6 +33,9 @@ function InvokeRuntimeWithFunctions(
 ): FunctionsRuntimeInstance {
   const serializedTriggers = triggers.toString();
 
+  opts = opts || {};
+  opts.ignore_warnings = true;
+
   return InvokeRuntime(process.execPath, frb, {
     ...opts,
     serializedTriggers,
@@ -180,6 +183,7 @@ describe("FunctionsEmulator-Runtime", () => {
           if (el.level !== "USER") {
             return;
           }
+
           expect(JSON.parse(el.text)).to.deep.eq({ operand: 4 });
         });
 
@@ -681,6 +685,7 @@ describe("FunctionsEmulator-Runtime", () => {
           if (el.level !== "USER") {
             return;
           }
+
           expect(JSON.parse(el.text)).to.deep.eq({ before_exists: false, after_exists: true });
         });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1456 
	 
### Scenarios Tested

When the size of a message to stdout is over 8192 bytes you get multiple "data" callbacks or it gets truncated, which messes up our communication with the runtime.

With this change, we chunk messages proactively.

### Sample Commands

N/A