### PR TITLE
Clarify emulator logs

### DIFF
--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -17,7 +17,7 @@ module.exports = new Command("emulators:start")
       throw e;
     }
 
-    utils.logSuccess("All emulators started, it is now safe to connect.");
+    utils.logLabeledSuccess("emulators", "All emulators started, it is now safe to connect.");
 
     // Hang until explicitly killed
     await new Promise((res, rej) => {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -66,7 +66,7 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
     );
     utils.logLabeledBullet(
       name,
-      `To select a different host/port for the emulator, update your firebase.json:
+      `To select a different host/port for the emulator, specify that host/port in a firebase.json config file:
     {
       // ...
       "emulators": {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -66,7 +66,7 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
     );
     utils.logLabeledBullet(
       name,
-      `To select a different host/port for the emulator, update your "firebase.json":
+      `To select a different host/port for the emulator, update your firebase.json:
     {
       // ...
       "emulators": {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -307,7 +307,9 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
       } else {
         utils.logLabeledWarning(
           "database",
-          `Realtime Database rules file ${clc.bold(rules)} specified in firebase.json does not exist.`
+          `Realtime Database rules file ${clc.bold(
+            rules
+          )} specified in firebase.json does not exist.`
         );
       }
     } else {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -60,8 +60,13 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
   if (!portOpen) {
     await cleanShutdown();
     const description = Constants.description(name);
-    utils.logWarning(`Port ${port} is not open on ${host}, could not start ${description}.`);
-    utils.logBullet(`To select a different host/port for the emulator, update your "firebase.json":
+    utils.logLabeledWarning(
+      name,
+      `Port ${port} is not open on ${host}, could not start ${description}.`
+    );
+    utils.logLabeledBullet(
+      name,
+      `To select a different host/port for the emulator, update your "firebase.json":
     {
       // ...
       "emulators": {
@@ -70,7 +75,8 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
           "port": "${clc.yellow("PORT")}"
         }
       }
-    }`);
+    }`
+    );
     return utils.reject(`Could not start ${name} emulator, port taken.`, {});
   }
 
@@ -78,10 +84,10 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
 }
 
 export async function cleanShutdown(): Promise<boolean> {
-  utils.logBullet("Shutting down emulators.");
+  utils.logLabeledBullet("emulators", "Shutting down emulators.");
 
   for (const name of EmulatorRegistry.listRunning()) {
-    utils.logBullet(`Stoppping ${Constants.description(name)}`);
+    utils.logLabeledBullet(name, `Stopping ${Constants.description(name)}`);
     await EmulatorRegistry.stop(name);
   }
 
@@ -141,7 +147,8 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
     const requested: string[] = options.only.split(",");
     const ignored = _.difference(requested, targets);
     for (const name of ignored) {
-      utils.logWarning(
+      utils.logLabeledWarning(
+        name,
         `Not starting the ${clc.bold(name)} emulator, make sure you have run ${clc.bold(
           "firebase init"
         )}.`
@@ -239,19 +246,29 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
     }
 
     const rulesLocalPath = options.config.get("firestore.rules");
+    const foundRulesFile = rulesLocalPath && fs.existsSync(rulesLocalPath);
     if (rulesLocalPath) {
       const rules: string = path.join(options.projectRoot, rulesLocalPath);
       if (fs.existsSync(rules)) {
         args.rules = rules;
       } else {
-        utils.logWarning(
-          `Firestore rules file ${clc.bold(
-            rules
-          )} specified in firebase.json does not exist, starting Firestore emulator without rules.`
+        utils.logLabeledWarning(
+          "firestore",
+          `Firestore rules file ${clc.bold(rules)} specified in firebase.json does not exist.`
         );
       }
     } else {
-      utils.logWarning(`No Firestore rules file specified in firebase.json, using default rules.`);
+      utils.logLabeledWarning(
+        "firestore",
+        "Did not find a Cloud Firestore rules file specified in a firebase.json config file."
+      );
+    }
+
+    if (!foundRulesFile) {
+      utils.logLabeledWarning(
+        "firestore",
+        "The emulator will default to allowing all reads and wries. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration."
+      );
     }
 
     const firestoreEmulator = new FirestoreEmulator(args);
@@ -282,19 +299,29 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
     }
 
     const rulesLocalPath = options.config.get("database.rules");
+    const foundRulesFile = rulesLocalPath && fs.existsSync(rulesLocalPath);
     if (rulesLocalPath) {
       const rules: string = path.join(options.projectRoot, rulesLocalPath);
       if (fs.existsSync(rules)) {
         args.rules = rules;
       } else {
-        utils.logWarning(
-          `Database rules file ${clc.bold(
-            rules
-          )} specified in firebase.json does not exist, starting Database emulator without rules.`
+        utils.logLabeledWarning(
+          "database",
+          `Database rules file ${clc.bold(rules)} specified in firebase.json does not exist.`
         );
       }
     } else {
-      utils.logWarning(`No Database rules file specified in firebase.json, using default rules.`);
+      utils.logLabeledWarning(
+        "database",
+        "Did not find a Realtime Database rules file specified in a firebase.json config file."
+      );
+    }
+
+    if (!foundRulesFile) {
+      utils.logLabeledWarning(
+        "database",
+        "The emulator will default to allowing all reads and wries. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration."
+      );
     }
 
     const databaseEmulator = new DatabaseEmulator(args);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -254,7 +254,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
       } else {
         utils.logLabeledWarning(
           "firestore",
-          `Firestore rules file ${clc.bold(rules)} specified in firebase.json does not exist.`
+          `Cloud Firestore rules file ${clc.bold(rules)} specified in firebase.json does not exist.`
         );
       }
     } else {
@@ -267,7 +267,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
     if (!foundRulesFile) {
       utils.logLabeledWarning(
         "firestore",
-        "The emulator will default to allowing all reads and wries. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration."
+        "The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration."
       );
     }
 
@@ -307,7 +307,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
       } else {
         utils.logLabeledWarning(
           "database",
-          `Database rules file ${clc.bold(rules)} specified in firebase.json does not exist.`
+          `Realtime Database rules file ${clc.bold(rules)} specified in firebase.json does not exist.`
         );
       }
     } else {
@@ -320,7 +320,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
     if (!foundRulesFile) {
       utils.logLabeledWarning(
         "database",
-        "The emulator will default to allowing all reads and wries. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration."
+        "The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration."
       );
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Make a few changes to emulator logs:

- More consistent log labeling, no raw logging.
- Make behavior around default rules clearer.

	 
### Scenarios Tested

```
$ firebase --project=fir-dumpster emulators:start --only database,firestore
⚠  Could not find config (firebase.json) so using defaults.
i  emulators: Starting emulators: firestore, database
✔  hub: emulator hub started at http://localhost:4400
⚠  firestore: Did not find a Cloud Firestore rules file specified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all reads and wries. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  firestore: Serving ALL traffic (including WebChannel) on http://localhost:8080
⚠  firestore: Support for WebChannel on a separate port (8081) is DEPRECATED and will go away soon. Please use port above instead.
i  firestore: firestore emulator logging to firestore-debug.log
✔  firestore: firestore emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
⚠  database: Did not find a Realtime Database rules file specified in a firebase.json config file.
⚠  database: The emulator will default to allowing all reads and wries. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  database: database emulator logging to database-debug.log
✔  database: database emulator started at http://localhost:9000
i  database: For testing set FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000
✔  emulators: All emulators started, it is now safe to connect.
^Ci  emulators: Shutting down emulators.
i  hub: Stopping emulator hub
i  firestore: Stopping firestore emulator
i  database: Stopping database emulator
```

### Sample Commands

N/A