### PR TITLE
Changes to logging for WebSocket transport

### DIFF
--- a/src/bin/firebase.js
+++ b/src/bin/firebase.js
@@ -2,6 +2,8 @@
 "use strict";
 
 // Make check for Node 6, which is no longer supported by the CLI.
+import { tryStringify } from "../utils";
+
 const semver = require("semver");
 const pkg = require("../../package.json");
 const nodeVersion = process.version;
@@ -50,7 +52,7 @@ logger.add(
     level: "debug",
     filename: logFilename,
     format: winston.format.printf((info) => {
-      const segments = [info.message, ...(info[SPLAT] || [])].map(logger.tryStringify);
+      const segments = [info.message, ...(info[SPLAT] || [])].map(tryStringify);
       return `[${info.level}] ${ansiStrip(segments.join(" "))}`;
     }),
   })

--- a/src/bin/firebase.js
+++ b/src/bin/firebase.js
@@ -2,8 +2,6 @@
 "use strict";
 
 // Make check for Node 6, which is no longer supported by the CLI.
-import { tryStringify } from "../utils";
-
 const semver = require("semver");
 const pkg = require("../../package.json");
 const nodeVersion = process.version;
@@ -52,7 +50,7 @@ logger.add(
     level: "debug",
     filename: logFilename,
     format: winston.format.printf((info) => {
-      const segments = [info.message, ...(info[SPLAT] || [])].map(tryStringify);
+      const segments = [info.message, ...(info[SPLAT] || [])].map(utils.tryStringify);
       return `[${info.level}] ${ansiStrip(segments.join(" "))}`;
     }),
   })

--- a/src/command.ts
+++ b/src/command.ts
@@ -242,7 +242,9 @@ export class Command {
           new winston.transports.Console({
             level: "info",
             format: winston.format.printf((info) =>
-              [info.message, ...(info[SPLAT] || [])].filter(chunk => typeof chunk == "string").join(" ")
+              [info.message, ...(info[SPLAT] || [])]
+                .filter((chunk) => typeof chunk == "string")
+                .join(" ")
             ),
           })
         );

--- a/src/command.ts
+++ b/src/command.ts
@@ -242,7 +242,7 @@ export class Command {
           new winston.transports.Console({
             level: "info",
             format: winston.format.printf((info) =>
-              [info.message, ...(info[SPLAT] || [])].join(" ")
+              [info.message, ...(info[SPLAT] || [])].filter(chunk => typeof chunk == "string").join(" ")
             ),
           })
         );

--- a/src/command.ts
+++ b/src/command.ts
@@ -5,7 +5,7 @@ import { SPLAT } from "triple-beam";
 import * as winston from "winston";
 
 import { FirebaseError } from "./error";
-import { getInheritedOption } from "./utils";
+import { getInheritedOption, tryStringify } from "./utils";
 import { load } from "./rc";
 import { load as _load } from "./config";
 import { configstore } from "./configstore";
@@ -232,7 +232,7 @@ export class Command {
           new winston.transports.Console({
             level: "debug",
             format: winston.format.printf((info) => {
-              const segments = [info.message, ...(info[SPLAT] || [])].map(logger.tryStringify);
+              const segments = [info.message, ...(info[SPLAT] || [])].map(tryStringify);
               return `${ansiStrip(segments.join(" "))}`;
             }),
           })

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -38,7 +38,7 @@ export class EmulatorLogger {
    * Within this file, utils.logFoo() or logger.Foo() should not be called directly,
    * so that we can respect the "quiet" flag.
    */
-  static log(type: LogType, text: string): void {
+  static log(type: LogType, text: string, data?: any): void {
     if (EmulatorLogger.shouldSupress(type)) {
       logger.debug(`${type}: ${text}`);
       return;
@@ -46,28 +46,28 @@ export class EmulatorLogger {
 
     switch (type) {
       case "DEBUG":
-        logger.debug(text);
+        logger.debug(text, data);
         break;
       case "INFO":
-        logger.info(text);
+        logger.info(text, data);
         break;
       case "USER":
-        logger.info(text);
+        logger.info(text, data);
         break;
       case "BULLET":
-        utils.logBullet(text);
+        utils.logBullet(text, data);
         break;
       case "WARN":
-        utils.logWarning(text);
+        utils.logWarning(text, data);
         break;
       case "WARN_ONCE":
         if (!this.warnOnceCache.has(text)) {
-          utils.logWarning(text);
+          utils.logWarning(text, data);
           this.warnOnceCache.add(text);
         }
         break;
       case "SUCCESS":
-        utils.logSuccess(text);
+        utils.logSuccess(text, data);
         break;
     }
   }
@@ -81,7 +81,7 @@ export class EmulatorLogger {
         EmulatorLogger.handleSystemLog(log);
         break;
       case "USER":
-        EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`);
+        EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`, logger.tryParse(log.text));
         break;
       case "DEBUG":
         if (log.data && Object.keys(log.data).length > 0) {

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -3,6 +3,7 @@ import * as clc from "cli-color";
 import * as utils from "../utils";
 import * as logger from "../logger";
 import { EmulatorLog } from "./types";
+import { tryParse } from "../utils";
 
 /**
  * DEBUG - lowest level, not needed for most usages.
@@ -82,7 +83,7 @@ export class EmulatorLogger {
         break;
       case "USER":
         EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`, {
-          user: logger.tryParse(log.text),
+          user: tryParse(log.text),
         });
         break;
       case "DEBUG":

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -81,7 +81,7 @@ export class EmulatorLogger {
         EmulatorLogger.handleSystemLog(log);
         break;
       case "USER":
-        EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`, logger.tryParse(log.text));
+        EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`, {user: logger.tryParse(log.text)});
         break;
       case "DEBUG":
         if (log.data && Object.keys(log.data).length > 0) {

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -81,7 +81,9 @@ export class EmulatorLogger {
         EmulatorLogger.handleSystemLog(log);
         break;
       case "USER":
-        EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`, {user: logger.tryParse(log.text)});
+        EmulatorLogger.log("USER", `${clc.blackBright("> ")} ${log.text}`, {
+          user: logger.tryParse(log.text),
+        });
         break;
       case "DEBUG":
         if (log.data && Object.keys(log.data).length > 0) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -29,6 +29,16 @@ logger.tryStringify = (value) => {
   }
 };
 
+logger.tryParse = (value) => {
+  if (typeof value !== "string") return value;
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
 const debug = logger.debug;
 logger.debug = function(...args) {
   args[0] = "[" + new Date().toISOString() + "] " + (args[0] || "");

--- a/src/logger.js
+++ b/src/logger.js
@@ -19,26 +19,6 @@ const logger = expandErrors(winston.createLogger());
 // Set a default silent logger to suppress logs during tests
 logger.add(new winston.transports.Console({ silent: true }));
 
-logger.tryStringify = (value) => {
-  if (typeof value === "string") return value;
-
-  try {
-    return JSON.stringify(value);
-  } catch {
-    return value;
-  }
-};
-
-logger.tryParse = (value) => {
-  if (typeof value !== "string") return value;
-
-  try {
-    return JSON.parse(value);
-  } catch {
-    return value;
-  }
-};
-
 const debug = logger.debug;
 logger.debug = function(...args) {
   args[0] = "[" + new Date().toISOString() + "] " + (args[0] || "");

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -258,3 +258,35 @@ export async function promiseProps(obj: any): Promise<any> {
   });
   return Promise.all(promises).then(() => resultObj);
 }
+
+/**
+ * Attempts to call JSON.stringify on an object, if it throws return the original value
+ * @param value
+ */
+export function tryStringify(value: any) {
+  if (typeof value === "string") {
+    return value;
+  }
+
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
+ * Attempts to call JSON.parse on an object, if it throws return the original value
+ * @param value
+ */
+export function tryParse(value: any) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}


### PR DESCRIPTION
Alright, I believe this is the last changes which could impact anything outside the emulator. We now detect when non-string objects are passed to logging methods and split where they go.

The functionality should be...
1) Debug transport should serialize and append to single line log
2) Console transport should ignore non-strings
3) WebSocket transport should serialize and ship in larger log bundle for each log