### PR TITLE
Don't force reauth when previews are enabled

### DIFF
--- a/src/handlePreviewToggles.js
+++ b/src/handlePreviewToggles.js
@@ -1,22 +1,21 @@
 "use strict";
 
-var _ = require("lodash");
-var clc = require("cli-color");
+import { unset, has } from "lodash";
+import { bold } from "cli-color";
 
-var auth = require("./auth");
-var configstore = require("./configstore");
-var previews = require("./previews");
+import * as configstore from "./configstore";
+import * as previews from "./previews";
 
-var _errorOut = function(name) {
-  console.log(clc.bold.red("Error:"), "Did not recognize preview feature", clc.bold(name));
+function _errorOut(name) {
+  console.log(bold.red("Error:"), "Did not recognize preview feature", bold(name));
   process.exit(1);
-};
+}
 
 module.exports = function(args) {
-  var isValidPreview = _.has(previews, args[1]);
+  const isValidPreview = has(previews, args[1]);
   if (args[0] === "--open-sesame") {
     if (isValidPreview) {
-      console.log("Enabling preview feature", clc.bold(args[1]) + "...");
+      console.log("Enabling preview feature", bold(args[1]) + "...");
       previews[args[1]] = true;
       configstore.set("previews", previews);
       console.log("Preview feature enabled!");
@@ -26,8 +25,8 @@ module.exports = function(args) {
     _errorOut();
   } else if (args[0] === "--close-sesame") {
     if (isValidPreview) {
-      console.log("Disabling preview feature", clc.bold(args[1]));
-      _.unset(previews, args[1]);
+      console.log("Disabling preview feature", bold(args[1]));
+      unset(previews, args[1]);
       configstore.set("previews", previews);
       return process.exit(0);
     }

--- a/src/handlePreviewToggles.js
+++ b/src/handlePreviewToggles.js
@@ -19,20 +19,8 @@ module.exports = function(args) {
       console.log("Enabling preview feature", clc.bold(args[1]) + "...");
       previews[args[1]] = true;
       configstore.set("previews", previews);
-      var tokens = configstore.get("tokens");
-
-      var next;
-      if (tokens && tokens.refresh_token) {
-        next = auth.logout(tokens.refresh_token);
-      } else {
-        next = Promise.resolve();
-      }
-      return next.then(function() {
-        console.log("Preview feature enabled!");
-        console.log();
-        console.log("Please run", clc.bold("firebase login"), "to re-authorize the CLI.");
-        return process.exit(0);
-      });
+      console.log("Preview feature enabled!");
+      return process.exit(0);
     }
 
     _errorOut();


### PR DESCRIPTION
When previews were first introduced, it included changes to how OAuth worked and it made sense to force a logout. It's unlikely that any future previews will require this, and it's intrusive to have to reauth when this is called, so I'm removing that.