### PR TITLE
Only fail spinners if they are spinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Clean up extraneous error messages in extensions commands.

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -89,7 +89,9 @@ export default new Command("ext:configure <extensionInstanceId>")
       );
       return res;
     } catch (err) {
-      spinner.fail();
+      if (spinner.isSpinning) {
+        spinner.fail();
+      }
       if (!(err instanceof FirebaseError)) {
         throw new FirebaseError(`Error occurred while configuring the instance: ${err.message}`, {
           original: err,

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -101,7 +101,9 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
       )
     );
   } catch (err) {
-    spinner.fail();
+    if (spinner.isSpinning) {
+      spinner.fail();
+    }
     if (err instanceof FirebaseError) {
       throw err;
     }

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -97,7 +97,9 @@ export default new Command("ext:uninstall <extensionInstanceId>")
         }
       }
     } catch (err) {
-      spinner.fail();
+      if (spinner.isSpinning) {
+        spinner.fail();
+      }
       if (err instanceof FirebaseError) {
         throw err;
       }


### PR DESCRIPTION
### Description
Only call spinner.fail() if spinner.isSpinning. This prevents some awkward UX when errors are thrown from certain lines.