### PR TITLE
Validate project ids for commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@
 * **BREAKING:** `firebase serve` can no longer start the Cloud Firestore or Realtime Database emulators.
 * **BREAKING:** Unifies the Cloud Functions for Firebase emulator within `firebase serve` and `firebase emulators:start`.
 * **BREAKING**: Removes support for separate WebChannel port in the Cloud Firestore emulator. Use the main port instead.
-* **BREAKING**: Rejectes project IDs with invalid format.
+* **BREAKING**: Rejects project IDs with invalid format.
 * Updates underlying logging infrastructure.
 * Replaces deprecated `google-auto-auth` package with `google-auth-library`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,6 @@
 * **BREAKING:** `firebase serve` can no longer start the Cloud Firestore or Realtime Database emulators.
 * **BREAKING:** Unifies the Cloud Functions for Firebase emulator within `firebase serve` and `firebase emulators:start`.
 * **BREAKING**: Removes support for separate WebChannel port in the Cloud Firestore emulator. Use the main port instead.
+* **BREAKING**: Rejectes project IDs with invalid format.
 * Updates underlying logging infrastructure.
 * Replaces deprecated `google-auto-auth` package with `google-auth-library`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,6 @@
 * **BREAKING:** `firebase serve` can no longer start the Cloud Firestore or Realtime Database emulators.
 * **BREAKING:** Unifies the Cloud Functions for Firebase emulator within `firebase serve` and `firebase emulators:start`.
 * **BREAKING**: Removes support for separate WebChannel port in the Cloud Firestore emulator. Use the main port instead.
-* **BREAKING**: Rejects project IDs with invalid format.
+* **BREAKING**: Rejects Firebase project IDs with invalid format.
 * Updates underlying logging infrastructure.
 * Replaces deprecated `google-auto-auth` package with `google-auth-library`.

--- a/src/command.ts
+++ b/src/command.ts
@@ -315,10 +315,15 @@ export class Command {
 // https://cloud.google.com/resource-manager/reference/rest/v1beta1/projects#resource:-project
 // However, the regex below, matching internal ones, is more permissive so that
 // some legacy projects with irregular project IDs still works.
-const PROJECT_ID_REGEX = /^(?:[^:]+:)?[a-z0-9\-]+$/;
+const PROJECT_ID_REGEX = /^(?:[^:]+:)?[a-z0-9-]+$/;
 
+/**
+ * Validate the project id and throw on invalid format.
+ * @param project the project id to validate
+ * @throws {FirebaseError} if project id has invalid format.
+ */
 export function validateProjectId(project: string): void {
-  if (project.match(PROJECT_ID_REGEX)) {
+  if (PROJECT_ID_REGEX.test(project)) {
     return;
   }
   const invalidMessage = "Invalid project id: " + clc.bold(project) + ".";

--- a/src/command.ts
+++ b/src/command.ts
@@ -326,7 +326,7 @@ export function validateProjectId(project: string): void {
   if (PROJECT_ID_REGEX.test(project)) {
     return;
   }
-  track("error", "invalid-project-id");
+  track("Project ID Check", "invalid");
   const invalidMessage = "Invalid project id: " + clc.bold(project) + ".";
   if (project.toLowerCase() !== project) {
     // Attempt to be more helpful in case uppercase letters are used.

--- a/src/command.ts
+++ b/src/command.ts
@@ -12,6 +12,7 @@ import { configstore } from "./configstore";
 import { detectProjectRoot } from "./detectProjectRoot";
 import logger = require("./logger");
 import track = require("./track");
+import clc = require("cli-color");
 const ansiStrip = require("cli-color/strip") as (input: string) => string;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -257,6 +258,7 @@ export class Command {
 
     options.projectRoot = detectProjectRoot(options.cwd);
     this.applyRC(options);
+    if (options.project) validateProjectId(options.project);
   }
 
   /**
@@ -306,5 +308,24 @@ export class Command {
       }
       return this.actionFn(...args);
     };
+  }
+}
+
+// Project IDs must follow a certain format, as documented at:
+// https://cloud.google.com/resource-manager/reference/rest/v1beta1/projects#resource:-project
+// However, the regex below, matching internal ones, is more permissive so that
+// some legacy projects with irregular project IDs still works.
+const PROJECT_ID_REGEX = /^(?:[^:]+:)?[a-z0-9\-]+$/;
+
+export function validateProjectId(project: string): void {
+  if (project.match(PROJECT_ID_REGEX)) {
+    return;
+  }
+  const invalidMessage = "Invalid project id: " + clc.bold(project) + ".";
+  if (project.toLowerCase() !== project) {
+    // Attempt to be more helpful in case uppercase letters are used.
+    throw new FirebaseError(invalidMessage + "\nNote: Project id must be all lowercase.");
+  } else {
+    throw new FirebaseError(invalidMessage);
   }
 }

--- a/src/command.ts
+++ b/src/command.ts
@@ -326,6 +326,7 @@ export function validateProjectId(project: string): void {
   if (PROJECT_ID_REGEX.test(project)) {
     return;
   }
+  track("error", "invalid-project-id");
   const invalidMessage = "Invalid project id: " + clc.bold(project) + ".";
   if (project.toLowerCase() !== project) {
     // Attempt to be more helpful in case uppercase letters are used.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

This PR makes Firebase CLI check project id format and block the ones that are obviously wrong, like `things with space` or `Uppercase-Letters`.

### Scenarios Tested

See test cases added, and sample commands below:

### Sample Commands

```bash
$ firebase emulators:start --project Wow
Error: Invalid project id: Wow.
Note: Project id must be all lowercase.
$ firebase emulators:start --project wow
# works fine
$ firebase emulators:start --project a.b.c
Error: Invalid project id: a.b.c
$ firebase use --add a-real-project-here --alias a.b.c
# works fine, aliases are allowed
$ firebase emulators:start --project a.b.c
# now works, since the aliased project id is valid
```