### PR TITLE
Integration with firebase-functions 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 * Added support for managing the Realtime Database setting `strictTriggerValidation`.
 * Fixes trigger parser to not rely on prototype methods (#1687).
 * Fixes bug where standalone CLI would hang in the Android Studio integrated terminal.
+* Fixes a bug where accessing refs from background function arguments would point to prod (#1682).

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -18,7 +18,7 @@ const TYPE_VERBOSITY: { [type in LogType]: number } = {
   SUCCESS: 1,
   USER: 2,
   WARN: 2,
-  WARN_ONCE: 2
+  WARN_ONCE: 2,
 };
 
 export enum Verbosity {
@@ -29,7 +29,7 @@ export enum Verbosity {
 
 export class EmulatorLogger {
   static verbosity: Verbosity = Verbosity.DEBUG;
-  static warnOnceCache: { [text:string]: boolean } = {};
+  static warnOnceCache: { [text: string]: boolean } = {};
 
   /**
    * Within this file, utils.logFoo() or logger.Foo() should not be called directly,

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -29,7 +29,7 @@ export enum Verbosity {
 
 export class EmulatorLogger {
   static verbosity: Verbosity = Verbosity.DEBUG;
-  static warnOnceCache: { [text: string]: boolean } = {};
+  static warnOnceCache = new Set<String>();
 
   /**
    * Within this file, utils.logFoo() or logger.Foo() should not be called directly,
@@ -58,9 +58,9 @@ export class EmulatorLogger {
         utils.logWarning(text);
         break;
       case "WARN_ONCE":
-        if (!this.warnOnceCache[text]) {
+        if (!this.warnOnceCache.has(text)) {
           utils.logWarning(text);
-          this.warnOnceCache[text] = true;
+          this.warnOnceCache.add(text);
         }
         break;
       case "SUCCESS":
@@ -90,9 +90,9 @@ export class EmulatorLogger {
         utils.logLabeledWarning(label, text);
         break;
       case "WARN_ONCE":
-        if (!this.warnOnceCache[text]) {
+        if (!this.warnOnceCache.has(text)) {
           utils.logLabeledWarning(label, text);
-          this.warnOnceCache[text] = true;
+          this.warnOnceCache.add(text);
         }
         break;
     }

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -7,8 +7,9 @@ import * as logger from "../logger";
  * SUCCESS - useful to humans, similar to bullet but in a 'success' style.
  * USER - logged by user code, always show to humans.
  * WARN - warnings from our code that humans need.
+ * WARN_ONCE - warnings from our code that humans need, but only once per session.
  */
-type LogType = "DEBUG" | "INFO" | "BULLET" | "SUCCESS" | "USER" | "WARN";
+type LogType = "DEBUG" | "INFO" | "BULLET" | "SUCCESS" | "USER" | "WARN" | "WARN_ONCE";
 
 const TYPE_VERBOSITY: { [type in LogType]: number } = {
   DEBUG: 0,
@@ -17,6 +18,7 @@ const TYPE_VERBOSITY: { [type in LogType]: number } = {
   SUCCESS: 1,
   USER: 2,
   WARN: 2,
+  WARN_ONCE: 2
 };
 
 export enum Verbosity {
@@ -27,6 +29,7 @@ export enum Verbosity {
 
 export class EmulatorLogger {
   static verbosity: Verbosity = Verbosity.DEBUG;
+  static warnOnceCache: { [text:string]: boolean } = {};
 
   /**
    * Within this file, utils.logFoo() or logger.Foo() should not be called directly,
@@ -54,6 +57,12 @@ export class EmulatorLogger {
       case "WARN":
         utils.logWarning(text);
         break;
+      case "WARN_ONCE":
+        if (!this.warnOnceCache[text]) {
+          utils.logWarning(text);
+          this.warnOnceCache[text] = true;
+        }
+        break;
       case "SUCCESS":
         utils.logSuccess(text);
         break;
@@ -79,6 +88,12 @@ export class EmulatorLogger {
         break;
       case "WARN":
         utils.logLabeledWarning(label, text);
+        break;
+      case "WARN_ONCE":
+        if (!this.warnOnceCache[text]) {
+          utils.logLabeledWarning(label, text);
+          this.warnOnceCache[text] = true;
+        }
         break;
     }
   }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -299,25 +299,19 @@ export class FunctionsEmulator implements EmulatorInstance {
       case "googleapis-network-access":
         EmulatorLogger.log(
           "WARN",
-          `Google API requested!\n   - URL: "${
-            systemLog.data.href
-          }"\n   - Be careful, this may be a production service.`
+          `Google API requested!\n   - URL: "${systemLog.data.href}"\n   - Be careful, this may be a production service.`
         );
         break;
       case "unidentified-network-access":
         EmulatorLogger.log(
           "WARN",
-          `External network resource requested!\n   - URL: "${
-            systemLog.data.href
-          }"\n - Be careful, this may be a production service.`
+          `External network resource requested!\n   - URL: "${systemLog.data.href}"\n - Be careful, this may be a production service.`
         );
         break;
       case "functions-config-missing-value":
         EmulatorLogger.log(
           "WARN",
-          `Non-existent functions.config() value requested!\n   - Path: "${
-            systemLog.data.valuePath
-          }"\n   - Learn more at https://firebase.google.com/docs/functions/local-emulator`
+          `Non-existent functions.config() value requested!\n   - Path: "${systemLog.data.valuePath}"\n   - Learn more at https://firebase.google.com/docs/functions/local-emulator`
         );
         break;
       case "non-default-admin-app-used":
@@ -342,21 +336,15 @@ export class FunctionsEmulator implements EmulatorInstance {
       case "uninstalled-module":
         EmulatorLogger.log(
           "WARN",
-          `The Cloud Functions emulator requires the module "${
-            systemLog.data.name
-          }" to be installed. This package is in your package.json, but it's not available. \
+          `The Cloud Functions emulator requires the module "${systemLog.data.name}" to be installed. This package is in your package.json, but it's not available. \
 You probably need to run "npm install" in your functions directory.`
         );
         break;
       case "out-of-date-module":
         EmulatorLogger.log(
           "WARN",
-          `The Cloud Functions emulator requires the module "${
-            systemLog.data.name
-          }" to be version >${systemLog.data.minVersion}.0.0 so your version is too old. \
-You can probably fix this by running "npm install ${
-            systemLog.data.name
-          }@latest" in your functions directory.`
+          `The Cloud Functions emulator requires the module "${systemLog.data.name}" to be version >${systemLog.data.minVersion}.0.0 so your version is too old. \
+You can probably fix this by running "npm install ${systemLog.data.name}@latest" in your functions directory.`
         );
         break;
       case "missing-package-json":
@@ -551,9 +539,7 @@ You can probably fix this by running "npm install ${
 
       const ignoreTriggers = triggerResults.filter((r) => r.ignored);
       for (const result of ignoreTriggers) {
-        const msg = `function ignored because the ${
-          result.type
-        } emulator does not exist or is not running.`;
+        const msg = `function ignored because the ${result.type} emulator does not exist or is not running.`;
         EmulatorLogger.logLabeled("BULLET", `functions[${result.name}]`, msg);
       }
     };
@@ -608,9 +594,7 @@ You can probably fix this by running "npm install ${
       } else {
         EmulatorLogger.log(
           "WARN",
-          `No project in use. Registering function trigger for sentinel namespace '${
-            Constants.DEFAULT_DATABASE_EMULATOR_NAMESPACE
-          }'`
+          `No project in use. Registering function trigger for sentinel namespace '${Constants.DEFAULT_DATABASE_EMULATOR_NAMESPACE}'`
         );
       }
       request.post(
@@ -645,9 +629,7 @@ You can probably fix this by running "npm install ${
 
     return new Promise<boolean>((resolve, reject) => {
       request.put(
-        `http://localhost:${firestorePort}/emulator/v1/projects/${projectId}/triggers/${
-          definition.name
-        }`,
+        `http://localhost:${firestorePort}/emulator/v1/projects/${projectId}/triggers/${definition.name}`,
         {
           body: bundle,
         },

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -411,6 +411,9 @@ You can probably fix this by running "npm install ${
       case "WARN":
         EmulatorLogger.logLabeled("WARN", "functions", log.text);
         break;
+      case "WARN_ONCE":
+        EmulatorLogger.logLabeled("WARN_ONCE", "functions", log.text);
+        break;
       case "FATAL":
         EmulatorLogger.logLabeled("WARN", "functions", log.text);
         break;

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -299,19 +299,25 @@ export class FunctionsEmulator implements EmulatorInstance {
       case "googleapis-network-access":
         EmulatorLogger.log(
           "WARN",
-          `Google API requested!\n   - URL: "${systemLog.data.href}"\n   - Be careful, this may be a production service.`
+          `Google API requested!\n   - URL: "${
+            systemLog.data.href
+          }"\n   - Be careful, this may be a production service.`
         );
         break;
       case "unidentified-network-access":
         EmulatorLogger.log(
           "WARN",
-          `External network resource requested!\n   - URL: "${systemLog.data.href}"\n - Be careful, this may be a production service.`
+          `External network resource requested!\n   - URL: "${
+            systemLog.data.href
+          }"\n - Be careful, this may be a production service.`
         );
         break;
       case "functions-config-missing-value":
         EmulatorLogger.log(
           "WARN",
-          `Non-existent functions.config() value requested!\n   - Path: "${systemLog.data.valuePath}"\n   - Learn more at https://firebase.google.com/docs/functions/local-emulator`
+          `Non-existent functions.config() value requested!\n   - Path: "${
+            systemLog.data.valuePath
+          }"\n   - Learn more at https://firebase.google.com/docs/functions/local-emulator`
         );
         break;
       case "non-default-admin-app-used":
@@ -336,15 +342,21 @@ export class FunctionsEmulator implements EmulatorInstance {
       case "uninstalled-module":
         EmulatorLogger.log(
           "WARN",
-          `The Cloud Functions emulator requires the module "${systemLog.data.name}" to be installed. This package is in your package.json, but it's not available. \
+          `The Cloud Functions emulator requires the module "${
+            systemLog.data.name
+          }" to be installed. This package is in your package.json, but it's not available. \
 You probably need to run "npm install" in your functions directory.`
         );
         break;
       case "out-of-date-module":
         EmulatorLogger.log(
           "WARN",
-          `The Cloud Functions emulator requires the module "${systemLog.data.name}" to be version >${systemLog.data.minVersion}.0.0 so your version is too old. \
-You can probably fix this by running "npm install ${systemLog.data.name}@latest" in your functions directory.`
+          `The Cloud Functions emulator requires the module "${
+            systemLog.data.name
+          }" to be version >${systemLog.data.minVersion}.0.0 so your version is too old. \
+You can probably fix this by running "npm install ${
+            systemLog.data.name
+          }@latest" in your functions directory.`
         );
         break;
       case "missing-package-json":
@@ -539,7 +551,9 @@ You can probably fix this by running "npm install ${systemLog.data.name}@latest"
 
       const ignoreTriggers = triggerResults.filter((r) => r.ignored);
       for (const result of ignoreTriggers) {
-        const msg = `function ignored because the ${result.type} emulator does not exist or is not running.`;
+        const msg = `function ignored because the ${
+          result.type
+        } emulator does not exist or is not running.`;
         EmulatorLogger.logLabeled("BULLET", `functions[${result.name}]`, msg);
       }
     };
@@ -594,7 +608,9 @@ You can probably fix this by running "npm install ${systemLog.data.name}@latest"
       } else {
         EmulatorLogger.log(
           "WARN",
-          `No project in use. Registering function trigger for sentinel namespace '${Constants.DEFAULT_DATABASE_EMULATOR_NAMESPACE}'`
+          `No project in use. Registering function trigger for sentinel namespace '${
+            Constants.DEFAULT_DATABASE_EMULATOR_NAMESPACE
+          }'`
         );
       }
       request.post(
@@ -629,7 +645,9 @@ You can probably fix this by running "npm install ${systemLog.data.name}@latest"
 
     return new Promise<boolean>((resolve, reject) => {
       request.put(
-        `http://localhost:${firestorePort}/emulator/v1/projects/${projectId}/triggers/${definition.name}`,
+        `http://localhost:${firestorePort}/emulator/v1/projects/${projectId}/triggers/${
+          definition.name
+        }`,
         {
           body: bundle,
         },

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -256,8 +256,12 @@ async function assertResolveDeveloperNodeModule(
   name: string
 ): Promise<SuccessfulModuleResolution> {
   const resolution = await resolveDeveloperNodeModule(frb, name);
-  if (!(resolution.installed && resolution.declared && resolution.resolution && resolution.version)) {
-    throw new Error(`Assertion failure: could not fully resolve ${name}: ${JSON.stringify(resolution)}`);
+  if (
+    !(resolution.installed && resolution.declared && resolution.resolution && resolution.version)
+  ) {
+    throw new Error(
+      `Assertion failure: could not fully resolve ${name}: ${JSON.stringify(resolution)}`
+    );
   }
 
   return resolution as SuccessfulModuleResolution;
@@ -450,7 +454,10 @@ function InitializeNetworkFiltering(frb: FunctionsRuntimeBundle): void {
 https://github.com/firebase/firebase-functions/blob/9e3bda13565454543b4c7b2fd10fb627a6a3ab97/src/providers/https.ts#L66
    */
 async function InitializeFirebaseFunctionsStubs(frb: FunctionsRuntimeBundle): Promise<void> {
-  const firebaseFunctionsResolution = await assertResolveDeveloperNodeModule(frb, "firebase-functions");
+  const firebaseFunctionsResolution = await assertResolveDeveloperNodeModule(
+    frb,
+    "firebase-functions"
+  );
   const firebaseFunctionsRoot = findModuleRoot(
     "firebase-functions",
     firebaseFunctionsResolution.resolution
@@ -573,16 +580,15 @@ async function InitializeFirebaseAdminStubs(frb: FunctionsRuntimeBundle): Promis
 
       // Tell the Firebase Functions SDK to use the proxied app so that things like "change.after.ref"
       // point to the right place.
-      const functionsVersion = parseVersionString(functionsResolution.version)
+      const functionsVersion = parseVersionString(functionsResolution.version);
       if (functionsVersion.major >= 3 && functionsVersion.minor >= 3) {
         localFunctionsModel.app.setEmulatedAdminApp(defaultApp);
       } else {
         new EmulatorLog(
           "WARN_ONCE",
-          "runtime-status", 
-          `You're using firebase-functions v${
-              functionsResolution.version
-          }, please upgrade to firebase-functions v3.3.0 or higher for best results.`).log()
+          "runtime-status",
+          `You're using firebase-functions v${functionsResolution.version}, please upgrade to firebase-functions v3.3.0 or higher for best results.`
+        ).log();
       }
 
       return defaultApp;
@@ -992,9 +998,7 @@ async function main(): Promise<void> {
     new EmulatorLog(
       "WARN",
       "runtime-status",
-      `Your GOOGLE_APPLICATION_CREDENTIALS environment variable points to ${
-        process.env.GOOGLE_APPLICATION_CREDENTIALS
-      }. Non-emulated services will access production using these credentials. Be careful!`
+      `Your GOOGLE_APPLICATION_CREDENTIALS environment variable points to ${process.env.GOOGLE_APPLICATION_CREDENTIALS}. Non-emulated services will access production using these credentials. Be careful!`
     ).log();
   }
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -587,7 +587,9 @@ async function InitializeFirebaseAdminStubs(frb: FunctionsRuntimeBundle): Promis
         new EmulatorLog(
           "WARN_ONCE",
           "runtime-status",
-          `You're using firebase-functions v${functionsResolution.version}, please upgrade to firebase-functions v3.3.0 or higher for best results.`
+          `You're using firebase-functions v${
+            functionsResolution.version
+          }, please upgrade to firebase-functions v3.3.0 or higher for best results.`
         ).log();
       }
 
@@ -998,7 +1000,9 @@ async function main(): Promise<void> {
     new EmulatorLog(
       "WARN",
       "runtime-status",
-      `Your GOOGLE_APPLICATION_CREDENTIALS environment variable points to ${process.env.GOOGLE_APPLICATION_CREDENTIALS}. Non-emulated services will access production using these credentials. Be careful!`
+      `Your GOOGLE_APPLICATION_CREDENTIALS environment variable points to ${
+        process.env.GOOGLE_APPLICATION_CREDENTIALS
+      }. Non-emulated services will access production using these credentials. Be careful!`
     ).log();
   }
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -25,6 +25,8 @@ import * as _ from "lodash";
 const DATABASE_APP = "__database__";
 
 let hasInitializedFirestore = false;
+let hasAccessedFirestore = false;
+let hasAccessedDatabase = false;
 
 let defaultApp: admin.app.App;
 let databaseApp: admin.app.App;
@@ -683,19 +685,31 @@ async function makeProxiedFirestore(
 }
 
 function warnAboutFirestoreProd(): void {
+  if (hasAccessedFirestore) {
+    return;
+  }
+
   new EmulatorLog(
-    "WARN_ONCE",
+    "WARN",
     "runtime-status",
     "The Cloud Firestore emulator is not running, so calls to Firestore will affect production."
   ).log();
+
+  hasAccessedFirestore = true;
 }
 
 function warnAboutDatabaseProd(): void {
+  if (hasAccessedDatabase) {
+    return;
+  }
+
   new EmulatorLog(
     "WARN_ONCE",
     "runtime-status",
     "The Realtime Database emulator is not running, so calls to Realtime Database will affect production."
   ).log();
+
+  hasAccessedDatabase = true;
 }
 
 function InitializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -11,10 +11,7 @@ import {
   getEmulatedTriggersFromDefinitions,
   getTemporarySocketPath,
 } from "./functionsEmulatorShared";
-import {
-  parseVersionString,
-  compareVersionStrings
-} from "./functionsEmulatorUtils"
+import { parseVersionString, compareVersionStrings } from "./functionsEmulatorUtils";
 import * as express from "express";
 import * as path from "path";
 import * as admin from "firebase-admin";

--- a/src/emulator/functionsEmulatorUtils.ts
+++ b/src/emulator/functionsEmulatorUtils.ts
@@ -6,6 +6,12 @@ which is ran in a separate node process, so it is likely to have unintended side
 const wildcardRegex = new RegExp("{[^/{}]*}");
 const wildcardKeyRegex = new RegExp("^{(.+)}$");
 
+export interface ModuleVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
 export function extractParamsFromPath(
   wildcardPath: string,
   snapshotPath: string
@@ -62,4 +68,48 @@ export function removePathSegments(path: string, count: number): string {
     .split("/")
     .slice(count)
     .join("/");
+}
+
+/**
+ * Parse a semver version string into parts, filling in 0s where empty.
+ */
+export function parseVersionString(version?: string): ModuleVersion {
+  const parts = (version || "0").split(".");
+
+  // Make sure "parts" always has 3 elements. Extras are ignored.
+  parts.push("0");
+  parts.push("0");
+
+  return {
+    major: parseInt(parts[0], 10),
+    minor: parseInt(parts[1], 10),
+    patch: parseInt(parts[2], 10),
+  };
+}
+
+/**
+ * Compare two SemVer version strings. 
+ * 
+ * Returns:
+ *   - Positive number if a is greater.
+ *   - Negative number if b is greater.
+ *   - Zero if they are the same.
+ */
+export function compareVersionStrings(a?: string, b?: string) {
+  const versionA = parseVersionString(a);
+  const versionB = parseVersionString(b);
+
+  if (versionA.major != versionB.major) {
+    return versionA.major - versionB.major;
+  }
+
+  if (versionA.minor != versionB.minor) {
+    return versionA.minor - versionB.minor;
+  }
+
+  if (versionA.patch != versionB.patch) {
+    return versionA.patch - versionB.patch;
+  }
+
+  return 0;
 }

--- a/src/emulator/functionsEmulatorUtils.ts
+++ b/src/emulator/functionsEmulatorUtils.ts
@@ -1,6 +1,9 @@
-/*
-Please be careful when adding require/imports to this file, it is pulled into functionsEmulatorRuntime
-which is ran in a separate node process, so it is likely to have unintended side-effects for you.
+/**
+ * Please be careful when adding require/imports to this file, it is pulled into functionsEmulatorRuntime
+ * which is ran in a separate node process, so it is likely to have unintended side-effects for you.
+ *
+ * TODO(samstern): Merge this with functionsEmulatorShared
+ * TODO(samstern): Audit dependencies of functionsEmulatorShared
  */
 
 const wildcardRegex = new RegExp("{[^/{}]*}");
@@ -88,8 +91,8 @@ export function parseVersionString(version?: string): ModuleVersion {
 }
 
 /**
- * Compare two SemVer version strings. 
- * 
+ * Compare two SemVer version strings.
+ *
  * Returns:
  *   - Positive number if a is greater.
  *   - Negative number if b is greater.

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -130,7 +130,7 @@ export class EmulatorLog {
   private static LOG_BUFFER: string[] = [];
 
   constructor(
-    public level: "DEBUG" | "INFO" | "WARN" | "ERROR" | "FATAL" | "SYSTEM" | "USER",
+    public level: "DEBUG" | "INFO" | "WARN" | "WARN_ONCE" | "ERROR" | "FATAL" | "SYSTEM" | "USER",
     public type: string,
     public text: string,
     public data?: any,

--- a/src/test/emulators/functionsEmulatorUtils.spec.ts
+++ b/src/test/emulators/functionsEmulatorUtils.spec.ts
@@ -3,6 +3,7 @@ import {
   extractParamsFromPath,
   isValidWildcardMatch,
   trimSlashes,
+  compareVersionStrings,
 } from "../../emulator/functionsEmulatorUtils";
 
 describe("FunctionsEmulatorUtils", () => {
@@ -91,6 +92,29 @@ describe("FunctionsEmulatorUtils", () => {
     });
     it("should do both", () => {
       expect(trimSlashes("///a////b//c/")).to.equal("a/b/c");
+    });
+  });
+
+  describe("compareVersonStrings", () => {
+    it("should detect a higher major version", () => {
+      expect(compareVersionStrings("4.0.0", "3.2.1")).to.be.gt(0);
+      expect(compareVersionStrings("3.2.1", "4.0.0")).to.be.lt(0);
+    });
+
+    it("should detect a higher minor version", () => {
+      expect(compareVersionStrings("4.1.0", "4.0.1")).to.be.gt(0);
+      expect(compareVersionStrings("4.0.1", "4.1.0")).to.be.lt(0);
+    });
+
+    it("should detect a higher patch version", () => {
+      expect(compareVersionStrings("4.0.1", "4.0.0")).to.be.gt(0);
+      expect(compareVersionStrings("4.0.0", "4.0.1")).to.be.lt(0);
+    });
+
+    it("should detect the same version", () => {
+      expect(compareVersionStrings("4.0.0", "4.0.0")).to.eql(0);
+      expect(compareVersionStrings("4.0", "4.0.0")).to.eql(0);
+      expect(compareVersionStrings("4", "4.0.0")).to.eql(0);
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1682 

If the developer is using `firebase-functions@3.3.0` or later we can now override the internal FirebaseApp.  If they are not we log a one-time warning.

I added the concept of `WARN_ONCE` for warnings we only want to log once per session, not ocne per functions execution.
	 
### Scenarios Tested

I am using these function:
```js
const functions = require("firebase-functions");
const admin = require("firebase-admin");
admin.initializeApp();

exports.triggerFirestoreFn = functions.https.onRequest(async (req, res) => {
  await admin.firestore().doc('/foo/bar').set({
    date: new Date()
  });

  res.json({ ok: true });
})

exports.firestoreFn = functions.firestore.document('/foo/bar').onWrite(async (change, ctx) => {
  const ref = change.after.ref;
  console.log(JSON.stringify(ref.firestore._settings));
  return true;
})
```

If the user has `3.2.0`:

  * The warning is displayed.
  * The ref clearly points to prod (BAD).

```
$ npx firebase emulators:exec "http http://localhost:5001/fir-dumpster/us-central1/triggerFirestoreFn"
i  Starting emulators: ["functions","firestore"]
✔  functions: Using node@8 from host.
✔  functions: Emulator started at http://localhost:5001
i  firestore: Serving ALL traffic (including WebChannel) on http://localhost:8080
⚠  firestore: Support for WebChannel on a separate port (8081) is DEPRECATED and will go away soon. Please use port above instead.
i  firestore: Emulator logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  functions: Watching "/tmp/tmp.rVfBbr6iiZ/functions" for Cloud Functions...
⚠  functions: You're using firebase-functions v3.2.0. Please upgrade to firebase-functions v3.3.0 or higher to benefit from the latest emulator integration.
✔  functions[triggerFirestoreFn]: http function initialized (http://localhost:5001/fir-dumpster/us-central1/triggerFirestoreFn).
✔  functions[firestoreFn]: firestore function initialized.
i  Running script: http http://localhost:5001/fir-dumpster/us-central1/triggerFirestoreFn
i  functions: Beginning execution of "triggerFirestoreFn"
i  functions: Finished "triggerFirestoreFn" in ~1s
HTTP/1.1 200 OK
connection: keep-alive
content-length: 11
content-type: application/json; charset=utf-8
date: Thu, 10 Oct 2019 23:00:50 GMT
etag: W/"b-Ai2R8hgEarLmHKwesT1qcY913ys"
x-powered-by: Express

{
    "ok": true
}

✔  Script exited successfully (code 0)
i  functions: Beginning execution of "firestoreFn"
>  {"projectId":"fir-dumpster","firebaseVersion":"8.6.0","libName":"gccl","libVersion":"2.4.0 fire/8.6.0"}
i  functions: Finished "firestoreFn" in ~1s
i  Shutting down emulators.
i  Stopping functions emulator
i  Stopping firestore emulator
```

If the user has `3.3.0`:

  * The warning is not displayed.
  * The ref clearly points to the local emulator (GOOD).
 
```
$ npx firebase emulators:exec "http http://localhost:5001/fir-dumpster/us-central1/triggerFirestoreFn"
i  Starting emulators: ["functions","firestore"]
✔  functions: Using node@8 from host.
✔  functions: Emulator started at http://localhost:5001
i  firestore: Serving ALL traffic (including WebChannel) on http://localhost:8080
⚠  firestore: Support for WebChannel on a separate port (8081) is DEPRECATED and will go away soon. Please use port above instead.
i  firestore: Emulator logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  functions: Watching "/tmp/tmp.rVfBbr6iiZ/functions" for Cloud Functions...
✔  functions[triggerFirestoreFn]: http function initialized (http://localhost:5001/fir-dumpster/us-central1/triggerFirestoreFn).
✔  functions[firestoreFn]: firestore function initialized.
i  Running script: http http://localhost:5001/fir-dumpster/us-central1/triggerFirestoreFn
i  functions: Beginning execution of "triggerFirestoreFn"
HTTP/1.1 200 OK
connection: keep-alive
content-length: 11
content-type: application/json; charset=utf-8
date: Thu, 10 Oct 2019 23:01:25 GMT
etag: W/"b-Ai2R8hgEarLmHKwesT1qcY913ys"
x-powered-by: Express

{
    "ok": true
}

i  functions: Finished "triggerFirestoreFn" in ~1s
✔  Script exited successfully (code 0)
i  functions: Beginning execution of "firestoreFn"
>  {"projectId":"fir-dumpster","firebaseVersion":"8.6.0","libName":"gccl","libVersion":"2.4.0 fire/8.6.0","port":8080,"servicePath":"localhost","service":"firestore.googleapis.com","sslCreds":{"callCredentials":{}},"customHeaders":{"Authorization":"Bearer owner"}}
i  functions: Finished "firestoreFn" in ~1s
i  Shutting down emulators.
i  Stopping functions emulator
i  Stopping firestore emulator
```

### Sample Commands

N/A