### PR TITLE
Update download path of Firestore emulator

### DIFF
--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -38,7 +38,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.10.2.jar"),
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.10.3.jar"),
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:


### PR DESCRIPTION
Oops, I forgot to update the version of the `downloadPath` in 
https://github.com/firebase/firebase-tools/pull/1955