### PR TITLE
Add FIREBASE_EMULATOR_HUB env var in emulators:exec.

### DIFF
--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -13,6 +13,7 @@ import { EmulatorRegistry } from "../emulator/registry";
 import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 import * as commandUtils from "../emulator/commandUtils";
 import * as getProjectId from "../getProjectId";
+import { EmulatorHub } from "../emulator/hub";
 
 async function runScript(script: string, extraEnv: Record<string, string>): Promise<number> {
   utils.logBullet(`Running script: ${clc.bold(script)}`);
@@ -33,6 +34,13 @@ async function runScript(script: string, extraEnv: Record<string, string>): Prom
 
     env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV] = address;
     env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV_ALT] = address;
+  }
+
+  const hubInstance = EmulatorRegistry.get(Emulators.HUB);
+  if (hubInstance) {
+    const info = hubInstance.getInfo();
+    const address = `${info.host}:${info.port}`;
+    env[EmulatorHub.EMULATOR_HUB_ENV] = address;
   }
 
   const proc = childProcess.spawn(script, {

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -28,6 +28,7 @@ export interface EmulatorHubArgs {
 }
 
 export class EmulatorHub implements EmulatorInstance {
+  static EMULATOR_HUB_ENV = "FIREBASE_EMULATOR_HUB";
   static CLI_VERSION = pkg.version;
   static PATH_EXPORT = "/_admin/export";
   static PATH_EMULATORS = "/emulators";


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This PR sets a `FIREBASE_EMULATOR_HUB` env var when running `emulators:exec`.

### Scenarios Tested

```sh
$ node lib/bin/firebase.js emulators:exec --project bar --only firestore,database 'curl $FIREBASE_EMULATOR_HUB/emulators'
(snip tons of output)
i  Running script: curl $FIREBASE_EMULATOR_HUB/emulators
{"hub":{"host":"localhost","port":4000},"firestore":{"host":"localhost","port":8080},"database":{"host":"localhost","port":9000}}
✔  Script exited successfully (code 0)
```

### Sample Commands

`firebase emulators:exec` will now set the env var.