### PR TITLE
Fix small issues with init emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Fixes issue where custom emulator ports were strings not numbers (#2287).
+- Fixes issue where Emulator UI was never downloaded during `firebase init emulators`.

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -46,7 +46,7 @@ export async function doSetup(setup: any, config: any) {
     } else {
       await prompt(setup.config.emulators[selected], [
         {
-          type: "input",
+          type: "number",
           name: "port",
           message: `Which port do you want to use for the ${clc.underline(selected)} emulator?`,
           default: Constants.getDefaultPort(selected as Emulators),
@@ -76,7 +76,7 @@ export async function doSetup(setup: any, config: any) {
       if (ui.enabled) {
         await prompt(ui, [
           {
-            type: "input",
+            type: "number",
             name: "port",
             message: `Which port do you want to use for the ${clc.underline(
               uiDesc
@@ -105,6 +105,10 @@ export async function doSetup(setup: any, config: any) {
       if (isDownloadableEmulator(selected)) {
         await downloadIfNecessary(selected);
       }
+    }
+
+    if (_.get(setup, "config.emulators.ui.enabled")) {
+      downloadIfNecessary(Emulators.UI);
     }
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

- Fixes #2287
- Fixes an issue with UI not being downloaded

### Scenarios Tested

Run `firebase init emulators` on a fresh project, selecting only Firestore and UI and selecting custom ports for both.

### Sample Commands

N/A