### PR TITLE
Add offline support to hosting emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 * Clean up extraneous error messages in extensions commands.
 * Adds breakpoint debugging for the Cloud Functions emulator using the `--inspect-functions` flag (#1360).
+* Adds the ability for the Hosting emulator start offline through `emulators:start` (#1854).

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -37,7 +37,7 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
     !controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
 
   try {
-    requireAuth(options);
+    await requireAuth(options);
   } catch (e) {
     logger.debug(e);
     utils.logLabeledWarning(

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -30,6 +30,7 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
   };
   const optionsWithConfig = options.config ? options : optionsWithDefaultConfig;
 
+  // TODO(samstern): Do we still want to do this?
   const requiresAuth = controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
 
   const canStartWithoutConfig =

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -37,7 +37,7 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
     !controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
 
   try {
-    requireAuth();
+    requireAuth(options);
   } catch (e) {
     logger.debug(e);
     utils.logLabeledWarning(

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -1,6 +1,8 @@
+import * as clc from "cli-color";
 import * as controller from "../emulator/controller";
 import * as Config from "../config";
 import * as utils from "../utils";
+import * as logger from "../logger";
 import requireAuth = require("../requireAuth");
 import requireConfig = require("../requireConfig");
 import { Emulators } from "../emulator/types";
@@ -29,22 +31,27 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
     config: DEFAULT_CONFIG,
   };
   const optionsWithConfig = options.config ? options : optionsWithDefaultConfig;
-
-  // TODO(samstern): Do we still want to do this?
-  const requiresAuth = controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
-
   const canStartWithoutConfig =
     options.only &&
     !controller.shouldStart(optionsWithConfig, Emulators.FUNCTIONS) &&
     !controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
+
+  try {
+    requireAuth();
+  } catch (e) {
+    logger.debug(e);
+    utils.logLabeledWarning(
+      "emulators",
+      `You are not currently authenticated so some features may not work correctly. Please run ${clc.bold(
+        "firebase login"
+      )} to authenticate the CLI.`
+    );
+  }
 
   if (canStartWithoutConfig && !options.config) {
     utils.logWarning("Could not find config (firebase.json) so using defaults.");
     options.config = DEFAULT_CONFIG;
   } else {
     await requireConfig(options);
-    if (requiresAuth) {
-      await requireAuth(options);
-    }
   }
 }

--- a/src/fetchWebSetup.ts
+++ b/src/fetchWebSetup.ts
@@ -1,5 +1,6 @@
 import * as api from "./api";
 import * as getProjectId from "./getProjectId";
+import * as configstore from "./configstore";
 
 export interface WebConfig {
   projectId: string;
@@ -12,6 +13,18 @@ export interface WebConfig {
   messagingSenderId?: string;
 }
 
+function configKey(projectId: string): string {
+  return "webconfig." + projectId;
+}
+
+/**
+ * Get the last known result of fetchWebSetup from the cache.
+ */
+export function getCachedWebSetup(options: any) {
+  const projectId = getProjectId(options, false);
+  return configstore.get(configKey(projectId));
+}
+
 /**
  * TODO: deprecate this function in favor of `getAppConfig()` in `/src/management/apps.ts`
  */
@@ -21,5 +34,7 @@ export async function fetchWebSetup(options: any): Promise<WebConfig> {
     auth: true,
     origin: api.firebaseApiOrigin,
   });
-  return response.body;
+  const config = response.body;
+  configstore.set(configKey(config.projectId), config);
+  return config;
 }

--- a/src/fetchWebSetup.ts
+++ b/src/fetchWebSetup.ts
@@ -13,16 +13,21 @@ export interface WebConfig {
   messagingSenderId?: string;
 }
 
-function configKey(projectId: string): string {
-  return "webconfig." + projectId;
+const CONFIGSTORE_KEY = "webconfig";
+
+function setCachedWebSetup(projectId: string, config: WebConfig) {
+  const allConfigs = configstore.get(CONFIGSTORE_KEY) || {};
+  allConfigs[projectId] = config;
+  configstore.set(CONFIGSTORE_KEY, allConfigs);
 }
 
 /**
- * Get the last known result of fetchWebSetup from the cache.
+ * Get the last known WebConfig from the cache.
  */
-export function getCachedWebSetup(options: any) {
+export function getCachedWebSetup(options: any): WebConfig | undefined {
   const projectId = getProjectId(options, false);
-  return configstore.get(configKey(projectId));
+  const allConfigs = configstore.get(CONFIGSTORE_KEY) || {};
+  return allConfigs[projectId];
 }
 
 /**
@@ -35,6 +40,6 @@ export async function fetchWebSetup(options: any): Promise<WebConfig> {
     origin: api.firebaseApiOrigin,
   });
   const config = response.body;
-  configstore.set(configKey(config.projectId), config);
+  setCachedWebSetup(config.projectId, config);
   return config;
 }

--- a/src/hosting/implicitInit.js
+++ b/src/hosting/implicitInit.js
@@ -19,7 +19,7 @@ module.exports = async function(options) {
     if (statusCode === 403) {
       utils.logLabeledWarning(
         "hosting",
-        `Authentication error when trying to fetch web configuration, have you run ${clc.bold(
+        `Authentication error when trying to fetch your current web app configuration, have you run ${clc.bold(
           "firebase login"
         )}?`
       );

--- a/src/hosting/implicitInit.js
+++ b/src/hosting/implicitInit.js
@@ -1,17 +1,41 @@
 "use strict";
 
 var fs = require("fs");
-
-var { fetchWebSetup } = require("../fetchWebSetup");
+var { fetchWebSetup, getCachedWebSetup } = require("../fetchWebSetup");
+var utils = require("../utils");
+var logger = require("../logger");
 
 var INIT_TEMPLATE = fs.readFileSync(__dirname + "/../../templates/hosting/init.js", "utf8");
 
-module.exports = function(options) {
-  return fetchWebSetup(options).then(function(config) {
-    var configJson = JSON.stringify(config, null, 2);
-    return {
-      js: INIT_TEMPLATE.replace("{/*--CONFIG--*/}", configJson),
-      json: configJson,
-    };
-  });
+module.exports = async function(options) {
+  let config;
+  try {
+    config = await fetchWebSetup(options);
+  } catch (e) {
+    logger.debug("fetchWebSetup error: " + e);
+  }
+
+  if (!config) {
+    config = getCachedWebSetup(options);
+    if (config) {
+      utils.logLabeledWarning(
+        "hosting",
+        "You are offline, using web app configuration from cache."
+      );
+    }
+  }
+
+  if (!config) {
+    config = undefined;
+    utils.logLabeledWarning(
+      "hosting",
+      "You are offline and there is no cached configuration on this machine. You must call firebase.initializeApp({...}) in your code before using Firebase."
+    );
+  }
+
+  const configJson = JSON.stringify(config, null, 2);
+  return {
+    js: INIT_TEMPLATE.replace("/*--CONFIG--*/", `var firebaseConfig = ${configJson};`),
+    json: configJson,
+  };
 };

--- a/templates/hosting/init.js
+++ b/templates/hosting/init.js
@@ -1,2 +1,5 @@
 if (typeof firebase === 'undefined') throw new Error('hosting/init-error: Firebase SDK not detected. You must include it before /__/firebase/init.js');
-firebase.initializeApp({/*--CONFIG--*/});
+/*--CONFIG--*/
+if (firebaseConfig) {
+  firebase.initializeApp({});
+}

--- a/templates/hosting/init.js
+++ b/templates/hosting/init.js
@@ -1,5 +1,5 @@
 if (typeof firebase === 'undefined') throw new Error('hosting/init-error: Firebase SDK not detected. You must include it before /__/firebase/init.js');
 /*--CONFIG--*/
 if (firebaseConfig) {
-  firebase.initializeApp({});
+  firebase.initializeApp(firebaseConfig);
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This is in response to #1854.  While I don't think it's a good idea to modify `firebase serve` extensively anymore, we can make `firebase emulators:start` support running all emulators offline.  Previously Hosting was the only holdout.

We add a new entry to the configstore file (normally `~/.config/configstore/firebase-tools.json`) that stores a per-project Firebase web config, it looks like this:

```js
{
       // ...
	"webconfig": {
		"fir-dumpster": {
			"projectId": "fir-dumpster",
			"databaseURL": "https://fir-dumpster.firebaseio.com",
			// ...
		},
               "other-project": {
                       // ...
               }
	}
}
```

This cached config is written every time the Hosting server is started offline and **never** used in place of a successful online fetch.  It is only consulted when the online fetch fails as a backup, and the user is warned.
	 
### Scenarios Tested

**Run hosting emulator offline without ever having run it online**

```
$ firebase emulators:start --only hosting
i  emulators: Starting emulators: hosting
⚠  hosting: You are offline and there is no cached configuration on this machine. You must call firebase.initializeApp({...}) in your code before using Firebase.
i  hosting: Serving hosting files from: public
✔  hosting: Local server: http://localhost:5000
✔  hosting: Emulator started at http://localhost:5000
✔  All emulators started, it is now safe to connect.
```

**Run hosting emulator offline after >=1 successful online run**

```
$ firebase emulators:start --only hosting
i  emulators: Starting emulators: hosting
⚠  hosting: You are offline, using web app configuration from cache.
i  hosting: Serving hosting files from: public
✔  hosting: Local server: http://localhost:5000
✔  hosting: Emulator started at http://localhost:5000
✔  All emulators started, it is now safe to connect.
```

**Run hosting emulator without logging in**
```bash
$ firebase emulators:start --only hosting
i  emulators: Starting emulators: hosting
⚠  hosting: Authentication error when trying to fetch web configuration, have you run firebase login?
⚠  hosting: Using web app configuration from cache.
i  hosting: Serving hosting files from: public
✔  hosting: Local server: http://localhost:5000
✔  hosting: Emulator started at http://localhost:5000
✔  All emulators started, it is now safe to connect.
```

**Hosting emulator offline, try to access magic `__firebase/*` js files on page load**
```bash
$ firebase emulators:start --only hosting
i  emulators: Starting emulators: hosting
⚠  hosting: You are offline, using web app configuration from cache.
i  hosting: Serving hosting files from: public
✔  hosting: Local server: http://localhost:5000
✔  hosting: Emulator started at http://localhost:5000
✔  All emulators started, it is now safe to connect.
...
⚠  hosting: Could not load Firebase SDK firebase-app.js v7.6.0, check your internet connection.
⚠  hosting: Could not load Firebase SDK firebase-auth.js v7.6.0, check your internet connection.
⚠  hosting: Could not load Firebase SDK firebase-database.js v7.6.0, check your internet connection.
⚠  hosting: Could not load Firebase SDK firebase-messaging.js v7.6.0, check your internet connection.
⚠  hosting: Could not load Firebase SDK firebase-storage.js v7.6.0, check your internet connection.
```

### Sample Commands

N/A
