### PR TITLE
Finish env overrides for DB commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Improves error messages for Cloud Functions for Firebase deployment permissions. (#2086)
-- Makes Firestore commands respect `FIRESTORE_EMULATOR_HOST` when appropriate.
+- Makes `firestore:delete` respect `FIRESTORE_EMULATOR_HOST`.
+- Makes `database:get`, `database:set`, `database:push`, and `database:update` respect `FIREBASE_DATABASE_EMULATOR_HOST`.

--- a/src/api.js
+++ b/src/api.js
@@ -122,16 +122,14 @@ var api = {
     "https://extensions-registry.firebaseapp.com"
   ),
   firedataOrigin: utils.envOverride("FIREBASE_FIREDATA_URL", "https://mobilesdk-pa.googleapis.com"),
-  firestoreOrigin: utils.envOverride(
-    "FIRESTORE_URL",
-    utils.envOverride(
-      Constants.FIRESTORE_EMULATOR_HOST,
-      "https://firestore.googleapis.com",
-      (val) => {
-        return `http://${val}`;
-      }
-    )
+  firestoreOriginOrEmulator: utils.envOverride(
+    Constants.FIRESTORE_EMULATOR_HOST,
+    "https://firestore.googleapis.com",
+    (val) => {
+      return `http://${val}`;
+    }
   ),
+  firestoreOrigin: utils.envOverride("FIRESTORE_URL", "https://firestore.googleapis.com"),
   functionsOrigin: utils.envOverride(
     "FIREBASE_FUNCTIONS_URL",
     "https://cloudfunctions.googleapis.com"
@@ -150,6 +148,13 @@ var api = {
   extensionsOrigin: utils.envOverride(
     "FIREBASE_EXT_URL",
     "https://firebaseextensions.googleapis.com"
+  ),
+  realtimeOriginOrEmulator: utils.envOverride(
+    Constants.FIREBASE_DATABASE_EMULATOR_HOST,
+    "https://firebaseio.com",
+    (val) => {
+      return `http://${val}`;
+    }
   ),
   realtimeOrigin: utils.envOverride("FIREBASE_REALTIME_URL", "https://firebaseio.com"),
   rtdbMetadataOrigin: utils.envOverride(

--- a/src/commands/database-get.js
+++ b/src/commands/database-get.js
@@ -8,7 +8,8 @@ var api = require("../api");
 var responseToError = require("../responseToError");
 var logger = require("../logger");
 var { FirebaseError } = require("../error");
-var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
+var { Emulators } = require("../emulator/types");
+var { printNoticeIfEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var _ = require("lodash");
@@ -56,7 +57,7 @@ module.exports = new Command("database:get <path>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.get"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, true)
+  .before(printNoticeIfEmulated, Emulators.DATABASE)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/src/commands/database-get.js
+++ b/src/commands/database-get.js
@@ -14,6 +14,7 @@ var { printNoticeIfEmulated } = require("../emulator/commandUtils");
 var utils = require("../utils");
 var _ = require("lodash");
 var fs = require("fs");
+var url = require("url");
 
 var _applyStringOpts = function(dest, src, keys, jsonKeys) {
   _.forEach(keys, function(key) {
@@ -87,7 +88,7 @@ module.exports = new Command("database:get <path>")
       ["orderBy", "startAt", "endAt", "equalTo"]
     );
 
-    const urlObj = new URL(url);
+    const urlObj = new url.URL(url);
     Object.keys(query).forEach((key) => {
       urlObj.searchParams.set(key, query[key]);
     });

--- a/src/commands/database-get.js
+++ b/src/commands/database-get.js
@@ -64,7 +64,11 @@ module.exports = new Command("database:get <path>")
       return utils.reject("Path must begin with /", { exit: 1 });
     }
 
-    let url = utils.getDatabaseUrl(api.realtimeOriginOrEmulator, options.instance, path + ".json");
+    let dbUrl = utils.getDatabaseUrl(
+      api.realtimeOriginOrEmulator,
+      options.instance,
+      path + ".json"
+    );
     var query = {};
     if (options.shallow) {
       query.shallow = "true";
@@ -88,16 +92,16 @@ module.exports = new Command("database:get <path>")
       ["orderBy", "startAt", "endAt", "equalTo"]
     );
 
-    const urlObj = new url.URL(url);
+    const urlObj = new url.URL(dbUrl);
     Object.keys(query).forEach((key) => {
       urlObj.searchParams.set(key, query[key]);
     });
 
-    url = urlObj.href;
+    dbUrl = urlObj.href;
 
-    logger.debug("Query URL: ", url);
+    logger.debug("Query URL: ", dbUrl);
     var reqOptions = {
-      url: url,
+      url: dbUrl,
     };
 
     return api.addRequestHeaders(reqOptions).then(function(reqOptionsWithToken) {

--- a/src/commands/database-instances-create.ts
+++ b/src/commands/database-instances-create.ts
@@ -3,10 +3,12 @@ import logger = require("../logger");
 import { requirePermissions } from "../requirePermissions";
 import getProjectNumber = require("../getProjectNumber");
 import firedata = require("../gcp/firedata");
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:instances:create <instanceName>")
   .description("create a realtime database instance")
   .before(requirePermissions, ["firebasedatabase.instances.create"])
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(async (instanceName: string, options: any) => {
     const projectNumber = await getProjectNumber(options);
     const instance = await firedata.createDatabaseInstance(projectNumber, instanceName);

--- a/src/commands/database-instances-create.ts
+++ b/src/commands/database-instances-create.ts
@@ -3,12 +3,13 @@ import logger = require("../logger");
 import { requirePermissions } from "../requirePermissions";
 import getProjectNumber = require("../getProjectNumber");
 import firedata = require("../gcp/firedata");
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
 
 export default new Command("database:instances:create <instanceName>")
   .description("create a realtime database instance")
   .before(requirePermissions, ["firebasedatabase.instances.create"])
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (instanceName: string, options: any) => {
     const projectNumber = await getProjectNumber(options);
     const instance = await firedata.createDatabaseInstance(projectNumber, instanceName);

--- a/src/commands/database-instances-list.ts
+++ b/src/commands/database-instances-list.ts
@@ -3,12 +3,13 @@ import logger = require("../logger");
 import { requirePermissions } from "../requirePermissions";
 import getProjectNumber = require("../getProjectNumber");
 import firedata = require("../gcp/firedata");
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:instances:list")
   .description("list realtime database instances")
   .before(requirePermissions, ["firebasedatabase.instances.list"])
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (options: any) => {
     const projectNumber = await getProjectNumber(options);
     const instances = await firedata.listDatabaseInstances(projectNumber);

--- a/src/commands/database-instances-list.ts
+++ b/src/commands/database-instances-list.ts
@@ -3,10 +3,12 @@ import logger = require("../logger");
 import { requirePermissions } from "../requirePermissions";
 import getProjectNumber = require("../getProjectNumber");
 import firedata = require("../gcp/firedata");
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:instances:list")
   .description("list realtime database instances")
   .before(requirePermissions, ["firebasedatabase.instances.list"])
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(async (options: any) => {
     const projectNumber = await getProjectNumber(options);
     const instances = await firedata.listDatabaseInstances(projectNumber);

--- a/src/commands/database-profile.js
+++ b/src/commands/database-profile.js
@@ -7,7 +7,8 @@ var requireInstance = require("../requireInstance");
 var { requirePermissions } = require("../requirePermissions");
 var utils = require("../utils");
 var profiler = require("../profiler");
-var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
+var { Emulators } = require("../emulator/types");
+var { warnEmulatorNotSupported } = require("../emulator/commandUtils");
 
 var description = "profile the Realtime Database and generate a usage report";
 
@@ -31,7 +32,7 @@ module.exports = new Command("database:profile")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(function(options) {
     // Validate options
     if (options.raw && options.input) {

--- a/src/commands/database-profile.js
+++ b/src/commands/database-profile.js
@@ -7,6 +7,7 @@ var requireInstance = require("../requireInstance");
 var { requirePermissions } = require("../requirePermissions");
 var utils = require("../utils");
 var profiler = require("../profiler");
+var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
 
 var description = "profile the Realtime Database and generate a usage report";
 
@@ -30,6 +31,7 @@ module.exports = new Command("database:profile")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(function(options) {
     // Validate options
     if (options.raw && options.input) {

--- a/src/commands/database-push.js
+++ b/src/commands/database-push.js
@@ -7,6 +7,7 @@ var request = require("request");
 var api = require("../api");
 var responseToError = require("../responseToError");
 var { FirebaseError } = require("../error");
+var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var clc = require("cli-color");
@@ -23,6 +24,7 @@ module.exports = new Command("database:push <path> [infile]")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, true)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });
@@ -30,7 +32,9 @@ module.exports = new Command("database:push <path> [infile]")
 
     var inStream =
       utils.stringToStream(options.data) || (infile ? fs.createReadStream(infile) : process.stdin);
-    var url = utils.addSubdomain(api.realtimeOrigin, options.instance) + path + ".json?";
+
+    const origin = api.realtimeOriginOrEmulator;
+    var url = utils.getDatabaseUrl(origin, options.instance, path + ".json");
 
     if (!infile && !options.data) {
       utils.explainStdin();
@@ -60,7 +64,11 @@ module.exports = new Command("database:push <path> [infile]")
               path += "/";
             }
 
-            var consoleUrl = utils.consoleUrl(options.project, "/database/data" + path + body.name);
+            var consoleUrl = utils.getDatabaseViewDataUrl(
+              origin,
+              options.instance,
+              path + body.name
+            );
 
             utils.logSuccess("Data pushed successfully");
             logger.info();

--- a/src/commands/database-push.js
+++ b/src/commands/database-push.js
@@ -7,7 +7,8 @@ var request = require("request");
 var api = require("../api");
 var responseToError = require("../responseToError");
 var { FirebaseError } = require("../error");
-var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
+var { Emulators } = require("../emulator/types");
+var { printNoticeIfEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var clc = require("cli-color");
@@ -24,7 +25,7 @@ module.exports = new Command("database:push <path> [infile]")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, true)
+  .before(printNoticeIfEmulated, Emulators.DATABASE)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/src/commands/database-remove.js
+++ b/src/commands/database-remove.js
@@ -5,7 +5,8 @@ var requireInstance = require("../requireInstance");
 var { requirePermissions } = require("../requirePermissions");
 var DatabaseRemove = require("../database/remove").default;
 var api = require("../api");
-var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
+var { Emulators } = require("../emulator/types");
+var { warnEmulatorNotSupported } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var { prompt } = require("../prompt");
@@ -21,7 +22,7 @@ module.exports = new Command("database:remove <path>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/src/commands/database-remove.js
+++ b/src/commands/database-remove.js
@@ -5,6 +5,7 @@ var requireInstance = require("../requireInstance");
 var { requirePermissions } = require("../requirePermissions");
 var DatabaseRemove = require("../database/remove").default;
 var api = require("../api");
+var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var { prompt } = require("../prompt");
@@ -20,6 +21,7 @@ module.exports = new Command("database:remove <path>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(function(path, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/src/commands/database-rules-canary.ts
+++ b/src/commands/database-rules-canary.ts
@@ -3,6 +3,7 @@ import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:rules:canary <rulesetId>")
   .description("mark a staged ruleset as the canary ruleset")
@@ -12,6 +13,7 @@ export default new Command("database:rules:canary <rulesetId>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(async (rulesetId: string, options: any) => {
     const oldLabels = await metadata.getRulesetLabels(options.instance);
     const newLabels = {

--- a/src/commands/database-rules-canary.ts
+++ b/src/commands/database-rules-canary.ts
@@ -1,9 +1,9 @@
 import { Command } from "../command";
-import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:rules:canary <rulesetId>")
   .description("mark a staged ruleset as the canary ruleset")
@@ -13,7 +13,7 @@ export default new Command("database:rules:canary <rulesetId>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (rulesetId: string, options: any) => {
     const oldLabels = await metadata.getRulesetLabels(options.instance);
     const newLabels = {

--- a/src/commands/database-rules-get.ts
+++ b/src/commands/database-rules-get.ts
@@ -3,7 +3,8 @@ import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:rules:get <rulesetId>")
   .description("get a realtime database ruleset by id")
@@ -13,7 +14,7 @@ export default new Command("database:rules:get <rulesetId>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.get"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (rulesetId: metadata.RulesetId, options: any) => {
     const ruleset = await metadata.getRuleset(options.instance, rulesetId);
     logger.info(`Ruleset ${ruleset.id} was created at ${ruleset.createdAt}`);

--- a/src/commands/database-rules-get.ts
+++ b/src/commands/database-rules-get.ts
@@ -3,6 +3,7 @@ import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:rules:get <rulesetId>")
   .description("get a realtime database ruleset by id")
@@ -12,6 +13,7 @@ export default new Command("database:rules:get <rulesetId>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.get"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(async (rulesetId: metadata.RulesetId, options: any) => {
     const ruleset = await metadata.getRuleset(options.instance, rulesetId);
     logger.info(`Ruleset ${ruleset.id} was created at ${ruleset.createdAt}`);

--- a/src/commands/database-rules-list.ts
+++ b/src/commands/database-rules-list.ts
@@ -3,7 +3,8 @@ import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:rules:list")
   .description("list realtime database rulesets")
@@ -13,7 +14,7 @@ export default new Command("database:rules:list")
   )
   .before(requirePermissions, ["firebasedatabase.instances.get"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (options: any) => {
     const labeled = await metadata.getRulesetLabels(options.instance);
     const rulesets = await metadata.listAllRulesets(options.instance);

--- a/src/commands/database-rules-list.ts
+++ b/src/commands/database-rules-list.ts
@@ -3,6 +3,7 @@ import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:rules:list")
   .description("list realtime database rulesets")
@@ -12,6 +13,7 @@ export default new Command("database:rules:list")
   )
   .before(requirePermissions, ["firebasedatabase.instances.get"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(async (options: any) => {
     const labeled = await metadata.getRulesetLabels(options.instance);
     const rulesets = await metadata.listAllRulesets(options.instance);

--- a/src/commands/database-rules-release.ts
+++ b/src/commands/database-rules-release.ts
@@ -1,9 +1,9 @@
 import { Command } from "../command";
-import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:rules:release <rulesetId>")
   .description("mark a staged ruleset as the stable ruleset")
@@ -13,7 +13,7 @@ export default new Command("database:rules:release <rulesetId>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (rulesetId: string, options: any) => {
     const oldLabels = await metadata.getRulesetLabels(options.instance);
     const newLabels = {

--- a/src/commands/database-rules-release.ts
+++ b/src/commands/database-rules-release.ts
@@ -3,6 +3,7 @@ import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:rules:release <rulesetId>")
   .description("mark a staged ruleset as the stable ruleset")
@@ -12,6 +13,7 @@ export default new Command("database:rules:release <rulesetId>")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(async (rulesetId: string, options: any) => {
     const oldLabels = await metadata.getRulesetLabels(options.instance);
     const newLabels = {

--- a/src/commands/database-rules-stage.ts
+++ b/src/commands/database-rules-stage.ts
@@ -5,7 +5,8 @@ import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:rules:stage")
   .description("create a new realtime database ruleset")
@@ -15,7 +16,7 @@ export default new Command("database:rules:stage")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (options: any) => {
     const filepath = options.config.data.database.rules;
     logger.info(`staging ruleset from ${filepath}`);

--- a/src/commands/database-rules-stage.ts
+++ b/src/commands/database-rules-stage.ts
@@ -5,6 +5,7 @@ import { requirePermissions } from "../requirePermissions";
 import * as metadata from "../database/metadata";
 import * as fs from "fs-extra";
 import * as path from "path";
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:rules:stage")
   .description("create a new realtime database ruleset")
@@ -14,6 +15,7 @@ export default new Command("database:rules:stage")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action(async (options: any) => {
     const filepath = options.config.data.database.rules;
     logger.info(`staging ruleset from ${filepath}`);

--- a/src/commands/database-set.js
+++ b/src/commands/database-set.js
@@ -7,7 +7,8 @@ var request = require("request");
 var api = require("../api");
 var responseToError = require("../responseToError");
 var { FirebaseError } = require("../error");
-var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
+var { Emulators } = require("../emulator/types");
+var { printNoticeIfEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var clc = require("cli-color");
@@ -26,7 +27,7 @@ module.exports = new Command("database:set <path> [infile]")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, true)
+  .before(printNoticeIfEmulated, Emulators.DATABASE)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/src/commands/database-set.js
+++ b/src/commands/database-set.js
@@ -7,6 +7,7 @@ var request = require("request");
 var api = require("../api");
 var responseToError = require("../responseToError");
 var { FirebaseError } = require("../error");
+var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var clc = require("cli-color");
@@ -25,20 +26,22 @@ module.exports = new Command("database:set <path> [infile]")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, true)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });
     }
+
+    const origin = api.realtimeOriginOrEmulator;
+    const dbPath = utils.getDatabaseUrl(origin, options.instance, path);
+    const dbJsonPath = utils.getDatabaseUrl(origin, options.instance, path + ".json");
 
     return prompt(options, [
       {
         type: "confirm",
         name: "confirm",
         default: false,
-        message:
-          "You are about to overwrite all data at " +
-          clc.cyan(utils.addSubdomain(api.realtimeOrigin, options.instance) + path) +
-          ". Are you sure?",
+        message: "You are about to overwrite all data at " + clc.cyan(dbPath) + ". Are you sure?",
       },
     ]).then(function() {
       if (!options.confirm) {
@@ -48,14 +51,13 @@ module.exports = new Command("database:set <path> [infile]")
       var inStream =
         utils.stringToStream(options.data) ||
         (infile ? fs.createReadStream(infile) : process.stdin);
-      var url = utils.addSubdomain(api.realtimeOrigin, options.instance) + path + ".json?";
 
       if (!infile && !options.data) {
         utils.explainStdin();
       }
 
       var reqOptions = {
-        url: url,
+        url: dbJsonPath,
         json: true,
       };
 
@@ -65,6 +67,7 @@ module.exports = new Command("database:set <path> [infile]")
             request.put(reqOptionsWithToken, function(err, res, body) {
               logger.info();
               if (err) {
+                logger.debug(err);
                 return reject(
                   new FirebaseError("Unexpected error while setting data", {
                     exit: 2,
@@ -78,7 +81,7 @@ module.exports = new Command("database:set <path> [infile]")
               logger.info();
               logger.info(
                 clc.bold("View data at:"),
-                utils.consoleUrl(options.project, "/database/data" + path)
+                utils.getDatabaseViewDataUrl(origin, options.instance, path)
               );
               return resolve();
             })

--- a/src/commands/database-settings-get.ts
+++ b/src/commands/database-settings-get.ts
@@ -4,7 +4,6 @@ import * as request from "request";
 
 import * as responseToError from "../responseToError";
 import { Command } from "../command";
-import * as logger from "../logger";
 import { FirebaseError } from "../error";
 import { requirePermissions } from "../requirePermissions";
 import * as utils from "../utils";
@@ -16,7 +15,8 @@ import {
   HELP_TEXT,
   INVALID_PATH_ERROR,
 } from "../database/settings";
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:settings:get <path>")
   .description("read the realtime database setting at path")
@@ -27,7 +27,7 @@ export default new Command("database:settings:get <path>")
   .help(HELP_TEXT)
   .before(requirePermissions, ["firebasedatabase.instances.get"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action((path: string, options: any) => {
     if (!DATABASE_SETTINGS.has(path)) {
       return utils.reject(INVALID_PATH_ERROR, { exit: 1 });

--- a/src/commands/database-settings-get.ts
+++ b/src/commands/database-settings-get.ts
@@ -16,6 +16,7 @@ import {
   HELP_TEXT,
   INVALID_PATH_ERROR,
 } from "../database/settings";
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:settings:get <path>")
   .description("read the realtime database setting at path")
@@ -26,6 +27,7 @@ export default new Command("database:settings:get <path>")
   .help(HELP_TEXT)
   .before(requirePermissions, ["firebasedatabase.instances.get"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action((path: string, options: any) => {
     if (!DATABASE_SETTINGS.has(path)) {
       return utils.reject(INVALID_PATH_ERROR, { exit: 1 });

--- a/src/commands/database-settings-set.ts
+++ b/src/commands/database-settings-set.ts
@@ -16,6 +16,7 @@ import {
   HELP_TEXT,
   INVALID_PATH_ERROR,
 } from "../database/settings";
+import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
 
 export default new Command("database:settings:set <path> <value>")
   .description("set the realtime database setting at path.")
@@ -26,6 +27,7 @@ export default new Command("database:settings:set <path> <value>")
   .help(HELP_TEXT)
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, false)
   .action((path: string, value: string, options: any) => {
     const setting = DATABASE_SETTINGS.get(path);
     if (setting === undefined) {

--- a/src/commands/database-settings-set.ts
+++ b/src/commands/database-settings-set.ts
@@ -16,7 +16,8 @@ import {
   HELP_TEXT,
   INVALID_PATH_ERROR,
 } from "../database/settings";
-import { warnRealtimeDatabaseEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 export default new Command("database:settings:set <path> <value>")
   .description("set the realtime database setting at path.")
@@ -27,7 +28,7 @@ export default new Command("database:settings:set <path> <value>")
   .help(HELP_TEXT)
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action((path: string, value: string, options: any) => {
     const setting = DATABASE_SETTINGS.get(path);
     if (setting === undefined) {

--- a/src/commands/database-update.js
+++ b/src/commands/database-update.js
@@ -7,7 +7,8 @@ var request = require("request");
 var api = require("../api");
 var responseToError = require("../responseToError");
 var { FirebaseError } = require("../error");
-var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
+var { Emulators } = require("../emulator/types");
+var { printNoticeIfEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var clc = require("cli-color");
@@ -26,7 +27,7 @@ module.exports = new Command("database:update <path> [infile]")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
-  .before(warnRealtimeDatabaseEmulated, true)
+  .before(printNoticeIfEmulated, Emulators.DATABASE)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });

--- a/src/commands/database-update.js
+++ b/src/commands/database-update.js
@@ -7,6 +7,7 @@ var request = require("request");
 var api = require("../api");
 var responseToError = require("../responseToError");
 var { FirebaseError } = require("../error");
+var { warnRealtimeDatabaseEmulated } = require("../emulator/commandUtils");
 
 var utils = require("../utils");
 var clc = require("cli-color");
@@ -25,20 +26,20 @@ module.exports = new Command("database:update <path> [infile]")
   )
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireInstance)
+  .before(warnRealtimeDatabaseEmulated, true)
   .action(function(path, infile, options) {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });
     }
 
+    const origin = api.realtimeOriginOrEmulator;
+    const url = utils.getDatabaseUrl(origin, options.instance, path);
     return prompt(options, [
       {
         type: "confirm",
         name: "confirm",
         default: false,
-        message:
-          "You are about to modify data at " +
-          clc.cyan(utils.addSubdomain(api.realtimeOrigin, options.instance) + path) +
-          ". Are you sure?",
+        message: "You are about to modify data at " + clc.cyan(url) + ". Are you sure?",
       },
     ]).then(function() {
       if (!options.confirm) {
@@ -48,14 +49,14 @@ module.exports = new Command("database:update <path> [infile]")
       var inStream =
         utils.stringToStream(options.data) ||
         (infile ? fs.createReadStream(infile) : process.stdin);
-      var url = utils.addSubdomain(api.realtimeOrigin, options.instance) + path + ".json?";
+      var jsonUrl = utils.getDatabaseUrl(origin, options.instance, path + ".json");
 
       if (!infile && !options.data) {
         utils.explainStdin();
       }
 
       var reqOptions = {
-        url: url,
+        url: jsonUrl,
         json: true,
       };
 
@@ -78,7 +79,7 @@ module.exports = new Command("database:update <path> [infile]")
               logger.info();
               logger.info(
                 clc.bold("View data at:"),
-                utils.consoleUrl(options.project, "/database/data" + path)
+                utils.getDatabaseViewDataUrl(origin, options.project, path)
               );
               return resolve();
             })

--- a/src/commands/firestore-delete.ts
+++ b/src/commands/firestore-delete.ts
@@ -2,7 +2,8 @@
 
 import * as clc from "cli-color";
 import { Command } from "../command";
-import { warnFirestoreEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { printNoticeIfEmulated } from "../emulator/commandUtils";
 import * as FirestoreDelete from "../firestore/delete";
 import { prompt } from "../prompt";
 import { requirePermissions } from "../requirePermissions";
@@ -71,7 +72,7 @@ module.exports = new Command("firestore:delete [path]")
       "including all collections and documents. Any other flags or arguments will be ignored."
   )
   .option("-y, --yes", "No confirmation. Otherwise, a confirmation prompt will appear.")
-  .before(warnFirestoreEmulated, true)
+  .before(printNoticeIfEmulated, Emulators.FIRESTORE)
   .before(requirePermissions, ["datastore.entities.list", "datastore.entities.delete"])
   .action(async (path: string | undefined, options: any) => {
     // Guarantee path

--- a/src/commands/firestore-delete.ts
+++ b/src/commands/firestore-delete.ts
@@ -2,7 +2,7 @@
 
 import * as clc from "cli-color";
 import { Command } from "../command";
-import * as commandUtils from "../emulator/commandUtils";
+import { warnFirestoreEmulated } from "../emulator/commandUtils";
 import * as FirestoreDelete from "../firestore/delete";
 import { prompt } from "../prompt";
 import { requirePermissions } from "../requirePermissions";
@@ -71,7 +71,7 @@ module.exports = new Command("firestore:delete [path]")
       "including all collections and documents. Any other flags or arguments will be ignored."
   )
   .option("-y, --yes", "No confirmation. Otherwise, a confirmation prompt will appear.")
-  .before(commandUtils.warnFirestoreEmulated)
+  .before(warnFirestoreEmulated, true)
   .before(requirePermissions, ["datastore.entities.list", "datastore.entities.delete"])
   .action(async (path: string | undefined, options: any) => {
     // Guarantee path

--- a/src/commands/firestore-indexes-list.ts
+++ b/src/commands/firestore-indexes-list.ts
@@ -3,7 +3,8 @@ import * as clc from "cli-color";
 import * as fsi from "../firestore/indexes";
 import * as logger from "../logger";
 import { requirePermissions } from "../requirePermissions";
-import { warnFirestoreEmulated } from "../emulator/commandUtils";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
 module.exports = new Command("firestore:indexes")
   .description("List indexes in your project's Cloud Firestore database.")
@@ -13,7 +14,7 @@ module.exports = new Command("firestore:indexes")
       "JSON specification format."
   )
   .before(requirePermissions, ["datastore.indexes.list"])
-  .before(warnFirestoreEmulated, false)
+  .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (options: any) => {
     const indexApi = new fsi.FirestoreIndexes();
 

--- a/src/commands/firestore-indexes-list.ts
+++ b/src/commands/firestore-indexes-list.ts
@@ -3,6 +3,7 @@ import * as clc from "cli-color";
 import * as fsi from "../firestore/indexes";
 import * as logger from "../logger";
 import { requirePermissions } from "../requirePermissions";
+import { warnFirestoreEmulated } from "../emulator/commandUtils";
 
 module.exports = new Command("firestore:indexes")
   .description("List indexes in your project's Cloud Firestore database.")
@@ -12,6 +13,7 @@ module.exports = new Command("firestore:indexes")
       "JSON specification format."
   )
   .before(requirePermissions, ["datastore.indexes.list"])
+  .before(warnFirestoreEmulated, false)
   .action(async (options: any) => {
     const indexApi = new fsi.FirestoreIndexes();
 

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -50,7 +50,6 @@ export function warnRealtimeDatabaseEmulated(
   options: any,
   emulatorSupported: boolean
 ): void | Promise<void> {
-  console.log("SUPPORTED: ", emulatorSupported);
   const envKey = Constants.FIREBASE_DATABASE_EMULATOR_HOST;
   const envVal = process.env[envKey];
   if (envVal) {

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -46,7 +46,7 @@ export const DESC_TEST_PARAMS =
  */
 const DEFAULT_CONFIG = new Config({ database: {}, firestore: {}, functions: {}, hosting: {} }, {});
 
-export function printNoticeIfEmulated(options: any, emulator: Emulators): void {
+export function printNoticeIfEmulated(options: any, emulator: Emulators.DATABASE | Emulators.FIRESTORE): void {
   if (emulator !== Emulators.DATABASE && emulator !== Emulators.FIRESTORE) {
     return;
   }

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -52,7 +52,10 @@ export function printNoticeIfEmulated(options: any, emulator: Emulators): void {
   }
 
   const emuName = Constants.description(emulator);
-  const envKey = emulator === Emulators.DATABASE ? Constants.FIREBASE_DATABASE_EMULATOR_HOST : Constants.FIRESTORE_EMULATOR_HOST;
+  const envKey =
+    emulator === Emulators.DATABASE
+      ? Constants.FIREBASE_DATABASE_EMULATOR_HOST
+      : Constants.FIRESTORE_EMULATOR_HOST;
   const envVal = process.env[envKey];
   if (envVal) {
     utils.logBullet(
@@ -69,7 +72,10 @@ export function warnEmulatorNotSupported(options: any, emulator: Emulators): voi
   }
 
   const emuName = Constants.description(emulator);
-  const envKey = emulator === Emulators.DATABASE ? Constants.FIREBASE_DATABASE_EMULATOR_HOST : Constants.FIRESTORE_EMULATOR_HOST;
+  const envKey =
+    emulator === Emulators.DATABASE
+      ? Constants.FIREBASE_DATABASE_EMULATOR_HOST
+      : Constants.FIRESTORE_EMULATOR_HOST;
   const envVal = process.env[envKey];
 
   if (envVal) {

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -13,6 +13,7 @@ import { FirebaseError } from "../error";
 import { EmulatorRegistry } from "../emulator/registry";
 import { FirestoreEmulator } from "../emulator/firestoreEmulator";
 import * as getProjectId from "../getProjectId";
+import { prompt } from "../prompt";
 import { EmulatorHub } from "./hub";
 
 export const FLAG_ONLY = "--only <emulators>";
@@ -45,27 +46,82 @@ export const DESC_TEST_PARAMS =
  */
 const DEFAULT_CONFIG = new Config({ database: {}, firestore: {}, functions: {}, hosting: {} }, {});
 
-export function warnRealtimeDatabaseEmulated(): void {
+export function warnRealtimeDatabaseEmulated(
+  options: any,
+  emulatorSupported: boolean
+): void | Promise<void> {
+  console.log("SUPPORTED: ", emulatorSupported);
   const envKey = Constants.FIREBASE_DATABASE_EMULATOR_HOST;
   const envVal = process.env[envKey];
   if (envVal) {
-    utils.logWarning(
-      `You have set ${clc.bold(
-        `${envKey}=${envVal}`
-      )}, this command will execute against the Realtime Database emulator running at that address.`
-    );
+    if (emulatorSupported) {
+      utils.logBullet(
+        `You have set ${clc.bold(
+          `${envKey}=${envVal}`
+        )}, this command will execute against the Realtime Database emulator running at that address.`
+      );
+    } else {
+      utils.logWarning(
+        `You have set ${clc.bold(
+          `${envKey}=${envVal}`
+        )}, however this command does not support running against the emulator so this action will affect production.`
+      );
+
+      const opts = {
+        confirm: undefined,
+      };
+      return prompt(opts, [
+        {
+          type: "confirm",
+          name: "confirm",
+          default: false,
+          message: "Do you want to continue?",
+        },
+      ]).then(() => {
+        if (!opts.confirm) {
+          return utils.reject("Command aborted.", { exit: 1 });
+        }
+      });
+    }
   }
 }
 
-export function warnFirestoreEmulated(): void {
+export function warnFirestoreEmulated(
+  options: any,
+  emulatorSupported: boolean
+): void | Promise<void> {
   const envKey = Constants.FIRESTORE_EMULATOR_HOST;
   const envVal = process.env[envKey];
   if (envVal) {
-    utils.logWarning(
-      `You have set ${clc.bold(
-        `${envKey}=${envVal}`
-      )}, this command will execute against the Cloud Firestore emulator running at that address.`
-    );
+    if (emulatorSupported) {
+      utils.logBullet(
+        `You have set ${clc.bold(
+          `${envKey}=${envVal}`
+        )}, this command will execute against the Cloud Firestore emulator running at that address.`
+      );
+    } else {
+      utils.logWarning(
+        `You have set ${clc.bold(
+          `${envKey}=${envVal}`
+        )}, however this command does not support running against the emulator so this action will affect production.`
+      );
+
+      const promptRes = {
+        confirm: false,
+      };
+      return prompt(promptRes, [
+        {
+          type: "confirm",
+          name: "confirm",
+          default: false,
+          message: "Do you want to continue?",
+        },
+      ]).then(() => {
+        if (!promptRes.confirm) {
+          return utils.reject("Command aborted.", { exit: 1 });
+        }
+      });
+    }
   }
 }
 

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -46,7 +46,10 @@ export const DESC_TEST_PARAMS =
  */
 const DEFAULT_CONFIG = new Config({ database: {}, firestore: {}, functions: {}, hosting: {} }, {});
 
-export function printNoticeIfEmulated(options: any, emulator: Emulators.DATABASE | Emulators.FIRESTORE): void {
+export function printNoticeIfEmulated(
+  options: any,
+  emulator: Emulators.DATABASE | Emulators.FIRESTORE
+): void {
   if (emulator !== Emulators.DATABASE && emulator !== Emulators.FIRESTORE) {
     return;
   }
@@ -66,7 +69,10 @@ export function printNoticeIfEmulated(options: any, emulator: Emulators.DATABASE
   }
 }
 
-export function warnEmulatorNotSupported(options: any, emulator: Emulators): void | Promise<void> {
+export function warnEmulatorNotSupported(
+  options: any,
+  emulator: Emulators.DATABASE | Emulators.FIRESTORE
+): void | Promise<void> {
   if (emulator !== Emulators.DATABASE && emulator !== Emulators.FIRESTORE) {
     return;
   }

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -46,81 +46,54 @@ export const DESC_TEST_PARAMS =
  */
 const DEFAULT_CONFIG = new Config({ database: {}, firestore: {}, functions: {}, hosting: {} }, {});
 
-export function warnRealtimeDatabaseEmulated(
-  options: any,
-  emulatorSupported: boolean
-): void | Promise<void> {
-  const envKey = Constants.FIREBASE_DATABASE_EMULATOR_HOST;
+export function printNoticeIfEmulated(options: any, emulator: Emulators): void {
+  if (emulator !== Emulators.DATABASE && emulator !== Emulators.FIRESTORE) {
+    return;
+  }
+
+  const emuName = Constants.description(emulator);
+  const envKey = emulator === Emulators.DATABASE ? Constants.FIREBASE_DATABASE_EMULATOR_HOST : Constants.FIRESTORE_EMULATOR_HOST;
   const envVal = process.env[envKey];
   if (envVal) {
-    if (emulatorSupported) {
-      utils.logBullet(
-        `You have set ${clc.bold(
-          `${envKey}=${envVal}`
-        )}, this command will execute against the Realtime Database emulator running at that address.`
-      );
-    } else {
-      utils.logWarning(
-        `You have set ${clc.bold(
-          `${envKey}=${envVal}`
-        )}, however this command does not support running against the emulator so this action will affect production.`
-      );
-
-      const opts = {
-        confirm: undefined,
-      };
-      return prompt(opts, [
-        {
-          type: "confirm",
-          name: "confirm",
-          default: false,
-          message: "Do you want to continue?",
-        },
-      ]).then(() => {
-        if (!opts.confirm) {
-          return utils.reject("Command aborted.", { exit: 1 });
-        }
-      });
-    }
+    utils.logBullet(
+      `You have set ${clc.bold(
+        `${envKey}=${envVal}`
+      )}, this command will execute against the ${emuName} emulator running at that address.`
+    );
   }
 }
 
-export function warnFirestoreEmulated(
-  options: any,
-  emulatorSupported: boolean
-): void | Promise<void> {
-  const envKey = Constants.FIRESTORE_EMULATOR_HOST;
-  const envVal = process.env[envKey];
-  if (envVal) {
-    if (emulatorSupported) {
-      utils.logBullet(
-        `You have set ${clc.bold(
-          `${envKey}=${envVal}`
-        )}, this command will execute against the Cloud Firestore emulator running at that address.`
-      );
-    } else {
-      utils.logWarning(
-        `You have set ${clc.bold(
-          `${envKey}=${envVal}`
-        )}, however this command does not support running against the emulator so this action will affect production.`
-      );
+export function warnEmulatorNotSupported(options: any, emulator: Emulators): void | Promise<void> {
+  if (emulator !== Emulators.DATABASE && emulator !== Emulators.FIRESTORE) {
+    return;
+  }
 
-      const promptRes = {
-        confirm: false,
-      };
-      return prompt(promptRes, [
-        {
-          type: "confirm",
-          name: "confirm",
-          default: false,
-          message: "Do you want to continue?",
-        },
-      ]).then(() => {
-        if (!promptRes.confirm) {
-          return utils.reject("Command aborted.", { exit: 1 });
-        }
-      });
-    }
+  const emuName = Constants.description(emulator);
+  const envKey = emulator === Emulators.DATABASE ? Constants.FIREBASE_DATABASE_EMULATOR_HOST : Constants.FIRESTORE_EMULATOR_HOST;
+  const envVal = process.env[envKey];
+
+  if (envVal) {
+    utils.logWarning(
+      `You have set ${clc.bold(
+        `${envKey}=${envVal}`
+      )}, however this command does not support running against the ${emuName} emulator so this action will affect production.`
+    );
+
+    const opts = {
+      confirm: undefined,
+    };
+    return prompt(opts, [
+      {
+        type: "confirm",
+        name: "confirm",
+        default: false,
+        message: "Do you want to continue?",
+      },
+    ]).then(() => {
+      if (!opts.confirm) {
+        return utils.reject("Command aborted.", { exit: 1 });
+      }
+    });
   }
 }
 

--- a/src/firestore/delete.js
+++ b/src/firestore/delete.js
@@ -226,7 +226,7 @@ FirestoreDelete.prototype._getDescendantBatch = function(allDescendants, batchSi
     .request("POST", "/v1beta1/" + url, {
       auth: true,
       data: body,
-      origin: api.firestoreOrigin,
+      origin: api.firestoreOriginOrEmulator,
     })
     .then(function(res) {
       // Return the 'document' property for each element in the response,

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -14,7 +14,7 @@ export async function listCollectionIds(project: string): Promise<string[]> {
   return api
     .request("POST", url, {
       auth: true,
-      origin: api.firestoreOrigin,
+      origin: api.firestoreOriginOrEmulator,
       data: {
         // Maximum 32-bit integer
         pageSize: 2147483647,
@@ -37,7 +37,7 @@ export async function listCollectionIds(project: string): Promise<string[]> {
 export async function deleteDocument(doc: any): Promise<any> {
   return api.request("DELETE", _API_ROOT + doc.name, {
     auth: true,
-    origin: api.firestoreOrigin,
+    origin: api.firestoreOriginOrEmulator,
   });
 }
 
@@ -64,7 +64,7 @@ export async function deleteDocuments(project: string, docs: any[]): Promise<num
     const res = await api.request("POST", url, {
       auth: true,
       data: body,
-      origin: api.firestoreOrigin,
+      origin: api.firestoreOriginOrEmulator,
     });
     return res.body.writeResults.length;
   } catch (err) {

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 
 import * as utils from "../utils";
+import { exec } from "child_process";
 
 describe("utils", () => {
   describe("consoleUrl", () => {
@@ -66,6 +67,66 @@ describe("utils", () => {
       expect(utils.envOverride("FOO_BAR_BAZ", "notset", coerce)).to.deep.equal("notset");
 
       delete process.env.FOO_BAR_BAZ;
+    });
+  });
+
+  describe("getDatabaseUrl", () => {
+    it("should create a url for prod", () => {
+      expect(utils.getDatabaseUrl("https://firebaseio.com", "fir-proj", "/")).to.equal(
+        "https://fir-proj.firebaseio.com/"
+      );
+      expect(utils.getDatabaseUrl("https://firebaseio.com", "fir-proj", "/foo/bar")).to.equal(
+        "https://fir-proj.firebaseio.com/foo/bar"
+      );
+      expect(utils.getDatabaseUrl("https://firebaseio.com", "fir-proj", "/foo/bar.json")).to.equal(
+        "https://fir-proj.firebaseio.com/foo/bar.json"
+      );
+    });
+
+    it("should create a url for the emulator", () => {
+      expect(utils.getDatabaseUrl("http://localhost:9000", "fir-proj", "/")).to.equal(
+        "http://localhost:9000/?ns=fir-proj"
+      );
+      expect(utils.getDatabaseUrl("http://localhost:9000", "fir-proj", "/foo/bar")).to.equal(
+        "http://localhost:9000/foo/bar?ns=fir-proj"
+      );
+      expect(utils.getDatabaseUrl("http://localhost:9000", "fir-proj", "/foo/bar.json")).to.equal(
+        "http://localhost:9000/foo/bar.json?ns=fir-proj"
+      );
+    });
+  });
+
+  describe("getDatabaseViewDataUrl", () => {
+    it("should get a view data url for prod", () => {
+      expect(
+        utils.getDatabaseViewDataUrl("https://firebaseio.com", "fir-proj", "/foo/bar")
+      ).to.equal("https://console.firebase.google.com/project/fir-proj/database/data/foo/bar");
+    });
+
+    it("should get a view data url for the emulator", () => {
+      expect(
+        utils.getDatabaseViewDataUrl("http://localhost:9000", "fir-proj", "/foo/bar")
+      ).to.equal("http://localhost:9000/foo/bar.json?ns=fir-proj");
+    });
+  });
+
+  describe("addDatabaseNamespace", () => {
+    it("should add the namespace for prod", () => {
+      expect(utils.addDatabaseNamespace("https://firebaseio.com/", "fir-proj")).to.equal(
+        "https://fir-proj.firebaseio.com/"
+      );
+      expect(utils.addDatabaseNamespace("https://firebaseio.com/foo/bar", "fir-proj")).to.equal(
+        "https://fir-proj.firebaseio.com/foo/bar"
+      );
+    });
+
+    it("should add the namespace for the emulator", () => {
+      expect(utils.addDatabaseNamespace("http://localhost:9000/", "fir-proj")).to.equal(
+        "http://localhost:9000/?ns=fir-proj"
+      );
+      expect(utils.addDatabaseNamespace("http://localhost:9000/foo/bar", "fir-proj")).to.equal(
+        "http://localhost:9000/foo/bar?ns=fir-proj"
+      );
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import * as _ from "lodash";
+import * as url from "url";
 import * as clc from "cli-color";
 import { Readable } from "stream";
 import * as winston from "winston";
@@ -60,6 +61,46 @@ export function envOverride(
     return currentEnvValue;
   }
   return value;
+}
+
+/**
+ * TODO(samstern): Docs
+ */
+export function getDatabaseUrl(origin: string, namespace: string, pathname: string): string {
+  const withPath = url.resolve(origin, pathname);
+  return addDatabaseNamespace(withPath, namespace);
+}
+
+/**
+ * TODO(samstern): Docs
+ */
+export function getDatabaseViewDataUrl(
+  origin: string,
+  namespace: string,
+  pathname: string
+): string {
+  const url = new URL(origin);
+  if (url.hostname.includes("firebaseio.com")) {
+    return consoleUrl(namespace, "/database/data" + pathname);
+  } else {
+    // TODO(samstern): View in GUI
+    return getDatabaseUrl(origin, namespace, pathname + ".json");
+  }
+}
+
+/**
+ * TODO(samstern): Docs
+ */
+export function addDatabaseNamespace(origin: string, namespace: string): string {
+  const url = new URL(origin);
+  if (url.hostname.includes("firebaseio.com")) {
+    return addSubdomain(origin, namespace);
+  } else {
+    const params = new URLSearchParams({
+      ns: namespace,
+    });
+    return url.href + "?" + params.toString();
+  }
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -105,7 +105,6 @@ export function addDatabaseNamespace(origin: string, namespace: string): string 
     });
     url.searchParams.set("ns", namespace);
     return url.href;
-    // return url.href + "?" + params.toString();
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,7 +64,7 @@ export function envOverride(
 }
 
 /**
- * TODO(samstern): Docs
+ * Get the full URL to a path in the database or database emulator.
  */
 export function getDatabaseUrl(origin: string, namespace: string, pathname: string): string {
   const withPath = url.resolve(origin, pathname);
@@ -72,7 +72,9 @@ export function getDatabaseUrl(origin: string, namespace: string, pathname: stri
 }
 
 /**
- * TODO(samstern): Docs
+ * Get the URL to view data in the database or database emulator.
+ *  - Prod: Firebase Console URL
+ *  - Emulator: Localhost URL to a `.json` endpoint.
  */
 export function getDatabaseViewDataUrl(
   origin: string,
@@ -89,7 +91,9 @@ export function getDatabaseViewDataUrl(
 }
 
 /**
- * TODO(samstern): Docs
+ * Add the namespace to a database or database emulator URL.
+ *  - Prod: Add a subdomain.
+ *  - Emulator: Add `?ns=` parameter.
  */
 export function addDatabaseNamespace(origin: string, namespace: string): string {
   const url = new URL(origin);
@@ -99,7 +103,9 @@ export function addDatabaseNamespace(origin: string, namespace: string): string 
     const params = new URLSearchParams({
       ns: namespace,
     });
-    return url.href + "?" + params.toString();
+    url.searchParams.set("ns", namespace);
+    return url.href;
+    // return url.href + "?" + params.toString();
   }
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,8 +81,8 @@ export function getDatabaseViewDataUrl(
   namespace: string,
   pathname: string
 ): string {
-  const url = new URL(origin);
-  if (url.hostname.includes("firebaseio.com")) {
+  const urlObj = new url.URL(origin);
+  if (urlObj.hostname.includes("firebaseio.com")) {
     return consoleUrl(namespace, "/database/data" + pathname);
   } else {
     // TODO(samstern): View in GUI
@@ -96,15 +96,12 @@ export function getDatabaseViewDataUrl(
  *  - Emulator: Add `?ns=` parameter.
  */
 export function addDatabaseNamespace(origin: string, namespace: string): string {
-  const url = new URL(origin);
-  if (url.hostname.includes("firebaseio.com")) {
+  const urlObj = new url.URL(origin);
+  if (urlObj.hostname.includes("firebaseio.com")) {
     return addSubdomain(origin, namespace);
   } else {
-    const params = new URLSearchParams({
-      ns: namespace,
-    });
-    url.searchParams.set("ns", namespace);
-    return url.href;
+    urlObj.searchParams.set("ns", namespace);
+    return urlObj.href;
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This finishes adding support for `FIRESTORE_EMULATOR_HOST` and `FIREBASE_DATABASE_EMULATOR_HOST` wherever reasonable and adds warnings/prompts to all other commands that may confuse developers.

TODO:

- [x] Finish documenting new `utils` methods
- [x] Unit tests

### Scenarios Tested

**Database Set and Get**

These operations are supported.

```bash
$ FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000 firebase database:set /foo/bar data.json
i  You have set FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000, this command will execute against the Realtime Database emulator running at that address.
? You are about to overwrite all data at http://localhost:9000/foo/bar?ns=fir-dumpster. Are you sure? Yes

✔  Data persisted successfully

View data at: http://localhost:9000/foo/bar.json?ns=fir-dumpster
```

```-
$ FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000 firebase database:get /foo/bar
i  You have set FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000, this command will execute against the Realtime Database emulator running at that address.
{"hello":"world"}
```

**Database Remove**

This operation is not supported.

```bash
$ FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000 firebase database:remove /foo/list
⚠  You have set FIREBASE_DATABASE_EMULATOR_HOST=localhost:9000, however this command does not support running against the emulator
 so this action will affect production.
? Do you want to continue? No

Error: Command aborted.
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
