### PR TITLE
Fix issue with firestore emulator: ternary not supported.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Fixes an auth issue with `https.onCall` functions when runtime options (`runWith`) are specified (#2059).
+* Fixed an issue with the Firestore emulator where ternary operators were not allowed.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -45,8 +45,8 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
       cacheDir: CACHE_DIR,
       remoteUrl:
         "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.2.jar",
-      expectedSize: 63439953,
-      expectedChecksum: "aa9a62f7b586731ed7664ab42fd20038",
+      expectedSize: 89334889,
+      expectedChecksum: "e6f010eb356cbe92c97fe11098599566",
       namePrefix: "cloud-firestore-emulator",
     },
   },

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -39,12 +39,12 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.1.jar"),
-    version: "1.11.1",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.2.jar"),
+    version: "1.11.2",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.1.jar",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.2.jar",
       expectedSize: 63439953,
       expectedChecksum: "aa9a62f7b586731ed7664ab42fd20038",
       namePrefix: "cloud-firestore-emulator",


### PR DESCRIPTION
### Description

Bumps the version of the firestore emulator to include the ternary operator