### PR TITLE
No more requireAuth() for functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Introduce experimental support for browser clients to the Firestore emulator.
+* No longer require authentication to run the functions emulator.

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -1,7 +1,6 @@
 import * as controller from "../emulator/controller";
 import * as Config from "../config";
 import * as utils from "../utils";
-import getProjectNumber = require("../getProjectNumber");
 import requireAuth = require("../requireAuth");
 import requireConfig = require("../requireConfig");
 import { Emulators } from "../emulator/types";
@@ -20,6 +19,8 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
   };
   const optionsWithConfig = options.config ? options : optionsWithDefaultConfig;
 
+  const requiresAuth = controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
+
   const canStartWithoutConfig =
     options.only &&
     !controller.shouldStart(optionsWithConfig, Emulators.FUNCTIONS) &&
@@ -30,6 +31,8 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
     options.config = DEFAULT_CONFIG;
   } else {
     await requireConfig(options);
-    await requireAuth(options);
+    if (requiresAuth) {
+      await requireAuth(options);
+    }
   }
 }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -413,7 +413,6 @@ You can probably fix this by running "npm install ${
   nodeBinary: string = "";
 
   private server?: http.Server;
-  private firebaseConfig: any;
   private functionsDir: string = "";
   private triggers: EmulatedTriggerDefinition[] = [];
   private knownTriggerIDs: { [triggerId: string]: boolean } = {};
@@ -432,15 +431,6 @@ You can probably fix this by running "npm install ${
 
   async start(): Promise<void> {
     this.nodeBinary = await this.askInstallNodeVersion(this.functionsDir);
-
-    // TODO: This call requires authentication, which we should remove eventually
-    try {
-      this.firebaseConfig = await functionsConfig.getFirebaseConfig(this.options);
-    } catch (e) {
-      utils.logWarning(`Could not fetch config for project ${clc.bold(this.projectId)}.`);
-      throw e;
-    }
-
     const { host, port } = this.getInfo();
     this.server = FunctionsEmulator.createHubServer(this.getBaseBundle(), this.nodeBinary).listen(
       port,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Previously we required auth if you were running the functions emulator.  This was to populate a `this.firebaseConfig` variable that is apparently not used at all ... so we must have found a different way to get the information we need.

Now only hosting requires auth (which is probably not something we can remove).
	 
### Scenarios Tested

Using these functions:
```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp();

exports.writeToFirestore = functions.https.onRequest(async (req, res) => {
    await admin.firestore().collection('test').doc('test').set({
        now: new Date().toISOString()
    });

    res.json({
        status: 'ok'
    });
});

exports.firestoreReaction = functions.firestore.document('test/test').onWrite(async (change, ctx) => {
    console.log('Received firestore write');
    return true;
});
```

Here is an end-to-end test with a project that does not exist:

```bash
$ npx firebase --project=samstern-dne emulators:start --only firestore,functionsi  Starting emulators: ["functions","firestore"]
⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: Emulator started at http://localhost:5002
i  firestore: Emulator logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  functions: Watching "/tmp/tmp.j7dq65Weid/functions" for Cloud Functions...
✔  functions[writeToFirestore]: http function initialized (http://localhost:5002/samstern-dne/us-central1/writeToFirestore).
✔  functions[firestoreReaction]: firestore function initialized.
✔  All emulators started, it is now safe to connect.
```

```bash
$ http http://localhost:5002/samstern-dne/us-central1/writeToFirestoreHTTP/1.1 200 OK
connection: keep-alive
content-length: 15
content-type: application/json; charset=utf-8
date: Thu, 01 Aug 2019 18:12:48 GMT
etag: W/"f-VaSQ4oDUiZblZNAEkkN+sX+q3Sg"
x-powered-by: Express

{
    "status": "ok"
}
```

```bash
i  functions: Beginning execution of "writeToFirestore"
i  functions: Finished "writeToFirestore" in ~1s
i  functions: Beginning execution of "firestoreReaction"
>  Received firestore write
i  functions: Finished "firestoreReaction" in ~1s
```

### Sample Commands

N/A