### PR TITLE
Bug that prevents passing false option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Adds the ability to select an extension to install from a list of available official extensions when `firebase ext:install -i` or `firebase ext:install --interactive` is run.
+* Fixes a small bug that caused `false` values in the `options` object to be ignored. 

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -24,7 +24,7 @@ export type Question = inquirer.Question;
 export async function prompt(options: { [key: string]: any }, questions: Question[]): Promise<any> {
   const prompts = [];
   for (const question of questions) {
-    if (question.name && !options[question.name]) {
+    if (question.name && options[question.name] === undefined) {
       prompts.push(question);
     }
   }


### PR DESCRIPTION
When using firebase-tools as a module, we might want to pass in an option with a value of `false`.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This pull request contains a tiny bug fix.

When using firebase-tools as a module, i.e. calling functions that correspond to the CLI commands, it should be possible to pass in an `options` object that makes interaction at the command line unnecessary. For example if you call `login()` there's a command line prompt asking if you want to allow the collection of usage data. You should be able to prevent this by passing in `{collectUsage: false}`. However, because of this little bug, we still get prompted.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
	 
### Scenarios Tested

```
var client = require('firebase-tools');
client.login({collectUsage: false});
```

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Note

I couldn't get all the tests to pass on my local machine even before I made any changes. Maybe in light of this I should open an issue instead of a pull request?

Another option to fix this bug would be to use the `hasOwnProperty` method on the `options` object.

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
