### PR TITLE
Release Firestore Emulator 1.9.0 and remove WebChannel workaround.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Firestore Emulator now serves WebChannel traffic on the same port as gRPC.

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -20,7 +20,6 @@ export interface FirestoreEmulatorArgs {
   rules?: string;
   functions_emulator?: string;
   auto_download?: boolean;
-  webchannel_port?: number;
 }
 
 export class FirestoreEmulator implements EmulatorInstance {
@@ -54,29 +53,6 @@ export class FirestoreEmulator implements EmulatorInstance {
           utils.logLabeledSuccess("firestore", "Rules updated.");
         }
       });
-    }
-
-    // Find a port for WebChannel traffic
-    const host = this.getInfo().host;
-    const basePort = this.getInfo().port;
-    const port = basePort + 1;
-    const stopPort = port + 10;
-    try {
-      const webChannelPort = await pf.getPortPromise({
-        port,
-        stopPort,
-      });
-      this.args.webchannel_port = webChannelPort;
-
-      utils.logLabeledBullet(
-        "firestore",
-        `Serving WebChannel traffic on at ${clc.bold(`http://${host}:${webChannelPort}`)}`
-      );
-    } catch (e) {
-      utils.logLabeledWarning(
-        "firestore",
-        `Not serving WebChannel traffic, unable to find an open port in range ${port}:${stopPort}]`
-      );
     }
 
     return javaEmulators.start(Emulators.FIRESTORE, this.args);

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -40,7 +40,7 @@ const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
     stdout: null,
     cacheDir: CACHE_DIR,
     remoteUrl:
-      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.8.4.jar",
+      "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.9.0.jar",
     expectedSize: 60090442,
     expectedChecksum: "45967ccda9f453f836b924e8bb1aea17",
     localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.8.4.jar"),
@@ -57,7 +57,7 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
   firestore: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.firestore.localPath],
-    optionalArgs: ["port", "webchannel_port", "host", "rules", "functions_emulator"],
+    optionalArgs: ["port", "host", "rules", "functions_emulator"],
   },
 };
 

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -41,9 +41,9 @@ const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
     cacheDir: CACHE_DIR,
     remoteUrl:
       "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.9.0.jar",
-    expectedSize: 60090442,
-    expectedChecksum: "45967ccda9f453f836b924e8bb1aea17",
-    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.8.4.jar"),
+    expectedSize: 60831386,
+    expectedChecksum: "36e64e09ecda06a05d1d3d1bb5450b33",
+    localPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.9.0.jar"),
     namePrefix: "cloud-firestore-emulator",
   },
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This updates the Firestore Emulator to 1.9.0, which serves WebChannel on the same port. Since it is no longer needed to specify a different port, I've also removed the logic from the CLI.
	 
### Scenarios Tested

Manually tested.

### Sample Commands

`firebase emulators:start --only firestore`