### PR TITLE
Fix requireAsync and requireResolveAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Makes `functions:shell` terminate the server together with the shell
+- Fixes issue where functions emulator would fail while looking for `tsconfig.json` (#2353)

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -51,7 +51,13 @@ function requireAsync(moduleName: string, opts?: { paths: string[] }): Promise<a
 }
 
 function requireResolveAsync(moduleName: string, opts?: { paths: string[] }): Promise<string> {
-  return Promise.resolve(require.resolve(moduleName, opts));
+  return new Promise((res, rej) => {
+    try {
+      res(require.resolve(moduleName, opts));
+    } catch (e) {
+      rej(e);
+    }
+  });
 }
 
 interface PackageJSON {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -41,7 +41,13 @@ function noOp(): false {
 }
 
 function requireAsync(moduleName: string, opts?: { paths: string[] }): Promise<any> {
-  return Promise.resolve(require(require.resolve(moduleName, opts)));
+  return new Promise((res, rej) => {
+    try {
+      res(require(require.resolve(moduleName, opts)));
+    } catch (e) {
+      rej(e);
+    }
+  });
 }
 
 function requireResolveAsync(moduleName: string, opts?: { paths: string[] }): Promise<string> {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2353

This was a bug resulting from the resent `async` / `await` lint cleanup.

### Scenarios Tested

```js
const functions = require('firebase-functions');

// THIS DOES NOT EXIST
const utils = require('../util');

exports.helloWorld = functions.https.onRequest((request, response) => {
 response.send("Hello from Firebase!");
});
```

**without tsconfig.json**
```
⚠  Error: Cannot find module '../util'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.625w4mnk/functions/index.js:2:15)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
⚠  We were unable to load your functions code. (see above)
```

**with tsconfig.json**
```
⚠  Error: Cannot find module '../util'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Module.require (internal/modules/cjs/loader.js:692:17)
    at require (internal/modules/cjs/helpers.js:25:18)
    at Object.<anonymous> (/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.625w4mnk/functions/index.js:2:15)
    at Module._compile (internal/modules/cjs/loader.js:778:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:789:10)
    at Module.load (internal/modules/cjs/loader.js:653:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:593:12)
    at Function.Module._load (internal/modules/cjs/loader.js:585:3)
⚠  We were unable to load your functions code. (see above)
   - It appears your code is written in Typescript, which must be compiled before emulation.
```

### Sample Commands

N/A