### PR TITLE
Terminate server together with the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Makes `functions:shell` terminate the server together with the shell

--- a/src/functionsShellCommandAction.js
+++ b/src/functionsShellCommandAction.js
@@ -100,10 +100,9 @@ module.exports = async function(options) {
       replServer.context.help =
         "Instructions for the Functions Shell can be found at: " +
         "https://firebase.google.com/docs/functions/local-emulator";
-    })
-    .then(function() {
+
       return new Promise(function(resolve) {
-        process.on("SIGINT", function() {
+        replServer.on("exit", function() {
           return serveFunctions
             .stop()
             .then(resolve)


### PR DESCRIPTION
### Description

Previously the interrupt handler for `functions:shell` was only triggered once the repl had been
exited. Thus you had to interrupt the process three times before it ended.
