### PR TITLE
add new ts rules to eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,6 +29,8 @@ module.exports = {
         {
             "files": ["*.ts"],
             "extends": [
+                // All rules after what would be `eslint:recommended` above
+                // need to be re-iterated here (since they override eachother).
                 "plugin:@typescript-eslint/eslint-recommended",
                 "plugin:@typescript-eslint/recommended",
                 "plugin:@typescript-eslint/recommended-requiring-type-checking",
@@ -37,6 +39,7 @@ module.exports = {
                 "prettier/@typescript-eslint",
             ],
             "rules": Object.assign(
+                // Typescript specific rules.
                 {
                     "@typescript-eslint/await-thenable": "warn", // TODO(bkendall): remove, allow to error.
                     "@typescript-eslint/ban-types": "warn", // TODO(bkendall): remove, allow to error.
@@ -53,6 +56,7 @@ module.exports = {
                     "@typescript-eslint/require-await": "warn", // TODO(bkendall): remove, allow to error.
                     "@typescript-eslint/unbound-method": "warn", // TODO(bkendall): remove, allow to error.
                 },
+                // eslint rules.
                 {
                     "camelcase": "warn", // TODO(bkendall): remove, allow to error.
                     "new-cap": "warn", // TODO(bkendall): remove, allow to error.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,4 @@
-const globalRules = {
+const GLOBAL_RULES = {
     "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
     "no-restricted-globals": ["error", "name", "length"], // This is a keeper.
     "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
@@ -24,7 +24,7 @@ module.exports = {
         {
             "prettier/prettier": "error",
         },
-        globalRules),
+        GLOBAL_RULES),
     "overrides": [
         {
             "files": ["*.ts"],
@@ -62,7 +62,7 @@ module.exports = {
                     "no-unused-vars": "warn", // TODO(bkendall): remove, allow to error.
                     "require-atomic-updates": "warn", // TODO(bkendall): remove, allow to error.
                 }, 
-                globalRules),
+                GLOBAL_RULES),
         },
         {
             "files": ["*.js"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,14 @@
+const globalRules = {
+    "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
+    "no-restricted-globals": ["error", "name", "length"], // This is a keeper.
+    "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
+    "prefer-const": "warn", // TODO(bkendall): remove, allow to error.
+    "prefer-promise-reject-errors": "warn", // TODO(bkendall): remove, allow to error.
+    "prefer-spread": "warn", // TODO(bkendall): remove, allow to error.
+    "require-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
+    "valid-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
+}
+
 module.exports = {
     "env": {
         "es6": true,
@@ -9,29 +20,49 @@ module.exports = {
         "prettier",
         "prettier/@typescript-eslint",
     ],
-    "rules": {
-        "prettier/prettier": "error",
-        "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
-        "no-restricted-globals": ["error", "name", "length"], // This is a keeper.
-        "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
-        "prefer-const": "warn", // TODO(bkendall): remove, allow to error.
-        "prefer-promise-reject-errors": "warn", // TODO(bkendall): remove, allow to error.
-        "prefer-spread": "warn", // TODO(bkendall): remove, allow to error.
-        "require-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
-        "valid-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
-    },
+    "rules": Object.assign(
+        {
+            "prettier/prettier": "error",
+        },
+        globalRules),
     "overrides": [
         {
             "files": ["*.ts"],
-            "rules": {
-                "camelcase": "warn", // TODO(bkendall): remove, allow to error.
-                "new-cap": "warn", // TODO(bkendall): remove, allow to error.
-                "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
-                "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
-                "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.
-                "no-unused-vars": "warn", // TODO(bkendall): remove, allow to error.
-                "require-atomic-updates": "warn", // TODO(bkendall): remove, allow to error.
-            },
+            "extends": [
+                "plugin:@typescript-eslint/eslint-recommended",
+                "plugin:@typescript-eslint/recommended",
+                "plugin:@typescript-eslint/recommended-requiring-type-checking",
+                "google",
+                "prettier",
+                "prettier/@typescript-eslint",
+            ],
+            "rules": Object.assign(
+                {
+                    "@typescript-eslint/await-thenable": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/ban-types": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/camelcase": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/no-inferrable-types": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/no-misused-promises": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/no-unnecessary-type-assertion": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/no-use-before-define": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/no-use-before-define": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/no-var-requires": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/prefer-includes": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/prefer-regexp-exec": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/prefer-string-starts-ends-with": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/require-await": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/unbound-method": "warn", // TODO(bkendall): remove, allow to error.
+                },
+                {
+                    "camelcase": "warn", // TODO(bkendall): remove, allow to error.
+                    "new-cap": "warn", // TODO(bkendall): remove, allow to error.
+                    "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
+                    "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
+                    "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.
+                    "no-unused-vars": "warn", // TODO(bkendall): remove, allow to error.
+                    "require-atomic-updates": "warn", // TODO(bkendall): remove, allow to error.
+                }, 
+                globalRules),
         },
         {
             "files": ["*.js"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
                     "@typescript-eslint/await-thenable": "warn", // TODO(bkendall): remove, allow to error.
                     "@typescript-eslint/ban-types": "warn", // TODO(bkendall): remove, allow to error.
                     "@typescript-eslint/camelcase": "warn", // TODO(bkendall): remove, allow to error.
+                    "@typescript-eslint/explicit-function-return-type": ["warn", { allowExpressions: true }], // TODO(bkendall): SET to error.
                     "@typescript-eslint/no-inferrable-types": "warn", // TODO(bkendall): remove, allow to error.
                     "@typescript-eslint/no-misused-promises": "warn", // TODO(bkendall): remove, allow to error.
                     "@typescript-eslint/no-unnecessary-type-assertion": "warn", // TODO(bkendall): remove, allow to error.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,14 +1,3 @@
-const GLOBAL_RULES = {
-    "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
-    "no-restricted-globals": ["error", "name", "length"], // This is a keeper.
-    "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
-    "prefer-const": "warn", // TODO(bkendall): remove, allow to error.
-    "prefer-promise-reject-errors": "warn", // TODO(bkendall): remove, allow to error.
-    "prefer-spread": "warn", // TODO(bkendall): remove, allow to error.
-    "require-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
-    "valid-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
-}
-
 module.exports = {
     "env": {
         "es6": true,
@@ -16,62 +5,65 @@ module.exports = {
     },
     "extends": [
         "eslint:recommended",
+        "plugin:@typescript-eslint/eslint-recommended",
+        "plugin:@typescript-eslint/recommended",
+        "plugin:@typescript-eslint/recommended-requiring-type-checking",
         "google",
         "prettier",
         "prettier/@typescript-eslint",
     ],
-    "rules": Object.assign(
-        {
-            "prettier/prettier": "error",
-        },
-        GLOBAL_RULES),
+    "rules": {
+        "prettier/prettier": "error",
+        "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
+        "no-restricted-globals": ["error", "name", "length"],
+        "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
+        "prefer-const": "warn", // TODO(bkendall): remove, allow to error.
+        "prefer-promise-reject-errors": "warn", // TODO(bkendall): remove, allow to error.
+        "prefer-spread": "warn", // TODO(bkendall): remove, allow to error.
+        "require-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
+        "valid-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
+    },
     "overrides": [
         {
             "files": ["*.ts"],
-            "extends": [
-                // All rules after what would be `eslint:recommended` above
-                // need to be re-iterated here (since they override eachother).
-                "plugin:@typescript-eslint/eslint-recommended",
-                "plugin:@typescript-eslint/recommended",
-                "plugin:@typescript-eslint/recommended-requiring-type-checking",
-                "google",
-                "prettier",
-                "prettier/@typescript-eslint",
-            ],
-            "rules": Object.assign(
-                // Typescript specific rules.
-                {
-                    "@typescript-eslint/await-thenable": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/ban-types": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/camelcase": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/explicit-function-return-type": ["warn", { allowExpressions: true }], // TODO(bkendall): SET to error.
-                    "@typescript-eslint/no-inferrable-types": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/no-misused-promises": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/no-unnecessary-type-assertion": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/no-use-before-define": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/no-use-before-define": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/no-var-requires": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/prefer-includes": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/prefer-regexp-exec": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/prefer-string-starts-ends-with": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/require-await": "warn", // TODO(bkendall): remove, allow to error.
-                    "@typescript-eslint/unbound-method": "warn", // TODO(bkendall): remove, allow to error.
-                },
-                // eslint rules.
-                {
-                    "camelcase": "warn", // TODO(bkendall): remove, allow to error.
-                    "new-cap": "warn", // TODO(bkendall): remove, allow to error.
-                    "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
-                    "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
-                    "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.
-                    "no-unused-vars": "warn", // TODO(bkendall): remove, allow to error.
-                    "require-atomic-updates": "warn", // TODO(bkendall): remove, allow to error.
-                }, 
-                GLOBAL_RULES),
+            "rules": {
+                "@typescript-eslint/await-thenable": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/ban-types": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/camelcase": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/explicit-function-return-type": ["warn", { allowExpressions: true }], // TODO(bkendall): SET to error.
+                "@typescript-eslint/no-inferrable-types": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/no-misused-promises": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/no-unnecessary-type-assertion": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/no-use-before-define": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/no-use-before-define": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/no-var-requires": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/prefer-includes": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/prefer-regexp-exec": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/prefer-string-starts-ends-with": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/require-await": "warn", // TODO(bkendall): remove, allow to error.
+                "@typescript-eslint/unbound-method": "warn", // TODO(bkendall): remove, allow to error.
+                "camelcase": "warn", // TODO(bkendall): remove, allow to error.
+                "new-cap": "warn", // TODO(bkendall): remove, allow to error.
+                "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
+                "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
+                "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.
+                "no-unused-vars": "warn", // TODO(bkendall): remove, allow to error.
+                "require-atomic-updates": "warn", // TODO(bkendall): remove, allow to error.
+            },
         },
         {
             "files": ["*.js"],
             "rules": {
+                "@typescript-eslint/camelcase": "off",
+                "@typescript-eslint/explicit-function-return-type": "off",
+                "@typescript-eslint/no-empty-function": "off",
+                "@typescript-eslint/no-misused-promises": "off",
+                "@typescript-eslint/no-this-alias": "off",
+                "@typescript-eslint/no-use-before-define": "off",
+                "@typescript-eslint/no-var-requires": "off",
+                "@typescript-eslint/prefer-includes": "off",
+                "@typescript-eslint/prefer-regexp-exec": "off",
+                "@typescript-eslint/unbound-method": "off",
                 "no-extra-boolean-cast": "warn", // TODO(bkendall): remove, allow to error.
                 "no-invalid-this": "warn", // TODO(bkendall): remove, allow to error.
                 "no-redeclare": "warn", // TODO(bkendall): remove, allow to error.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Enabling more Typescript rules. These are TS specific and should be removed once fixed. I cleaned up the global override rules as well, since this is getting a bit complex. It's difficult when there's two different types of files (and eslint isn't smart enough to not apply `@typescript-eslint` rules to `js` files on its own).
	 
### Scenarios Tested



### Sample Commands

`npm lint`, `npm format`.
