### PR TITLE
Ignore contents of .git directory when archiving extensions source code.

### DIFF
--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -310,7 +310,10 @@ export async function ensureExtensionsApiEnabled(options: any): Promise<void> {
  * @returns the path where the source was uploaded to
  */
 async function archiveAndUploadSource(extPath: string, bucketName: string): Promise<string> {
-  const zippedSource = await archiveDirectory(extPath, { type: "zip", ignore: ["node_modules"] });
+  const zippedSource = await archiveDirectory(extPath, {
+    type: "zip",
+    ignore: ["node_modules", ".git"],
+  });
   return await uploadObject(zippedSource, bucketName);
 }
 


### PR DESCRIPTION
### Description

In addition to ignoring nodes_module directory, we also ignore `.git` directory when archiving source code of an extension. This will reduce the overall size of the archive uploaded to the GCS bucket (though negligible in most cases, `.git` dir can get pretty big with enough history e.g. `firebase/firebase-tools`'s `.git` directory is ~54MB).