### PR TITLE
Release RTDB Emulator v4.3.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Adds the ability to select an extension to install from a list of available official extensions when `firebase ext:install -i` or `firebase ext:install --interactive` is run.
+* Release RTDB Emulator v4.3.1.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 * Adds the ability to select an extension to install from a list of available official extensions when `firebase ext:install -i` or `firebase ext:install --interactive` is run.
 * Fixes a small bug that caused `false` values in the `options` object to be ignored. 
-* Release RTDB Emulator v4.3.1.
+* Release Database Emulator v4.3.1.

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -27,13 +27,13 @@ const CACHE_DIR =
 
 const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
   database: {
-    downloadPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.2.0.jar"),
+    downloadPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.3.1.jar"),
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.2.0.jar",
-      expectedSize: 17131418,
-      expectedChecksum: "d9d825b2f321e05ca8dc9b758eec6ba6",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.3.1.jar",
+      expectedSize: 27893859,
+      expectedChecksum: "7d84e76144093406331571969f30444e",
       namePrefix: "firebase-database-emulator",
     },
   },


### PR DESCRIPTION

### Description

This bumps the RTDB emulator to v4.3.1. Note that v4.3.0 is broken and therefore skipped.

### Scenarios Tested

Manually started emulator and tested that it accepts REST writes.