### PR TITLE
Re-use runtime workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Functions emulator now re-uses workers to avoid running global code on each execution (#1353).

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -239,7 +239,7 @@ export class FunctionsEmulator implements EmulatorInstance {
 
       // If the original request had a body, forward that over the connection.
       // TODO: Why is this not handled by the pipe?
-      if (reqBody) {
+      if (reqBody.length > 0) {
         runtimeReq.write(reqBody);
         runtimeReq.end();
       }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -196,7 +196,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       const log = await waitForLog(worker.runtime.events, "SYSTEM", "runtime-status", (log) => {
         return log.data.state === "ready";
       });
-      worker.runtime.metadata = log.data.socketPath;
+      worker.runtime.metadata.socketPath = log.data.socketPath;
 
       logger.debug(JSON.stringify(worker.runtime.metadata));
       track(EVENT_INVOKE, "https");
@@ -206,9 +206,9 @@ export class FunctionsEmulator implements EmulatorInstance {
         `[functions] Runtime ready! Sending request! ${JSON.stringify(worker.runtime.metadata)}`
       );
 
-      // We do this instead of just 302'ing because many HTTP clients don't respect 302s so it may cause unexpected
-      // situations - not to mention CORS troubles and this enables us to use a socketPath (IPC socket) instead of
-      // consuming yet another port which is probably faster as well.
+      // We do this instead of just 302'ing because many HTTP clients don't respect 302s so it may
+      // cause unexpected situations - not to mention CORS troubles and this enables us to use
+      // a socketPath (IPC socket) instead of consuming yet another port which is probably faster as well.
       const runtimeReq = http.request(
         {
           method,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -674,6 +674,7 @@ You can probably fix this by running "npm install ${
   }
 
   async stop(): Promise<void> {
+    WORKER_POOL.exit();
     Promise.resolve(this.server && this.server.close());
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -62,12 +62,13 @@ export interface FunctionsRuntimeInstance {
   events: EventEmitter;
   // A promise which is fulfilled when the runtime has exited
   exit: Promise<number>;
+
   // A function to manually kill the child process as normal cleanup
-  shutdown: () => void;
+  shutdown(): void;
   // A function to manually kill the child process in case of errors
-  kill: (signal?: string) => void;
+  kill(signal?: string): void;
   // Send an IPC message to the child process
-  send: (args: FunctionsRuntimeArgs) => boolean;
+  send(args: FunctionsRuntimeArgs): boolean;
 }
 
 interface RequestWithRawBody extends express.Request {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -288,7 +288,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       triggerType,
     };
 
-    const worker = InvokeRuntime(nodeBinary, runtimeBundle, runtimeOpts || {});
+    const worker = invokeRuntime(nodeBinary, runtimeBundle, runtimeOpts || {});
     return worker;
   }
 
@@ -490,7 +490,7 @@ You can probably fix this by running "npm install ${
       // in the pool that would cause us to run old code.
       WORKER_POOL.refresh();
 
-      const worker = InvokeRuntime(this.nodeBinary, this.getBaseBundle());
+      const worker = invokeRuntime(this.nodeBinary, this.getBaseBundle());
 
       const triggerParseEvent = await EmulatorLog.waitForLog(
         worker.runtime.events,
@@ -780,7 +780,7 @@ export interface InvokeRuntimeOpts {
   ignore_warnings?: boolean;
 }
 
-export function InvokeRuntime(
+export function invokeRuntime(
   nodeBinary: string,
   frb: FunctionsRuntimeBundle,
   opts?: InvokeRuntimeOpts

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -155,7 +155,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       // For analytics, track the invoked service
       track(EVENT_INVOKE, log.data.service);
 
-      await worker.waitForNotBusy();
+      await worker.waitForDone();
       return res.json({ status: "acknowledged" });
     };
 
@@ -258,7 +258,7 @@ export class FunctionsEmulator implements EmulatorInstance {
           res.end();
         });
 
-      await worker.waitForNotBusy();
+      await worker.waitForDone();
     };
 
     // The ordering here is important. The longer routes (background)

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -969,6 +969,10 @@ async function InvokeTrigger(
     throw new Error("frb.triggerId unexpectedly null");
   }
 
+  new EmulatorLog("INFO", "runtime-status", `Beginning execution of "${frb.triggerId}"`, {
+    frb,
+  }).log();
+
   const trigger = triggers[frb.triggerId];
   logDebug("", trigger.definition);
   const mode = trigger.definition.httpsTrigger ? "HTTPS" : "BACKGROUND";
@@ -1019,12 +1023,6 @@ async function InitializeRuntime(
   frb: FunctionsRuntimeBundle,
   serializedFunctionTrigger?: string
 ): Promise<EmulatedTriggerMap | undefined> {
-  if (frb.triggerId) {
-    new EmulatorLog("INFO", "runtime-status", `Beginning execution of "${frb.triggerId}"`, {
-      frb,
-    }).log();
-  }
-
   logDebug(`Disabled runtime features: ${JSON.stringify(frb.disabled_features)}`);
 
   const verified = await verifyDeveloperNodeModules(frb);

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1109,8 +1109,7 @@ async function main(): Promise<void> {
   });
 
   process.on("message", async (message: string) => {
-    // TODO: Log message receipt in a better way
-    console.log("GOT MESSAGE");
+    // TODO: Log message receipt
 
     let runtimeArgs: FunctionsRuntimeArgs;
     try {
@@ -1140,7 +1139,7 @@ async function main(): Promise<void> {
     try {
       await InvokeTrigger(runtimeArgs.frb, triggers);
       await EmulatorLog.waitForFlush();
-      new EmulatorLog("SYSTEM", "runtime-status", "Runtime is now idle", { state: "idle" });
+      new EmulatorLog("SYSTEM", "runtime-status", "Runtime is now idle", { state: "idle" }).log();
     } catch (err) {
       new EmulatorLog("FATAL", "runtime-error", err.stack ? err.stack : err).log();
       process.exit(1);

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -856,7 +856,11 @@ async function ProcessBackground(
   frb: FunctionsRuntimeBundle,
   trigger: EmulatedTrigger
 ): Promise<void> {
-  new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready" }).log();
+  const service = trigger.definition.eventTrigger
+    ? trigger.definition.eventTrigger.service
+    : "unknown";
+
+  new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready", service }).log();
 
   const proto = frb.proto;
   logDebug("ProcessBackground", proto);

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -33,7 +33,11 @@ export interface EmulatedTriggerMap {
   [name: string]: EmulatedTrigger;
 }
 
-// This bundle gets passed from hub -> runtime as a CLI arg
+export interface FunctionsRuntimeArgs {
+  frb: FunctionsRuntimeBundle;
+  serializedTriggers?: string;
+}
+
 export interface FunctionsRuntimeBundle {
   projectId: string;
   proto?: any;

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -129,7 +129,7 @@ export class RuntimeWorkerPool {
    * kill itself after it's done with its current task.
    */
   refresh() {
-    for (let arr of this.workers.values()) {
+    for (const arr of this.workers.values()) {
       arr.forEach((w) => {
         if (w.state === RuntimeWorkerState.IDLE) {
           this.log(`Shutting down IDLE worker (${w.triggerId})`);
@@ -146,7 +146,7 @@ export class RuntimeWorkerPool {
    * Immediately kill all workers.
    */
   exit() {
-    for (let arr of this.workers.values()) {
+    for (const arr of this.workers.values()) {
       arr.forEach((w) => {
         if (w.state === RuntimeWorkerState.IDLE) {
           w.runtime.shutdown();
@@ -192,11 +192,8 @@ export class RuntimeWorkerPool {
   }
 
   private cleanUpWorkers() {
-    for (let entry of this.workers.entries()) {
-      const key = entry[0];
-      const keyWorkers = entry[1];
-
-      // Drop all finished workers from the pool
+    // Drop all finished workers from the pool
+    for (const [key, keyWorkers] of this.workers.entries()) {
       const notDoneWorkers = keyWorkers.filter((worker) => {
         return worker.state !== RuntimeWorkerState.FINISHED;
       });

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -135,6 +135,21 @@ export class RuntimeWorkerPool {
     });
   }
 
+  /**
+   * Immediately kill all workers.
+   */
+  exit() {
+    Object.values(this.workers).forEach((arr) => {
+      arr.forEach((w) => {
+        if (w.state === RuntimeWorkerState.IDLE) {
+          w.runtime.shutdown();
+        } else {
+          w.runtime.kill();
+        }
+      });
+    });
+  }
+
   getIdleWorker(triggerId: string | undefined): RuntimeWorker | undefined {
     this.cleanUpWorkers();
 

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -21,14 +21,12 @@ export class RuntimeWorker {
     this.runtime.events.on("log", (log: EmulatorLog) => {
       if (log.type === "runtime-status") {
         if (log.data.state === "idle") {
-          console.log("Worker going idle");
           this.state = RuntimeWorkerState.IDLE;
         }
       }
     });
 
     this.runtime.exit.then(() => {
-      console.log("Worker exiting");
       this.state = RuntimeWorkerState.DONE;
     });
   }
@@ -38,8 +36,6 @@ export class RuntimeWorker {
 
     // TODO: handle errors
     const args: FunctionsRuntimeArgs = { frb, serializedTriggers };
-
-    console.log("executing: " + frb.triggerId);
     this.runtime.send(args);
   }
 

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -163,7 +163,7 @@ export class RuntimeWorkerPool {
     const key = this.getTriggerKey(triggerId);
     if (!this.workers[key]) {
       this.workers[key] = [];
-      return undefined;
+      return;
     }
 
     for (const worker of this.workers[key]) {
@@ -172,7 +172,7 @@ export class RuntimeWorkerPool {
       }
     }
 
-    return undefined;
+    return;
   }
 
   addWorker(triggerId: string | undefined, runtime: FunctionsRuntimeInstance): RuntimeWorker {

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -7,7 +7,7 @@ import { EmulatorLogger } from "./emulatorLogger";
 
 type LogListener = (el: EmulatorLog) => any;
 
-enum RuntimeWorkerState {
+export enum RuntimeWorkerState {
   // Worker is ready to accept new work
   IDLE = "IDLE",
 
@@ -27,8 +27,9 @@ export class RuntimeWorker {
   readonly triggerId: string;
   readonly runtime: FunctionsRuntimeInstance;
 
+  stateEvents: EventEmitter = new EventEmitter();
+
   private logListeners: Array<LogListener> = [];
-  private stateEvents: EventEmitter = new EventEmitter();
   private _state: RuntimeWorkerState = RuntimeWorkerState.IDLE;
 
   constructor(triggerId: string, runtime: FunctionsRuntimeInstance) {
@@ -91,8 +92,8 @@ export class RuntimeWorker {
     this.runtime.events.on("log", listener);
   }
 
-  waitForNotBusy(): Promise<any> {
-    if (this.state !== RuntimeWorkerState.BUSY) {
+  waitForDone(): Promise<any> {
+    if (this.state === RuntimeWorkerState.IDLE || this.state === RuntimeWorkerState.FINISHED) {
       return Promise.resolve();
     }
 

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -1,18 +1,29 @@
+import * as uuid from "uuid";
 import { FunctionsRuntimeInstance } from "./functionsEmulator";
 import { EmulatorLog } from "./types";
 import { FunctionsRuntimeBundle, FunctionsRuntimeArgs } from "./functionsEmulatorShared";
 import { EventEmitter } from "events";
-import { list } from "tar";
+import { EmulatorLogger } from "./emulatorLogger";
 
 type LogListener = (el: EmulatorLog) => any;
 
 enum RuntimeWorkerState {
+  // Worker is ready to accept new work
   IDLE = "IDLE",
+
+  // Worker is currently doing work
   BUSY = "BUSY",
+
+  // Worker is BUSY and when done will be killed rather
+  // than recycled.
+  FINISHING = "FINISHING",
+
+  // Worker has exited and cannot be re-used
   FINISHED = "FINISHED",
 }
 
 export class RuntimeWorker {
+  readonly id: string;
   readonly triggerId: string;
   readonly runtime: FunctionsRuntimeInstance;
 
@@ -21,18 +32,25 @@ export class RuntimeWorker {
   private _state: RuntimeWorkerState = RuntimeWorkerState.IDLE;
 
   constructor(triggerId: string, runtime: FunctionsRuntimeInstance) {
+    this.id = uuid.v4();
     this.triggerId = triggerId;
     this.runtime = runtime;
 
     this.runtime.events.on("log", (log: EmulatorLog) => {
       if (log.type === "runtime-status") {
         if (log.data.state === "idle") {
-          this.state = RuntimeWorkerState.IDLE;
+          if (this.state === RuntimeWorkerState.BUSY) {
+            this.state = RuntimeWorkerState.IDLE;
+          } else if (this.state === RuntimeWorkerState.FINISHING) {
+            this.log(`IDLE --> FINISHING`);
+            this.runtime.shutdown();
+          }
         }
       }
     });
 
     this.runtime.exit.then(() => {
+      this.log("exited");
       this.state = RuntimeWorkerState.FINISHED;
     });
   }
@@ -49,13 +67,18 @@ export class RuntimeWorker {
 
   set state(state: RuntimeWorkerState) {
     if (state === RuntimeWorkerState.IDLE) {
-      // Remove all of the log listeners every time we move to IDLE
+      // Remove all temporary log listeners every time we move to IDLE
       for (const l of this.logListeners) {
         this.runtime.events.removeListener("log", l);
       }
       this.logListeners = [];
     }
 
+    if (state === RuntimeWorkerState.FINISHED) {
+      this.runtime.events.removeAllListeners();
+    }
+
+    this.log(state);
     this._state = state;
     this.stateEvents.emit(this._state);
   }
@@ -83,10 +106,34 @@ export class RuntimeWorker {
   waitForSystemLog(filter: (el: EmulatorLog) => boolean): Promise<EmulatorLog> {
     return EmulatorLog.waitForLog(this.runtime.events, "SYSTEM", "runtime-status", filter);
   }
+
+  private log(msg: string): void {
+    EmulatorLogger.log("DEBUG", `[worker-${this.triggerId}-${this.id}]: ${msg}`);
+  }
 }
 
 export class RuntimeWorkerPool {
   workers: { [triggerId: string]: Array<RuntimeWorker> } = {};
+
+  /**
+   * When code changes (or in some other rare circumstances) we need to get
+   * a new pool of workers. For each IDLE worker we kill it immediately. For
+   * each BUSY worker we move it to the FINISHING state so that it will
+   * kill itself after the next run.
+   */
+  refresh() {
+    Object.values(this.workers).forEach((arr) => {
+      arr.forEach((w) => {
+        if (w.state === RuntimeWorkerState.IDLE) {
+          this.log(`Shutting down IDLE worker (${w.triggerId})`);
+          w.runtime.shutdown();
+        } else if (w.state === RuntimeWorkerState.BUSY) {
+          this.log(`Marking BUSY worker to finish (${w.triggerId})`);
+          w.state = RuntimeWorkerState.FINISHING;
+        }
+      });
+    });
+  }
 
   getIdleWorker(triggerId: string | undefined): RuntimeWorker | undefined {
     this.cleanUpWorkers();
@@ -120,19 +167,12 @@ export class RuntimeWorkerPool {
   }
 
   private getTriggerKey(triggerId?: string) {
-    return triggerId || "__diagnostic__";
+    return triggerId || "~diagnostic~";
   }
 
   private cleanUpWorkers() {
     Object.keys(this.workers).forEach((key: string) => {
       const keyWorkers = this.workers[key];
-
-      // For each finished worker, detach any event listeners.
-      for (const w of keyWorkers) {
-        if (w.state === RuntimeWorkerState.FINISHED) {
-          w.runtime.events.removeAllListeners();
-        }
-      }
 
       // Drop all finished workers from the pool
       const notDoneWorkers = keyWorkers.filter((worker) => {
@@ -140,5 +180,9 @@ export class RuntimeWorkerPool {
       });
       this.workers[key] = notDoneWorkers;
     });
+  }
+
+  private log(msg: string): void {
+    EmulatorLogger.log("DEBUG", `[worker-pool]: ${msg}`);
   }
 }

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -1,0 +1,97 @@
+import { FunctionsRuntimeInstance } from "./functionsEmulator";
+import { EmulatorLog, waitForLog } from "./types";
+import { FunctionsRuntimeBundle, FunctionsRuntimeArgs } from "./functionsEmulatorShared";
+
+export enum RuntimeWorkerState {
+  IDLE,
+  BUSY,
+  DONE,
+}
+
+export class RuntimeWorker {
+  state: RuntimeWorkerState;
+  triggerId: string;
+  runtime: FunctionsRuntimeInstance;
+
+  constructor(triggerId: string, runtime: FunctionsRuntimeInstance) {
+    this.state = RuntimeWorkerState.IDLE;
+    this.triggerId = triggerId;
+    this.runtime = runtime;
+
+    this.runtime.events.on("log", (log: EmulatorLog) => {
+      if (log.type === "runtime-status") {
+        if (log.data.state === "idle") {
+          this.state = RuntimeWorkerState.IDLE;
+        }
+      }
+    });
+
+    this.runtime.exit.then(() => {
+      this.state = RuntimeWorkerState.DONE;
+    });
+  }
+
+  execute(frb: FunctionsRuntimeBundle, serializedTriggers?: string) {
+    this.state = RuntimeWorkerState.BUSY;
+
+    // TODO: handle errors
+    // TODO: what about serialized triggers
+    const args: FunctionsRuntimeArgs = { frb, serializedTriggers };
+    this.runtime.send(args);
+  }
+
+  waitForIdleOrExit(): Promise<any> {
+    if (this.state === RuntimeWorkerState.IDLE) {
+      return Promise.resolve();
+    }
+
+    return new Promise((res) => {
+      // Idle event (via log)
+      waitForLog(this.runtime.events, "SYSTEM", "runtime-status", (log: EmulatorLog) => {
+        return log.data.state === "idle";
+      }).then(res);
+
+      // Exit event (via process)
+      this.runtime.exit.then(res);
+    });
+  }
+}
+
+export class RuntimeWorkerPool {
+  workers: { [triggerId: string]: Array<RuntimeWorker> } = {};
+
+  getIdleWorker(triggerId: string | undefined): RuntimeWorker | undefined {
+    const key = this.getTriggerKey(triggerId);
+
+    // TODO: Clean up 'DONE' workers
+    if (!this.workers[key]) {
+      this.workers[key] = [];
+      return undefined;
+    }
+
+    for (const worker of this.workers[key]) {
+      if (worker.state === RuntimeWorkerState.IDLE) {
+        return worker;
+      }
+    }
+
+    return undefined;
+  }
+
+  addWorker(triggerId: string | undefined, runtime: FunctionsRuntimeInstance): RuntimeWorker {
+    const key = this.getTriggerKey(triggerId);
+    const worker = new RuntimeWorker(key, runtime);
+
+    if (this.workers[key]) {
+      this.workers[key].push(worker);
+    } else {
+      this.workers[key] = [worker];
+    }
+
+    return worker;
+  }
+
+  private getTriggerKey(triggerId?: string) {
+    return triggerId || "__diagnostic__";
+  }
+}

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -21,22 +21,25 @@ export class RuntimeWorker {
     this.runtime.events.on("log", (log: EmulatorLog) => {
       if (log.type === "runtime-status") {
         if (log.data.state === "idle") {
+          console.log("Worker going idle");
           this.state = RuntimeWorkerState.IDLE;
         }
       }
     });
 
     this.runtime.exit.then(() => {
+      console.log("Worker exiting");
       this.state = RuntimeWorkerState.DONE;
     });
   }
 
-  execute(frb: FunctionsRuntimeBundle, serializedTriggers?: string) {
+  async execute(frb: FunctionsRuntimeBundle, serializedTriggers?: string) {
     this.state = RuntimeWorkerState.BUSY;
 
     // TODO: handle errors
-    // TODO: what about serialized triggers
     const args: FunctionsRuntimeArgs = { frb, serializedTriggers };
+
+    console.log("executing: " + frb.triggerId);
     this.runtime.send(args);
   }
 

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -126,7 +126,7 @@ export class RuntimeWorkerPool {
    * When code changes (or in some other rare circumstances) we need to get
    * a new pool of workers. For each IDLE worker we kill it immediately. For
    * each BUSY worker we move it to the FINISHING state so that it will
-   * kill itself after the next run.
+   * kill itself after it's done with its current task.
    */
   refresh() {
     Object.values(this.workers).forEach((arr) => {

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -98,9 +98,15 @@ export class RuntimeWorker {
     }
 
     return new Promise((res) => {
+      const listener = () => {
+        this.stateEvents.removeListener(RuntimeWorkerState.IDLE, listener);
+        this.stateEvents.removeListener(RuntimeWorkerState.FINISHED, listener);
+        res();
+      };
+
       // Finish on either IDLE or FINISHED states
-      this.stateEvents.once(RuntimeWorkerState.IDLE, res);
-      this.stateEvents.once(RuntimeWorkerState.FINISHED, res);
+      this.stateEvents.once(RuntimeWorkerState.IDLE, listener);
+      this.stateEvents.once(RuntimeWorkerState.FINISHED, listener);
     });
   }
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -213,7 +213,7 @@ export function waitForLog(
   filter?: (el: EmulatorLog) => boolean
 ): Promise<EmulatorLog> {
   return new Promise((resolve, reject) => {
-    emitter.on("log", (el: EmulatorLog) => {
+    const listener = (el: EmulatorLog) => {
       const levelTypeMatch = el.level === level && el.type === type;
       let filterMatch = true;
       if (filter) {
@@ -221,9 +221,11 @@ export function waitForLog(
       }
 
       if (levelTypeMatch && filterMatch) {
+        emitter.removeListener("log", listener);
         resolve(el);
       }
-    });
+    };
+    emitter.on("log", listener);
   });
 }
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -1,4 +1,5 @@
 import { ChildProcess } from "child_process";
+import { EventEmitter } from "events";
 
 export enum Emulators {
   FUNCTIONS = "functions",
@@ -202,6 +203,28 @@ export class EmulatorLog {
       pretty ? 2 : 0
     );
   }
+}
+
+// Should this be a static function of EmulatorLog?  Probably.
+export function waitForLog(
+  emitter: EventEmitter,
+  level: string,
+  type: string,
+  filter?: (el: EmulatorLog) => boolean
+): Promise<EmulatorLog> {
+  return new Promise((resolve, reject) => {
+    emitter.on("log", (el: EmulatorLog) => {
+      const levelTypeMatch = el.level === level && el.type === type;
+      let filterMatch = true;
+      if (filter) {
+        filterMatch = filter(el);
+      }
+
+      if (levelTypeMatch && filterMatch) {
+        resolve(el);
+      }
+    });
+  });
 }
 
 /**

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -95,6 +95,29 @@ export class EmulatorLog {
     });
   }
 
+  static waitForLog(
+    emitter: EventEmitter,
+    level: string,
+    type: string,
+    filter?: (el: EmulatorLog) => boolean
+  ): Promise<EmulatorLog> {
+    return new Promise((resolve, reject) => {
+      const listener = (el: EmulatorLog) => {
+        const levelTypeMatch = el.level === level && el.type === type;
+        let filterMatch = true;
+        if (filter) {
+          filterMatch = filter(el);
+        }
+
+        if (levelTypeMatch && filterMatch) {
+          emitter.removeListener("log", listener);
+          resolve(el);
+        }
+      };
+      emitter.on("log", listener);
+    });
+  }
+
   static fromJSON(json: string): EmulatorLog {
     let parsedLog;
     let isNotJSON = false;
@@ -203,30 +226,6 @@ export class EmulatorLog {
       pretty ? 2 : 0
     );
   }
-}
-
-// Should this be a static function of EmulatorLog?  Probably.
-export function waitForLog(
-  emitter: EventEmitter,
-  level: string,
-  type: string,
-  filter?: (el: EmulatorLog) => boolean
-): Promise<EmulatorLog> {
-  return new Promise((resolve, reject) => {
-    const listener = (el: EmulatorLog) => {
-      const levelTypeMatch = el.level === level && el.type === type;
-      let filterMatch = true;
-      if (filter) {
-        filterMatch = filter(el);
-      }
-
-      if (levelTypeMatch && filterMatch) {
-        emitter.removeListener("log", listener);
-        resolve(el);
-      }
-    };
-    emitter.on("log", listener);
-  });
 }
 
 /**

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -8,6 +8,7 @@ import {
   FunctionsRuntimeBundle,
 } from "../../emulator/functionsEmulatorShared";
 import * as express from "express";
+import { RuntimeWorker } from "../../emulator/functionsRuntimeWorker";
 
 if ((process.env.DEBUG || "").toLowerCase().indexOf("spec") >= 0) {
   // tslint:disable-next-line:no-var-requires
@@ -28,7 +29,7 @@ function UseFunctions(triggers: () => {}): void {
     triggerType: EmulatedTriggerType,
     nodeBinary: string,
     proto?: any
-  ): FunctionsRuntimeInstance => {
+  ): RuntimeWorker => {
     return startFunctionRuntime(bundleTemplate, triggerId, triggerType, nodeBinary, proto, {
       serializedTriggers,
     });

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -4,7 +4,7 @@ import {
   InvokeRuntime,
   InvokeRuntimeOpts,
 } from "../../emulator/functionsEmulator";
-import { EmulatorLog, waitForLog } from "../../emulator/types";
+import { EmulatorLog } from "../../emulator/types";
 import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import { Change } from "firebase-functions";
 import { DocumentSnapshot } from "firebase-functions/lib/providers/firestore";
@@ -55,7 +55,7 @@ async function CallHTTPSFunction(
   options: any = {},
   requestData?: string
 ): Promise<string> {
-  await waitForLog(runtime.events, "SYSTEM", "runtime-status", (el) => {
+  await EmulatorLog.waitForLog(runtime.events, "SYSTEM", "runtime-status", (el) => {
     return el.data.state === "ready";
   });
 

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -55,9 +55,10 @@ async function CallHTTPSFunction(
   options: any = {},
   requestData?: string
 ): Promise<string> {
-  await EmulatorLog.waitForLog(runtime.events, "SYSTEM", "runtime-status", (el) => {
+  const log = await EmulatorLog.waitForLog(runtime.events, "SYSTEM", "runtime-status", (el) => {
     return el.data.state === "ready";
   });
+  runtime.metadata.socketPath = log.data.socketPath;
 
   const dataPromise = new Promise<string>((resolve, reject) => {
     const path = `/${frb.projectId}/us-central1/${frb.triggerId}`;
@@ -277,8 +278,10 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
+        console.log('Calling function');
         const data = await CallHTTPSFunction(runtime, FunctionRuntimeBundles.onRequest);
 
+        console.log('Okie dokie');
         const info = JSON.parse(data);
         expect(info.appFirestoreSettings).to.deep.eq(info.adminFirestoreSettings);
         expect(info.appDatabaseRef).to.eq(info.adminDatabaseRef);

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -36,10 +36,11 @@ function InvokeRuntimeWithFunctions(
   opts = opts || {};
   opts.ignore_warnings = true;
 
+  // TODO: I think we always want to invoke a new one here
   return InvokeRuntime(process.execPath, frb, {
     ...opts,
     serializedTriggers,
-  });
+  }).runtime;
 }
 
 /**

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -278,10 +278,10 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        console.log('Calling function');
+        console.log("Calling function");
         const data = await CallHTTPSFunction(runtime, FunctionRuntimeBundles.onRequest);
 
-        console.log('Okie dokie');
+        console.log("Okie dokie");
         const info = JSON.parse(data);
         expect(info.appFirestoreSettings).to.deep.eq(info.adminFirestoreSettings);
         expect(info.appDatabaseRef).to.eq(info.adminDatabaseRef);

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -277,10 +277,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        console.log("Calling function");
         const data = await CallHTTPSFunction(runtime, FunctionRuntimeBundles.onRequest);
-
-        console.log("Okie dokie");
         const info = JSON.parse(data);
         expect(info.appFirestoreSettings).to.deep.eq(info.adminFirestoreSettings);
         expect(info.appDatabaseRef).to.eq(info.adminDatabaseRef);

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -36,7 +36,6 @@ function InvokeRuntimeWithFunctions(
   opts = opts || {};
   opts.ignore_warnings = true;
 
-  // TODO: I think we always want to invoke a new one here
   return InvokeRuntime(process.execPath, frb, {
     ...opts,
     serializedTriggers,

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -4,7 +4,7 @@ import {
   InvokeRuntime,
   InvokeRuntimeOpts,
 } from "../../emulator/functionsEmulator";
-import { EmulatorLog } from "../../emulator/types";
+import { EmulatorLog, waitForLog } from "../../emulator/types";
 import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 import { Change } from "firebase-functions";
 import { DocumentSnapshot } from "firebase-functions/lib/providers/firestore";
@@ -55,8 +55,10 @@ async function CallHTTPSFunction(
   options: any = {},
   requestData?: string
 ): Promise<string> {
-  // TODO
-  await runtime.ready;
+  await waitForLog(runtime.events, "SYSTEM", "runtime-status", (el) => {
+    return el.data.state === "ready";
+  });
+
   const dataPromise = new Promise<string>((resolve, reject) => {
     const path = `/${frb.projectId}/us-central1/${frb.triggerId}`;
     const requestOptions: request.CoreOptions = {

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -55,6 +55,7 @@ async function CallHTTPSFunction(
   options: any = {},
   requestData?: string
 ): Promise<string> {
+  // TODO
   await runtime.ready;
   const dataPromise = new Promise<string>((resolve, reject) => {
     const path = `/${frb.projectId}/us-central1/${frb.triggerId}`;

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import {
   FunctionsRuntimeInstance,
-  InvokeRuntime,
+  invokeRuntime,
   InvokeRuntimeOpts,
 } from "../../emulator/functionsEmulator";
 import { EmulatorLog } from "../../emulator/types";
@@ -36,7 +36,7 @@ function InvokeRuntimeWithFunctions(
   opts = opts || {};
   opts.ignore_warnings = true;
 
-  return InvokeRuntime(process.execPath, frb, {
+  return invokeRuntime(process.execPath, frb, {
     ...opts,
     serializedTriggers,
   }).runtime;

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -149,7 +149,8 @@ describe("FunctionsRuntimeWorker", () => {
 
       // Add a worker and make sure it's there
       const worker = pool.addWorker(trigger, new MockRuntimeInstance(true));
-      expect(pool.workers[trigger].length).to.eql(1);
+      const triggerWorkers = pool.workers.get(trigger);
+      expect(triggerWorkers).length.to.eq(1);
       expect(pool.getIdleWorker(trigger)).to.eql(worker);
 
       // Make the worker busy, confirm nothing is idle

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -150,7 +150,7 @@ describe("FunctionsRuntimeWorker", () => {
       // Add a worker and make sure it's there
       const worker = pool.addWorker(trigger, new MockRuntimeInstance(true));
       const triggerWorkers = pool.workers.get(trigger);
-      expect(triggerWorkers).length.to.eq(1);
+      expect(triggerWorkers!.length).length.to.eq(1);
       expect(pool.getIdleWorker(trigger)).to.eql(worker);
 
       // Make the worker busy, confirm nothing is idle

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -1,0 +1,234 @@
+import { expect } from "chai";
+import { FunctionsRuntimeInstance } from "../../emulator/functionsEmulator";
+import { EventEmitter } from "events";
+import {
+  FunctionsRuntimeArgs,
+  FunctionsRuntimeBundle,
+  EmulatedTriggerType,
+} from "../../emulator/functionsEmulatorShared";
+import {
+  RuntimeWorker,
+  RuntimeWorkerState,
+  RuntimeWorkerPool,
+} from "../../emulator/functionsRuntimeWorker";
+
+/**
+ * Fake runtime instance we can use to simulate different subprocess conditions.
+ * It automatically fails or succeeds 10ms after being given work to do.
+ */
+class MockRuntimeInstance implements FunctionsRuntimeInstance {
+  metadata: { [key: string]: any } = {};
+  events: EventEmitter = new EventEmitter();
+  exit: Promise<number>;
+
+  constructor(private success: boolean) {
+    this.exit = new Promise((res) => {
+      this.events.on("exit", res);
+    });
+  }
+
+  shutdown(): void {
+    this.events.emit("exit", { reason: "shutdown" });
+  }
+
+  kill(signal?: string): void {
+    this.events.emit("exit", { reason: "kill" });
+  }
+
+  send(args: FunctionsRuntimeArgs): boolean {
+    setTimeout(() => {
+      if (this.success) {
+        this.logRuntimeStatus({ state: "idle" });
+      } else {
+        this.kill();
+      }
+    }, 10);
+    return true;
+  }
+
+  logRuntimeStatus(data: any) {
+    this.events.emit("log", { type: "runtime-status", data });
+  }
+}
+
+/**
+ * Test helper to count worker state transitions.
+ */
+class WorkerStateCounter {
+  counts: { [state in RuntimeWorkerState]: number } = {
+    IDLE: 0,
+    BUSY: 0,
+    FINISHING: 0,
+    FINISHED: 0,
+  };
+
+  constructor(worker: RuntimeWorker) {
+    this.increment(worker.state);
+    worker.stateEvents.on(RuntimeWorkerState.IDLE, () => {
+      this.increment(RuntimeWorkerState.IDLE);
+    });
+    worker.stateEvents.on(RuntimeWorkerState.BUSY, () => {
+      this.increment(RuntimeWorkerState.BUSY);
+    });
+    worker.stateEvents.on(RuntimeWorkerState.FINISHING, () => {
+      this.increment(RuntimeWorkerState.FINISHING);
+    });
+    worker.stateEvents.on(RuntimeWorkerState.FINISHED, () => {
+      this.increment(RuntimeWorkerState.FINISHED);
+    });
+  }
+
+  private increment(state: RuntimeWorkerState) {
+    this.counts[state]++;
+  }
+
+  get total() {
+    return this.counts.IDLE + this.counts.BUSY + this.counts.FINISHING + this.counts.FINISHED;
+  }
+}
+
+class MockRuntimeBundle implements FunctionsRuntimeBundle {
+  projectId = "project-1234";
+  triggerType = EmulatedTriggerType.HTTPS;
+  cwd = "/home/users/dir";
+  ports = {};
+
+  constructor(public triggerId: string) {}
+}
+
+describe("FunctionsRuntimeWorker", () => {
+  describe("RuntimeWorker", () => {
+    it("goes from idle --> busy --> idle in normal operation", async () => {
+      const worker = new RuntimeWorker("trigger", new MockRuntimeInstance(true));
+      const counter = new WorkerStateCounter(worker);
+
+      worker.execute(new MockRuntimeBundle("trigger"));
+      await worker.waitForDone();
+
+      expect(counter.counts.BUSY).to.eql(1);
+      expect(counter.counts.IDLE).to.eql(2);
+      expect(counter.total).to.eql(3);
+    });
+
+    it("goes from idle --> busy --> finished when there's an error", async () => {
+      const worker = new RuntimeWorker("trigger", new MockRuntimeInstance(false));
+      const counter = new WorkerStateCounter(worker);
+
+      worker.execute(new MockRuntimeBundle("trigger"));
+      await worker.waitForDone();
+
+      expect(counter.counts.IDLE).to.eql(1);
+      expect(counter.counts.BUSY).to.eql(1);
+      expect(counter.counts.FINISHED).to.eql(1);
+      expect(counter.total).to.eql(3);
+    });
+
+    it("goes from busy --> finishing --> finished when marked", async () => {
+      const worker = new RuntimeWorker("trigger", new MockRuntimeInstance(true));
+      const counter = new WorkerStateCounter(worker);
+
+      worker.execute(new MockRuntimeBundle("trigger"));
+      worker.state = RuntimeWorkerState.FINISHING;
+      await worker.waitForDone();
+
+      expect(counter.counts.IDLE).to.eql(1);
+      expect(counter.counts.BUSY).to.eql(1);
+      expect(counter.counts.FINISHING).to.eql(1);
+      expect(counter.counts.FINISHED).to.eql(1);
+      expect(counter.total).to.eql(4);
+    });
+  });
+
+  describe("RuntimeWorkerPool", () => {
+    it("properly manages a single worker", async () => {
+      const pool = new RuntimeWorkerPool();
+      const trigger = "trigger1";
+
+      // No idle workers to begin
+      expect(pool.getIdleWorker(trigger)).to.be.undefined;
+
+      // Add a worker and make sure it's there
+      const worker = pool.addWorker(trigger, new MockRuntimeInstance(true));
+      expect(pool.workers[trigger].length).to.eql(1);
+      expect(pool.getIdleWorker(trigger)).to.eql(worker);
+
+      // Make the worker busy, confirm nothing is idle
+      worker.execute(new MockRuntimeBundle(trigger));
+      expect(pool.getIdleWorker(trigger)).to.be.undefined;
+
+      // When the worker is finished work, confirm it's idle again
+      await worker.waitForDone();
+      expect(pool.getIdleWorker(trigger)).to.eql(worker);
+    });
+
+    it("does not consider failed workers idle", async () => {
+      const pool = new RuntimeWorkerPool();
+      const trigger = "trigger1";
+
+      // No idle workers to begin
+      expect(pool.getIdleWorker(trigger)).to.be.undefined;
+
+      // Add a worker to the pool that will fail, confirm it begins idle
+      const worker = pool.addWorker(trigger, new MockRuntimeInstance(false));
+      expect(pool.getIdleWorker(trigger)).to.eql(worker);
+
+      // Make the worker execute (and fail)
+      worker.execute(new MockRuntimeBundle(trigger));
+      await worker.waitForDone();
+
+      // Confirm there are no idle workers
+      expect(pool.getIdleWorker(trigger)).to.be.undefined;
+    });
+
+    it("exit() kills idle and busy workers", async () => {
+      const pool = new RuntimeWorkerPool();
+      const trigger = "trigger1";
+
+      const busyWorker = pool.addWorker(trigger, new MockRuntimeInstance(true));
+      const busyWorkerCounter = new WorkerStateCounter(busyWorker);
+
+      const idleWorker = pool.addWorker(trigger, new MockRuntimeInstance(true));
+      const idleWorkerCounter = new WorkerStateCounter(idleWorker);
+
+      busyWorker.execute(new MockRuntimeBundle(trigger));
+      pool.exit();
+
+      await busyWorker.waitForDone();
+      await idleWorker.waitForDone();
+
+      expect(busyWorkerCounter.counts.IDLE).to.eql(1);
+      expect(busyWorkerCounter.counts.BUSY).to.eql(1);
+      expect(busyWorkerCounter.counts.FINISHED).to.eql(1);
+      expect(busyWorkerCounter.total).to.eql(3);
+
+      expect(idleWorkerCounter.counts.IDLE).to.eql(1);
+      expect(idleWorkerCounter.counts.FINISHED).to.eql(1);
+      expect(idleWorkerCounter.total).to.eql(2);
+    });
+
+    it("refresh() kills idle workers and marks busy ones as finishing", async () => {
+      const pool = new RuntimeWorkerPool();
+      const trigger = "trigger1";
+
+      const busyWorker = pool.addWorker(trigger, new MockRuntimeInstance(true));
+      const busyWorkerCounter = new WorkerStateCounter(busyWorker);
+
+      const idleWorker = pool.addWorker(trigger, new MockRuntimeInstance(true));
+      const idleWorkerCounter = new WorkerStateCounter(idleWorker);
+
+      busyWorker.execute(new MockRuntimeBundle(trigger));
+      pool.refresh();
+
+      await busyWorker.waitForDone();
+      await idleWorker.waitForDone();
+
+      expect(busyWorkerCounter.counts.BUSY).to.eql(1);
+      expect(busyWorkerCounter.counts.FINISHING).to.eql(1);
+      expect(busyWorkerCounter.counts.FINISHED).to.eql(1);
+
+      expect(idleWorkerCounter.counts.IDLE).to.eql(1);
+      expect(idleWorkerCounter.counts.FINISHING).to.eql(0);
+      expect(idleWorkerCounter.counts.FINISHED).to.eql(1);
+    });
+  });
+});


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1353 

New architecture:

The functions emulator manages a `RuntimeWorkerPool` full of `RuntimeWorkers`.  These wrap an instance of `FunctionsRuntimeInstance` which were previously launched as one-time-use.

A `RuntimeWorker` listens for important changes within the `FunctionsRuntimeInstance` and summarizes them into a state.  This worker is also responsible for sending IPC messages to the child process.

A `RuntimeWorker` has four possible states:

  * `IDLE` - ready to receive a request.
  * `BUSY` - currently executing a request.
  * `FINISHING` - `BUSY` but will never return to `IDLE`.  Basically "die when you're done please".
  * `FINISHED` - the process is dead.  Will never be revived, this worker is trash now.

Within the runtime I changed the execution flow.  The `main()` function only does the trigger discovery and stubbing at first.  Then it listens for an IPC message telling it to run a function.  This message handler can support mutliple invocations as long as the function doesn't experience any unhandled errors.

### Scenarios Tested

All scenarios use this test code:

```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp();

console.log("Code Reloaded:", new Date());

exports.simpleFunction = functions.https.onRequest(async (req, res) => {
    console.log('simpleFunction');
    res.json({ name: 'simpleFunction', date: new Date() });
});

exports.slowFunction = functions.https.onRequest(async (req, res) => {
    console.log('slowFunction');
    setTimeout(() => {
        res.json({ name: 'slowFunction', date: new Date() });
    }, 5000);
});

exports.functionThatSometimesThrows = functions.https.onRequest(async (req, res) => {
    console.log('functionThatSometimesThrows');
    const rand = Math.random();
    if (rand <= 0.33) {
        throw new Error('Ooops I did a bad thing!');
    }

    res.json({ name: 'functionThatSometimesThrows', date: new Date() });
});

exports.firestoreWriter = functions.https.onRequest(async (req, res) => {
    console.log('firestoreWriter');
    await admin.firestore().doc('/foo/bar').set({ date: new Date() });
    console.log(`Wrote to /foo/bar`);
    res.json({ name: 'firestoreWriter', date: new Date() });
});

exports.firestoreReader = functions.firestore.document('/foo/bar').onWrite(async (change, ctx) => {
    console.log('firestoreReader');
    console.log(`Detected change at ${change.after.ref.path}`);
    return true;
});
```

**Repeated execution, same code**
Notice the code above the function definition is only executed one time.

```
>  Code Reloaded: 2019-10-18T22:12:27.050Z
i  functions: Beginning execution of "simpleFunction"
>  simpleFunction
i  functions: Finished "simpleFunction" in ~1s
i  functions: Beginning execution of "simpleFunction"
>  simpleFunction
i  functions: Finished "simpleFunction" in ~1s
i  functions: Beginning execution of "simpleFunction"
>  simpleFunction
i  functions: Finished "simpleFunction" in ~1s
```

**Repeated execution with a code change in the middle**
Notice that the code reloads and then the console.log is different.  Unfortunately we need to do two reloads of the code after a file save: one "diagnostic" to do trigger discovery and then a second one to actually run the function for the first time.

```
>  Code Reloaded: 2019-10-18T22:12:59.143Z
i  functions: Beginning execution of "simpleFunction"
>  simpleFunction
i  functions: Finished "simpleFunction" in ~1s
>  Code Reloaded: 2019-10-18T22:13:06.256Z
>  Code Reloaded: 2019-10-18T22:13:11.251Z
i  functions: Beginning execution of "simpleFunction"
>  simpleFunction - xxx
i  functions: Finished "simpleFunction" in ~1s
i  functions: Beginning execution of "simpleFunction"
>  simpleFunction - xxx
i  functions: Finished "simpleFunction" in ~1s
i  functions: Beginning execution of "simpleFunction"
>  simpleFunction - xxx
i  functions: Finished "simpleFunction" in ~1s
```

**Function that sometimes throws errors**
This test is meant to show how an error thrown in a function will cause the worker to be discarded.

```
>  Code Reloaded: 2019-10-18T22:15:04.667Z
i  functions: Beginning execution of "functionThatSometimesThrows"
>  functionThatSometimesThrows
i  functions: Finished "functionThatSometimesThrows" in ~1s
i  functions: Beginning execution of "functionThatSometimesThrows"
>  functionThatSometimesThrows
⚠  functions: Error: Ooops I did a bad thing!
    at exports.functionThatSometimesThrows.functions.https.onRequest (/tmp/tmp.e4vfaKijHH/functions/index.js:23:15)
    at Run (/usr/local/google/home/samstern/Projects/firebase/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:612:20)
    at /usr/local/google/home/samstern/Projects/firebase/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:586:19
    at Generator.next (<anonymous>)
    at /usr/local/google/home/samstern/Projects/firebase/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (/usr/local/google/home/samstern/Projects/firebase/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:3:12)
    at Run (/usr/local/google/home/samstern/Projects/firebase/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:579:12)
    at /usr/local/google/home/samstern/Projects/firebase/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:611:15
    at Generator.next (<anonymous>)
⚠  Your function was killed because it raised an unhandled error.
>  Code Reloaded: 2019-10-18T22:15:11.150Z
i  functions: Beginning execution of "functionThatSometimesThrows"
>  functionThatSometimesThrows
i  functions: Finished "functionThatSometimesThrows" in ~1s
```

**Slow Function**
Here I call the same function twice before the first one finishes, which means that we need a second worker (scale up) and therefore the globals are loaded twice.  However a third invocation that waits for one to finish re-uses an existing idling worker.

```
>  Code Reloaded: 2019-10-18T22:16:57.435Z
i  functions: Beginning execution of "slowFunction"
>  slowFunction
>  Code Reloaded: 2019-10-18T22:16:58.933Z
i  functions: Beginning execution of "slowFunction"
>  slowFunction
i  functions: Finished "slowFunction" in ~5s
i  functions: Finished "slowFunction" in ~5s
i  functions: Beginning execution of "slowFunction"
>  slowFunction
i  functions: Finished "slowFunction" in ~5s
```

**Background Triggers**
Just to show that this all works for non-HTTP triggers.  Each separate trigger has its own worker pool so running this chain twice causes two code reloads (would be 4 in the old system).

```
>  Code Reloaded: 2019-10-18T22:18:10.268Z
i  functions: Beginning execution of "firestoreWriter"
>  firestoreWriter
>  Wrote to /foo/bar
i  functions: Finished "firestoreWriter" in ~1s
>  Code Reloaded: 2019-10-18T22:18:11.060Z
i  functions: Beginning execution of "firestoreReader"
>  firestoreReader
>  Detected change at foo/bar
i  functions: Finished "firestoreReader" in ~1s
i  functions: Beginning execution of "firestoreWriter"
>  firestoreWriter
>  Wrote to /foo/bar
i  functions: Beginning execution of "firestoreReader"
>  firestoreReader
>  Detected change at foo/bar
i  functions: Finished "firestoreReader" in ~1s
i  functions: Finished "firestoreWriter" in ~1s
```

### Sample Commands

N/A
