### PR TITLE
Follow up to RuntimeWorkers change

### DIFF
--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -114,7 +114,16 @@ export async function startAll(options: any): Promise<void> {
 
   if (shouldStart(options, Emulators.FUNCTIONS)) {
     const functionsAddr = Constants.getAddress(Emulators.FUNCTIONS, options);
-    const functionsEmulator = new FunctionsEmulator(options, {
+
+    const projectId = getProjectId(options, false);
+    const functionsDir = path.join(
+      options.config.projectDir,
+      options.config.get("functions.source")
+    );
+
+    const functionsEmulator = new FunctionsEmulator({
+      projectId,
+      functionsDir,
       host: functionsAddr.host,
       port: functionsAddr.port,
     });

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -1,5 +1,8 @@
+import * as clc from "cli-color";
+
 import * as utils from "../utils";
 import * as logger from "../logger";
+import { EmulatorLog } from "./types";
 
 /**
  * DEBUG - lowest level, not needed for most usages.
@@ -66,6 +69,143 @@ export class EmulatorLogger {
       case "SUCCESS":
         utils.logSuccess(text);
         break;
+    }
+  }
+
+  static handleRuntimeLog(log: EmulatorLog, ignore: string[] = []): void {
+    if (ignore.indexOf(log.level) >= 0) {
+      return;
+    }
+    switch (log.level) {
+      case "SYSTEM":
+        EmulatorLogger.handleSystemLog(log);
+        break;
+      case "USER":
+        EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`);
+        break;
+      case "DEBUG":
+        if (log.data && log.data !== {}) {
+          EmulatorLogger.log("DEBUG", `[${log.type}] ${log.text} ${JSON.stringify(log.data)}`);
+        } else {
+          EmulatorLogger.log("DEBUG", `[${log.type}] ${log.text}`);
+        }
+        break;
+      case "INFO":
+        EmulatorLogger.logLabeled("BULLET", "functions", log.text);
+        break;
+      case "WARN":
+        EmulatorLogger.logLabeled("WARN", "functions", log.text);
+        break;
+      case "WARN_ONCE":
+        EmulatorLogger.logLabeled("WARN_ONCE", "functions", log.text);
+        break;
+      case "FATAL":
+        EmulatorLogger.logLabeled("WARN", "functions", log.text);
+        break;
+      default:
+        EmulatorLogger.log("INFO", `${log.level}: ${log.text}`);
+        break;
+    }
+  }
+
+  static handleSystemLog(systemLog: EmulatorLog): void {
+    switch (systemLog.type) {
+      case "runtime-status":
+        if (systemLog.text === "killed") {
+          EmulatorLogger.log(
+            "WARN",
+            `Your function was killed because it raised an unhandled error.`
+          );
+        }
+        break;
+      case "googleapis-network-access":
+        EmulatorLogger.log(
+          "WARN",
+          `Google API requested!\n   - URL: "${
+            systemLog.data.href
+          }"\n   - Be careful, this may be a production service.`
+        );
+        break;
+      case "unidentified-network-access":
+        EmulatorLogger.log(
+          "WARN",
+          `External network resource requested!\n   - URL: "${
+            systemLog.data.href
+          }"\n - Be careful, this may be a production service.`
+        );
+        break;
+      case "functions-config-missing-value":
+        EmulatorLogger.log(
+          "WARN",
+          `Non-existent functions.config() value requested!\n   - Path: "${
+            systemLog.data.valuePath
+          }"\n   - Learn more at https://firebase.google.com/docs/functions/local-emulator`
+        );
+        break;
+      case "non-default-admin-app-used":
+        EmulatorLogger.log(
+          "WARN",
+          `Non-default "firebase-admin" instance created!\n   ` +
+            `- This instance will *not* be mocked and will access production resources.`
+        );
+        break;
+      case "missing-module":
+        EmulatorLogger.log(
+          "WARN",
+          `The Cloud Functions emulator requires the module "${
+            systemLog.data.name
+          }" to be installed as a ${
+            systemLog.data.isDev ? "development dependency" : "dependency"
+          }. To fix this, run "npm install ${systemLog.data.isDev ? "--save-dev" : "--save"} ${
+            systemLog.data.name
+          }" in your functions directory.`
+        );
+        break;
+      case "uninstalled-module":
+        EmulatorLogger.log(
+          "WARN",
+          `The Cloud Functions emulator requires the module "${
+            systemLog.data.name
+          }" to be installed. This package is in your package.json, but it's not available. \
+You probably need to run "npm install" in your functions directory.`
+        );
+        break;
+      case "out-of-date-module":
+        EmulatorLogger.log(
+          "WARN",
+          `The Cloud Functions emulator requires the module "${
+            systemLog.data.name
+          }" to be version >${systemLog.data.minVersion}.0.0 so your version is too old. \
+You can probably fix this by running "npm install ${
+            systemLog.data.name
+          }@latest" in your functions directory.`
+        );
+        break;
+      case "missing-package-json":
+        EmulatorLogger.log(
+          "WARN",
+          `The Cloud Functions directory you specified does not have a "package.json" file, so we can't load it.`
+        );
+        break;
+      case "function-code-resolution-failed":
+        EmulatorLogger.log("WARN", systemLog.data.error);
+        const helper = ["We were unable to load your functions code. (see above)"];
+        if (systemLog.data.isPotentially.wrong_directory) {
+          helper.push(`   - There is no "package.json" file in your functions directory.`);
+        }
+        if (systemLog.data.isPotentially.typescript) {
+          helper.push(
+            "   - It appears your code is written in Typescript, which must be compiled before emulation."
+          );
+        }
+        if (systemLog.data.isPotentially.uncompiled) {
+          helper.push(
+            `   - You may be able to run "npm run build" in your functions directory to resolve this.`
+          );
+        }
+        utils.logWarning(helper.join("\n"));
+      default:
+      // Silence
     }
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -572,7 +572,6 @@ export class FunctionsEmulator implements EmulatorInstance {
         database: EmulatorRegistry.getPort(Emulators.DATABASE),
       },
       disabled_features: this.args.disabledRuntimeFeatures,
-      socketPath: "",
     };
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -178,10 +178,8 @@ export class FunctionsEmulator implements EmulatorInstance {
         }
       });
 
-      // TODO: do I need to wait?
-      await worker.waitForSystemLog((el) => {
-        return el.data.state === "ready";
-      });
+      // Wait for the worker to set up its internal HTTP server
+      await worker.waitForSocketReady();
 
       track(EVENT_INVOKE, "https");
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -853,7 +853,7 @@ async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
     );
 
     const instance = ephemeralServer.listen(socketPath, () => {
-      new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready", socketPath }).log();
+      new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready" }).log();
     });
   });
 }

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -846,8 +846,9 @@ async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
       [`/${frb.projectId}/${frb.triggerId}`, `/${frb.projectId}/:region/${frb.triggerId}`],
       functionRouter
     );
+
     const instance = ephemeralServer.listen(socketPath, () => {
-      logReady({ socketPath });
+      new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready" , socketPath }).log();
     });
   });
 }
@@ -856,12 +857,6 @@ async function processBackground(
   frb: FunctionsRuntimeBundle,
   trigger: EmulatedTrigger
 ): Promise<void> {
-  const service = trigger.definition.eventTrigger
-    ? trigger.definition.eventTrigger.service
-    : "unknown";
-
-  logReady({ service });
-
   const proto = frb.proto;
   logDebug("ProcessBackground", proto);
 
@@ -879,15 +874,6 @@ async function processBackground(
   }
 
   await runBackground({ data, context }, trigger.getRawFunction());
-}
-
-function logReady(data: any) {
-  new EmulatorLog(
-    "SYSTEM",
-    "runtime-status",
-    "ready",
-    Object.assign({ state: "ready" }, data)
-  ).log();
 }
 
 /**

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -796,7 +796,7 @@ async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
   const functionRouter = express.Router();
   const socketPath = frb.socketPath;
 
-  if (!socketPath || socketPath === "") {
+  if (!socketPath) {
     new EmulatorLog("FATAL", "runtime-error", "Called processHTTPS with no socketPath").log();
     return;
   }

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -847,7 +847,7 @@ async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
       functionRouter
     );
     const instance = ephemeralServer.listen(socketPath, () => {
-      new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready", socketPath }).log();
+      logReady({ socketPath });
     });
   });
 }
@@ -860,7 +860,7 @@ async function processBackground(
     ? trigger.definition.eventTrigger.service
     : "unknown";
 
-  new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready", service }).log();
+  logReady({ service });
 
   const proto = frb.proto;
   logDebug("ProcessBackground", proto);
@@ -879,6 +879,15 @@ async function processBackground(
   }
 
   await runBackground({ data, context }, trigger.getRawFunction());
+}
+
+function logReady(data: any) {
+  new EmulatorLog(
+    "SYSTEM",
+    "runtime-status",
+    "ready",
+    Object.assign({ state: "ready" }, data)
+  ).log();
 }
 
 /**
@@ -1161,6 +1170,7 @@ async function main(): Promise<void> {
       .catch((err) => {
         // All errors *should* be handled within handleMessage. But just in case,
         // we want to exit fatally on any error related to message handling.
+        logDebug(`Error in handleMessage: ${message} => ${err}: ${err.stack}`);
         new EmulatorLog("FATAL", "runtime-error", err).log();
         return flushAndExit(1);
       });

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -7,6 +7,7 @@ import * as os from "os";
 import * as path from "path";
 import * as express from "express";
 import * as fs from "fs";
+import { InvokeRuntimeOpts } from "./functionsEmulator";
 
 export enum EmulatedTriggerType {
   BACKGROUND = "BACKGROUND",
@@ -35,7 +36,7 @@ export interface EmulatedTriggerMap {
 
 export interface FunctionsRuntimeArgs {
   frb: FunctionsRuntimeBundle;
-  serializedTriggers?: string;
+  opts?: InvokeRuntimeOpts;
 }
 
 export interface FunctionsRuntimeBundle {
@@ -49,6 +50,7 @@ export interface FunctionsRuntimeBundle {
   };
   disabled_features?: FunctionsRuntimeFeatures;
   cwd: string;
+  socketPath: string;
 }
 
 export interface FunctionsRuntimeFeatures {
@@ -130,13 +132,13 @@ export function getEmulatedTriggersFromDefinitions(
   }, {});
 }
 
-export function getTemporarySocketPath(pid: number): string {
+export function getTemporarySocketPath(id: string, cwd: string): string {
   // See "net" package docs for information about IPC pipes on Windows
   // https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections
   if (process.platform === "win32") {
-    return path.join("\\\\?\\pipe", process.cwd(), pid.toString());
+    return path.join("\\\\?\\pipe", cwd, id.toString());
   } else {
-    return path.join(os.tmpdir(), `firebase_emulator_invocation_${pid}.sock`);
+    return path.join(os.tmpdir(), `firebase_emulator_invocation_${id}.sock`);
   }
 }
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -48,9 +48,9 @@ export interface FunctionsRuntimeBundle {
     firestore?: number;
     database?: number;
   };
+  socketPath?: string;
   disabled_features?: FunctionsRuntimeFeatures;
   cwd: string;
-  socketPath: string;
 }
 
 export interface FunctionsRuntimeFeatures {

--- a/src/emulator/functionsEmulatorShell.ts
+++ b/src/emulator/functionsEmulatorShell.ts
@@ -35,7 +35,7 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
         this.urls[name] = FunctionsEmulator.getHttpFunctionUrl(
           this.emu.getInfo().host,
           this.emu.getInfo().port,
-          this.emu.projectId,
+          this.emu.getProjectId(),
           name,
           getFunctionRegion(trigger)
         );
@@ -72,7 +72,7 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
       data,
     };
 
-    FunctionsEmulator.startFunctionRuntime(
+    this.emu.startFunctionRuntime(
       this.emu.getBaseBundle(),
       name,
       EmulatedTriggerType.BACKGROUND,

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -127,8 +127,10 @@ export class RuntimeWorker {
     });
   }
 
-  waitForSystemLog(filter: (el: EmulatorLog) => boolean): Promise<EmulatorLog> {
-    return EmulatorLog.waitForLog(this.runtime.events, "SYSTEM", "runtime-status", filter);
+  waitForSocketReady(): Promise<any> {
+    return EmulatorLog.waitForLog(this.runtime.events, "SYSTEM", "runtime-status", (el) => {
+      return el.data.state === "ready";
+    });
   }
 
   private log(msg: string): void {

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -1,5 +1,7 @@
+import * as path from "path";
 import { FunctionsEmulator, FunctionsEmulatorArgs } from "../emulator/functionsEmulator";
 import { EmulatorServer } from "../emulator/emulatorServer";
+import * as getProjectId from "../getProjectId";
 
 // TODO(samstern): It would be better to convert this to an EmulatorServer
 // but we don't have the "options" object until start() is called.
@@ -7,7 +9,16 @@ module.exports = {
   emulatorServer: undefined,
 
   async start(options: any, args?: FunctionsEmulatorArgs): Promise<void> {
-    args = args || {};
+    const projectId = getProjectId(options, false);
+    const functionsDir = path.join(
+      options.config.projectDir,
+      options.config.get("functions.source")
+    );
+
+    args = args || {
+      projectId,
+      functionsDir,
+    };
 
     if (!args.disabledRuntimeFeatures) {
       // When running the functions emulator through 'firebase serve' we disable some
@@ -38,7 +49,7 @@ module.exports = {
       }
     }
 
-    this.emulatorServer = new EmulatorServer(new FunctionsEmulator(options, args));
+    this.emulatorServer = new EmulatorServer(new FunctionsEmulator(args));
     await this.emulatorServer.start();
   },
 

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -19,11 +19,15 @@ if ((process.env.DEBUG || "").toLowerCase().indexOf("spec") >= 0) {
   });
 }
 
-const startFunctionRuntime = FunctionsEmulator.startFunctionRuntime;
+const functionsEmulator = new FunctionsEmulator({
+  projectId: "",
+  functionsDir: "",
+});
+const startFunctionRuntime = functionsEmulator.startFunctionRuntime;
 function UseFunctions(triggers: () => {}): void {
   const serializedTriggers = triggers.toString();
 
-  FunctionsEmulator.startFunctionRuntime = (
+  functionsEmulator.startFunctionRuntime = (
     bundleTemplate: FunctionsRuntimeBundle,
     triggerId: string,
     triggerType: EmulatedTriggerType,
@@ -50,7 +54,7 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     await supertest(
-      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
     )
       .get("/fake-project-id/us-central1/function_id")
       .expect(200)
@@ -72,7 +76,7 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     await supertest(
-      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
     )
       .get("/fake-project-id/us-central1/function_id/")
       .expect(200)
@@ -94,7 +98,7 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     await supertest(
-      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
     )
       .get("/fake-project-id/us-central1/function_id/a/b")
       .expect(200)
@@ -116,7 +120,7 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     await supertest(
-      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
     )
       .get("/fake-project-id/us-central1/function_id/sub/route/a")
       .expect(200)
@@ -138,7 +142,7 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     await supertest(
-      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
     )
       .get("/fake-project-id/us-central1/function_id/sub/route/a")
       .expect(200)
@@ -160,7 +164,7 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     await supertest(
-      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
     )
       .post("/fake-project-id/us-central1/function_id/sub/route/a")
       .send({ hello: "world" })
@@ -183,7 +187,7 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     await supertest(
-      FunctionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
     )
       .get("/fake-project-id/us-central1/function_id/sub/route/a?hello=world")
       .expect(200)

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -1,11 +1,8 @@
 import { expect } from "chai";
-import {
-  FunctionsRuntimeInstance,
-  invokeRuntime,
-  InvokeRuntimeOpts,
-} from "../../emulator/functionsEmulator";
+import { invokeRuntime, InvokeRuntimeOpts } from "../../emulator/functionsEmulator";
 import { EmulatorLog } from "../../emulator/types";
 import { FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
+import { RuntimeWorker } from "../../emulator/functionsRuntimeWorker";
 import { Change } from "firebase-functions";
 import { DocumentSnapshot } from "firebase-functions/lib/providers/firestore";
 import { FunctionRuntimeBundles, TIMEOUT_LONG, TIMEOUT_MED } from "./fixtures";
@@ -13,9 +10,8 @@ import * as request from "request";
 import * as express from "express";
 import * as _ from "lodash";
 
-async function _countLogEntries(
-  runtime: FunctionsRuntimeInstance
-): Promise<{ [key: string]: number }> {
+async function _countLogEntries(worker: RuntimeWorker): Promise<{ [key: string]: number }> {
+  const runtime = worker.runtime;
   const counts: { [key: string]: number } = {};
 
   runtime.events.on("log", (el: EmulatorLog) => {
@@ -30,16 +26,14 @@ function InvokeRuntimeWithFunctions(
   frb: FunctionsRuntimeBundle,
   triggers: () => {},
   opts?: InvokeRuntimeOpts
-): FunctionsRuntimeInstance {
+): RuntimeWorker {
   const serializedTriggers = triggers.toString();
 
   opts = opts || {};
   opts.ignore_warnings = true;
+  opts.serializedTriggers = serializedTriggers;
 
-  return invokeRuntime(process.execPath, frb, {
-    ...opts,
-    serializedTriggers,
-  }).runtime;
+  return invokeRuntime(process.execPath, frb, opts);
 }
 
 /**
@@ -49,15 +43,19 @@ function InvokeRuntimeWithFunctions(
  *   3) Wait for the runtime to exit
  */
 async function CallHTTPSFunction(
-  runtime: FunctionsRuntimeInstance,
+  worker: RuntimeWorker,
   frb: FunctionsRuntimeBundle,
   options: any = {},
   requestData?: string
 ): Promise<string> {
-  const log = await EmulatorLog.waitForLog(runtime.events, "SYSTEM", "runtime-status", (el) => {
-    return el.data.state === "ready";
-  });
-  runtime.metadata.socketPath = log.data.socketPath;
+  const log = await EmulatorLog.waitForLog(
+    worker.runtime.events,
+    "SYSTEM",
+    "runtime-status",
+    (el) => {
+      return el.data.state === "ready";
+    }
+  );
 
   const dataPromise = new Promise<string>((resolve, reject) => {
     const path = `/${frb.projectId}/us-central1/${frb.triggerId}`;
@@ -70,22 +68,23 @@ async function CallHTTPSFunction(
       requestOptions.body = requestData;
     }
 
-    request(
-      `http://unix:${runtime.metadata.socketPath}:${path}`,
-      requestOptions,
-      (err, res, body) => {
-        if (err) {
-          reject(err);
-          return;
-        }
+    if (!worker.lastArgs) {
+      throw new Error("Can't talk to worker with undefined args");
+    }
 
-        resolve(body);
+    const socketPath = worker.lastArgs.frb.socketPath;
+    request(`http://unix:${socketPath}:${path}`, requestOptions, (err, res, body) => {
+      if (err) {
+        reject(err);
+        return;
       }
-    );
+
+      resolve(body);
+    });
   });
 
   const result = await dataPromise;
-  await runtime.exit;
+  await worker.runtime.exit;
 
   return result;
 }
@@ -94,7 +93,7 @@ describe("FunctionsEmulator-Runtime", () => {
   describe("Stubs, Mocks, and Helpers (aka Magic, Glee, and Awesomeness)", () => {
     describe("_InitializeNetworkFiltering(...)", () => {
       it("should log outgoing unknown HTTP requests via 'http'", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -109,12 +108,12 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["unidentified-network-access"]).to.gte(1);
       }).timeout(TIMEOUT_LONG);
 
       it("should log outgoing unknown HTTP requests via 'https'", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -127,13 +126,13 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
 
         expect(logs["unidentified-network-access"]).to.gte(1);
       }).timeout(TIMEOUT_LONG);
 
       it("should log outgoing Google API requests", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -146,7 +145,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
 
         expect(logs["googleapis-network-access"]).to.gte(1);
       }).timeout(TIMEOUT_LONG);
@@ -154,7 +153,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
     describe("_InitializeFirebaseAdminStubs(...)", () => {
       it("should provide stubbed default app from initializeApp", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -164,12 +163,12 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["default-admin-app-used"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should provide non-stubbed non-default app from initializeApp", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp(); // We still need to initialize default for snapshots
           require("firebase-admin").initializeApp({}, "non-default");
           return {
@@ -179,12 +178,12 @@ describe("FunctionsEmulator-Runtime", () => {
               .onCreate(async () => {}),
           };
         });
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["non-default-admin-app-used"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should route all sub-fields accordingly", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -198,7 +197,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        runtime.events.on("log", (el: EmulatorLog) => {
+        worker.runtime.events.on("log", (el: EmulatorLog) => {
           if (el.level !== "USER") {
             return;
           }
@@ -206,12 +205,12 @@ describe("FunctionsEmulator-Runtime", () => {
           expect(JSON.parse(el.text)).to.deep.eq({ operand: 4 });
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["function-log"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should provide a stubbed Firestore through admin.firestore()", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
           const firestore = admin.firestore();
@@ -228,12 +227,12 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["set-firestore-settings"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should provide a stubbed Firestore through app.firestore()", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           const admin = require("firebase-admin");
           const app = admin.initializeApp();
           const firestore = app.firestore();
@@ -250,12 +249,12 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["set-firestore-settings"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should provide the same stubs through admin-global or through the default app", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onRequest, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onRequest, () => {
           const admin = require("firebase-admin");
           const app = admin.initializeApp();
 
@@ -277,7 +276,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, FunctionRuntimeBundles.onRequest);
+        const data = await CallHTTPSFunction(worker, FunctionRuntimeBundles.onRequest);
         const info = JSON.parse(data);
         expect(info.appFirestoreSettings).to.deep.eq(info.adminFirestoreSettings);
         expect(info.appDatabaseRef).to.eq(info.adminDatabaseRef);
@@ -287,7 +286,7 @@ describe("FunctionsEmulator-Runtime", () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
         frb.ports = {};
 
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -298,7 +297,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, frb);
+        const data = await CallHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
 
         expect(info.projectId).to.eql("fake-project-id");
@@ -312,7 +311,7 @@ describe("FunctionsEmulator-Runtime", () => {
           firestore: 9090,
         };
 
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -323,7 +322,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, frb);
+        const data = await CallHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
 
         expect(info.projectId).to.eql("fake-project-id");
@@ -335,7 +334,7 @@ describe("FunctionsEmulator-Runtime", () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
         frb.ports = {};
 
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -351,7 +350,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, frb);
+        const data = await CallHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
         expect(info.url).to.eql("https://fake-project-id.firebaseio.com/");
       }).timeout(TIMEOUT_MED);
@@ -362,7 +361,7 @@ describe("FunctionsEmulator-Runtime", () => {
           database: 9090,
         };
 
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -378,13 +377,13 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, frb);
+        const data = await CallHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
         expect(info.url).to.eql("http://localhost:9090/");
       }).timeout(TIMEOUT_MED);
 
       it("should merge .settings() with emulator settings", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
           admin.firestore().settings({
@@ -399,11 +398,11 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        runtime.events.on("log", (el: EmulatorLog) => {
+        worker.runtime.events.on("log", (el: EmulatorLog) => {
           expect(el.text.indexOf("You can only call settings() once")).to.eq(-1);
         });
 
-        await runtime.exit;
+        await worker.runtime.exit;
       }).timeout(TIMEOUT_MED);
 
       it("should merge .initializeApp arguments from user", async () => {
@@ -412,7 +411,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return;
         }
 
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           const admin = require("firebase-admin");
           admin.initializeApp({
             databaseURL: "fake-app-id.firebaseio.com",
@@ -432,7 +431,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        runtime.events.on("log", (el: EmulatorLog) => {
+        worker.runtime.events.on("log", (el: EmulatorLog) => {
           if (el.level !== "USER") {
             return;
           }
@@ -443,16 +442,16 @@ describe("FunctionsEmulator-Runtime", () => {
                 "Firebase correctly (https://fake-app-id.firebaseio.com)"
             )
           ).to.gte(0);
-          runtime.kill();
+          worker.runtime.kill();
         });
 
-        await runtime.exit;
+        await worker.runtime.exit;
       }).timeout(TIMEOUT_MED);
     });
 
     describe("_InitializeFunctionsConfigHelper()", () => {
       it("should tell the user if they've accessed a non-existent function field", async () => {
-        const runtime = InvokeRuntimeWithFunctions(
+        const worker = InvokeRuntimeWithFunctions(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp();
@@ -476,7 +475,7 @@ describe("FunctionsEmulator-Runtime", () => {
           }
         );
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["functions-config-missing-value"]).to.eq(2);
       }).timeout(TIMEOUT_MED);
     });
@@ -486,7 +485,7 @@ describe("FunctionsEmulator-Runtime", () => {
     describe("HTTPS", () => {
       it("should handle a GET request", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -497,14 +496,14 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, frb);
+        const data = await CallHTTPSFunction(worker, frb);
 
         expect(JSON.parse(data)).to.deep.equal({ from_trigger: true });
       }).timeout(TIMEOUT_MED);
 
       it("should handle a POST request with form data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -517,7 +516,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const reqData = "name=sparky";
         const data = await CallHTTPSFunction(
-          runtime,
+          worker,
           frb,
           {
             headers: {
@@ -533,7 +532,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with JSON data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -546,7 +545,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const reqData = '{"name": "sparky"}';
         const data = await CallHTTPSFunction(
-          runtime,
+          worker,
           frb,
           {
             headers: {
@@ -562,7 +561,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with text data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -575,7 +574,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const reqData = "name is sparky";
         const data = await CallHTTPSFunction(
-          runtime,
+          worker,
           frb,
           {
             headers: {
@@ -591,7 +590,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with any other type", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -604,7 +603,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const reqData = "name is sparky";
         const data = await CallHTTPSFunction(
-          runtime,
+          worker,
           frb,
           {
             headers: {
@@ -621,7 +620,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request and store rawBody", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -634,7 +633,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const reqData = "How are you?";
         const data = await CallHTTPSFunction(
-          runtime,
+          worker,
           frb,
           {
             headers: {
@@ -650,7 +649,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should forward request to Express app", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           const app = require("express")();
           app.all("/", (req: express.Request, res: express.Response) => {
@@ -663,7 +662,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, frb, {
+        const data = await CallHTTPSFunction(worker, frb, {
           headers: {
             "x-hello": "world",
           },
@@ -674,7 +673,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle `x-forwarded-host`", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -685,7 +684,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(runtime, frb, {
+        const data = await CallHTTPSFunction(worker, frb, {
           headers: {
             "x-forwarded-host": "real-hostname",
           },
@@ -697,7 +696,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
     describe("Cloud Firestore", () => {
       it("should provide Change for firestore.onWrite()", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -714,7 +713,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        runtime.events.on("log", (el: EmulatorLog) => {
+        worker.runtime.events.on("log", (el: EmulatorLog) => {
           if (el.level !== "USER") {
             return;
           }
@@ -722,12 +721,12 @@ describe("FunctionsEmulator-Runtime", () => {
           expect(JSON.parse(el.text)).to.deep.eq({ before_exists: false, after_exists: true });
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["function-log"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should provide Change for firestore.onUpdate()", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onUpdate, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onUpdate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -744,19 +743,19 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        runtime.events.on("log", (el: EmulatorLog) => {
+        worker.runtime.events.on("log", (el: EmulatorLog) => {
           if (el.level !== "USER") {
             return;
           }
           expect(JSON.parse(el.text)).to.deep.eq({ before_exists: true, after_exists: true });
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["function-log"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should provide DocumentSnapshot for firestore.onDelete()", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onDelete, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onDelete, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -772,19 +771,19 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        runtime.events.on("log", (el: EmulatorLog) => {
+        worker.runtime.events.on("log", (el: EmulatorLog) => {
           if (el.level !== "USER") {
             return;
           }
           expect(JSON.parse(el.text)).to.deep.eq({ snap_exists: true });
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["function-log"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
 
       it("should provide DocumentSnapshot for firestore.onCreate()", async () => {
-        const runtime = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
+        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -800,14 +799,14 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        runtime.events.on("log", (el: EmulatorLog) => {
+        worker.runtime.events.on("log", (el: EmulatorLog) => {
           if (el.level !== "USER") {
             return;
           }
           expect(JSON.parse(el.text)).to.deep.eq({ snap_exists: true });
         });
 
-        const logs = await _countLogEntries(runtime);
+        const logs = await _countLogEntries(worker);
         expect(logs["function-log"]).to.eq(1);
       }).timeout(TIMEOUT_MED);
     });
@@ -815,7 +814,7 @@ describe("FunctionsEmulator-Runtime", () => {
     describe("Error handling", () => {
       it("Should handle regular functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
@@ -824,10 +823,10 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = _countLogEntries(runtime);
+        const logs = _countLogEntries(worker);
 
         try {
-          await CallHTTPSFunction(runtime, frb);
+          await CallHTTPSFunction(worker, frb);
         } catch (e) {
           // No-op
         }
@@ -837,7 +836,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("Should handle async functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest(
@@ -848,10 +847,10 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = _countLogEntries(runtime);
+        const logs = _countLogEntries(worker);
 
         try {
-          await CallHTTPSFunction(runtime, frb);
+          await CallHTTPSFunction(worker, frb);
         } catch {
           // No-op
         }
@@ -861,7 +860,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("Should handle async/runWith functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const runtime = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -872,10 +871,10 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const logs = _countLogEntries(runtime);
+        const logs = _countLogEntries(worker);
 
         try {
-          await CallHTTPSFunction(runtime, frb);
+          await CallHTTPSFunction(worker, frb);
         } catch {
           // No-op
         }

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -48,14 +48,7 @@ async function CallHTTPSFunction(
   options: any = {},
   requestData?: string
 ): Promise<string> {
-  const log = await EmulatorLog.waitForLog(
-    worker.runtime.events,
-    "SYSTEM",
-    "runtime-status",
-    (el) => {
-      return el.data.state === "ready";
-    }
-  );
+  await worker.waitForSocketReady();
 
   const dataPromise = new Promise<string>((resolve, reject) => {
     const path = `/${frb.projectId}/us-central1/${frb.triggerId}`;

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -93,7 +93,6 @@ class MockRuntimeBundle implements FunctionsRuntimeBundle {
   triggerType = EmulatedTriggerType.HTTPS;
   cwd = "/home/users/dir";
   ports = {};
-  socketPath = "";
 
   constructor(public triggerId: string) {}
 }

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -17,6 +17,7 @@ import {
  * It automatically fails or succeeds 10ms after being given work to do.
  */
 class MockRuntimeInstance implements FunctionsRuntimeInstance {
+  pid: number = 12345;
   metadata: { [key: string]: any } = {};
   events: EventEmitter = new EventEmitter();
   exit: Promise<number>;
@@ -92,6 +93,7 @@ class MockRuntimeBundle implements FunctionsRuntimeBundle {
   triggerType = EmulatedTriggerType.HTTPS;
   cwd = "/home/users/dir";
   ports = {};
+  socketPath = "";
 
   constructor(public triggerId: string) {}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This is a follow up to #1733 to make some of the changes that @yuchenshi asked for.  This was a nice and productive rabbit hole.

Changes include:

  * Make `FunctionsEmulator` no longer rely on the `options` object
  * Change `static` methods from `FunctionsEmulator` that were only static for testing purposes
  * Move all of the logging code into `EmulatorLogger` where it belongs
  * Assign the `socketPath` for HTTPS functions **before** the function runs so that we don't have to
    wait async for it to bubble up.
  * Remove the `waitForSystemLog` function from the worker class, it's not needed anymore.
  * Remove waiting for `ready` from background functions where it's not needed.
	 
### Scenarios Tested

In addition to making the test suite run, I tested that these functions all work as expected:
```js
exports.helloWorld = functions.https.onRequest(async (req, res) => {
    res.json({
        hello: 'world',
        date: new Date()
    });
});

exports.firestoreWriter = functions.https.onRequest(async (req, res) => {
    await admin.firestore().doc('foo/bar').set({
        date: new Date()
    });
});

exports.firestoreReader = functions.firestore.document('foo/bar').onWrite(async (change, ctx) => {
    console.log("Firestore Write:", JSON.stringify(change.after.data()));
});
```

### Sample Commands

N/A