### PR TITLE
Support GUI in firebase init emulators.

### DIFF
--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -5,6 +5,7 @@ import { prompt } from "../../prompt";
 import { Emulators, ALL_SERVICE_EMULATORS, isDownloadableEmulator } from "../../emulator/types";
 import { Constants } from "../../emulator/constants";
 import { downloadIfNecessary } from "../../emulator/downloadableEmulators";
+import previews = require("../../previews");
 
 interface EmulatorsInitSelections {
   emulators?: Emulators[];
@@ -56,6 +57,41 @@ export async function doSetup(setup: any, config: any) {
   }
 
   if (selections.emulators.length) {
+    if (previews.emulatorgui) {
+      if (setup.config.emulators.gui && setup.config.emulators.gui.enabled !== false) {
+        const currentPort = setup.config.emulators.gui.port || "(automatic)";
+        utils.logBullet(`Emulator GUI already enabled with port: ${clc.cyan(currentPort)}`);
+      } else {
+        const gui = setup.config.emulators.gui || {};
+        setup.config.emulators.gui = gui;
+
+        await prompt(gui, [
+          {
+            name: "enabled",
+            type: "confirm",
+            message: "Would you like to enable the Emulator GUI?",
+            default: true,
+          },
+        ]);
+
+        if (gui.enabled) {
+          await prompt(gui, [
+            {
+              type: "input",
+              name: "port",
+              message: `Which port do you want to use for the ${clc.underline(
+                "Emulator GUI"
+              )} (leave empty to use any available port)?`,
+            },
+          ]);
+          if (!gui.port) {
+            // Don't write `port: ""` into the config file.
+            delete gui.port;
+          }
+        }
+      }
+    }
+
     await prompt(selections, [
       {
         name: "download",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR adds prompts about Emulator GUI to the `firebase init emulators`. Googlers, please see go/firebase-cli-emulator-gui for the exact semantics for this approved change. No changelogs since this is all behind a preview flag.

This is a follow up to #2222 and should be merged after #2222.

### Scenarios Tested

1. `firebase init emulators` on a project without GUI preferences ==> Snippet in the section below.
2. `firebase init emulators` with GUI enabled already => prints out a confirmation and skips Emulator GUI questions
3. `firebase init emulators` with GUI explicitly disabled => skips Emulator GUI questions

### Sample Commands

```bash
$ firebase init emulators

<snip>

=== Emulators Setup
? Which Firebase emulators do you want to set up? Press Space to select emulators, then Enter to confirm your choices. (Press <space> to select, <a> to toggle all, <i> to invert selection)Functions, Firestore, Database, Hosting
i  Port for functions already configured: 5001
i  Port for firestore already configured: 8080
i  Port for database already configured: 9999
i  Port for hosting already configured: 5000
? Would you like to enable the Emulator GUI? Yes
? Which port do you want to use for the Emulator GUI (leave empty to use any available port)? 
? Would you like to download the emulators now? No

i  Writing configuration info to firebase.json...
i  Writing project information to .firebaserc...

✔  Firebase initialization complete!
```