### PR TITLE
Use GCS REST API in place of Firebase Storage REST API.

### DIFF
--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -1,7 +1,7 @@
 import * as _ from "lodash";
 import * as ora from "ora";
 
-import { firebaseStorageOrigin } from "../api";
+import { storageOrigin } from "../api";
 import { archiveDirectory } from "../archiveDirectory";
 import { convertOfficialExtensionsToList } from "./utils";
 import { getFirebaseConfig } from "../functionsConfig";
@@ -333,7 +333,7 @@ export async function createSourceFromLocation(
       uploadSpinner.start();
       objectPath = await archiveAndUploadSource(sourceUri, EXTENSIONS_BUCKET_NAME);
       uploadSpinner.succeed(" Uploaded extension source code");
-      packageUri = firebaseStorageOrigin + objectPath + "?alt=media";
+      packageUri = storageOrigin + objectPath + "?alt=media";
       extensionRoot = "/";
     } catch (err) {
       uploadSpinner.fail();

--- a/src/gcp/storage.js
+++ b/src/gcp/storage.js
@@ -56,8 +56,8 @@ async function _uploadObject(source, bucketName) {
   if (path.extname(source.file) !== ".zip") {
     throw new FirebaseError(`Expected a file name ending in .zip, got ${source.file}`);
   }
-  const location = `/v0/b/${bucketName}/o/${path.basename(source.file)}`;
-  await api.request("POST", location, {
+  const location = `/${bucketName}/${path.basename(source.file)}`;
+  await api.request("PUT", location, {
     auth: true,
     data: source.stream,
     headers: {
@@ -65,7 +65,7 @@ async function _uploadObject(source, bucketName) {
       "x-goog-content-length-range": "0,123289600",
     },
     json: false,
-    origin: api.firebaseStorageOrigin,
+    origin: api.storageOrigin,
     logOptions: { skipRequestBody: true },
   });
   return location;
@@ -78,7 +78,7 @@ async function _uploadObject(source, bucketName) {
 function _deleteObject(location) {
   return api.request("DELETE", location, {
     auth: true,
-    origin: api.firebaseStorageOrigin,
+    origin: api.storageOrigin,
   });
 }
 

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -648,8 +648,7 @@ describe("extensionsHelper", () => {
     let uploadStub: sinon.SinonStub;
     let createSourceStub: sinon.SinonStub;
     let deleteStub: sinon.SinonStub;
-    const testUrl =
-      "https://firebasestorage.googleapis.com/v0/b/firebase-ext-eap-uploads/o/object.zip";
+    const testUrl = "https://storage.googleapis.com/firebase-ext-eap-uploads/object.zip";
     const testSource = {
       name: "test",
       packageUri: testUrl,
@@ -665,7 +664,7 @@ describe("extensionsHelper", () => {
       archiveStub = sinon.stub(archiveDirectory, "archiveDirectory").resolves({});
       uploadStub = sinon
         .stub(storage, "uploadObject")
-        .resolves("/v0/b/firebase-ext-eap-uploads/o/object.zip");
+        .resolves("/firebase-ext-eap-uploads/object.zip");
       createSourceStub = sinon.stub(extensionsApi, "createSource").resolves(testSource);
       deleteStub = sinon.stub(storage, "deleteObject").resolves();
     });
@@ -682,7 +681,7 @@ describe("extensionsHelper", () => {
       expect(uploadStub).to.have.been.calledWith({}, extensionsHelper.EXTENSIONS_BUCKET_NAME);
       expect(createSourceStub).to.have.been.calledWith("test-proj", testUrl + "?alt=media", "/");
       expect(deleteStub).to.have.been.calledWith(
-        `/v0/b/${extensionsHelper.EXTENSIONS_BUCKET_NAME}/o/object.zip`
+        `/${extensionsHelper.EXTENSIONS_BUCKET_NAME}/object.zip`
       );
     });
 
@@ -696,7 +695,7 @@ describe("extensionsHelper", () => {
       expect(uploadStub).to.have.been.calledWith({}, extensionsHelper.EXTENSIONS_BUCKET_NAME);
       expect(createSourceStub).to.have.been.calledWith("test-proj", testUrl + "?alt=media", "/");
       expect(deleteStub).to.have.been.calledWith(
-        `/v0/b/${extensionsHelper.EXTENSIONS_BUCKET_NAME}/o/object.zip`
+        `/${extensionsHelper.EXTENSIONS_BUCKET_NAME}/object.zip`
       );
     });
 


### PR DESCRIPTION
### Description

Firebase Storage REST API has a small issue now where file uploads for payloads >100KB reliably fails for some storage buckets.

Here, we change the implementation of `src/gcp/storage.js` to call GCS REST API to upload payloads (it doesn't fail for payloads >100KB).
 
Given that `storage.js` is placed under`gcp/` directory, I think the transition to use GCP API vs Firebase API makes sense.

### Scenarios Tested
Try installing an extension (whose total archive size would exceed 100KB) using its local source:

```
git clone git@github.com:firebase/extensions.git && cd extensions
firebase ext:install ./firestore-counter --project={project-id} --debug
```

Without the proposed change, the command fails with a 503 from the Firebase Storage API
```
[debug] [2020-05-29T18:18:17.476Z] >>> HTTP REQUEST POST https://firebasestorage.googleapis.com/v0/b/firebase-ext-eap-uploads/o/firebase-archive-10246n4tFTiaFcPmm.zip  
 <request body omitted>
[debug] [2020-05-29T18:18:19.211Z] <<< HTTP RESPONSE 503 {"x-guploader-uploadid":"AAANsUmdotV4qnjGKD7lViB9G4hQh9im1UXUmvMEpcpEGv2NKw6SEQc-sf_bBrzq1V6FN6RAEmUaeF0MKSE6tl5cLfAmI4XndQ","content-length":"0","date":"Fri, 29 May 2020 18:18:19 GMT","server":"UploadServer","content-type":"text/html; charset=UTF-8","alt-svc":"h3-27=\":443\"; ma=2592000,h3-25=\":443\"; ma=2592000,h3-T050=\":443\"; ma=2592000,h3-Q050=\":443\"; ma=2592000,h3-Q049=\":443\"; ma=2592000,h3-Q048=\":443\"; ma=2592000,h3-Q046=\":443\"; ma=2592000,h3-Q043=\":443\"; ma=2592000,quic=\":443\"; ma=2592000; v=\"46,43\""}
```