### PR TITLE
Make functions run in GMT time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes bug causing Hosting emulator to serve invalid /\_\_/\* files.
+- Fixes bug where functions would run in local time zone instead of UTC (#2253).

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -584,6 +584,7 @@ function warnAboutDatabaseProd(): void {
 }
 
 function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): void {
+  process.env.TZ = "UTC";
   process.env.GCLOUD_PROJECT = frb.projectId;
   process.env.FUNCTIONS_EMULATOR = "true";
 

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -679,6 +679,23 @@ describe("FunctionsEmulator-Runtime", () => {
 
         expect(JSON.parse(data)).to.deep.equal({ hostname: "real-hostname" });
       }).timeout(TIMEOUT_MED);
+
+      it("should report GMT time zone", async () => {
+        const frb = FunctionRuntimeBundles.onRequest;
+        const worker = InvokeRuntimeWithFunctions(frb, () => {
+          return {
+            function_id: require("firebase-functions").https.onRequest(
+              async (req: any, res: any) => {
+                const now = new Date();
+                res.json({ offset: now.getTimezoneOffset() });
+              }
+            ),
+          };
+        });
+
+        const data = await CallHTTPSFunction(worker, frb);
+        expect(JSON.parse(data)).to.deep.equal({ offset: 0 });
+      });
     });
 
     describe("Cloud Firestore", () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2253

See comments in that issue for proof that this matches production.

### Scenarios Tested

Unit tested.

### Sample Commands

N/A