### PR TITLE
Remove app distribution from previews

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -13,10 +13,8 @@ module.exports = function(client) {
     return cmd.runner();
   };
 
-  if (previews.appdistribution) {
-    client.appdistribution = {};
-    client.appdistribution.distribute = loadCommand("appdistribution-distribute");
-  }
+  client.appdistribution = {};
+  client.appdistribution.distribute = loadCommand("appdistribution-distribute");
   client.apps = {};
   client.apps.list = loadCommand("apps-list");
   client.apps.create = loadCommand("apps-create");

--- a/src/previews.js
+++ b/src/previews.js
@@ -6,7 +6,6 @@ var configstore = require("./configstore");
 var previews = _.assign(
   {
     // insert previews here...
-    appdistribution: false,
     mods: false,
     ext: false,
   },


### PR DESCRIPTION
### Description

Allow users to see the appdistribution:distribute command without using open-sesame
	 
### Scenarios Tested

Verified that the command is visible in the list without using open-sesame
