### PR TITLE
Adds a warning when rewriting to functions that do not exist in us-central1

### DIFF
--- a/src/deploy/hosting/checkFunctionRewrites.ts
+++ b/src/deploy/hosting/checkFunctionRewrites.ts
@@ -1,0 +1,18 @@
+import { list } from "../../gcp/cloudfunctions";
+
+export async function checkFunctionRewrites(
+  projectId: string,
+  functionNames: string[]
+): Promise<{ found: string[]; missing: string[]; passed: boolean }> {
+  const listResult = await list(projectId, "us-central1");
+  const foundNames: string[] = listResult.map((fn: { functionName: string }) => fn.functionName);
+
+  const missing: string[] = [];
+  const found: string[] = [];
+
+  functionNames.forEach((name) =>
+    foundNames.includes(name) ? found.push(name) : missing.push(name)
+  );
+
+  return { missing, found, passed: missing.length === 0 };
+}

--- a/src/deploy/hosting/index.js
+++ b/src/deploy/hosting/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 module.exports = {
-  prepare: require("./prepare"),
+  prepare: require("./prepare").prepare,
   deploy: require("./deploy"),
   release: require("./release"),
 };


### PR DESCRIPTION
As extensively documented in #842 it is often surprising when Firebase Hosting is unable to rewrite to functions outside of `us-central` and the error encountered when trying to access a rewrite to a non-existent function isn't very helpful. To that end I've added a new prominent warning when deploying rewrites for missing functions:

![missing function warning](https://user-images.githubusercontent.com/1022/78952040-0d45ae00-7a89-11ea-801a-4b873cc36981.png)

This is a warning and not an error so as not to be a breaking change to current behavior. An unanswered question is whether this warning should be suppressed when a matching Cloud Function is present in the local directory and ready to deploy -- I could see a good argument that it ought to be, but that would be a substantially more difficult change to make technically and I'm looking for a small QoL improvement here.