### PR TITLE
Add warning message for restricted ports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes error message when `firebase init firestore` is used on a project with Cloud Firestore in Datastore mode.
 - Fixes error message when Java version is too low to run the emulators (#2307).
 - Fixes issue where `firebase init storage` incorrectly reports Cloud Storage has not been used.
+- Adds warning message when an emulator starts on a port restricted by Chrome (#2276).

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -92,7 +92,7 @@ async function getAndCheckAddress(emulator: Emulators, options: any): Promise<Ad
     logger.logLabeled(
       "WARN",
       emulator,
-      `Port ${port} is restricted by some web browsers, including Chrome. You may want to choose a different port such as ${suggested}`
+      `Port ${port} is restricted by some web browsers, including Chrome. You may want to choose a different port such as ${suggested}.`
     );
   }
 

--- a/src/emulator/emulatorServer.ts
+++ b/src/emulator/emulatorServer.ts
@@ -1,6 +1,6 @@
 import { EmulatorInstance } from "./types";
 import { EmulatorRegistry } from "./registry";
-import * as controller from "./controller";
+import * as portUtils from "./portUtils";
 import { FirebaseError } from "../error";
 
 /**
@@ -12,7 +12,7 @@ export class EmulatorServer {
 
   async start(): Promise<void> {
     const { port, host } = this.instance.getInfo();
-    const portOpen = await controller.checkPortOpen(port, host);
+    const portOpen = await portUtils.checkPortOpen(port, host);
 
     if (!portOpen) {
       throw new FirebaseError(

--- a/src/emulator/portUtils.ts
+++ b/src/emulator/portUtils.ts
@@ -1,0 +1,148 @@
+import * as pf from "portfinder";
+import * as tcpport from "tcp-port-used";
+
+import { FirebaseError } from "../error";
+import * as logger from "../logger";
+
+// See:
+// - https://stackoverflow.com/questions/4313403/why-do-browsers-block-some-ports
+// - https://chromium.googlesource.com/chromium/src.git/+/refs/heads/master/net/base/port_util.cc
+const RESTRICTED_PORTS = [
+  1, // tcpmux
+  7, // echo
+  9, // discard
+  11, // systat
+  13, // daytime
+  15, // netstat
+  17, // qotd
+  19, // chargen
+  20, // ftp data
+  21, // ftp access
+  22, // ssh
+  23, // telnet
+  25, // smtp
+  37, // time
+  42, // name
+  43, // nicname
+  53, // domain
+  77, // priv-rjs
+  79, // finger
+  87, // ttylink
+  95, // supdup
+  101, // hostriame
+  102, // iso-tsap
+  103, // gppitnp
+  104, // acr-nema
+  109, // pop2
+  110, // pop3
+  111, // sunrpc
+  113, // auth
+  115, // sftp
+  117, // uucp-path
+  119, // nntp
+  123, // NTP
+  135, // loc-srv /epmap
+  139, // netbios
+  143, // imap2
+  179, // BGP
+  389, // ldap
+  427, // SLP (Also used by Apple Filing Protocol)
+  465, // smtp+ssl
+  512, // print / exec
+  513, // login
+  514, // shell
+  515, // printer
+  526, // tempo
+  530, // courier
+  531, // chat
+  532, // netnews
+  540, // uucp
+  548, // AFP (Apple Filing Protocol)
+  556, // remotefs
+  563, // nntp+ssl
+  587, // smtp (rfc6409)
+  601, // syslog-conn (rfc3195)
+  636, // ldap+ssl
+  993, // ldap+ssl
+  995, // pop3+ssl
+  2049, // nfs
+  3659, // apple-sasl / PasswordServer
+  4045, // lockd
+  6000, // X11
+  6665, // Alternate IRC [Apple addition]
+  6666, // Alternate IRC [Apple addition]
+  6667, // Standard IRC [Apple addition]
+  6668, // Alternate IRC [Apple addition]
+  6669, // Alternate IRC [Apple addition]
+  6697, // IRC + TLS
+];
+
+/**
+ * Check if a given port is restricted by Chrome.
+ */
+export function isRestricted(port: number): boolean {
+  return RESTRICTED_PORTS.includes(port);
+}
+
+/**
+ * Suggest a port equal to or higher than the given port which is not restricted by Chrome.
+ */
+export function suggestUnrestricted(port: number): number {
+  if (!isRestricted(port)) {
+    return port;
+  }
+
+  let newPort = port;
+  while (isRestricted(newPort)) {
+    newPort++;
+  }
+
+  return newPort;
+}
+
+/**
+ * Find an available (unused) port on the given host.
+ * @param host the host.
+ * @param start the lowest port to search.
+ * @param avoidRestricted when true (default) ports which are restricted by Chrome are excluded.
+ */
+export async function findAvailablePort(
+  host: string,
+  start: number,
+  avoidRestricted: boolean = true
+): Promise<number> {
+  const openPort = await pf.getPortPromise({ host, port: start });
+
+  if (avoidRestricted && isRestricted(openPort)) {
+    logger.debug(`portUtils: skipping restricted port ${openPort}`);
+    return findAvailablePort(host, suggestUnrestricted(openPort), avoidRestricted);
+  }
+
+  return openPort;
+}
+
+/**
+ * Check if a port is open on the given host.
+ */
+export async function checkPortOpen(port: number, host: string): Promise<boolean> {
+  try {
+    const inUse = await tcpport.check(port, host);
+    return !inUse;
+  } catch (e) {
+    logger.debug(`port check error: ${e}`);
+    return false;
+  }
+}
+
+/**
+ * Wait for a port to close on the given host. Checks every 250ms for up to 30s.
+ */
+export async function waitForPortClosed(port: number, host: string): Promise<void> {
+  const interval = 250;
+  const timeout = 30000;
+  try {
+    await tcpport.waitUntilUsedOnHost(port, host, interval, timeout);
+  } catch (e) {
+    throw new FirebaseError(`TIMEOUT: Port ${port} on ${host} was not active within ${timeout}ms`);
+  }
+}

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -1,6 +1,6 @@
 import { ALL_EMULATORS, EmulatorInstance, Emulators, EmulatorInfo } from "./types";
 import { FirebaseError } from "../error";
-import * as controller from "./controller";
+import * as portUtils from "./portUtils";
 import { Constants } from "./constants";
 
 /**
@@ -20,7 +20,7 @@ export class EmulatorRegistry {
     await instance.start();
 
     const info = instance.getInfo();
-    await controller.waitForPortClosed(info.port, info.host);
+    await portUtils.waitForPortClosed(info.port, info.host);
     this.set(instance.getName(), instance);
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2276 

cc @dutzi

### Scenarios Tested

firebase.json
```json
{
  "emulators": {
    "functions": {
      "port": 6000
    },
    "pubsub": {
      "port": 8085
    },
    "ui": {
      "enabled": true,
      "port": 6665
    }
  }
}
```

result
```
$ firebase emulators:start
i  emulators: Starting emulators: functions, pubsub
⚠  functions: Port 6000 is restricted by some web browsers, including Chrome. You may want to choose a different port such as 6001
✔  functions: Using node@10 from host.
i  pubsub: Pub/Sub Emulator logging to pubsub-debug.log
⚠  ui: Port 6665 is restricted by some web browsers, including Chrome. You may want to choose a different port such as 6670
i  ui: Emulator UI logging to ui-debug.log
i  functions: Watching "/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.40DIyUVI/functions" for Cloud Functions...
✔  functions[launchWorkers]: http function initialized (http://localhost:6000/fir-dumpster/us-central1/launchWorkers).
✔  functions[worker]: pubsub function initialized.

┌───────────────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! View status and logs at http://localhost:6665 │
└───────────────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Functions │ localhost:6000 │ http://localhost:6665/functions │
├───────────┼────────────────┼─────────────────────────────────┤
│ Pub/Sub   │ localhost:8085 │ n/a                             │
└───────────┴────────────────┴─────────────────────────────────┘
  Other reserved ports: 4400, 4500
```

### Sample Commands

N/A