### PR TITLE
remove old code path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Improves login flow when using the `--reauth` flag.
+- Removes old code paths that are no longer used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,1 @@
 - Improves login flow when using the `--reauth` flag.
-- Removes old code paths that are no longer used.

--- a/src/api.js
+++ b/src/api.js
@@ -100,7 +100,6 @@ var api = {
     "FIREBASE_CLOUDLOGGING_URL",
     "https://logging.googleapis.com"
   ),
-  adminOrigin: utils.envOverride("FIREBASE_ADMIN_URL", "https://admin.firebase.com"),
   appDistributionOrigin: utils.envOverride(
     "FIREBASE_APP_DISTRIBUTION_URL",
     "https://firebaseappdistribution.googleapis.com"
@@ -225,12 +224,15 @@ var api = {
     options = _.extend(
       {
         data: {},
-        origin: api.adminOrigin, // default to hitting the admin backend
         resolveOnHTTPError: false, // by default, status codes >= 400 leads to reject
         json: true,
       },
       options
     );
+
+    if (!options.origin) {
+      throw new FirebaseError("Cannot make request without an origin", { exit: 2 });
+    }
 
     var validMethods = ["GET", "PUT", "POST", "DELETE", "PATCH"];
 

--- a/src/api.js
+++ b/src/api.js
@@ -300,32 +300,6 @@ var api = {
       return Promise.reject(err);
     });
   },
-
-  /**
-   * Deprecated. Call `listFirebaseProjects()` from `./management/project.ts` instead
-   * TODO: remove this function
-   */
-  getProjects: function() {
-    logger.debug(
-      `[WARNING] ${new Error("getProjects() is deprecated - update the implementation").stack}`
-    );
-    return api
-      .request("GET", "/v1/projects", {
-        auth: true,
-      })
-      .then(function(res) {
-        if (res.body && res.body.projects) {
-          return res.body.projects;
-        }
-
-        return Promise.reject(
-          new FirebaseError("Server Error: Unexpected Response. Please try again", {
-            context: res,
-            exit: 2,
-          })
-        );
-      });
-  },
 };
 
 module.exports = api;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Removes the old codepath for fetching projects and removes an origin that only was used in said codepath.