### PR TITLE
Use ADC for Emulator Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ jobs:
         - TEST_NAME="Emulator End-to-End Tests"
       before_script:
         - echo "==== ${TEST_NAME} ===="
+        - ./scripts/decrypt-app-credentials.sh
       script: 
         - ./scripts/test-triggers-end-to-end.sh
       after_script: skip

--- a/scripts/set-default-credentials.sh
+++ b/scripts/set-default-credentials.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -e
+
+CWD="$(pwd)"
+
+if [ "${TRAVIS}" != "true" ]; then
+  export TRAVIS_COMMIT="localtesting"
+  export TRAVIS_JOB_ID="$(echo $RANDOM)"
+  export TRAVIS_REPO_SLUG="firebase/firebase-tools"
+fi
+
+GOOGLE_APPLICATION_CREDENTIALS="${CWD}/scripts/creds-private.json"
+if [ "${TRAVIS_REPO_SLUG}" == "firebase/firebase-tools" ]; then
+  GOOGLE_APPLICATION_CREDENTIALS="${CWD}/scripts/creds-public.json"
+fi
+export GOOGLE_APPLICATION_CREDENTIALS
+
+echo ""

--- a/scripts/set-default-credentials.sh
+++ b/scripts/set-default-credentials.sh
@@ -15,4 +15,4 @@ if [ "${TRAVIS_REPO_SLUG}" == "firebase/firebase-tools" ]; then
 fi
 export GOOGLE_APPLICATION_CREDENTIALS
 
-echo ""
+echo "Application Default Credentials: ${GOOGLE_APPLICATION_CREDENTIALS}"

--- a/scripts/test-hosting.sh
+++ b/scripts/test-hosting.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -e
-
-./set-default-credentials.sh
-
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CWD="$(pwd)"
+
+$DIR/set-default-credentials.sh
+
 TARGET_FILE="${TRAVIS_COMMIT}-${TRAVIS_JOB_ID}.txt"
 
 echo "Running in ${CWD}"

--- a/scripts/test-hosting.sh
+++ b/scripts/test-hosting.sh
@@ -1,20 +1,10 @@
 #!/usr/bin/env bash
 set -e
 
-if [ "${TRAVIS}" != "true" ]; then
-  TRAVIS_COMMIT="localtesting"
-  TRAVIS_JOB_ID="$(echo $RANDOM)"
-  TRAVIS_REPO_SLUG="firebase/firebase-tools"
-fi
+./set-default-credentials.sh
 
 CWD="$(pwd)"
 TARGET_FILE="${TRAVIS_COMMIT}-${TRAVIS_JOB_ID}.txt"
-
-GOOGLE_APPLICATION_CREDENTIALS="${CWD}/scripts/creds-private.json"
-if [ "${TRAVIS_REPO_SLUG}" == "firebase/firebase-tools" ]; then
-  GOOGLE_APPLICATION_CREDENTIALS="${CWD}/scripts/creds-public.json"
-fi
-export GOOGLE_APPLICATION_CREDENTIALS
 
 echo "Running in ${CWD}"
 echo "Running with node: $(which node)"

--- a/scripts/test-hosting.sh
+++ b/scripts/test-hosting.sh
@@ -3,7 +3,7 @@ set -e
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 CWD="$(pwd)"
 
-$DIR/set-default-credentials.sh
+source $DIR/set-default-credentials.sh
 
 TARGET_FILE="${TRAVIS_COMMIT}-${TRAVIS_JOB_ID}.txt"
 

--- a/scripts/test-triggers-end-to-end.sh
+++ b/scripts/test-triggers-end-to-end.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -xe
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-./set-default-credentials.sh
+$DIR/set-default-credentials.sh
 
 FIREBASE_CLI="./lib/bin/firebase.js"
 

--- a/scripts/test-triggers-end-to-end.sh
+++ b/scripts/test-triggers-end-to-end.sh
@@ -2,7 +2,7 @@
 set -xe
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-$DIR/set-default-credentials.sh
+source $DIR/set-default-credentials.sh
 
 FIREBASE_CLI="./lib/bin/firebase.js"
 

--- a/scripts/test-triggers-end-to-end.sh
+++ b/scripts/test-triggers-end-to-end.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
 set -xe
+
+./set-default-credentials.sh
 
 FIREBASE_CLI="./lib/bin/firebase.js"
 

--- a/scripts/triggers-end-to-end-tests/run.spec.js
+++ b/scripts/triggers-end-to-end-tests/run.spec.js
@@ -81,10 +81,9 @@ TriggerEndToEndTest.prototype.startEmulators = function startEmulators() {
   var self = this;
   self.emulators_process = subprocess.spawn("node", [
     PROJECT_ROOT + "/lib/bin/firebase.js",
-    "--debug",
+    "emulators:start",
     "--project",
     FIREBASE_PROJECT,
-    "emulators:start",
   ]);
 
   self.emulators_process.stdout.on("data", function(data) {

--- a/scripts/triggers-end-to-end-tests/run.spec.js
+++ b/scripts/triggers-end-to-end-tests/run.spec.js
@@ -81,9 +81,10 @@ TriggerEndToEndTest.prototype.startEmulators = function startEmulators() {
   var self = this;
   self.emulators_process = subprocess.spawn("node", [
     PROJECT_ROOT + "/lib/bin/firebase.js",
-    "emulators:start",
+    "--debug",
     "--project",
     FIREBASE_PROJECT,
+    "emulators:start",
   ]);
 
   self.emulators_process.stdout.on("data", function(data) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Emulator tests relied on global `$FIREBASE_TOKEN` which broken when I pressed the wrong button.
 
### Scenarios Tested

See Travis.

### Sample Commands

N/A