### PR TITLE
add check for empty outdated output (npm 6.10 issue)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -9,3 +9,4 @@
 * Update functions init templates to `v3.1.0`
 * Fix emulation of https functions.
 * Fix bug where calling `clearFirestoreData` against the Firestore Emulator fails if more than 500 documents exist.
+* Fix issue with npm `6.10` where an internal version check of the `firebase-functions` SDK caused a crash.

--- a/src/checkFirebaseSDKVersion.js
+++ b/src/checkFirebaseSDKVersion.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var _ = require("lodash");
 var clc = require("cli-color");
 var path = require("path");
 
@@ -37,7 +38,8 @@ module.exports = function(options) {
       resolve();
     }
   }).then(function(output) {
-    if (!output) {
+    console.log("OPUTPUT", output)
+    if (!output || _.isEmpty(output)) {
       return;
     }
     var wanted = output["firebase-functions"].wanted;

--- a/src/checkFirebaseSDKVersion.js
+++ b/src/checkFirebaseSDKVersion.js
@@ -38,7 +38,6 @@ module.exports = function(options) {
       resolve();
     }
   }).then(function(output) {
-    console.log("OPUTPUT", output)
     if (!output || _.isEmpty(output)) {
       return;
     }


### PR DESCRIPTION
### Description

npm's outdated started returning an empty object rather than nothing, which caused issues. This checks to see if it's an empty object before we do anything else.
	 
### Scenarios Tested

`firebase deploy` with functions.