### PR TITLE
Fixes verbose logging with winston@3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,3 @@
 * **BREAKING:** Remove `firebase tools:migrate` command.
 * **BREAKING:** Remove `firebase setup:web` command.
 * Updated underlying logging infrastructure.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 * **BREAKING:** Remove `firebase tools:migrate` command.
 * **BREAKING:** Remove `firebase setup:web` command.
 * Updated underlying logging infrastructure.
+

--- a/src/bin/firebase.js
+++ b/src/bin/firebase.js
@@ -43,6 +43,8 @@ if (!process.env.DEBUG && _.includes(args, "--debug")) {
   process.env.DEBUG = true;
 }
 
+process.env.IS_FIREBASE_CLI = true;
+
 logger.add(
   new winston.transports.File({
     level: "debug",

--- a/src/command.ts
+++ b/src/command.ts
@@ -223,6 +223,7 @@ export class Command {
     if (getInheritedOption(options, "debug")) {
       options.debug = true;
     }
+
     if (getInheritedOption(options, "json")) {
       options.nonInteractive = true;
     } else {
@@ -236,7 +237,7 @@ export class Command {
             }),
           })
         );
-      } else {
+      } else if (process.env.IS_FIREBASE_CLI) {
         logger.add(
           new winston.transports.Console({
             level: "info",

--- a/src/logger.js
+++ b/src/logger.js
@@ -16,6 +16,11 @@ function expandErrors(logger) {
 
 const logger = expandErrors(winston.createLogger());
 
+// Set a default silent logger to suppress logs during tests
+logger.add(
+  new winston.transports.Console({ silent: true })
+);
+
 logger.tryStringify = (value) => {
   if (typeof value === "string") return value;
 

--- a/src/logger.js
+++ b/src/logger.js
@@ -17,9 +17,7 @@ function expandErrors(logger) {
 const logger = expandErrors(winston.createLogger());
 
 // Set a default silent logger to suppress logs during tests
-logger.add(
-  new winston.transports.Console({ silent: true })
-);
+logger.add(new winston.transports.Console({ silent: true }));
 
 logger.tryStringify = (value) => {
   if (typeof value === "string") return value;


### PR DESCRIPTION
@samtstern  found a bug where the new logger changes resulted in extra verbosity in tests. This was due to moving the initialization of the stdout winston transport down the chain from the main `src/bin/firebase.js` file to `src/commands.ts`. Since the tests never import `firebase.js` directly, they would never initialize a winston transport before, but now, since the initialization happens slightly later in `command.ts` and some tests do pull in that file, we see a transport getting added mid-mocha run which produces the regular log output.

We can't move the initialization earlier, so I simply added an env variable which is set by `firebase.js` then checked for in `commands.ts`. If the env variable exists, we set a transport on stdout, if it doesn't, we do not.

The other approach I considered, which would have been slightly cleaner, would have been to simply check `require.main === require("bin/firebase")` however doing that require would invoke the `firebase.js` script which may have unintended side-effects. 

Winston also throws a warning now when no transport is provided, so we add a silent console logger which suppresses these warnings when running tests. 