### PR TITLE
Enable functions runtime engine config through firebase.json

### DIFF
--- a/src/deploy/functions/prepare.js
+++ b/src/deploy/functions/prepare.js
@@ -19,6 +19,7 @@ module.exports = function(context, options, payload) {
   var projectDir = options.config.projectDir;
   var functionNames = payload.functions;
   var projectId = getProjectId(options);
+  var runtimeFromConfig = options.config.get("functions.runtime");
 
   try {
     validator.functionsDirectoryExists(options.cwd, sourceDirName);
@@ -26,12 +27,12 @@ module.exports = function(context, options, payload) {
     // it's annoying that we have to pass in both sourceDirName and sourceDir
     // but they are two different methods on the config object, so cannot get
     // sourceDir from sourceDirName without passing in config
-    validator.packageJsonIsValid(sourceDirName, sourceDir, projectDir);
+    validator.packageJsonIsValid(sourceDirName, sourceDir, projectDir, !!runtimeFromConfig);
   } catch (e) {
     return Promise.reject(e);
   }
 
-  context.runtimeChoice = getRuntimeChoice(sourceDir);
+  context.runtimeChoice = getRuntimeChoice(sourceDir, runtimeFromConfig);
 
   return Promise.all([
     ensureApiEnabled.ensure(options.project, "cloudfunctions.googleapis.com", "functions"),

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -5,6 +5,7 @@ import * as clc from "cli-color";
 import * as logger from "../../logger";
 import * as projectPath from "../../projectPath";
 import * as fsutils from "../../fsutils";
+import { RUNTIME_NOT_SET } from "../../parseRuntimeAndValidateSDK";
 
 // have to require this because no @types/cjson available
 // tslint:disable-next-line
@@ -49,12 +50,14 @@ export function functionNamesAreValid(functionNames: {}): void {
  * @param sourceDirName Name of source directory.
  * @param sourceDir Relative path of source directory.
  * @param projectDir Relative path of project directory.
+ * @param hasRuntimeConfigInConfig Whether the runtime was chosen in the `functions` section of firebase.json.
  * @throws { FirebaseError } Package.json must be present and valid.
  */
 export function packageJsonIsValid(
   sourceDirName: string,
   sourceDir: string,
-  projectDir: string
+  projectDir: string,
+  hasRuntimeConfigInConfig: boolean
 ): void {
   const packageJsonFile = path.join(sourceDir, "package.json");
   if (!fsutils.fileExistsSync(packageJsonFile)) {
@@ -62,14 +65,18 @@ export function packageJsonIsValid(
     throw new FirebaseError(msg);
   }
 
+  let data;
   try {
-    const data = cjson.load(packageJsonFile);
+    data = cjson.load(packageJsonFile);
     logger.debug("> [functions] package.json contents:", JSON.stringify(data, null, 2));
     assertFunctionsSourcePresent(data, sourceDir, projectDir);
-    assertEnginesFieldPresent(data, sourceDirName);
   } catch (e) {
     const msg = `There was an error reading ${sourceDirName}${path.sep}package.json:\n\n ${e.message}`;
     throw new FirebaseError(msg);
+  }
+
+  if (!hasRuntimeConfigInConfig) {
+    assertEnginesFieldPresent(data);
   }
 }
 
@@ -94,17 +101,10 @@ function assertFunctionsSourcePresent(data: any, sourceDir: string, projectDir: 
 /**
  * Asserts the engines field is present in package.json.
  * @param data Object representing package.json file.
- * @param sourceDirName Name of the functions source directory.
  * @throws { FirebaseError } Engines field must be present in package.json.
  */
-function assertEnginesFieldPresent(data: any, sourceDirName: string): void {
+function assertEnginesFieldPresent(data: any): void {
   if (!data.engines || !data.engines.node) {
-    const msg =
-      `Engines field is required but was not found in ${sourceDirName}${path.sep}package.json.\n` +
-      `To fix this, add the following lines to your package.json: \n
-      "engines": {
-        "node": "10"
-      }\n`;
-    throw new FirebaseError(msg);
+    throw new FirebaseError(RUNTIME_NOT_SET);
   }
 }

--- a/src/parseRuntimeAndValidateSDK.ts
+++ b/src/parseRuntimeAndValidateSDK.ts
@@ -25,7 +25,19 @@ const ENGINE_RUNTIMES: { [key: string]: string } = {
   10: "nodejs10",
 };
 
-export const UNSUPPORTED_NODE_VERSION_MSG = clc.bold(
+const ENGINE_RUNTIMES_NAMES = Object.values(ENGINE_RUNTIMES);
+
+export const RUNTIME_NOT_SET =
+  "`runtime` field is required but was not found in firebase.json.\n" +
+  "To fix this, add the following lines to the `functions` section of your firebase.json:\n" +
+  '"runtime": "nodejs10"\n';
+
+export const UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG = clc.bold(
+  `functions.runtime value is unsupported. ` +
+    `The only valid choices are: ${clc.bold("nodejs8")} and ${clc.bold("nodejs10")}.`
+);
+
+export const UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG = clc.bold(
   `package.json in functions directory has an engines field which is unsupported. ` +
     `The only valid choices are: ${clc.bold('{"node": "8"}')} and ${clc.bold('{"node": "10"}')}.`
 );
@@ -70,40 +82,46 @@ export function getHumanFriendlyRuntimeName(runtime: string): string {
   return _.get(MESSAGE_FRIENDLY_RUNTIMES, runtime, runtime);
 }
 
-/**
- * Returns the Node.js version to be used for the function(s) as defined in the
- * package.json.
- * @param sourceDir directory where the functions are defined.
- * @return The runtime, e.g. `nodejs10`.
- */
-export function getRuntimeChoice(sourceDir: string): string {
+function getRuntimeChoiceFromPackageJson(sourceDir: string): string {
   const packageJsonPath = path.join(sourceDir, "package.json");
   const loaded = cjson.load(packageJsonPath);
   const engines = loaded.engines;
   if (!engines || !engines.node) {
-    // We should really never hit this, since deploy/functions/prepare already checked that package.json has an "engines" field.
-    throw new FirebaseError(
-      `Engines field is required but was not found in package.json.\n` +
-        `To fix this, add the following lines to your package.json: \n
-      "engines": {
-        "node": "10"
-      }\n`
-    );
+    // We should really never hit this, since deploy/functions/prepare already checked that
+    // the runtime is defined in either firebase.json or the "engines" field of the package.json.
+    throw new FirebaseError(RUNTIME_NOT_SET);
   }
-  const runtime = ENGINE_RUNTIMES[engines.node];
-  if (!runtime) {
+
+  return ENGINE_RUNTIMES[engines.node];
+}
+
+/**
+ * Returns the Node.js version to be used for the function(s) as defined in the
+ * either the `runtime` field of firebase.json or the package.json.
+ * @param sourceDir directory where the functions are defined.
+ * @param runtimeFromConfig runtime from the `functions` section of firebase.json file (may be empty).
+ * @return The runtime, e.g. `nodejs10`.
+ */
+export function getRuntimeChoice(sourceDir: string, runtimeFromConfig?: string): string {
+  const runtime = runtimeFromConfig || getRuntimeChoiceFromPackageJson(sourceDir);
+  const errorMessage = runtimeFromConfig
+    ? UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG
+    : UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG;
+
+  if (!runtime || !ENGINE_RUNTIMES_NAMES.includes(runtime)) {
     track("functions_runtime_notices", "package_missing_runtime");
-    throw new FirebaseError(UNSUPPORTED_NODE_VERSION_MSG, { exit: 1 });
+    throw new FirebaseError(errorMessage, { exit: 1 });
   }
 
   if (runtime === "nodejs6") {
     track("functions_runtime_notices", "nodejs6_deploy_prohibited");
-    throw new FirebaseError(UNSUPPORTED_NODE_VERSION_MSG, { exit: 1 });
-  } else {
-    if (functionsSDKTooOld(sourceDir, ">=2")) {
-      track("functions_runtime_notices", "functions_sdk_too_old");
-      utils.logWarning(FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
-    }
+    throw new FirebaseError(errorMessage, { exit: 1 });
   }
+
+  if (functionsSDKTooOld(sourceDir, ">=2")) {
+    track("functions_runtime_notices", "functions_sdk_too_old");
+    utils.logWarning(FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
+  }
+
   return runtime;
 }

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -4,6 +4,7 @@ import * as validate from "../../../deploy/functions/validate";
 import * as projectPath from "../../../projectPath";
 import { FirebaseError } from "../../../error";
 import * as sinon from "sinon";
+import { RUNTIME_NOT_SET } from "../../../parseRuntimeAndValidateSDK";
 
 // have to require this because no @types/cjson available
 // tslint:disable-next-line
@@ -100,7 +101,7 @@ describe("validate", () => {
       fileExistsStub.withArgs("sourceDir/package.json").returns(false);
 
       expect(() => {
-        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", false);
       }).to.throw(FirebaseError, "No npm package found");
     });
 
@@ -110,7 +111,7 @@ describe("validate", () => {
       fileExistsStub.withArgs("sourceDir/index.js").returns(false);
 
       expect(() => {
-        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", false);
       }).to.throw(FirebaseError, "does not exist, can't deploy");
     });
 
@@ -120,38 +121,50 @@ describe("validate", () => {
       fileExistsStub.withArgs("sourceDir/src/main.js").returns(false);
 
       expect(() => {
-        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", false);
       }).to.throw(FirebaseError, "does not exist, can't deploy");
     });
 
-    it("should throw error if engines field is not set", () => {
+    it("should not throw error if runtime is set in the config and the engines field is not set", () => {
       cjsonLoadStub.returns({ name: "my-project" });
       fileExistsStub.withArgs("sourceDir/package.json").returns(true);
       fileExistsStub.withArgs("sourceDir/index.js").returns(true);
 
       expect(() => {
-        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
-      }).to.throw(FirebaseError, "Engines field is required but was not found");
-    });
-
-    it("should throw error if engines field is set but node field missing", () => {
-      cjsonLoadStub.returns({ name: "my-project", engines: {} });
-      fileExistsStub.withArgs("sourceDir/package.json").returns(true);
-      fileExistsStub.withArgs("sourceDir/index.js").returns(true);
-
-      expect(() => {
-        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
-      }).to.throw(FirebaseError, "Engines field is required but was not found");
-    });
-
-    it("should not throw error if package.json, functions file exists and engines present", () => {
-      cjsonLoadStub.returns({ name: "my-project", engines: { node: "8" } });
-      fileExistsStub.withArgs("sourceDir/package.json").returns(true);
-      fileExistsStub.withArgs("sourceDir/index.js").returns(true);
-
-      expect(() => {
-        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir");
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", true);
       }).to.not.throw();
+    });
+
+    context("runtime is not set in the config", () => {
+      it("should throw error if runtime is not set in the config and the engines field is not set", () => {
+        cjsonLoadStub.returns({ name: "my-project" });
+        fileExistsStub.withArgs("sourceDir/package.json").returns(true);
+        fileExistsStub.withArgs("sourceDir/index.js").returns(true);
+
+        expect(() => {
+          validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", false);
+        }).to.throw(FirebaseError, RUNTIME_NOT_SET);
+      });
+
+      it("should throw error if engines field is set but node field missing", () => {
+        cjsonLoadStub.returns({ name: "my-project", engines: {} });
+        fileExistsStub.withArgs("sourceDir/package.json").returns(true);
+        fileExistsStub.withArgs("sourceDir/index.js").returns(true);
+
+        expect(() => {
+          validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", false);
+        }).to.throw(FirebaseError, RUNTIME_NOT_SET);
+      });
+
+      it("should not throw error if package.json, functions file exists and engines present", () => {
+        cjsonLoadStub.returns({ name: "my-project", engines: { node: "8" } });
+        fileExistsStub.withArgs("sourceDir/package.json").returns(true);
+        fileExistsStub.withArgs("sourceDir/index.js").returns(true);
+
+        expect(() => {
+          validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", false);
+        }).to.not.throw();
+      });
     });
   });
 });

--- a/src/test/parseRuntimeAndValidateSDK.spec.ts
+++ b/src/test/parseRuntimeAndValidateSDK.spec.ts
@@ -8,7 +8,7 @@ import { FirebaseError } from "../error";
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const cjson = require("cjson");
 
-describe("getRuntimeName", () => {
+describe("getHumanFriendlyRuntimeName", () => {
   it("should properly convert raw runtime to human friendly runtime", () => {
     expect(runtime.getHumanFriendlyRuntimeName("nodejs6")).to.contain("Node.js");
   });
@@ -30,52 +30,91 @@ describe("getRuntimeChoice", () => {
     sandbox.restore();
   });
 
-  it("should error if package.json engines field is set to node 6", () => {
-    cjsonStub.returns({ engines: { node: "6" } });
-    SDKVersionStub.returns("2.0.0");
+  context("when the runtime is set in firebase.json", () => {
+    it("should error if runtime field is set to node 6", () => {
+      SDKVersionStub.returns("2.0.0");
 
-    expect(() => {
-      runtime.getRuntimeChoice("path/to/source");
-    }).to.throw(runtime.UNSUPPORTED_NODE_VERSION_MSG);
-  });
-
-  it("should return node 8 if package.json engines field is set to node 8", () => {
-    cjsonStub.returns({ engines: { node: "8" } });
-    SDKVersionStub.returns("2.0.0");
-
-    expect(runtime.getRuntimeChoice("path/to/source")).to.equal("nodejs8");
-  });
-
-  it("should return node 10 if package.json engines field is set to node 10", () => {
-    cjsonStub.returns({ engines: { node: "10" } });
-    SDKVersionStub.returns("3.4.0");
-
-    expect(runtime.getRuntimeChoice("path/to/source")).to.equal("nodejs10");
-    expect(warningSpy).not.called;
-  });
-
-  it("should print warning when firebase-functions version is below 2.0.0", () => {
-    cjsonStub.returns({ engines: { node: "10" } });
-    SDKVersionStub.returns("0.5.0");
-
-    runtime.getRuntimeChoice("path/to/source");
-    expect(warningSpy).calledWith(runtime.FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
-  });
-
-  it("should not throw error if user's SDK version fails to be fetched", () => {
-    cjsonStub.returns({ engines: { node: "10" } });
-    // Intentionally not setting SDKVersionStub so it can fail to be fetched.
-    expect(runtime.getRuntimeChoice("path/to/source")).to.equal("nodejs10");
-    expect(warningSpy).not.called;
-  });
-
-  it("should throw error if unsupported node version set in package.json", () => {
-    cjsonStub.returns({
-      engines: { node: "11" },
+      expect(() => {
+        runtime.getRuntimeChoice("path/to/source", "nodejs6");
+      }).to.throw(runtime.UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG);
     });
-    expect(() => runtime.getRuntimeChoice("path/to/source")).to.throw(
-      FirebaseError,
-      runtime.UNSUPPORTED_NODE_VERSION_MSG
-    );
+
+    it("should return node 8 if runtime field is set to node 8", () => {
+      SDKVersionStub.returns("2.0.0");
+
+      expect(runtime.getRuntimeChoice("path/to/source", "nodejs8")).to.equal("nodejs8");
+    });
+
+    it("should return node 10 if runtime field is set to node 10", () => {
+      SDKVersionStub.returns("3.4.0");
+
+      expect(runtime.getRuntimeChoice("path/to/source", "nodejs10")).to.equal("nodejs10");
+      expect(warningSpy).not.called;
+    });
+
+    it("should print warning when firebase-functions version is below 2.0.0", () => {
+      SDKVersionStub.returns("0.5.0");
+
+      runtime.getRuntimeChoice("path/to/source", "nodejs10");
+      expect(warningSpy).calledWith(runtime.FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
+    });
+
+    it("should throw error if unsupported node version set", () => {
+      expect(() => runtime.getRuntimeChoice("path/to/source", "nodejs11")).to.throw(
+        FirebaseError,
+        runtime.UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG
+      );
+    });
+  });
+
+  context("when the runtime is not set in firebase.json", () => {
+    it("should error if engines field is set to node 6", () => {
+      cjsonStub.returns({ engines: { node: "6" } });
+      SDKVersionStub.returns("2.0.0");
+
+      expect(() => {
+        runtime.getRuntimeChoice("path/to/source", "");
+      }).to.throw(runtime.UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG);
+    });
+
+    it("should return node 8 if engines field is set to node 8", () => {
+      cjsonStub.returns({ engines: { node: "8" } });
+      SDKVersionStub.returns("2.0.0");
+
+      expect(runtime.getRuntimeChoice("path/to/source", "")).to.equal("nodejs8");
+    });
+
+    it("should return node 10 if engines field is set to node 10", () => {
+      cjsonStub.returns({ engines: { node: "10" } });
+      SDKVersionStub.returns("3.4.0");
+
+      expect(runtime.getRuntimeChoice("path/to/source", "")).to.equal("nodejs10");
+      expect(warningSpy).not.called;
+    });
+
+    it("should print warning when firebase-functions version is below 2.0.0", () => {
+      cjsonStub.returns({ engines: { node: "10" } });
+      SDKVersionStub.returns("0.5.0");
+
+      runtime.getRuntimeChoice("path/to/source", "");
+      expect(warningSpy).calledWith(runtime.FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
+    });
+
+    it("should not throw error if user's SDK version fails to be fetched", () => {
+      cjsonStub.returns({ engines: { node: "10" } });
+      // Intentionally not setting SDKVersionStub so it can fail to be fetched.
+      expect(runtime.getRuntimeChoice("path/to/source", "")).to.equal("nodejs10");
+      expect(warningSpy).not.called;
+    });
+
+    it("should throw error if unsupported node version set", () => {
+      cjsonStub.returns({
+        engines: { node: "11" },
+      });
+      expect(() => runtime.getRuntimeChoice("path/to/source", "")).to.throw(
+        FirebaseError,
+        runtime.UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG
+      );
+    });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This is the implementation for https://github.com/firebase/firebase-tools/issues/1450.
The goal is to allow the configuration of the nodejs runtime in `firebase.json`, like so:
```json
{
  "functions": {
    "runtime": "nodejs10"
  }
}
```

The new method takes precedence over the old one, so if the runtime in configured in both `firebase.json` and `package.json`, the latter will be ignored.

I did my best to keep the compat and display meaningful error messages.

I can't update the doc however, I don't know where it is. [This](https://firebase.google.com/docs/functions/manage-functions#set_nodejs_version) looks like the only page that will be affected.

Depending on what you want to do with it, I could also add deprecation message for the `package.json` method if it's the only one set.

### Scenarios Tested

Ran `npm run test` and `npm run build`. I also tested the following by hand use the command `firebase deploy --only functions`:
* No config set anywhere
> i  deploying functions
> 
> Error: `runtime` field is required but was not found in firebase.json.
> To fix this, add the following lines to the `functions` section of your firebase.json:
> "runtime": "nodejs10"
* `nodejs6`, `nodejs11`, or `wat` set in `firebase.json`:
> i  deploying functions
> 
> Error: functions.runtime value is unsupported. The only valid choices are: nodejs8 and nodejs10.
* `nodejs8` in `firebase.json`:
> i  deploying functions
> i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
> ✔  functions: required API cloudfunctions.googleapis.com is enabled
> ...
* `6`, `11`, `>=8`, or `wat` set in the `package.json`'s `engine.node` field:
> i  deploying functions
> 
> Error: package.json in functions directory has an engines field which is unsupported. The only valid choices are: {"node": "8"} and {"node": "10"}.
* `8` config set in `package.json`:
> i  deploying functions
> i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
> ✔  functions: required API cloudfunctions.googleapis.com is enabled
> ...

### Sample Commands
N/A
