### PR TITLE
Fix bug where you can get 'string is undefined'

### DIFF
--- a/src/localFunction.js
+++ b/src/localFunction.js
@@ -132,7 +132,7 @@ LocalFunction.prototype._requestCallBack = function(err, response, body) {
   // and pretty-print it. We can't blindly stringify because stringifying
   // a string results in some ugly escaping.
   var bodyString = body;
-  if (typeof body === "string" || body instanceof string) {
+  if (typeof body === "string") {
     try {
       bodyString = JSON.stringify(JSON.parse(bodyString), null, 2);
     } catch (e) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

When playing with callable functions on `7.2.0` I got some errors like this:
```
firebase > 
firebase > ReferenceError: string is not defined
    at Request.LocalFunction._requestCallBack [as _callback] (/Users/samstern/.nvm/versions/node/v8.12.0/lib/node_modules/firebase-tools/lib/localFunction.js:115:53)
    at Request.self.callback (/Users/samstern/.nvm/versions/node/v8.12.0/lib/node_modules/firebase-tools/node_modules/request/request.js:185:22)
```
	 
### Scenarios Tested

Fixed interactively.  Seems like `instanceof` was not appropriate for a primitive anyway:
https://2ality.com/2017/08/type-right.html

### Sample Commands

N/A