### PR TITLE
add script to lint changed files and print warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "clean": "rm -rf lib",
     "format": "npm run lint -- --fix --quiet",
     "lint": "eslint '**/*.{js,ts}'",
+    "lint:changed-files": "ts-node ./scripts/lint-changed-files.ts",
     "mocha": "nyc mocha --opts mocha.opts",
     "prepare": "npm run clean && npm run build -- --build tsconfig.publish.json",
-    "test": "npm run lint -- --quiet && npm run mocha"
+    "test": "npm run lint -- --quiet && npm run lint:changed-files && npm run mocha"
   },
   "files": [
     "lib",

--- a/scripts/lint-changed-files.ts
+++ b/scripts/lint-changed-files.ts
@@ -27,6 +27,8 @@ function main(): void {
   const files: string[] = [];
   const ignoredFiles: string[] = [];
 
+  const otherArgs = process.argv.slice(2);
+
   let cmpBranch = "master";
   if (process.env.CI) {
     cmpBranch = "origin/master";
@@ -64,7 +66,7 @@ function main(): void {
   }
 
   try {
-    execSync(`eslint ${files.join(" ")}`, {
+    execSync(`eslint ${otherArgs.join(" ")} ${files.join(" ")}`, {
       cwd: root,
       stdio: ["pipe", process.stdout, process.stderr],
     });

--- a/scripts/lint-changed-files.ts
+++ b/scripts/lint-changed-files.ts
@@ -11,10 +11,28 @@ const root = resolve(__dirname, "..");
 const deletedFileRegex = /^D\s.+$/;
 const extensionsToCheck = [".js", ".ts"];
 
-function main() {
+/**
+ * Returns the last element of an array.
+ * @param arr any array.
+ * @return the last element of the array.
+ */
+function last<T>(arr: Array<T>): T {
+  return arr[arr.length - 1];
+}
+
+/**
+ * Main function of the script.
+ */
+function main(): void {
   const files: string[] = [];
   const ignoredFiles: string[] = [];
-  const gitOutput = execSync("git diff --name-status master", { cwd: root })
+
+  let cmpBranch = "master";
+  if (process.env.CI) {
+    cmpBranch = "origin/master";
+  }
+
+  const gitOutput = execSync(`git diff --name-status ${cmpBranch}`, { cwd: root })
     .toString()
     .trim();
 
@@ -58,7 +76,3 @@ function main() {
 }
 
 main();
-
-function last<T>(arr: Array<T>): T {
-  return arr[arr.length - 1];
-}

--- a/scripts/lint-changed-files.ts
+++ b/scripts/lint-changed-files.ts
@@ -1,0 +1,64 @@
+/*
+ * lint-changed-files looks at the list of files that have changed from the
+ * working branch and runs the linter on them. 
+ */
+
+import { execSync } from "child_process";
+import { extname, resolve } from "path";
+
+const root = resolve(__dirname, "..");
+
+const deletedFileRegex = /^D\s.+$/;
+const extensionsToCheck = [".js", ".ts"];
+
+function main() {
+  const files: string[] = [];
+  const ignoredFiles: string[] = [];
+  const gitOutput = execSync("git diff --name-status master", { cwd: root })
+    .toString()
+    .trim();
+
+  for (const line of gitOutput.split("\n")) {
+    const l = line.trim();
+    if (deletedFileRegex.test(l)) {
+      continue;
+    }
+    const entries = l.split(/\s/);
+    const file = last(entries);
+    if (extensionsToCheck.includes(extname(file))) {
+      files.push(file);
+    } else {
+      ignoredFiles.push(file);
+    }
+  }
+
+  if (ignoredFiles.length) {
+    console.log("Ignoring changed files:");
+    for (const f of ignoredFiles) {
+      console.log(` - ${f}`);
+    }
+    console.log();
+  }
+
+  if (!files.length) {
+    console.log("No changed files to lint.");
+    return;
+  }
+
+  try {
+    execSync(`eslint ${files.join(" ")}`, {
+      cwd: root,
+      stdio: ["pipe", process.stdout, process.stderr],
+    });
+  } catch (e) {
+    console.error("eslint failed, see errors above.");
+    console.error();
+    process.exit(e.status);
+  }
+}
+
+main();
+
+function last<T>(arr: Array<T>): T {
+  return arr[arr.length - 1];
+}


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

In the ongoing effort to clean up the codebase, this script will check any changed files in a given branch (changed from `master`) and print out the warnings in a more clear way when running `npm test`.

Part of me wonders if this should become its own Action - then it's clear what had failed. Though, it makes it hard if `npm test` doesn't explicitly do it too. I'm open to suggestions...