### PR TITLE
Add a message if the public folder is not declared in the hosting config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 Adds warning message when installing a closed or open alpha extension.
 Adds support for scheduled pubsub functions to pubsub emulator.
+Returns an error if the `public` parameter is not configured for Hosting in `firebase.json` or via the `-p` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-Adds warning message when installing a closed or open alpha extension.
-Adds support for scheduled pubsub functions to pubsub emulator.
-Returns an error if the `public` parameter is not configured for Hosting in `firebase.json` or via the `-p` parameter.
+- Adds warning message when installing a closed or open alpha extension.
+- Adds support for scheduled pubsub functions to pubsub emulator.
+- Returns an error if the `public` parameter is not configured for Hosting in `firebase.json` or via the `-p` parameter.

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -55,6 +55,12 @@ module.exports = function(context, options) {
       throw new FirebaseError('Must supply either "site" or "target" in each "hosting" config.');
     }
 
+    if (!cfg.public) {
+      throw new FirebaseError(
+        'Must supply a public directory using "public" in each "hosting" config.'
+      );
+    }
+
     if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, cfg.public))) {
       throw new FirebaseError(
         `Specified public directory '${cfg.public}' does not exist, ` +


### PR DESCRIPTION
### Description

Fixes #1987 and Fixes #116 

Add a friendly error message if the public folder isn't set in the hosting config, instead of `Error: An unexpected error has occurred.`
	 
### Scenarios Tested

Ran `firebase deploy --only hosting` with & without a "public" folder listed in a multisite hosting config
Ran `firebase deploy --only hosting` with & without a "public" folder listed in a single site hosting config
Ran `firebase deploy --only hosting -p <folder>` with & without a "public" folder listed in a single site hosting config

### Sample Commands

n/a