### PR TITLE
add better jsdoc rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,19 +8,21 @@ module.exports = {
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
         "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        "plugin:jsdoc/recommended",
         "google",
         "prettier",
         "prettier/@typescript-eslint",
     ],
     "rules": {
+        "jsdoc/newline-after-description": "off",
         "prettier/prettier": "error",
+        "valid-jsdoc": "off", // This is deprecated but included in recommended configs.
         "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
         "no-restricted-globals": ["error", "name", "length"],
         "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
         "prefer-const": "warn", // TODO(bkendall): remove, allow to error.
         "prefer-promise-reject-errors": "warn", // TODO(bkendall): remove, allow to error.
         "require-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
-        "valid-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
     },
     "overrides": [
         {
@@ -42,6 +44,8 @@ module.exports = {
                 "@typescript-eslint/require-await": "warn", // TODO(bkendall): remove, allow to error.
                 "@typescript-eslint/unbound-method": "warn", // TODO(bkendall): remove, allow to error.
                 "camelcase": "warn", // TODO(bkendall): remove, allow to error.
+                "jsdoc/require-param-type": "off",
+                "jsdoc/require-returns-type": "off",
                 "new-cap": "warn", // TODO(bkendall): remove, allow to error.
                 "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
                 "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
@@ -86,6 +90,14 @@ module.exports = {
     "plugins": [
         "prettier",
         "@typescript-eslint",
+        "jsdoc",
     ],
+    "settings": {
+        "jsdoc": {
+            "tagNamePreference": {
+                "returns": "return"
+            }
+        }
+    },
     "parser": "@typescript-eslint/parser",
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -2016,6 +2016,12 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
       "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
+    "comment-parser": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.0.tgz",
+      "integrity": "sha512-m0SGP0RFO4P3hIBlIor4sBFPe5Y4HUeGgo/UZK/1Zdea5eUiqxroQ3lFqBDDSfWo9z9Q6LLnt2u0JqwacVEd/A==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -2808,6 +2814,37 @@
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-17.1.0.tgz",
+      "integrity": "sha512-nIsSjuJOa95O5ayhFDdtaa1y0t1CGAksemcqXGTkXE49xOzZSMUChixzCP6feL+hfRcDZHWoHk17lOlblGFkaw==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.7.0",
+        "debug": "^4.1.1",
+        "jsdoctypeparser": "^5.1.1",
+        "lodash": "^4.17.15",
+        "object.entries-ponyfill": "^1.0.1",
+        "regextras": "^0.6.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-prettier": {
@@ -5099,6 +5136,12 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "jsdoctypeparser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-5.1.1.tgz",
+      "integrity": "sha512-APGygIJrT5bbz5lsVt8vyLJC0miEbQf/z9ZBfTr4RYvdia8AhWMRlYgivvwHG5zKD/VW3d6qpChCy64hpQET3A==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5992,6 +6035,12 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object.entries-ponyfill": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/object.entries-ponyfill/-/object.entries-ponyfill-1.0.1.tgz",
+      "integrity": "sha1-Kavfd8v70mVm3RqiTp2I9lQz0lY=",
+      "dev": true
+    },
     "on-finished": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
@@ -6508,6 +6557,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "regextras": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.6.1.tgz",
+      "integrity": "sha512-EzIHww9xV2Kpqx+corS/I7OBmf2rZ0pKKJPsw5Dc+l6Zq1TslDmtRIP9maVn3UH+72MIXmn8zzDgP07ihQogUA==",
       "dev": true
     },
     "registry-auth-token": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "eslint": "^6.4.0",
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^6.3.0",
+    "eslint-plugin-jsdoc": "^17.1.0",
     "eslint-plugin-prettier": "^3.0.0",
     "firebase": "^7.1.0",
     "firebase-admin": "^8.6.1",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Since the `jsdoc` rules in eslint are [deprecated](https://eslint.org/blog/2018/11/jsdoc-end-of-life), let's move to the more configurable `jsdoc` plugin as suggested by the deprecation posting.

No changes have to be made as no additional errors are created by this change. I have started turning some things off in TS (since defining types in JSdoc in typescript is redundant)