### PR TITLE
fix ext:list when there are no exts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,1 @@
 - Fixes an issue where `ext:list` would fail when no extensions were installed.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Fixes an issue where `ext:list` would fail when no extensions were installed.
+

--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -199,7 +199,9 @@ export async function listInstances(projectId: string): Promise<ExtensionInstanc
         pageToken,
       },
     });
-    instances.push(...res.body.instances);
+    if (Array.isArray(res.body.instances)) {
+      instances.push(...res.body.instances);
+    }
     if (res.body.nextPageToken) {
       await getNextPage(res.body.nextPageToken);
     }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When no extensions are installed in a project, I was seeing errors when trying to list extensions (`req.body` came back as an empty object). This adds a check to prevent the error I was seeing.

### Scenarios Tested

`firebase ext:list`