### PR TITLE
Delete old emulators on download

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,2 @@
 * Fixes issue deploying scheduled functions for non `us-central` project locations.
+* Cleans up unnecessary emulator JAR files when a new one is downloaded.

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -33,7 +33,7 @@ module.exports = (name: DownloadableEmulator) => {
     });
 };
 
-function removeOldJars(emulator: JavaEmulatorDetails) {
+function removeOldJars(emulator: JavaEmulatorDetails): void {
   const current = emulator.localPath;
   const files = fs.readdirSync(emulator.cacheDir);
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -67,6 +67,7 @@ export interface JavaEmulatorDetails {
   expectedSize: number;
   expectedChecksum: string;
   localPath: string;
+  namePrefix: string;
 }
 
 export interface Address {

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -32,6 +32,7 @@ const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
     expectedSize: 17097803,
     expectedChecksum: "102c8de422db81933a0f29fede5a80a0",
     localPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.0.0.jar"),
+    namePrefix: "firebase-database-emulator",
   },
   firestore: {
     name: Emulators.FIRESTORE,
@@ -43,6 +44,7 @@ const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
     expectedSize: 57896541,
     expectedChecksum: "8e27495a42ee5ab6507e1069b36545d4",
     localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.6.2.jar"),
+    namePrefix: "cloud-firestore-emulator",
   },
 };
 

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -184,6 +184,14 @@ export async function start(targetName: JavaEmulators, args: any): Promise<void>
   const hasEmulator = fs.existsSync(emulator.localPath);
   if (!hasEmulator) {
     if (args.auto_download) {
+      if (process.env.CI) {
+        utils.logWarning(
+          `It appears you are running in a CI environment. You can avoid downloading the ${
+            emulator.name
+          } emulator repeatedly by caching the ${emulator.cacheDir} directory.`
+        );
+      }
+
       await downloadEmulator(targetName);
     } else {
       utils.logWarning("Setup required, please run: firebase setup:emulators:" + emulator.name);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1439
	 
### Scenarios Tested

**Removing old JARs**
```bash
# 1) Check the cache
$ ls ~/.cache/firebase/emulators/
cloud-firestore-emulator-v1.6.0.jar  cloud-firestore-emulator-v1.6.1.jar  firebase-database-emulator-v4.0.0.jar

# 2) Start the Firestore emulator, it downloads the new version and removes the old ones 
$ npx firebase emulators:start --only firestore
i  Starting emulators: ["firestore"]
i  firestore: downloading cloud-firestore-emulator-v1.6.2.jar...
Progress: ===============================================================================================================> (100% of 58MB)
i  firestore: Removing outdated emulator: cloud-firestore-emulator-v1.6.0.jar
i  firestore: Removing outdated emulator: cloud-firestore-emulator-v1.6.1.jar
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
^Ci  Shutting down emulators.
i  Stopping firestore emulator

#3) Check the cache again
$ ls ~/.cache/firebase/emulators/
cloud-firestore-emulator-v1.6.2.jar  firebase-database-emulator-v4.0.0.jar

#4) Start the emulator, no download or removal
$ npx firebase emulators:start --only firestore
i  Starting emulators: ["firestore"]
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
^Ci  Shutting down emulators.
i  Stopping firestore emulator
```

**CI Download Warning**
```bash
$ CI=true npx firebase emulators:start --only firestore
i  Starting emulators: ["firestore"]
⚠  It appears you are running in a CI environment. You can avoid downloading the firestore emulator repeatedly by caching the /usr/local/google/home/samstern/.cache/firebase/emulators directory.
i  firestore: downloading cloud-firestore-emulator-v1.6.2.jar...
Progress: ===============================================================================================================> (100% of 58MB)
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
