### PR TITLE
Have the console print a newline character at the end of firestore:de…

### DIFF
--- a/src/firestore/delete.js
+++ b/src/firestore/delete.js
@@ -244,7 +244,7 @@ FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSi
 /**
  * Progress bar shared by the class.
  */
-FirestoreDelete.progressBar = new ProgressBar("Deleted :current docs (:rate docs/s)", {
+FirestoreDelete.progressBar = new ProgressBar("Deleted :current docs (:rate docs/s)\n", {
   total: Number.MAX_SAFE_INTEGER,
 });
 
@@ -266,7 +266,6 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   // All temporary variables for the deletion queue.
   var queue = [];
   var numPendingDeletes = 0;
-  var deletedDoc = false;
   var pagesRemaining = true;
   var pageIncoming = false;
   var lastDocName;
@@ -361,11 +360,6 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         clearInterval(intervalId);
 
         if (failures.length == 0) {
-          // Log an empty string so that the console adds a newline after
-          // the progress bar is done.
-          if (deletedDoc) {
-            console.log("");
-          }
           resolve();
         } else {
           reject("Failed to delete documents " + failures);

--- a/src/firestore/delete.js
+++ b/src/firestore/delete.js
@@ -321,7 +321,6 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
     }
 
     numPendingDeletes++;
-    deletedDoc = true;
     firestore
       .deleteDocuments(self.project, toDelete)
       .then(function(numDeleted) {

--- a/src/firestore/delete.js
+++ b/src/firestore/delete.js
@@ -266,6 +266,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
   // All temporary variables for the deletion queue.
   var queue = [];
   var numPendingDeletes = 0;
+  var deletedDoc = false;
   var pagesRemaining = true;
   var pageIncoming = false;
   var lastDocName;
@@ -321,6 +322,7 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
     }
 
     numPendingDeletes++;
+    deletedDoc = true;
     firestore
       .deleteDocuments(self.project, toDelete)
       .then(function(numDeleted) {
@@ -359,6 +361,11 @@ FirestoreDelete.prototype._recursiveBatchDelete = function() {
         clearInterval(intervalId);
 
         if (failures.length == 0) {
+          // Log an empty string so that the console adds a newline after
+          // the progress bar is done.
+          if (deletedDoc) {
+            console.log("");
+          }
           resolve();
         } else {
           reject("Failed to delete documents " + failures);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Have the console start the next command after `firestore:delete` on a new line.

Fixes issue [#1737](https://github.com/firebase/firebase-tools/issues/1737).
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- Running `firestore:delete` successfully and at least one document is deleted.
- Running `firestore:delete` successfully and no documents are deleted.

I couldn't get all of the error codepaths to execute, but if anyone has suggestions I am open to testing those as well.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

Run `firestore:delete` on a document or collection with one or more documents and the console will start the next command on a new line.