### PR TITLE
Revive the check for package-lock.json changes.

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -101,3 +101,20 @@ jobs:
       - name: Print debug logs
         if: failure()
         run: find . -type f -name "*debug.log" | xargs cat
+
+  check-package-lock:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm install --package-lock-only
+    - run: "git diff --exit-code -- package-lock.json || (echo 'Error: package-lock.json is changed during npm install! Please make sure to use npm >= 6.9.0 and commit package-lock.json.' && false)"


### PR DESCRIPTION
This PR brings back the check for package-lock.json changes, which we did not port over when we migrated to GitHub Actions.

It catches unwanted changes, like those ones highlighted by #2096. For more background, see #1460 for why the check helps.

The action definition here is tried-and-true on firebase-tools-ui and has caught real issues. The check is really fast and it won't slow the build down thanks to the parallel execution on Github Actions.