### PR TITLE
Release Firestore emulator 1.10.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 *  Adds breakpoint debugging to `functions:shell` (#1872)
 *  Removes function timeouts when breakpoint debugging is enabled (#1931)
 *  Fixes unhandled error when invoking a non-existent function (#1937)
-*  Add support for `update_transforms` in Firestore commit and batchWrite API.
 *  [Firestore emulator] Add support for `update_transforms` in Firestore commit and batchWrite API.
 *  [Firestore emulator] Send resume tokens on the Listen stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 *  Removes function timeouts when breakpoint debugging is enabled (#1931)
 *  Fixes unhandled error when invoking a non-existent function (#1937)
 *  Add support for `update_transforms` in Firestore commit and batchWrite API.
+*  [Firestore emulator] Add support for `update_transforms` in Firestore commit and batchWrite API.
+*  [Firestore emulator] Send resume tokens on the Listen stream

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -44,7 +44,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar",
       expectedSize: 88950303,
-      expectedChecksum: "81704b24737d4968734d3e175f4cde71",
+      expectedChecksum: "f551a9c1716cd412d04fc971ef3e945b",
       namePrefix: "cloud-firestore-emulator",
     },
   },

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -38,11 +38,11 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.10.3.jar"),
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.10.4.jar"),
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.3.jar",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar",
       expectedSize: 88888524,
       expectedChecksum: "f551a9c1716cd412d04fc971ef3e945b",
       namePrefix: "cloud-firestore-emulator",

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -61,7 +61,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.1.0.zip",
       expectedSize: 36623622,
-      expectedChecksum: "81704b24737d4968734d3e175f4cde71",
+      expectedChecksum: "f551a9c1716cd412d04fc971ef3e945b",
       namePrefix: "pubsub-emulator",
     },
   },

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -44,7 +44,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.3.jar",
       expectedSize: 88888524,
-      expectedChecksum: "24df64503865ac84ff5f2761319afd9d",
+      expectedChecksum: "f551a9c1716cd412d04fc971ef3e945b",
       namePrefix: "cloud-firestore-emulator",
     },
   },

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -43,8 +43,8 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       cacheDir: CACHE_DIR,
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar",
-      expectedSize: 88888524,
-      expectedChecksum: "f551a9c1716cd412d04fc971ef3e945b",
+      expectedSize: 88950303,
+      expectedChecksum: "24df64503865ac84ff5f2761319afd9d",
       namePrefix: "cloud-firestore-emulator",
     },
   },

--- a/src/serve/javaEmulators.ts
+++ b/src/serve/javaEmulators.ts
@@ -44,7 +44,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.10.4.jar",
       expectedSize: 88950303,
-      expectedChecksum: "24df64503865ac84ff5f2761319afd9d",
+      expectedChecksum: "81704b24737d4968734d3e175f4cde71",
       namePrefix: "cloud-firestore-emulator",
     },
   },
@@ -61,7 +61,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.1.0.zip",
       expectedSize: 36623622,
-      expectedChecksum: "f551a9c1716cd412d04fc971ef3e945b",
+      expectedChecksum: "81704b24737d4968734d3e175f4cde71",
       namePrefix: "pubsub-emulator",
     },
   },

--- a/src/test/serve/javaEmulators.spec.ts
+++ b/src/test/serve/javaEmulators.spec.ts
@@ -1,0 +1,20 @@
+import { expect } from "chai";
+import * as path from "path";
+
+import * as javaEmulators from "../../serve/javaEmulators";
+import { Emulators } from "../../emulator/types";
+
+type DownloadableEmulator = Emulators.FIRESTORE | Emulators.DATABASE | Emulators.PUBSUB;
+
+function checkDownloadPath(name: DownloadableEmulator) {
+  const emulator = javaEmulators.getDownloadDetails(name);
+  expect(path.basename(emulator.opts.remoteUrl)).to.include(path.basename(emulator.downloadPath));
+}
+
+describe("downloadDetails", () => {
+  it("should match part of remoteUrl", async () => {
+    checkDownloadPath(Emulators.FIRESTORE);
+    checkDownloadPath(Emulators.DATABASE);
+    checkDownloadPath(Emulators.PUBSUB);
+  });
+});

--- a/src/test/serve/javaEmulators.spec.ts
+++ b/src/test/serve/javaEmulators.spec.ts
@@ -6,13 +6,13 @@ import { Emulators } from "../../emulator/types";
 
 type DownloadableEmulator = Emulators.FIRESTORE | Emulators.DATABASE | Emulators.PUBSUB;
 
-function checkDownloadPath(name: DownloadableEmulator) {
+function checkDownloadPath(name: DownloadableEmulator): void {
   const emulator = javaEmulators.getDownloadDetails(name);
   expect(path.basename(emulator.opts.remoteUrl)).to.include(path.basename(emulator.downloadPath));
 }
 
 describe("downloadDetails", () => {
-  it("should match part of remoteUrl", async () => {
+  it("should match part of remoteUrl", () => {
     checkDownloadPath(Emulators.FIRESTORE);
     checkDownloadPath(Emulators.DATABASE);
     checkDownloadPath(Emulators.PUBSUB);

--- a/src/test/serve/javaEmulators.spec.ts
+++ b/src/test/serve/javaEmulators.spec.ts
@@ -8,11 +8,11 @@ type DownloadableEmulator = Emulators.FIRESTORE | Emulators.DATABASE | Emulators
 
 function checkDownloadPath(name: DownloadableEmulator): void {
   const emulator = javaEmulators.getDownloadDetails(name);
-  expect(path.basename(emulator.opts.remoteUrl)).to.include(path.basename(emulator.downloadPath));
+  expect(path.basename(emulator.opts.remoteUrl)).to.eq(path.basename(emulator.downloadPath));
 }
 
 describe("downloadDetails", () => {
-  it("should match part of remoteUrl", () => {
+  it("should match the basename of remoteUrl", () => {
     checkDownloadPath(Emulators.FIRESTORE);
     checkDownloadPath(Emulators.DATABASE);
     checkDownloadPath(Emulators.PUBSUB);


### PR DESCRIPTION
Gil requested to recut a release to include his last change.

I also added a test to make sure `downloadPath` matches the `remoteUrl`.