### PR TITLE
Fixing regression to SELECT and MULTISELECT params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Fixes issue with `context.auth.uid` in callable Cloud Functions for Firebase (#2057).
+* Fixes issue with `SELECT` and `MULTISELECT` params in Extensions.

--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -87,9 +87,9 @@ export interface Param {
 }
 
 export enum ParamType {
-  STRING = "string",
-  SELECT = "select",
-  MULTISELECT = "multiselect",
+  STRING = "STRING",
+  SELECT = "SELECT",
+  MULTISELECT = "MULTISELECT",
 }
 
 export interface ParamOption {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -223,7 +223,7 @@ export function validateSpec(spec: any) {
         );
       }
     }
-    if (param.type && (param.type == ParamType.SELECT || param.type == ParamType.MULTISELECT)) {
+    if (param.type && (param.type == InputParamType.SELECT || param.type == InputParamType.MULTISELECT)) {
       if (param.validationRegex) {
         errors.push(
           `Param${

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -30,7 +30,7 @@ import { envOverride } from "../utils";
  * This DOES NOT represent the param.type strings that the backend returns in spec.
  * ParamType, defined in extensionsApi.ts, describes the returned strings.
  */
-enum SpecParamType {
+export enum SpecParamType {
   SELECT = "select",
   MULTISELECT = "multiselect",
   STRING = "string",

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -190,11 +190,11 @@ export function validateSpec(spec: any) {
     if (!param.label) {
       errors.push(`Param${param.param ? ` ${param.param}` : ""} is missing required field: label`);
     }
-     enum InputParamType {
-       SELECT = "select",
-       MULTISELECT = "multiselect",
-       STRING = "string"
-     }
+    enum InputParamType {
+      SELECT = "select",
+      MULTISELECT = "multiselect",
+      STRING = "string",
+    }
     if (param.type && !_.includes(InputParamType, param.type)) {
       errors.push(
         `Invalid type ${param.type} for param${
@@ -223,7 +223,7 @@ export function validateSpec(spec: any) {
         );
       }
     }
-    if (paramType && (paramType == ParamType.SELECT || paramType == ParamType.MULTISELECT)) {
+    if (param.type && (param.type == ParamType.SELECT || param.type == ParamType.MULTISELECT)) {
       if (param.validationRegex) {
         errors.push(
           `Param${

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -190,14 +190,19 @@ export function validateSpec(spec: any) {
     if (!param.label) {
       errors.push(`Param${param.param ? ` ${param.param}` : ""} is missing required field: label`);
     }
-    if (param.type && !_.includes(ParamType, param.type)) {
+     enum InputParamType {
+       SELECT = "select",
+       MULTISELECT = "multiselect",
+       STRING = "string"
+     }
+    if (param.type && !_.includes(InputParamType, param.type)) {
       errors.push(
         `Invalid type ${param.type} for param${
           param.param ? ` ${param.param}` : ""
         }. Valid types are ${_.values(ParamType).join(", ")}`
       );
     }
-    if (!param.type || param.type == ParamType.STRING) {
+    if (!param.type || param.type == InputParamType.STRING) {
       // ParamType defaults to STRING
       if (param.options) {
         errors.push(
@@ -218,7 +223,7 @@ export function validateSpec(spec: any) {
         );
       }
     }
-    if (param.type && (param.type == ParamType.SELECT || param.type == ParamType.MULTISELECT)) {
+    if (paramType && (paramType == ParamType.SELECT || paramType == ParamType.MULTISELECT)) {
       if (param.validationRegex) {
         errors.push(
           `Param${

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -452,20 +452,6 @@ describe("extensionsHelper", () => {
       }).to.throw(FirebaseError, /param/);
     });
 
-    it("should error if a param is malformed", () => {
-      const testSpec = {
-        version: "0.1.0",
-        specVersion: "v1beta",
-        params: [{}],
-        resources: [],
-        sourceUrl: "https://test-source.fake",
-      };
-
-      expect(() => {
-        extensionsHelper.validateSpec(testSpec);
-      }).to.throw(FirebaseError, /param/);
-    });
-
     it("should error if a STRING param has options.", () => {
       const testSpec = {
         version: "0.1.0",
@@ -484,7 +470,7 @@ describe("extensionsHelper", () => {
       const testSpec = {
         version: "0.1.0",
         specVersion: "v1beta",
-        params: [{ type: extensionsApi.ParamType.SELECT, validationRegex: "test" }],
+        params: [{ type: extensionsHelper.SpecParamType.SELECT, validationRegex: "test" }],
         resources: [],
         sourceUrl: "https://test-source.fake",
       };
@@ -510,7 +496,9 @@ describe("extensionsHelper", () => {
       const testSpec = {
         version: "0.1.0",
         specVersion: "v1beta",
-        params: [{ type: "string", validationRegex: "test", default: "fail" }],
+        params: [
+          { type: extensionsHelper.SpecParamType.STRING, validationRegex: "test", default: "fail" },
+        ],
         resources: [],
         sourceUrl: "https://test-source.fake",
       };


### PR DESCRIPTION
### Description
The extensions backend expects paramType to be passed in all lowercase, and returns it all uppercase. This PR changes validateSpec to match that behavior, and reverts ParamType to all uppercase to fix a regression that broke SELECT and MULTISELECT params.
	 
### Scenarios Tested
SELECT params are working again!
<img width="1436" alt="Screen Shot 2020-03-24 at 11 53 58 AM" src="https://user-images.githubusercontent.com/4635763/77465653-334f2b00-6dc6-11ea-98a1-38a6ff63a487.png">
ValidateSpec still works correctly!