### PR TITLE
Add Bind Host to Functions Emulator inspect argument

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -593,7 +593,8 @@ export class FunctionsEmulator implements EmulatorInstance {
     }
 
     if (this.args.debugPort) {
-      args.unshift(`--inspect=${this.args.debugPort}`);
+      const { host } = this.getInfo();
+      args.unshift(`--inspect=${host}:${this.args.debugPort}`);
     }
 
     const childProcess = spawn(opts.nodeBinary, args, {


### PR DESCRIPTION
### Description

Returns host from the `functionsEmulator::getinfo()` function in case no arg was passed and binds inspect to the same host the functions emulator is running on.

This is useful for running on Docker containers where services need to bind to `0.0.0.0`. Issue was also raised in the now archived cloud-functions-emulator repo here https://github.com/googlearchive/cloud-functions-emulator/issues/325 and a similar fix is proposed in their pull request here. https://github.com/googlearchive/cloud-functions-emulator/pull/326
	 
### Scenarios Tested

With no host passed in the `firebase.json` debug binds to default localhost sample test output for the command `firebase emulators:start --inspect-functions`

```
i  emulators: Starting emulators: functions
⚠  functions: You are running the functions emulator in debug mode (port=9229). This means that functions will execute in sequence rather than in parallel.
✔  functions: Using node@8 from host.
✔  functions: Emulator started at http://localhost:5001
i  functions: Watching "/home/node/app/functions" for Cloud Functions...
>  Debugger listening on ws://localhost:9229/bed89267-5c07-47c1-87fc-41154f0e40d3
```

Adding the following to firebase.json

```
    "emulators": {
        "functions": {
          "host": "0.0.0.0"
        }
      }
```

and running the same command as above results in ...

```
i  emulators: Starting emulators: functions
⚠  functions: You are running the functions emulator in debug mode (port=9229). This means that functions will execute in sequence rather than in parallel.
✔  functions: Using node@8 from host.
✔  functions: Emulator started at http://0.0.0.0:5001
i  functions: Watching "/home/node/app/functions" for Cloud Functions...
>  Debugger listening on ws://0.0.0.0:9229/6f51ba0f-d092-4cb4-87e2-e0da4392bbf4
```

Confirmed I could connect to debugger with vsCode and the following `launch.json`

```
{
    "version": "0.2.0",
    "configurations": [
        {
            "type": "node",
            "request": "attach",
            "name": "Attach",
            "address": "0.0.0.0",
            "port": 9229,
            "restart": true,
            "skipFiles": [
                "<node_internals>/**"
            ]
        }
}
```