### PR TITLE
enforce require await

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -47,10 +47,8 @@ module.exports = {
         "@typescript-eslint/prefer-includes": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/prefer-regexp-exec": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/prefer-string-starts-ends-with": "warn", // TODO(bkendall): remove, allow to error.
-        "@typescript-eslint/require-await": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/unbound-method": "warn", // TODO(bkendall): remove, allow to error.
         camelcase: "warn", // TODO(bkendall): remove, allow to error.
-        "new-cap": "warn", // TODO(bkendall): remove, allow to error.
         "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
         "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
         "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.

--- a/src/appdistribution/distribution.ts
+++ b/src/appdistribution/distribution.ts
@@ -62,7 +62,7 @@ export class Distribution {
    *
    * This is used to check the distribution upload status.
    */
-  async binaryName(app: AppDistributionApp): Promise<string> {
+  binaryName(app: AppDistributionApp): Promise<string> {
     return new Promise<string>((resolve) => {
       const hash = crypto.createHash("sha256");
       const stream = this.readStream();

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -60,11 +60,11 @@ export class DatabaseEmulator implements EmulatorInstance {
     return downloadableEmulators.start(Emulators.DATABASE, this.args);
   }
 
-  async connect(): Promise<void> {
-    return;
+  connect(): Promise<void> {
+    return Promise.resolve();
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
     return downloadableEmulators.stop(Emulators.DATABASE);
   }
 

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -49,7 +49,7 @@ module.exports = async (name: DownloadableEmulator) => {
 function unzip(zipPath: string, unzipDir: string): Promise<void> {
   return new Promise((resolve, reject) => {
     fs.createReadStream(zipPath)
-      .pipe(unzipper.Extract({ path: unzipDir }))
+      .pipe(unzipper.Extract({ path: unzipDir })) // eslint-disable-line new-cap
       .on("error", reject)
       .on("finish", resolve);
   });
@@ -126,7 +126,7 @@ function downloadToTmp(remoteUrl: string): Promise<string> {
 /**
  * Checks whether the file at `filepath` has the expected size.
  */
-async function validateSize(filepath: string, expectedSize: number): Promise<void> {
+function validateSize(filepath: string, expectedSize: number): Promise<void> {
   return new Promise((resolve, reject) => {
     const stat = fs.statSync(filepath);
     return stat.size === expectedSize
@@ -143,7 +143,7 @@ async function validateSize(filepath: string, expectedSize: number): Promise<voi
 /**
  * Checks whether the file at `filepath` has the expected checksum.
  */
-async function validateChecksum(filepath: string, expectedChecksum: string): Promise<void> {
+function validateChecksum(filepath: string, expectedChecksum: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const hash = crypto.createHash("md5");
     const stream = fs.createReadStream(filepath);

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -62,11 +62,11 @@ export class FirestoreEmulator implements EmulatorInstance {
     return downloadableEmulators.start(Emulators.FIRESTORE, this.args);
   }
 
-  async connect(): Promise<void> {
-    return;
+  connect(): Promise<void> {
+    return Promise.resolve();
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
     if (this.rulesWatcher) {
       this.rulesWatcher.close();
     }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -360,7 +360,7 @@ export class FunctionsEmulator implements EmulatorInstance {
   async stop(): Promise<void> {
     this.workQueue.stop();
     this.workerPool.exit();
-    Promise.resolve(this.server && this.server.close());
+    await Promise.resolve(this.server && this.server.close());
   }
 
   addRealtimeDatabaseTrigger(
@@ -551,7 +551,7 @@ export class FunctionsEmulator implements EmulatorInstance {
    *  specified in extension.yaml. This will ALWAYS be populated when emulating extensions, even if they
    *  are using the default version.
    */
-  async askInstallNodeVersion(cwd: string, nodeMajorVersion?: string): Promise<string> {
+  askInstallNodeVersion(cwd: string, nodeMajorVersion?: string): Promise<string> {
     const pkg = require(path.join(cwd, "package.json"));
     // If the developer hasn't specified a Node to use, inform them that it's an option and use default
     if ((!pkg.engines || !pkg.engines.node) && !nodeMajorVersion) {
@@ -560,7 +560,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         "Your functions directory does not specify a Node version.\n   " +
           "- Learn more at https://firebase.google.com/docs/functions/manage-functions#set_runtime_options"
       );
-      return process.execPath;
+      return Promise.resolve(process.execPath);
     }
 
     const hostMajorVersion = process.versions.node.split(".")[0];
@@ -583,7 +583,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         "functions",
         `Using node@${requestedMajorVersion} from host.`
       );
-      return process.execPath;
+      return Promise.resolve(process.execPath);
     }
 
     // If the requested version is already locally available, let's use that
@@ -593,7 +593,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         "functions",
         `Using node@${requestedMajorVersion} from local cache.`
       );
-      return localNodePath;
+      return Promise.resolve(localNodePath);
     }
 
     /*
@@ -605,7 +605,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       `Your requested "node" version "${requestedMajorVersion}" doesn't match your global version "${hostMajorVersion}"`
     );
 
-    return process.execPath;
+    return Promise.resolve(process.execPath);
   }
 
   invokeRuntime(frb: FunctionsRuntimeBundle, opts: InvokeRuntimeOpts): RuntimeWorker {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -40,15 +40,12 @@ function noOp(): false {
   return false;
 }
 
-async function requireAsync(moduleName: string, opts?: { paths: string[] }): Promise<any> {
-  return require(require.resolve(moduleName, opts));
+function requireAsync(moduleName: string, opts?: { paths: string[] }): Promise<any> {
+  return Promise.resolve(require(require.resolve(moduleName, opts)));
 }
 
-async function requireResolveAsync(
-  moduleName: string,
-  opts?: { paths: string[] }
-): Promise<string> {
-  return require.resolve(moduleName, opts);
+function requireResolveAsync(moduleName: string, opts?: { paths: string[] }): Promise<string> {
+  return Promise.resolve(require.resolve(moduleName, opts));
 }
 
 interface PackageJSON {
@@ -365,7 +362,7 @@ function initializeNetworkFiltering(frb: FunctionsRuntimeBundle): void {
       try {
         return original(...args);
       } catch (e) {
-        const newed = new original(...args);
+        const newed = new original(...args); // eslint-disable-line new-cap
         return newed;
       }
     };
@@ -712,7 +709,7 @@ function rawBodySaver(req: express.Request, res: express.Response, buf: Buffer):
 
 async function processHTTPS(frb: FunctionsRuntimeBundle, trigger: EmulatedTrigger): Promise<void> {
   const ephemeralServer = express();
-  const functionRouter = express.Router();
+  const functionRouter = express.Router(); // eslint-disable-line new-cap
   const socketPath = frb.socketPath;
 
   if (!socketPath) {

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -63,7 +63,7 @@ export class RuntimeWorker {
     });
   }
 
-  execute(frb: FunctionsRuntimeBundle, opts?: InvokeRuntimeOpts): Promise<void> {
+  execute(frb: FunctionsRuntimeBundle, opts?: InvokeRuntimeOpts): void {
     // Make a copy so we don't edit it
     const execFrb: FunctionsRuntimeBundle = { ...frb };
 
@@ -77,7 +77,6 @@ export class RuntimeWorker {
     this.state = RuntimeWorkerState.BUSY;
     this.lastArgs = args;
     this.runtime.send(args);
-    return Promise.resolve();
   }
 
   get state(): RuntimeWorkerState {

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -63,7 +63,7 @@ export class RuntimeWorker {
     });
   }
 
-  async execute(frb: FunctionsRuntimeBundle, opts?: InvokeRuntimeOpts) {
+  execute(frb: FunctionsRuntimeBundle, opts?: InvokeRuntimeOpts): Promise<void> {
     // Make a copy so we don't edit it
     const execFrb: FunctionsRuntimeBundle = { ...frb };
 
@@ -77,6 +77,7 @@ export class RuntimeWorker {
     this.state = RuntimeWorkerState.BUSY;
     this.lastArgs = args;
     this.runtime.send(args);
+    return Promise.resolve();
   }
 
   get state(): RuntimeWorkerState {

--- a/src/emulator/hostingEmulator.ts
+++ b/src/emulator/hostingEmulator.ts
@@ -11,18 +11,18 @@ interface HostingEmulatorArgs {
 export class HostingEmulator implements EmulatorInstance {
   constructor(private args: HostingEmulatorArgs) {}
 
-  async start(): Promise<void> {
+  start(): Promise<void> {
     this.args.options.host = this.args.host;
     this.args.options.port = this.args.port;
 
     return serveHosting.start(this.args.options);
   }
 
-  async connect(): Promise<void> {
-    return;
+  connect(): Promise<void> {
+    return Promise.resolve();
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
     return serveHosting.stop();
   }
 

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -70,11 +70,11 @@ export class EmulatorHub implements EmulatorInstance {
     this.hub = express();
     this.hub.use(bodyParser.json());
 
-    this.hub.get("/", async (req, res) => {
+    this.hub.get("/", (req, res) => {
       res.json(this.getLocator());
     });
 
-    this.hub.get(EmulatorHub.PATH_EMULATORS, async (req, res) => {
+    this.hub.get(EmulatorHub.PATH_EMULATORS, (req, res) => {
       const body: GetEmulatorsResponse = {};
       EmulatorRegistry.listRunning().forEach((name) => {
         body[name] = EmulatorRegistry.get(name)!.getInfo();

--- a/src/emulator/loggingEmulator.ts
+++ b/src/emulator/loggingEmulator.ts
@@ -34,20 +34,21 @@ export class LoggingEmulator implements EmulatorInstance {
 
   constructor(private args: LoggingEmulatorArgs) {}
 
-  async start(): Promise<void> {
+  start(): Promise<void> {
     this.transport = new WebSocketTransport();
     this.transport.start(this.getInfo());
     logger.add(this.transport);
+    return Promise.resolve();
   }
 
-  async connect(): Promise<void> {
-    return;
+  connect(): Promise<void> {
+    return Promise.resolve();
   }
 
-  async stop(): Promise<void> {
+  stop(): Promise<void> {
     logger.remove(this.transport);
 
-    if (this.transport && this.transport.wss) {
+    if (this.transport?.wss) {
       const wss = this.transport.wss;
       return new Promise((resolve, reject) => {
         wss.close((err) => {
@@ -56,6 +57,8 @@ export class LoggingEmulator implements EmulatorInstance {
         });
       });
     }
+
+    return Promise.resolve();
   }
 
   getInfo(): EmulatorInfo {

--- a/src/emulator/pubsubEmulator.ts
+++ b/src/emulator/pubsubEmulator.ts
@@ -42,8 +42,8 @@ export class PubsubEmulator implements EmulatorInstance {
     return downloadableEmulators.start(Emulators.PUBSUB, this.args);
   }
 
-  async connect(): Promise<void> {
-    return;
+  connect(): Promise<void> {
+    return Promise.resolve();
   }
 
   async stop(): Promise<void> {

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -35,8 +35,8 @@ export class EmulatorUI implements EmulatorInstance {
     return downloadableEmulators.start(Emulators.UI, { auto_download }, env);
   }
 
-  async connect(): Promise<void> {
-    return;
+  connect(): Promise<void> {
+    return Promise.resolve();
   }
 
   stop(): Promise<void> {

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -13,7 +13,7 @@ import * as getProjectId from "../../getProjectId";
 import { Emulators } from "../../emulator/types";
 
 export async function buildOptions(options: any): Promise<any> {
-  const extensionDir = await specHelper.findExtensionYaml(process.cwd());
+  const extensionDir = specHelper.findExtensionYaml(process.cwd());
   options.extensionDir = extensionDir;
   const extensionYaml = await specHelper.readExtensionYaml(extensionDir);
   extensionsHelper.validateSpec(extensionYaml);

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -36,7 +36,7 @@ function wrappedSafeLoad(source: string): any {
  * directory that contains one. Throws an error if none is found.
  * @param directory the directory to start from searching from.
  */
-export function findExtensionYaml(directory: string): Promise<string> {
+export function findExtensionYaml(directory: string): string {
   while (!fileExistsSync(path.resolve(directory, SPEC_FILE))) {
     const parentDir = path.dirname(directory);
     if (parentDir === directory) {
@@ -46,7 +46,7 @@ export function findExtensionYaml(directory: string): Promise<string> {
     }
     directory = parentDir;
   }
-  return Promise.resolve(directory);
+  return directory;
 }
 
 /**

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -36,7 +36,7 @@ function wrappedSafeLoad(source: string): any {
  * directory that contains one. Throws an error if none is found.
  * @param directory the directory to start from searching from.
  */
-export async function findExtensionYaml(directory: string): Promise<string> {
+export function findExtensionYaml(directory: string): Promise<string> {
   while (!fileExistsSync(path.resolve(directory, SPEC_FILE))) {
     const parentDir = path.dirname(directory);
     if (parentDir === directory) {
@@ -46,7 +46,7 @@ export async function findExtensionYaml(directory: string): Promise<string> {
     }
     directory = parentDir;
   }
-  return directory;
+  return Promise.resolve(directory);
 }
 
 /**
@@ -62,7 +62,7 @@ export async function readExtensionYaml(directory: string): Promise<ExtensionSpe
 /**
  * Retrieves a file from the directory.
  */
-export async function readFileFromDirectory(
+export function readFileFromDirectory(
   directory: string,
   file: string
 ): Promise<{ [key: string]: any }> {

--- a/src/extensions/localHelper.ts
+++ b/src/extensions/localHelper.ts
@@ -14,9 +14,9 @@ const EXTENSIONS_PREINSTALL_FILE = "PREINSTALL.md";
  * @param directory the directory to look for extension.yaml and PRESINSTALL.md in
  */
 export async function getLocalExtensionSpec(directory: string): Promise<ExtensionSpec> {
-  const spec = await parseYAML(await readFile(path.resolve(directory, EXTENSIONS_SPEC_FILE)));
+  const spec = await parseYAML(readFile(path.resolve(directory, EXTENSIONS_SPEC_FILE)));
   try {
-    const preinstall = await readFile(path.resolve(directory, EXTENSIONS_PREINSTALL_FILE));
+    const preinstall = readFile(path.resolve(directory, EXTENSIONS_PREINSTALL_FILE));
     spec.preinstallContent = preinstall;
   } catch (err) {
     logger.debug(`No PREINSTALL.md found in directory ${directory}.`);
@@ -29,7 +29,7 @@ export async function getLocalExtensionSpec(directory: string): Promise<Extensio
  * @param directory the directory containing the file
  * @param file the name of the file
  */
-export function readFile(pathToFile: string): Promise<string> {
+export function readFile(pathToFile: string): string {
   try {
     return fs.readFileSync(pathToFile, "utf8");
   } catch (err) {

--- a/src/extensions/localHelper.ts
+++ b/src/extensions/localHelper.ts
@@ -29,7 +29,7 @@ export async function getLocalExtensionSpec(directory: string): Promise<Extensio
  * @param directory the directory containing the file
  * @param file the name of the file
  */
-export async function readFile(pathToFile: string): Promise<string> {
+export function readFile(pathToFile: string): Promise<string> {
   try {
     return fs.readFileSync(pathToFile, "utf8");
   } catch (err) {

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -8,7 +8,7 @@ const _API_ROOT = "/v1beta1/";
  * @param {string} project the Google Cloud project ID.
  * @return {Promise<string[]>} a promise for an array of collection IDs.
  */
-export async function listCollectionIds(project: string): Promise<string[]> {
+export function listCollectionIds(project: string): Promise<string[]> {
   const url =
     _API_ROOT + "projects/" + project + "/databases/(default)/documents:listCollectionIds";
   return api

--- a/src/init/features/firestore/indexes.ts
+++ b/src/init/features/firestore/indexes.ts
@@ -14,7 +14,7 @@ const INDEXES_TEMPLATE = fs.readFileSync(
   "utf8"
 );
 
-export async function initIndexes(setup: any, config: any): Promise<any> {
+export function initIndexes(setup: any, config: any): Promise<any> {
   logger.info();
   logger.info("Firestore indexes allow you to perform complex queries while");
   logger.info("maintaining performance that scales with the size of the result");
@@ -57,7 +57,7 @@ export async function initIndexes(setup: any, config: any): Promise<any> {
     });
 }
 
-async function getIndexesFromConsole(projectId: any): Promise<any> {
+function getIndexesFromConsole(projectId: any): Promise<any> {
   const indexesPromise = indexes.listIndexes(projectId);
   const fieldOverridesPromise = indexes.listFieldOverrides(projectId);
 

--- a/src/init/features/firestore/rules.ts
+++ b/src/init/features/firestore/rules.ts
@@ -14,7 +14,7 @@ const RULES_TEMPLATE = fs.readFileSync(
   "utf8"
 );
 
-export async function initRules(setup: any, config: any): Promise<any> {
+export function initRules(setup: any, config: any): Promise<any> {
   logger.info();
   logger.info("Firestore Security Rules allow you to define how and when to allow");
   logger.info("requests. You can keep these rules in your project directory");
@@ -58,7 +58,7 @@ export async function initRules(setup: any, config: any): Promise<any> {
     });
 }
 
-async function getRulesFromConsole(projectId: string): Promise<any> {
+function getRulesFromConsole(projectId: string): Promise<any> {
   return gcp.rules
     .getLatestRulesetName(projectId, "cloud.firestore")
     .then((name) => {

--- a/src/test/database/fakeListRemote.spec.ts
+++ b/src/test/database/fakeListRemote.spec.ts
@@ -22,7 +22,7 @@ export class FakeListRemote implements ListRemote {
     this.delay = 0;
   }
 
-  async listPath(
+  listPath(
     path: string,
     numChildren: number,
     startAfter?: string,
@@ -43,9 +43,9 @@ export class FakeListRemote implements ListRemote {
         keys = keys.filter((key) => key > startAfter);
       }
       keys = keys.slice(0, numChildren);
-      return keys;
+      return Promise.resolve(keys);
     }
-    return [];
+    return Promise.resolve([]);
   }
 
   private size(data: any): number {

--- a/src/test/database/fakeListRemote.spec.ts
+++ b/src/test/database/fakeListRemote.spec.ts
@@ -29,7 +29,7 @@ export class FakeListRemote implements ListRemote {
     timeout?: number
   ): Promise<string[]> {
     if (timeout === 0) {
-      throw new Error("timeout");
+      return Promise.reject(new Error("timeout"));
     }
     const d = this.dataAtPath(path);
     if (d) {

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -44,7 +44,7 @@ functionsEmulator.setTriggersForTesting([
 
 // TODO(samstern): This is an ugly way to just override the InvokeRuntimeOpts on each call
 const startFunctionRuntime = functionsEmulator.startFunctionRuntime.bind(functionsEmulator);
-function UseFunctions(triggers: () => {}): void {
+function useFunctions(triggers: () => {}): void {
   const serializedTriggers = triggers.toString();
 
   functionsEmulator.startFunctionRuntime = (
@@ -62,7 +62,7 @@ function UseFunctions(triggers: () => {}): void {
 
 describe("FunctionsEmulator-Hub", () => {
   it("should route requests to /:project_id/:region/:trigger_id to HTTPS Function", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
         function_id: require("firebase-functions").https.onRequest(
@@ -82,7 +82,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should route requests to /:project_id/:region/:trigger_id/ to HTTPS Function", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
         function_id: require("firebase-functions").https.onRequest(
@@ -102,7 +102,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should route requests to /:project_id/:region/:trigger_id/a/b to HTTPS Function", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
         function_id: require("firebase-functions").https.onRequest(
@@ -122,7 +122,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should reject requests to a non-emulator path", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       return {
         function_id: require("firebase-functions").https.onRequest(
           (req: express.Request, res: express.Response) => {
@@ -138,7 +138,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should rewrite req.path to hide /:project_id/:region/:trigger_id", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
         function_id: require("firebase-functions").https.onRequest(
@@ -158,7 +158,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should rewrite req.baseUrl to show /:project_id/:region/:trigger_id", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
         function_id: require("firebase-functions").https.onRequest(
@@ -178,7 +178,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should route request body", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
         function_id: require("firebase-functions").https.onRequest(
@@ -199,7 +199,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should route query parameters", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
         function_id: require("firebase-functions").https.onRequest(
@@ -219,7 +219,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should override callable auth", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       return {
         callable_function_id: require("firebase-functions").https.onCall((data: any, ctx: any) => {
           return {
@@ -267,7 +267,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should override callable auth with unicode", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       return {
         callable_function_id: require("firebase-functions").https.onCall((data: any, ctx: any) => {
           return {
@@ -316,7 +316,7 @@ describe("FunctionsEmulator-Hub", () => {
   }).timeout(TIMEOUT_LONG);
 
   it("should override callable auth with a poorly padded ID Token", async () => {
-    UseFunctions(() => {
+    useFunctions(() => {
       return {
         callable_function_id: require("firebase-functions").https.onCall((data: any, ctx: any) => {
           return {

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -156,7 +156,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(async () => {}),
+              .onCreate(() => {}),
           };
         });
 
@@ -172,7 +172,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(async () => {}),
+              .onCreate(() => {}),
           };
         });
 
@@ -197,9 +197,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(() => {
-                return Promise.resolve();
-              }),
+              .onCreate(() => {}),
           };
         });
         const logs = await _countLogEntries(worker);
@@ -831,11 +829,12 @@ describe("FunctionsEmulator-Runtime", () => {
         const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
-              return new Promise((resolve, reject) => {
-                reject(new Error("not a thing"));
-              });
-            }),
+            function_id: require("firebase-functions").https.onRequest(
+              async (req: any, res: any) => {
+                await Promise.resolve(); // Required `await` for `async`.
+                return Promise.reject(new Error("not a thing"));
+              }
+            ),
           };
         });
 
@@ -857,10 +856,9 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .runWith({})
-              .https.onRequest((req: any, res: any) => {
-                return new Promise((resolve, reject) => {
-                  reject(new Error("not a thing"));
-                });
+              .https.onRequest(async (req: any, res: any) => {
+                await Promise.resolve(); // Required `await` for `async`.
+                return Promise.reject(new Error("not a thing"));
               }),
           };
         });

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -28,7 +28,7 @@ async function _countLogEntries(worker: RuntimeWorker): Promise<{ [key: string]:
   return counts;
 }
 
-function InvokeRuntimeWithFunctions(
+function invokeRuntimeWithFunctions(
   frb: FunctionsRuntimeBundle,
   triggers: () => {},
   opts?: InvokeRuntimeOpts
@@ -48,7 +48,7 @@ function InvokeRuntimeWithFunctions(
  *   2) Call the runtime with the specified bundle and collect all data.
  *   3) Wait for the runtime to exit
  */
-async function CallHTTPSFunction(
+async function callHTTPSFunction(
   worker: RuntimeWorker,
   frb: FunctionsRuntimeBundle,
   options: any = {},
@@ -92,14 +92,13 @@ describe("FunctionsEmulator-Runtime", () => {
   describe("Stubs, Mocks, and Helpers (aka Magic, Glee, and Awesomeness)", () => {
     describe("_InitializeNetworkFiltering(...)", () => {
       it("should log outgoing unknown HTTP requests via 'http'", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
               .onCreate(async () => {
                 await new Promise((resolve) => {
-                  // tslint:disable-next-line:no-console
                   console.log(require("http").get.toString());
                   require("http").get("http://example.com", resolve);
                 });
@@ -112,7 +111,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_LONG);
 
       it("should log outgoing unknown HTTP requests via 'https'", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -131,7 +130,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_LONG);
 
       it("should log outgoing Google API requests", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
@@ -152,12 +151,11 @@ describe("FunctionsEmulator-Runtime", () => {
 
     describe("_InitializeFirebaseAdminStubs(...)", () => {
       it("should provide stubbed default app from initializeApp", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              // tslint:disable-next-line:no-empty
               .onCreate(async () => {}),
           };
         });
@@ -167,14 +165,13 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide a stubbed app with custom options", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp({
             custom: true,
           });
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              // tslint:disable-next-line:no-empty
               .onCreate(async () => {}),
           };
         });
@@ -194,13 +191,12 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide non-stubbed non-default app from initializeApp", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp(); // We still need to initialize default for snapshots
           require("firebase-admin").initializeApp({}, "non-default");
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              // tslint:disable-next-line:no-empty
               .onCreate(async () => {}),
           };
         });
@@ -209,13 +205,12 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should route all sub-fields accordingly", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(async () => {
-                // tslint:disable-next-line:no-console
+              .onCreate(() => {
                 console.log(
                   JSON.stringify(require("firebase-admin").firestore.FieldValue.increment(4))
                 );
@@ -239,7 +234,7 @@ describe("FunctionsEmulator-Runtime", () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
         frb.emulators = {};
 
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -250,7 +245,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
 
         expect(info.projectId).to.eql("fake-project-id");
@@ -267,7 +262,7 @@ describe("FunctionsEmulator-Runtime", () => {
           },
         };
 
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           return {
             function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
               res.json({
@@ -277,7 +272,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
         const res = JSON.parse(data);
 
         expect(res.var).to.eql("localhost:9090");
@@ -292,7 +287,7 @@ describe("FunctionsEmulator-Runtime", () => {
           },
         };
 
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -303,7 +298,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
 
         expect(info.projectId).to.eql("fake-project-id");
@@ -315,7 +310,7 @@ describe("FunctionsEmulator-Runtime", () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
         frb.emulators = {};
 
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -331,7 +326,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
         expect(info.url).to.eql("https://fake-project-id.firebaseio.com/");
       }).timeout(TIMEOUT_MED);
@@ -345,7 +340,7 @@ describe("FunctionsEmulator-Runtime", () => {
           },
         };
 
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           return {
             function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
               res.json({
@@ -355,7 +350,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
         const res = JSON.parse(data);
 
         expect(res.var).to.eql("localhost:9000");
@@ -370,7 +365,7 @@ describe("FunctionsEmulator-Runtime", () => {
           },
         };
 
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
 
@@ -386,7 +381,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
         expect(info.url).to.eql("http://localhost:9090/");
       }).timeout(TIMEOUT_MED);
@@ -397,7 +392,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return;
         }
 
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onCreate, () => {
           const admin = require("firebase-admin");
           admin.initializeApp({
             databaseURL: "fake-app-id.firebaseio.com",
@@ -407,7 +402,7 @@ describe("FunctionsEmulator-Runtime", () => {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
               .onCreate(async (snap: any, ctx: any) => {
-                admin
+                await admin
                   .database()
                   .ref("write-test")
                   .set({
@@ -438,16 +433,14 @@ describe("FunctionsEmulator-Runtime", () => {
 
   describe("_InitializeFunctionsConfigHelper()", () => {
     it("should tell the user if they've accessed a non-existent function field", async () => {
-      const worker = InvokeRuntimeWithFunctions(
+      const worker = invokeRuntimeWithFunctions(
         FunctionRuntimeBundles.onCreate,
         () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(async () => {
-                /* tslint:disable:no-console */
-
+              .onCreate(() => {
                 // Exists
                 console.log(require("firebase-functions").config().real);
 
@@ -476,37 +469,33 @@ describe("FunctionsEmulator-Runtime", () => {
     describe("HTTPS", () => {
       it("should handle a GET request", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                res.json({ from_trigger: true });
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              res.json({ from_trigger: true });
+            }),
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
 
         expect(JSON.parse(data)).to.deep.equal({ from_trigger: true });
       }).timeout(TIMEOUT_MED);
 
       it("should handle a POST request with form data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                res.json(req.body);
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              res.json(req.body);
+            }),
           };
         });
 
         const reqData = "name=sparky";
-        const data = await CallHTTPSFunction(
+        const data = await callHTTPSFunction(
           worker,
           frb,
           {
@@ -523,19 +512,17 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with JSON data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                res.json(req.body);
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              res.json(req.body);
+            }),
           };
         });
 
         const reqData = '{"name": "sparky"}';
-        const data = await CallHTTPSFunction(
+        const data = await callHTTPSFunction(
           worker,
           frb,
           {
@@ -552,19 +539,17 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with text data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                res.json(req.body);
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              res.json(req.body);
+            }),
           };
         });
 
         const reqData = "name is sparky";
-        const data = await CallHTTPSFunction(
+        const data = await callHTTPSFunction(
           worker,
           frb,
           {
@@ -581,19 +566,17 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with any other type", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                res.json(req.body);
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              res.json(req.body);
+            }),
           };
         });
 
         const reqData = "name is sparky";
-        const data = await CallHTTPSFunction(
+        const data = await callHTTPSFunction(
           worker,
           frb,
           {
@@ -611,19 +594,17 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request and store rawBody", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                res.send(req.rawBody);
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              res.send(req.rawBody);
+            }),
           };
         });
 
         const reqData = "How are you?";
-        const data = await CallHTTPSFunction(
+        const data = await callHTTPSFunction(
           worker,
           frb,
           {
@@ -640,7 +621,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should forward request to Express app", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           const app = require("express")();
           app.all("/", (req: express.Request, res: express.Response) => {
@@ -653,7 +634,7 @@ describe("FunctionsEmulator-Runtime", () => {
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb, {
+        const data = await callHTTPSFunction(worker, frb, {
           headers: {
             "x-hello": "world",
           },
@@ -664,18 +645,16 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle `x-forwarded-host`", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                res.json({ hostname: req.hostname });
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              res.json({ hostname: req.hostname });
+            }),
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb, {
+        const data = await callHTTPSFunction(worker, frb, {
           headers: {
             "x-forwarded-host": "real-hostname",
           },
@@ -686,31 +665,28 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should report GMT time zone", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                const now = new Date();
-                res.json({ offset: now.getTimezoneOffset() });
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              const now = new Date();
+              res.json({ offset: now.getTimezoneOffset() });
+            }),
           };
         });
 
-        const data = await CallHTTPSFunction(worker, frb);
+        const data = await callHTTPSFunction(worker, frb);
         expect(JSON.parse(data)).to.deep.equal({ offset: 0 });
       });
     }).timeout(TIMEOUT_MED);
 
     describe("Cloud Firestore", () => {
       it("should provide Change for firestore.onWrite()", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onWrite(async (change: Change<DocumentSnapshot>) => {
-                /* tslint:disable:no-console */
+              .onWrite((change: Change<DocumentSnapshot>) => {
                 console.log(
                   JSON.stringify({
                     before_exists: change.before.exists,
@@ -734,13 +710,12 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide Change for firestore.onUpdate()", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onUpdate, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onUpdate, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onUpdate(async (change: Change<DocumentSnapshot>) => {
-                /* tslint:disable:no-console */
+              .onUpdate((change: Change<DocumentSnapshot>) => {
                 console.log(
                   JSON.stringify({
                     before_exists: change.before.exists,
@@ -763,13 +738,12 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide DocumentSnapshot for firestore.onDelete()", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onDelete, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onDelete, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onDelete(async (snap: DocumentSnapshot) => {
-                /* tslint:disable:no-console */
+              .onDelete((snap: DocumentSnapshot) => {
                 console.log(
                   JSON.stringify({
                     snap_exists: snap.exists,
@@ -791,13 +765,12 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide DocumentSnapshot for firestore.onCreate()", async () => {
-        const worker = InvokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
+        const worker = invokeRuntimeWithFunctions(FunctionRuntimeBundles.onWrite, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(async (snap: DocumentSnapshot) => {
-                /* tslint:disable:no-console */
+              .onCreate((snap: DocumentSnapshot) => {
                 console.log(
                   JSON.stringify({
                     snap_exists: snap.exists,
@@ -822,11 +795,11 @@ describe("FunctionsEmulator-Runtime", () => {
     describe("Error handling", () => {
       it("Should handle regular functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
-              (global as any)["not a thing"]();
+              throw new Error("not a thing");
             }),
           };
         });
@@ -834,7 +807,7 @@ describe("FunctionsEmulator-Runtime", () => {
         const logs = _countLogEntries(worker);
 
         try {
-          await CallHTTPSFunction(worker, frb);
+          await callHTTPSFunction(worker, frb);
         } catch (e) {
           // No-op
         }
@@ -844,21 +817,21 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("Should handle async functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
-            function_id: require("firebase-functions").https.onRequest(
-              async (req: any, res: any) => {
-                (global as any)["not a thing"]();
-              }
-            ),
+            function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
+              return new Promise((resolve, reject) => {
+                reject(new Error("not a thing"));
+              });
+            }),
           };
         });
 
         const logs = _countLogEntries(worker);
 
         try {
-          await CallHTTPSFunction(worker, frb);
+          await callHTTPSFunction(worker, frb);
         } catch {
           // No-op
         }
@@ -868,13 +841,15 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("Should handle async/runWith functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = InvokeRuntimeWithFunctions(frb, () => {
+        const worker = invokeRuntimeWithFunctions(frb, () => {
           require("firebase-admin").initializeApp();
           return {
             function_id: require("firebase-functions")
               .runWith({})
-              .https.onRequest(async (req: any, res: any) => {
-                (global as any)["not a thing"]();
+              .https.onRequest((req: any, res: any) => {
+                return new Promise((resolve, reject) => {
+                  reject(new Error("not a thing"));
+                });
               }),
           };
         });
@@ -882,7 +857,7 @@ describe("FunctionsEmulator-Runtime", () => {
         const logs = _countLogEntries(worker);
 
         try {
-          await CallHTTPSFunction(worker, frb);
+          await callHTTPSFunction(worker, frb);
         } catch {
           // No-op
         }

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -197,7 +197,9 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(async () => {}),
+              .onCreate(() => {
+                return Promise.resolve();
+              }),
           };
         });
         const logs = await _countLogEntries(worker);
@@ -214,6 +216,7 @@ describe("FunctionsEmulator-Runtime", () => {
                 console.log(
                   JSON.stringify(require("firebase-admin").firestore.FieldValue.increment(4))
                 );
+                return Promise.resolve();
               }),
           };
         });
@@ -241,6 +244,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
               res.json(admin.firestore()._settings);
+              return Promise.resolve();
             }),
           };
         });
@@ -268,6 +272,7 @@ describe("FunctionsEmulator-Runtime", () => {
               res.json({
                 var: process.env.FIRESTORE_EMULATOR_HOST,
               });
+              return Promise.resolve();
             }),
           };
         });
@@ -294,6 +299,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions").https.onRequest((req: any, res: any) => {
               res.json(admin.firestore()._settings);
+              return Promise.resolve();
             }),
           };
         });
@@ -322,6 +328,7 @@ describe("FunctionsEmulator-Runtime", () => {
                   .ref()
                   .toString(),
               });
+              return Promise.resolve();
             }),
           };
         });
@@ -693,6 +700,7 @@ describe("FunctionsEmulator-Runtime", () => {
                     after_exists: change.after.exists,
                   })
                 );
+                return Promise.resolve();
               }),
           };
         });
@@ -722,6 +730,7 @@ describe("FunctionsEmulator-Runtime", () => {
                     after_exists: change.after.exists,
                   })
                 );
+                return Promise.resolve();
               }),
           };
         });
@@ -749,6 +758,7 @@ describe("FunctionsEmulator-Runtime", () => {
                     snap_exists: snap.exists,
                   })
                 );
+                return Promise.resolve();
               }),
           };
         });
@@ -776,6 +786,7 @@ describe("FunctionsEmulator-Runtime", () => {
                     snap_exists: snap.exists,
                   })
                 );
+                return Promise.resolve();
               }),
           };
         });

--- a/src/test/emulators/registry.spec.ts
+++ b/src/test/emulators/registry.spec.ts
@@ -8,7 +8,7 @@ describe("EmulatorRegistry", () => {
     await EmulatorRegistry.stopAll();
   });
 
-  it("should not report any running emulators when empty", async () => {
+  it("should not report any running emulators when empty", () => {
     for (const name of ALL_EMULATORS) {
       expect(EmulatorRegistry.isRunning(name)).to.be.false;
     }

--- a/src/test/extensions/localHelper.spec.ts
+++ b/src/test/extensions/localHelper.spec.ts
@@ -49,7 +49,7 @@ describe("localHelper", () => {
       });
     });
 
-    describe("other YAML errors", async () => {
+    describe("other YAML errors", () => {
       beforeEach(() => {
         sandbox.stub(yaml, "safeLoad").throws(new Error("not the files you are looking for"));
       });

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -120,7 +120,7 @@ describe("paramHelper", () => {
         ANOTHER_PARAMETER: "aValue",
       });
 
-      expect(
+      await expect(
         paramHelper.getParams(PROJECT_ID, TEST_PARAMS, "./a/path/to/a/file.env")
       ).to.be.rejectedWith(
         FirebaseError,
@@ -147,7 +147,7 @@ describe("paramHelper", () => {
     it("should throw FirebaseError if an invalid envFilePath is provided", async () => {
       dotenvStub.throws({ message: "Error during parsing" });
 
-      expect(
+      await expect(
         paramHelper.getParams(PROJECT_ID, TEST_PARAMS, "./a/path/to/a/file.env")
       ).to.be.rejectedWith(FirebaseError, "Error reading env file: Error during parsing");
     });

--- a/src/test/init/features/storage.spec.ts
+++ b/src/test/init/features/storage.spec.ts
@@ -49,7 +49,7 @@ describe("storage", () => {
       };
       checkApiStub.returns(true);
 
-      expect(doSetup(setup, new Config("/path/to/src", {}))).to.eventually.be.rejectedWith(
+      await expect(doSetup(setup, new Config("/path/to/src", {}))).to.eventually.be.rejectedWith(
         FirebaseError,
         "Cloud resource location is not set"
       );
@@ -63,7 +63,7 @@ describe("storage", () => {
       };
       checkApiStub.returns(false);
 
-      expect(doSetup(setup, new Config("/path/to/src", {}))).to.eventually.be.rejectedWith(
+      await expect(doSetup(setup, new Config("/path/to/src", {}))).to.eventually.be.rejectedWith(
         FirebaseError,
         "It looks like you haven't used Cloud Storage"
       );

--- a/src/test/prompt.spec.ts
+++ b/src/test/prompt.spec.ts
@@ -26,7 +26,10 @@ describe("prompt", () => {
       const o = { nonInteractive: true };
       const qs: prompt.Question[] = [{ name: "foo" }];
 
-      expect(prompt.prompt(o, qs)).to.be.rejectedWith(FirebaseError, /required.+non\-interactive/);
+      await expect(prompt.prompt(o, qs)).to.be.rejectedWith(
+        FirebaseError,
+        /required.+non-interactive/
+      );
     });
 
     it("should utilize inquirer to prompt for the questions", async () => {

--- a/src/test/throttler/throttler.spec.ts
+++ b/src/test/throttler/throttler.spec.ts
@@ -10,17 +10,17 @@ import RetriesExhaustedError from "../../throttler/errors/retries-exhausted-erro
 
 const TEST_ERROR = new Error("foobar");
 
-type ThrottlerConstructor = new <T, R>(options: ThrottlerOptions<T, R>) => Throttler<T, R>;
+type ThrottlerConstructorType = new <T, R>(options: ThrottlerOptions<T, R>) => Throttler<T, R>;
 
-const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
+const throttlerTest = (ThrottlerConstructor: ThrottlerConstructorType): void => {
   it("should have no waiting task after creation", () => {
-    const queue = new throttlerConstructor({});
+    const queue = new ThrottlerConstructor({});
     expect(queue.hasWaitingTask()).to.equal(false);
   });
 
   it("should return the task as the task name", () => {
     const handler = sinon.stub().resolves();
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       handler,
     });
 
@@ -32,7 +32,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
 
   it("should return the index as the task name", () => {
     const handler = sinon.stub().resolves();
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       handler,
     });
 
@@ -43,7 +43,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
 
   it("should return 'finished task' as the task name", () => {
     const handler = sinon.stub().resolves();
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       handler,
     });
 
@@ -57,7 +57,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
 
   it("should handle function tasks", () => {
     const task = sinon.stub().resolves();
-    const q = new throttlerConstructor({});
+    const q = new ThrottlerConstructor({});
 
     q.add(task);
     q.close();
@@ -74,7 +74,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
 
   it("should handle tasks", () => {
     const handler = sinon.stub().resolves();
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       handler,
     });
 
@@ -93,7 +93,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
 
   it("should not retry", () => {
     const handler = sinon.stub().rejects(TEST_ERROR);
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       handler,
       retries: 0,
     });
@@ -123,7 +123,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
 
   it("should retry the number of retries, plus one", () => {
     const handler = sinon.stub().rejects(TEST_ERROR);
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       backoff: 0,
       handler,
       retries: 3,
@@ -167,7 +167,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
       return Promise.reject();
     };
 
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       backoff: 0,
       concurrency: 2,
       handler,
@@ -204,7 +204,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
       .onCall(8)
       .resolves(0);
 
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       backoff: 0,
       concurrency: 1, // this makes sure only one task is running at a time, so not flaky
       handler,
@@ -236,7 +236,7 @@ const throttlerTest = (throttlerConstructor: ThrottlerConstructor) => {
       return Promise.resolve(`result: ${task}`);
     };
 
-    const q = new throttlerConstructor({
+    const q = new ThrottlerConstructor({
       handler,
     });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

TLDR: `async function`s should have awaits in them.

`async` is required for using `await`. This rule helps enforce that that is what `async` is used for. In fixing this, I explicitly return promises where they are expected, which is a more consistent path than some of the `async` cases that did not use `await` but just used the magic wrapping to return a promise-wrapped value (which, at that point, it should be a synchronous function, generally).