### PR TITLE
Displays updateWarnings during ext:update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-* Display updateWarnings during ext:update.
+* Display update warnings during `ext:update`.
 * Fixes an issue where all multi-site pre- and post-deploy hooks trigger for targeted deploys (#1160).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,1 @@
-* Adds support for immutable params in `ext:configure`.
-* Fixes an issue where console.log() sometimes printed incorrectly (#1817)
-* Improved Firebase App Distribution binary uploading.
+* Display updateWarnings during ext:update.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6852,9 +6852,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "portfinder": "^1.0.23",
     "progress": "^2.0.3",
     "request": "^2.87.0",
-    "semver": "^5.0.3",
+    "semver": "^5.7.1",
     "superstatic": "^6.0.1",
     "tar": "^4.3.0",
     "tcp-port-used": "^1.0.1",

--- a/src/commands/ext-info.ts
+++ b/src/commands/ext-info.ts
@@ -2,7 +2,7 @@ import * as clc from "cli-color";
 import * as _ from "lodash";
 
 import { Command } from "../command";
-import { resolveSource } from "../extensions/resolveSource";
+import { resolveRegistryEntry, resolveSourceUrl } from "../extensions/resolveSource";
 import * as extensionsApi from "../extensions/extensionsApi";
 import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
 import * as logger from "../logger";
@@ -22,7 +22,9 @@ export default new Command("ext:info <extensionName>")
   .before(requirePermissions, ["firebasemods.sources.get"])
   .before(ensureExtensionsApiEnabled)
   .action(async (extensionName: string, options: any) => {
-    const sourceUrl = await resolveSource(extensionName);
+    const [name, version] = extensionName.split("@");
+    const registryEntry = await resolveRegistryEntry(name);
+    const sourceUrl = await resolveSourceUrl(registryEntry, version);
     const source = await extensionsApi.getSource(sourceUrl);
     const spec = source.spec;
     if (!options.markdown) {

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -13,7 +13,7 @@ import { getRandomString } from "../extensions/generateInstanceId";
 import * as getProjectId from "../getProjectId";
 import { createServiceAccountAndSetRoles } from "../extensions/rolesHelper";
 import * as extensionsApi from "../extensions/extensionsApi";
-import { resolveSource } from "../extensions/resolveSource";
+import { resolveRegistryEntry, resolveSourceUrl } from "../extensions/resolveSource";
 import * as paramHelper from "../extensions/paramHelper";
 import {
   ensureExtensionsApiEnabled,
@@ -123,7 +123,9 @@ export default new Command("ext:install <extensionName>")
     try {
       const projectId = getProjectId(options, false);
       const paramFilePath = options.params;
-      const sourceUrl = await resolveSource(extensionName);
+      const [name, version] = extensionName.split("@");
+      const registryEntry = await resolveRegistryEntry(name);
+      const sourceUrl = await resolveSourceUrl(registryEntry, version);
       const source = await extensionsApi.getSource(sourceUrl);
       return installExtension({
         paramFilePath,

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -114,7 +114,9 @@ export default new Command("ext:update <extensionInstanceId>")
         )
       );
     } catch (err) {
-      spinner.fail();
+      if (spinner.isSpinning) {
+        spinner.fail();
+      }
       if (!(err instanceof FirebaseError)) {
         throw new FirebaseError(`Error occurred while updating the instance: ${err.message}`, {
           original: err,

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -1,19 +1,19 @@
-import * as _ from "lodash";
 import * as clc from "cli-color";
+import * as _ from "lodash";
 import * as marked from "marked";
 import * as ora from "ora";
-import TerminalRenderer = require("marked-terminal");
-
 import { Command } from "../command";
 import { FirebaseError } from "../error";
-import * as getProjectId from "../getProjectId";
-import * as resolveSource from "../extensions/resolveSource";
 import * as extensionsApi from "../extensions/extensionsApi";
 import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
 import * as paramHelper from "../extensions/paramHelper";
+import * as resolveSource from "../extensions/resolveSource";
 import { displayChanges, update, UpdateOptions } from "../extensions/updateHelper";
+import * as getProjectId from "../getProjectId";
 import { requirePermissions } from "../requirePermissions";
 import * as utils from "../utils";
+import TerminalRenderer = require("marked-terminal");
+
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -56,7 +56,7 @@ export default new Command("ext:update <extensionInstanceId>")
       const targetVersion = resolveSource.getTargetVersion(registryEntry, "latest");
       utils.logLabeledBullet(
         logPrefix,
-        `Updating ${instanceId} from version ${currentSpec.version} to version ${targetVersion}`
+        `Updating ${instanceId} from version ${clc.bold(currentSpec.version)} to version ${clc.bold(targetVersion)}`
       );
       await resolveSource.promptForUpdateWarnings(
         registryEntry,

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -54,7 +54,10 @@ export default new Command("ext:update <extensionInstanceId>")
 
       const registryEntry = await resolveSource.resolveRegistryEntry(currentSpec.name);
       const targetVersion = resolveSource.getTargetVersion(registryEntry, "latest");
-      utils.logLabeledBullet(logPrefix, `Updating ${instanceId} from version ${currentSpec.version} to version ${targetVersion}`)
+      utils.logLabeledBullet(
+        logPrefix,
+        `Updating ${instanceId} from version ${currentSpec.version} to version ${targetVersion}`
+      );
       await resolveSource.checkForUpdateWarnings(registryEntry, currentSpec.version, targetVersion);
       const sourceUrl = resolveSource.resolveSourceUrl(registryEntry, targetVersion);
       const newSource = await extensionsApi.getSource(sourceUrl);

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -58,7 +58,11 @@ export default new Command("ext:update <extensionInstanceId>")
         logPrefix,
         `Updating ${instanceId} from version ${currentSpec.version} to version ${targetVersion}`
       );
-      await resolveSource.checkForUpdateWarnings(registryEntry, currentSpec.version, targetVersion);
+      await resolveSource.promptForUpdateWarnings(
+        registryEntry,
+        currentSpec.version,
+        targetVersion
+      );
       const sourceUrl = resolveSource.resolveSourceUrl(registryEntry, targetVersion);
       const newSource = await extensionsApi.getSource(sourceUrl);
       const newSpec = newSource.spec;

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -51,7 +51,7 @@ export default new Command("ext:update <extensionInstanceId>")
         "config.source.spec"
       );
       const currentParams = _.get(existingInstance, "config.params");
-      const sourceUrl = await resolveSource(currentSpec.name);
+      const sourceUrl = await resolveSource(currentSpec.name, currentSpec.specVersion);
       const newSource = await extensionsApi.getSource(sourceUrl);
       const newSpec = newSource.spec;
       if (currentSpec.version === newSpec.version) {

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -51,7 +51,7 @@ export default new Command("ext:update <extensionInstanceId>")
         "config.source.spec"
       );
       const currentParams = _.get(existingInstance, "config.params");
-      const sourceUrl = await resolveSource(currentSpec.name, currentSpec.specVersion);
+      const sourceUrl = await resolveSource(currentSpec.name, currentSpec.version);
       const newSource = await extensionsApi.getSource(sourceUrl);
       const newSpec = newSource.spec;
       if (currentSpec.version === newSpec.version) {

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -14,7 +14,6 @@ import { requirePermissions } from "../requirePermissions";
 import * as utils from "../utils";
 import TerminalRenderer = require("marked-terminal");
 
-
 marked.setOptions({
   renderer: new TerminalRenderer(),
 });
@@ -56,7 +55,9 @@ export default new Command("ext:update <extensionInstanceId>")
       const targetVersion = resolveSource.getTargetVersion(registryEntry, "latest");
       utils.logLabeledBullet(
         logPrefix,
-        `Updating ${instanceId} from version ${clc.bold(currentSpec.version)} to version ${clc.bold(targetVersion)}`
+        `Updating ${instanceId} from version ${clc.bold(currentSpec.version)} to version ${clc.bold(
+          targetVersion
+        )}`
       );
       await resolveSource.promptForUpdateWarnings(
         registryEntry,

--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -34,7 +34,7 @@ export interface ExtensionSource {
 export interface ExtensionSpec {
   specVersion?: string;
   name: string;
-  version?: string;
+  version: string;
   description?: string;
   apis?: Api[];
   roles?: Role[];

--- a/src/extensions/resolveSource.ts
+++ b/src/extensions/resolveSource.ts
@@ -4,7 +4,7 @@ import * as semver from "semver";
 import * as api from "../api";
 import { FirebaseError } from "../error";
 import { logPrefix } from "./extensionsHelper";
-import { displayUpdateWarning } from "./updateHelper";
+import { confirmUpdateWarning } from "./updateHelper";
 import * as utils from "../utils";
 
 const EXTENSIONS_REGISTRY_ENDPOINT = "/extensions.json";
@@ -41,6 +41,10 @@ export function resolveSourceUrl(registryEntry: RegistryEntry, version: string):
   return sourceUrl;
 }
 
+/**
+ * Looks up and returns a entry from the official extensions registry.
+ * @param name the name of the extension to get the RegistryEntry for
+ */
 export async function resolveRegistryEntry(name: string): Promise<RegistryEntry> {
   const extensionsRegistry = await getExtensionRegistry();
   const registryEntry = _.get(extensionsRegistry, name);
@@ -50,9 +54,14 @@ export async function resolveRegistryEntry(name: string): Promise<RegistryEntry>
   return registryEntry; 
 }
 
-export function getTargetVersion(registryEntry: RegistryEntry, version?: string): string {
+/**
+ * Resolves a version or label to a version.
+ * @param registryEntry A registry entry to get the version from.
+ * @param versionOrLabel A version or label to resolve. Defaults to 'latest'.
+ */
+export function getTargetVersion(registryEntry: RegistryEntry, versionOrLabel?: string): string {
   // The version to search for when a user passes a version x.y.z or no version
-  const seekVersion = version || "latest";
+  const seekVersion = versionOrLabel || "latest";
 
   // The version to search for when a user passes a label like 'latest'
   const versionFromLabel = _.get(registryEntry, ["labels", seekVersion]);
@@ -77,7 +86,7 @@ export async function checkForUpdateWarnings(
         const updateWarnings = registryEntry.updateWarnings[targetRange];
         for (const updateWarning of updateWarnings) {
           if (semver.satisfies(startVersion, updateWarning.from)) {
-            await displayUpdateWarning(updateWarning);
+            await confirmUpdateWarning(updateWarning);
             break;
           }
         }

--- a/src/extensions/resolveSource.ts
+++ b/src/extensions/resolveSource.ts
@@ -43,7 +43,7 @@ export async function resolveSource(extensionName: string, startVersion?: string
   const versionFromLabel = _.get(extension, ["labels", seekVersion]);
 
   if (startVersion) {
-    checkForUpdateWarnings(extension, startVersion, versionFromLabel || seekVersion);
+    await checkForUpdateWarnings(extension, startVersion, versionFromLabel || seekVersion);
   }
   const source =
     _.get(extension, ["versions", seekVersion]) || _.get(extension, ["versions", versionFromLabel]);

--- a/src/extensions/resolveSource.ts
+++ b/src/extensions/resolveSource.ts
@@ -3,7 +3,9 @@ import * as clc from "cli-color";
 import * as semver from "semver";
 import * as api from "../api";
 import { FirebaseError } from "../error";
+import { logPrefix } from "./extensionsHelper";
 import { displayUpdateWarning } from "./updateHelper";
+import * as utils from "../utils";
 
 const EXTENSIONS_REGISTRY_ENDPOINT = "/extensions.json";
 
@@ -43,6 +45,10 @@ export async function resolveSource(extensionName: string, startVersion?: string
   const versionFromLabel = _.get(extension, ["labels", seekVersion]);
 
   if (startVersion) {
+    utils.logLabeledBullet(
+      logPrefix,
+      `Updating from version ${startVersion} to version ${versionFromLabel || seekVersion}.`
+    );
     await checkForUpdateWarnings(extension, startVersion, versionFromLabel || seekVersion);
   }
   const source =

--- a/src/extensions/resolveSource.ts
+++ b/src/extensions/resolveSource.ts
@@ -31,8 +31,7 @@ export interface UpdateWarning {
  */
 export function resolveSourceUrl(registryEntry: RegistryEntry, version: string): string {
   const targetVersion = getTargetVersion(registryEntry, version);
-  const sourceUrl =
-    _.get(registryEntry, ["versions", targetVersion])
+  const sourceUrl = _.get(registryEntry, ["versions", targetVersion]);
   if (!sourceUrl) {
     throw new FirebaseError(
       `Could not resolve version ${clc.bold(version)} of extension ${clc.bold(registryEntry.name)}.`
@@ -51,7 +50,7 @@ export async function resolveRegistryEntry(name: string): Promise<RegistryEntry>
   if (!registryEntry) {
     throw new FirebaseError(`Unable to find extension source named ${clc.bold(name)}.`);
   }
-  return registryEntry; 
+  return registryEntry;
 }
 
 /**

--- a/src/extensions/resolveSource.ts
+++ b/src/extensions/resolveSource.ts
@@ -3,9 +3,7 @@ import * as clc from "cli-color";
 import * as semver from "semver";
 import * as api from "../api";
 import { FirebaseError } from "../error";
-import { logPrefix } from "./extensionsHelper";
 import { confirmUpdateWarning } from "./updateHelper";
-import * as utils from "../utils";
 
 const EXTENSIONS_REGISTRY_ENDPOINT = "/extensions.json";
 
@@ -25,9 +23,8 @@ export interface UpdateWarning {
 
 /**
  * Gets the sourceUrl for a given extension name and version from the official extensions registry
- *
- * @param name the name of the extension to get the ExtensionSource for
- * @returns the source corresponding to extensionName in the registry
+ * @param name the name of the extension.
+ * @returns the source corresponding to extensionName in the registry.
  */
 export function resolveSourceUrl(registryEntry: RegistryEntry, version: string): string {
   const targetVersion = getTargetVersion(registryEntry, version);
@@ -42,7 +39,7 @@ export function resolveSourceUrl(registryEntry: RegistryEntry, version: string):
 
 /**
  * Looks up and returns a entry from the official extensions registry.
- * @param name the name of the extension to get the RegistryEntry for
+ * @param name the name of the extension.
  */
 export async function resolveRegistryEntry(name: string): Promise<RegistryEntry> {
   const extensionsRegistry = await getExtensionRegistry();
@@ -59,22 +56,23 @@ export async function resolveRegistryEntry(name: string): Promise<RegistryEntry>
  * @param versionOrLabel A version or label to resolve. Defaults to 'latest'.
  */
 export function getTargetVersion(registryEntry: RegistryEntry, versionOrLabel?: string): string {
-  // The version to search for when a user passes a version x.y.z or no version
+  // The version to search for when a user passes a version x.y.z or no version.
   const seekVersion = versionOrLabel || "latest";
 
-  // The version to search for when a user passes a label like 'latest'
+  // The version to search for when a user passes a label like 'latest'.
   const versionFromLabel = _.get(registryEntry, ["labels", seekVersion]);
 
   return versionFromLabel || seekVersion;
 }
 
 /**
- * Checks for and displays updateWarnings that apply to the given start and end versions.
- * @param registryEntry the registry entry to check for updateWarnings in
+ * Checks for and prompts the user to accept updateWarnings that apply to the given start and end versions.
+ * @param registryEntry the registry entry to check for updateWarnings.
  * @param startVersion the version that you are updating from.
- * @param endVersion the version you are updating to
+ * @param endVersion the version you are updating to.
+ * @throws FirebaseError if the user doesn't accept the update warning prompt.
  */
-export async function checkForUpdateWarnings(
+export async function promptForUpdateWarnings(
   registryEntry: RegistryEntry,
   startVersion: string,
   endVersion: string

--- a/src/extensions/updateHelper.ts
+++ b/src/extensions/updateHelper.ts
@@ -29,9 +29,6 @@ export function displayChangesNoInput(
   newSpec: extensionsApi.ExtensionSpec
 ): string[] {
   const lines: string[] = [];
-  if (spec.version !== newSpec.version) {
-    lines.push("", "**Version:**", `- ${spec.version}`, `+ ${newSpec.version}`);
-  }
   if (spec.displayName !== newSpec.displayName) {
     lines.push(
       "",

--- a/src/extensions/updateHelper.ts
+++ b/src/extensions/updateHelper.ts
@@ -159,7 +159,7 @@ async function getConsent(field: string, message: string): Promise<void> {
  * Displays an update warning as markdown, and prompts the user for confirmation.
  * @param updateWarning The update warning to display and prompt for.
  */
-export async function displayUpdateWarning(updateWarning: UpdateWarning): Promise<void> {
+export async function confirmUpdateWarning(updateWarning: UpdateWarning): Promise<void> {
   logger.info(marked(updateWarning.description));
   if (updateWarning.action) {
     logger.info(marked(updateWarning.action));

--- a/src/extensions/updateHelper.ts
+++ b/src/extensions/updateHelper.ts
@@ -6,6 +6,7 @@ import TerminalRenderer = require("marked-terminal");
 import * as checkProjectBilling from "./checkProjectBilling";
 import { FirebaseError } from "../error";
 import * as logger from "../logger";
+import { UpdateWarning } from "./resolveSource";
 import * as rolesHelper from "./rolesHelper";
 import * as extensionsApi from "./extensionsApi";
 import { promptOnce } from "../prompt";
@@ -151,6 +152,25 @@ async function getConsent(field: string, message: string): Promise<void> {
       `Without explicit consent for the change to ${field}, we cannot update this extension instance.`,
       { exit: 2 }
     );
+  }
+}
+
+/**
+ * Displays an update warning as markdown, and prompts the user for confirmation.
+ * @param updateWarning The update warning to display and prompt for.
+ */
+export async function displayUpdateWarning(updateWarning: UpdateWarning): Promise<void> {
+  logger.info(marked(updateWarning.description));
+  if (updateWarning.action) {
+    logger.info(marked(updateWarning.action));
+  }
+  const continueUpdate = await promptOnce({
+    type: "confirm",
+    message: "Do you wish to continue with this update?",
+    default: false,
+  });
+  if (!continueUpdate) {
+    throw new FirebaseError(`Update cancelled.`, { exit: 2 });
   }
 }
 

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -135,7 +135,7 @@ describe("extensions", () => {
           name: "sources/blah",
           packageUri: "https://test.fake/pacakge.zip",
           hash: "abc123",
-          spec: { name: "", sourceUrl: "", roles: [], resources: [], params: [] },
+          spec: { name: "", version: "0.1.0", sourceUrl: "", roles: [], resources: [], params: [] },
         },
         {},
         "my-service-account@proj.gserviceaccount.com"
@@ -156,7 +156,14 @@ describe("extensions", () => {
             name: "sources/blah",
             packageUri: "https://test.fake/pacakge.zip",
             hash: "abc123",
-            spec: { name: "", sourceUrl: "", roles: [], resources: [], params: [] },
+            spec: {
+              name: "",
+              version: "0.1.0",
+              sourceUrl: "",
+              roles: [],
+              resources: [],
+              params: [],
+            },
           },
           {},
           "my-service-account@proj.gserviceaccount.com"
@@ -181,7 +188,14 @@ describe("extensions", () => {
             name: "sources/blah",
             packageUri: "https://test.fake/pacakge.zip",
             hash: "abc123",
-            spec: { name: "", sourceUrl: "", roles: [], resources: [], params: [] },
+            spec: {
+              name: "",
+              version: "0.1.0",
+              sourceUrl: "",
+              roles: [],
+              resources: [],
+              params: [],
+            },
           },
           {},
           "my-service-account@proj.gserviceaccount.com"
@@ -258,7 +272,12 @@ describe("extensions", () => {
       name: "abc123",
       packageUri: "www.google.com/pack.zip",
       hash: "abc123",
-      spec: { name: "abc123", resources: [], sourceUrl: "www.google.com/pack.zip" },
+      spec: {
+        name: "abc123",
+        version: "0.1.0",
+        resources: [],
+        sourceUrl: "www.google.com/pack.zip",
+      },
     };
     afterEach(() => {
       nock.cleanAll();

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -63,6 +63,7 @@ const TEST_PARAMS_3 = [
 
 const SPEC = {
   name: "test",
+  version: "0.1.0",
   roles: [],
   resources: [],
   sourceUrl: "test.com",
@@ -192,6 +193,7 @@ describe("paramHelper", () => {
             hash: "",
             spec: {
               name: "",
+              version: "0.1.0",
               roles: [],
               resources: [],
               params: TEST_PARAMS,

--- a/src/test/extensions/resolveSource.spec.ts
+++ b/src/test/extensions/resolveSource.spec.ts
@@ -1,0 +1,77 @@
+import * as _ from "lodash";
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import * as resolveSource from "../../extensions/resolveSource";
+import * as updateHelper from "../../extensions/updateHelper";
+
+const testRegistryEntry = {
+  name: "test-stuff",
+  labels: {
+    latest: "0.2.0",
+  },
+  versions: {
+    "0.1.0": "projects/firebasemods/sources/2kd",
+    "0.1.1": "projects/firebasemods/sources/xyz",
+    "0.1.2": "projects/firebasemods/sources/123",
+    "0.2.0": "projects/firebasemods/sources/abc",
+  },
+  updateWarnings: {
+    ">0.1.0 <0.2.0": [
+      {
+        from: "0.1.0",
+        description:
+          "Starting Jan 15, HTTP functions will be private by default. [Learn more](https://someurl.com)",
+        action:
+          "After updating, it is highly recommended that you switch your Cloud Scheduler jobs to <b>PubSub</b>",
+      },
+    ],
+    ">=0.2.0": [
+      {
+        from: "0.1.0",
+        description:
+          "Starting Jan 15, HTTP functions will be private by default. [Learn more](https://someurl.com)",
+        action:
+          "After updating, you must switch your Cloud Scheduler jobs to <b>PubSub</b>, otherwise your extension will stop running.",
+      },
+      {
+        from: ">0.1.0",
+        description:
+          "Starting Jan 15, HTTP functions will be private by default. [Learn more](https://someurl.com)",
+        action:
+          "If you have not already done so during a previous update, after updating, you must switch your Cloud Scheduler jobs to <b>PubSub</b>, otherwise your extension will stop running.",
+      },
+    ],
+  },
+};
+
+describe("checkForUpdateWarnings", () => {
+  let displayUpdateWarningSpy: sinon.SinonStub;
+
+  beforeEach(() => {
+    displayUpdateWarningSpy = sinon.stub(updateHelper, "displayUpdateWarning").resolves();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should display the correct warning", async () => {
+    await resolveSource.checkForUpdateWarnings(testRegistryEntry, "0.1.0", "0.2.0");
+
+    const expectedUpdateWarning = {
+      from: "0.1.0",
+      description:
+        "Starting Jan 15, HTTP functions will be private by default. [Learn more](https://someurl.com)",
+      action:
+        "After updating, you must switch your Cloud Scheduler jobs to <b>PubSub</b>, otherwise your extension will stop running.",
+    };
+    expect(displayUpdateWarningSpy).to.have.been.calledWith(expectedUpdateWarning);
+  });
+
+  it("should display no warnings if none are applicable", async () => {
+    await resolveSource.checkForUpdateWarnings(testRegistryEntry, "0.1.1", "0.1.2");
+
+    expect(displayUpdateWarningSpy).not.to.have.been.called;
+  });
+});

--- a/src/test/extensions/resolveSource.spec.ts
+++ b/src/test/extensions/resolveSource.spec.ts
@@ -46,10 +46,10 @@ const testRegistryEntry = {
 };
 
 describe("checkForUpdateWarnings", () => {
-  let displayUpdateWarningSpy: sinon.SinonStub;
+  let confirmUpdateWarningSpy: sinon.SinonStub;
 
   beforeEach(() => {
-    displayUpdateWarningSpy = sinon.stub(updateHelper, "displayUpdateWarning").resolves();
+    confirmUpdateWarningSpy = sinon.stub(updateHelper, "confirmUpdateWarning").resolves();
   });
 
   afterEach(() => {
@@ -66,12 +66,12 @@ describe("checkForUpdateWarnings", () => {
       action:
         "After updating, you must switch your Cloud Scheduler jobs to <b>PubSub</b>, otherwise your extension will stop running.",
     };
-    expect(displayUpdateWarningSpy).to.have.been.calledWith(expectedUpdateWarning);
+    expect(confirmUpdateWarningSpy).to.have.been.calledWith(expectedUpdateWarning);
   });
 
   it("should display no warnings if none are applicable", async () => {
     await resolveSource.checkForUpdateWarnings(testRegistryEntry, "0.1.1", "0.1.2");
 
-    expect(displayUpdateWarningSpy).not.to.have.been.called;
+    expect(confirmUpdateWarningSpy).not.to.have.been.called;
   });
 });

--- a/src/test/extensions/resolveSource.spec.ts
+++ b/src/test/extensions/resolveSource.spec.ts
@@ -57,7 +57,7 @@ describe("checkForUpdateWarnings", () => {
   });
 
   it("should display the correct warning", async () => {
-    await resolveSource.checkForUpdateWarnings(testRegistryEntry, "0.1.0", "0.2.0");
+    await resolveSource.promptForUpdateWarnings(testRegistryEntry, "0.1.0", "0.2.0");
 
     const expectedUpdateWarning = {
       from: "0.1.0",
@@ -70,7 +70,7 @@ describe("checkForUpdateWarnings", () => {
   });
 
   it("should display no warnings if none are applicable", async () => {
-    await resolveSource.checkForUpdateWarnings(testRegistryEntry, "0.1.1", "0.1.2");
+    await resolveSource.promptForUpdateWarnings(testRegistryEntry, "0.1.1", "0.1.2");
 
     expect(confirmUpdateWarningSpy).not.to.have.been.called;
   });

--- a/src/test/extensions/updateHelper.spec.ts
+++ b/src/test/extensions/updateHelper.spec.ts
@@ -27,16 +27,6 @@ const SPEC = {
 
 describe("updateHelper", () => {
   describe("displayChangesNoInput", () => {
-    it("should display changes to version", () => {
-      const newSpec = _.cloneDeep(SPEC);
-      newSpec.version = "1.1.0";
-
-      const loggedLines = updateHelper.displayChangesNoInput(SPEC, newSpec);
-
-      const expected = ["", "**Version:**", "- 1.0.0", "+ 1.1.0"];
-      expect(loggedLines).to.eql(expected);
-    });
-
     it("should display changes to display name", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.displayName = "new";


### PR DESCRIPTION
### Description
During ext:update, if the extensions registry contains an updateWarning that applies to the start and end versions, display them and prompt the user for confirmation.
### Scenarios Tested
Added some unit tests for the version matching logic. Once the staging registry is updated with the updateWarnings field, I'll test with that as well and post screenshots here.
<img width="761" alt="Screen Shot 2019-12-05 at 9 04 28 AM" src="https://user-images.githubusercontent.com/4635763/70256973-5766fd80-173e-11ea-81c5-57bad09c5f28.png">

Also tested out ext:install and ext:info to confirm that they still work as intended