### PR TITLE
Rename JavaEmulators to DownloadableEmulators.

### DIFF
--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -5,7 +5,7 @@ import * as path from "path";
 
 import * as api from "../api";
 import * as utils from "../utils";
-import * as javaEmulators from "../serve/javaEmulators";
+import * as downloadableEmulators from "./downloadableEmulators";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../emulator/types";
 import { Constants } from "./constants";
 import { FirebaseError } from "../error";
@@ -45,7 +45,7 @@ export class DatabaseEmulator implements EmulatorInstance {
       });
     }
 
-    return javaEmulators.start(Emulators.DATABASE, this.args);
+    return downloadableEmulators.start(Emulators.DATABASE, this.args);
   }
 
   async connect(): Promise<void> {
@@ -53,7 +53,7 @@ export class DatabaseEmulator implements EmulatorInstance {
   }
 
   async stop(): Promise<void> {
-    return javaEmulators.stop(Emulators.DATABASE);
+    return downloadableEmulators.stop(Emulators.DATABASE);
   }
 
   getInfo(): EmulatorInfo {

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -5,7 +5,7 @@ import * as ProgressBar from "progress";
 import { FirebaseError } from "../error";
 import * as utils from "../utils";
 import { Emulators, EmulatorDownloadDetails } from "./types";
-import * as javaEmulators from "../serve/javaEmulators";
+import * as downloadableEmulators from "./downloadableEmulators";
 import * as tmp from "tmp";
 import * as fs from "fs-extra";
 import * as path from "path";
@@ -16,7 +16,7 @@ tmp.setGracefulCleanup();
 type DownloadableEmulator = Emulators.FIRESTORE | Emulators.DATABASE | Emulators.PUBSUB;
 
 module.exports = async (name: DownloadableEmulator) => {
-  const emulator = javaEmulators.getDownloadDetails(name);
+  const emulator = downloadableEmulators.getDownloadDetails(name);
   utils.logLabeledBullet(name, `downloading ${path.basename(emulator.downloadPath)}...`);
   fs.ensureDirSync(emulator.opts.cacheDir);
 

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -1,11 +1,11 @@
 import {
   Emulators,
-  JavaEmulators,
+  DownloadableEmulators,
   JavaEmulatorCommand,
   JavaEmulatorDetails,
   EmulatorDownloadDetails,
-} from "../emulator/types";
-import { Constants } from "../emulator/constants";
+} from "./types";
+import { Constants } from "./constants";
 
 import { FirebaseError } from "../error";
 import * as childProcess from "child_process";
@@ -25,7 +25,7 @@ const EMULATOR_INSTANCE_KILL_TIMEOUT = 2000; /* ms */
 const CACHE_DIR =
   process.env.FIREBASE_EMULATORS_PATH || path.join(os.homedir(), ".cache", "firebase", "emulators");
 
-const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
+const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails } = {
   database: {
     downloadPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.4.0.jar"),
     version: "4.4.0",
@@ -83,7 +83,7 @@ const DownloadDetails: { [s in JavaEmulators]: EmulatorDownloadDetails } = {
   },
 };
 
-const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
+const EmulatorDetails: { [s in DownloadableEmulators]: JavaEmulatorDetails } = {
   database: {
     name: Emulators.DATABASE,
     instance: null,
@@ -106,7 +106,7 @@ const EmulatorDetails: { [s in JavaEmulators]: JavaEmulatorDetails } = {
   },
 };
 
-const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
+const Commands: { [s in DownloadableEmulators]: JavaEmulatorCommand } = {
   database: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", getExecPath(Emulators.DATABASE)],
@@ -140,7 +140,7 @@ const Commands: { [s in JavaEmulators]: JavaEmulatorCommand } = {
   },
 };
 
-function getExecPath(name: JavaEmulators): string {
+function getExecPath(name: DownloadableEmulators): string {
   const details = getDownloadDetails(name);
   return details.binaryPath || details.downloadPath;
 }
@@ -154,7 +154,10 @@ function _getLogFileName(name: string): string {
  * @param emulator - string identifier for the emulator to start.
  * @param args - map<string,string> of addittional args
  */
-function _getCommand(emulator: JavaEmulators, args: { [s: string]: any }): JavaEmulatorCommand {
+function _getCommand(
+  emulator: DownloadableEmulators,
+  args: { [s: string]: any }
+): JavaEmulatorCommand {
   const baseCmd = Commands[emulator];
 
   const defaultPort = Constants.getDefaultPort(emulator);
@@ -267,15 +270,15 @@ async function _runBinary(
   });
 }
 
-export function getDownloadDetails(emulator: JavaEmulators): EmulatorDownloadDetails {
+export function getDownloadDetails(emulator: DownloadableEmulators): EmulatorDownloadDetails {
   return DownloadDetails[emulator];
 }
 
-export function get(emulator: JavaEmulators): JavaEmulatorDetails {
+export function get(emulator: DownloadableEmulators): JavaEmulatorDetails {
   return EmulatorDetails[emulator];
 }
 
-export async function stop(targetName: JavaEmulators): Promise<void> {
+export async function stop(targetName: DownloadableEmulators): Promise<void> {
   const emulator = EmulatorDetails[targetName];
   return new Promise((resolve, reject) => {
     if (emulator.instance) {
@@ -298,7 +301,7 @@ export async function stop(targetName: JavaEmulators): Promise<void> {
   });
 }
 
-export async function downloadIfNecessary(targetName: JavaEmulators): Promise<void> {
+export async function downloadIfNecessary(targetName: DownloadableEmulators): Promise<void> {
   const hasEmulator = fs.existsSync(getExecPath(targetName));
 
   if (hasEmulator) {
@@ -309,7 +312,7 @@ export async function downloadIfNecessary(targetName: JavaEmulators): Promise<vo
 }
 
 export async function start(
-  targetName: JavaEmulators,
+  targetName: DownloadableEmulators,
   args: any,
   extraEnv: NodeJS.ProcessEnv = {}
 ): Promise<void> {

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -1,8 +1,8 @@
 import {
   Emulators,
   DownloadableEmulators,
-  JavaEmulatorCommand,
-  JavaEmulatorDetails,
+  DownloadableEmulatorCommand,
+  DownloadableEmulatorDetails,
   EmulatorDownloadDetails,
 } from "./types";
 import { Constants } from "./constants";
@@ -83,7 +83,7 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
   },
 };
 
-const EmulatorDetails: { [s in DownloadableEmulators]: JavaEmulatorDetails } = {
+const EmulatorDetails: { [s in DownloadableEmulators]: DownloadableEmulatorDetails } = {
   database: {
     name: Emulators.DATABASE,
     instance: null,
@@ -106,7 +106,7 @@ const EmulatorDetails: { [s in DownloadableEmulators]: JavaEmulatorDetails } = {
   },
 };
 
-const Commands: { [s in DownloadableEmulators]: JavaEmulatorCommand } = {
+const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = {
   database: {
     binary: "java",
     args: ["-Duser.language=en", "-jar", getExecPath(Emulators.DATABASE)],
@@ -157,7 +157,7 @@ function _getLogFileName(name: string): string {
 function _getCommand(
   emulator: DownloadableEmulators,
   args: { [s: string]: any }
-): JavaEmulatorCommand {
+): DownloadableEmulatorCommand {
   const baseCmd = Commands[emulator];
 
   const defaultPort = Constants.getDefaultPort(emulator);
@@ -196,7 +196,7 @@ function _getCommand(
   };
 }
 
-function _fatal(emulator: JavaEmulatorDetails, errorMsg: string): void {
+function _fatal(emulator: DownloadableEmulatorDetails, errorMsg: string): void {
   if (emulator.instance) {
     emulator.instance.kill("SIGINT");
   }
@@ -204,8 +204,8 @@ function _fatal(emulator: JavaEmulatorDetails, errorMsg: string): void {
 }
 
 async function _runBinary(
-  emulator: JavaEmulatorDetails,
-  command: JavaEmulatorCommand,
+  emulator: DownloadableEmulatorDetails,
+  command: DownloadableEmulatorCommand,
   extraEnv: NodeJS.ProcessEnv
 ): Promise<void> {
   return new Promise((resolve) => {
@@ -274,7 +274,7 @@ export function getDownloadDetails(emulator: DownloadableEmulators): EmulatorDow
   return DownloadDetails[emulator];
 }
 
-export function get(emulator: DownloadableEmulators): JavaEmulatorDetails {
+export function get(emulator: DownloadableEmulators): DownloadableEmulatorDetails {
   return EmulatorDetails[emulator];
 }
 

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -6,7 +6,7 @@ import * as pf from "portfinder";
 
 import * as api from "../api";
 import * as utils from "../utils";
-import * as javaEmulators from "../serve/javaEmulators";
+import * as downloadableEmulators from "./downloadableEmulators";
 import { EmulatorInfo, EmulatorInstance, Emulators, Severity } from "../emulator/types";
 import { EmulatorRegistry } from "./registry";
 import { Constants } from "./constants";
@@ -85,7 +85,7 @@ export class FirestoreEmulator implements EmulatorInstance {
       // serve WebChannel on the main port anyway.
     }
 
-    return javaEmulators.start(Emulators.FIRESTORE, this.args);
+    return downloadableEmulators.start(Emulators.FIRESTORE, this.args);
   }
 
   async connect(): Promise<void> {
@@ -97,7 +97,7 @@ export class FirestoreEmulator implements EmulatorInstance {
       this.rulesWatcher.close();
     }
 
-    return javaEmulators.stop(Emulators.FIRESTORE);
+    return downloadableEmulators.stop(Emulators.FIRESTORE);
   }
 
   getInfo(): EmulatorInfo {

--- a/src/emulator/gui.ts
+++ b/src/emulator/gui.ts
@@ -1,5 +1,5 @@
 import { EmulatorInstance, EmulatorInfo, Emulators } from "./types";
-import * as javaEmulators from "../serve/javaEmulators";
+import * as downloadableEmulators from "./downloadableEmulators";
 import { EmulatorRegistry } from "./registry";
 import { EmulatorHub } from "./hub";
 import { FirebaseError } from "../error";
@@ -32,7 +32,7 @@ export class EmulatorGUI implements EmulatorInstance {
       [EmulatorHub.EMULATOR_HUB_ENV]: `${hubInfo.host}:${hubInfo.port}`,
     };
 
-    return javaEmulators.start(Emulators.GUI, { auto_download }, env);
+    return downloadableEmulators.start(Emulators.GUI, { auto_download }, env);
   }
 
   async connect(): Promise<void> {
@@ -40,7 +40,7 @@ export class EmulatorGUI implements EmulatorInstance {
   }
 
   stop(): Promise<void> {
-    return javaEmulators.stop(Emulators.GUI);
+    return downloadableEmulators.stop(Emulators.GUI);
   }
 
   getInfo(): EmulatorInfo {

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -6,7 +6,7 @@ import { IMPORT_EXPORT_EMULATORS, Emulators, ALL_EMULATORS } from "./types";
 import { EmulatorRegistry } from "./registry";
 import { FirebaseError } from "../error";
 import { EmulatorHub } from "./hub";
-import { getDownloadDetails } from "../serve/javaEmulators";
+import { getDownloadDetails } from "./downloadableEmulators";
 
 export interface ExportMetadata {
   version: string;

--- a/src/emulator/pubsubEmulator.ts
+++ b/src/emulator/pubsubEmulator.ts
@@ -2,7 +2,7 @@ import * as uuid from "uuid";
 import { PubSub, Subscription, Message } from "@google-cloud/pubsub";
 
 import * as api from "../api";
-import * as javaEmulators from "../serve/javaEmulators";
+import * as downloadableEmulators from "./downloadableEmulators";
 import { EmulatorLogger } from "./emulatorLogger";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../emulator/types";
 import { Constants } from "./constants";
@@ -37,7 +37,7 @@ export class PubsubEmulator implements EmulatorInstance {
   }
 
   async start(): Promise<void> {
-    return javaEmulators.start(Emulators.PUBSUB, this.args);
+    return downloadableEmulators.start(Emulators.PUBSUB, this.args);
   }
 
   async connect(): Promise<void> {
@@ -45,7 +45,7 @@ export class PubsubEmulator implements EmulatorInstance {
   }
 
   async stop(): Promise<void> {
-    await javaEmulators.stop(Emulators.PUBSUB);
+    await downloadableEmulators.stop(Emulators.PUBSUB);
   }
 
   getInfo(): EmulatorInfo {

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -11,7 +11,7 @@ export enum Emulators {
   GUI = "gui",
 }
 
-export type JavaEmulators =
+export type DownloadableEmulators =
   | Emulators.FIRESTORE
   | Emulators.DATABASE
   | Emulators.PUBSUB
@@ -39,7 +39,7 @@ export const EMULATORS_SUPPORTED_BY_GUI = [Emulators.DATABASE];
 // TODO: Is there a way we can just allow iteration over the enum?
 export const ALL_EMULATORS = [Emulators.HUB, Emulators.GUI, ...ALL_SERVICE_EMULATORS];
 
-export function isJavaEmulator(value: string): value is JavaEmulators {
+export function isJavaEmulator(value: string): value is DownloadableEmulators {
   return isEmulator(value) && JAVA_EMULATORS.indexOf(value) >= 0;
 }
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -16,7 +16,7 @@ export type DownloadableEmulators =
   | Emulators.DATABASE
   | Emulators.PUBSUB
   | Emulators.GUI;
-export const JAVA_EMULATORS = [
+export const DOWNLOADABLE_EMULATORS = [
   Emulators.FIRESTORE,
   Emulators.DATABASE,
   Emulators.PUBSUB,
@@ -39,8 +39,8 @@ export const EMULATORS_SUPPORTED_BY_GUI = [Emulators.DATABASE];
 // TODO: Is there a way we can just allow iteration over the enum?
 export const ALL_EMULATORS = [Emulators.HUB, Emulators.GUI, ...ALL_SERVICE_EMULATORS];
 
-export function isJavaEmulator(value: string): value is DownloadableEmulators {
-  return isEmulator(value) && JAVA_EMULATORS.indexOf(value) >= 0;
+export function isDownloadableEmulator(value: string): value is DownloadableEmulators {
+  return isEmulator(value) && DOWNLOADABLE_EMULATORS.indexOf(value) >= 0;
 }
 
 export function isEmulator(value: string): value is Emulators {
@@ -84,7 +84,7 @@ export interface EmulatorInfo {
   port: number;
 }
 
-export interface JavaEmulatorCommand {
+export interface DownloadableEmulatorCommand {
   binary: string;
   args: string[];
   optionalArgs: string[];
@@ -117,7 +117,7 @@ export interface EmulatorDownloadDetails {
   binaryPath?: string;
 }
 
-export interface JavaEmulatorDetails {
+export interface DownloadableEmulatorDetails {
   name: Emulators;
   instance: ChildProcess | null;
   stdout: any | null;

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -2,7 +2,7 @@ import * as clc from "cli-color";
 import * as _ from "lodash";
 import * as utils from "../../utils";
 import { prompt } from "../../prompt";
-import { Emulators, ALL_SERVICE_EMULATORS, isJavaEmulator } from "../../emulator/types";
+import { Emulators, ALL_SERVICE_EMULATORS, isDownloadableEmulator } from "../../emulator/types";
 import { Constants } from "../../emulator/constants";
 import { downloadIfNecessary } from "../../emulator/downloadableEmulators";
 
@@ -68,7 +68,7 @@ export async function doSetup(setup: any, config: any) {
 
   if (selections.download) {
     for (const selected of selections.emulators) {
-      if (isJavaEmulator(selected)) {
+      if (isDownloadableEmulator(selected)) {
         await downloadIfNecessary(selected);
       }
     }

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -4,7 +4,7 @@ import * as utils from "../../utils";
 import { prompt } from "../../prompt";
 import { Emulators, ALL_SERVICE_EMULATORS, isJavaEmulator } from "../../emulator/types";
 import { Constants } from "../../emulator/constants";
-import { downloadIfNecessary } from "../../serve/javaEmulators";
+import { downloadIfNecessary } from "../../emulator/downloadableEmulators";
 
 interface EmulatorsInitSelections {
   emulators?: Emulators[];

--- a/src/test/emulators/downloadableEmulators.spec.ts
+++ b/src/test/emulators/downloadableEmulators.spec.ts
@@ -1,13 +1,13 @@
 import { expect } from "chai";
 import * as path from "path";
 
-import * as javaEmulators from "../../serve/javaEmulators";
+import * as downloadableEmulators from "../../emulator/downloadableEmulators";
 import { Emulators } from "../../emulator/types";
 
 type DownloadableEmulator = Emulators.FIRESTORE | Emulators.DATABASE | Emulators.PUBSUB;
 
 function checkDownloadPath(name: DownloadableEmulator): void {
-  const emulator = javaEmulators.getDownloadDetails(name);
+  const emulator = downloadableEmulators.getDownloadDetails(name);
   expect(path.basename(emulator.opts.remoteUrl)).to.eq(path.basename(emulator.downloadPath));
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This is a no-op refactor to rename `JavaEmulators` to `DownloadableEmulators`, as a requested follow-up in #1986. It also moves the emulators source file from `src/serve` to `src/emulators` to be closer with files that depends on it.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
	 
### Scenarios Tested

Tested that `npm install` still compiles and `emulators:start` still work. Also, type checks are successful so I assume things are fine. Typescript for the win!

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
