### PR TITLE
prefer arrow fns, turn off `no-var` in `.js` files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,12 +16,14 @@ module.exports = {
   rules: {
     "jsdoc/newline-after-description": "off",
     "jsdoc/require-jsdoc": ["warn", { publicOnly: true }],
-    "prettier/prettier": "error",
-    "valid-jsdoc": "off", // This is deprecated but included in recommended configs.
-    "require-jsdoc": "off", // This rule is deprecated and superseded by jsdoc/require-jsdoc.
-    "require-atomic-updates": "off", // This rule is so noisy and isn't useful: https://github.com/eslint/eslint/issues/11899
-    "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
     "no-restricted-globals": ["error", "name", "length"],
+    "prefer-arrow-callback": "error",
+    "prettier/prettier": "error",
+    "require-atomic-updates": "off", // This rule is so noisy and isn't useful: https://github.com/eslint/eslint/issues/11899
+    "require-jsdoc": "off", // This rule is deprecated and superseded by jsdoc/require-jsdoc.
+    "valid-jsdoc": "off", // This is deprecated but included in recommended configs.
+
+    "no-prototype-builtins": "warn", // TODO(bkendall): remove, allow to error.
     "no-useless-escape": "warn", // TODO(bkendall): remove, allow to error.
     "prefer-const": "warn", // TODO(bkendall): remove, allow to error.
     "prefer-promise-reject-errors": "warn", // TODO(bkendall): remove, allow to error.
@@ -30,6 +32,9 @@ module.exports = {
     {
       files: ["*.ts"],
       rules: {
+        "jsdoc/require-param-type": "off",
+        "jsdoc/require-returns-type": "off",
+
         "@typescript-eslint/await-thenable": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/ban-types": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/camelcase": "warn", // TODO(bkendall): remove, allow to error.
@@ -46,8 +51,6 @@ module.exports = {
         "@typescript-eslint/require-await": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/unbound-method": "warn", // TODO(bkendall): remove, allow to error.
         camelcase: "warn", // TODO(bkendall): remove, allow to error.
-        "jsdoc/require-param-type": "off",
-        "jsdoc/require-returns-type": "off",
         "new-cap": "warn", // TODO(bkendall): remove, allow to error.
         "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
         "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
@@ -68,8 +71,10 @@ module.exports = {
         "@typescript-eslint/prefer-includes": "off",
         "@typescript-eslint/prefer-regexp-exec": "off",
         "@typescript-eslint/unbound-method": "off",
+
         "no-invalid-this": "warn", // TODO(bkendall): remove, allow to error.
         "no-var": "warn", // TODO(bkendall): remove, allow to error.
+        "prefer-arrow-callback": "warn", // TODO(bkendall): remove, allow to error.
       },
     },
     {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -73,8 +73,8 @@ module.exports = {
         "@typescript-eslint/unbound-method": "off",
 
         "no-invalid-this": "warn", // TODO(bkendall): remove, allow to error.
-        "no-var": "warn", // TODO(bkendall): remove, allow to error.
-        "prefer-arrow-callback": "warn", // TODO(bkendall): remove, allow to error.
+        "no-var": "off", // TODO(bkendall): remove, allow to error.
+        "prefer-arrow-callback": "off", // TODO(bkendall): remove, allow to error.
       },
     },
     {

--- a/scripts/extensions-emulator-tests/test.spec.ts
+++ b/scripts/extensions-emulator-tests/test.spec.ts
@@ -163,7 +163,7 @@ class TriggerEndToEndTest {
 
     const req = request.get(url);
 
-    req.on("response", function(response: request.Response) {
+    req.on("response", (response: request.Response) => {
       response.body = "";
       response.on("data", (data) => {
         response.body += data.toString();
@@ -173,7 +173,7 @@ class TriggerEndToEndTest {
       });
     });
 
-    req.once("error", function(err: Error) {
+    req.once("error", (err: Error) => {
       done(err);
     });
   }
@@ -203,7 +203,7 @@ class TriggerEndToEndTest {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function readConfig(configPath: string, done: (err: any, conf?: Config) => any): void {
-  fs.readFile(configPath, function(err: Error | null, data: Buffer) {
+  fs.readFile(configPath, (err: Error | null, data: Buffer) => {
     if (err) {
       done(err);
       return;
@@ -219,7 +219,7 @@ function readConfig(configPath: string, done: (err: any, conf?: Config) => any):
   });
 }
 
-describe("extension emulator", function() {
+describe("extension emulator", () => {
   let test: TriggerEndToEndTest;
 
   before(function(done) {
@@ -231,10 +231,7 @@ describe("extension emulator", function() {
     async.series(
       [
         function(done: (err?: Error) => void) {
-          readConfig(`${EXTENSION_ROOT}/${TEST_CONFIG_FILE}`, function(
-            err: Error,
-            config?: Config
-          ) {
+          readConfig(`${EXTENSION_ROOT}/${TEST_CONFIG_FILE}`, (err: Error, config?: Config) => {
             if (err) {
               done(new Error("Error reading test config: " + err));
               return;
@@ -265,14 +262,14 @@ describe("extension emulator", function() {
     done();
   });
 
-  it("should execute an HTTP function", function(done) {
-    test.invokeHttpFunction(TEST_FUNCTION_NAME, function(
-      err: Error | null,
-      response?: request.Response
-    ) {
-      expect(response?.statusCode).to.equal(200);
-      expect(response?.body).to.equal("Hello World from greet-the-world");
-      done(err);
-    });
+  it("should execute an HTTP function", (done) => {
+    test.invokeHttpFunction(
+      TEST_FUNCTION_NAME,
+      (err: Error | null, response?: request.Response) => {
+        expect(response?.statusCode).to.equal(200);
+        expect(response?.body).to.equal("Hello World from greet-the-world");
+        done(err);
+      }
+    );
   }).timeout(EMULATOR_TEST_TIMEOUT);
 });

--- a/src/deploy/storage/release.ts
+++ b/src/deploy/storage/release.ts
@@ -17,11 +17,9 @@ export default async function(context: any, options: any): Promise<void> {
   const toRelease: Array<{ bucket: string; rules: any }> = [];
   for (const ruleConfig of rules) {
     if (ruleConfig.target) {
-      options.rc
-        .target(options.project, "storage", ruleConfig.target)
-        .forEach(function(bucket: string) {
-          toRelease.push({ bucket: bucket, rules: ruleConfig.rules });
-        });
+      options.rc.target(options.project, "storage", ruleConfig.target).forEach((bucket: string) => {
+        toRelease.push({ bucket: bucket, rules: ruleConfig.rules });
+      });
     } else {
       toRelease.push({ bucket: ruleConfig.bucket, rules: ruleConfig.rules });
     }

--- a/src/errorOut.ts
+++ b/src/errorOut.ts
@@ -18,7 +18,7 @@ export function errorOut(error: Error): void {
 
   logError(fbError);
   process.exitCode = fbError.exit || 2;
-  setTimeout(function() {
+  setTimeout(() => {
     process.exit();
   }, 250);
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you. 

-->


### Description

1. Sets preference for arrow functions in callbacks in TS files.
1. Turns off `no-var` checking in JS files (which silences ~1500 messages).

Turning off `no-var`: since we're really trying to move to TS, I don't think it's worth being super noisy about `var`. New code should fix it as is required, but we're not going to go clean these up (and I don't want to automatically do it because then it touches nearly every file's history again, which is not super useful)