### PR TITLE
Updates field name for Cloud resource location.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+* Fixes issue deploying scheduled functions in for non `us-central` project locations.

--- a/src/functionsConfig.js
+++ b/src/functionsConfig.js
@@ -45,9 +45,9 @@ exports.idsToVarName = function(projectId, configId, varId) {
 };
 
 exports.getAppEngineLocation = function(config) {
-  var appEngineLocation = config.cloudResourceLocation;
+  var appEngineLocation = config.locationId;
   if (appEngineLocation && appEngineLocation.match(/[^\d]$/)) {
-    // For some regions, such as us-central1, the cloudResourceLocation has the trailing digit cut off
+    // For some regions, such as us-central1, the locationId has the trailing digit cut off
     appEngineLocation = appEngineLocation + "1";
   }
   return appEngineLocation || "us-central1";


### PR DESCRIPTION
When changing API calls for fetching project information, I missed a field rename for the cloud resource location. Quick fix for that.

Verified by creating a project in `europe-west2`, reproducing the bug, then seeing the bug fixed after trying with this patch.

Fixes #1500
Fixes #1507 