### PR TITLE
allow a command-specified project to be selected during init

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     ],
     "rules": {
         "jsdoc/newline-after-description": "off",
+        "jsdoc/require-jsdoc": ["warn", { publicOnly: true }],
         "prettier/prettier": "error",
         "valid-jsdoc": "off", // This is deprecated but included in recommended configs.
         "require-jsdoc": "off", // This rule is deprecated and superseded by jsdoc/require-jsdoc.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 * Fixes a bug where unidentified commands gave an unhelpful error message (#1889).
 * Prevents potential false-negative permissions check errors from erroring command.
 * Adds `-s, --site` flag to `hosting:disable` command, allowing it to be run against the non-default site of a project.
+* During `init`, a provided `--project` will be respected and cause the selection prompt to be skipped.

--- a/mocha.opts
+++ b/mocha.opts
@@ -3,4 +3,4 @@
 --require src/test/helpers/mocha-bootstrap.js
 --recursive
 --timeout=1000
-src/test/**/*.{ts,js}
+src/test/init/features/project.spec.ts

--- a/mocha.opts
+++ b/mocha.opts
@@ -3,4 +3,4 @@
 --require src/test/helpers/mocha-bootstrap.js
 --recursive
 --timeout=1000
-src/test/init/features/project.spec.ts
+src/test/**/*.{ts,js}

--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -32,11 +32,6 @@ export interface ProjectInfo {
   location?: string; // maps to FirebaseProjectMetadata.resources.locationId
 }
 
-/**
- * Transforms project metadata to a ProjectInfo object.
- * @param projectMetaData project metadata.
- * @return a ProjectInfo object.
- */
 function toProjectInfo(projectMetaData: FirebaseProjectMetadata): ProjectInfo {
   const { projectId, displayName, resources } = projectMetaData;
   return {
@@ -47,10 +42,6 @@ function toProjectInfo(projectMetaData: FirebaseProjectMetadata): ProjectInfo {
   };
 }
 
-/**
- * Prompts to create a project.
- * @return the project metadata.
- */
 async function promptAndCreateNewProject(): Promise<FirebaseProjectMetadata> {
   utils.logBullet(
     "If you want to create a project in a Google Cloud organization or folder, please use " +
@@ -67,10 +58,6 @@ async function promptAndCreateNewProject(): Promise<FirebaseProjectMetadata> {
   });
 }
 
-/**
- * Prompts for a project and adds Firebase resources to it.
- * @return the project metadata.
- */
 async function promptAndAddFirebaseToCloudProject(): Promise<FirebaseProjectMetadata> {
   const projectId = await promptAvailableProjectId();
   if (!projectId) {

--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -32,6 +32,11 @@ export interface ProjectInfo {
   location?: string; // maps to FirebaseProjectMetadata.resources.locationId
 }
 
+/**
+ * Transforms project metadata to a ProjectInfo object.
+ * @param projectMetaData project metadata.
+ * @return a ProjectInfo object.
+ */
 function toProjectInfo(projectMetaData: FirebaseProjectMetadata): ProjectInfo {
   const { projectId, displayName, resources } = projectMetaData;
   return {
@@ -42,6 +47,10 @@ function toProjectInfo(projectMetaData: FirebaseProjectMetadata): ProjectInfo {
   };
 }
 
+/**
+ * Prompts to create a project.
+ * @return the project metadata.
+ */
 async function promptAndCreateNewProject(): Promise<FirebaseProjectMetadata> {
   utils.logBullet(
     "If you want to create a project in a Google Cloud organization or folder, please use " +
@@ -58,12 +67,48 @@ async function promptAndCreateNewProject(): Promise<FirebaseProjectMetadata> {
   });
 }
 
+/**
+ * Prompts for a project and adds Firebase resources to it.
+ * @return the project metadata.
+ */
 async function promptAndAddFirebaseToCloudProject(): Promise<FirebaseProjectMetadata> {
   const projectId = await promptAvailableProjectId();
   if (!projectId) {
     throw new FirebaseError("Project ID cannot be empty");
   }
   return await addFirebaseToCloudProjectAndLog(projectId);
+}
+
+/**
+ * Prompt the user about how they would like to select a project.
+ * @param options the Firebase CLI options object.
+ * @return the project metadata, or undefined if no project was selected.
+ */
+async function projectChoicePrompt(options: any): Promise<FirebaseProjectMetadata | undefined> {
+  const choices = [
+    { name: OPTION_USE_PROJECT, value: OPTION_USE_PROJECT },
+    { name: OPTION_NEW_PROJECT, value: OPTION_NEW_PROJECT },
+    { name: OPTION_ADD_FIREBASE, value: OPTION_ADD_FIREBASE },
+    { name: OPTION_NO_PROJECT, value: OPTION_NO_PROJECT },
+  ];
+  const projectSetupOption: string = await promptOnce({
+    type: "list",
+    name: "id",
+    message: "Please select an option:",
+    choices,
+  });
+
+  switch (projectSetupOption) {
+    case OPTION_USE_PROJECT:
+      return getOrPromptProject(options);
+    case OPTION_NEW_PROJECT:
+      return promptAndCreateNewProject();
+    case OPTION_ADD_FIREBASE:
+      return promptAndAddFirebaseToCloudProject();
+    default:
+      // Do nothing if user chooses NO_PROJECT
+      return;
+  }
 }
 
 /**
@@ -94,33 +139,16 @@ export async function doSetup(setup: any, config: Config, options: any): Promise
     return;
   }
 
-  const choices = [
-    { name: OPTION_USE_PROJECT, value: OPTION_USE_PROJECT },
-    { name: OPTION_NEW_PROJECT, value: OPTION_NEW_PROJECT },
-    { name: OPTION_ADD_FIREBASE, value: OPTION_ADD_FIREBASE },
-    { name: OPTION_NO_PROJECT, value: OPTION_NO_PROJECT },
-  ];
-  const projectSetupOption: string = await promptOnce({
-    type: "list",
-    name: "id",
-    message: "Please select an option:",
-    choices,
-  });
-
   let projectMetaData;
-  switch (projectSetupOption) {
-    case OPTION_USE_PROJECT:
-      projectMetaData = await getOrPromptProject(options);
-      break;
-    case OPTION_NEW_PROJECT:
-      projectMetaData = await promptAndCreateNewProject();
-      break;
-    case OPTION_ADD_FIREBASE:
-      projectMetaData = await promptAndAddFirebaseToCloudProject();
-      break;
-    default:
-      // Do nothing if user chooses NO_PROJECT
+
+  // If the user presented a project with `--project`, try to fetch that project.
+  if (options.project) {
+    projectMetaData = await getFirebaseProject(options.project);
+  } else {
+    projectMetaData = await projectChoicePrompt(options);
+    if (!projectMetaData) {
       return;
+    }
   }
 
   const projectInfo = toProjectInfo(projectMetaData);

--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -140,7 +140,6 @@ export async function doSetup(setup: any, config: Config, options: any): Promise
   }
 
   let projectMetaData;
-
   // If the user presented a project with `--project`, try to fetch that project.
   if (options.project) {
     projectMetaData = await getFirebaseProject(options.project);

--- a/src/test/init/features/project.spec.ts
+++ b/src/test/init/features/project.spec.ts
@@ -63,6 +63,7 @@ describe("project", () => {
       it("should set up the correct properties in the project", async () => {
         const options = { project: "my-project" };
         const setup = { config: {}, rcfile: {} };
+        getProjectStub.onFirstCall().resolves(TEST_FIREBASE_PROJECT);
         promptOnceStub.onFirstCall().resolves("Use an existing project");
         getOrPromptProjectStub.onFirstCall().resolves(TEST_FIREBASE_PROJECT);
 
@@ -72,8 +73,8 @@ describe("project", () => {
         expect(_.get(setup, "instance")).to.deep.equal("my-project");
         expect(_.get(setup, "projectLocation")).to.deep.equal("us-central");
         expect(_.get(setup.rcfile, "projects.default")).to.deep.equal("my-project-123");
-        expect(promptOnceStub).to.be.calledOnce;
-        expect(getOrPromptProjectStub).to.be.calledOnceWith(options);
+        expect(promptOnceStub).to.not.be.called;
+        expect(getOrPromptProjectStub).to.not.be.called;
       });
     });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

When running `firebase init --project <project>`, the init flow will now attempt to use the provided project. If that project does not exist, the command fails. If a project is omitted, the normal prompt flow appears.
	 
### Scenarios Tested

* init with a project that exists
* init with a project that doesn't exist
* init without a project