### PR TITLE
Fix export users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 * Firestore Emulator now serves WebChannel traffic on the same port as gRPC.
 * Fix bug where emulators could not find free ports on Windows Subsystem for Linux.
+* Fixes invalid JSON output in `auth.export` within a scripting environment.

--- a/src/accountExporter.js
+++ b/src/accountExporter.js
@@ -119,7 +119,7 @@ var validateOptions = function(options, fileName) {
   return exportOptions;
 };
 
-var _writeUsersToFile = (function() {
+var _createWriteUsersToFile = function() {
   var jsonSep = "";
   return function(userList, format, writeStream) {
     userList.map(function(user) {
@@ -136,9 +136,12 @@ var _writeUsersToFile = (function() {
       }
     });
   };
-})();
+};
 
 var serialExportUsers = function(projectId, options) {
+  if (!options.writeUsersToFile) {
+    options.writeUsersToFile = _createWriteUsersToFile();
+  }
   var postBody = {
     targetProjectId: projectId,
     maxResults: options.batchSize,
@@ -156,7 +159,7 @@ var serialExportUsers = function(projectId, options) {
     .then(function(ret) {
       var userList = ret.body.users;
       if (userList && userList.length > 0) {
-        _writeUsersToFile(userList, options.format, options.writeStream);
+        options.writeUsersToFile(userList, options.format, options.writeStream);
         utils.logSuccess("Exported " + userList.length + " account(s) successfully.");
         // The identitytoolkit API do not return a nextPageToken value
         // consistently when the last page is reached


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

This PR fixes a bug in `auth.export` command. When `serialExportUsers` function (used by the command) is called more than once, it adds a redundant comma, which breaks the JSON format.

The first call:

```
{"users": [
{
  "localId": "DxADx87BFyPe8HhD4dOAyuwXECu1",
  ...
```

The second call (and all consecutive):

```
{"users": [
,
{
  "localId": "DxADx87BFyPe8HhD4dOAyuwXECu1",
  ...
```

The bug is caused by a global variable `jsonSep` in an internal `_writeUsersToFile` function. I assume that it was first introduced to make JSON streamable.

I changed the code to make it generate `writeUsersToFile` shared among recursive calls.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

When the package is used via Node.js API:

```
import * as tools from 'firebase-tools'
tools.auth.export(path)
```

Always produce valid JSON. Before the changes, the second `tools.auth.export` call produces malformed JSON (see the `,` as the first array element):

```
{"users": [
,
{
  "localId": "DxADx87BFyPe8HhD4dOAyuwXECu1"
},
{
  "localId": "hoW2ffPbIpW3ToLpxmk86lymT5w2"
},
{
  "localId": "z2ppbzpxMwbwpQhqTqKhrerM2rZ2"
}]}
```