### PR TITLE
Substitute project variables into params during update

### DIFF
--- a/src/commands/mods-update.ts
+++ b/src/commands/mods-update.ts
@@ -53,7 +53,12 @@ export default new Command("mods:update <instanceId>")
       const newSource = await modsApi.getSource(sourceUrl);
       const newSpec = newSource.spec;
       await displayChanges(currentSpec, newSpec);
-      const newParams = await paramHelper.promptForNewParams(currentSpec, newSpec, currentParams);
+      const newParams = await paramHelper.promptForNewParams(
+        currentSpec,
+        newSpec,
+        currentParams,
+        projectId
+      );
       const rolesToRemove = _.differenceWith(
         currentSpec.roles,
         _.get(newSpec, "roles", []),

--- a/src/mods/askUserForParam.ts
+++ b/src/mods/askUserForParam.ts
@@ -61,6 +61,7 @@ export async function askForParam(paramSpec: Param): Promise<string> {
   const description = paramSpec.description || "";
   const label = paramSpec.label.trim();
   logger.info(`\n${clc.bold(label)}: ${marked(description).trim()}`);
+
   while (!valid) {
     switch (paramSpec.type) {
       case ParamType.SELECT:

--- a/src/mods/askUserForParam.ts
+++ b/src/mods/askUserForParam.ts
@@ -61,7 +61,7 @@ export async function askForParam(paramSpec: Param): Promise<string> {
   const description = paramSpec.description || "";
   const label = paramSpec.label.trim();
   logger.info(`\n${clc.bold(label)}: ${marked(description).trim()}`);
-
+  // tslint:disable
   while (!valid) {
     switch (paramSpec.type) {
       case ParamType.SELECT:
@@ -101,12 +101,14 @@ export async function askForParam(paramSpec: Param): Promise<string> {
         break;
       default:
         // Default to ParamType.STRING
+        console.log('made it to default');
         response = await promptOnce({
           name: paramSpec.param,
           type: "input",
           default: paramSpec.default,
           message: `Enter a value for ${label}:`,
         });
+        console.log("not past tho");
     }
 
     valid = checkResponse(response, paramSpec);

--- a/src/mods/askUserForParam.ts
+++ b/src/mods/askUserForParam.ts
@@ -61,7 +61,6 @@ export async function askForParam(paramSpec: Param): Promise<string> {
   const description = paramSpec.description || "";
   const label = paramSpec.label.trim();
   logger.info(`\n${clc.bold(label)}: ${marked(description).trim()}`);
-  // tslint:disable
   while (!valid) {
     switch (paramSpec.type) {
       case ParamType.SELECT:
@@ -101,14 +100,12 @@ export async function askForParam(paramSpec: Param): Promise<string> {
         break;
       default:
         // Default to ParamType.STRING
-        console.log('made it to default');
         response = await promptOnce({
           name: paramSpec.param,
           type: "input",
           default: paramSpec.default,
           message: `Enter a value for ${label}:`,
         });
-        console.log("not past tho");
     }
 
     valid = checkResponse(response, paramSpec);

--- a/src/mods/askUserForParam.ts
+++ b/src/mods/askUserForParam.ts
@@ -147,7 +147,7 @@ export async function ask(
   }
 
   utils.logLabeledBullet(logPrefix, "answer the questions below to configure your mod:");
-  const substituted = substituteParams(paramSpecs, firebaseProjectParams) as Param[];
+  const substituted = substituteParams(paramSpecs, firebaseProjectParams);
   const result: any = {};
   const promises = _.map(substituted, (paramSpec: Param) => {
     return async () => {

--- a/src/mods/modsHelper.ts
+++ b/src/mods/modsHelper.ts
@@ -6,6 +6,7 @@ import { checkResponse } from "./askUserForParam";
 import { ensure } from "../ensureApiEnabled";
 import * as getProjectId from "../getProjectId";
 import { generateInstanceId } from "../mods/generateInstanceId";
+import { Param } from "../mods/modsApi";
 import { promptOnce } from "../prompt";
 import * as logger from "../logger";
 
@@ -55,7 +56,7 @@ export async function getFirebaseProjectParams(projectId: string): Promise<any> 
  * @param params params to substitute the placeholders for
  * @return Resources object with substituted params
  */
-export function substituteParams(original: object[], params: { [key: string]: string }): object[] {
+export function substituteParams(original: object[], params: { [key: string]: string }): Param[] {
   const startingString = JSON.stringify(original);
   const reduceFunction = (intermediateResult: string, paramVal: string, paramKey: string) => {
     const regex = new RegExp("\\$\\{" + paramKey + "\\}", "g");

--- a/src/mods/paramHelper.ts
+++ b/src/mods/paramHelper.ts
@@ -102,9 +102,12 @@ export async function promptForNewParams(
 ): Promise<any> {
   let paramsDiffDeletions = _.differenceWith(spec.params, _.get(newSpec, "params", []), _.isEqual);
   let paramsDiffAdditions = _.differenceWith(newSpec.params, _.get(spec, "params", []), _.isEqual);
+  // tslint:disable
   const firebaseProjectParams = await getFirebaseProjectParams(projectId);
   paramsDiffDeletions = substituteParams(paramsDiffDeletions, firebaseProjectParams);
+  console.log(paramsDiffDeletions)
   paramsDiffAdditions = substituteParams(paramsDiffAdditions, firebaseProjectParams);
+  console.log(paramsDiffAdditions)
   if (paramsDiffDeletions.length) {
     logger.info("The following params will no longer be used:");
     paramsDiffDeletions.forEach((param) => {
@@ -113,9 +116,12 @@ export async function promptForNewParams(
     });
   }
   if (paramsDiffAdditions.length) {
+    console.log("hello from joe");
     logger.info("Please configure the following new params:");
     for (const param of paramsDiffAdditions) {
+      console.log('bouta promtped');
       const chosenValue = await askUserForParam.askForParam(param);
+      console.log('promtped');
       currentParams[param.param] = chosenValue;
     }
   }

--- a/src/mods/paramHelper.ts
+++ b/src/mods/paramHelper.ts
@@ -102,12 +102,9 @@ export async function promptForNewParams(
 ): Promise<any> {
   let paramsDiffDeletions = _.differenceWith(spec.params, _.get(newSpec, "params", []), _.isEqual);
   let paramsDiffAdditions = _.differenceWith(newSpec.params, _.get(spec, "params", []), _.isEqual);
-  // tslint:disable
   const firebaseProjectParams = await getFirebaseProjectParams(projectId);
   paramsDiffDeletions = substituteParams(paramsDiffDeletions, firebaseProjectParams);
-  console.log(paramsDiffDeletions)
   paramsDiffAdditions = substituteParams(paramsDiffAdditions, firebaseProjectParams);
-  console.log(paramsDiffAdditions)
   if (paramsDiffDeletions.length) {
     logger.info("The following params will no longer be used:");
     paramsDiffDeletions.forEach((param) => {
@@ -116,12 +113,9 @@ export async function promptForNewParams(
     });
   }
   if (paramsDiffAdditions.length) {
-    console.log("hello from joe");
     logger.info("Please configure the following new params:");
     for (const param of paramsDiffAdditions) {
-      console.log('bouta promtped');
       const chosenValue = await askUserForParam.askForParam(param);
-      console.log('promtped');
       currentParams[param.param] = chosenValue;
     }
   }

--- a/src/mods/paramHelper.ts
+++ b/src/mods/paramHelper.ts
@@ -10,6 +10,7 @@ import * as modsApi from "./modsApi";
 import {
   getFirebaseProjectParams,
   populateDefaultParams,
+  substituteParams,
   validateCommandLineParams,
 } from "../mods/modsHelper";
 import * as askUserForParam from "../mods/askUserForParam";
@@ -96,18 +97,14 @@ export async function getParams(
 export async function promptForNewParams(
   spec: modsApi.ModSpec,
   newSpec: modsApi.ModSpec,
-  currentParams: { [option: string]: string }
+  currentParams: { [option: string]: string },
+  projectId: string
 ): Promise<any> {
-  const paramsDiffDeletions = _.differenceWith(
-    spec.params,
-    _.get(newSpec, "params", []),
-    _.isEqual
-  );
-  const paramsDiffAdditions = _.differenceWith(
-    newSpec.params,
-    _.get(spec, "params", []),
-    _.isEqual
-  );
+  let paramsDiffDeletions = _.differenceWith(spec.params, _.get(newSpec, "params", []), _.isEqual);
+  let paramsDiffAdditions = _.differenceWith(newSpec.params, _.get(spec, "params", []), _.isEqual);
+  const firebaseProjectParams = await getFirebaseProjectParams(projectId);
+  paramsDiffDeletions = substituteParams(paramsDiffDeletions, firebaseProjectParams);
+  paramsDiffAdditions = substituteParams(paramsDiffAdditions, firebaseProjectParams);
   if (paramsDiffDeletions.length) {
     logger.info("The following params will no longer be used:");
     paramsDiffDeletions.forEach((param) => {

--- a/src/mods/paramHelper.ts
+++ b/src/mods/paramHelper.ts
@@ -100,11 +100,14 @@ export async function promptForNewParams(
   currentParams: { [option: string]: string },
   projectId: string
 ): Promise<any> {
-  let paramsDiffDeletions = _.differenceWith(spec.params, _.get(newSpec, "params", []), _.isEqual);
-  let paramsDiffAdditions = _.differenceWith(newSpec.params, _.get(spec, "params", []), _.isEqual);
   const firebaseProjectParams = await getFirebaseProjectParams(projectId);
+
+  let paramsDiffDeletions = _.differenceWith(spec.params, _.get(newSpec, "params", []), _.isEqual);
   paramsDiffDeletions = substituteParams(paramsDiffDeletions, firebaseProjectParams);
+  
+  let paramsDiffAdditions = _.differenceWith(newSpec.params, _.get(spec, "params", []), _.isEqual);
   paramsDiffAdditions = substituteParams(paramsDiffAdditions, firebaseProjectParams);
+
   if (paramsDiffDeletions.length) {
     logger.info("The following params will no longer be used:");
     paramsDiffDeletions.forEach((param) => {

--- a/src/mods/paramHelper.ts
+++ b/src/mods/paramHelper.ts
@@ -104,7 +104,7 @@ export async function promptForNewParams(
 
   let paramsDiffDeletions = _.differenceWith(spec.params, _.get(newSpec, "params", []), _.isEqual);
   paramsDiffDeletions = substituteParams(paramsDiffDeletions, firebaseProjectParams);
-  
+
   let paramsDiffAdditions = _.differenceWith(newSpec.params, _.get(spec, "params", []), _.isEqual);
   paramsDiffAdditions = substituteParams(paramsDiffAdditions, firebaseProjectParams);
 

--- a/src/test/mods/paramHelper.spec.ts
+++ b/src/test/mods/paramHelper.spec.ts
@@ -263,10 +263,15 @@ describe("paramHelper", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.params = TEST_PARAMS_2;
 
-      const newParams = await paramHelper.promptForNewParams(SPEC, newSpec, {
-        A_PARAMETER: "value",
-        ANOTHER_PARAMETER: "value",
-      });
+      const newParams = await paramHelper.promptForNewParams(
+        SPEC,
+        newSpec,
+        {
+          A_PARAMETER: "value",
+          ANOTHER_PARAMETER: "value",
+        },
+        PROJECT_ID
+      );
 
       const expected = {
         ANOTHER_PARAMETER: "value",
@@ -297,10 +302,15 @@ describe("paramHelper", () => {
       promptStub.resolves("Fail");
       const newSpec = _.cloneDeep(SPEC);
 
-      const newParams = await paramHelper.promptForNewParams(SPEC, newSpec, {
-        A_PARAMETER: "value",
-        ANOTHER_PARAMETER: "value",
-      });
+      const newParams = await paramHelper.promptForNewParams(
+        SPEC,
+        newSpec,
+        {
+          A_PARAMETER: "value",
+          ANOTHER_PARAMETER: "value",
+        },
+        PROJECT_ID
+      );
 
       const expected = {
         ANOTHER_PARAMETER: "value",
@@ -316,10 +326,15 @@ describe("paramHelper", () => {
       newSpec.params = TEST_PARAMS_2;
 
       expect(
-        paramHelper.promptForNewParams(SPEC, newSpec, {
-          A_PARAMETER: "value",
-          ANOTHER_PARAMETER: "value",
-        })
+        paramHelper.promptForNewParams(
+          SPEC,
+          newSpec,
+          {
+            A_PARAMETER: "value",
+            ANOTHER_PARAMETER: "value",
+          },
+          PROJECT_ID
+        )
       ).to.be.rejectedWith(FirebaseError, "this is an error");
       // Ensure that we don't continue prompting if one fails
       expect(promptStub).to.have.been.calledOnce;

--- a/src/test/mods/paramHelper.spec.ts
+++ b/src/test/mods/paramHelper.spec.ts
@@ -330,7 +330,7 @@ describe.only("paramHelper", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.params = TEST_PARAMS_2;
 
-      expect(
+      await expect(
         paramHelper.promptForNewParams(
           SPEC,
           newSpec,

--- a/src/test/mods/paramHelper.spec.ts
+++ b/src/test/mods/paramHelper.spec.ts
@@ -55,7 +55,7 @@ const SPEC = {
   params: TEST_PARAMS,
 };
 
-describe("paramHelper", () => {
+describe.only("paramHelper", () => {
   describe("getParams", () => {
     let fsStub: sinon.SinonStub;
     let dotenvStub: sinon.SinonStub;
@@ -250,12 +250,17 @@ describe("paramHelper", () => {
 
   describe("promptForNewParams", () => {
     let promptStub: sinon.SinonStub;
+    let getFirebaseVariableStub: sinon.SinonStub;
     beforeEach(() => {
       promptStub = sinon.stub(prompt, "promptOnce");
+      getFirebaseVariableStub = sinon
+        .stub(modsHelper, "getFirebaseProjectParams")
+        .resolves({ PROJECT_ID });
     });
 
     afterEach(() => {
       promptStub.restore();
+      getFirebaseVariableStub.restore();
     });
 
     it("should prompt the user for any params in the new spec that are not in the current one", async () => {

--- a/src/test/mods/paramHelper.spec.ts
+++ b/src/test/mods/paramHelper.spec.ts
@@ -55,7 +55,7 @@ const SPEC = {
   params: TEST_PARAMS,
 };
 
-describe.only("paramHelper", () => {
+describe("paramHelper", () => {
   describe("getParams", () => {
     let fsStub: sinon.SinonStub;
     let dotenvStub: sinon.SinonStub;

--- a/src/test/mods/paramHelper.spec.ts
+++ b/src/test/mods/paramHelper.spec.ts
@@ -259,8 +259,7 @@ describe("paramHelper", () => {
     });
 
     afterEach(() => {
-      promptStub.restore();
-      getFirebaseVariableStub.restore();
+      sinon.restore();
     });
 
     it("should prompt the user for any params in the new spec that are not in the current one", async () => {


### PR DESCRIPTION
### Description
During updates, project variables in param defaults and descriptions were not being subbed (ie appearing as "${FOO}" instead of as "BAR"). 

Internal bug reference: 138816891

### Scenarios Tested
I tested this through the unit tests, and by updating an instance to a source that was modified to include a new param that had ${PROJECT_ID} as its default.

