### PR TITLE
Re-add all triggers to shell on repl reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Makes `functions:shell` terminate the server together with the shell
+- Makes `functions:shell` respect the `.clear` command
 - Fixes issue where functions emulator would fail while looking for `tsconfig.json` (#2353)

--- a/src/functionsShellCommandAction.js
+++ b/src/functionsShellCommandAction.js
@@ -59,6 +59,19 @@ module.exports = async function(options) {
         process.exit();
       }
 
+      var initializeContext = function(context) {
+        _.forEach(emulator.triggers, function(trigger) {
+          if (_.includes(emulator.emulatedFunctions, trigger.name)) {
+            var localFunction = new LocalFunction(trigger, emulator.urls, emulator);
+            var triggerNameDotNotation = trigger.name.replace(/\-/g, ".");
+            _.set(context, triggerNameDotNotation, localFunction.call);
+          }
+        });
+        context.help =
+          "Instructions for the Functions Shell can be found at: " +
+          "https://firebase.google.com/docs/functions/local-emulator";
+      };
+
       for (const e of runningEmulators) {
         const info = remoteEmulators[e];
         utils.logLabeledBullet(
@@ -90,16 +103,8 @@ module.exports = async function(options) {
         writer: writer,
         useColors: true,
       });
-      _.forEach(emulator.triggers, function(trigger) {
-        if (_.includes(emulator.emulatedFunctions, trigger.name)) {
-          var localFunction = new LocalFunction(trigger, emulator.urls, emulator);
-          var triggerNameDotNotation = trigger.name.replace(/\-/g, ".");
-          _.set(replServer.context, triggerNameDotNotation, localFunction.call);
-        }
-      });
-      replServer.context.help =
-        "Instructions for the Functions Shell can be found at: " +
-        "https://firebase.google.com/docs/functions/local-emulator";
+      initializeContext(replServer.context);
+      replServer.on("reset", initializeContext);
 
       return new Promise(function(resolve) {
         replServer.on("exit", function() {

--- a/src/functionsShellCommandAction.js
+++ b/src/functionsShellCommandAction.js
@@ -63,7 +63,7 @@ module.exports = async function(options) {
         _.forEach(emulator.triggers, function(trigger) {
           if (_.includes(emulator.emulatedFunctions, trigger.name)) {
             var localFunction = new LocalFunction(trigger, emulator.urls, emulator);
-            var triggerNameDotNotation = trigger.name.replace(/\-/g, ".");
+            var triggerNameDotNotation = trigger.name.replace(/-/g, ".");
             _.set(context, triggerNameDotNotation, localFunction.call);
           }
         });


### PR DESCRIPTION
### Description

This change makes `functions:shell` respect the `.clear` command in the repl.