### PR TITLE
Prevents api enablement messages if options.markdown is true

### DIFF
--- a/src/mods/modsHelper.ts
+++ b/src/mods/modsHelper.ts
@@ -169,6 +169,6 @@ export async function ensureModsApiEnabled(options: any): Promise<void> {
   const projectId = getProjectId(options);
   await Promise.all([
     ensure(projectId, "deploymentmanager.googleapis.com", "deploymentManager", true),
-    ensure(projectId, "firebasemods.googleapis.com", "mods", false),
+    ensure(projectId, "firebasemods.googleapis.com", "mods", options.markdown),
   ]);
 }


### PR DESCRIPTION
### Description
Prevents api enablement messages from printing out if the --markdown flag is used.
	 
### Scenarios Tested
With --markdown
<img width="1422" alt="Screen Shot 2019-08-08 at 11 03 10 AM" src="https://user-images.githubusercontent.com/4635763/62726713-bb65f900-b9cc-11e9-84ae-b48ed7be42ee.png">
Without --markdown
<img width="1408" alt="Screen Shot 2019-08-08 at 11 03 25 AM" src="https://user-images.githubusercontent.com/4635763/62726740-c3be3400-b9cc-11e9-9894-28d5aa8ac54e.png">

