### PR TITLE
Remove app distribution auto-provisioning, wrap in preview

### DIFF
--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -8,6 +8,17 @@ import { FirebaseError } from "../error";
 const pkg = require("../../package.json");
 
 /**
+ * Helper interface for an app that is provisioned with App Distribution
+ */
+export interface AppDistributionApp {
+  projectNumber: string;
+  appId: string;
+  platform: string;
+  bundleId: string;
+  contactEmail: string;
+}
+
+/**
  * Proxies HTTPS requests to the App Distribution server backend.
  */
 export class AppDistributionClient {
@@ -16,13 +27,13 @@ export class AppDistributionClient {
 
   constructor(private readonly appId: string) {}
 
-  async provisionApp(): Promise<void> {
-    await api.request("POST", `/v1alpha/apps/${this.appId}`, {
+  async getApp(): Promise<AppDistributionApp> {
+    utils.logBullet("getting app details...");
+
+    return await api.request("GET", `/v1alpha/apps/${this.appId}`, {
       origin: api.appDistributionOrigin,
       auth: true,
     });
-
-    utils.logSuccess("provisioned for app distribution");
   }
 
   async getJwtToken(): Promise<string> {

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -78,16 +78,15 @@ module.exports = new Command("appdistribution:distribute <distribution-file>")
       app = await requests.getApp();
     } catch (err) {
       throw new FirebaseError(
-        "your app could not be found, make sure to onboard your app with App " +
-          "Distribution in the Firebase console",
+        "App Distribution is not enabled for app ${appId}. Please visit the Firebase Console to get started.",
         { exit: 1 }
       );
     }
 
     if (!app.contactEmail) {
       throw new FirebaseError(
-        "we could not find a contact email associated with this app, make sure to " +
-          "set this within App Distribution in the Firebase console.",
+        "We could not find a contact email associated with this app. Please visit App Distribution within " +
+          "the Firebase Console to set one up.",
         { exit: 1 }
       );
     }

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -13,8 +13,10 @@ module.exports = function(client) {
     return cmd.runner();
   };
 
-  client.appdistribution = {};
-  client.appdistribution.distribute = loadCommand("appdistribution-distribute");
+  if (previews.appdistribution) {
+    client.appdistribution = {};
+    client.appdistribution.distribute = loadCommand("appdistribution-distribute");
+  }
   client.apps = {};
   client.apps.list = loadCommand("apps-list");
   client.apps.create = loadCommand("apps-create");

--- a/src/previews.js
+++ b/src/previews.js
@@ -6,6 +6,7 @@ var configstore = require("./configstore");
 var previews = _.assign(
   {
     // insert previews here...
+    appdistribution: false,
     mods: false,
     ext: false,
   },

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -5,7 +5,7 @@ import { FirebaseError } from "../../error";
 import * as api from "../../api";
 import * as nock from "nock";
 
-describe("distribution", () => {
+describe.only("distribution", () => {
   const appId = "1:12345789:ios:abc123def456";
   const distribution = new AppDistributionClient(appId);
 
@@ -20,19 +20,26 @@ describe("distribution", () => {
     sandbox.restore();
   });
 
-  describe("provisionApp", () => {
-    it("should throw error when request fails", () => {
+  describe("getApp", () => {
+    it("should throw error when app does not exist", () => {
       nock(api.appDistributionOrigin)
-        .post(`/v1alpha/apps/${appId}`)
-        .reply(400, {});
-      return expect(distribution.provisionApp()).to.be.rejected;
+        .get(`/v1alpha/apps/${appId}`)
+        .reply(404, {});
+      return expect(distribution.getApp()).to.be.rejected;
     });
 
     it("should resolve when request succeeds", () => {
       nock(api.appDistributionOrigin)
-        .post(`/v1alpha/apps/${appId}`)
+        .get(`/v1alpha/apps/${appId}`)
         .reply(200, {});
-      return expect(distribution.provisionApp()).to.be.fulfilled;
+      return expect(distribution.getApp()).to.be.fulfilled;
+    });
+
+    it("should throw an error when the request fails", () => {
+      nock(api.appDistributionOrigin)
+        .get(`/v1alpha/apps/${appId}`)
+        .reply(404, {});
+      return expect(distribution.getApp()).to.be.rejected;
     });
   });
 

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -5,7 +5,7 @@ import { FirebaseError } from "../../error";
 import * as api from "../../api";
 import * as nock from "nock";
 
-describe.only("distribution", () => {
+describe("distribution", () => {
   const appId = "1:12345789:ios:abc123def456";
   const distribution = new AppDistributionClient(appId);
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Prevent apps from being auto-provisioned with App Distribution, and instead send customers to the Firebase console to onboard their app with App Distribution (to enforce a developer contact email to be set).

Also wraps the `distribute` command in a preview since this product is still in closed alpha.
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Have tested distributing both iOS and Android apps with comma separated lists of tester email addresses,  a plain text file containing a comma-separated list of tester email addresses, a comma separated lists of group aliases, and  a plain text file containing a comma-separated list of group aliases. 
### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
```
./firebase-cli appdistribution:distribute test.ipa  \
    --app 1:1234567890:ios:0a1b2c3d4e5f67890  \
    --release-notes "Bug fixes and improvements" --testers-path testers.txt
```