### PR TITLE
specify a dependency of google-gax@~1.12.0 to keep node 8 working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Set a dependency (`google-gax`) so that the CLI coontinues to install successfully on Node 8 environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-* Set a dependency (`google-gax`) so that the CLI coontinues to install successfully on Node 8 environments.
+* Set a dependency (`google-gax`) so that the CLI continues to install successfully on Node 8 environments.

--- a/package-lock.json
+++ b/package-lock.json
@@ -810,9 +810,9 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "0.6.9",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.9.tgz",
-      "integrity": "sha512-r1nDOEEiYmAsVYBaS4DPPqdwPOXPw7YhVOnnpPdWhlNtKbYzPash6DqWTTza9gBiYMA5d2Wiq6HzrPqsRaP4yA==",
+      "version": "0.6.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.6.15.tgz",
+      "integrity": "sha512-BFK5YMu8JILedibo0nr3NYM0ZC5hCZuXtzk10wEUp3d3pH11PjdvTfN1yEJ0VsfBY5Gtp3WOQ+t7Byq0NzH/iQ==",
       "requires": {
         "semver": "^6.2.0"
       },
@@ -3931,12 +3931,13 @@
       }
     },
     "google-gax": {
-      "version": "1.7.5",
-      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.7.5.tgz",
-      "integrity": "sha512-Tz2DFs8umzDcCBTi2W1cY4vEgAKaYRj70g6Hh/MiiZaJizrly7PgyxsIYUGi7sOpEuAbARQymYKvy5mNi8hEbg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/google-gax/-/google-gax-1.12.0.tgz",
+      "integrity": "sha512-BeeoxVO6y9K20gUsexUwptutd0PfrTItrA02JWwwstlBIOAcvgFp86MHWufQsnrkPVhxBjHXq65aIkSejtJjDg==",
       "requires": {
-        "@grpc/grpc-js": "0.6.9",
+        "@grpc/grpc-js": "^0.6.12",
         "@grpc/proto-loader": "^0.5.1",
+        "@types/long": "^4.0.0",
         "abort-controller": "^3.0.0",
         "duplexify": "^3.6.0",
         "google-auth-library": "^5.0.0",
@@ -3959,46 +3960,65 @@
           }
         },
         "gcp-metadata": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.2.0.tgz",
-          "integrity": "sha512-ympv+yQ6k5QuWCuwQqnGEvFGS7MBKdcQdj1i188v3bW9QLFIchTGaBCEZxSQapT0jffdn1vdt8oJhB5VBWQO1Q==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.3.0.tgz",
+          "integrity": "sha512-uO3P/aByOQmoDu5bOYBODHmD1oDCZw7/R8SYY0MdmMQSZVEmeTSxmiM1vwde+YHYSpkaQnAAMAIZuOqLvgfp/Q==",
           "requires": {
-            "gaxios": "^2.0.1",
+            "gaxios": "^2.1.0",
             "json-bigint": "^0.3.0"
           }
         },
         "google-auth-library": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.5.0.tgz",
-          "integrity": "sha512-TNeraw4miu6/FhO0jDrHiJuRx3SBrAhxHSPj7+rhif43bKE34UItXX9lejKxo3E8FNytuY4LIVIvpcqMQHSYZw==",
+          "version": "5.8.0",
+          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.8.0.tgz",
+          "integrity": "sha512-aXVUAUAhyof66F1STizYRQwO8nAqp7DDhF0tvfyXyZof8LxXaYtOk7CJeZ+o7G+o1EfqJZi9AAlK3FhZVzYWuQ==",
           "requires": {
             "arrify": "^2.0.0",
             "base64-js": "^1.3.0",
             "fast-text-encoding": "^1.0.0",
-            "gaxios": "^2.0.0",
-            "gcp-metadata": "^3.2.0",
+            "gaxios": "^2.1.0",
+            "gcp-metadata": "^3.3.0",
             "gtoken": "^4.1.0",
-            "jws": "^3.1.5",
+            "jws": "^4.0.0",
             "lru-cache": "^5.0.0"
           }
         },
         "google-p12-pem": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.2.tgz",
-          "integrity": "sha512-UfnEARfJKI6pbmC1hfFFm+UAcZxeIwTiEcHfqKe/drMsXD/ilnVjF7zgOGpHXyhuvX6jNJK3S8A0hOQjwtFxEw==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
+          "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
           "requires": {
             "node-forge": "^0.9.0"
           }
         },
         "gtoken": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.0.tgz",
-          "integrity": "sha512-wqyn2gf5buzEZN4QNmmiiW2i2JkEdZnL7Z/9p44RtZqgt4077m4khRgAYNuu8cBwHWCc6MsP6eDUn/KkF6jFIw==",
+          "version": "4.1.4",
+          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
+          "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
           "requires": {
-            "gaxios": "^2.0.0",
+            "gaxios": "^2.1.0",
             "google-p12-pem": "^2.0.0",
-            "jws": "^3.1.5",
+            "jws": "^4.0.0",
             "mime": "^2.2.0"
+          }
+        },
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
           }
         },
         "lru-cache": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "fs-extra": "^0.23.1",
     "glob": "^7.1.2",
     "google-auto-auth": "^0.7.2",
+    "google-gax": "~1.12.0",
     "inquirer": "~6.3.1",
     "jsonschema": "^1.0.2",
     "jsonwebtoken": "^8.2.1",


### PR DESCRIPTION
## Description

Fixes #1916

This adds a dependency on `google-gax` at a version that does not include the `semver` version that does not support node 8. This seems like not my favorite way to solve this, but I believe it does.
	 
### Scenarios Tested

Installing in node 8 from a local package:

- In the repo: `npm pack`
- Outside the repo, on node 8: `npm i -g path/to/archive.tar.gz`