### PR TITLE
Fix response body for app distribution `getApp` call

### DIFF
--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -30,10 +30,12 @@ export class AppDistributionClient {
   async getApp(): Promise<AppDistributionApp> {
     utils.logBullet("getting app details...");
 
-    return await api.request("GET", `/v1alpha/apps/${this.appId}`, {
+    const apiResponse = await api.request("GET", `/v1alpha/apps/${this.appId}`, {
       origin: api.appDistributionOrigin,
       auth: true,
     });
+
+    return _.get(apiResponse, "body");
   }
 
   async getJwtToken(): Promise<string> {


### PR DESCRIPTION
### Description

Fixing a bug where `getApp` returns the entire response wrapper instead of just the response body (which is what we want).

### Testing

Verified locally via `npm link`.