### PR TITLE
Loop the modules properties without prototype methods. Fixes #1687

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fixes trigger parser to not rely on prototype methods (#1687).

--- a/src/extractTriggers.js
+++ b/src/extractTriggers.js
@@ -5,28 +5,24 @@
 
 var extractTriggers = function(mod, triggers, prefix) {
   prefix = prefix || "";
-  for (var funcName in mod) {
-    if (mod.hasOwnProperty(funcName)) {
-      var child = mod[funcName];
-      if (typeof child === "function" && child.__trigger && typeof child.__trigger === "object") {
-        if (funcName.indexOf("-") >= 0) {
-          throw new Error(
-            'Function name "' + funcName + '" is invalid. Function names cannot contain dashes.'
-          );
-        }
-
-        var trigger = {};
-        for (var key in child.__trigger) {
-          if (child.__trigger.hasOwnProperty(key)) {
-            trigger[key] = child.__trigger[key];
-          }
-        }
-        trigger.name = prefix + funcName;
-        trigger.entryPoint = trigger.name.replace(/-/g, ".");
-        triggers.push(trigger);
-      } else if (typeof child === "object") {
-        extractTriggers(child, triggers, prefix + funcName + "-");
+  for (var funcName of Object.keys(mod)) {
+    var child = mod[funcName];
+    if (typeof child === "function" && child.__trigger && typeof child.__trigger === "object") {
+      if (funcName.indexOf("-") >= 0) {
+        throw new Error(
+          'Function name "' + funcName + '" is invalid. Function names cannot contain dashes.'
+        );
       }
+
+      var trigger = {};
+      for (var key of Object.keys(child.__trigger)) {
+        trigger[key] = child.__trigger[key];
+      }
+      trigger.name = prefix + funcName;
+      trigger.entryPoint = trigger.name.replace(/-/g, ".");
+      triggers.push(trigger);
+    } else if (typeof child === "object") {
+      extractTriggers(child, triggers, prefix + funcName + "-");
     }
   }
 };


### PR DESCRIPTION
### Description

This fixes optimizations/bundles without `Object.__proto__` not having the `hasOwnProperty` method and failing to be deployed because of that, as described in #1687 

This is a simple fix with no major stuff involved.