### PR TITLE
Function Create: ensure functions are public when created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Fixed an issue in Firestore Emulator where batchGet and transactions does not work over REST.
+* Make additional setIamPolicy call when creating HTTP functions to ensure they continue to be publicly available.

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -216,7 +216,12 @@ module.exports = function(context, options, payload) {
                 })
                 .then((createRes) => {
                   return gcp.cloudfunctions
-                    .setIamPolicy({ functionName, projectId, region, policy: DEFAULT_PUBLIC_POLICY })
+                    .setIamPolicy({
+                      functionName,
+                      projectId,
+                      region,
+                      policy: DEFAULT_PUBLIC_POLICY,
+                    })
                     .then(() => {
                       return createRes;
                     });

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -215,16 +215,20 @@ module.exports = function(context, options, payload) {
                   timeout: functionInfo.timeout,
                 })
                 .then((createRes) => {
-                  return gcp.cloudfunctions
-                    .setIamPolicy({
-                      functionName,
-                      projectId,
-                      region,
-                      policy: DEFAULT_PUBLIC_POLICY,
-                    })
-                    .then(() => {
-                      return createRes;
-                    });
+                  if (_.has(functionTrigger, "httpsTrigger")) {
+                    logger.debug(`Setting public policy for function ${functionName}`);
+                    return gcp.cloudfunctions
+                      .setIamPolicy({
+                        functionName,
+                        projectId,
+                        region,
+                        policy: DEFAULT_PUBLIC_POLICY,
+                      })
+                      .then(() => {
+                        return createRes;
+                      });
+                  }
+                  return createRes;
                 });
             },
             trigger: functionTrigger,

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -205,7 +205,11 @@ module.exports = function(context, options, payload) {
                   timeout: functionInfo.timeout,
                 })
                 .then((createRes) => {
-                  return gcp.cloudfunctions.setIamPolicy({ functionName, projectId, region }).then(() => { return createRes; });
+                  return gcp.cloudfunctions
+                    .setIamPolicy({ functionName, projectId, region })
+                    .then(() => {
+                      return createRes;
+                    });
                 });
             },
             trigger: functionTrigger,

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -23,6 +23,16 @@ var timings = {};
 var deployments = [];
 var failedDeployments = [];
 
+const DEFAULT_PUBLIC_POLICY = {
+  version: 3,
+  bindings: [
+    {
+      role: "roles/cloudfunctions.invoker",
+      members: ["allUsers"],
+    },
+  ],
+};
+
 function _startTimer(name, type) {
   timings[name] = { type: type, t0: process.hrtime() };
 }
@@ -206,7 +216,7 @@ module.exports = function(context, options, payload) {
                 })
                 .then((createRes) => {
                   return gcp.cloudfunctions
-                    .setIamPolicy({ functionName, projectId, region })
+                    .setIamPolicy({ functionName, projectId, region, policy: DEFAULT_PUBLIC_POLICY })
                     .then(() => {
                       return createRes;
                     });

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -189,20 +189,24 @@ module.exports = function(context, options, payload) {
 
           deployments.push({
             name: name,
-            retryFunction: function() {
-              return gcp.cloudfunctions.create({
-                projectId: projectId,
-                region: region,
-                eventType: eventType,
-                functionName: functionName,
-                entryPoint: functionInfo.entryPoint,
-                trigger: functionTrigger,
-                labels: _.assign({}, deploymentTool.labels, functionInfo.labels),
-                sourceUploadUrl: sourceUrl,
-                runtime: runtime,
-                availableMemoryMb: functionInfo.availableMemoryMb,
-                timeout: functionInfo.timeout,
-              });
+            retryFunction: () => {
+              return gcp.cloudfunctions
+                .create({
+                  projectId: projectId,
+                  region: region,
+                  eventType: eventType,
+                  functionName: functionName,
+                  entryPoint: functionInfo.entryPoint,
+                  trigger: functionTrigger,
+                  labels: _.assign({}, deploymentTool.labels, functionInfo.labels),
+                  sourceUploadUrl: sourceUrl,
+                  runtime: runtime,
+                  availableMemoryMb: functionInfo.availableMemoryMb,
+                  timeout: functionInfo.timeout,
+                })
+                .then((createRes) => {
+                  return gcp.cloudfunctions.setIamPolicy({ functionName, projectId, region }).then(() => { return createRes; });
+                });
             },
             trigger: functionTrigger,
           });

--- a/src/gcp/cloudfunctions.js
+++ b/src/gcp/cloudfunctions.js
@@ -94,6 +94,32 @@ function _createFunction(options) {
     );
 }
 
+async function _setIamPolicy(options) {
+  const name = `projects/${options.projectId}/locations/${options.region}/functions/${options.functionName}`;
+  const endpoint = `/${API_VERSION}/${name}:setIamPolicy`;
+
+  try {
+    const res = await api.request("POST", endpoint, {
+      auth: true,
+      data: {
+        policy: {
+          version: 3,
+          bindings: [
+            {
+              role: "roles/cloudfunctions.invoker",
+              members: ["allUsers"],
+            },
+          ],
+        },
+        updateMask: ["version", "bindings"].join(),
+      },
+      origin: api.functionsOrigin,
+    });
+  } catch (err) {
+    throw new FirebaseError(`Failed to set the IAM Policy on the function ${options.functionName}`, { original: err })
+  }
+}
+
 function _updateFunction(options) {
   var location = "projects/" + options.projectId + "/locations/" + options.region;
   var func = location + "/functions/" + options.functionName;
@@ -249,4 +275,5 @@ module.exports = {
   list: _listFunctions,
   listAll: _listAllFunctions,
   check: _checkOperation,
+  setIamPolicy: _setIamPolicy,
 };

--- a/src/gcp/cloudfunctions.js
+++ b/src/gcp/cloudfunctions.js
@@ -95,11 +95,13 @@ function _createFunction(options) {
 }
 
 async function _setIamPolicy(options) {
-  const name = `projects/${options.projectId}/locations/${options.region}/functions/${options.functionName}`;
+  const name = `projects/${options.projectId}/locations/${options.region}/functions/${
+    options.functionName
+  }`;
   const endpoint = `/${API_VERSION}/${name}:setIamPolicy`;
 
   try {
-    const res = await api.request("POST", endpoint, {
+    await api.request("POST", endpoint, {
       auth: true,
       data: {
         policy: {
@@ -116,7 +118,10 @@ async function _setIamPolicy(options) {
       origin: api.functionsOrigin,
     });
   } catch (err) {
-    throw new FirebaseError(`Failed to set the IAM Policy on the function ${options.functionName}`, { original: err })
+    throw new FirebaseError(
+      `Failed to set the IAM Policy on the function ${options.functionName}`,
+      { original: err }
+    );
   }
 }
 

--- a/src/gcp/cloudfunctions.js
+++ b/src/gcp/cloudfunctions.js
@@ -94,6 +94,14 @@ function _createFunction(options) {
     );
 }
 
+/**
+ * Sets the IAM policy of a Google Cloud Function.
+ * @param {*} options Options object.
+ * @param {string} options.projectId Project that owns the Function.
+ * @param {string} options.region Region in which the Function exists.
+ * @param {string} options.functionName Name of the Function.
+ * @param {*} options.policy The [policy](https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/setIamPolicy) to set.
+ */
 async function _setIamPolicy(options) {
   const name = `projects/${options.projectId}/locations/${options.region}/functions/${
     options.functionName
@@ -104,16 +112,8 @@ async function _setIamPolicy(options) {
     await api.request("POST", endpoint, {
       auth: true,
       data: {
-        policy: {
-          version: 3,
-          bindings: [
-            {
-              role: "roles/cloudfunctions.invoker",
-              members: ["allUsers"],
-            },
-          ],
-        },
-        updateMask: ["version", "bindings"].join(),
+        policy: options.policy,
+        updateMask: Object.keys(options.policy).join(),
       },
       origin: api.functionsOrigin,
     });

--- a/src/gcp/cloudfunctions.js
+++ b/src/gcp/cloudfunctions.js
@@ -113,7 +113,7 @@ async function _setIamPolicy(options) {
       auth: true,
       data: {
         policy: options.policy,
-        updateMask: Object.keys(options.policy).join(),
+        updateMask: Object.keys(options.policy).join(","),
       },
       origin: api.functionsOrigin,
     });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

To ensure that Firebase Functions remain publicly available when they are created, we need to follow up the `create` call for a Function with a [`setIamPolicy`](https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions/setIamPolicy) call with the appropriate information to keep it public. This will help maintain our current behavior when the GCF endpoint does _not_ create public functions by default.

Internal bug link: b/143784350
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- `node ./scripts/test-functions-deploy.js`
- Deployed new functions and made sure they were still public.
