### PR TITLE
Release Firestore Emulator v1.11.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Set a dependency (`google-gax`) so that the CLI continues to install successfully on Node 8 environments.
+* Release Firestore Emulator v1.11.0 which enforces document size limit like production.

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -38,13 +38,13 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.10.2.jar"),
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.0.jar"),
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.2.jar",
-      expectedSize: 63708915,
-      expectedChecksum: "d101a23eea4c6cdc5bcf5a7ef32dc6e5",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.0.jar",
+      expectedSize: 62998400,
+      expectedChecksum: "1818398208b8e056dae21756b6491c62",
       namePrefix: "cloud-firestore-emulator",
     },
   },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Release Firestore Emulator v1.11.0.
	 
### Scenarios Tested

Manually tested.

### Sample Commands

`firebase emulators:start --only firestore`