### PR TITLE
Fix port checking with external host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 *  Adds breakpoint debugging to `functions:shell` (#1872)
 *  Removes function timeouts when breakpoint debugging is enabled (#1931)
 *  Fixes unhandled error when invoking a non-existent function (#1937)
-*  Fixes a bug where emulators could not bind to external IP (#1949()
+*  Fixes a bug where emulators could not bind to external IP (#1949)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 *  Adds breakpoint debugging to `functions:shell` (#1872)
 *  Removes function timeouts when breakpoint debugging is enabled (#1931)
 *  Fixes unhandled error when invoking a non-existent function (#1937)
+*  Fixes a bug where emulators could not bind to external IP (#1949()

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -33,7 +33,7 @@ export async function waitForPortClosed(port: number, host: string): Promise<voi
   const interval = 250;
   const timeout = 30000;
   try {
-    await tcpport.waitUntilUsed(port, interval, timeout);
+    await tcpport.waitUntilUsedOnHost(port, host, interval, timeout);
   } catch (e) {
     throw new FirebaseError(`TIMEOUT: Port ${port} on ${host} was not active within ${timeout}ms`);
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1949, extremely simple fix
	 
### Scenarios Tested

```
$ firebase serve -o 172.31.140.75 --only functions
⚠  Your requested "node" version "8" doesn't match your global version "13"
✔  functions: Emulator started at http://172.31.140.75:5000
i  functions: Watching "/tmp/tmp.klIR8ia9uW/functions" for Cloud Functions...
✔  functions[helloWorld]: http function initialized (http://172.31.140.75:5000/fir-dumpster/us-central1/helloWorld).
```

### Sample Commands

N/A