### PR TITLE
docs: replace deprecated method on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The Firebase CLI can also be used programmatically as a standard Node module. Ea
 
 ```js
 var client = require("firebase-tools");
-client
+client.projects
   .list()
   .then(function(data) {
     console.log(data);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
This should replace the deprecated `client.list()` method with `client.projects.list()` on our README.md file.

Fixes #2274 

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
