### PR TITLE
Relax project auth requirements for RTDB/Firestore Emulators

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -4,3 +4,4 @@
 * Improves RTDB emulator support for JWT algorithms and arbitrary Google Cloud auth tokens.
 * Fixes an issue where functions:shell logs could be double escaped.
 * Fixes an issue with false noisy logging about emulators not running.
+* Allow starting the RTDB or Firestore emulators with any project ID.

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -31,6 +31,5 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
   } else {
     await requireConfig(options);
     await requireAuth(options);
-    await getProjectNumber(options);
   }
 }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -434,7 +434,12 @@ You can probably fix this by running "npm install ${
     this.nodeBinary = await this.askInstallNodeVersion(this.functionsDir);
 
     // TODO: This call requires authentication, which we should remove eventually
-    this.firebaseConfig = await functionsConfig.getFirebaseConfig(this.options);
+    try {
+      this.firebaseConfig = await functionsConfig.getFirebaseConfig(this.options);
+    } catch (e) {
+      utils.logWarning(`Could not fetch config for project ${clc.bold(this.projectId)}.`);
+      throw e;
+    }
 
     const { host, port } = this.getInfo();
     this.server = FunctionsEmulator.createHubServer(this.getBaseBundle(), this.nodeBinary).listen(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

We mistakenly were asking for the project number before starting any emulators, which we do not need at all. This means that we were stopping people from starting the Firestore/RTDB emulators for "dummy" projects.
	 
### Scenarios Tested

These tests use the project ID `samstern-dne` which is for a project that does not exist.

**Firestore Only**
```bash
$ npx firebase --project=samstern-dne emulators:start --only firestorei  Starting emulators: ["firestore"]
i  firestore: Emulator logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
✔  All emulators started, it is now safe to connect
```

**Database Only**
```bash
$ npx firebase --project=samstern-dne emulators:start --only database
i  Starting emulators: ["database"]
i  database: Emulator logging to database-debug.log
✔  database: Emulator started at http://localhost:9000
✔  All emulators started, it is now safe to connect.
```

**Functions Only**
```
$ npx firebase --project=samstern-dne emulators:start --only functions
i  Starting emulators: ["functions"]
✔  functions: Using node@8 from host.
⚠  Could not fetch config for project samstern-dne.
i  Shutting down emulators.

Error: HTTP Error: 403, Permission denied or not found.
```

**Real Project**
```bash
$ npx firebase --project=fir-dumpster emulators:start
i  Starting emulators: ["functions","firestore","database"]
✔  functions: Using node@8 from host.
✔  functions: Emulator started at http://localhost:5001
i  firestore: Emulator logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  database: Emulator logging to database-debug.log
✔  database: Emulator started at http://localhost:9000
i  functions: Watching "/tmp/tmp.tkVh7jwr4l/functions" for Cloud Functions...
✔  functions: [http] function helloJSON initialized (http://localhost:5001/fir-dumpster/us-central1/helloJSON).
# ...
✔  All emulators started, it is now safe to connect.
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
