### PR TITLE
Pass full path to getRuntimeChoice. Fixes #2138

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes error when deploying functions from project subdirectory. (#2138)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixes error when deploying functions from project subdirectory. (#2138)
+- Fixes error when deploying Cloud Functions for Firebase from a project subdirectory. (#2138)

--- a/src/deploy/functions/prepare.js
+++ b/src/deploy/functions/prepare.js
@@ -31,7 +31,7 @@ module.exports = function(context, options, payload) {
     return Promise.reject(e);
   }
 
-  context.runtimeChoice = getRuntimeChoice(sourceDirName);
+  context.runtimeChoice = getRuntimeChoice(sourceDir);
 
   return Promise.all([
     ensureApiEnabled.ensure(options.project, "cloudfunctions.googleapis.com", "functions"),


### PR DESCRIPTION
Fixes #2138 by passing the full path to `getRuntimeChoice`. I verified that when deploying from `functions` directory without this patch, it fails with an unexpected error and with this patch it succeeds.