### PR TITLE
Add shell debugging and fix timeout issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+*  Adds breakpoint debugging to `functions:shell` (#1872)
+*  Removes function timeouts when breakpoint debugging is enabled (#1931)

--- a/src/commands/functions-shell.js
+++ b/src/commands/functions-shell.js
@@ -4,10 +4,12 @@ var { Command } = require("../command");
 var { requirePermissions } = require("../requirePermissions");
 var action = require("../functionsShellCommandAction");
 var requireConfig = require("../requireConfig");
+var commandUtils = require("../emulator/commandUtils");
 
 module.exports = new Command("functions:shell")
   .description("launch full Node shell with emulated functions")
-  .option("-p, --port <port>", "the port on which to emulate functions (default: 5000)", 5000)
+  .option("-p, --port <port>", "the port on which to emulate functions", 5000)
+  .option(commandUtils.FLAG_INSPECT_FUNCTIONS, commandUtils.DESC_INSPECT_FUNCTIONS)
   .before(requireConfig)
   .before(requirePermissions)
   .action(action);

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -6,6 +6,7 @@ import * as logger from "../logger";
 import requireAuth = require("../requireAuth");
 import requireConfig = require("../requireConfig");
 import { Emulators } from "../emulator/types";
+import { FirebaseError } from "../error";
 
 export const FLAG_ONLY: string = "--only <emulators>";
 export const DESC_ONLY: string =
@@ -54,4 +55,20 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
   } else {
     await requireConfig(options);
   }
+}
+
+export function parseInspectionPort(options: any): number {
+  let port = options.inspectFunctions;
+  if (port === true) {
+    port = "9229";
+  }
+
+  const parsed = Number(port);
+  if (isNaN(parsed) || parsed < 1024 || parsed > 65535) {
+    throw new FirebaseError(
+      `"${port}" is not a valid port for debugging, please pass an integer between 1024 and 65535.`
+    );
+  }
+
+  return parsed;
 }

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -16,6 +16,7 @@ import { HostingEmulator } from "../emulator/hostingEmulator";
 import { FirebaseError } from "../error";
 import * as getProjectId from "../getProjectId";
 import { PubsubEmulator } from "./pubsubEmulator";
+import * as commandUtils from "./commandUtils";
 
 export const VALID_EMULATOR_STRINGS: string[] = ALL_EMULATORS;
 
@@ -133,21 +134,8 @@ export async function startAll(options: any): Promise<void> {
     );
 
     let inspectFunctions: number | undefined;
-
-    // If the flag is provided without a value, use the Node.js default
-    if (options.inspectFunctions === true) {
-      options.inspectFunctions = "9229";
-    }
-
     if (options.inspectFunctions) {
-      inspectFunctions = Number(options.inspectFunctions);
-      if (isNaN(inspectFunctions) || inspectFunctions < 1024 || inspectFunctions > 65535) {
-        throw new FirebaseError(
-          `"${
-            options.inspectFunctions
-          }" is not a valid value for the --inspect-functions flag, please pass an integer between 1024 and 65535.`
-        );
-      }
+      inspectFunctions = commandUtils.parseInspectionPort(options);
 
       // TODO(samstern): Add a link to documentation
       utils.logLabeledWarning(

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -115,6 +115,13 @@ export class FunctionsEmulator implements EmulatorInstance {
     // TODO: Would prefer not to have static state but here we are!
     EmulatorLogger.verbosity = this.args.quiet ? Verbosity.QUIET : Verbosity.DEBUG;
 
+    // When debugging is enabled, the "timeout" feature needs to be disabled so that
+    // functions don't timeout while a breakpoint is active.
+    if (this.args.debugPort) {
+      this.args.disabledRuntimeFeatures = this.args.disabledRuntimeFeatures || {};
+      this.args.disabledRuntimeFeatures.timeout = true;
+    }
+
     const mode = this.args.debugPort
       ? FunctionsExecutionMode.SEQUENTIAL
       : FunctionsExecutionMode.AUTO;

--- a/src/functionsShellCommandAction.js
+++ b/src/functionsShellCommandAction.js
@@ -10,15 +10,23 @@ var serveFunctions = require("./serve/functions");
 var LocalFunction = require("./localFunction");
 var logger = require("./logger");
 var shell = require("./emulator/functionsEmulatorShell");
+var commandUtitls = require("./emulator/commandUtils");
 
 module.exports = function(options) {
   options.port = parseInt(options.port, 10);
+
+  let debugPort = undefined;
+  if (options.inspectFunctions) {
+    debugPort = commandUtitls.parseInspectionPort(options);
+  }
+
   return serveFunctions
     .start(options, {
       // TODO(samstern): Note that these are not acctually valid FunctionsEmulatorArgs
       // and when we eventually move to all TypeScript we'll have to start adding
       // projectId and functionsDir here.
       quiet: true,
+      debugPort,
     })
     .then(function() {
       return serveFunctions.connect();


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

  * Adds `--inspect-functions` capability to `functions:shell` (fixes #1872)
  * Changes timeout behavior when debugging is enabled (fixes #1931)
	 
### Scenarios Tested

Was able to successfully:

- Set a breakpoint in a function with `functions:shell`
- Run an emulated function with debugging on for more than the default timeout, no error
- Run an emulated function with debugging off for more than the default timeout, got error

Used this test case for everything:
```js
exports.helloWorld = functions
  .runWith({
    timeoutSeconds: 10
  })
  .https.onRequest((request, response) => {
    setTimeout(() => {
      response.send("Hello from Firebase!");
    }, 11 * 1000);
  });
```


### Sample Commands

```
$ firebase functions:shell --help
Usage: firebase functions:shell [options]

launch full Node shell with emulated functions

Options:
  -p, --port <port>           the port on which to emulate functions (default: 5000)
  --inspect-functions [port]  emulate Cloud Functions in debug mode with the node 
                              inspector on the given port (9229 if not specified)
  -h, --help                  output usage information
```