### PR TITLE
Un-escape new line characters from --releaseNotes arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Fixes a bug where rounds=0 was accepted for SHA1 hashes (#1617).
+* Allows support for using `\n` in the `--releaseNotes` option of the `appdistribution:distribute` command (#1739).

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -22,7 +22,8 @@ function getAppId(appId: string): string {
 
 function getReleaseNotes(releaseNotes: string, releaseNotesFile: string): string {
   if (releaseNotes) {
-    return releaseNotes;
+    // Un-escape new lines from argument string
+    return releaseNotes.replace(/\\n/g, "\n");
   } else if (releaseNotesFile) {
     ensureFileExists(releaseNotesFile);
     return fs.readFileSync(releaseNotesFile, "utf8");


### PR DESCRIPTION
### Description

This allows support for using `\n` as a new line character in the `--releaseNotes` option of the `appdistribution:distribute` command.

Tested locally by uploading a real distribution and verifying that the release notes were correct in our backend:

Command: `firebase /path/to/my.apk --app <app_id> --release-notes "New\nline"`

Before: `New\\nline`
After: `New\nline`