### PR TITLE
Switches firebasemods.*.* permissions to firebaseextensions.*.*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Fixes an issue where the functions and hosting emulators would crash when not properly initialized (#2112).
 - Fixes an issue where `use` would allow an invalid project identifier.
 - Fixes an issue where custom options passed to `admin.initializeApp()` in the functions emulator were improperly augmented.
+- Changes `firebasemods.*.*` IAM permissions to `firebaseextensions.*.*`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,4 @@
 - Fixes an issue where the functions and hosting emulators would crash when not properly initialized (#2112).
 - Fixes an issue where `use` would allow an invalid project identifier.
 - Fixes an issue where custom options passed to `admin.initializeApp()` in the functions emulator were improperly augmented.
-- Changes `firebasemods.*.*` IAM permissions to `firebaseextensions.*.*`
+- Changes `firebasemods.*.*` IAM permission checks to `firebaseextensions.*.*`

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -24,7 +24,10 @@ marked.setOptions({
 export default new Command("ext:configure <extensionInstanceId>")
   .description("configure an existing extension instance")
   .option("--params <paramsFile>", "path of params file with .env format.")
-  .before(requirePermissions, ["firebasemods.instances.update", "firebasemods.instances.get"])
+  .before(requirePermissions, [
+    "firebaseextensions.instances.update",
+    "firebaseextensions.instances.get",
+  ])
   .action(async (instanceId: string, options: any) => {
     const spinner = ora.default(
       `Configuring ${clc.bold(instanceId)}. This usually takes 3 to 5 minutes...`

--- a/src/commands/ext-info.ts
+++ b/src/commands/ext-info.ts
@@ -27,7 +27,7 @@ export default new Command("ext:info <extensionName>")
       }
       spec = await getLocalExtensionSpec(extensionName);
     } else {
-      await requirePermissions(options, ["firebasemods.sources.get"]);
+      await requirePermissions(options, ["firebaseextensions.sources.get"]);
       await ensureExtensionsApiEnabled(options);
 
       const [name, version] = extensionName.split("@");

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -144,7 +144,7 @@ export default new Command("ext:install [extensionName]")
       : "" + "or run with `-i` to see all available extensions."
   )
   .option("--params <paramsFile>", "name of params variables file with .env format.")
-  .before(requirePermissions, ["firebasemods.instances.create"])
+  .before(requirePermissions, ["firebaseextensions.instances.create"])
   .before(ensureExtensionsApiEnabled)
   .action(async (extensionName: string, options: any) => {
     const projectId = getProjectId(options, false);

--- a/src/commands/ext-list.ts
+++ b/src/commands/ext-list.ts
@@ -6,7 +6,7 @@ import { requirePermissions } from "../requirePermissions";
 
 module.exports = new Command("ext:list")
   .description("list all the extensions that are installed in your Firebase project")
-  .before(requirePermissions, ["firebasemods.instances.list"])
+  .before(requirePermissions, ["firebaseextensions.instances.list"])
   .before(ensureExtensionsApiEnabled)
   .action((options: any) => {
     const projectId = getProjectId(options);

--- a/src/commands/ext-sources-create.ts
+++ b/src/commands/ext-sources-create.ts
@@ -18,7 +18,7 @@ export default new Command("ext:sources:create <sourceLocation>")
       "For example, if your extension.yaml is in the my/extension directory of the archive, " +
       "you should use sourceUrl#my/extension. If no extensionRoot is specified, / is assumed."
   )
-  .before(requirePermissions, ["firebasemods.sources.create"])
+  .before(requirePermissions, ["firebaseextensions.sources.create"])
   .before(ensureExtensionsApiEnabled)
   .action(async (sourceLocation: string, options: any) => {
     const projectId = getProjectId(options);

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -19,7 +19,7 @@ import * as logger from "../logger";
 export default new Command("ext:uninstall <extensionInstanceId>")
   .description("uninstall an extension that is installed in your Firebase project by instance ID")
   .option("-f, --force", "No confirmation. Otherwise, a confirmation prompt will appear.")
-  .before(requirePermissions, ["firebasemods.instances.delete"])
+  .before(requirePermissions, ["firebaseextensions.instances.delete"])
   .before(ensureExtensionsApiEnabled)
   .action(async (instanceId: string, options: any) => {
     const projectId = getProjectId(options);

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -23,7 +23,10 @@ marked.setOptions({
  */
 export default new Command("ext:update <extensionInstanceId>")
   .description("update an existing extension instance to the latest version")
-  .before(requirePermissions, ["firebasemods.instances.update", "firebasemods.instances.get"])
+  .before(requirePermissions, [
+    "firebaseextensions.instances.update",
+    "firebaseextensions.instances.get",
+  ])
   .before(ensureExtensionsApiEnabled)
   .action(async (instanceId: string, options: any) => {
     const spinner = ora.default(

--- a/src/commands/ext.ts
+++ b/src/commands/ext.ts
@@ -36,7 +36,7 @@ module.exports = new Command("ext")
 
     // Print out a list of all extension instances on project, if called with a project.
     try {
-      await requirePermissions(options, ["firebasemods.instances.list"]);
+      await requirePermissions(options, ["firebaseextensions.instances.list"]);
       const projectId = getProjectId(options);
       return listExtensions(projectId);
     } catch (err) {


### PR DESCRIPTION
### Description
Switches the ext commands to looks for the new 'firebaseextensions.*.*' permissions instead of 'firebasemods.*.*'
### Scenarios Tested
Permissions checks still working as intended on all ext commands.
![Screen Shot 2020-05-11 at 11 02 26 AM](https://user-images.githubusercontent.com/4635763/81595546-86317180-9377-11ea-91f3-3cb3d2bb1260.png)
![Screen Shot 2020-05-11 at 11 02 20 AM](https://user-images.githubusercontent.com/4635763/81595566-8af62580-9377-11ea-99c4-ca7b06a5b128.png)
![Screen Shot 2020-05-11 at 11 02 10 AM](https://user-images.githubusercontent.com/4635763/81595578-8fbad980-9377-11ea-98ba-17df7ce8f85d.png)
