### PR TITLE
fix build container to have later npm

### DIFF
--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -4,6 +4,9 @@ FROM node:8.16.0
 RUN apt-get update && \
     apt-get install -y curl git jq
 
+# Install npm at 6.10.2.
+RUN npm install --global npm@6.10.2
+
 # Install hub
 RUN curl -fsSL --output hub.tgz https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz
 RUN tar --strip-components=2 -C /usr/bin -xf hub.tgz hub-linux-amd64-2.11.2/bin/hub


### PR DESCRIPTION
### Description

The default `npm` in the `node:8.16.0` container changes the `package-lock.json` file which breaks deploying. Update the version to something a hair later, and everything's okay (it's what just released `firebase-tools`!).