### PR TITLE
Prevent pipeline.js from moving standaline scripts on build

### DIFF
--- a/scripts/firepit-builder/pipeline.js
+++ b/scripts/firepit-builder/pipeline.js
@@ -49,7 +49,7 @@ if (isLocalFirepit) {
   cp("-R", path.join(__dirname, "../vendor"), "firepit/vendor");
 } else {
   echo("Attempting to use firebase-tools/standalone...");
-  mv("node_modules/firebase-tools/standalone", "firepit");
+  cp("-r", "node_modules/firebase-tools/standalone", "firepit");
   echo("Success!");
 }
 

--- a/standalone/firepit.js
+++ b/standalone/firepit.js
@@ -831,6 +831,8 @@ function uninstallLegacyFirepit() {
     __dirname,
     "vendor/node_modules/firebase-tools/package.json"
   );
+  debug(`Doing JSON parses for version checks at ${firepitFirebaseToolsPackagePath}`);
+  debug(shell.ls(path.join(__dirname, "vendor/node_modules/")));
   const firepitFirebaseToolsPackage = JSON.parse(
     shell.cat(firepitFirebaseToolsPackagePath)
   );

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firepit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -28,7 +28,7 @@
     ]
   },
   "devDependencies": {
-    "pkg": "^4.3.8",
+    "pkg": "^4.4.2",
     "prettier": "^1.15.3"
   }
 }


### PR DESCRIPTION
There was a minor bug in the `firepit-builder` which made local development harder because it would remove the `standalone/` folder instead of just copying it to the right place.