### PR TITLE
Improve error message for filterTargets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Makes `functions:shell` terminate the server together with the shell
 - Fixes issue where functions emulator would fail while looking for `tsconfig.json` (#2353)
-- Improve error message for `deploy` and `serve` when invalid targets are specified (#2363)
+- Improves error messages for `deploy` and `serve` when invalid targets are specified (#2363)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Makes `functions:shell` terminate the server together with the shell
 - Fixes issue where functions emulator would fail while looking for `tsconfig.json` (#2353)
+- Improve error message for `deploy` and `serve` when invalid targets are specified (#2363)

--- a/src/filterTargets.js
+++ b/src/filterTargets.js
@@ -29,7 +29,7 @@ module.exports = function(options, validTargets) {
 
     if (process.platform === "win32") {
       msg +=
-        'If you are using PowerShell make sure you place quotes around any comma-separated lists (ex: --only "functions,firestore").';
+        ' If you are using PowerShell make sure you place quotes around any comma-separated lists (ex: --only "functions,firestore").';
     }
 
     throw new FirebaseError(msg, { exit: 1 });

--- a/src/filterTargets.js
+++ b/src/filterTargets.js
@@ -19,12 +19,20 @@ module.exports = function(options, validTargets) {
   }
 
   if (targets.length === 0) {
-    throw new FirebaseError(
-      "Cannot understand what targets to deploy. Check that you specified valid targets" +
-        " if you used the --only or --except flag. Otherwise, check your firebase.json to" +
-        " ensure that your project is initialized for the desired features.",
-      { exit: 1 }
-    );
+    let msg = "Cannot understand what targets to deploy/serve.";
+
+    if (options.only) {
+      msg += ` No targets in firebase.json match '--only ${options.only}'.`;
+    } else if (options.except) {
+      msg += ` No targets in firebase.json match '--except ${options.except}'.`;
+    }
+
+    if (process.platform === "win32") {
+      msg +=
+        'If you are using PowerShell make sure you place quotes around any comma-separated lists (ex: --only "functions,firestore").';
+    }
+
+    throw new FirebaseError(msg, { exit: 1 });
   }
   return targets;
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2363

### Scenarios Tested

```
$ firebase serve --only foobar

=== Serving from '/Users/samstern/Scratch/firebase-functions-yarn-2'...


Error: Cannot understand what targets to deploy/serve. No targets in firebase.json match '--only foobar'.
```
### Sample Commands

N/A