### PR TITLE
update projects:create description copy

### DIFF
--- a/src/commands/projects-create.ts
+++ b/src/commands/projects-create.ts
@@ -10,7 +10,9 @@ import { prompt } from "../prompt";
 import * as requireAuth from "../requireAuth";
 
 module.exports = new Command("projects:create [projectId]")
-  .description("create a new firebase project")
+  .description(
+    "creates a new Google Cloud Platform project, then adds Firebase resources to the project"
+  )
   .option("-n, --display-name <displayName>", "(optional) display name for the project")
   .option(
     "-o, --organization <organizationId>",
@@ -22,6 +24,7 @@ module.exports = new Command("projects:create [projectId]")
   )
   .before(requireAuth)
   .action(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     async (projectId: string | undefined, options: any): Promise<FirebaseProjectMetadata> => {
       options.projectId = projectId; // add projectId into options to pass into prompt function
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
The description has been updated!

Now, `firebase help projects:create` says the following:

```
» firebase help projects:create
Usage: firebase projects:create [options] [projectId]

creates a new Google Cloud Platform project, then adds Firebase resources to the project

Options:
  -n, --display-name <displayName>     (optional) display name for the project
  -o, --organization <organizationId>  (optional) ID of the parent Google Cloud Platform organization under which to create this project
  -f, --folder <folderId>              (optional) ID of the parent Google Cloud Platform folder in which to create this project
  -h, --help                           output usage information
```

b/143297827