### PR TITLE
Move internal emulators HTTP to api.js

### DIFF
--- a/scripts/triggers-end-to-end-tests/functions/package.json
+++ b/scripts/triggers-end-to-end-tests/functions/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "^1.1.5",
-    "firebase-admin": "^8.0.0",
+    "firebase-admin": "^8.9.2",
     "firebase-functions": "^3.3.0"
   },
   "devDependencies": {

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -71,9 +71,6 @@ export class DatabaseEmulator implements EmulatorInstance {
     return Emulators.DATABASE;
   }
 
-  // status: response.statusCode,
-  // response: response,
-  // body: body,
   private async updateRules(content: string): Promise<any> {
     const { host, port } = this.getInfo();
     try {

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -2,12 +2,13 @@ import * as chokidar from "chokidar";
 import * as clc from "cli-color";
 import * as fs from "fs";
 import * as path from "path";
-import * as request from "request";
 
+import * as api from "../api";
 import * as utils from "../utils";
 import * as javaEmulators from "../serve/javaEmulators";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../emulator/types";
 import { Constants } from "./constants";
+import { FirebaseError } from "../error";
 
 export interface DatabaseEmulatorArgs {
   port?: number;
@@ -38,6 +39,7 @@ export class DatabaseEmulator implements EmulatorInstance {
           await this.updateRules(newContent);
           utils.logLabeledSuccess("database", "Rules updated.");
         } catch (e) {
+          console.log("ERROR", e);
           utils.logWarning(this.prettyPrintRulesError(rulesPath, e));
           utils.logWarning("Failed to update rules");
         }
@@ -69,26 +71,25 @@ export class DatabaseEmulator implements EmulatorInstance {
     return Emulators.DATABASE;
   }
 
-  private updateRules(content: string): Promise<any> {
+  // status: response.statusCode,
+  // response: response,
+  // body: body,
+  private async updateRules(content: string): Promise<any> {
     const { host, port } = this.getInfo();
-    return new Promise((resolve, reject) => {
-      request.put(
-        {
-          uri: `http://${host}:${[port]}/.settings/rules.json?ns=${this.args.projectId}`,
-          headers: { Authorization: "Bearer owner" },
-          body: content,
-        },
-        (err, resp, body) => {
-          if (err) {
-            reject(err);
-          } else if (resp.statusCode !== 200) {
-            reject(JSON.parse(body).error);
-          } else {
-            resolve();
-          }
-        }
-      );
-    });
+    try {
+      await api.request("PUT", `/.settings/rules.json?ns=${this.args.projectId}`, {
+        origin: `http://${host}:${[port]}`,
+        headers: { Authorization: "Bearer owner" },
+        data: content,
+        json: false,
+      });
+    } catch (e) {
+      // The body is already parsed as JSON
+      if (e.context && e.context.body) {
+        throw e.context.body.error;
+      }
+      throw e.original;
+    }
   }
 
   private prettyPrintRulesError(filePath: string, error: string): string {

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -39,7 +39,6 @@ export class DatabaseEmulator implements EmulatorInstance {
           await this.updateRules(newContent);
           utils.logLabeledSuccess("database", "Rules updated.");
         } catch (e) {
-          console.log("ERROR", e);
           utils.logWarning(this.prettyPrintRulesError(rulesPath, e));
           utils.logWarning("Failed to update rules");
         }

--- a/src/emulator/pubsubEmulator.ts
+++ b/src/emulator/pubsubEmulator.ts
@@ -1,14 +1,13 @@
-import * as request from "request";
 import * as uuid from "uuid";
 import { PubSub, Subscription, Message } from "@google-cloud/pubsub";
 
+import * as api from "../api";
 import * as javaEmulators from "../serve/javaEmulators";
 import { EmulatorLogger } from "./emulatorLogger";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../emulator/types";
 import { Constants } from "./constants";
 import { FirebaseError } from "../error";
 import { EmulatorRegistry } from "./registry";
-import { response } from "express";
 
 export interface PubsubEmulatorArgs {
   projectId: string;
@@ -107,19 +106,21 @@ export class PubsubEmulator implements EmulatorInstance {
     this.subscriptions.set(topicName, sub);
   }
 
-  private onMessage(topicName: string, message: Message) {
+  private async onMessage(topicName: string, message: Message) {
     EmulatorLogger.logLabeled("DEBUG", "pubsub", `onMessage(${topicName}, ${message.id})`);
     const topicTriggers = this.triggers.get(topicName);
     if (!topicTriggers || topicTriggers.size === 0) {
       throw new FirebaseError(`No trigger for topic: ${topicName}`);
     }
 
-    const functionsPort = EmulatorRegistry.getPort(Emulators.FUNCTIONS);
-    if (!functionsPort) {
+    const functionsEmu = EmulatorRegistry.get(Emulators.FUNCTIONS);
+    if (!functionsEmu) {
       throw new FirebaseError(
         `Attempted to execute pubsub trigger for topic ${topicName} but could not find Functions emulator`
       );
     }
+    const functionsPort = functionsEmu.getInfo().port;
+    const functionsHost = functionsEmu.getInfo().host;
 
     EmulatorLogger.logLabeled(
       "DEBUG",
@@ -149,41 +150,25 @@ export class PubsubEmulator implements EmulatorInstance {
         },
       };
 
-      const functionsUrl = `http://localhost:${functionsPort}/functions/projects/${
-        this.args.projectId
-      }/triggers/${trigger}`;
-
-      request.post(
-        functionsUrl,
-        {
-          body: body,
-          json: true,
-        },
-        (err: any, res: request.Response) => {
-          if (err) {
-            EmulatorLogger.logLabeled(
-              "DEBUG",
-              "pubsub",
-              `Error running functions: ${JSON.stringify(err)}`
-            );
+      try {
+        await api.request(
+          "POST",
+          `/functions/projects/${this.args.projectId}/triggers/${trigger}`,
+          {
+            origin: `http://${functionsHost}:${functionsPort}`,
+            data: body,
           }
+        );
+      } catch (e) {
+        EmulatorLogger.logLabeled("DEBUG", "pubsub", e);
+      }
 
-          if (res) {
-            EmulatorLogger.logLabeled(
-              "DEBUG",
-              "pubsub",
-              `Functions emulator response: HTTP ${res.statusCode} ${JSON.stringify(res.body)}`
-            );
-          }
-
-          // If this is the last trigger we need to run, ack the message.
-          remaining--;
-          if (remaining <= 0) {
-            EmulatorLogger.logLabeled("DEBUG", "pubsub", `Acking message ${message.id}`);
-            message.ack();
-          }
-        }
-      );
+      // If this is the last trigger we need to run, ack the message.
+      remaining--;
+      if (remaining <= 0) {
+        EmulatorLogger.logLabeled("DEBUG", "pubsub", `Acking message ${message.id}`);
+        message.ack();
+      }
     }
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This is motivated by two things:

1. Request is deprecated
2. We have insufficient logging leading to issues like #1980 being hard to debug

### Scenarios Tested

I manually tested all of the rules live reloading stuff for both databases with invalid/valid rules.  I also used the following functions testbed:

```js
exports.fireThings = functions.https.onRequest(async (req, res) => {
    await pubsub.topic("test-topic").publishJSON({ hello: 'world' });
    console.log("Sent PubSub");

    await admin.database().ref("a/b").set({
        date: new Date()
    });
    console.log("Wrote to RTDB");

    await admin.firestore().doc("/a/b").set({
        date: new Date()
    });
    console.log("Wrote to Firestore");

    res.json({
        status: 'ok'
    });
});

exports.pubSubTrigger = functions.pubsub.topic("test-topic").onPublish(async (msg, context) => {
    console.log("pubSubTrigger");
});

exports.databaseTrigger = functions.database.ref("a/b").onWrite(async (change, ctx) => {
    console.log("databaseTrigger");
});

exports.firestoreTrigger = functions.firestore.document("/a/b").onWrite(async (change, ctx) => {
    console.log("firestoreTrigger");
});
```

### Sample Commands

N/A