### PR TITLE
Make functions:shell discover emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Improves error messages for Cloud Functions for Firebase deployment permissions. (#2086)
 - Makes `firestore:delete` respect `FIRESTORE_EMULATOR_HOST`.
 - Makes `database:get`, `database:set`, `database:push`, and `database:update` respect `FIREBASE_DATABASE_EMULATOR_HOST`.
+- Makes `functions:shell` connect to running service emulators when appropriate.

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -27,6 +27,8 @@ export interface EmulatorHubArgs {
   host?: string;
 }
 
+export type GetEmulatorsResponse = Record<string, EmulatorInfo>;
+
 export class EmulatorHub implements EmulatorInstance {
   static EMULATOR_HUB_ENV = "FIREBASE_EMULATOR_HUB";
   static CLI_VERSION = pkg.version;
@@ -73,7 +75,7 @@ export class EmulatorHub implements EmulatorInstance {
     });
 
     this.hub.get(EmulatorHub.PATH_EMULATORS, async (req, res) => {
-      const body: Record<string, EmulatorInfo> = {};
+      const body: GetEmulatorsResponse = {};
       EmulatorRegistry.listRunning().forEach((name) => {
         body[name] = EmulatorRegistry.get(name)!.getInfo();
       });

--- a/src/emulator/hubClient.ts
+++ b/src/emulator/hubClient.ts
@@ -1,0 +1,55 @@
+import * as api from "../api";
+import { EmulatorHub, Locator, GetEmulatorsResponse } from "./hub";
+import { FirebaseError } from "../error";
+
+export class EmulatorHubClient {
+  private locator: Locator | undefined;
+
+  constructor(private projectId: string) {
+    this.locator = EmulatorHub.readLocatorFile(projectId);
+  }
+
+  foundHub(): boolean {
+    return this.locator !== undefined;
+  }
+
+  getStatus(): Promise<void> {
+    return api.request("GET", "/", {
+      origin: this.origin,
+    });
+  }
+
+  getEmulators(): Promise<GetEmulatorsResponse> {
+    return api
+      .request("GET", EmulatorHub.PATH_EMULATORS, {
+        origin: this.origin,
+        json: true,
+      })
+      .then((res) => {
+        return res.body as GetEmulatorsResponse;
+      });
+  }
+
+  postExport(path: string): Promise<void> {
+    return api.request("POST", EmulatorHub.PATH_EXPORT, {
+      origin: this.origin,
+      json: true,
+      data: {
+        path,
+      },
+    });
+  }
+
+  get origin(): string {
+    const locator = this.assertLocator();
+    return `http://${locator.host}:${locator.port}`;
+  }
+
+  private assertLocator(): Locator {
+    if (this.locator === undefined) {
+      throw new FirebaseError(`Cannot contact the Emulator Hub for project ${this.projectId}`);
+    }
+
+    return this.locator;
+  }
+}

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -35,6 +35,12 @@ export const ALL_SERVICE_EMULATORS = [
   Emulators.PUBSUB,
 ];
 
+export const EMULATORS_SUPPORTED_BY_FUNCTIONS = [
+  Emulators.FIRESTORE,
+  Emulators.DATABASE,
+  Emulators.PUBSUB,
+];
+
 export const EMULATORS_SUPPORTED_BY_GUI = [
   Emulators.DATABASE,
   Emulators.FIRESTORE,

--- a/src/functionsShellCommandAction.js
+++ b/src/functionsShellCommandAction.js
@@ -65,12 +65,12 @@ module.exports = async function(options) {
           "functions",
           `Connected to running ${clc.bold(e)} emulator at ${info.host}:${
             info.port
-          }, Calls to this service will affect the emulator`
+          }, calls to this service will affect the emulator`
         );
       }
       utils.logLabeledWarning(
         "functions",
-        `The following emulators are not running, Calls to these services will affect production: ${clc.bold(
+        `The following emulators are not running, calls to these services will affect production: ${clc.bold(
           otherEmulators.join(", ")
         )}`
       );

--- a/src/test/hosting/cloudRunProxy.spec.ts
+++ b/src/test/hosting/cloudRunProxy.spec.ts
@@ -66,7 +66,7 @@ describe("cloudRunProxy", () => {
       .then(() => {
         expect(spyMw.calledOnce).to.be.true;
       });
-  });
+  }).timeout(2500);
 
   it("should resolve a function returns middleware that proxies to the live version", async () => {
     nock(cloudRunApiOrigin)


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Allows `functions:shell` to use the Emulator Hub to discover emulators running in another process and talk to them.

Fixes #2116

### Scenarios Tested

Using these functions:
```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp();

exports.writeToDatabase = functions.https.onRequest(async (request, response) => {
  const db = admin.database();
  console.log("RTDB", db.ref().toString());

  await db.ref('/foo').set({
    hello: "world",
    date: new Date().toISOString()
  });

  response.json({
    status: 'ok'
  });
});

exports.writeToFirestore = functions.https.onRequest(async (request, response) => {
  const db = admin.firestore();
  console.log("Firestore", db._settings);

  await db.doc('/foo/bar').set({
    hello: "world",
    date: new Date().toISOString()
  });

  response.json({
    status: 'ok'
  });
});
```

In one terminal I run:
```
firebase emulators:start --only database
```

In another terminal, the shell:
```
$ firebase functions:shell
⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: functions emulator started at http://localhost:5000
i  functions: Loaded functions: writeToDatabase, writeToFirestore
i  functions: Connected to running database emulator at localhost:9000, calls to this service will affect the emulator
⚠  functions: The following emulators are not running, calls to these services will affect production: firestore, pubsub
firebase > writeToDatabase()
Sent request to function.
firebase > >  RTDB http://localhost:9000/

RESPONSE RECEIVED FROM FUNCTION: 200, {
  "status": "ok"
}

firebase > writeToFirestore()
Sent request to function.
firebase > ⚠  functions: The Cloud Firestore emulator is not running, so calls to Firestore will affect production.
>  Firestore { projectId: 'fir-dumpster',
>    firebaseVersion: '8.10.0',
>    libName: 'gccl',
>    libVersion: '3.7.3 fire/8.10.0' }
⚠  Google API requested!
   - URL: "https://oauth2.googleapis.com/token"
   - Be careful, this may be a production service.

RESPONSE RECEIVED FROM FUNCTION: 200, {
  "status": "ok"
}
```

### Sample Commands

N/A