### PR TITLE
Increase minimum Node.js version to v8.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Improves login flow when using the `--reauth` flag.
+- Increases minimum Node.js version to v8.6.0, accurately reflecting underlying requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Improves login flow when using the `--reauth` flag.
-- Increases minimum Node.js version to v8.6.0, accurately reflecting underlying requirements.
+- Increases minimum Node.js version to v8.6.0, accurately reflecting underlying requirements of the CLI tool.

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   ],
   "preferGlobal": true,
   "engines": {
-    "node": ">= 8.0.0"
+    "node": ">= 8.6.0"
   },
   "author": "Firebase (https://firebase.google.com/)",
   "license": "MIT",


### PR DESCRIPTION
Some of our dependencies rely on object rest/spread operators which only became available in 8.6.0
