### PR TITLE
Add error message for bad Java version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes error message when `firebase init firestore` is used on a project with Cloud Firestore in Datastore mode.
+- Fixes error message when Java version is too low to run the emulators (#2307).

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -199,9 +199,6 @@ function _getCommand(
 }
 
 function _fatal(emulator: DownloadableEmulatorDetails, errorMsg: string): void {
-  if (emulator.instance) {
-    emulator.instance.kill("SIGINT");
-  }
   throw new FirebaseError(emulator.name + ": " + errorMsg, { exit: 1 });
 }
 
@@ -252,6 +249,14 @@ async function _runBinary(
     emulator.instance.stderr.on("data", (data) => {
       logger.log("DEBUG", data.toString());
       emulator.stdout.write(data);
+
+      if (data.toString().includes("java.lang.UnsupportedClassVersionError")) {
+        logger.logLabeled(
+          "WARN",
+          emulator.name,
+          "Unsupported java version, make sure java --version reports 1.8 or higher."
+        );
+      }
     });
 
     emulator.instance.on("error", (err: any) => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2307 (to some extent)

### Scenarios Tested

**Java 8**
```
$ JAVA_HOME=$(/usr/libexec/java_home -v 1.8) firebase emulators:start --only firestore
i  emulators: Starting emulators: firestore
i  firestore: Firestore Emulator logging to firestore-debug.log
i  ui: Emulator UI logging to ui-debug.log

┌───────────────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! View status and logs at http://localhost:4000 │
└───────────────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Firestore │ localhost:8040 │ http://localhost:4000/firestore │
└───────────┴────────────────┴─────────────────────────────────┘
  Other reserved ports: 4400, 4500

Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
```

**Java 7**
```
$ JAVA_HOME=$(/usr/libexec/java_home -v 1.7) firebase emulators:start --only firestore
i  emulators: Starting emulators: firestore
i  firestore: Firestore Emulator logging to firestore-debug.log
⚠  firestore: Unsupported java version, make sure java --version reports 1.8 or higher.

Error: firestore: Firestore Emulator has exited with code: 1
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
