### PR TITLE
Fix context.auth.uid in callable functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fix issue with `context.auth.uid` in callable Cloud Functions (#2057).

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -703,7 +703,7 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     try {
       const decoded = jwt.decode(idToken, { complete: true });
-      if (!decoded || typeof decoded !== 'object') {
+      if (!decoded || typeof decoded !== "object") {
         return;
       }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -28,6 +28,7 @@ import {
   getFunctionRegion,
   getFunctionService,
   FunctionsRuntimeArgs,
+  HttpConstants,
 } from "./functionsEmulatorShared";
 import { EmulatorRegistry } from "./registry";
 import { EventEmitter } from "events";
@@ -739,7 +740,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         };
 
         delete req.headers["authorization"];
-        req.headers["X-Callable-Context-Auth"] = JSON.stringify(contextAuth);
+        req.headers[HttpConstants.CALLABLE_AUTH_HEADER] = JSON.stringify(contextAuth);
       }
     }
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -10,6 +10,7 @@ import {
   FunctionsRuntimeFeatures,
   getEmulatedTriggersFromDefinitions,
   FunctionsRuntimeArgs,
+  HttpConstants,
 } from "./functionsEmulatorShared";
 import { parseVersionString, compareVersionStrings } from "./functionsEmulatorUtils";
 import * as express from "express";
@@ -479,16 +480,17 @@ async function initializeFirebaseFunctionsStubs(frb: FunctionsRuntimeBundle): Pr
   httpsProvider.onCall = (handler: (data: any, context: any) => any | Promise<any>) => {
     // Look for a special header provided by the functions emulator that lets us mock out
     // callable functions auth.
-    const authContextHeaderKey = "X-Callable-Context-Auth";
     const newHandler = (data: any, context: any) => {
       if (context.rawRequest) {
-        const authContext = context.rawRequest.header(authContextHeaderKey);
+        const authContext = context.rawRequest.header(HttpConstants.CALLABLE_AUTH_HEADER);
         if (authContext) {
           logDebug("Callable functions auth override", {
-            key: authContextHeaderKey,
+            key: HttpConstants.CALLABLE_AUTH_HEADER,
             value: authContext,
           });
           context.auth = JSON.parse(authContext);
+        } else {
+          logDebug("No callable functions auth found");
         }
       }
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -87,6 +87,10 @@ const memoryLookup = {
   "2GB": 2048,
 };
 
+export class HttpConstants {
+  static readonly CALLABLE_AUTH_HEADER: string = "x-callable-context-auth";
+}
+
 export class EmulatedTrigger {
   /*
   Here we create a trigger from a single definition (data about what resources does this trigger on, etc) and

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -243,21 +243,23 @@ describe("FunctionsEmulator-Hub", () => {
         expect(res.body).to.deep.equal({
           result: {
             auth: {
-              provider_id: "anonymous",
-              iss: "https://securetoken.google.com/fir-dumpster",
-              aud: "fir-dumpster",
-              auth_time: 1585053264,
-              user_id: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
-              sub: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
               uid: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
-              iat: 1585053264,
-              exp: 1585056864,
-              firebase: {
-                identities: {},
-                sign_in_provider: "anonymous",
+              token: {
+                provider_id: "anonymous",
+                iss: "https://securetoken.google.com/fir-dumpster",
+                aud: "fir-dumpster",
+                auth_time: 1585053264,
+                user_id: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
+                sub: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
+                uid: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
+                iat: 1585053264,
+                exp: 1585056864,
+                firebase: {
+                  identities: {},
+                  sign_in_provider: "anonymous",
+                },
               },
             },
-            uid: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
           },
         });
       });

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -229,13 +229,13 @@ describe("FunctionsEmulator-Hub", () => {
     });
 
     // For token info:
-    // https://jwt.io/#debugger-io?token=eyJhbGciOiJub25lIiwia2lkIjoiZmFrZWtpZCJ9.eyJ1aWQiOiJhbGljZSIsImVtYWlsIjoiYWxpY2VAZXhhbXBsZS5jb20iLCJpYXQiOjAsInN1YiI6ImFsaWNlIn0.
+    // https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjFmODhiODE0MjljYzQ1MWEzMzVjMmY1Y2RiM2RmYjM0ZWIzYmJjN2YiLCJ0eXAiOiJKV1QifQ.eyJwcm92aWRlcl9pZCI6ImFub255bW91cyIsImlzcyI6Imh0dHBzOi8vc2VjdXJldG9rZW4uZ29vZ2xlLmNvbS9maXItZHVtcHN0ZXIiLCJhdWQiOiJmaXItZHVtcHN0ZXIiLCJhdXRoX3RpbWUiOjE1ODUwNTMyNjQsInVzZXJfaWQiOiJTbW56OE8xcmxkZmptZHg4QVJVdE12WG1tdzYyIiwic3ViIjoiU21uejhPMXJsZGZqbWR4OEFSVXRNdlhtbXc2MiIsImlhdCI6MTU4NTA1MzI2NCwiZXhwIjoxNTg1MDU2ODY0LCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7fSwic2lnbl9pbl9wcm92aWRlciI6ImFub255bW91cyJ9fQ.ujOthXwov9NJAOmJfumkDzMQgj8P1YRWkhFeq_HqHpPmth1BbtrQ_duwFoFmAPGjnGTuozUi0YUl8eKh4p2CqXi-Wf_OLSumxNnJWhj_tm7OvYWjvUy0ZvjilPBrhQ17_lRnhyOVSLSXfneqehYvE85YkBkFy3GtOpN49fRdmBT7B71Yx8E8SM7fohlia-ah7_uSNpuJXzQ9-0rv6HH9uBYCmjUxb9MiuKwkIjDoYtjTuaqG8-4w8bPrKHmg6V7HeDSNItUcfDbALZiTsM5uob_uuVTwjCCQnwryB5Y3bmdksTqCvp8U7ZTU04HS9CJawTa-zuDXIwlOvsC-J8oQQw
     await supertest(functionsEmulator.createHubServer())
       .post("/fake-project-id/us-central1/callable_function_id")
       .set({
         "Content-Type": "application/json",
         Authorization:
-          "Bearer eyJhbGciOiJub25lIiwia2lkIjoiZmFrZWtpZCJ9.eyJ1aWQiOiJhbGljZSIsImVtYWlsIjoiYWxpY2VAZXhhbXBsZS5jb20iLCJpYXQiOjAsInN1YiI6ImFsaWNlIn0.",
+          "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjFmODhiODE0MjljYzQ1MWEzMzVjMmY1Y2RiM2RmYjM0ZWIzYmJjN2YiLCJ0eXAiOiJKV1QifQ.eyJwcm92aWRlcl9pZCI6ImFub255bW91cyIsImlzcyI6Imh0dHBzOi8vc2VjdXJldG9rZW4uZ29vZ2xlLmNvbS9maXItZHVtcHN0ZXIiLCJhdWQiOiJmaXItZHVtcHN0ZXIiLCJhdXRoX3RpbWUiOjE1ODUwNTMyNjQsInVzZXJfaWQiOiJTbW56OE8xcmxkZmptZHg4QVJVdE12WG1tdzYyIiwic3ViIjoiU21uejhPMXJsZGZqbWR4OEFSVXRNdlhtbXc2MiIsImlhdCI6MTU4NTA1MzI2NCwiZXhwIjoxNTg1MDU2ODY0LCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7fSwic2lnbl9pbl9wcm92aWRlciI6ImFub255bW91cyJ9fQ.ujOthXwov9NJAOmJfumkDzMQgj8P1YRWkhFeq_HqHpPmth1BbtrQ_duwFoFmAPGjnGTuozUi0YUl8eKh4p2CqXi-Wf_OLSumxNnJWhj_tm7OvYWjvUy0ZvjilPBrhQ17_lRnhyOVSLSXfneqehYvE85YkBkFy3GtOpN49fRdmBT7B71Yx8E8SM7fohlia-ah7_uSNpuJXzQ9-0rv6HH9uBYCmjUxb9MiuKwkIjDoYtjTuaqG8-4w8bPrKHmg6V7HeDSNItUcfDbALZiTsM5uob_uuVTwjCCQnwryB5Y3bmdksTqCvp8U7ZTU04HS9CJawTa-zuDXIwlOvsC-J8oQQw",
       })
       .send({ data: {} })
       .expect(200)
@@ -243,14 +243,21 @@ describe("FunctionsEmulator-Hub", () => {
         expect(res.body).to.deep.equal({
           result: {
             auth: {
-              token: {
-                email: "alice@example.com",
-                iat: 0,
-                sub: "alice",
-                uid: "alice",
+              provider_id: "anonymous",
+              iss: "https://securetoken.google.com/fir-dumpster",
+              aud: "fir-dumpster",
+              auth_time: 1585053264,
+              user_id: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
+              sub: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
+              uid: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
+              iat: 1585053264,
+              exp: 1585056864,
+              firebase: {
+                identities: {},
+                sign_in_provider: "anonymous",
               },
-              uid: "alice",
             },
+            uid: "Smnz8O1rldfjmdx8ARUtMvXmmw62",
           },
         });
       });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #2057

Changes:
  * It turns out that `firebase-functions` manually makes the `uid` field inside the token from the `sub` field, so we have to replicate that behavior.
  * Realized we already had a dependency on `jsonwebtoken` so stopped doing my own parsing.
  * Updated unit tests to use a real token.
	 
### Scenarios Tested

I tested with a local hosting site that calls into the Cloud Functions emulator:

**functions/index.js**
```js
const functions = require('firebase-functions');
const util = require('util');

exports.helloWorld = functions.https.onCall(async (data, context) => {
  console.log("helloWorld", util.inspect(context.auth));
  return {
    auth: context.auth
  };
});
```

**public/index.html**
```html
    <script>
      document.addEventListener('DOMContentLoaded', async function() {
        const auth = firebase.auth();
        firebase.auth().onAuthStateChanged(user => {
          console.log("USER", user);
        });
        await firebase.auth().signInAnonymously();

        firebase.functions().useFunctionsEmulator("http://localhost:5011")
        const helloWorld = firebase.functions().httpsCallable('helloWorld');
        helloWorld({text: "hello"}).then(function(result) {
          console.log(result.data);
        });
      });
    </script>
```

Result in the Chrome debugger:
<img width="519" alt="Screen Shot 2020-03-24 at 9 05 11 AM" src="https://user-images.githubusercontent.com/8466666/77428520-9634c800-6dae-11ea-9c98-8940c8987593.png">


### Sample Commands

N/A