### PR TITLE
Add back FIREBASE_EMULATOR_HUB in emulators:exec.

### DIFF
--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -13,6 +13,7 @@ import { DatabaseEmulator } from "../emulator/databaseEmulator";
 import { EmulatorRegistry } from "../emulator/registry";
 import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 import * as getProjectId from "../getProjectId";
+import { EmulatorHub } from "./hub";
 
 export const FLAG_ONLY = "--only <emulators>";
 export const DESC_ONLY =
@@ -110,6 +111,13 @@ async function runScript(script: string, extraEnv: Record<string, string>): Prom
 
     env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV] = address;
     env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV_ALT] = address;
+  }
+
+  const hubInstance = EmulatorRegistry.get(Emulators.HUB);
+  if (hubInstance) {
+    const info = hubInstance.getInfo();
+    const address = `${info.host}:${info.port}`;
+    env[EmulatorHub.EMULATOR_HUB_ENV] = address;
   }
 
   const proc = childProcess.spawn(script, {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This adds back the `FIREBASE_EMULATOR_HUB` env var that we removed from ` emulators:exec` in 18802d0a4d9f851d8573ec949a66444092710726
	 
### Scenarios Tested

Manual testing `node ~/w/firebase-tools/lib/bin/firebase.js emulators:exec env | grep HUB`
