### PR TITLE
auth:export - Ensure all fetched and transformed data is written to file before exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Ensures `auth:export` results are fully flushed to the output file.

--- a/src/accountExporter.js
+++ b/src/accountExporter.js
@@ -158,6 +158,11 @@ var serialExportUsers = function(projectId, options) {
       if (userList && userList.length > 0) {
         _writeUsersToFile(userList, options.format, options.writeStream);
         utils.logSuccess("Exported " + userList.length + " account(s) successfully.");
+        // The identitytoolkit API do not return a nextPageToken value
+        // consistently when the last page is reached
+        if (!ret.body.nextPageToken) {
+          return;
+        }
         options.nextPageToken = ret.body.nextPageToken;
         return serialExportUsers(projectId, options);
       }

--- a/src/commands/auth-export.js
+++ b/src/commands/auth-export.js
@@ -41,5 +41,10 @@ module.exports = new Command("auth:export [dataFile]")
         writeStream.write("]}");
       }
       writeStream.end();
+      return new Promise((resolve, reject) => {
+        writeStream.on("finish", resolve);
+        writeStream.on("close", resolve);
+        writeStream.on("error", reject);
+      });
     });
   });

--- a/src/commands/auth-export.js
+++ b/src/commands/auth-export.js
@@ -41,7 +41,9 @@ module.exports = new Command("auth:export [dataFile]")
         writeStream.write("]}");
       }
       writeStream.end();
-      return new Promise((resolve, reject) => {
+      // Ensure process ends only when all data have been flushed
+      // to the output file
+      return new Promise(function(resolve, reject) {
         writeStream.on("finish", resolve);
         writeStream.on("close", resolve);
         writeStream.on("error", reject);


### PR DESCRIPTION
### Description

Fix remaining issue #1635 after #1636.
Basically, since the `serialExportUsers` method is now returning early if now token was returned from the Google API, the data written to the output file `WriteStream` for the last request does not have enough time to be flushed before the command ends.
This PR makes sure that it is the case.