### PR TITLE
hosting pre/postdeploy hooks now obey targeting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 * Adds support for immutable params in `ext:configure`.
 * Fixes an issue where console.log() sometimes printed incorrectly (#1817)
 * Improved Firebase App Distribution binary uploading.
+* Fixes an issue where all multi-site pre- and post-deploy hooks trigger for targeted deploys (#1160)

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -141,7 +141,7 @@ function getReleventConfigs(target, options) {
     });
 
   return targetConfigs.filter(function(config) {
-    return _.includes(onlyTargets, config.target);
+    return !config.target || _.includes(onlyTargets, config.target);
   });
 }
 

--- a/src/deploy/lifecycleHooks.js
+++ b/src/deploy/lifecycleHooks.js
@@ -141,7 +141,7 @@ function getReleventConfigs(target, options) {
     });
 
   return targetConfigs.filter(function(config) {
-    return _.includes(onlyTargets, config.target) || config;
+    return _.includes(onlyTargets, config.target);
   });
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
Fixes #1160 - pre/postdeploy hooks now obey targeting.
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
Ran multiple targeted deploys
 - Full deploy (`firebase deploy`)
 - Only hosting (`firebase deploy --only hosting`)
 - Only functions (`firebase deploy --only functions`)
 - Hosting, 2 targets  (`firebase deploy --only hosting:x,hosting:y`)
 - Hosting, 3 targets (`firebase deploy --only hosting:x,hosting:y,hosting:z`)
 - Functions, 2 targets (`firebase deploy --only functions:x,functions:y`)
 - Functions, 3 targets (`firebase deploy --only functions:x,functions,y,functions:z`)
