### PR TITLE
Updating App Distribution polling mechanism to use the new upload_status endpoint

### DIFF
--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -18,12 +18,26 @@ export interface AppDistributionApp {
   contactEmail: string;
 }
 
+export enum UploadStatus {
+  SUCCESS = "SUCCESS",
+  IN_PROGRESS = "IN_PROGRESS",
+  ERROR = "ERROR",
+}
+export interface UploadStatusResponse {
+  status: UploadStatus;
+  message: string;
+  errorCode: string;
+  release: {
+    id: string;
+  };
+}
+
 /**
  * Proxies HTTPS requests to the App Distribution server backend.
  */
 export class AppDistributionClient {
   static MAX_POLLING_RETRIES = 15;
-  static POLLING_INTERVAL_MS = 1000;
+  static POLLING_INTERVAL_MS = 2000;
 
   constructor(private readonly appId: string) {}
 
@@ -69,32 +83,36 @@ export class AppDistributionClient {
   }
 
   async pollReleaseIdByHash(hash: string, retryCount = 0): Promise<string> {
-    try {
-      return await this.getReleaseIdByHash(hash);
-    } catch (err) {
+    const uploadStatus = await this.getUploadStatus(hash);
+    if (uploadStatus.status === UploadStatus.IN_PROGRESS) {
       if (retryCount >= AppDistributionClient.MAX_POLLING_RETRIES) {
-        throw new FirebaseError(`failed to find the uploaded release: ${err.message}`, { exit: 1 });
+        throw new FirebaseError(
+          "failed to fetch release information: polling timeout exceeded, please try again",
+          { exit: 1 }
+        );
       }
-
       await new Promise((resolve) =>
         setTimeout(resolve, AppDistributionClient.POLLING_INTERVAL_MS)
       );
-
       return this.pollReleaseIdByHash(hash, retryCount + 1);
+    } else if (uploadStatus.status === UploadStatus.SUCCESS) {
+      return uploadStatus.release.id;
+    } else {
+      throw new FirebaseError(`error processing the binary: ${uploadStatus.message}`);
     }
   }
 
-  async getReleaseIdByHash(hash: string): Promise<string> {
+  async getUploadStatus(hash: string): Promise<UploadStatusResponse> {
     const apiResponse = await api.request(
       "GET",
-      `/v1alpha/apps/${this.appId}/release_by_hash/${hash}`,
+      `/v1alpha/apps/${this.appId}/upload_status/${hash}`,
       {
         origin: api.appDistributionOrigin,
         auth: true,
       }
     );
 
-    return _.get(apiResponse, "body.release.id");
+    return _.get(apiResponse, "body");
   }
 
   async addReleaseNotes(releaseId: string, releaseNotes: string): Promise<void> {

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -3,7 +3,7 @@ import * as fs from "fs-extra";
 import { Command } from "../command";
 import * as utils from "../utils";
 import * as requireAuth from "../requireAuth";
-import { AppDistributionApp, AppDistributionClient } from "../appdistribution/client";
+import { AppDistributionApp, AppDistributionClient, UploadStatus } from "../appdistribution/client";
 import { FirebaseError } from "../error";
 import { Distribution } from "../appdistribution/distribution";
 
@@ -102,10 +102,11 @@ module.exports = new Command("appdistribution:distribute <distribution-file>")
 
     // Upload the distribution if it hasn't been uploaded before
     let releaseId: string;
-    try {
-      releaseId = await requests.getReleaseIdByHash(releaseHash);
+    const uploadStatus = await requests.getUploadStatus(releaseHash);
+    if (uploadStatus.status === UploadStatus.SUCCESS) {
       utils.logWarning("this distribution has been uploaded before, skipping upload");
-    } catch (err) {
+      releaseId = uploadStatus.release.id;
+    } else {
       // If there's an error, we know that the distribution hasn't been uploaded before
       utils.logBullet("uploading distribution...");
 
@@ -115,7 +116,7 @@ module.exports = new Command("appdistribution:distribute <distribution-file>")
 
         // The upload process is asynchronous, so poll to figure out when the upload has finished successfully
         releaseId = await requests.pollReleaseIdByHash(releaseEtag);
-        utils.logSuccess("uploaded distribution successfully");
+        utils.logSuccess("uploaded distribution successfully!");
       } catch (err) {
         throw new FirebaseError(`failed to upload distribution. ${err.message}`, { exit: 1 });
       }

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -1,6 +1,10 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { AppDistributionClient } from "../../appdistribution/client";
+import {
+  AppDistributionClient,
+  UploadStatus,
+  UploadStatusResponse,
+} from "../../appdistribution/client";
 import { FirebaseError } from "../../error";
 import * as api from "../../api";
 import * as nock from "nock";
@@ -70,55 +74,64 @@ describe("distribution", () => {
   });
 
   describe("pollReleaseIdByHash", () => {
-    describe("when request fails", () => {
+    describe("when getUploadStatus returns IN_PROGRESS", () => {
       it("should throw error when retry count >= AppDistributionClient.MAX_POLLING_RETRIES", () => {
-        sandbox.stub(distribution, "getReleaseIdByHash").rejects(new Error("Can't find release"));
+        sandbox.stub(distribution, "getUploadStatus").resolves({
+          status: UploadStatus.IN_PROGRESS,
+        });
         return expect(
           distribution.pollReleaseIdByHash("mock-hash", AppDistributionClient.MAX_POLLING_RETRIES)
-        ).to.be.rejectedWith(FirebaseError, "Can't find release");
+        ).to.be.rejectedWith(
+          FirebaseError,
+          "failed to fetch release information: polling timeout exceeded, please try again"
+        );
       });
     });
 
     it("should return release id when request succeeds", () => {
       const releaseId = "fake-release-id";
-      sandbox.stub(distribution, "getReleaseIdByHash").resolves(releaseId);
+      sandbox.stub(distribution, "getUploadStatus").resolves({
+        status: UploadStatus.SUCCESS,
+        release: {
+          id: releaseId,
+        },
+      });
       return expect(
         distribution.pollReleaseIdByHash("mock-hash", AppDistributionClient.MAX_POLLING_RETRIES)
       ).to.eventually.eq(releaseId);
     });
   });
 
-  describe("getReleaseIdByHash", () => {
+  describe("getUploadStatus", () => {
     it("should throw an error when request fails", () => {
       const fakeHash = "fake-hash";
       nock(api.appDistributionOrigin)
-        .get(`/v1alpha/apps/${appId}/release_by_hash/${fakeHash}`)
+        .get(`/v1alpha/apps/${appId}/upload_status/${fakeHash}`)
         .reply(400, {});
 
-      return expect(distribution.getReleaseIdByHash(fakeHash)).to.be.rejectedWith(
+      return expect(distribution.getUploadStatus(fakeHash)).to.be.rejectedWith(
         FirebaseError,
         "HTTP Error: 400"
       );
     });
 
     describe("when request succeeds", () => {
-      it("should return undefined when it cannot parse the response", () => {
-        const fakeHash = "fake-hash";
-        nock(api.appDistributionOrigin)
-          .get(`/v1alpha/apps/${appId}/release_by_hash/${fakeHash}`)
-          .reply(200, {});
-
-        return expect(distribution.getReleaseIdByHash(fakeHash)).to.eventually.eq(undefined);
-      });
-
-      it("should return the release id", () => {
+      it("should return the upload status", () => {
         const releaseId = "fake-release-id";
         const fakeHash = "fake-hash";
+        const response: UploadStatusResponse = {
+          status: UploadStatus.SUCCESS,
+          errorCode: "0",
+          message: "",
+          release: {
+            id: releaseId,
+          },
+        };
         nock(api.appDistributionOrigin)
-          .get(`/v1alpha/apps/${appId}/release_by_hash/${fakeHash}`)
-          .reply(200, { release: { id: releaseId } });
+          .get(`/v1alpha/apps/${appId}/upload_status/${fakeHash}`)
+          .reply(200, response);
 
-        return expect(distribution.getReleaseIdByHash(fakeHash)).to.eventually.eq(releaseId);
+        return expect(distribution.getUploadStatus(fakeHash)).to.eventually.deep.eq(response);
       });
     });
   });


### PR DESCRIPTION
### Description
1. Updating the polling mechanism after a distribution upload to use the new upload_status endpoint
2. Changed the polling interval to poll `15 times` every `2 seconds` to be consistent with the polling interval in the firebase console
	 
### Scenarios Tested
Updated existing tests to handle the updated polling mechanism and verified it by running `npm test` locally