### PR TITLE
Fix firepit instant builds after "list" command removal

### DIFF
--- a/standalone/welcome.js
+++ b/standalone/welcome.js
@@ -124,7 +124,7 @@ async function CheckIsLoggedIn() {
     const finish = SimpleSpinner(
       `${chalk.cyan("~")} Checking your Firebase credentials`
     );
-    const listSpawn = fork(firebase_bin, ["list", "--json"], { silent: true });
+    const listSpawn = fork(firebase_bin, ["projects:list", "--json"], { silent: true });
     let listSpawnData = "";
 
     listSpawn.stdout.on("data", buf => {


### PR DESCRIPTION
We removed `list` which broken new firepit instant builds (only instant, not headless) for the ten people who use those.