### PR TITLE
Ys/remove legacy webchannel port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,6 @@
 * **BREAKING:** Remove support for top-level `hosting` config.
 * **BREAKING:** `firebase serve` can no longer start the Cloud Firestore or Realtime Database emulators.
 * **BREAKING:** The Cloud Functions emulator within `firebase serve` now has identical behavior to the emulator within `firebase emulators:start`.
+* **BREAKING**: Remove support for separate WebChannel port in the Cloud Firestore emulator. Use the main port instead.
 * Updated underlying logging infrastructure.
 * Replace deprecated `google-auto-auth` package with `google-auth-library`.

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -19,7 +19,6 @@ export interface FirestoreEmulatorArgs {
   rules?: string;
   functions_emulator?: string;
   auto_download?: boolean;
-  webchannel_port?: number;
   seed_from_export?: string;
 }
 
@@ -56,33 +55,6 @@ export class FirestoreEmulator implements EmulatorInstance {
           utils.logLabeledSuccess("firestore", "Rules updated.");
         }
       });
-    }
-
-    // Firestore Emulator now serves WebChannel on the same port as gRPC, but
-    // for backward compatibility reasons, let's tell it to ALSO serve
-    // WebChannel on port+1, if it is available.
-    const host = this.getInfo().host;
-    const basePort = this.getInfo().port;
-    const port = basePort + 1;
-    try {
-      const webChannelPort = await pf.getPortPromise({
-        port,
-        stopPort: port,
-      });
-      this.args.webchannel_port = webChannelPort;
-
-      utils.logLabeledBullet(
-        "firestore",
-        `Serving ALL traffic (including WebChannel) on ${clc.bold(`http://${host}:${basePort}`)}`
-      );
-      utils.logLabeledWarning(
-        "firestore",
-        `Support for WebChannel on a separate port (${webChannelPort}) is DEPRECATED and will go away soon. ` +
-          "Please use port above instead."
-      );
-    } catch (e) {
-      // We don't need to take any action here since the emulator will still
-      // serve WebChannel on the main port anyway.
     }
 
     return downloadableEmulators.start(Emulators.FIRESTORE, this.args);


### PR DESCRIPTION
### Description

This PR removes the separate port (port + 1) for WebChannel requests for Firestore Emulator. Instead, the Firestore Emulator has been handling both HTTP and WebChannel traffic on the main port for a few months already. The separation has been long deprecated since it causes a lot of problems with no real benefit.

Developers should move to use the main port (default 8080) for their web app in all times.

### Scenarios Tested

Started Firestore Emulator and made sure it still works.