### PR TITLE
Set FIREBASE_CONFIG env variable functions functions creates and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Sets FIREBASE_CONFIG environment variable during functions deploys to fix "process.env.GCLOUD_PROJECT is not set" issues during deployment or execution.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Sets FIREBASE_CONFIG environment variable during functions deploys to fix "process.env.GCLOUD_PROJECT is not set" issues during deployment or execution.
+- Sets the `FIREBASE_CONFIG` environment variable during deploys of Cloud Functions for Firebase to fix "process.env.GCLOUD_PROJECT is not set" issues during deployment or execution.

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -172,6 +172,10 @@ module.exports = function(context, options, payload) {
       deleteReleaseNames = functionFilterGroups.length > 0 ? releaseNames : existingNames;
       helper.logFilters(existingNames, releaseNames, functionFilterGroups);
 
+      const envVariables = {
+        FIREBASE_CONFIG: JSON.stringify(context.firebaseConfig),
+      };
+
       // Create functions
       _.chain(uploadedNames)
         .difference(existingNames)
@@ -212,6 +216,7 @@ module.exports = function(context, options, payload) {
                   availableMemoryMb: functionInfo.availableMemoryMb,
                   timeout: functionInfo.timeout,
                   maxInstances: functionInfo.maxInstances,
+                  environmentVariables: envVariables,
                 })
                 .then((createRes) => {
                   if (_.has(functionTrigger, "httpsTrigger")) {
@@ -287,6 +292,7 @@ module.exports = function(context, options, payload) {
               timeout: functionInfo.timeout,
               runtime: runtime,
               maxInstances: functionInfo.maxInstances,
+              environmentVariables: envVariables,
             };
             utils.logBullet(
               clc.bold.cyan("functions: ") +

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -172,7 +172,7 @@ module.exports = function(context, options, payload) {
       deleteReleaseNames = functionFilterGroups.length > 0 ? releaseNames : existingNames;
       helper.logFilters(existingNames, releaseNames, functionFilterGroups);
 
-      const envVariables = {
+      const defaultEnvVariables = {
         FIREBASE_CONFIG: JSON.stringify(context.firebaseConfig),
       };
 
@@ -216,7 +216,7 @@ module.exports = function(context, options, payload) {
                   availableMemoryMb: functionInfo.availableMemoryMb,
                   timeout: functionInfo.timeout,
                   maxInstances: functionInfo.maxInstances,
-                  environmentVariables: envVariables,
+                  environmentVariables: defaultEnvVariables,
                 })
                 .then((createRes) => {
                   if (_.has(functionTrigger, "httpsTrigger")) {
@@ -292,7 +292,7 @@ module.exports = function(context, options, payload) {
               timeout: functionInfo.timeout,
               runtime: runtime,
               maxInstances: functionInfo.maxInstances,
-              environmentVariables: envVariables,
+              environmentVariables: _.assign({}, existingFunction.environmentVariables, defaultEnvVariables),
             };
             utils.logBullet(
               clc.bold.cyan("functions: ") +

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -292,7 +292,11 @@ module.exports = function(context, options, payload) {
               timeout: functionInfo.timeout,
               runtime: runtime,
               maxInstances: functionInfo.maxInstances,
-              environmentVariables: _.assign({}, existingFunction.environmentVariables, defaultEnvVariables),
+              environmentVariables: _.assign(
+                {},
+                existingFunction.environmentVariables,
+                defaultEnvVariables
+              ),
             };
             utils.logBullet(
               clc.bold.cyan("functions: ") +

--- a/src/gcp/cloudfunctions.js
+++ b/src/gcp/cloudfunctions.js
@@ -78,9 +78,11 @@ function _createFunction(options) {
   if (options.timeout) {
     data.timeout = options.timeout;
   }
-
   if (options.maxInstances) {
     data.maxInstances = Number(options.maxInstances);
+  }
+  if (options.environmentVariables) {
+    data.environmentVariables = options.environmentVariables;
   }
 
   return api
@@ -166,6 +168,10 @@ function _updateFunction(options) {
   if (options.maxInstances) {
     data.maxInstances = Number(options.maxInstances);
     masks.push("maxInstances");
+  }
+  if (options.environmentVariables) {
+    data.environmentVariables = options.environmentVariables;
+    masks.push("environmentVariables");
   }
   if (options.trigger.eventTrigger) {
     masks = _.concat(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Set the FIREBASE_CONFIG env variable when a function is created or updated, instead of solely relying on the SDK to parse it from `.runtimeconfig.json`. This will prevent issues like https://github.com/firebase/firebase-functions/issues/669 (but only for users that update their CLI). 

I initially tried to set GCLOUD_PROJECT too but that resulted in a server error:
```
 HTTP RESPONSE BODY {"error":{"code":400,"message":"The request has errors","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.BadRequest","fieldViolations":[{"field":"environment_variables","description":"environment variable name GCLOUD_PROJECT is reserved by the system: it cannot be set by users"}]}]}}
```
But it's actually not a problem, since firebase-functions SDK will generate GCLOUD_PROJECT from FIREBASE_CONFIG anyhow (https://github.com/firebase/firebase-functions/blob/master/src/setup.ts#L38)

### Scenarios Tested

- Create a new function, verify in Cloud Console that FIREBASE_CONFIG env variable is set (tried Node 8 and Node 10)
- Update a function that previously was deployed with an older version of the CLI, then verify in Cloud Console that  FIREBASE_CONFIG env variable is set
- Update a function that had a custom env variable, and verified that it still persisted

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
