### PR TITLE
Add explicit encoding to all readFileSync calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 * Release RTDB Emulator v4.4.1: Bugfix for unreleased feature.
 * Fixes a bug when using `firebase-tools` to delete Firestore documents inside the Functions emulator (#2001).
 * Fixes a bug where `.runtimeconfig.json` files were not properly detected (#1836).
+* Fixes a bug where rules were sometimes read as blank after a file save (#1980).

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -190,7 +190,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
   if (options.import) {
     const importDir = path.resolve(options.import);
     exportMetadata = JSON.parse(
-      fs.readFileSync(path.join(importDir, HubExport.METADATA_FILE_NAME)).toString()
+      fs.readFileSync(path.join(importDir, HubExport.METADATA_FILE_NAME), "utf8").toString()
     ) as ExportMetadata;
   }
 

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -32,7 +32,7 @@ export class DatabaseEmulator implements EmulatorInstance {
       const rulesPath = this.args.rules;
       this.rulesWatcher = chokidar.watch(rulesPath, { persistent: true, ignoreInitial: true });
       this.rulesWatcher.on("change", async (event, stats) => {
-        const newContent = fs.readFileSync(rulesPath).toString();
+        const newContent = fs.readFileSync(rulesPath, "utf8").toString();
 
         utils.logLabeledBullet("database", "Change detected, updating rules...");
         try {

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -41,7 +41,7 @@ export class FirestoreEmulator implements EmulatorInstance {
       const rulesPath = this.args.rules;
       this.rulesWatcher = chokidar.watch(rulesPath, { persistent: true, ignoreInitial: true });
       this.rulesWatcher.on("change", async (event, stats) => {
-        const newContent = fs.readFileSync(rulesPath).toString();
+        const newContent = fs.readFileSync(rulesPath, "utf8").toString();
 
         utils.logLabeledBullet("firestore", "Change detected, updating rules...");
         const issues = await this.updateRules(newContent);

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -723,7 +723,7 @@ function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
   // Look for .runtimeconfig.json in the functions directory
   const configPath = `${frb.cwd}/.runtimeconfig.json`;
   try {
-    const configContent = fs.readFileSync(configPath);
+    const configContent = fs.readFileSync(configPath, "utf8");
     if (configContent) {
       logDebug(`Found local functions config: ${configPath}`);
       process.env.CLOUD_RUNTIME_CONFIG = configContent.toString();

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -211,7 +211,7 @@ export function findModuleRoot(moduleName: string, filepath: string): string {
         chunks = hierarchy;
       }
       const packagePath = path.join(chunks.join(path.sep), "package.json");
-      const serializedPackage = fs.readFileSync(packagePath).toString();
+      const serializedPackage = fs.readFileSync(packagePath, "utf8").toString();
       if (JSON.parse(serializedPackage).name === moduleName) {
         return chunks.join("/");
       }

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -44,7 +44,7 @@ export class EmulatorHub implements EmulatorInstance {
       return undefined;
     }
 
-    const data = fs.readFileSync(locatorPath).toString();
+    const data = fs.readFileSync(locatorPath, "utf8").toString();
     const locator = JSON.parse(data) as Locator;
 
     if (locator.version !== this.CLI_VERSION) {

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -28,7 +28,7 @@ export class HubExport {
       return undefined;
     }
 
-    return JSON.parse(fs.readFileSync(metadataPath).toString()) as ExportMetadata;
+    return JSON.parse(fs.readFileSync(metadataPath, "utf8").toString()) as ExportMetadata;
   }
 
   public async exportAll(): Promise<void> {

--- a/src/extensions/emulator/paramHelper.ts
+++ b/src/extensions/emulator/paramHelper.ts
@@ -7,7 +7,7 @@ import { FirebaseError } from "../../error";
 
 export function readParamsFile(envFilePath: string): any {
   try {
-    const buf = fs.readFileSync(path.resolve(envFilePath));
+    const buf = fs.readFileSync(path.resolve(envFilePath), "utf8");
     return dotenv.parse(buf.toString().trim(), { debug: true });
   } catch (err) {
     throw new FirebaseError(`Error reading --test-params file: ${err.message}\n`, {

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -64,7 +64,7 @@ export async function getParams(
   let commandLineParams;
   if (envFilePath) {
     try {
-      const buf = fs.readFileSync(path.resolve(envFilePath));
+      const buf = fs.readFileSync(path.resolve(envFilePath), "utf8");
       commandLineParams = dotenv.parse(buf.toString().trim(), { debug: true });
       track("Extension Env File", "Present");
     } catch (err) {

--- a/src/parseBoltRules.js
+++ b/src/parseBoltRules.js
@@ -6,7 +6,7 @@ var { FirebaseError } = require("./error");
 var clc = require("cli-color");
 
 module.exports = function(filename) {
-  var ruleSrc = fs.readFileSync(filename);
+  var ruleSrc = fs.readFileSync(filename, "utf8");
 
   var result = spawn.sync("firebase-bolt", {
     input: ruleSrc,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #1980 (we think)

### Scenarios Tested

N/A this is a speculative but harmless fix.

### Sample Commands

N/A