### PR TITLE
Set GCLOUD_PROJECT in emulators:exec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 * Clean up extraneous error messages in extensions commands.
 * Adds breakpoint debugging for the Cloud Functions emulator using the `--inspect-functions` flag (#1360).
 * Adds the ability for the Hosting emulator start offline through `emulators:start` (#1854).
+* Sets the GCLOUD_PROJECT environment variable for scripts ran through 'emulators:exec'.

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -12,11 +12,16 @@ import { DatabaseEmulator } from "../emulator/databaseEmulator";
 import { EmulatorRegistry } from "../emulator/registry";
 import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 import * as commandUtils from "../emulator/commandUtils";
+import * as getProjectId from "../getProjectId";
 
-async function runScript(script: string): Promise<number> {
+async function runScript(script: string, projectId: string | undefined): Promise<number> {
   utils.logBullet(`Running script: ${clc.bold(script)}`);
 
   const env: NodeJS.ProcessEnv = { ...process.env };
+
+  if (projectId) {
+    env.GCLOUD_PROJECT = projectId;
+  }
 
   const databaseInstance = EmulatorRegistry.get(Emulators.DATABASE);
   if (databaseInstance) {
@@ -84,10 +89,11 @@ module.exports = new Command("emulators:exec <script>")
   .option(commandUtils.FLAG_ONLY, commandUtils.DESC_ONLY)
   .option(commandUtils.FLAG_INSPECT_FUNCTIONS, commandUtils.DESC_INSPECT_FUNCTIONS)
   .action(async (script: string, options: any) => {
+    const projectId = getProjectId(options, true);
     let exitCode = 0;
     try {
       await controller.startAll(options);
-      exitCode = await runScript(script);
+      exitCode = await runScript(script, projectId);
     } catch (e) {
       logger.debug("Error in emulators:exec", e);
       throw e;


### PR DESCRIPTION

### Scenarios Tested

Manually tested:

* `firebase emulators:exec --project foo 'env | grep GCLOUD'` correctly outputs `GCLOUD_PROJECT=foo`
* `firebase emulators:exec  'env | grep GCLOUD'` gives nothing if `firebase.json` not present
* `firebase emulators:exec  'env | grep GCLOUD'` uses project id from `firebase.json` if available

### Sample Commands

See above.