### PR TITLE
Unremove but deprecate separate port for WebChannel.

### DIFF
--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -20,6 +20,7 @@ export interface FirestoreEmulatorArgs {
   rules?: string;
   functions_emulator?: string;
   auto_download?: boolean;
+  webchannel_port?: number;
 }
 
 export class FirestoreEmulator implements EmulatorInstance {
@@ -53,6 +54,32 @@ export class FirestoreEmulator implements EmulatorInstance {
           utils.logLabeledSuccess("firestore", "Rules updated.");
         }
       });
+    }
+
+    // Firestore Emulator now serves WebChannel on the same port as gRPC, but
+    // for backward compatibility reasons, let's tell it to ALSO serve
+    // WebChannel on port+1, if it is available.
+    const host = this.getInfo().host;
+    const basePort = this.getInfo().port;
+    const port = basePort + 1;
+    try {
+      const webChannelPort = await pf.getPortPromise({
+        port,
+        stopPort: port,
+      });
+      this.args.webchannel_port = webChannelPort;
+
+      utils.logLabeledBullet(
+        "firestore",
+        `Serving ALL traffic (including WebChannel) on ${clc.bold(`http://${host}:${basePort}`)}`
+      );
+      utils.logLabeledWarning(
+        "firestore",
+        `Support for WebChannel on a separate port (${webChannelPort}) is DEPRECATED and will go away soon. Please use port above instead.`
+      );
+    } catch (e) {
+      // We don't need to take any action here since the emulator will still
+      // serve WebChannel on the main port anyway.
     }
 
     return javaEmulators.start(Emulators.FIRESTORE, this.args);

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -76,7 +76,7 @@ export class FirestoreEmulator implements EmulatorInstance {
       utils.logLabeledWarning(
         "firestore",
         `Support for WebChannel on a separate port (${webChannelPort}) is DEPRECATED and will go away soon. ` +
-        'Please use port above instead.'
+        "Please use port above instead."
       );
     } catch (e) {
       // We don't need to take any action here since the emulator will still

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -76,7 +76,7 @@ export class FirestoreEmulator implements EmulatorInstance {
       utils.logLabeledWarning(
         "firestore",
         `Support for WebChannel on a separate port (${webChannelPort}) is DEPRECATED and will go away soon. ` +
-        "Please use port above instead."
+          "Please use port above instead."
       );
     } catch (e) {
       // We don't need to take any action here since the emulator will still

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -75,7 +75,8 @@ export class FirestoreEmulator implements EmulatorInstance {
       );
       utils.logLabeledWarning(
         "firestore",
-        `Support for WebChannel on a separate port (${webChannelPort}) is DEPRECATED and will go away soon. Please use port above instead.`
+        `Support for WebChannel on a separate port (${webChannelPort}) is DEPRECATED and will go away soon. ` +
+        'Please use port above instead.'
       );
     } catch (e) {
       // We don't need to take any action here since the emulator will still

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -57,7 +57,7 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
   firestore: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", EmulatorDetails.firestore.localPath],
-    optionalArgs: ["port", "host", "rules", "functions_emulator"],
+    optionalArgs: ["port", "webchannel_port", "host", "rules", "functions_emulator"],
   },
 };
 


### PR DESCRIPTION
# Description

This reverts part of firebase/firebase-tools#1689 so that port 8081 still works, but is clearly marked as deprecated. This avoids breaking casual uses of that port.

### Scenarios Tested

Manually started emulators.

### Sample Commands

firebase emulators:start --only firestore

![image](https://user-images.githubusercontent.com/22875286/66350883-430aae00-e911-11e9-8bf3-c5269d54cbc2.png)
