### PR TITLE
Fix functions emulator log

### DIFF
--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -175,7 +175,7 @@ You probably need to run "npm install" in your functions directory.`
           "WARN",
           `The Cloud Functions emulator requires the module "${
             systemLog.data.name
-          }" to be version >${systemLog.data.minVersion}.0.0 so your version is too old. \
+          }" to be version >${systemLog.data.minVersion} so your version is too old. \
 You can probably fix this by running "npm install ${
             systemLog.data.name
           }@latest" in your functions directory.`


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Currently the log looks like this:
```
⚠  The Cloud Functions emulator requires the module "firebase-admin" to be version >8.0.0.0.0 so your version is too old. You can probably fix this by running "npm install firebase-admin@latest" in your functions directory.
```

I mean it's true but ... no lol.

### Scenarios Tested

See above.

### Sample Commands

N/A