### PR TITLE
Add hub API for listing emulators.

### DIFF
--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -10,6 +10,7 @@ import * as logger from "../logger";
 import { Constants } from "./constants";
 import { Emulators, EmulatorInstance, EmulatorInfo, IMPORT_EXPORT_EMULATORS } from "./types";
 import { HubExport } from "./hubExport";
+import { EmulatorRegistry } from "./registry";
 
 // We use the CLI version from package.json
 const pkg = require("../../package.json");
@@ -29,6 +30,7 @@ export interface EmulatorHubArgs {
 export class EmulatorHub implements EmulatorInstance {
   static CLI_VERSION = pkg.version;
   static PATH_EXPORT = "/_admin/export";
+  static PATH_EMULATORS = "/emulators";
 
   /**
    * Given a project ID, find and read the Locator file for the emulator hub.
@@ -67,6 +69,14 @@ export class EmulatorHub implements EmulatorInstance {
 
     this.hub.get("/", async (req, res) => {
       res.json(this.getLocator());
+    });
+
+    this.hub.get(EmulatorHub.PATH_EMULATORS, async (req, res) => {
+      const body: Record<string, EmulatorInfo> = {};
+      EmulatorRegistry.listRunning().forEach(name => {
+        body[name] = EmulatorRegistry.get(name)!.getInfo();
+      });
+      res.json(body);
     });
 
     this.hub.post(EmulatorHub.PATH_EXPORT, async (req, res) => {

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -73,7 +73,7 @@ export class EmulatorHub implements EmulatorInstance {
 
     this.hub.get(EmulatorHub.PATH_EMULATORS, async (req, res) => {
       const body: Record<string, EmulatorInfo> = {};
-      EmulatorRegistry.listRunning().forEach(name => {
+      EmulatorRegistry.listRunning().forEach((name) => {
         body[name] = EmulatorRegistry.get(name)!.getInfo();
       });
       res.json(body);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This PR adds an API in hub for listing all emulators running. See below.
	 
### Scenarios Tested

Manually tested:

```sh
$ curl http://localhost:4000/emulators
{"hub":{"host":"localhost","port":4000},"firestore":{"host":"localhost","port":8080},"database":{"host":"localhost","port":9000}}
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
