### PR TITLE
Fix Firestore deletion and functions.confg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 * Release RTDB Emulator v4.4.1: Bugfix for unreleased feature.
+* Fixes a bug when using `firebase-tools` to delete Firestore documents inside the Functions emulator (#2001).
+* Fixes a bug where `.runtimeconfig.json` files were not properly detected (#1836).

--- a/src/api.js
+++ b/src/api.js
@@ -3,7 +3,7 @@
 var _ = require("lodash");
 var querystring = require("querystring");
 var request = require("request");
-var url = require('url');
+var url = require("url");
 
 var { FirebaseError } = require("./error");
 var logger = require("./logger");

--- a/src/api.js
+++ b/src/api.js
@@ -3,6 +3,7 @@
 var _ = require("lodash");
 var querystring = require("querystring");
 var request = require("request");
+var url = require('url');
 
 var { FirebaseError } = require("./error");
 var logger = require("./logger");
@@ -253,8 +254,11 @@ var api = {
     };
 
     var secureRequest = true;
-    if (options.origin && options.origin.startsWith("http://")) {
-      secureRequest = false;
+    if (options.origin) {
+      // Only 'https' requests are secure. Protocol includes the final ':'
+      // https://developer.mozilla.org/en-US/docs/Web/API/URL/protocol
+      const originUrl = url.parse(options.origin);
+      secureRequest = originUrl.protocol === "https:";
     }
 
     if (options.auth === true) {

--- a/src/api.js
+++ b/src/api.js
@@ -251,12 +251,22 @@ var api = {
     var requestFunction = function() {
       return _request(reqOptions, options.logOptions);
     };
+
+    var secureRequest = true;
+    if (options.origin && options.origin.startsWith("http://")) {
+      secureRequest = false;
+    }
+
     if (options.auth === true) {
-      requestFunction = function() {
-        return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
-          return _request(reqOptionsWithToken, options.logOptions);
-        });
-      };
+      if (secureRequest) {
+        requestFunction = function() {
+          return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {
+            return _request(reqOptionsWithToken, options.logOptions);
+          });
+        };
+      } else {
+        logger.debug(`Ignoring options.auth for insecure origin: ${options.origin}`);
+      }
     }
 
     return requestFunction().catch(function(err) {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1036,7 +1036,7 @@ async function invokeTrigger(
         "runtime-status",
         `Your function timed out after ~${trigger.definition.timeout ||
           "60s"}. To configure this timeout, see
-      https:// firebase.google.com/docs/functions/manage-functions#set_timeout_and_memory_allocation.`
+      https://firebase.google.com/docs/functions/manage-functions#set_timeout_and_memory_allocation.`
       ).log();
       throw new Error("Function timed out.");
     }, trigger.timeoutMs);

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -16,6 +16,7 @@ import * as express from "express";
 import * as path from "path";
 import * as admin from "firebase-admin";
 import * as bodyParser from "body-parser";
+import * as fs from "fs";
 import { URL } from "url";
 import * as _ from "lodash";
 
@@ -394,7 +395,7 @@ function initializeNetworkFiltering(frb: FunctionsRuntimeBundle): void {
         .filter((v) => v);
       const href = (hrefs.length && hrefs[0]) || "";
 
-      if (href && !history[href]) {
+      if (href && !history[href] && !href.startsWith("http://localhost")) {
         history[href] = true;
         if (href.indexOf("googleapis.com") !== -1) {
           new EmulatorLog("SYSTEM", "googleapis-network-access", "", {
@@ -719,6 +720,18 @@ function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
   process.env.GCLOUD_PROJECT = frb.projectId;
   process.env.FUNCTIONS_EMULATOR = "true";
 
+  // Look for .runtimeconfig.json in the functions directory
+  const configPath = `${frb.cwd}/.runtimeconfig.json`;
+  try {
+    const configContent = fs.readFileSync(configPath);
+    if (configContent) {
+      logDebug(`Found local functions config: ${configPath}`);
+      process.env.CLOUD_RUNTIME_CONFIG = configContent.toString();
+    }
+  } catch (e) {
+    // Ignore, config is optional
+  }
+
   // Do our best to provide reasonable FIREBASE_CONFIG, based on firebase-functions implementation
   // https://github.com/firebase/firebase-functions/blob/59d6a7e056a7244e700dc7b6a180e25b38b647fd/src/setup.ts#L45
   process.env.FIREBASE_CONFIG = JSON.stringify({
@@ -756,7 +769,9 @@ function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
   // TODO(samstern): This should be done for RTDB as well but it's hard
   // because the convention in prod is subdomain not ?ns=
   if (frb.emulators.firestore) {
-    process.env.FIRESTORE_URL = `${frb.emulators.firestore.host}:${frb.emulators.firestore.port}`;
+    process.env.FIRESTORE_URL = `http://${frb.emulators.firestore.host}:${
+      frb.emulators.firestore.port
+    }`;
   }
 
   if (frb.emulators.pubsub && isFeatureEnabled(frb, "pubsub_emulator")) {
@@ -766,9 +781,9 @@ function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
   }
 }
 
-async function initializeFunctionsConfigHelper(functionsDir: string): Promise<void> {
+async function initializeFunctionsConfigHelper(frb: FunctionsRuntimeBundle): Promise<void> {
   const functionsResolution = await requireResolveAsync("firebase-functions", {
-    paths: [functionsDir],
+    paths: [frb.cwd],
   });
 
   const ff = require(functionsResolution);
@@ -791,7 +806,17 @@ async function initializeFunctionsConfigHelper(functionsDir: string): Promise<vo
             return value;
           } else {
             const valuePath = [parentKey, childKey].join(".");
-            new EmulatorLog("SYSTEM", "functions-config-missing-value", "", { valuePath }).log();
+
+            // Calling console.log() or util.inspect() on a config value can cause spurious logging
+            // if we don't ignore certain known-bad paths.
+            const ignore =
+              valuePath.endsWith(".inspect") ||
+              valuePath.endsWith(".toJSON") ||
+              valuePath.includes("Symbol(") ||
+              valuePath.includes("Symbol.iterator");
+            if (!ignore) {
+              new EmulatorLog("SYSTEM", "functions-config-missing-value", "", { valuePath }).log();
+            }
             return undefined;
           }
         })
@@ -1011,7 +1036,7 @@ async function invokeTrigger(
         "runtime-status",
         `Your function timed out after ~${trigger.definition.timeout ||
           "60s"}. To configure this timeout, see
-      https://firebase.google.com/docs/functions/manage-functions#set_timeout_and_memory_allocation.`
+      https:// firebase.google.com/docs/functions/manage-functions#set_timeout_and_memory_allocation.`
       ).log();
       throw new Error("Function timed out.");
     }, trigger.timeoutMs);
@@ -1072,7 +1097,7 @@ async function initializeRuntime(
   }
 
   if (isFeatureEnabled(frb, "functions_config_helper")) {
-    await initializeFunctionsConfigHelper(frb.cwd);
+    await initializeFunctionsConfigHelper(frb);
   }
 
   // TODO: Should this feature have a flag as well or is it required?


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #2001
Fixes #1836

### Scenarios Tested

I used the following functions code for testing:
```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp();

const tools = require('firebase-tools');

exports.firestoreDelete = functions.https.onRequest(async (req, res) => {
  console.log("Functions config:", JSON.stringify(functions.config()));
  const db = admin.firestore();

  console.log('Adding');
  for (let i = 0; i < 10; i++) {
    await db.collection('things').add({
      i
    });
  }

  const beforeSnap = await db.collection('things').get();

  console.log('Deleting');
  await tools.firestore.delete('/things', {
        project: process.env.GCLOUD_PROJECT,
        recursive: true,
        yes: true,
        token: functions.config().fb.token,
  });

  const afterSnap = await db.collection('things').get();
  res.json({
    before: beforeSnap.size,
    after: afterSnap.size
  });
});
```

Here is the test case output:
```bash
$ firebase emulators:exec "http http://localhost:5001/fir-dumpster/us-central1/firestoreDelete" --only functions,firestore
i  emulators: Starting emulators: functions, firestore
✔  hub: emulator hub started at http://localhost:4400
✔  functions: Using node@8 from host.
✔  functions: functions emulator started at http://localhost:5001
i  firestore: Serving ALL traffic (including WebChannel) on http://localhost:8080
⚠  firestore: Support for WebChannel on a separate port (8081) is DEPRECATED and will go away soon. Please use port above instead.
i  firestore: firestore emulator logging to firestore-debug.log
✔  firestore: firestore emulator started at http://localhost:8080
i  firestore: For testing set FIRESTORE_EMULATOR_HOST=localhost:8080
i  functions: Watching "/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.CvrhDdRm/functions" for Cloud Functions...
✔  functions[firestoreDelete]: http function initialized (http://localhost:5001/fir-dumpster/us-central1/firestoreDelete).
i  Running script: http http://localhost:5001/fir-dumpster/us-central1/firestoreDelete
i  functions: Beginning execution of "firestoreDelete"
>  Functions config: {"foo":{"bar":"baz"}}
>  Adding
>  Deleting
⚠  Non-existent functions.config() value requested!
   - Path: "fb.token"
   - Learn more at https://firebase.google.com/docs/functions/local-emulator
⚠  Google API requested!
   - URL: "https://cloudresourcemanager.googleapis.com/v1/projects/fir-dumpster:testIamPermissions"
   - Be careful, this may be a production service.
i  functions: Finished "firestoreDelete" in ~1s
HTTP/1.1 200 OK
connection: keep-alive
content-length: 23
content-type: application/json; charset=utf-8
date: Thu, 19 Mar 2020 14:30:53 GMT
etag: W/"17-+93Ry33n84TmzeDjO+6Fdv3WhfE"
x-powered-by: Express

{
    "after": 0,
    "before": 10
}

✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  hub: Stopping emulator hub
i  functions: Stopping functions emulator
i  firestore: Stopping firestore emulator
```

### Sample Commands

N/A