### PR TITLE
Fix commands with default arguments

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -140,7 +140,11 @@ export class Command {
       // command. Therefore, if we check the number of arguments we have
       // against the number of arguments the action function has, we can error
       // out if we would provide too many.
-      if (args.length > this.actionFn.length) {
+      // TODO(bkendall): it would be nice to not depend on this internal
+      //   property of Commander, but that's the limitation we have today. What
+      //   we would like is the following:
+      //   > if (args.length > this.actionFn.length)
+      if (args.length > cmd._args.length) {
         client.errorOut(
           new FirebaseError(
             `Too many arguments. Run ${bold("firebase help " + this.name)} for usage instructions`,

--- a/src/command.ts
+++ b/src/command.ts
@@ -144,7 +144,7 @@ export class Command {
       //   property of Commander, but that's the limitation we have today. What
       //   we would like is the following:
       //   > if (args.length > this.actionFn.length)
-      if (args.length > cmd._args.length) {
+      if (args.length - 1 > cmd._args.length) {
         client.errorOut(
           new FirebaseError(
             `Too many arguments. Run ${bold("firebase help " + this.name)} for usage instructions`,


### PR DESCRIPTION
### Description

If an action function has default arguments, `.length` on the function will only count the arguments that come before the first default argument.

This is a fix for #1784.
	 
### Scenarios Tested

`firebase apps:list foo` should have triggered the "too many arguments" situation. this PR restores that behavior.