### PR TITLE
fix #1774

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Makes `functions:shell` respect the `.clear` command
 - Fixes issue where functions emulator would fail while looking for `tsconfig.json` (#2353)
 - Improves error messages for `deploy` and `serve` when invalid targets are specified (#2363)
+- Fixes #1774 by removing "]0;Firebase CLI" from stdout (#2330)

--- a/standalone/firepit.js
+++ b/standalone/firepit.js
@@ -979,8 +979,6 @@ function SetWindowTitle(title) {
    */
   if (isWindows) {
     process.title = title;
-  } else {
-    process.stdout.write(String.fromCharCode(27) + "]0;" + title + String.fromCharCode(7));
   }
 }
 


### PR DESCRIPTION
https://github.com/firebase/firebase-tools/issues/1774

### Description

"]0;Firebase CLI" is still appended by fireprit.js
when `config.template.js`'s `headless` value is `false`
which is dynamically set by `pipeline.js`.

Some environment still print `]0;Firebase CLI` in the ahead of stdout.

For example, if you print out:

    firebase functions:config:get > config.json

The created `config.json` becomes invalid JSON.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
