### PR TITLE
Properly mock https.onCall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fixes an auth issue with `https.onCall` functions when rurntime options (`runWith`) are specified (#2059).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-* Fixes an auth issue with `https.onCall` functions when rurntime options (`runWith`) are specified (#2059).
+* Fixes an auth issue with `https.onCall` functions when runtime options (`runWith`) are specified (#2059).


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

Fixes #2059

The way we were mocking before didn't work if a `.runWith` call was chained in.  This is much more resilient.
	 
### Scenarios Tested

Used the exact setup in #2059

### Sample Commands

N/A