### PR TITLE
Error out if any GCF regions are unreachable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 * Fixes a bug where rounds=0 was accepted for SHA1 hashes (#1617).
 * Allows support for using `\n` in the `--releaseNotes` option of the `appdistribution:distribute` command (#1739).
+* Improves error handling of unreachable regions for Cloud Functions deploys.

--- a/src/gcp/cloudfunctions.js
+++ b/src/gcp/cloudfunctions.js
@@ -189,6 +189,13 @@ function _listFunctions(projectId, region) {
     })
     .then(
       function(resp) {
+        if (resp.body.unreachable && resp.body.unreachable.length > 0) {
+          return utils.reject(
+            "Some Cloud Functions regions were unreachable, please try again later.",
+            { exit: 2 }
+          );
+        }
+
         var functionsList = resp.body.functions || [];
         _.forEach(functionsList, function(f) {
           f.functionName = f.name.substring(f.name.lastIndexOf("/") + 1);


### PR DESCRIPTION
This is the most straightforward solution (I think) to adapting to the upcoming behavior change to ListFunctions. We could definitely get more fancy (only error out if any of the functions being deployed are in the regions that are unreachable) but I think a quick fix with that as a followup sometime later might be the sanest approach. WDYT?