### PR TITLE
Remove deep functions.config() proxying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Remove proxying of `functions.config()` inside the Functions emulator.
+- Remove deep proxying of `functions.config()` inside the Functions emulator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Remove proxying of `functions.config()` inside the Functions emulator.

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -173,6 +173,12 @@ export class EmulatorLogger {
           `External network resource requested!\n   - URL: "${systemLog.data.href}"\n - Be careful, this may be a production service.`
         );
         break;
+      case "functions-config-missing-value":
+        this.log(
+          "WARN_ONCE",
+          `It looks like you're trying to access functions.config().${systemLog.data.key} but there is no value there. You can learn more about setting up config here: https://firebase.google.com/docs/functions/local-emulator`
+        );
+        break;
       case "non-default-admin-app-used":
         this.log(
           "WARN",

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -173,12 +173,6 @@ export class EmulatorLogger {
           `External network resource requested!\n   - URL: "${systemLog.data.href}"\n - Be careful, this may be a production service.`
         );
         break;
-      case "functions-config-missing-value":
-        this.log(
-          "WARN",
-          `Non-existent functions.config() value requested!\n   - Path: "${systemLog.data.valuePath}"\n   - Learn more at https://firebase.google.com/docs/functions/local-emulator`
-        );
-        break;
       case "non-default-admin-app-used":
         this.log(
           "WARN",

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -434,38 +434,6 @@ describe("FunctionsEmulator-Runtime", () => {
         await worker.runtime.exit;
       }).timeout(TIMEOUT_MED);
     });
-
-    describe("_InitializeFunctionsConfigHelper()", () => {
-      it("should tell the user if they've accessed a non-existent function field", async () => {
-        const worker = InvokeRuntimeWithFunctions(
-          FunctionRuntimeBundles.onCreate,
-          () => {
-            require("firebase-admin").initializeApp();
-            return {
-              function_id: require("firebase-functions")
-                .firestore.document("test/test")
-                .onCreate(async () => {
-                  /* tslint:disable:no-console */
-                  console.log(require("firebase-functions").config().doesnt.exist);
-                  console.log(require("firebase-functions").config().does.exist);
-                  console.log(require("firebase-functions").config().also_doesnt.exist);
-                }),
-            };
-          },
-          {
-            nodeBinary: process.execPath,
-            env: {
-              CLOUD_RUNTIME_CONFIG: JSON.stringify({
-                does: { exist: "already exists" },
-              }),
-            },
-          }
-        );
-
-        const logs = await _countLogEntries(worker);
-        expect(logs["functions-config-missing-value"]).to.eq(2);
-      }).timeout(TIMEOUT_MED);
-    });
   });
 
   describe("Runtime", () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2273

Since #2041 we now correctly support `.runtimeconfig.json` inside the Functions emulator.  Our proxying of config() was only for warnings but it can mess things up (see fixed bug) because a `Proxy` is not the same as a plain object in many ways.

I remove almost all the functionality but leave the warning

### Scenarios Tested

Here is my config:
```json
{
  "foo": {
    "hello": "world"
  }
}
```

I wrote this function and called it twice in a row:
```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp(functions.config().firebase);

exports.checkConfig = functions.https.onRequest(async (request, response) => {
  const fooVal = functions.config().foo;
  console.log("Foo config", fooVal);

  const barVal = functions.config().bar;
  console.log("Bar config", barVal);

  response.send("Hello from Firebase!");
});

```

Here are the logs:
```
i  functions: Beginning execution of "checkConfig"
>  Foo config { hello: 'world' }
>  Bar config undefined
⚠  It looks like you're trying to access functions.config().bar but there is no value there. You can learn more about setting up config here: https://firebase.google.com/docs/functions/local-emulator
i  functions: Finished "checkConfig" in ~1s
i  functions: Beginning execution of "checkConfig"
>  Foo config { hello: 'world' }
>  Bar config undefined
i  functions: Finished "checkConfig" in ~1s
```

### Sample Commands

N/A