### PR TITLE
remove the require-jsdoc eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,12 +17,12 @@ module.exports = {
         "jsdoc/newline-after-description": "off",
         "prettier/prettier": "error",
         "valid-jsdoc": "off", // This is deprecated but included in recommended configs.
+        "require-jsdoc": "off", // This rule is deprecated and superseded by jsdoc/require-jsdoc.
         "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
         "no-restricted-globals": ["error", "name", "length"],
         "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
         "prefer-const": "warn", // TODO(bkendall): remove, allow to error.
         "prefer-promise-reject-errors": "warn", // TODO(bkendall): remove, allow to error.
-        "require-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
     },
     "overrides": [
         {
@@ -76,9 +76,7 @@ module.exports = {
             "env": {
                 "mocha": true,
             },
-            "rules": {
-                "require-jsdoc": "warn", // TODO(bkendall): remove, allow to error.
-            },
+            "rules": {},
         },
     ],
     "globals": {},


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Disabling the `require-jsdoc` rule, which is superseded by `jsdoc/require-jsdoc`. This prevents duplicate lint warnings from showing up.