### PR TITLE
Fixes logs when making a tyypo in a command

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -1,19 +1,15 @@
 import { bold } from "cli-color";
 import { CommanderStatic } from "commander";
 import { first, last, get, size, head, keys, values } from "lodash";
-import { SPLAT } from "triple-beam";
-import * as winston from "winston";
 
 import { FirebaseError } from "./error";
-import { getInheritedOption, tryStringify } from "./utils";
+import { getInheritedOption, setupLoggers } from "./utils";
 import { load } from "./rc";
 import { load as _load } from "./config";
 import { configstore } from "./configstore";
 import { detectProjectRoot } from "./detectProjectRoot";
-import logger = require("./logger");
 import track = require("./track");
 import clc = require("cli-color");
-const ansiStrip = require("cli-color/strip") as (input: string) => string;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ActionFunction = (...args: any[]) => any;
@@ -228,28 +224,7 @@ export class Command {
     if (getInheritedOption(options, "json")) {
       options.nonInteractive = true;
     } else {
-      if (process.env.DEBUG) {
-        logger.add(
-          new winston.transports.Console({
-            level: "debug",
-            format: winston.format.printf((info) => {
-              const segments = [info.message, ...(info[SPLAT] || [])].map(tryStringify);
-              return `${ansiStrip(segments.join(" "))}`;
-            }),
-          })
-        );
-      } else if (process.env.IS_FIREBASE_CLI) {
-        logger.add(
-          new winston.transports.Console({
-            level: "info",
-            format: winston.format.printf((info) =>
-              [info.message, ...(info[SPLAT] || [])]
-                .filter((chunk) => typeof chunk == "string")
-                .join(" ")
-            ),
-          })
-        );
-      }
+      setupLoggers();
     }
 
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ var program = require("commander");
 var pkg = require("../package.json");
 var clc = require("cli-color");
 var logger = require("./logger");
+var { setupLoggers } = require("./utils");
 var didYouMean = require("didyoumean");
 
 program.version(pkg.version);
@@ -67,6 +68,8 @@ var RENAMED_COMMANDS = {
 
 // Default handler, this is called when no other command action matches.
 program.action(function(_, args) {
+  setupLoggers();
+
   var cmd = args[0];
   logger.error(clc.bold.red("Error:"), clc.bold(cmd), "is not a Firebase command");
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,13 +1,13 @@
 import * as _ from "lodash";
 import * as clc from "cli-color";
 import { Readable } from "stream";
+import * as winston from "winston";
+import { SPLAT } from "triple-beam";
+const ansiStrip = require("cli-color/strip") as (input: string) => string;
 
 import { configstore } from "./configstore";
 import { FirebaseError } from "./error";
 import * as logger from "./logger";
-import * as winston from "winston";
-import { SPLAT } from "triple-beam";
-const ansiStrip = require("cli-color/strip") as (input: string) => string;
 
 const IS_WINDOWS = process.platform === "win32";
 const SUCCESS_CHAR = IS_WINDOWS ? "+" : "✔";


### PR DESCRIPTION
The winston transports never got initialized when command routing fell back to the default route so I generalized the code and manually initialized it when we're not using the `Command` class (where it's normally `add`'d)