### PR TITLE
Allow skipping informational IAM check via env.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Allow skipping informational permissions check by setting `FIREBASE_SKIP_INFORMATIONAL_IAM`. (Fixes #2083)
+* Allows skipping informational permissions check by setting `FIREBASE_SKIP_INFORMATIONAL_IAM` environment variable. (#2083)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Allow skipping informational permissions check by setting `FIREBASE_SKIP_INFORMATIONAL_IAM`. (Fixes #2083)

--- a/src/requirePermissions.ts
+++ b/src/requirePermissions.ts
@@ -15,6 +15,14 @@ export async function requirePermissions(options: any, permissions: string[] = [
   const requiredPermissions = BASE_PERMISSIONS.concat(permissions).sort();
 
   await requireAuth(options);
+
+  if (process.env.FIREBASE_SKIP_INFORMATIONAL_IAM) {
+    debug(
+      "[iam] skipping informational IAM permission check as FIREBASE_SKIP_INFORMATIONAL_IAM is present"
+    );
+    return;
+  }
+
   debug(
     `[iam] checking project ${projectId} for permissions ${JSON.stringify(requiredPermissions)}`
   );


### PR DESCRIPTION
Fixes #2083 -- this allows an escape hatch for users who are running into issues with the informational `testIamPermissions` checks that are run before (nearly) every command. By setting the `FIREBASE_SKIP_INFORMATIONAL_IAM` (intentionally long and cumbersome) environment variable, the method will return early thus avoiding the API call.