### PR TITLE
Improve logging for functions emulator

### DIFF
--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -1,6 +1,7 @@
 import * as Command from "../command";
 import * as controller from "../emulator/controller";
 import { beforeEmulatorCommand } from "../emulator/commandUtils";
+import * as utils from "../utils";
 
 module.exports = new Command("emulators:start")
   .before(beforeEmulatorCommand)
@@ -19,6 +20,8 @@ module.exports = new Command("emulators:start")
       await controller.cleanShutdown();
       throw e;
     }
+
+    utils.logSuccess("All emulators started, it is now safe to connect.");
 
     // Hang until explicitly killed
     await new Promise((res, rej) => {

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -12,9 +12,21 @@ const DEFAULT_PORTS: { [s in Emulators]: number } = {
 const DEFAULT_HOST = "localhost";
 
 export class Constants {
+  static DEFAULT_DATABASE_EMULATOR_NAMESPACE = "fake-server";
+
   static SERVICE_FIRESTORE = "firestore.googleapis.com";
   static SERVICE_REALTIME_DATABASE = "firebaseio.com";
-  static DEFAULT_DATABASE_EMULATOR_NAMESPACE = "fake-server";
+
+  static getServiceName(service: string): string {
+    switch (service) {
+      case this.SERVICE_FIRESTORE:
+        return "firestore";
+      case this.SERVICE_REALTIME_DATABASE:
+        return "database";
+      default:
+        return service;
+    }
+  }
 
   static getDefaultHost(emulator: Emulators): string {
     return DEFAULT_HOST;

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -64,6 +64,13 @@ interface RequestWithRawBody extends express.Request {
   rawBody: Buffer;
 }
 
+interface TriggerDescription {
+  name: string;
+  type: string;
+  details?: string;
+  ignored?: boolean;
+}
+
 export class FunctionsEmulator implements EmulatorInstance {
   static getHttpFunctionUrl(
     host: string,
@@ -488,6 +495,8 @@ You can probably fix this by running "npm install ${
 
       this.triggers = triggerDefinitions;
 
+      const triggerResults: TriggerDescription[] = [];
+
       for (const definition of toSetup) {
         if (definition.httpsTrigger) {
           // TODO(samstern): Right now we only emulate each function in one region, but it's possible
@@ -501,13 +510,18 @@ You can probably fix this by running "npm install ${
             region
           );
 
-          EmulatorLogger.logLabeled(
-            "BULLET",
-            "functions",
-            `HTTP trigger initialized at ${clc.bold(url)}`
-          );
+          triggerResults.push({
+            name: definition.name,
+            type: "http",
+            details: url,
+          });
         } else {
           const service: string = getFunctionService(definition);
+          const result: TriggerDescription = {
+            name: definition.name,
+            type: Constants.getServiceName(service),
+          };
+
           switch (service) {
             case Constants.SERVICE_FIRESTORE:
               await this.addFirestoreTrigger(this.projectId, definition);
@@ -517,16 +531,30 @@ You can probably fix this by running "npm install ${
               break;
             default:
               EmulatorLogger.log("DEBUG", `Unsupported trigger: ${JSON.stringify(definition)}`);
-              EmulatorLogger.log(
-                "INFO",
-                `Ignoring trigger "${
-                  definition.name
-                }" because the service "${service}" is not yet supported.`
-              );
+              result.ignored = true;
               break;
           }
+
+          triggerResults.push(result);
         }
+
         this.knownTriggerIDs[definition.name] = true;
+      }
+
+      const successTriggers = triggerResults.filter((r) => !r.ignored);
+      for (const result of successTriggers) {
+        const msg = result.details
+          ? `[${result.type}] function ${clc.bold(result.name)} initialized (${result.details}).`
+          : `[${result.type}] function ${clc.bold(result.name)} initialized.`;
+        EmulatorLogger.logLabeled("SUCCESS", "functions", msg);
+      }
+
+      const ignoreTriggers = triggerResults.filter((r) => r.ignored);
+      for (const result of ignoreTriggers) {
+        const msg = `Function ${clc.bold(result.name)} ignored because the emulator for ${
+          result.type
+        } does not exist or is not running.`;
+        EmulatorLogger.logLabeled("BULLET", "functions", msg);
       }
     };
 
@@ -580,11 +608,6 @@ You can probably fix this by running "npm install ${
       },
     ]);
 
-    EmulatorLogger.logLabeled(
-      "BULLET",
-      "functions",
-      `Setting up Realtime Database trigger "${definition.name}"`
-    );
     logger.debug(`addDatabaseTrigger`, JSON.stringify(bundle));
     return new Promise((resolve, reject) => {
       let setTriggersPath = `http://localhost:${databasePort}/.settings/functionTriggers.json`;
@@ -613,16 +636,6 @@ You can probably fix this by running "npm install ${
             return;
           }
 
-          if (res.statusCode === 200) {
-            EmulatorLogger.logLabeled(
-              "SUCCESS",
-              "functions",
-              `Trigger "${
-                definition.name
-              }" has been acknowledged by the Realtime Database emulator.`
-            );
-          }
-
           resolve();
         }
       );
@@ -640,13 +653,8 @@ You can probably fix this by running "npm install ${
     }
 
     const bundle = JSON.stringify({ eventTrigger: definition.eventTrigger });
-    EmulatorLogger.logLabeled(
-      "BULLET",
-      "functions",
-      `Setting up Cloud Firestore trigger "${definition.name}"`
-    );
-
     logger.debug(`addFirestoreTrigger`, JSON.stringify(bundle));
+
     return new Promise((resolve, reject) => {
       request.put(
         `http://localhost:${firestorePort}/emulator/v1/projects/${projectId}/triggers/${
@@ -660,14 +668,6 @@ You can probably fix this by running "npm install ${
             EmulatorLogger.log("WARN", "Error adding trigger: " + err);
             reject();
             return;
-          }
-
-          if (res.statusCode === 200) {
-            EmulatorLogger.logLabeled(
-              "SUCCESS",
-              "functions",
-              `Trigger "${definition.name}" has been acknowledged by the Cloud Firestore emulator.`
-            );
           }
 
           resolve();

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -120,7 +120,10 @@ async function _runBinary(
       return;
     }
 
-    utils.logLabeledBullet(emulator.name, `Logging to ${clc.bold(_getLogFileName(emulator.name))}`);
+    utils.logLabeledBullet(
+      emulator.name,
+      `Emulator logging to ${clc.bold(_getLogFileName(emulator.name))}`
+    );
 
     emulator.instance.stdout.on("data", (data) => {
       logger.debug(data.toString());


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Now we wait until the end and log one line about each function, all in the same format.

**Before**
```bash
$ firebase emulators:start
i  Starting emulators: ["functions","firestore","database"]
⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: Emulator started at http://localhost:5001
i  firestore: Logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  database: Logging to database-debug.log
✔  database: Emulator started at http://localhost:9000
i  functions: Watching "/tmp/tmp.tkVh7jwr4l/functions" for Cloud Functions...
i  functions: HTTP trigger initialized at http://localhost:5001/fir-dumpster/us-central1/info
i  functions: HTTP trigger initialized at http://localhost:5001/fir-dumpster/us-central1/writeToFirestore
i  functions: HTTP trigger initialized at http://localhost:5001/fir-dumpster/us-central1/writeToDatabase
i  functions: Setting up Cloud Firestore trigger "firestoreReaction"
✔  functions: Trigger "firestoreReaction" has been acknowledged by the Cloud Firestore emulator.
i  functions: Setting up Realtime Database trigger "databaseReaction"
✔  functions: Trigger "databaseReaction" has been acknowledged by the Realtime Database emulator.
Ignoring trigger "authFunction" because the service "firebaseauth.googleapis.com" is not yet supported.
```

**After**
```bash
$ npx firebase emulators:start
i  Starting emulators: ["functions","firestore","database"]
⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: Emulator started at http://localhost:5001
i  firestore: Emulator logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  database: Emulator logging to database-debug.log
✔  database: Emulator started at http://localhost:9000
i  functions: Watching "/tmp/tmp.tkVh7jwr4l/functions" for Cloud Functions...
✔  functions: [http] function info initialized (http://localhost:5001/fir-dumpster/us-central1/info).
✔  functions: [http] function writeToFirestore initialized (http://localhost:5001/fir-dumpster/us-central1/writeToFirestore).
✔  functions: [http] function writeToDatabase initialized (http://localhost:5001/fir-dumpster/us-central1/writeToDatabase).
✔  functions: [firestore] function firestoreReaction initialized.
✔  functions: [database] function databaseReaction initialized.
i  functions: Function authFunction ignored because the emulator for firebaseauth.googleapis.com does not exist or is not running.
✔  All emulators started, it is now safe to connect.
```
	 
### Scenarios Tested

Tested both successful and ignored functions.

### Sample Commands

See above.