### PR TITLE
Release Cloud Firestore Emulator v1.11.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 - Fixes bug causing Hosting emulator to serve invalid /\_\_/\* files.
+- Fixes bug in Firestore emulator for evaluating rules in query listening.
+- Fixes support in Firestore emulator for `?show_missing` in listing collection.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -39,14 +39,14 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.3.jar"),
-    version: "1.11.3",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.4.jar"),
+    version: "1.11.4",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.3.jar",
-      expectedSize: 63384036,
-      expectedChecksum: "6ce2af3b5c1b70cb1ff78db5df382b49",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.4.jar",
+      expectedSize: 63915084,
+      expectedChecksum: "53a1e2ee7b8a2b26a46f50167dcf4962",
       namePrefix: "cloud-firestore-emulator",
     },
   },


### PR DESCRIPTION
### Description

See changelog

### Scenarios Tested

`firebase emulators:start` now downloads the new version. I've also tested writing data to the new emulator and it still works.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
