### PR TITLE
Support launching Emulator GUI.

### DIFF
--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -101,7 +101,7 @@ module.exports = new Command("emulators:exec <script>")
     }
     let exitCode = 0;
     try {
-      await controller.startAll(options);
+      await controller.startAll(options, /* noGui = */ true);
       exitCode = await runScript(script, extraEnv);
     } catch (e) {
       logger.debug("Error in emulators:exec", e);

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -3,6 +3,7 @@ import * as url from "url";
 import { Address, Emulators } from "./types";
 
 const DEFAULT_PORTS: { [s in Emulators]: number } = {
+  gui: 3000,
   hub: 4000,
   hosting: 5000,
   functions: 5001,
@@ -57,6 +58,16 @@ export class Constants {
     const port = parseInt(portVal, 10);
 
     return { host, port };
+  }
+
+  static description(name: Emulators): string {
+    if (name === Emulators.HUB) {
+      return "emulator hub";
+    } else if (name === Emulators.GUI) {
+      return "emulator GUI";
+    } else {
+      return `${name} emulator`;
+    }
   }
 
   private static normalizeHost(host: string): string {

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -3,8 +3,8 @@ import * as url from "url";
 import { Address, Emulators } from "./types";
 
 const DEFAULT_PORTS: { [s in Emulators]: number } = {
-  gui: 3000,
-  hub: 4000,
+  gui: 4000,
+  hub: 4400,
   hosting: 5000,
   functions: 5001,
   firestore: 8080,

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -112,7 +112,7 @@ export function shouldStart(options: any, name: Emulators): boolean {
     return (
       previews.emulatorgui &&
       !!options.project &&
-      targets.some((target) => EMULATORS_SUPPORTED_BY_GUI.has(target))
+      targets.some((target) => EMULATORS_SUPPORTED_BY_GUI.indexOf(target) >= 0)
     );
   }
   return targets.indexOf(name) >= 0;

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -118,7 +118,7 @@ export function shouldStart(options: any, name: Emulators): boolean {
   return targets.indexOf(name) >= 0;
 }
 
-export async function startAll(options: any): Promise<void> {
+export async function startAll(options: any, noGui: boolean = false): Promise<void> {
   // Emulators config is specified in firebase.json as:
   // "emulators": {
   //   "firestore": {
@@ -336,7 +336,7 @@ export async function startAll(options: any): Promise<void> {
     await startEmulator(pubsubEmulator);
   }
 
-  if (shouldStart(options, Emulators.GUI)) {
+  if (!noGui && shouldStart(options, Emulators.GUI)) {
     // For the GUI we actually will find any available port
     // since we don't want to explode if the GUI can't start on 3000.
     const guiAddr = Constants.getAddress(Emulators.GUI, options);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -9,7 +9,12 @@ import * as logger from "../logger";
 import * as utils from "../utils";
 import * as track from "../track";
 import { EmulatorRegistry } from "../emulator/registry";
-import { EmulatorInstance, Emulators, ALL_SERVICE_EMULATORS, EMULATORS_SUPPORTED_BY_GUI } from "../emulator/types";
+import {
+  EmulatorInstance,
+  Emulators,
+  ALL_SERVICE_EMULATORS,
+  EMULATORS_SUPPORTED_BY_GUI,
+} from "../emulator/types";
 import { Constants } from "../emulator/constants";
 import { FunctionsEmulator } from "../emulator/functionsEmulator";
 import { DatabaseEmulator, DatabaseEmulatorArgs } from "../emulator/databaseEmulator";
@@ -104,8 +109,11 @@ export function shouldStart(options: any, name: Emulators): boolean {
   if (name === Emulators.GUI) {
     // The GUI only starts if we know the project ID AND at least one emulator
     // supported by GUI is launching.
-    return previews.emulatorgui && !!options.project &&
-      targets.some(target => EMULATORS_SUPPORTED_BY_GUI.has(target));
+    return (
+      previews.emulatorgui &&
+      !!options.project &&
+      targets.some((target) => EMULATORS_SUPPORTED_BY_GUI.has(target))
+    );
   }
   return targets.indexOf(name) >= 0;
 }

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -336,7 +336,7 @@ export async function startAll(options: any): Promise<void> {
     await startEmulator(pubsubEmulator);
   }
 
-  if (shouldStart(options, Emulators.GUI) && EmulatorRegistry.isRunning(Emulators.HUB)) {
+  if (shouldStart(options, Emulators.GUI)) {
     // For the GUI we actually will find any available port
     // since we don't want to explode if the GUI can't start on 3000.
     const guiAddr = Constants.getAddress(Emulators.GUI, options);
@@ -355,12 +355,10 @@ export async function startAll(options: any): Promise<void> {
       );
     }
 
-    const hubInfo = EmulatorRegistry.get(Emulators.HUB)!.getInfo();
     const gui = new EmulatorGUI({
       projectId,
       host: guiAddr.host,
       port: guiPort,
-      hubInfo,
       auto_download: true,
     });
     await startEmulator(gui);

--- a/src/emulator/gui.ts
+++ b/src/emulator/gui.ts
@@ -1,0 +1,50 @@
+import { EmulatorInstance, EmulatorInfo, Emulators } from "./types";
+import * as javaEmulators from "../serve/javaEmulators";
+import { EmulatorRegistry } from "./registry";
+import { DatabaseEmulator } from "./databaseEmulator";
+import { FirestoreEmulator } from "./firestoreEmulator";
+import * as url from "url";
+import { EmulatorHub } from "./hub";
+
+export interface EmulatorGUIOptions {
+  port: number;
+  host: string;
+  hubInfo: EmulatorInfo;
+  projectId: string;
+  auto_download?: boolean;
+}
+
+export class EmulatorGUI implements EmulatorInstance {
+  constructor(private args: EmulatorGUIOptions) {}
+
+  start(): Promise<void> {
+    const { hubInfo, auto_download } = this.args;
+    const env: NodeJS.ProcessEnv = {
+      HOST: this.args.host.toString(),
+      PORT: this.args.port.toString(),
+      GCLOUD_PROJECT: this.args.projectId,
+      [EmulatorHub.EMULATOR_HUB_ENV]: `${hubInfo.host}:${hubInfo.port}`,
+    };
+
+    return javaEmulators.start(Emulators.GUI, { auto_download }, env);
+  }
+
+  async connect(): Promise<void> {
+    return;
+  }
+
+  stop(): Promise<void> {
+    return javaEmulators.stop(Emulators.GUI);
+  }
+
+  getInfo(): EmulatorInfo {
+    return {
+      host: this.args.host,
+      port: this.args.port,
+    };
+  }
+
+  getName(): Emulators {
+    return Emulators.GUI;
+  }
+}

--- a/src/emulator/gui.ts
+++ b/src/emulator/gui.ts
@@ -17,7 +17,11 @@ export class EmulatorGUI implements EmulatorInstance {
 
   start(): Promise<void> {
     if (!EmulatorRegistry.isRunning(Emulators.HUB)) {
-      throw new FirebaseError(`Cannot start ${Constants.description(Emulators.GUI)} without ${Constants.description(Emulators.HUB)}!`);
+      throw new FirebaseError(
+        `Cannot start ${Constants.description(Emulators.GUI)} without ${Constants.description(
+          Emulators.HUB
+        )}!`
+      );
     }
     const hubInfo = EmulatorRegistry.get(Emulators.HUB)!.getInfo();
     const { auto_download, host, port, projectId } = this.args;

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -4,6 +4,7 @@ import { ALL_EMULATORS, EmulatorInstance, Emulators } from "./types";
 import { FirebaseError } from "../error";
 import * as utils from "../utils";
 import * as controller from "./controller";
+import { Constants } from "./constants";
 
 /**
  * Static registry for running emulators to discover each other.
@@ -13,8 +14,9 @@ import * as controller from "./controller";
  */
 export class EmulatorRegistry {
   static async start(instance: EmulatorInstance): Promise<void> {
+    const description = Constants.description(instance.getName());
     if (this.isRunning(instance.getName())) {
-      throw new FirebaseError(`Emulator ${instance.getName()} is already running!`, {});
+      throw new FirebaseError(`${description} is already running!`, {});
     }
 
     // Start the emulator and wait for it to grab its assigned port.
@@ -25,17 +27,10 @@ export class EmulatorRegistry {
 
     this.set(instance.getName(), instance);
 
-    if (instance.getName() === Emulators.HUB) {
-      utils.logLabeledSuccess(
-        "emulators",
-        `Emulator hub started at ${clc.bold.underline(`http://${info.host}:${info.port}`)}`
-      );
-    } else {
-      utils.logLabeledSuccess(
-        instance.getName(),
-        `Emulator started at ${clc.bold.underline(`http://${info.host}:${info.port}`)}`
-      );
-    }
+    utils.logLabeledSuccess(
+      instance.getName(),
+      `${description} started at ${clc.bold.underline(`http://${info.host}:${info.port}`)}`
+    );
   }
 
   static async stop(name: Emulators): Promise<void> {

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -34,7 +34,7 @@ export const ALL_SERVICE_EMULATORS = [
   Emulators.PUBSUB,
 ];
 
-export const EMULATORS_SUPPORTED_BY_GUI = new Set([Emulators.DATABASE]);
+export const EMULATORS_SUPPORTED_BY_GUI = [Emulators.DATABASE];
 
 // TODO: Is there a way we can just allow iteration over the enum?
 export const ALL_EMULATORS = [Emulators.HUB, Emulators.GUI, ...ALL_SERVICE_EMULATORS];

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -8,10 +8,20 @@ export enum Emulators {
   DATABASE = "database",
   HOSTING = "hosting",
   PUBSUB = "pubsub",
+  GUI = "gui",
 }
 
-export type JavaEmulators = Emulators.FIRESTORE | Emulators.DATABASE | Emulators.PUBSUB;
-export const JAVA_EMULATORS = [Emulators.FIRESTORE, Emulators.DATABASE, Emulators.PUBSUB];
+export type JavaEmulators =
+  | Emulators.FIRESTORE
+  | Emulators.DATABASE
+  | Emulators.PUBSUB
+  | Emulators.GUI;
+export const JAVA_EMULATORS = [
+  Emulators.FIRESTORE,
+  Emulators.DATABASE,
+  Emulators.PUBSUB,
+  Emulators.GUI,
+];
 
 export type ImportExportEmulators = Emulators.FIRESTORE;
 export const IMPORT_EXPORT_EMULATORS = [Emulators.FIRESTORE];
@@ -24,8 +34,12 @@ export const ALL_SERVICE_EMULATORS = [
   Emulators.PUBSUB,
 ];
 
+export const EMULATORS_SUPPORTED_BY_GUI = new Set([
+  Emulators.DATABASE,
+]);
+
 // TODO: Is there a way we can just allow iteration over the enum?
-export const ALL_EMULATORS = [Emulators.HUB, ...ALL_SERVICE_EMULATORS];
+export const ALL_EMULATORS = [Emulators.HUB, Emulators.GUI, ...ALL_SERVICE_EMULATORS];
 
 export function isJavaEmulator(value: string): value is JavaEmulators {
   return isEmulator(value) && JAVA_EMULATORS.indexOf(value) >= 0;

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -34,9 +34,7 @@ export const ALL_SERVICE_EMULATORS = [
   Emulators.PUBSUB,
 ];
 
-export const EMULATORS_SUPPORTED_BY_GUI = new Set([
-  Emulators.DATABASE,
-]);
+export const EMULATORS_SUPPORTED_BY_GUI = new Set([Emulators.DATABASE]);
 
 // TODO: Is there a way we can just allow iteration over the enum?
 export const ALL_EMULATORS = [Emulators.HUB, Emulators.GUI, ...ALL_SERVICE_EMULATORS];

--- a/src/previews.js
+++ b/src/previews.js
@@ -7,6 +7,7 @@ var previews = _.assign(
   {
     // insert previews here...
     rtdbrules: false,
+    emulatorgui: false,
   },
   configstore.get("previews")
 );


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This implements launching the UI from CLI as discussed in an internal proposal. ~~Please do not merge until said proposal is finalized.~~ EDIT: Proposal finalized with current API.
	 
### Scenarios Tested

```sh
$ node lib/bin/firebase.js --open-sesame emulatorgui
Enabling preview feature emulatorgui...
Preview feature enabled!

$ node lib/bin/firebase.js emulators:start --project foo --only firestore,database
⚠  Could not find config (firebase.json) so using defaults.
i  emulators: Starting emulators: firestore, database
✔  hub: emulator hub started at http://localhost:4000
⚠  No Firestore rules file specified in firebase.json, using default rules.
i  firestore: Serving ALL traffic (including WebChannel) on http://localhost:8080
⚠  firestore: Support for WebChannel on a separate port (8081) is DEPRECATED and will go away soon. Please use port above instead.
i  firestore: downloading cloud-firestore-emulator-v1.10.4.jar...
Progress: ==================================================> (100% of 89MB)
i  firestore: firestore emulator logging to firestore-debug.log
✔  firestore: firestore emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
⚠  No Database rules file specified in firebase.json, using default rules.
i  database: downloading firebase-database-emulator-v4.4.0.jar...
Progress: ==================================================> (100% of 28MB)
i  database: database emulator logging to database-debug.log
✔  database: database emulator started at http://localhost:9000
i  database: For testing set FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000
i  gui: downloading gui-v0.0.1.zip...
Progress: ===================================================> (100% of 2MB)
i  gui: emulator GUI logging to gui-debug.log
✔  gui: emulator GUI started at http://localhost:3000
✔  All emulators started, it is now safe to connect.
^Ci  Shutting down emulators.
i  Stoppping emulator hub
i  Stoppping emulator GUI
⚠  emulator GUI has exited upon receiving signal: SIGINT
i  Stoppping firestore emulator
i  Stoppping database emulator
```

Also tested that `--only firestore` won't start GUI (since GUI cannot do anything with Firestore Emulator yet). Also tested that GUI won't start without a project ID.

### Sample Commands

To enable feature preview:

```sh
$ firebase --open-sesame emulatorgui
```

GUI automatically starts with RTDB Emulator:

```sh
$ firebase emulators:start --project foo --only database
```

Changes to `firebase init emulators` will be included in a separate PR.