### PR TITLE
Clarify warning for unknown network requests

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -307,7 +307,9 @@ export class FunctionsEmulator implements EmulatorInstance {
       case "unidentified-network-access":
         EmulatorLogger.log(
           "WARN",
-          `Unknown network resource requested!\n   - URL: "${systemLog.data.href}"`
+          `External network resource requested!\n   - URL: "${
+            systemLog.data.href
+          }"\n - Be careful, this may be a production service.`
         );
         break;
       case "functions-config-missing-value":


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Issues like #1683 have shown that people find this message confusing. The new message should help people realize that this is just a warning and their network requests will still succeed.
	 
### Scenarios Tested

N/A

### Sample Commands

N/A