### PR TITLE
Return SDK config automatically if only one app in project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes issue where custom emulator ports were strings not numbers (#2287).
 - Fixes issue where Emulator UI was never downloaded during `firebase init emulators`.
+- Skip app selection `firebase apps:sdkconfig` if there is a single matching app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Fixes issue where custom emulator ports were strings not numbers (#2287).
 - Fixes issue where Emulator UI was never downloaded during `firebase init emulators`.
-- Skip app selection `firebase apps:sdkconfig` if there is a single matching app.
+- Skip app selection in `firebase apps:sdkconfig` if there is a single matching app.

--- a/src/commands/apps-sdkconfig.ts
+++ b/src/commands/apps-sdkconfig.ts
@@ -11,6 +11,7 @@ import {
   getAppPlatform,
   listFirebaseApps,
 } from "../management/apps";
+import * as getProjectId from "../getProjectId";
 import { getOrPromptProject } from "../management/projects";
 import { FirebaseError } from "../error";
 import { requireAuth } from "../requireAuth";
@@ -18,14 +19,9 @@ import * as logger from "../logger";
 import { promptOnce } from "../prompt";
 
 async function selectAppInteractively(
-  projectId: string,
+  apps: AppMetadata[],
   appPlatform: AppPlatform
 ): Promise<AppMetadata> {
-  if (!projectId) {
-    throw new FirebaseError("Project ID must not be empty.");
-  }
-
-  const apps = await listFirebaseApps(projectId, appPlatform);
   if (apps.length === 0) {
     throw new FirebaseError(
       `There are no ${appPlatform === AppPlatform.ANY ? "" : appPlatform + " "}apps ` +
@@ -66,15 +62,28 @@ module.exports = new Command("apps:sdkconfig [platform] [appId]")
       let appPlatform = getAppPlatform(platform);
 
       if (!appId) {
-        if (options.nonInteractive) {
-          throw new FirebaseError("App ID must not be empty.");
+        let projectId = getProjectId(options);
+        if (options.nonInteractive && !projectId) {
+          throw new FirebaseError("Must supply app and project ids in non-interactive mode.");
+        } else if (!projectId) {
+          const result = await getOrPromptProject(options);
+          projectId = result.projectId;
         }
 
-        const { projectId } = await getOrPromptProject(options);
-
-        const appMetadata: AppMetadata = await selectAppInteractively(projectId, appPlatform);
-        appId = appMetadata.appId;
-        appPlatform = appMetadata.platform;
+        const apps = await listFirebaseApps(projectId, appPlatform);
+        // if there's only one app, we don't need to prompt interactively
+        if (apps.length === 1) {
+          appId = apps[0].appId;
+          appPlatform = apps[0].platform;
+        } else if (options.nonInteractive) {
+          throw new FirebaseError(
+            `Project ${projectId} has multiple apps, must specify an app id.`
+          );
+        } else {
+          const appMetadata: AppMetadata = await selectAppInteractively(apps, appPlatform);
+          appId = appMetadata.appId;
+          appPlatform = appMetadata.platform;
+        }
       }
 
       let configData;


### PR DESCRIPTION
Currently, `firebase apps:sdkconfig web` (for example) will prompt the user to select a project if an `appId` is not specified. However, that means the person running the command has to already have the `appId` handy which is pretty inconvenient in the common case (a project has a single web app).

This PR changes the logic of the command such that it will simply return the SDK config iff there is a single app in the project. If there are multiple apps, the behavior remains the same as today.

### Why does this matter?

When building tooling for, e.g. inserting an SDK config based on the current project as per `firebase use`, it is currently necessary for users to somehow store and remember "this app id for this project." After this PR, this becomes automagic:

```
$ firebase use prod
$ firebase apps:sdkconfig web > somewhere.json
$ firebase use staging
$ firebase apps:sdkconfig web > somewhere.json
```