### PR TITLE
Use different method for setting Firepit title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 * Added support for managing the Realtime Database setting `strictTriggerValidation`.
 * Fixes trigger parser to not rely on prototype methods (#1687).
+* Fixes bug where standalone CLI would hang in the Android Studio integrated terminal.

--- a/standalone/firepit.js
+++ b/standalone/firepit.js
@@ -978,7 +978,7 @@ function SetWindowTitle(title) {
   if (isWindows) {
     process.title = title;
   } else {
-    process.stdout.write("\x1b]2;" + title + "\x1b\x5c");
+    process.stdout.write(String.fromCharCode(27) + "]0;" + title + String.fromCharCode(7));
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

The current method hangs the Android Studio integrated terminal.  I found this method on StackOverflow:
https://stackoverflow.com/a/30360821/324977
	 
### Scenarios Tested

I wrote the following simple script:

```
console.log("Hello");
process.stdout.write(String.fromCharCode(27) + ']0;' + "My Title" + String.fromCharCode(7));
console.log("Goodbye");
```

I confirmed that:

  * In iTerm2 it changes the title and prints both messages
  * In Android Studio it does nothing to the title but prints both messages

If you replace the middle line with the old method, it hangs the Android Studio terminal

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
