### PR TITLE
Fix deploys failing if exporting null in any exported object from functions directory

### DIFF
--- a/src/extractTriggers.js
+++ b/src/extractTriggers.js
@@ -21,7 +21,7 @@ var extractTriggers = function(mod, triggers, prefix) {
       trigger.name = prefix + funcName;
       trigger.entryPoint = trigger.name.replace(/-/g, ".");
       triggers.push(trigger);
-    } else if (typeof child === "object") {
+    } else if (typeof child === "object" && child !== null) {
       extractTriggers(child, triggers, prefix + funcName + "-");
     }
   }

--- a/src/test/extractTriggers.spec.js
+++ b/src/test/extractTriggers.spec.js
@@ -1,21 +1,21 @@
 "use strict";
 
-var chai = require("chai");
-var expect = chai.expect;
+const chai = require("chai");
+const expect = chai.expect;
 
-var extractTriggers = require("../extractTriggers");
+const extractTriggers = require("../extractTriggers");
 
-describe("extractTriggers", function () {
-  var fnWithTrigger = function () { };
+describe("extractTriggers", function() {
+  const fnWithTrigger = function() {};
   fnWithTrigger.__trigger = { service: "function.with.trigger" };
-  var fnWithoutTrigger = function () { };
-  var triggers;
+  const fnWithoutTrigger = function() {};
+  let triggers;
 
-  beforeEach(function () {
+  beforeEach(function() {
     triggers = [];
   });
 
-  it("should find exported functions with __trigger", function () {
+  it("should find exported functions with __trigger", function() {
     extractTriggers(
       {
         foo: fnWithTrigger,
@@ -28,7 +28,7 @@ describe("extractTriggers", function () {
     expect(triggers.length).to.eq(2);
   });
 
-  it("should attach name and entryPoint to exported triggers", function () {
+  it("should attach name and entryPoint to exported triggers", function() {
     extractTriggers(
       {
         foo: fnWithTrigger,
@@ -39,7 +39,7 @@ describe("extractTriggers", function () {
     expect(triggers[0].entryPoint).to.eq("foo");
   });
 
-  it("should find nested functions and set name and entryPoint", function () {
+  it("should find nested functions and set name and entryPoint", function() {
     extractTriggers(
       {
         foo: {
@@ -59,18 +59,20 @@ describe("extractTriggers", function () {
     expect(triggers.length).to.eq(3);
   });
 
-  it("should ignore null exports", function () {
-    expect(() => extractTriggers(
-      {
-        foo: {
-          bar: fnWithTrigger,
-          baz: null
-        }
-      },
-      triggers
-    )).not.to.throw();
+  it("should ignore null exports", function() {
+    expect(() =>
+      extractTriggers(
+        {
+          foo: {
+            bar: fnWithTrigger,
+            baz: null,
+          },
+        },
+        triggers
+      )
+    ).not.to.throw();
 
     expect(triggers[0].name).to.eq("foo-bar");
     expect(triggers.length).to.eq(1);
-  })
+  });
 });

--- a/src/test/extractTriggers.spec.js
+++ b/src/test/extractTriggers.spec.js
@@ -5,17 +5,17 @@ var expect = chai.expect;
 
 var extractTriggers = require("../extractTriggers");
 
-describe("extractTriggers", function() {
-  var fnWithTrigger = function() {};
+describe("extractTriggers", function () {
+  var fnWithTrigger = function () { };
   fnWithTrigger.__trigger = { service: "function.with.trigger" };
-  var fnWithoutTrigger = function() {};
+  var fnWithoutTrigger = function () { };
   var triggers;
 
-  beforeEach(function() {
+  beforeEach(function () {
     triggers = [];
   });
 
-  it("should find exported functions with __trigger", function() {
+  it("should find exported functions with __trigger", function () {
     extractTriggers(
       {
         foo: fnWithTrigger,
@@ -28,7 +28,7 @@ describe("extractTriggers", function() {
     expect(triggers.length).to.eq(2);
   });
 
-  it("should attach name and entryPoint to exported triggers", function() {
+  it("should attach name and entryPoint to exported triggers", function () {
     extractTriggers(
       {
         foo: fnWithTrigger,
@@ -39,7 +39,7 @@ describe("extractTriggers", function() {
     expect(triggers[0].entryPoint).to.eq("foo");
   });
 
-  it("should find nested functions and set name and entryPoint", function() {
+  it("should find nested functions and set name and entryPoint", function () {
     extractTriggers(
       {
         foo: {
@@ -58,4 +58,19 @@ describe("extractTriggers", function() {
     expect(triggers[0].entryPoint).to.eq("foo.bar");
     expect(triggers.length).to.eq(3);
   });
+
+  it("should ignore null exports", function () {
+    expect(() => extractTriggers(
+      {
+        foo: {
+          bar: fnWithTrigger,
+          baz: null
+        }
+      },
+      triggers
+    )).not.to.throw();
+
+    expect(triggers[0].name).to.eq("foo-bar");
+    expect(triggers.length).to.eq(1);
+  })
 });


### PR DESCRIPTION
### Description

This fixes a bug ```[ERROR] TypeError: Cannot convert undefined or null to object``` that will prevent the CLI from deploying functions if you're exporting `null` as a value in an object. E.g.

```ts
export const onWriteNotifier = functions
  .runWith({ memory: '512MB' })
  .database.ref('/foo')
  .onUpdate(async (change, context) => {
     console.log("Update");
  });

export const MY_OBJECT = {
  bar: 123,
  baz: null
};
```

The changes to the formating were done because otherwise "npm test" would complain with linter errors. I have simply run `eslint src/test/extractTriggers.spec.js --fix`

### Scenarios Tested

I have added a unit tests to verify the behavior.
