### PR TITLE
Deprecate tools:migrate command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Mark `tools:migrate` command as deprecated.

--- a/src/commands/tools-migrate.js
+++ b/src/commands/tools-migrate.js
@@ -18,11 +18,16 @@ Config.LEGACY_HOSTING_KEYS.forEach(function(key) {
   MOVE_KEYS[key] = "hosting." + key;
 });
 
+/**
+ * This command is deprecated.
+ * TODO: Remove this command
+ */
 module.exports = new Command("tools:migrate")
-  .description("ensure your firebase.json format is up to date")
+  .description("[DEPRECATED] ensure your firebase.json format is up to date")
   .option("-y, --confirm", "pass this option to bypass confirmation prompt")
   .before(requireAuth)
   .action(function(options) {
+    logger.warn("This command is deprecated and will be removed.");
     if (!options.config) {
       return utils.reject(
         "Must run " + clc.bold("tools:migrate") + " from a directory with a firebase.json"

--- a/src/identifierToProjectId.js
+++ b/src/identifierToProjectId.js
@@ -4,6 +4,10 @@ var _ = require("lodash");
 
 var api = require("./api");
 
+/**
+ * This function is deprecated due to its functionality is no longer relevant for the commands.
+ * TODO: remove this function
+ */
 module.exports = function(id) {
   return api.getProjects().then(function(projects) {
     // if exact match for a project id, return it

--- a/src/identifierToProjectId.js
+++ b/src/identifierToProjectId.js
@@ -6,7 +6,7 @@ var api = require("./api");
 
 /**
  * This function is deprecated due to its functionality is no longer relevant for the commands.
- * TODO: remove this function
+ * TODO: remove this function when tools:migrate is removed.
  */
 module.exports = function(id) {
   return api.getProjects().then(function(projects) {


### PR DESCRIPTION
### Description

- Deprecate the outdated `tools:migrate` command.
- Deprecate `identifierToProjectId.js` and its usages in `tools-migrate.js` and `requireAccess.ts`

**Existing PR for removing the command:** https://github.com/firebase/firebase-tools/pull/1587
