### PR TITLE
Remove Firebase Storage API check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes error message when `firebase init firestore` is used on a project with Cloud Firestore in Datastore mode.
+- Fixes issue where `firebase init storage` incorrectly reports Cloud Storage has not been used.

--- a/src/init/features/storage.ts
+++ b/src/init/features/storage.ts
@@ -1,11 +1,9 @@
 import * as clc from "cli-color";
 import * as fs from "fs";
 
-import * as apiEnabled from "../../ensureApiEnabled";
 import * as logger from "../../logger";
 import { promptOnce } from "../../prompt";
 import { ensureLocationSet } from "../../ensureCloudResourceLocation";
-import { FirebaseError } from "../../error";
 
 const RULES_TEMPLATE = fs.readFileSync(
   __dirname + "/../../../templates/init/storage/storage.rules",
@@ -13,21 +11,6 @@ const RULES_TEMPLATE = fs.readFileSync(
 );
 
 export async function doSetup(setup: any, config: any): Promise<void> {
-  const isStorageInabled = await apiEnabled.check(
-    setup.projectId,
-    "firebasestorage.googleapis.com",
-    "",
-    true
-  );
-  if (!isStorageInabled) {
-    throw new FirebaseError(
-      `It looks like you haven't used Cloud Storage in this project before. Go to ${clc.bold.underline(
-        `https://console.firebase.google.com/project/${setup.projectId}/storage`
-      )} to create your Storage bucket.`,
-      { exit: 1 }
-    );
-  }
-
   setup.config.storage = {};
   ensureLocationSet(setup.projectLocation, "Cloud Storage");
 

--- a/src/test/init/features/storage.spec.ts
+++ b/src/test/init/features/storage.spec.ts
@@ -6,18 +6,15 @@ import { FirebaseError } from "../../../error";
 import * as Config from "../../../config";
 import { doSetup } from "../../../init/features/storage";
 import * as prompt from "../../../prompt";
-import * as apiEnabled from "../../../ensureApiEnabled";
 
 describe("storage", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
   let writeProjectFileStub: sinon.SinonStub;
   let promptStub: sinon.SinonStub;
-  let checkApiStub: sinon.SinonStub;
 
   beforeEach(() => {
     writeProjectFileStub = sandbox.stub(Config.prototype, "writeProjectFile");
     promptStub = sandbox.stub(prompt, "promptOnce");
-    checkApiStub = sandbox.stub(apiEnabled, "check");
   });
 
   afterEach(() => {
@@ -32,7 +29,6 @@ describe("storage", () => {
         projectId: "my-project-123",
         projectLocation: "us-central",
       };
-      checkApiStub.returns(true);
       promptStub.returns("storage.rules");
       writeProjectFileStub.resolves();
 
@@ -47,25 +43,10 @@ describe("storage", () => {
         rcfile: {},
         projectId: "my-project-123",
       };
-      checkApiStub.returns(true);
 
       expect(doSetup(setup, new Config("/path/to/src", {}))).to.eventually.be.rejectedWith(
         FirebaseError,
         "Cloud resource location is not set"
-      );
-    });
-
-    it("should error when the Cloud Storage API is not enabled", async () => {
-      const setup = {
-        config: {},
-        rcfile: {},
-        projectId: "my-project-123",
-      };
-      checkApiStub.returns(false);
-
-      expect(doSetup(setup, new Config("/path/to/src", {}))).to.eventually.be.rejectedWith(
-        FirebaseError,
-        "It looks like you haven't used Cloud Storage"
       );
     });
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2316

### Scenarios Tested

`firebase init storage`

It turns out that `firebasestorage.googleapis.com` is not the right signal, it is often disabled on projects that use Storage already.

### Sample Commands

N/A