### PR TITLE
Improves error handling of Cloud Build enablement PERMISSION_DENIED.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Skip app selection in `firebase apps:sdkconfig` if there is a single matching app.
 - Fixes incorrect warning about emulator configuration (#2290).
 - Improves error messages for `firebase init` with new projects (#2266).
+- Improves handling of permission denied errors during API enablement.


### PR DESCRIPTION
This improves handling of Cloud Build API enablement errors (specifically `PERMISSION_DENIED`) by being specific about what needs to happen (aka ask an owner to go enable it) and by not erroring out if it happens before the actual deadline to enable.