### PR TITLE
Shorten socket paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,0 @@
-* Fixes a bug where the Functions emulator ignored the "host" configuration (#1722)
-* Fixes a bug where the Functions emulator accepted requests to too many paths (#1773)
-* Modifies `firebase ext:update` to not perform update if the extension is already up to date.
-* Print Firebase Console links for Extensions after operations.
-* Updated Firebase Extensions registry address.
-* Adds the `firebase init emulators` command.
-* Adds a Cloud Pub/Sub Emulator (#1748).
-* Fixes a bug where the Firestore emulator was unable to serve rule coverage HTML reports.
-* Fixes a bug in the Firestore emulator where rapidly overwriting the same document could trigger exceptions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fixes an issue where repeated invoations cause an `EADDRINUSE` error (#1815)

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -84,7 +84,7 @@ export class EmulatorLogger {
         EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`);
         break;
       case "DEBUG":
-        if (log.data && log.data !== {}) {
+        if (log.data && Object.keys(log.data).length > 0) {
           EmulatorLogger.log("DEBUG", `[${log.type}] ${log.text} ${JSON.stringify(log.data)}`);
         } else {
           EmulatorLogger.log("DEBUG", `[${log.type}] ${log.text}`);

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -140,14 +140,14 @@ export class FunctionsEmulator implements EmulatorInstance {
       req: express.Request,
       res: express.Response
     ) => {
-      await this.handleBackgroundTrigger(req, res);
+      this.handleBackgroundTrigger(req, res);
     };
 
     const httpsHandler: express.RequestHandler = async (
       req: express.Request,
       res: express.Response
     ) => {
-      await this.handleHttpsTrigger(req, res);
+      this.handleHttpsTrigger(req, res);
     };
 
     // The ordering here is important. The longer routes (background)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -29,7 +29,6 @@ import { EmulatorLogger, Verbosity } from "./emulatorLogger";
 import { RuntimeWorkerPool, RuntimeWorker } from "./functionsRuntimeWorker";
 import { PubsubEmulator } from "./pubsubEmulator";
 import { FirebaseError } from "../error";
-import { pubsub } from "firebase-functions";
 
 const EVENT_INVOKE = "functions:invoke";
 
@@ -141,14 +140,14 @@ export class FunctionsEmulator implements EmulatorInstance {
       req: express.Request,
       res: express.Response
     ) => {
-      this.handleBackgroundTrigger(req, res);
+      await this.handleBackgroundTrigger(req, res);
     };
 
     const httpsHandler: express.RequestHandler = async (
       req: express.Request,
       res: express.Response
     ) => {
-      this.handleHttpsTrigger(req, res);
+      await this.handleHttpsTrigger(req, res);
     };
 
     // The ordering here is important. The longer routes (background)

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -831,7 +831,7 @@ async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
 
         await runHTTPS([req, res], func);
       } catch (err) {
-        rejectEphemeralServer(err);  
+        rejectEphemeralServer(err);
       }
     };
 
@@ -874,7 +874,7 @@ async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
     const instance = ephemeralServer.listen(socketPath, () => {
       new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready" }).log();
     });
-    
+
     instance.on("error", rejectEphemeralServer);
   });
 }

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -18,8 +18,6 @@ import * as admin from "firebase-admin";
 import * as bodyParser from "body-parser";
 import { URL } from "url";
 import * as _ from "lodash";
-import * as fs from "fs";
-import { Socket } from "net";
 
 const DATABASE_APP = "__database__";
 
@@ -815,17 +813,11 @@ async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigge
         const func = trigger.getRawFunction();
         res.on("finish", () => {
           instance.close((err) => {
-            instance.getConnections((err, num) => {
-              logDebug(`Server has ${num} connections after close.`);
-            });
-
             if (err) {
               rejectEphemeralServer(err);
             } else {
               resolveEphemeralServer();
             }
-
-            logDebug(`Closed ephemeral server at socketPath: ${socketPath}`);
           });
         });
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -134,13 +134,13 @@ export function getEmulatedTriggersFromDefinitions(
   }, {});
 }
 
-export function getTemporarySocketPath(id: string, cwd: string): string {
+export function getTemporarySocketPath(pid: number, cwd: string): string {
   // See "net" package docs for information about IPC pipes on Windows
   // https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections
   if (process.platform === "win32") {
-    return path.join("\\\\?\\pipe", cwd, id.toString());
+    return path.join("\\\\?\\pipe", cwd, pid.toString());
   } else {
-    return path.join(os.tmpdir(), `firebase_emulator_invocation_${id}.sock`);
+    return path.join(os.tmpdir(), `fire_emu_${pid.toString()}.sock`);
   }
 }
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -137,6 +137,17 @@ export function getEmulatedTriggersFromDefinitions(
 export function getTemporarySocketPath(pid: number, cwd: string): string {
   // See "net" package docs for information about IPC pipes on Windows
   // https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections
+  //
+  // As noted in the linked documentation the socket path is truncated at a certain
+  // length:
+  // > On Unix, the local domain is also known as the Unix domain. The path is a filesystem pathname. 
+  // > It gets truncated to a length of sizeof(sockaddr_un.sun_path) - 1, which varies 91 and 107 bytes 
+  // > depending on the operating system. The typical values are 107 on Linux and 103 on macOS.
+  //
+  // On Mac our socket paths will begin with something like this:
+  //   /var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/{...}.sock
+  // Since the system prefix is about ~50 chargs we only have about ~50 more to work with
+  // before we will get truncated socket names and then undefined behavior. 
   if (process.platform === "win32") {
     return path.join("\\\\?\\pipe", cwd, pid.toString());
   } else {

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -140,14 +140,14 @@ export function getTemporarySocketPath(pid: number, cwd: string): string {
   //
   // As noted in the linked documentation the socket path is truncated at a certain
   // length:
-  // > On Unix, the local domain is also known as the Unix domain. The path is a filesystem pathname. 
-  // > It gets truncated to a length of sizeof(sockaddr_un.sun_path) - 1, which varies 91 and 107 bytes 
+  // > On Unix, the local domain is also known as the Unix domain. The path is a filesystem pathname.
+  // > It gets truncated to a length of sizeof(sockaddr_un.sun_path) - 1, which varies 91 and 107 bytes
   // > depending on the operating system. The typical values are 107 on Linux and 103 on macOS.
   //
   // On Mac our socket paths will begin with something like this:
   //   /var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/{...}.sock
   // Since the system prefix is about ~50 chargs we only have about ~50 more to work with
-  // before we will get truncated socket names and then undefined behavior. 
+  // before we will get truncated socket names and then undefined behavior.
   if (process.platform === "win32") {
     return path.join("\\\\?\\pipe", cwd, pid.toString());
   } else {

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -146,7 +146,7 @@ export function getTemporarySocketPath(pid: number, cwd: string): string {
   //
   // On Mac our socket paths will begin with something like this:
   //   /var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/{...}.sock
-  // Since the system prefix is about ~50 chargs we only have about ~50 more to work with
+  // Since the system prefix is about ~50 chars we only have about ~50 more to work with
   // before we will get truncated socket names and then undefined behavior.
   if (process.platform === "win32") {
     return path.join("\\\\?\\pipe", cwd, pid.toString());

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -69,7 +69,7 @@ export class RuntimeWorker {
 
     // TODO(samstern): I would like to do this elsewhere...
     if (!execFrb.socketPath) {
-      execFrb.socketPath = getTemporarySocketPath(this.id, execFrb.cwd);
+      execFrb.socketPath = getTemporarySocketPath(this.runtime.pid, execFrb.cwd);
       this.log(`Assigning socketPath: ${execFrb.socketPath}`);
     }
 

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -237,6 +237,7 @@ export class RuntimeWorkerPool {
   }
 
   addWorker(triggerId: string | undefined, runtime: FunctionsRuntimeInstance): RuntimeWorker {
+    this.log(`addWorker(${triggerId})`);
     const key = this.getTriggerKey(triggerId);
     const worker = new RuntimeWorker(key, runtime);
 

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -237,7 +237,6 @@ export class RuntimeWorkerPool {
   }
 
   addWorker(triggerId: string | undefined, runtime: FunctionsRuntimeInstance): RuntimeWorker {
-    this.log(`addWorker(${triggerId})`);
     const key = this.getTriggerKey(triggerId);
     const worker = new RuntimeWorker(key, runtime);
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1815 

This was one of the hardest bugs to find I've ever messed with.  In #1778 we started assigning socket paths like this:
```
/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/firebase_emulator_invocation_5d718fae-4531-49e1-8510-d3c0606adced.sock
```

Then we got strange `EADDRINUSE` errors on the  second invocation.  Well it turns out:
https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections

> On Unix, the local domain is also known as the Unix domain. The path is a filesystem pathname. It gets truncated to a length of sizeof(sockaddr_un.sun_path) - 1, which varies 91 and 107 bytes depending on the operating system. The typical values are 107 on Linux and 103 on macOS.

Our paths were in the ~119 range.  So ... yeah.

### Scenarios Tested

Making Requests:
```
$ http http://localhost:5001/fir-dumpster/us-central1/helloHTTP/1.1 200 OK
connection: keep-alive
content-length: 20
content-type: text/html; charset=utf-8
date: Wed, 20 Nov 2019 00:01:52 GMT
etag: W/"14-z3iZXchEt5DVWZKsMncy8Wl4KSQ"
x-powered-by: Express

Hello from Firebase!

$ http http://localhost:5001/fir-dumpster/us-central1/hello
HTTP/1.1 200 OK
connection: keep-alive
content-length: 20
content-type: text/html; charset=utf-8
date: Wed, 20 Nov 2019 00:01:53 GMT
etag: W/"14-z3iZXchEt5DVWZKsMncy8Wl4KSQ"
x-powered-by: Express

Hello from Firebase!
```

Emulator Logs:
```
i  functions: Beginning execution of "hello"
i  functions: Finished "hello" in ~1s
i  functions: Beginning execution of "hello"
i  functions: Finished "hello" in ~1s
```

Unfortunately I can't easily add a `mocha` test for this because the mocha tests don't re-use  function runtimes.

### Sample Commands

See #1815