### PR TITLE
Implement "Create a new project" option

### DIFF
--- a/src/commands/projects-create.ts
+++ b/src/commands/projects-create.ts
@@ -1,7 +1,7 @@
 import * as Command from "../command";
 import * as FirebaseError from "../error";
 import {
-  createFirebaseProject,
+  createFirebaseProjectAndLog,
   ProjectParentResourceType,
   PROJECTS_CREATE_QUESTIONS,
 } from "../management/projects";
@@ -43,7 +43,7 @@ module.exports = new Command("projects:create [projectId]")
         parentResource = { type: ProjectParentResourceType.FOLDER, id: options.folder };
       }
 
-      return createFirebaseProject(options.projectId, {
+      return createFirebaseProjectAndLog(options.projectId, {
         displayName: options.displayName,
         parentResource,
       });

--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -8,8 +8,6 @@ import {
   FirebaseProjectMetadata,
   getFirebaseProject,
   getProjectPage,
-  ProjectParentResource,
-  ProjectParentResourceType,
   PROJECTS_CREATE_QUESTIONS,
 } from "../../management/projects";
 import * as logger from "../../logger";
@@ -102,51 +100,21 @@ async function selectProjectFromList(
   return toProjectInfo(project);
 }
 
-async function promptParentResource(): Promise<ProjectParentResource | undefined> {
-  const confirm = await promptOnce({
-    type: "confirm",
-    message: "Do you want to create your project under a Google Cloud Platform parent resource?",
-  });
-
-  if (!confirm) {
-    return undefined;
-  }
-
-  const type: ProjectParentResourceType = await promptOnce({
-    type: "list",
-    name: "type",
-    message: "Please select the parent resource type:",
-    choices: [
-      { name: ProjectParentResourceType.FOLDER, value: ProjectParentResourceType.FOLDER },
-      {
-        name: ProjectParentResourceType.ORGANIZATION,
-        value: ProjectParentResourceType.ORGANIZATION,
-      },
-    ],
-  });
-  const id: string = await promptOnce({
-    type: "input",
-    name: "parentResourceString",
-    message: `Please input ${type} ID:`,
-  });
-
-  return { id, type };
-}
-
 async function promptAndCreateNewProject(): Promise<ProjectInfo> {
+  utils.logBullet(
+    "If you want to create a project in a Google Cloud organization or folder, please use " +
+      `"firebase projects:create" instead, and return to this command when you've created the project.`
+  );
+
   const promptAnswer: { projectId?: string; displayName?: string } = {};
   await prompt(promptAnswer, PROJECTS_CREATE_QUESTIONS);
-
   if (!promptAnswer.projectId) {
     throw new FirebaseError("Project ID cannot be empty");
   }
 
-  const parentResource = await promptParentResource();
-
   return toProjectInfo(
     await createFirebaseProjectAndLog(promptAnswer.projectId, {
       displayName: promptAnswer.displayName,
-      parentResource,
     })
   );
 }

--- a/src/management/projects.ts
+++ b/src/management/projects.ts
@@ -168,7 +168,8 @@ export async function getFirebaseProject(projectId: string): Promise<FirebasePro
   } catch (err) {
     logger.debug(err.message);
     throw new FirebaseError(
-      `Failed to get Firebase project ${projectId}. See firebase-debug.log for more info.`,
+      `Failed to get Firebase project ${projectId}` +
+        ". Please make sure the project exists and your account has permission to access it.",
       { exit: 2, original: err }
     );
   }

--- a/src/management/projects.ts
+++ b/src/management/projects.ts
@@ -57,7 +57,7 @@ export const PROJECTS_CREATE_QUESTIONS: Question[] = [
   },
 ];
 
-export async function createFirebaseProject(
+export async function createFirebaseProjectAndLog(
   projectId: string,
   options: { displayName?: string; parentResource?: ProjectParentResource }
 ): Promise<FirebaseProjectMetadata> {
@@ -71,7 +71,11 @@ export async function createFirebaseProject(
     spinner.succeed();
 
     logger.info("");
-    logger.info("🎉🎉🎉 Your Firebase project is ready! 🎉🎉🎉");
+    if (process.platform === "win32") {
+      logger.info("=== Your Firebase project is ready! ===");
+    } else {
+      logger.info("🎉🎉🎉 Your Firebase project is ready! 🎉🎉🎉");
+    }
     logger.info("");
     logger.info("Project information:");
     logger.info(`   - Project ID: ${clc.bold(projectInfo.projectId)}`);

--- a/src/test/init/features/project.spec.ts
+++ b/src/test/init/features/project.spec.ts
@@ -117,7 +117,8 @@ describe("project", () => {
 
     it("should throw error when getFirebaseProject throw an error", async () => {
       const options = { project: "my-project-123" };
-      getProjectStub.rejects("failed to get project");
+      const expectedError = new Error("Failed to get project");
+      getProjectStub.rejects(expectedError);
 
       let err;
       try {
@@ -126,9 +127,7 @@ describe("project", () => {
         err = e;
       }
 
-      expect(err.message).to.equal(
-        "Error getting project my-project-123. Please make sure the project exists and belongs to your account."
-      );
+      expect(err).to.equal(expectedError);
       expect(getProjectStub).to.be.calledWith("my-project-123");
     });
   });
@@ -165,7 +164,7 @@ describe("project", () => {
       const options = {};
       const setup = { config: {}, rcfile: {} };
       getProjectPageStub.returns({ projects: [TEST_FIREBASE_PROJECT, ANOTHER_FIREBASE_PROJECT] });
-      promptStub.returns("Don't setup a default project");
+      promptStub.returns("Don't set up a default project");
 
       await doSetup(setup, {}, options);
 

--- a/src/test/init/features/project.spec.ts
+++ b/src/test/init/features/project.spec.ts
@@ -206,7 +206,7 @@ describe("project", () => {
       });
     });
 
-    describe('with "Don\'t set up a default project" option', () => {
+    describe(`with "Don't set up a default project" option`, () => {
       it("should set up the correct properties when not choosing a project", async () => {
         const options = {};
         const setup = { config: {}, rcfile: {} };

--- a/src/test/init/features/project.spec.ts
+++ b/src/test/init/features/project.spec.ts
@@ -159,11 +159,7 @@ describe("project", () => {
       it("should create a new project and set up the correct properties", async () => {
         const options = {};
         const setup = { config: {}, rcfile: {} };
-        promptOnceStub
-          .onFirstCall()
-          .resolves("Create a new project")
-          .onSecondCall()
-          .resolves(false);
+        promptOnceStub.onFirstCall().resolves("Create a new project");
         const fakePromptFn = (promptAnswer: any) => {
           promptAnswer.projectId = "my-project-123";
           promptAnswer.displayName = "my-project";
@@ -180,51 +176,10 @@ describe("project", () => {
         expect(_.get(setup, "instance")).to.deep.equal("my-project");
         expect(_.get(setup, "projectLocation")).to.deep.equal("us-central");
         expect(_.get(setup.rcfile, "projects.default")).to.deep.equal("my-project-123");
-        expect(promptOnceStub).to.be.calledTwice;
+        expect(promptOnceStub).to.be.calledOnce;
         expect(promptStub).to.be.calledOnce;
         expect(createFirebaseProjectStub).to.be.calledOnceWith("my-project-123", {
           displayName: "my-project",
-          parentResource: undefined,
-        });
-      });
-
-      it("should create a new project with parent resource", async () => {
-        const options = {};
-        const setup = { config: {}, rcfile: {} };
-        promptOnceStub
-          .onFirstCall()
-          .resolves("Create a new project")
-          .onSecondCall()
-          .resolves(true)
-          .onThirdCall()
-          .resolves(projectManager.ProjectParentResourceType.FOLDER)
-          .onCall(3)
-          .resolves("12345");
-
-        const fakePromptFn = (promptAnswer: any) => {
-          promptAnswer.projectId = "my-project-123";
-          promptAnswer.displayName = "my-project";
-        };
-        promptStub
-          .withArgs({}, projectManager.PROJECTS_CREATE_QUESTIONS)
-          .onFirstCall()
-          .callsFake(fakePromptFn);
-        createFirebaseProjectStub.resolves(TEST_FIREBASE_PROJECT);
-
-        await doSetup(setup, {}, options);
-
-        expect(_.get(setup, "projectId")).to.deep.equal("my-project-123");
-        expect(_.get(setup, "instance")).to.deep.equal("my-project");
-        expect(_.get(setup, "projectLocation")).to.deep.equal("us-central");
-        expect(_.get(setup.rcfile, "projects.default")).to.deep.equal("my-project-123");
-        expect(promptOnceStub.callCount).to.equal(4);
-        expect(promptStub).to.be.calledOnce;
-        expect(createFirebaseProjectStub).to.be.calledOnceWith("my-project-123", {
-          displayName: "my-project",
-          parentResource: {
-            id: "12345",
-            type: projectManager.ProjectParentResourceType.FOLDER,
-          },
         });
       });
 

--- a/src/test/management/projects.spec.ts
+++ b/src/test/management/projects.spec.ts
@@ -379,7 +379,7 @@ describe("Project management", () => {
       expect(apiRequestStub).to.be.calledOnceWith("GET", "/v1beta1/projects?pageSize=1000");
     });
 
-    it("should rejects if error is thrown in subsequence api call", async () => {
+    it("should reject if error is thrown in subsequence api call", async () => {
       const projectCounts = 10;
       const pageSize = 5;
       const nextPageToken = "next-page-token";
@@ -450,7 +450,8 @@ describe("Project management", () => {
       }
 
       expect(err.message).to.equal(
-        `Failed to get Firebase project ${PROJECT_ID}. See firebase-debug.log for more info.`
+        `Failed to get Firebase project ${PROJECT_ID}. ` +
+          "Please make sure the project exists and your account has permission to access it."
       );
       expect(err.original).to.equal(expectedError);
       expect(apiRequestStub).to.be.calledOnceWith("GET", `/v1beta1/projects/${PROJECT_ID}`, {


### PR DESCRIPTION
### Description
Implement `Create a new project` option of `firebase init` command to actually create a new project instead of asking user to create the project with Firebase Console.

- **What changes:** if the default project is not set
    - Ask a selection question with 3 choices asking for user's desired behavior: `Use an existing project`, `Create a new project` and `Don't set up default project` 	 
    - `Use and existing project`: (**completed**) 
        - If the logged in account has at most 100 projects, list all projects and let user select project from the list
        - If the logged in account has more than 100 projects, prompt user for the project ID of the desired Firebase projects
    - **In this PR** `Create a new project`
        - Reuse the flow from `projects:create` command to create a new project
        - Set the new project as the default project for the current directory
    - `Don't set up default project` => do nothing

### API methods changes
- Moved `createFirebaseProject()`, which implements the whole project creation flow and command line output, from `commands/projects-create.ts` to `management/projects.ts` since this process is reused in `init/features/project.ts`

### Notes:
- This PR is implemented on top of all changes made in https://github.com/firebase/firebase-tools/pull/1506

### TODO:
- Write unit test for `createFirebaseProject()` method which was moved into `/management/projects.ts`, once the approach is approved (**Update:**  skipping testing since we already tested the underlying API methods)