### PR TITLE
Release Firestore Emulator v1.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 *  Adds breakpoint debugging to `functions:shell` (#1872)
 *  Removes function timeouts when breakpoint debugging is enabled (#1931)
 *  Fixes unhandled error when invoking a non-existent function (#1937)
+*  Add support for `update_transforms` in Firestore commit and batchWrite API.

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -44,7 +44,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.3.jar",
       expectedSize: 88888524,
-      expectedChecksum: "d101a23eea4c6cdc5bcf5a7ef32dc6e5",
+      expectedChecksum: "24df64503865ac84ff5f2761319afd9d",
       namePrefix: "cloud-firestore-emulator",
     },
   },

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -43,7 +43,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       cacheDir: CACHE_DIR,
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.3.jar",
-      expectedSize: 63708915,
+      expectedSize: 88888524,
       expectedChecksum: "d101a23eea4c6cdc5bcf5a7ef32dc6e5",
       namePrefix: "cloud-firestore-emulator",
     },

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -42,7 +42,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.2.jar",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.3.jar",
       expectedSize: 63708915,
       expectedChecksum: "d101a23eea4c6cdc5bcf5a7ef32dc6e5",
       namePrefix: "cloud-firestore-emulator",


### PR DESCRIPTION
Changelog:
* Add support for `update_transforms` for Firestore commit and batchWrite.

`update_transforms` can represent an update followed by a list of transforms in one Firestore Write proto.