### PR TITLE
Add host checking, restrict URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+* Fixes a bug where the Functions emulator ignored the "host" configuration (#1722)
+* Fixes a bug where the Functions emulator accepted requests to too many paths (#1773)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -19,22 +19,22 @@ import * as getProjectId from "../getProjectId";
 
 export const VALID_EMULATOR_STRINGS: string[] = ALL_EMULATORS;
 
-export async function checkPortOpen(port: number): Promise<boolean> {
+export async function checkPortOpen(port: number, host: string): Promise<boolean> {
   try {
-    const inUse = await tcpport.check(port);
+    const inUse = await tcpport.check(port, host);
     return !inUse;
   } catch (e) {
     return false;
   }
 }
 
-export async function waitForPortClosed(port: number): Promise<void> {
+export async function waitForPortClosed(port: number, host: string): Promise<void> {
   const interval = 250;
   const timeout = 30000;
   try {
     await tcpport.waitUntilUsed(port, interval, timeout);
   } catch (e) {
-    throw new FirebaseError(`TIMEOUT: Port ${port} was not active within ${timeout}ms`);
+    throw new FirebaseError(`TIMEOUT: Port ${port} on ${host} was not active within ${timeout}ms`);
   }
 }
 
@@ -45,8 +45,7 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
   // Log the command for analytics
   track("emulators:start", name);
 
-  // TODO(samstern): This check should only occur when the host is localhost
-  const portOpen = await checkPortOpen(info.port);
+  const portOpen = await checkPortOpen(info.port, info.host);
   if (!portOpen) {
     await cleanShutdown();
     utils.logWarning(`Port ${info.port} is not open, could not start ${name} emulator.`);

--- a/src/emulator/emulatorServer.ts
+++ b/src/emulator/emulatorServer.ts
@@ -11,7 +11,7 @@ export class EmulatorServer {
   constructor(public instance: EmulatorInstance) {}
 
   async start(): Promise<void> {
-    const { port, host }  = this.instance.getInfo();
+    const { port, host } = this.instance.getInfo();
     const portOpen = await controller.checkPortOpen(port, host);
 
     if (!portOpen) {

--- a/src/emulator/emulatorServer.ts
+++ b/src/emulator/emulatorServer.ts
@@ -11,12 +11,12 @@ export class EmulatorServer {
   constructor(public instance: EmulatorInstance) {}
 
   async start(): Promise<void> {
-    const port = this.instance.getInfo().port;
-    const portOpen = await controller.checkPortOpen(port);
+    const { port, host }  = this.instance.getInfo();
+    const portOpen = await controller.checkPortOpen(port, host);
 
     if (!portOpen) {
       throw new FirebaseError(
-        `Port ${port} is not open, could not start ${this.instance.getName()} emulator.`
+        `Port ${port} is not open on ${host}, could not start ${this.instance.getName()} emulator.`
       );
     }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -112,7 +112,9 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     // The URL for the function that the other emulators (Firestore, etc) use.
     // TODO(abehaskins): Make the other emulators use the route below and remove this.
-    const backgroundFunctionRoute = `/functions/projects/${this.args.projectId}/triggers/:trigger_name`;
+    const backgroundFunctionRoute = `/functions/projects/${
+      this.args.projectId
+    }/triggers/:trigger_name`;
 
     // The URL that the developer sees, this is the same URL that the legacy emulator used.
     const httpsFunctionRoute = `/${this.args.projectId}/:region/:trigger_name`;

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -112,10 +112,10 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     // The URL for the function that the other emulators (Firestore, etc) use.
     // TODO(abehaskins): Make the other emulators use the route below and remove this.
-    const backgroundFunctionRoute = "/functions/projects/:project_id/triggers/:trigger_name";
+    const backgroundFunctionRoute = `/functions/projects/${this.args.projectId}/triggers/:trigger_name`;
 
     // The URL that the developer sees, this is the same URL that the legacy emulator used.
-    const httpsFunctionRoute = `/:project_id/:region/:trigger_name`;
+    const httpsFunctionRoute = `/${this.args.projectId}/:region/:trigger_name`;
 
     // A trigger named "foo" needs to respond at "foo" as well as "foo/*" but not "fooBar".
     const httpsFunctionRoutes = [httpsFunctionRoute, `${httpsFunctionRoute}/*`];

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -19,10 +19,11 @@ export class EmulatorRegistry {
 
     // Start the emulator and wait for it to grab its assigned port.
     await instance.start();
-    await controller.waitForPortClosed(instance.getInfo().port);
+
+    const info = instance.getInfo();
+    await controller.waitForPortClosed(info.port, info.host);
 
     this.set(instance.getName(), instance);
-    const info = instance.getInfo();
     utils.logLabeledSuccess(
       instance.getName(),
       `Emulator started at ${clc.bold.underline(`http://${info.host}:${info.port}`)}`

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -107,7 +107,7 @@ describe("FunctionsEmulator-Hub", () => {
       });
   }).timeout(TIMEOUT_LONG);
 
-  it("should reject requests to /foo/bar/baz", async () => {
+  it("should reject requests to a non-emulator path", async () => {
     UseFunctions(() => {
       return {
         function_id: require("firebase-functions").https.onRequest(

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -20,7 +20,7 @@ if ((process.env.DEBUG || "").toLowerCase().indexOf("spec") >= 0) {
 }
 
 const functionsEmulator = new FunctionsEmulator({
-  projectId: "",
+  projectId: "fake-project-id",
   functionsDir: "",
 });
 const startFunctionRuntime = functionsEmulator.startFunctionRuntime;
@@ -105,6 +105,24 @@ describe("FunctionsEmulator-Hub", () => {
       .then((res) => {
         expect(res.body.path).to.deep.equal("/a/b");
       });
+  }).timeout(TIMEOUT_LONG);
+
+  it("should reject requests to /foo/bar/baz", async () => {
+    UseFunctions(() => {
+      return {
+        function_id: require("firebase-functions").https.onRequest(
+          (req: express.Request, res: express.Response) => {
+            res.json({ path: req.path });
+          }
+        ),
+      };
+    });
+
+    await supertest(
+      functionsEmulator.createHubServer(FunctionRuntimeBundles.template, process.execPath)
+    )
+      .get("/foo/bar/baz")
+      .expect(404);
   }).timeout(TIMEOUT_LONG);
 
   it("should rewrite req.path to hide /:project_id/:region/:trigger_id", async () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1722 
Fixes #1773 
	 
### Scenarios Tested

**functions**
```js
exports.helloWorld = functions.https.onRequest(async (req, res) => {
    res.json({
        hello: 'world',
        date: new Date()
    });
});

exports.firestoreWriter = functions.https.onRequest(async (req, res) => {
    await admin.firestore().doc('foo/bar').set({
        date: new Date()
    });

    res.json({ ok: 'ok' })
});

exports.firestoreReader = functions.firestore.document('foo/bar').onWrite(async (change, ctx) => {
    console.log("Firestore Write:", JSON.stringify(change.after.data()));
});
```

**firebase.json**
```json
{
  "emulators": {
    "functions": {
      "host": "0.0.0.0",
      "port": 5001
    },
    "database": {
      "port": 9000
    }
  }
}
```

Start the emulators:
```
$ npx firebase emulators:start --only functions,firestore
i  Starting emulators: ["functions","firestore"]
✔  functions: Using node@10 from host.
✔  functions: Emulator started at http://0.0.0.0:5001
i  firestore: Serving ALL traffic (including WebChannel) on http://localhost:8080
⚠  firestore: Support for WebChannel on a separate port (8081) is DEPRECATED and will go away soon. Please use port above instead.
i  firestore: Emulator logging to firestore-debug.log
✔  firestore: Emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  functions: Watching "/tmp/tmp.ITmKYw5141/functions" for Cloud Functions...
✔  functions[helloWorld]: http function initialized (http://0.0.0.0:5001/fir-dumpster/us-central1/helloWorld).
✔  functions[firestoreWriter]: http function initialized (http://0.0.0.0:5001/fir-dumpster/us-central1/firestoreWriter).
✔  functions[firestoreReader]: firestore function initialized.
✔  All emulators started, it is now safe to connect.
```

Run some functions:
```
$ http http://0.0.0.0:5001/fir-dumpster/us-central1/firestoreWriter
HTTP/1.1 200 OK
connection: keep-alive
content-length: 11
content-type: application/json; charset=utf-8
date: Sat, 09 Nov 2019 00:19:41 GMT
etag: W/"b-2F/2BWc0KYbtLqL5U2Kv5B6uQUQ"
x-powered-by: Express

{
    "ok": "ok"
}
```

Logs look good:
```
i  functions: Beginning execution of "firestoreWriter"
i  functions: Finished "firestoreWriter" in ~1s
i  functions: Beginning execution of "firestoreReader"
>  Firestore Write: {"date":{"_seconds":1573258780,"_nanoseconds":854000000}}
i  functions: Finished "firestoreReader" in ~1s
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
