### PR TITLE
Override Firestore host in emulator runtime

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -195,10 +195,10 @@ export class FunctionsEmulator implements EmulatorInstance {
     const bundleTemplate = this.getBaseBundle();
     const runtimeBundle: FunctionsRuntimeBundle = {
       ...bundleTemplate,
-      ports: {
-        firestore: EmulatorRegistry.getPort(Emulators.FIRESTORE),
-        database: EmulatorRegistry.getPort(Emulators.DATABASE),
-        pubsub: EmulatorRegistry.getPort(Emulators.PUBSUB),
+      emulators: {
+        firestore: EmulatorRegistry.getInfo(Emulators.FIRESTORE),
+        database: EmulatorRegistry.getInfo(Emulators.DATABASE),
+        pubsub: EmulatorRegistry.getInfo(Emulators.PUBSUB),
       },
       proto,
       triggerId,
@@ -511,10 +511,10 @@ export class FunctionsEmulator implements EmulatorInstance {
       projectId: this.args.projectId,
       triggerId: "",
       triggerType: undefined,
-      ports: {
-        firestore: EmulatorRegistry.getPort(Emulators.FIRESTORE),
-        database: EmulatorRegistry.getPort(Emulators.DATABASE),
-        pubsub: EmulatorRegistry.getPort(Emulators.PUBSUB),
+      emulators: {
+        firestore: EmulatorRegistry.getInfo(Emulators.FIRESTORE),
+        database: EmulatorRegistry.getInfo(Emulators.DATABASE),
+        pubsub: EmulatorRegistry.getInfo(Emulators.PUBSUB),
       },
       disabled_features: this.args.disabledRuntimeFeatures,
     };

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -528,8 +528,12 @@ async function initializeFirebaseAdminStubs(frb: FunctionsRuntimeBundle): Promis
 
   // Configuration for talking to the RTDB emulator
   const databaseConfig = getDefaultConfig();
-  databaseConfig.databaseURL = `http://localhost:${frb.ports.database}?ns=${frb.projectId}`;
-  databaseConfig.credential = makeFakeCredentials();
+  if (frb.emulators.database) {
+    databaseConfig.databaseURL = `http://${frb.emulators.database.host}:${
+      frb.emulators.database.port
+    }?ns=${frb.projectId}`;
+    databaseConfig.credential = makeFakeCredentials();
+  }
 
   const adminModuleProxy = new Proxied<typeof admin>(localAdminModule);
   const proxiedAdminModule = adminModuleProxy
@@ -575,7 +579,7 @@ async function initializeFirebaseAdminStubs(frb: FunctionsRuntimeBundle): Promis
       return defaultApp;
     })
     .when("firestore", (target) => {
-      if (frb.ports.firestore) {
+      if (frb.emulators.firestore) {
         return proxiedFirestore;
       } else {
         warnAboutFirestoreProd();
@@ -583,7 +587,7 @@ async function initializeFirebaseAdminStubs(frb: FunctionsRuntimeBundle): Promis
       }
     })
     .when("database", (target) => {
-      if (frb.ports.database) {
+      if (frb.emulators.database) {
         return proxiedDatabase;
       } else {
         warnAboutDatabaseProd();
@@ -609,7 +613,7 @@ function makeProxiedFirebaseApp(
   const appProxy = new Proxied<admin.app.App>(original);
   return appProxy
     .when("firestore", (target: any) => {
-      if (frb.ports.firestore) {
+      if (frb.emulators.firestore) {
         return proxiedFirestore;
       } else {
         warnAboutFirestoreProd();
@@ -617,7 +621,7 @@ function makeProxiedFirebaseApp(
       }
     })
     .when("database", (target: any) => {
-      if (frb.ports.database) {
+      if (frb.emulators.database) {
         return proxiedDatabase;
       } else {
         warnAboutDatabaseProd();
@@ -645,11 +649,11 @@ async function makeProxiedFirestore(
   const sslCreds = await getGRPCInsecureCredential(frb).catch(noOp);
 
   const initializeFirestoreSettings = (firestoreTarget: any, userSettings: any) => {
-    if (!hasInitializedFirestore && frb.ports.firestore) {
+    if (!hasInitializedFirestore && frb.emulators.firestore) {
       const emulatorSettings = {
         projectId: frb.projectId,
-        port: frb.ports.firestore,
-        servicePath: "localhost",
+        port: frb.emulators.firestore.port,
+        servicePath: frb.emulators.firestore.host,
         service: "firestore.googleapis.com",
         sslCreds,
         customHeaders: {
@@ -745,8 +749,18 @@ function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
     }
   }
 
-  if (frb.ports.pubsub && isFeatureEnabled(frb, "pubsub_emulator")) {
-    const pubsubHost = `localhost:${frb.ports.pubsub}`;
+  // The Firebase CLI is sometimes used as a module within Cloud Functions
+  // for tasks like deleting Firestore data. The CLI has an override system
+  // to change the host for most calls (see api.js)
+  //
+  // TODO(samstern): This should be done for RTDB as well but it's hard
+  // because the convention in prod is subdomain not ?ns=
+  if (frb.emulators.firestore) {
+    process.env.FIRESTORE_URL = `${frb.emulators.firestore.host}:${frb.emulators.firestore.port}`;
+  }
+
+  if (frb.emulators.pubsub && isFeatureEnabled(frb, "pubsub_emulator")) {
+    const pubsubHost = `${frb.emulators.pubsub.host}:${frb.emulators.pubsub.port}`;
     process.env.PUBSUB_EMULATOR_HOST = pubsubHost;
     logDebug(`Set PUBSUB_EMULATOR_HOST to ${pubsubHost}`);
   }

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -44,10 +44,19 @@ export interface FunctionsRuntimeBundle {
   proto?: any;
   triggerId?: string;
   triggerType?: EmulatedTriggerType;
-  ports: {
-    firestore?: number;
-    database?: number;
-    pubsub?: number;
+  emulators: {
+    firestore?: {
+      host: string;
+      port: number;
+    };
+    database?: {
+      host: string;
+      port: number;
+    };
+    pubsub?: {
+      host: string;
+      port: number;
+    };
   };
   socketPath?: string;
   disabled_features?: FunctionsRuntimeFeatures;

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -1,6 +1,6 @@
 import * as clc from "cli-color";
 
-import { ALL_EMULATORS, EmulatorInstance, Emulators } from "./types";
+import { ALL_EMULATORS, EmulatorInstance, Emulators, EmulatorInfo } from "./types";
 import { FirebaseError } from "../error";
 import * as utils from "../utils";
 import * as controller from "./controller";
@@ -60,6 +60,15 @@ export class EmulatorRegistry {
 
   static get(emulator: Emulators): EmulatorInstance | undefined {
     return this.INSTANCES.get(emulator);
+  }
+
+  static getInfo(emulator: Emulators): EmulatorInfo | undefined {
+    const instance = this.INSTANCES.get(emulator);
+    if (!instance) {
+      return undefined;
+    }
+
+    return instance.getInfo();
   }
 
   static getPort(emulator: Emulators): number | undefined {

--- a/src/test/emulators/fixtures.ts
+++ b/src/test/emulators/fixtures.ts
@@ -6,8 +6,11 @@ export const TIMEOUT_MED = 5000;
 export const MODULE_ROOT = findModuleRoot("firebase-tools", __dirname);
 export const FunctionRuntimeBundles = {
   onCreate: {
-    ports: {
-      firestore: 8080,
+    emulators: {
+      firestore: {
+        host: "localhost",
+        port: 8080,
+      },
     },
     cwd: MODULE_ROOT,
     proto: {
@@ -39,8 +42,11 @@ export const FunctionRuntimeBundles = {
   } as FunctionsRuntimeBundle,
 
   onWrite: {
-    ports: {
-      firestore: 8080,
+    emulators: {
+      firestore: {
+        host: "localhost",
+        port: 8080,
+      },
     },
     cwd: MODULE_ROOT,
     proto: {
@@ -72,8 +78,11 @@ export const FunctionRuntimeBundles = {
   } as FunctionsRuntimeBundle,
 
   onDelete: {
-    ports: {
-      firestore: 8080,
+    emulators: {
+      firestore: {
+        host: "localhost",
+        port: 8080,
+      },
     },
     cwd: MODULE_ROOT,
     proto: {
@@ -105,8 +114,11 @@ export const FunctionRuntimeBundles = {
   } as FunctionsRuntimeBundle,
 
   onUpdate: {
-    ports: {
-      firestore: 8080,
+    emulators: {
+      firestore: {
+        host: "localhost",
+        port: 8080,
+      },
     },
     cwd: MODULE_ROOT,
     proto: {
@@ -150,8 +162,11 @@ export const FunctionRuntimeBundles = {
   } as FunctionsRuntimeBundle,
 
   onRequest: {
-    ports: {
-      firestore: 8080,
+    emulators: {
+      firestore: {
+        host: "localhost",
+        port: 8080,
+      },
     },
     cwd: MODULE_ROOT,
     triggerId: "function_id",

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -283,7 +283,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should expose Firestore prod when the emulator is not running", async () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
-        frb.ports = {};
+        frb.emulators = {};
 
         const worker = InvokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
@@ -306,8 +306,11 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should expose a stubbed Firestore when the emulator is running", async () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
-        frb.ports = {
-          firestore: 9090,
+        frb.emulators = {
+          firestore: {
+            host: "localhost",
+            port: 9090,
+          },
         };
 
         const worker = InvokeRuntimeWithFunctions(frb, () => {
@@ -331,7 +334,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should expose RTDB prod when the emulator is not running", async () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
-        frb.ports = {};
+        frb.emulators = {};
 
         const worker = InvokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
@@ -356,8 +359,11 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should expose a stubbed RTDB when the emulator is running", async () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
-        frb.ports = {
-          database: 9090,
+        frb.emulators = {
+          database: {
+            host: "localhost",
+            port: 9090,
+          },
         };
 
         const worker = InvokeRuntimeWithFunctions(frb, () => {

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -93,7 +93,7 @@ class MockRuntimeBundle implements FunctionsRuntimeBundle {
   projectId = "project-1234";
   triggerType = EmulatedTriggerType.HTTPS;
   cwd = "/home/users/dir";
-  ports = {};
+  emulators = {};
 
   constructor(public triggerId: string) {}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #2001 
	 
### Scenarios Tested

I tested the scenario shown in #2001.  It's "fixed" in that no data in prod is affected anymore but it's not fixed because I believe I discovered a bug in the Firestore emulator as a result (https://github.com/firebase/firebase-tools/issues/2010).

### Sample Commands

N/A