### PR TITLE
Pubsub schedule to use specified region for the location

### DIFF
--- a/src/deploy/functions/createOrUpdateSchedulesAndTopics.ts
+++ b/src/deploy/functions/createOrUpdateSchedulesAndTopics.ts
@@ -55,7 +55,7 @@ export async function createOrUpdateSchedulesAndTopics(
     } else {
       await createOrReplaceJob(
         Object.assign(trigger.schedule as { schedule: string }, {
-          name: `projects/${projectId}/locations/${appEngineLocation}/jobs/firebase-schedule-${functionName}-${region}`,
+          name: `projects/${projectId}/locations/${region}/jobs/firebase-schedule-${functionName}-${region}`,
           pubsubTarget: {
             topicName: `projects/${projectId}/topics/firebase-schedule-${functionName}-${region}`,
             attributes: {


### PR DESCRIPTION
This is related to issue #1500 and I write a few comments regarding the issue there.

There's a level of inconsistency between whether Firebase uses `appEngineLocation` or `region` when constructing paths. This causes a bug when trying to use the following code:

```js
exports.schedule = functions
  .region('europe-west1')
  .pubsub
  .schedule('every 5 minutes')
  .timeZone('europe/london')
  .onRun((context) => {
    console.log('This will be run every 5 minutes!');
    return null;
  });
```

Even though I am specifying `europe-west1` and my app engine location is also europe-west1, the deployment gives a 400 error. This doesn't happen for functions or even normal topic `onPublish`.

This fix makes it so the `.region()` value is used for both parts of the path. Perhaps it's above me (and quite likely as I'm not a Firebase engineer by any means 😉) but I can't understand why it should be different, especially as the docs say that using `.region()` is the correct way to specify regions in functions.

I am also not certain whether this change is the correct way of doing this, and whether `region` even defaults to whatever value `appEngineLocation` uses, and whether `scheduleName` would need to be updated to also not use the appEngineLocation. But hopefully this PR allows the right people to fix this confusing issue.

Thanks 😄
Matt