### PR TITLE
Restore missing `apps:sdkconfig web` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fixes missing template for printing web SDK configuration.

--- a/templates/setup/web.js
+++ b/templates/setup/web.js
@@ -1,0 +1,5 @@
+// Copy and paste this into your JavaScript code to initialize the Firebase SDK.
+// You will also need to load the Firebase SDK.
+// See https://firebase.google.com/docs/web/setup for more details.
+
+firebase.initializeApp({/*--CONFIG--*/});


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

`firebase apps:sdkconfig web` was failing due to a missing template. This restores that template.