### PR TITLE
Fix `apps:sdkconfig` for web apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fix `apps:sdkconfig` by pointing it to the right template

--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -277,10 +277,13 @@ function getAppConfigResourceString(appId: string, platform: AppPlatform): strin
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseConfigFromResponse(responseBody: any, platform: AppPlatform): AppConfigurationData {
   if (platform === AppPlatform.WEB) {
-    const JS_TEMPLATE = fs.readFileSync(__dirname + "/../../templates/setup/web.js", "utf8");
+    const JS_TEMPLATE = fs.readFileSync(__dirname + "/../../templates/hosting/init.js", "utf8");
     return {
       fileName: WEB_CONFIG_FILE_NAME,
-      fileContents: JS_TEMPLATE.replace("{/*--CONFIG--*/}", JSON.stringify(responseBody, null, 2)),
+      fileContents: JS_TEMPLATE.replace(
+        "/*--CONFIG--*/",
+        `var firebaseConfig = ${JSON.stringify(responseBody, null, 2)}`
+      ),
     };
   } else if (platform === AppPlatform.ANDROID || platform === AppPlatform.IOS) {
     return {

--- a/src/test/management/apps.spec.ts
+++ b/src/test/management/apps.spec.ts
@@ -698,14 +698,14 @@ describe("App management", () => {
         apiKey: "api-key",
       };
       apiRequestStub.onFirstCall().resolves({ body: mockWebConfig });
-      readFileSyncStub.onFirstCall().returns("{/*--CONFIG--*/}");
+      readFileSyncStub.onFirstCall().returns("/*--CONFIG--*/");
 
       const configData = await getAppConfig(APP_ID, AppPlatform.WEB);
       const fileData = getAppConfigFile(configData, AppPlatform.WEB);
 
       expect(fileData).to.deep.equal({
         fileName: "google-config.js",
-        fileContents: JSON.stringify(mockWebConfig, null, 2),
+        fileContents: `var firebaseConfig = ${JSON.stringify(mockWebConfig, null, 2)}`,
       });
       expect(apiRequestStub).to.be.calledOnceWith(
         "GET",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

I note that there's also an alternative PR to this - #2087. That PR restores the older template, this one uses the in-repo one.

Fix the template name, and the templating of said template.
    
This PR fixes #2088, but creates worrying code duplication between
`src/hosting/implicitInit.ts` and `src/management/apps.ts`. It seems
like code in `src/hosting/implicitInit.ts` should use the code in
`src/management/apps.ts`, but that would break the caching in
(deprecated) `src/fetchWebSetup.ts`.
    
I'm willing to make necessary changes to tidy this up a little,
but the direction we want to take this is unclear to me.
	 
### Scenarios Tested

`firebase.js apps:sdkconfig --non-interactive web <app-id>`

### Sample Commands

None.