### PR TITLE
Add some Node.js 10 emulator runtime variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 * Ensures `auth:export` results are fully flushed to the output file.
 * Fix bug in Firestore emulator where concurrent requests for the same transaction would sometimes hang.
+* Set the predefined runtime environment variables in the functions emulator

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -19,6 +19,7 @@ import { ChildProcess, spawnSync } from "child_process";
 import {
   EmulatedTriggerDefinition,
   EmulatedTriggerMap,
+  EmulatedTriggerType,
   FunctionsRuntimeBundle,
   FunctionsRuntimeFeatures,
   getFunctionRegion,
@@ -125,6 +126,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       const runtime = FunctionsEmulator.startFunctionRuntime(
         bundleTemplate,
         triggerId,
+        EmulatedTriggerType.BACKGROUND,
         nodeBinary,
         proto
       );
@@ -166,7 +168,12 @@ export class FunctionsEmulator implements EmulatorInstance {
 
       const reqBody = (req as RequestWithRawBody).rawBody;
 
-      const runtime = FunctionsEmulator.startFunctionRuntime(bundleTemplate, triggerId, nodeBinary);
+      const runtime = FunctionsEmulator.startFunctionRuntime(
+        bundleTemplate,
+        triggerId,
+        EmulatedTriggerType.HTTPS,
+        nodeBinary
+      );
 
       runtime.events.on("log", (el: EmulatorLog) => {
         if (el.level === "FATAL") {
@@ -258,6 +265,7 @@ export class FunctionsEmulator implements EmulatorInstance {
   static startFunctionRuntime(
     bundleTemplate: FunctionsRuntimeBundle,
     triggerId: string,
+    triggerType: EmulatedTriggerType,
     nodeBinary: string,
     proto?: any,
     runtimeOpts?: InvokeRuntimeOpts
@@ -270,6 +278,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       },
       proto,
       triggerId,
+      triggerType,
     };
 
     const runtime = InvokeRuntime(nodeBinary, runtimeBundle, runtimeOpts || {});
@@ -677,6 +686,7 @@ You can probably fix this by running "npm install ${
       cwd: this.functionsDir,
       projectId: this.projectId,
       triggerId: "",
+      triggerType: undefined,
       ports: {
         firestore: EmulatorRegistry.getPort(Emulators.FIRESTORE),
         database: EmulatorRegistry.getPort(Emulators.DATABASE),

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -15,7 +15,6 @@ import * as express from "express";
 import * as path from "path";
 import * as admin from "firebase-admin";
 import * as bodyParser from "body-parser";
-import * as semver from "semver";
 import { URL } from "url";
 import * as _ from "lodash";
 
@@ -719,7 +718,8 @@ function InitializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
     // https://cloud.google.com/functions/docs/env-var
     const pkg = requirePackageJson(frb);
     if (pkg && pkg.engines && pkg.engines.node) {
-      if (semver.satisfies("10.0.0", pkg.engines.node)) {
+      const nodeVersion = parseVersionString(pkg.engines.node);
+      if (nodeVersion.major >= 10) {
         process.env.FUNCTION_TARGET = target;
         process.env.FUNCTION_SIGNATURE_TYPE = mode;
         process.env.K_SERVICE = service;

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -696,6 +696,14 @@ function InitializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
   process.env.GCLOUD_PROJECT = frb.projectId;
   process.env.FUNCTIONS_EMULATOR = "true";
 
+  const nodeVersion = parseVersionString(process.versions.node);
+  if (nodeVersion.major >= 10) {
+    const triggerId = frb.triggerId || "";
+    process.env.FUNCTION_TARGET = triggerId.replace(/-/g, ".");
+    process.env.K_SERVICE = triggerId;
+    process.env.K_REVISION = "0";
+  }
+
   // Do our best to provide reasonable FIREBASE_CONFIG, based on firebase-functions implementation
   // https://github.com/firebase/firebase-functions/blob/59d6a7e056a7244e700dc7b6a180e25b38b647fd/src/setup.ts#L45
   process.env.FIREBASE_CONFIG = JSON.stringify({

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -708,22 +708,24 @@ function InitializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
     projectId: process.env.GCLOUD_PROJECT,
   });
 
-  // Runtime values are based on information from the bundle. Proper information for this is
-  // available once the target code has been loaded, which is too late.
-  const service = frb.triggerId || "";
-  const target = service.replace(/-/g, ".");
-  const mode = frb.triggerType === EmulatedTriggerType.BACKGROUND ? "event" : "http";
+  if (frb.triggerId) {
+    // Runtime values are based on information from the bundle. Proper information for this is
+    // available once the target code has been loaded, which is too late.
+    const service = frb.triggerId || "";
+    const target = service.replace(/-/g, ".");
+    const mode = frb.triggerType === EmulatedTriggerType.BACKGROUND ? "event" : "http";
 
-  // Setup predefined environment variables for Node.js 10 and subsequent runtimes
-  // https://cloud.google.com/functions/docs/env-var
-  const pkg = requirePackageJson(frb);
-  if (pkg && pkg.engines && pkg.engines.node) {
-    if (semver.satisfies("10.0.0", pkg.engines.node)) {
-      process.env.FUNCTION_TARGET = target;
-      process.env.FUNCTION_SIGNATURE_TYPE = mode;
-      process.env.K_SERVICE = service;
-      process.env.K_REVISION = "1";
-      process.env.PORT = "80";
+    // Setup predefined environment variables for Node.js 10 and subsequent runtimes
+    // https://cloud.google.com/functions/docs/env-var
+    const pkg = requirePackageJson(frb);
+    if (pkg && pkg.engines && pkg.engines.node) {
+      if (semver.satisfies("10.0.0", pkg.engines.node)) {
+        process.env.FUNCTION_TARGET = target;
+        process.env.FUNCTION_SIGNATURE_TYPE = mode;
+        process.env.K_SERVICE = service;
+        process.env.K_REVISION = "1";
+        process.env.PORT = "80";
+      }
     }
   }
 }

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -4,6 +4,7 @@ import {
   EmulatedTrigger,
   EmulatedTriggerDefinition,
   EmulatedTriggerMap,
+  EmulatedTriggerType,
   findModuleRoot,
   FunctionsRuntimeBundle,
   FunctionsRuntimeFeatures,

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -8,6 +8,11 @@ import * as path from "path";
 import * as express from "express";
 import * as fs from "fs";
 
+export enum EmulatedTriggerType {
+  BACKGROUND = "BACKGROUND",
+  HTTPS = "HTTPS",
+}
+
 export interface EmulatedTriggerDefinition {
   entryPoint: string;
   name: string;
@@ -33,6 +38,7 @@ export interface FunctionsRuntimeBundle {
   projectId: string;
   proto?: any;
   triggerId?: string;
+  triggerType?: EmulatedTriggerType;
   ports: {
     firestore?: number;
     database?: number;

--- a/src/emulator/functionsEmulatorShell.ts
+++ b/src/emulator/functionsEmulatorShell.ts
@@ -1,7 +1,11 @@
 import * as _ from "lodash";
 import * as uuid from "uuid";
 import { FunctionsEmulator } from "./functionsEmulator";
-import { EmulatedTriggerDefinition, getFunctionRegion } from "./functionsEmulatorShared";
+import {
+  EmulatedTriggerDefinition,
+  EmulatedTriggerType,
+  getFunctionRegion,
+} from "./functionsEmulatorShared";
 import * as utils from "../utils";
 import * as logger from "../logger";
 import { FirebaseError } from "../error";
@@ -71,6 +75,7 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
     FunctionsEmulator.startFunctionRuntime(
       this.emu.getBaseBundle(),
       name,
+      EmulatedTriggerType.BACKGROUND,
       this.emu.nodeBinary,
       proto
     );

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -3,7 +3,10 @@ import { FunctionsEmulator, FunctionsRuntimeInstance } from "../../emulator/func
 import * as supertest from "supertest";
 import { FunctionRuntimeBundles, TIMEOUT_LONG, TIMEOUT_MED } from "./fixtures";
 import * as logger from "../../logger";
-import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
+import {
+  EmulatedTriggerType,
+  FunctionsRuntimeBundle,
+} from "../../emulator/functionsEmulatorShared";
 import * as express from "express";
 
 if ((process.env.DEBUG || "").toLowerCase().indexOf("spec") >= 0) {
@@ -22,10 +25,11 @@ function UseFunctions(triggers: () => {}): void {
   FunctionsEmulator.startFunctionRuntime = (
     bundleTemplate: FunctionsRuntimeBundle,
     triggerId: string,
+    triggerType: EmulatedTriggerType,
     nodeBinary: string,
     proto?: any
   ): FunctionsRuntimeInstance => {
-    return startFunctionRuntime(bundleTemplate, triggerId, nodeBinary, proto, {
+    return startFunctionRuntime(bundleTemplate, triggerId, triggerType, nodeBinary, proto, {
       serializedTriggers,
     });
   };


### PR DESCRIPTION
# Description

We're making use of `FUNCTION_TARGET` in production. It would help to have it locally in the emulator too.

This change adds some of the predefined environmental variables for Node.js 10 and subsequent runtimes.
https://cloud.google.com/functions/docs/env-var#nodejs_10_and_subsequent_runtimes