### PR TITLE
Allow killing emulators before startup completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Fixes an issue where the functions and hosting emulators would crash when not properly initialized (#2112).
 - Fixes an issue where `use` would allow an invalid project identifier.
 - Fixes an issue where custom options passed to `admin.initializeApp()` in the functions emulator were improperly augmented.
+- Fixes an issue where emulators could not be cleanly shut down if they had not started properly (#2228).

--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -2,6 +2,7 @@ import { Command } from "../command";
 import * as controller from "../emulator/controller";
 import * as commandUtils from "../emulator/commandUtils";
 import * as utils from "../utils";
+import { FirebaseError } from "../error";
 
 module.exports = new Command("emulators:start")
   .before(commandUtils.beforeEmulatorCommand)
@@ -10,6 +11,8 @@ module.exports = new Command("emulators:start")
   .option(commandUtils.FLAG_INSPECT_FUNCTIONS, commandUtils.DESC_INSPECT_FUNCTIONS)
   .option(commandUtils.FLAG_IMPORT, commandUtils.DESC_IMPORT)
   .action(async (options: any) => {
+    const killSignalPromise = commandUtils.shutdownWhenKilled();
+
     try {
       await controller.startAll(options);
     } catch (e) {
@@ -20,12 +23,5 @@ module.exports = new Command("emulators:start")
     utils.logLabeledSuccess("emulators", "All emulators started, it is now safe to connect.");
 
     // Hang until explicitly killed
-    await new Promise((res, rej) => {
-      process.on("SIGINT", () => {
-        controller
-          .cleanShutdown()
-          .then(res)
-          .catch(res);
-      });
-    });
+    await killSignalPromise;
   });

--- a/src/commands/ext-dev-emulators-start.ts
+++ b/src/commands/ext-dev-emulators-start.ts
@@ -12,6 +12,8 @@ module.exports = new Command("ext:dev:emulators:start")
   .option(commandUtils.FLAG_TEST_PARAMS, commandUtils.DESC_TEST_PARAMS)
   .option(commandUtils.FLAG_IMPORT, commandUtils.DESC_IMPORT)
   .action(async (options: any) => {
+    const killSignalPromise = commandUtils.shutdownWhenKilled();
+
     const emulatorOptions = await optionsHelper.buildOptions(options);
     try {
       commandUtils.beforeEmulatorCommand(emulatorOptions);
@@ -27,12 +29,5 @@ module.exports = new Command("ext:dev:emulators:start")
     utils.logSuccess("All emulators started, it is now safe to connect.");
 
     // Hang until explicitly killed
-    await new Promise((res, rej) => {
-      process.on("SIGINT", () => {
-        controller
-          .cleanShutdown()
-          .then(res)
-          .catch(res);
-      });
-    });
+    await killSignalPromise;
   });

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -156,6 +156,20 @@ export function parseInspectionPort(options: any): number {
   return parsed;
 }
 
+export function shutdownWhenKilled(): Promise<void> {
+  return new Promise((res, rej) => {
+    process.on("SIGINT", async () => {
+      try {
+        await controller.cleanShutdown();
+        res();
+        process.exit(0);
+      } catch (e) {
+        throw new FirebaseError("Failed to shut down cleanly", { original: e, exit: 1 });
+      }
+    });
+  });
+}
+
 async function runScript(script: string, extraEnv: Record<string, string>): Promise<number> {
   utils.logBullet(`Running script: ${clc.bold(script)}`);
 

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -115,15 +115,12 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
   await EmulatorRegistry.start(instance);
 }
 
-export async function cleanShutdown(): Promise<boolean> {
+export async function cleanShutdown(): Promise<void> {
   utils.logLabeledBullet("emulators", "Shutting down emulators.");
-
   for (const name of EmulatorRegistry.listRunning()) {
     utils.logLabeledBullet(name, `Stopping ${Constants.description(name)}`);
     await EmulatorRegistry.stop(name);
   }
-
-  return true;
 }
 
 export function filterEmulatorTargets(options: any): Emulators[] {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2228

Ex: clean early shutdown:
```
 firebase emulators:start 
i  emulators: Starting emulators: functions, firestore, database, hosting, pubsub
✔  hub: emulator hub started at http://localhost:4400
⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: functions emulator started at http://localhost:5001
i  firestore: firestore emulator logging to firestore-debug.log
^Ci  emulators: Shutting down emulators.
i  hub: Stopping emulator hub
i  functions: Stopping functions emulator
```

Ex: early shutdown with cleanup error:
```
$ firebase emulators:start 
i  emulators: Starting emulators: functions, firestore, database, hosting, pubsub
✔  hub: emulator hub started at http://localhost:4400
⚠  Your requested "node" version "8" doesn't match your global version "10"
✔  functions: functions emulator started at http://localhost:5001
i  firestore: firestore emulator logging to firestore-debug.log
^Ci  emulators: Shutting down emulators.
i  hub: Stopping emulator hub
i  functions: Stopping functions emulator
⚠  emulators: emulators failed to shut down cleanly, see firebase-debug.log for details.
```

### Scenarios Tested

I am now able to properly Ctrl+C the suite at any time during startup, including when startup hangs (example: invalid `functions/node_modules`)

### Sample Commands

N/A