### PR TITLE
make npm test's lint quiet again

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "lint": "npm run lint:ts && npm run lint:other",
     "lint:changed-files": "ts-node ./scripts/lint-changed-files.ts",
     "lint:other": "prettier --check '**/*.{md,yaml,yml}'",
+    "lint:quiet": "npm run lint:ts -- --quiet && npm run lint:other",
     "lint:ts": "eslint --config .eslintrc.js --ext .ts,.js .",
     "mocha": "nyc mocha --opts mocha.opts",
     "prepare": "npm run clean && npm run build -- --build tsconfig.publish.json",
-    "test": "npm run lint -- --quiet && npm run mocha",
+    "test": "npm run lint:quiet && npm run mocha",
     "test:client-integration": "./scripts/client-integration-tests/run.sh",
     "test:extensions-emulator": "./scripts/extensions-emulator-tests/run.sh"
   },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`npm test` had been making lint only print errors, but now it's printing warnings. When I added a second linter (for other files), my `--quiet` was lost. I added `lint:quiet` to do this explicit thing