### PR TITLE
Improve AppDistribution error handling

### DIFF
--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -22,7 +22,7 @@ export interface AppDistributionApp {
  * Proxies HTTPS requests to the App Distribution server backend.
  */
 export class AppDistributionClient {
-  static MAX_POLLING_RETRIES = 30;
+  static MAX_POLLING_RETRIES = 15;
   static POLLING_INTERVAL_MS = 1000;
 
   constructor(private readonly appId: string) {}

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -77,10 +77,16 @@ module.exports = new Command("appdistribution:distribute <distribution-file>")
     try {
       app = await requests.getApp();
     } catch (err) {
-      throw new FirebaseError(
-        `App Distribution is not enabled for app ${appId}. Please visit the Firebase Console to get started.`,
-        { exit: 1 }
-      );
+      if (err.status === 404) {
+        throw new FirebaseError(
+          `App Distribution could not find your app ${appId}. ` +
+            `Make sure to onboard your app by pressing the "Get started" ` +
+            "button on the App Distribution page in the Firebase console: " +
+            "https://console.firebase.google.com/project/_/appdistribution",
+          { exit: 1 }
+        );
+      }
+      throw new FirebaseError(`failed to fetch app information. ${err.message}`, { exit: 1 });
     }
 
     if (!app.contactEmail) {


### PR DESCRIPTION
### Description
- Clarify when the customer needs to click "Get Started" in the console,
as indicated by a 404.
- Surface error details for other unexpected error scenarios.
- Adjust the polling attempts from 30 -> 15 (there's no reason it should take that many tries, and even 15 is probably a bit conservative)
	 
### Scenarios Tested

App not provisioned:
```
node lib/bin/firebase.js appdistribution:distribute --app 1:... "<path/to/ipa>"
```

Output:
```
i  getting app details...

Error: App Distribution could not find your app 1:.... Make sure to onboard your app by pressing the "Get started" button on the App Distribution page in the Firebase console: https://console.firebase.google.com/project/_/appdistribution
```

App provisioned:
```
i  getting app details...
i  uploading distribution...
✔  uploaded distribution successfully
⚠  no release notes specified, skipping
⚠  no testers or groups specified, skipping
```
### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
