### PR TITLE
Extensions Tests Improvement

### DIFF
--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -1,6 +1,9 @@
 import * as _ from "lodash";
 import { expect } from "chai";
 import * as nock from "nock";
+import * as sinon from "sinon";
+
+import * as helpers from "../helpers";
 import * as api from "../../api";
 import { FirebaseError } from "../../error";
 
@@ -43,7 +46,16 @@ const PROJECT_ID = "test-project";
 const INSTANCE_ID = "test-extensions-instance";
 
 describe("extensions", () => {
+  beforeEach(() => {
+    helpers.mockAuth(sinon);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
   describe("listInstances", () => {
+
     afterEach(() => {
       nock.cleanAll();
     });
@@ -254,8 +266,6 @@ describe("extensions", () => {
         .reply(200, { name: "operations/abc123" });
       nock(api.extensionsOrigin)
         .get(`/${VERSION}/operations/abc123`)
-        .reply(200, { done: false })
-        .get(`/${VERSION}/operations/abc123`)
         .reply(200, { done: true });
 
       await extensionsApi.updateInstance(PROJECT_ID, INSTANCE_ID, testSource, {
@@ -263,7 +273,7 @@ describe("extensions", () => {
       });
 
       expect(nock.isDone()).to.be.true;
-    }).timeout(2000);
+    });
 
     it("should not include config.param in updateMask is params aren't changed", async () => {
       nock(api.extensionsOrigin)
@@ -272,14 +282,12 @@ describe("extensions", () => {
         .reply(200, { name: "operations/abc123" });
       nock(api.extensionsOrigin)
         .get(`/${VERSION}/operations/abc123`)
-        .reply(200, { done: false })
-        .get(`/${VERSION}/operations/abc123`)
         .reply(200, { done: true });
 
       await extensionsApi.updateInstance(PROJECT_ID, INSTANCE_ID, testSource);
 
       expect(nock.isDone()).to.be.true;
-    }).timeout(2000);
+    });
 
     it("should throw a FirebaseError if update returns an error response", async () => {
       nock(api.extensionsOrigin)

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -55,7 +55,6 @@ describe("extensions", () => {
   });
 
   describe("listInstances", () => {
-
     afterEach(() => {
       nock.cleanAll();
     });


### PR DESCRIPTION
### Description

The Extensions tests were being really slow, so I figured out why.

Added the `helpers.mockAuth(sinon)` call to speed up the auth calls.

There were a couple (expensive) additional "make sure the operation is polled" tests that I decided to opt to make only a single request because each polling operation takes 250ms (and it's not configurable - easily - from the tests as it's currently written).
	 
### Scenarios Tested

`npm test`