### PR TITLE
Warn when WSL users don't have Java

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 * Fixes trigger parser to not rely on prototype methods (#1687).
 * Fixes bug where standalone CLI would hang in the Android Studio integrated terminal.
 * Fixes a bug where accessing refs from background function arguments would point to prod (#1682).
+* Fixes a bug where WSL users without java would get an uncaught exception (#1713).

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -126,7 +126,7 @@ async function _runBinary(
     }
 
     if (emulator.instance == null) {
-      utils.logWarning(emulator.name, "Could not spawn child process for emulator.");
+      utils.logLabeledWarning(emulator.name, "Could not spawn child process for emulator.");
       return;
     }
 

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -119,7 +119,10 @@ async function _runBinary(
       if (e.code === "EACCES") {
         // Known issue when WSL users don't have java
         // https://github.com/Microsoft/WSL/issues/3886
-        utils.logLabeledWarning(emulator.name, `Could not spawn child process for emulator, do you have java installed?`);
+        utils.logLabeledWarning(
+          emulator.name,
+          `Could not spawn child process for emulator, do you have java installed?`
+        );
       }
 
       _fatal(emulator, e);

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -121,7 +121,7 @@ async function _runBinary(
         // https://github.com/Microsoft/WSL/issues/3886
         utils.logLabeledWarning(
           emulator.name,
-          `Could not spawn child process for emulator, do you have java installed?`
+          `Could not spawn child process for emulator, check that java is installed and on your $PATH.`
         );
       }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1713
	 
### Scenarios Tested

WSL with no Java:

```
$ ../firebase-tools/lib/bin/firebase.js --project=fir-dumpster emulators:start --only firestore
i  Starting emulators: ["firestore"]
⚠  No Firestore rules file specified in firebase.json, using default rules.
i  firestore: Serving ALL traffic (including WebChannel) on http://localhost:8080
⚠  firestore: Support for WebChannel on a separate port (8081) is DEPRECATED and will go away soon. Please use port above instead.
⚠  firestore: Could not spawn child process for emulator, do you have java installed?
i  Shutting down emulators.
```

### Sample Commands

N/A
