### PR TITLE
Add CoffeeScript support for Functions

### DIFF
--- a/src/init/features/functions/coffeescript.js
+++ b/src/init/features/functions/coffeescript.js
@@ -1,0 +1,51 @@
+"use strict";
+
+var _ = require("lodash");
+var fs = require("fs");
+var path = require("path");
+
+var npmDependencies = require("./npm-dependencies");
+var { prompt } = require("../../../prompt");
+
+var TEMPLATE_ROOT = path.resolve(__dirname, "../../../../templates/init/functions/coffeescript/");
+var PACKAGE_LINTING_TEMPLATE = fs.readFileSync(
+  path.join(TEMPLATE_ROOT, "package.lint.json"),
+  "utf8"
+);
+var PACKAGE_NO_LINTING_TEMPLATE = fs.readFileSync(
+  path.join(TEMPLATE_ROOT, "package.nolint.json"),
+  "utf8"
+);
+var INDEX_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "index.coffee"), "utf8");
+var GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
+
+module.exports = function(setup, config) {
+  return prompt(setup.functions, [
+    {
+      name: "lint",
+      type: "confirm",
+      message: "Do you want to use CoffeeLint to catch probable bugs and enforce style?",
+      default: true,
+    },
+  ])
+    .then(function() {
+      if (setup.functions.lint) {
+        _.set(setup, "config.functions.predeploy", [
+          'npm --prefix "$RESOURCE_DIR" run lint',
+          'npm --prefix "$RESOURCE_DIR" run build',
+        ]);
+        return config.askWriteProjectFile("functions/package.json", PACKAGE_LINTING_TEMPLATE);
+      }
+      _.set(setup, "config.functions.predeploy", 'npm --prefix "$RESOURCE_DIR" run build');
+      return config.askWriteProjectFile("functions/package.json", PACKAGE_NO_LINTING_TEMPLATE);
+    })
+    .then(function() {
+      return config.askWriteProjectFile("functions/src/index.coffee", INDEX_TEMPLATE);
+    })
+    .then(function() {
+      return config.askWriteProjectFile("functions/.gitignore", GITIGNORE_TEMPLATE);
+    })
+    .then(function() {
+      return npmDependencies.askInstallDependencies(setup, config);
+    });
+};

--- a/src/init/features/functions/index.js
+++ b/src/init/features/functions/index.js
@@ -47,6 +47,10 @@ module.exports = function(setup, config) {
             name: "TypeScript",
             value: "typescript",
           },
+          {
+            name: "CoffeeScript",
+            value: "coffeescript",
+          },
         ],
       },
     ]).then(function() {

--- a/templates/init/functions/coffeescript/_gitignore
+++ b/templates/init/functions/coffeescript/_gitignore
@@ -1,0 +1,5 @@
+## Compiled JavaScript files
+**/*.js
+**/*.js.map
+
+node_modules/

--- a/templates/init/functions/coffeescript/index.coffee
+++ b/templates/init/functions/coffeescript/index.coffee
@@ -1,0 +1,7 @@
+functions = require 'firebase-functions'
+
+# # Create and Deploy Your First Cloud Functions
+# # https://firebase.google.com/docs/functions/write-firebase-functions
+#
+# exports.helloWorld = functions.https.onRequest (request, response) =>
+#   response.send("Hello from Firebase!");

--- a/templates/init/functions/coffeescript/index.coffee
+++ b/templates/init/functions/coffeescript/index.coffee
@@ -4,4 +4,4 @@ functions = require 'firebase-functions'
 # # https://firebase.google.com/docs/functions/write-firebase-functions
 #
 # exports.helloWorld = functions.https.onRequest (request, response) =>
-#   response.send("Hello from Firebase!");
+#   response.send("Hello from Firebase!")

--- a/templates/init/functions/coffeescript/package.lint.json
+++ b/templates/init/functions/coffeescript/package.lint.json
@@ -1,0 +1,25 @@
+{
+  "name": "functions",
+  "scripts": {
+    "lint": "coffeelint src/*.coffee",
+    "build": "coffee -c -m -o lib/ src/*.coffee",
+    "serve": "npm run build && firebase serve --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "engines": {
+    "node": "8"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "firebase-admin": "^8.0.0",
+    "firebase-functions": "^3.1.0"
+  },
+  "devDependencies": {
+    "coffeelint": "^2.1.0",
+    "coffeescript": "^2.4.1"
+  },
+  "private": true
+}

--- a/templates/init/functions/coffeescript/package.nolint.json
+++ b/templates/init/functions/coffeescript/package.nolint.json
@@ -1,0 +1,23 @@
+{
+  "name": "functions",
+  "scripts": {
+    "build": "coffee -c -m -o lib/ src/*.coffee",
+    "serve": "npm run build && firebase serve --only functions",
+    "shell": "npm run build && firebase functions:shell",
+    "start": "npm run shell",
+    "deploy": "firebase deploy --only functions",
+    "logs": "firebase functions:log"
+  },
+  "engines": {
+    "node": "8"
+  },
+  "main": "lib/index.js",
+  "dependencies": {
+    "firebase-admin": "^8.0.0",
+    "firebase-functions": "^3.1.0"
+  },
+  "devDependencies": {
+    "coffeescript": "^2.4.1"
+  },
+  "private": true
+}


### PR DESCRIPTION
### Description
- adding init support for CoffeeScript with functions
- similar integration as TypeScript, using `coffeelint` for lint and `coffeescript` to pre-compile to JS
	 
### Scenarios Tested
- initializing a new functions project with `firebase init functions` and selecting `CoffeeScript`

### Sample Commands
- `firebase init functions`