### PR TITLE
fix apps:sdkconfig for web to return the JSON object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 * Adds support for setting `maxInstances` in Cloud Functions for Firebase.
 * Fixes a bug where rules were sometimes read as blank after a file save (#1980).
 * Fixes an issue where callable functions with authentication could not be emulated (#1475).
+* Adds an `sdkConfig` parameter to the results object of `apps:sdkconfig` requests for web apps.

--- a/src/commands/apps-sdkconfig.ts
+++ b/src/commands/apps-sdkconfig.ts
@@ -25,7 +25,7 @@ async function selectAppInteractively(
     throw new FirebaseError("Project ID must not be empty.");
   }
 
-  const apps: AppMetadata[] = await listFirebaseApps(projectId, appPlatform);
+  const apps = await listFirebaseApps(projectId, appPlatform);
   if (apps.length === 0) {
     throw new FirebaseError(
       `There are no ${appPlatform === AppPlatform.ANY ? "" : appPlatform + " "}apps ` +
@@ -33,6 +33,7 @@ async function selectAppInteractively(
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const choices = apps.map((app: any) => {
     return {
       name:
@@ -60,11 +61,8 @@ module.exports = new Command("apps:sdkconfig [platform] [appId]")
   .option("-o, --out [file]", "(optional) write config output to a file")
   .before(requireAuth)
   .action(
-    async (
-      platform: string = "",
-      appId: string = "",
-      options: any
-    ): Promise<AppConfigurationData> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (platform = "", appId = "", options: any): Promise<AppConfigurationData> => {
       let appPlatform = getAppPlatform(platform);
 
       if (!appId) {

--- a/src/commands/apps-sdkconfig.ts
+++ b/src/commands/apps-sdkconfig.ts
@@ -92,12 +92,12 @@ module.exports = new Command("apps:sdkconfig [platform] [appId]")
       spinner.succeed();
 
       const fileInfo = getAppConfigFile(configData, appPlatform);
+      if (appPlatform == AppPlatform.WEB) {
+        fileInfo.sdkConfig = configData;
+      }
 
       if (options.out === undefined) {
         logger.info(fileInfo.fileContents);
-        if (appPlatform == AppPlatform.WEB) {
-          return configData;
-        }
         return fileInfo;
       }
 

--- a/src/commands/apps-sdkconfig.ts
+++ b/src/commands/apps-sdkconfig.ts
@@ -7,6 +7,7 @@ import {
   AppMetadata,
   AppPlatform,
   getAppConfig,
+  getAppConfigFile,
   getAppPlatform,
   listFirebaseApps,
 } from "../management/apps";
@@ -88,12 +89,16 @@ module.exports = new Command("apps:sdkconfig [platform] [appId]")
         spinner.fail();
         throw err;
       }
-
       spinner.succeed();
 
+      const fileInfo = getAppConfigFile(configData, appPlatform);
+
       if (options.out === undefined) {
-        logger.info(configData.fileContents);
-        return configData;
+        logger.info(fileInfo.fileContents);
+        if (appPlatform == AppPlatform.WEB) {
+          return configData;
+        }
+        return fileInfo;
       }
 
       const shouldUseDefaultFilename = options.out === true || options.out === "";

--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -49,6 +49,11 @@ export enum AppPlatform {
   ANY = "ANY",
 }
 
+/**
+ * Returns the `AppPlatform` represented by the string.
+ * @param platform the platform to parse.
+ * @return the `AppPlatform`.
+ */
 export function getAppPlatform(platform: string): AppPlatform {
   switch (platform.toUpperCase()) {
     case "IOS":
@@ -235,13 +240,25 @@ function getListAppsResourceString(projectId: string, platform: AppPlatform): st
 }
 
 /**
- * Gets the configuration artifact associated with the specified a Firebase app
- * @return a promise that resolves to configuration file content of the requested app
+ * Returns information representing the file need to initalize the application.
+ * @param config the object from `getAppConfig`.
+ * @param platform the platform the `config` represents.
+ * @return the platform-specific file information (name and contents).
  */
-export async function getAppConfig(
-  appId: string,
-  platform: AppPlatform
-): Promise<AppConfigurationData> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function getAppConfigFile(config: any, platform: AppPlatform): AppConfigurationData {
+  return parseConfigFromResponse(config, platform);
+}
+
+/**
+ * Gets the configuration artifact associated with the specified a Firebase app.
+ * @param appId the ID of the app.
+ * @param platform the platform of the app.
+ * @return for web, an object with the variables set; for iOS and Android, a file name and
+ *   base64-encoded content string.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function getAppConfig(appId: string, platform: AppPlatform): Promise<any> {
   let response;
   try {
     response = await api.request("GET", getAppConfigResourceString(appId, platform), {
@@ -259,7 +276,7 @@ export async function getAppConfig(
       }
     );
   }
-  return parseConfigFromResponse(response.body, platform);
+  return response.body;
 }
 
 function getAppConfigResourceString(appId: string, platform: AppPlatform): string {
@@ -281,6 +298,7 @@ function getAppConfigResourceString(appId: string, platform: AppPlatform): strin
   return `/v1beta1/projects/-/${platformResource}/${appId}/config`;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseConfigFromResponse(responseBody: any, platform: AppPlatform): AppConfigurationData {
   if (platform === AppPlatform.WEB) {
     const JS_TEMPLATE = fs.readFileSync(__dirname + "/../../templates/setup/web.js", "utf8");

--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -38,7 +38,10 @@ export interface WebAppMetadata extends AppMetadata {
 
 export interface AppConfigurationData {
   fileName: string;
-  fileContents: string /* file contents in utf8 format */;
+  // File contents in utf8 format.
+  fileContents: string;
+  // Only for `AppPlatform.WEB`, the raw configuration parameters.
+  sdkConfig?: { [key: string]: string };
 }
 
 export enum AppPlatform {

--- a/src/test/management/apps.spec.ts
+++ b/src/test/management/apps.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import * as util from "util";
 import * as fs from "fs";
 
 import * as api from "../../api";
@@ -471,8 +470,8 @@ describe("App management", () => {
     it("should resolve with iOS app list", async () => {
       const appCounts = 10;
       const expectedAppList = generateIosAppList(appCounts);
-      const apiResponseAppList: any[] = expectedAppList.map((app) => {
-        const iosApp: any = { ...app };
+      const apiResponseAppList = expectedAppList.map((app) => {
+        const iosApp = { ...app };
         delete iosApp.platform;
         return iosApp;
       });
@@ -490,8 +489,8 @@ describe("App management", () => {
     it("should resolve with Android app list", async () => {
       const appCounts = 10;
       const expectedAppList = generateAndroidAppList(appCounts);
-      const apiResponseAppList: any[] = expectedAppList.map((app) => {
-        const androidApps: any = { ...app };
+      const apiResponseAppList = expectedAppList.map((app) => {
+        const androidApps = { ...app };
         delete androidApps.platform;
         return androidApps;
       });
@@ -509,8 +508,8 @@ describe("App management", () => {
     it("should resolve with Web app list", async () => {
       const appCounts = 10;
       const expectedAppList = generateWebAppList(appCounts);
-      const apiResponseAppList: any[] = expectedAppList.map((app) => {
-        const webApp: any = { ...app };
+      const apiResponseAppList = expectedAppList.map((app) => {
+        const webApp = { ...app };
         delete webApp.platform;
         return webApp;
       });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes apps:sdkconfig to return the json object in `--json` mode.

To do this, we have to make sure the command fetches the raw config object and is allowed to return _that_ value if the app is of type `web`. Otherwise, on other types, it prints out the files (or file name and content) as normal.
	 
### Scenarios Tested

web:

![image](https://user-images.githubusercontent.com/160236/77341975-bc922f00-6cec-11ea-9538-b58e939fde6d.png)

ios:

![image](https://user-images.githubusercontent.com/160236/77342175-0844d880-6ced-11ea-8ea2-8a736ed48128.png)
