### PR TITLE
Refactor finding open ports and allow disabling GUI.

### DIFF
--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -13,6 +13,17 @@ const DEFAULT_PORTS: { [s in Emulators]: number } = {
   pubsub: 8085,
 };
 
+export const FIND_AVAILBLE_PORT_BY_DEFAULT: Record<Emulators, boolean> = {
+  gui: true,
+  hub: true,
+  logging: true,
+  hosting: false,
+  functions: false,
+  firestore: false,
+  database: false,
+  pubsub: false,
+};
+
 const DEFAULT_HOST = "localhost";
 
 export class Constants {
@@ -77,16 +88,6 @@ export class Constants {
     return `emulators.${emulator.toString()}.port`;
   }
 
-  static getAddress(emulator: Emulators, options: any): Address {
-    const hostVal = options.config.get(this.getHostKey(emulator), DEFAULT_HOST);
-    const portVal = options.config.get(this.getPortKey(emulator), this.getDefaultPort(emulator));
-
-    const host = this.normalizeHost(hostVal);
-    const port = parseInt(portVal, 10);
-
-    return { host, port };
-  }
-
   static description(name: Emulators): string {
     if (name === Emulators.HUB) {
       return "emulator hub";
@@ -97,7 +98,7 @@ export class Constants {
     }
   }
 
-  private static normalizeHost(host: string): string {
+  static normalizeHost(host: string): string {
     let normalized = host;
     if (!normalized.startsWith("http")) {
       normalized = `http://${normalized}`;

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -14,8 +14,9 @@ import {
   EmulatorInstance,
   Emulators,
   EMULATORS_SUPPORTED_BY_GUI,
+  Address,
 } from "../emulator/types";
-import { Constants } from "../emulator/constants";
+import { Constants, FIND_AVAILBLE_PORT_BY_DEFAULT } from "../emulator/constants";
 import { FunctionsEmulator } from "../emulator/functionsEmulator";
 import { DatabaseEmulator, DatabaseEmulatorArgs } from "../emulator/databaseEmulator";
 import { FirestoreEmulator, FirestoreEmulatorArgs } from "../emulator/firestoreEmulator";
@@ -51,36 +52,65 @@ export async function waitForPortClosed(port: number, host: string): Promise<voi
   }
 }
 
-export async function startEmulator(instance: EmulatorInstance): Promise<void> {
-  const name = instance.getName();
-  const { host, port } = instance.getInfo();
+async function getAndCheckAddress(emulator: Emulators, options: any): Promise<Address> {
+  const host = Constants.normalizeHost(
+    options.config.get(Constants.getHostKey(emulator), Constants.getDefaultHost(emulator))
+  );
 
-  // Log the command for analytics
-  track("emulators:start", name);
+  const portVal = options.config.get(Constants.getPortKey(emulator), undefined);
+  let port;
+  let findAvailablePort = false;
+  if (portVal) {
+    port = parseInt(portVal, 10);
+  } else {
+    port = Constants.getDefaultPort(emulator);
+    findAvailablePort = FIND_AVAILBLE_PORT_BY_DEFAULT[emulator];
+  }
 
   const portOpen = await checkPortOpen(port, host);
   if (!portOpen) {
-    await cleanShutdown();
-    const description = Constants.description(name);
-    utils.logLabeledWarning(
-      name,
-      `Port ${port} is not open on ${host}, could not start ${description}.`
-    );
-    utils.logLabeledBullet(
-      name,
-      `To select a different host/port for the emulator, specify that host/port in a firebase.json config file:
-    {
-      // ...
-      "emulators": {
-        "${name}": {
-          "host": "${clc.yellow("HOST")}",
-          "port": "${clc.yellow("PORT")}"
-        }
+    if (findAvailablePort) {
+      const newPort = await pf.getPortPromise({ host, port });
+      if (newPort != port) {
+        utils.logLabeledWarning(
+          "emulators",
+          `${Constants.description(
+            emulator
+          )} unable to start on port ${port}, starting on ${newPort} instead.`
+        );
+        port = newPort;
       }
-    }`
-    );
-    return utils.reject(`Could not start ${name} emulator, port taken.`, {});
+    } else {
+      await cleanShutdown();
+      const description = Constants.description(emulator);
+      utils.logLabeledWarning(
+        emulator,
+        `Port ${port} is not open on ${host}, could not start ${description}.`
+      );
+      utils.logLabeledBullet(
+        emulator,
+        `To select a different host/port, specify that host/port in a firebase.json config file:
+      {
+        // ...
+        "emulators": {
+          "${emulator}": {
+            "host": "${clc.yellow("HOST")}",
+            "port": "${clc.yellow("PORT")}"
+          }
+        }
+      }`
+      );
+      return utils.reject(`Could not start ${description}, port taken.`, {});
+    }
   }
+  return { host, port };
+}
+
+export async function startEmulator(instance: EmulatorInstance): Promise<void> {
+  const name = instance.getName();
+
+  // Log the command for analytics
+  track("emulators:start", name);
 
   await EmulatorRegistry.start(instance);
 }
@@ -115,6 +145,11 @@ export function shouldStart(options: any, name: Emulators): boolean {
   }
   const targets = filterEmulatorTargets(options);
   if (name === Emulators.GUI) {
+    if (options.config.get("emulators.gui.enabled") === false) {
+      // Allow disabling GUI via `{emulators: {"gui": {"enabled": false}}}`.
+      // GUI is by default enabled if that option is not specified.
+      return false;
+    }
     // The GUI only starts if we know the project ID AND at least one emulator
     // supported by GUI is launching.
     return (
@@ -182,29 +217,8 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
   }
 
   if (shouldStart(options, Emulators.HUB)) {
-    // For the hub we actually will find any available port
-    // since we don't want to explode if the hub can't start on 4000
-    const hubAddr = Constants.getAddress(Emulators.HUB, options);
-    const hubPort = await pf.getPortPromise({
-      host: hubAddr.host,
-      port: hubAddr.port,
-      stopPort: hubAddr.port + 100,
-    });
-
-    if (hubPort != hubAddr.port) {
-      utils.logLabeledWarning(
-        "emulators",
-        `${Constants.description(Emulators.HUB)} unable to start on port ${
-          hubAddr.port
-        }, starting on ${hubPort}`
-      );
-    }
-
-    const hub = new EmulatorHub({
-      projectId,
-      host: hubAddr.host,
-      port: hubPort,
-    });
+    const hubAddr = await getAndCheckAddress(Emulators.HUB, options);
+    const hub = new EmulatorHub({ projectId, ...hubAddr });
     await startEmulator(hub);
   }
 
@@ -220,7 +234,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
   }
 
   if (shouldStart(options, Emulators.FUNCTIONS)) {
-    const functionsAddr = Constants.getAddress(Emulators.FUNCTIONS, options);
+    const functionsAddr = await getAndCheckAddress(Emulators.FUNCTIONS, options);
     const projectId = getProjectId(options, false);
     const functionsDir = path.join(
       options.extensionDir || options.config.projectDir,
@@ -252,7 +266,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
   }
 
   if (shouldStart(options, Emulators.FIRESTORE)) {
-    const firestoreAddr = Constants.getAddress(Emulators.FIRESTORE, options);
+    const firestoreAddr = await getAndCheckAddress(Emulators.FIRESTORE, options);
 
     const args: FirestoreEmulatorArgs = {
       host: firestoreAddr.host,
@@ -310,7 +324,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
   }
 
   if (shouldStart(options, Emulators.DATABASE)) {
-    const databaseAddr = Constants.getAddress(Emulators.DATABASE, options);
+    const databaseAddr = await getAndCheckAddress(Emulators.DATABASE, options);
 
     const args: DatabaseEmulatorArgs = {
       host: databaseAddr.host,
@@ -318,12 +332,6 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
       projectId,
       auto_download: true,
     };
-
-    if (shouldStart(options, Emulators.FUNCTIONS)) {
-      const functionsAddr = Constants.getAddress(Emulators.FUNCTIONS, options);
-      args.functions_emulator_host = functionsAddr.host;
-      args.functions_emulator_port = functionsAddr.port;
-    }
 
     const rc = dbRulesConfig.getRulesConfig(projectId, options);
     logger.debug("database rules config: ", JSON.stringify(rc));
@@ -361,7 +369,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
   }
 
   if (shouldStart(options, Emulators.HOSTING)) {
-    const hostingAddr = Constants.getAddress(Emulators.HOSTING, options);
+    const hostingAddr = await getAndCheckAddress(Emulators.HOSTING, options);
     const hostingEmulator = new HostingEmulator({
       host: hostingAddr.host,
       port: hostingAddr.port,
@@ -378,7 +386,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
       );
     }
 
-    const pubsubAddr = Constants.getAddress(Emulators.PUBSUB, options);
+    const pubsubAddr = await getAndCheckAddress(Emulators.PUBSUB, options);
     const pubsubEmulator = new PubsubEmulator({
       host: pubsubAddr.host,
       port: pubsubAddr.port,
@@ -389,7 +397,7 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
   }
 
   if (!noGui && shouldStart(options, Emulators.GUI)) {
-    const loggingAddr = Constants.getAddress(Emulators.LOGGING, options);
+    const loggingAddr = await getAndCheckAddress(Emulators.LOGGING, options);
     const loggingEmulator = new LoggingEmulator({
       host: loggingAddr.host,
       port: loggingAddr.port,
@@ -397,29 +405,11 @@ export async function startAll(options: any, noGui: boolean = false): Promise<vo
 
     await startEmulator(loggingEmulator);
 
-    // For the GUI we actually will find any available port
-    // since we don't want to explode if the GUI can't start on 3000.
-    const guiAddr = Constants.getAddress(Emulators.GUI, options);
-    const guiPort = await pf.getPortPromise({
-      host: guiAddr.host,
-      port: guiAddr.port,
-      stopPort: guiAddr.port + 100,
-    });
-
-    if (guiPort != guiAddr.port) {
-      utils.logLabeledWarning(
-        Emulators.GUI,
-        `${Constants.description(Emulators.GUI)} unable to start on port ${
-          guiAddr.port
-        }, starting on ${guiPort}`
-      );
-    }
-
+    const guiAddr = await getAndCheckAddress(Emulators.GUI, options);
     const gui = new EmulatorGUI({
       projectId,
-      host: guiAddr.host,
-      port: guiPort,
       auto_download: true,
+      ...guiAddr,
     });
     await startEmulator(gui);
   }

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -8,6 +8,7 @@ import * as utils from "../utils";
 import * as downloadableEmulators from "./downloadableEmulators";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../emulator/types";
 import { Constants } from "./constants";
+import { EmulatorRegistry } from "./registry";
 
 export interface DatabaseEmulatorArgs {
   port?: number;
@@ -25,6 +26,11 @@ export class DatabaseEmulator implements EmulatorInstance {
   constructor(private args: DatabaseEmulatorArgs) {}
 
   async start(): Promise<void> {
+    const functionsInfo = EmulatorRegistry.getInfo(Emulators.FUNCTIONS);
+    if (functionsInfo) {
+      this.args.functions_emulator_host = functionsInfo.host;
+      this.args.functions_emulator_port = functionsInfo.port;
+    }
     if (this.args.rules) {
       for (const c of this.args.rules) {
         const rulesPath = c.rules;

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -30,9 +30,9 @@ export class FirestoreEmulator implements EmulatorInstance {
   constructor(private args: FirestoreEmulatorArgs) {}
 
   async start(): Promise<void> {
-    const functionsPort = EmulatorRegistry.getPort(Emulators.FUNCTIONS);
-    if (functionsPort) {
-      this.args.functions_emulator = `localhost:${functionsPort}`;
+    const functionsInfo = EmulatorRegistry.getInfo(Emulators.FUNCTIONS);
+    if (functionsInfo) {
+      this.args.functions_emulator = `${functionsInfo.host}:${functionsInfo.port}`;
     }
 
     if (this.args.rules && this.args.projectId) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -159,7 +159,7 @@ export function logLabeledWarning(label: string, message: string, type = "warn")
 /**
  * Return a promise that rejects with a FirebaseError.
  */
-export function reject(message: string, options?: any): Promise<void> {
+export function reject(message: string, options?: any): Promise<never> {
   return Promise.reject(new FirebaseError(message, options));
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR makes it so that the GUI can be disabled via `{emulators: {"gui": {"enabled": false}}}`. Googlers, please see go/firebase-cli-emulator-gui for the exact semantics. No changelogs since this is all behind a preview flag.

I've also refactored checking ports and finding fallbacks so it is more clear. `firebase init emulators` change will be in a follow up PR.

### Scenarios Tested

Manually tested `firebase emulators:start` with the following cases:

1. No config => GUI automatically starts and picks a port (4000)
2. No config, port 4400 occupied => hubs starts on 4401 instead
3. `{"enabled": false}` for `emulators.gui` => GUI does not start
4. `{"host": "0.0.0.0", "port": "9999"}` for `emulators.gui` => GUI starts on specified host and port.
4. `{"host": "0.0.0.0", "port": "9999"}` for `emulators.gui` AND port 9999 occupied => Error (since an exact port is being requested)