### PR TITLE
[Feature] Added support for scheduled pubsub functions in emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 Adds warning message when installing a closed or open alpha extension.
+Adds support for scheduled pubsub functions to pubsub emulator.

--- a/scripts/triggers-end-to-end-tests/functions/index.js
+++ b/scripts/triggers-end-to-end-tests/functions/index.js
@@ -20,6 +20,7 @@ const START_DOCUMENT_NAME = "test/start";
 const END_DOCUMENT_NAME = "test/done";
 
 const PUBSUB_TOPIC = "test-topic";
+const PUBSUB_SCHEDULED_TOPIC = "firebase-schedule-pubsubScheduled";
 
 const pubsub = new PubSub();
 admin.initializeApp();
@@ -63,6 +64,15 @@ exports.writeToPubsub = functions.https.onRequest(async (req, res) => {
   res.json({ published: "ok" });
 });
 
+exports.writeToScheduledPubsub = functions.https.onRequest(async (req, res) => {
+  const msg = await pubsub
+    .topic(PUBSUB_SCHEDULED_TOPIC)
+    .publishJSON({ foo: "bar" }, { attr: "val" });
+  console.log("PubSub Emulator Host", process.env.PUBSUB_EMULATOR_HOST);
+  console.log("Wrote Scheduled PubSub Message", msg);
+  res.json({ published: "ok" });
+});
+
 exports.firestoreReaction = functions.firestore
   .document(START_DOCUMENT_NAME)
   .onWrite(async (/* change, ctx */) => {
@@ -103,5 +113,11 @@ exports.pubsubReaction = functions.pubsub.topic(PUBSUB_TOPIC).onPublish((msg /* 
   console.log(PUBSUB_FUNCTION_LOG);
   console.log("Message", JSON.stringify(msg.json));
   console.log("Attributes", JSON.stringify(msg.attributes));
+  return true;
+});
+
+exports.pubsubScheduled = functions.pubsub.schedule("every mon 07:00").onRun((context) => {
+  console.log(PUBSUB_FUNCTION_LOG);
+  console.log("Resource", JSON.stringify(context.resource));
   return true;
 });

--- a/scripts/triggers-end-to-end-tests/run.spec.js
+++ b/scripts/triggers-end-to-end-tests/run.spec.js
@@ -206,6 +206,10 @@ TriggerEndToEndTest.prototype.writeToPubsub = function writeToPubsub(done) {
   return this.invokeHttpFunction("writeToPubsub", done);
 };
 
+TriggerEndToEndTest.prototype.writeToScheduledPubsub = function writeToScheduledPubsub(done) {
+  return this.invokeHttpFunction("writeToScheduledPubsub", done);
+};
+
 TriggerEndToEndTest.prototype.waitForCondition = function(conditionFn, timeout, callback) {
   let elapsed = 0;
   let interval = 10;
@@ -456,6 +460,21 @@ describe("pubsub emulator function triggers", function() {
 
   it("should have have triggered cloud functions", function(done) {
     expect(test.pubsub_trigger_count).to.equal(1);
+    done();
+  });
+
+  it("should write to the scheduled pubsub emulator", function(done) {
+    this.timeout(EMULATOR_TEST_TIMEOUT);
+
+    test.writeToScheduledPubsub(function(err, response) {
+      expect(err).to.be.null;
+      expect(response.statusCode).to.equal(200);
+      setTimeout(done, EMULATORS_WRITE_DELAY_MS);
+    });
+  });
+
+  it("should have have triggered cloud functions", function(done) {
+    expect(test.pubsub_trigger_count).to.equal(2);
     done();
   });
 });

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -462,8 +462,16 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     // "resource":\"projects/{PROJECT_ID}/topics/{TOPIC_ID}";
     const resource = definition.eventTrigger.resource;
-    const resourceParts = resource.split("/");
-    const topic = resourceParts[resourceParts.length - 1];
+    let topic;
+    if (definition.schedule) {
+      // In production this topic liiks like
+      // "firebase-schedule-{FUNCTION_NAME}-{DEPLOY-LOCATION}", we simply drop
+      // the deploy location to match as closely as possible.
+      topic = "firebase-schedule-" + definition.name;
+    } else {
+      const resourceParts = resource.split("/");
+      topic = resourceParts[resourceParts.length - 1];
+    }
 
     try {
       await pubsubEmulator.addTrigger(topic, definition.name);

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -22,6 +22,12 @@ export interface EmulatedTriggerDefinition {
   availableMemoryMb?: "128MB" | "256MB" | "512MB" | "1GB" | "2GB";
   httpsTrigger?: any;
   eventTrigger?: EventTrigger;
+  schedule?: EventSchedule;
+}
+
+export interface EventSchedule {
+  schedule: string;
+  timeZone?: string;
 }
 
 export interface EventTrigger {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Adding support for emulated scheduled pubsub functions to be triggered manually. Previously, all scheduled pubsub functions in the emulator would be on the same topic (named "topic") as their resource is `projects/{PROJECT_NAME}/topic`. Updated to add the `schedule` to the function trigger definition and to change the topic name if the schedule is defined to match as closely as possible to what it looks like in production (namely, `firebase-schedule-{FUNCTION_NAME}-{DEPLOYMENT_LOCATION}`, i.e. `firebase-schedule-helloworld-uscentral-1`). Functions can now be invoked by publishing to that topic, exposing them individually. Originally brought up in issue #1748, but also was required for our own end to end tests.
<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
	 
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
