### PR TITLE
Support RE2 regexps in Hosting config.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Support the Firebase Hosting API's RE2-based header/rewrite feature.
+* Adds support for regular expression-based custom headers and rewrites for Firebase Hosting.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Support the Firebase Hosting API's RE2-based header/rewrite feature.

--- a/src/deploy/hosting/convertConfig.js
+++ b/src/deploy/hosting/convertConfig.js
@@ -1,4 +1,25 @@
 const _ = require("lodash");
+const { FirebaseError } = require("../../error");
+
+/**
+ * extractPattern contains the logic for extracting exactly one glob/regexp
+ * from a Hosting rewrite/redirect/header specification
+ */
+function extractPattern(type, spec) {
+  const glob = spec.source || spec.glob;
+  const regex = spec.regex;
+
+  if (glob && regex) {
+    throw new FirebaseError("Cannot specify a " + type + " pattern with both a glob and regex.");
+  } else if (glob) {
+    return { glob: glob };
+  } else if (regex) {
+    return { regex: regex };
+  }
+  throw new FirebaseError(
+    "Cannot specify a " + type + " with no pattern (either a glob or regex required)."
+  );
+}
 
 /**
  * convertConfig takes a hosting config object from firebase.json and transforms it into
@@ -14,7 +35,7 @@ module.exports = function(config) {
   // rewrites
   if (_.isArray(config.rewrites)) {
     out.rewrites = config.rewrites.map(function(rewrite) {
-      const vRewrite = { glob: rewrite.source };
+      const vRewrite = extractPattern("rewrite", rewrite);
       if (rewrite.destination) {
         vRewrite.path = rewrite.destination;
       } else if (rewrite.function) {
@@ -31,7 +52,8 @@ module.exports = function(config) {
   // redirects
   if (_.isArray(config.redirects)) {
     out.redirects = config.redirects.map(function(redirect) {
-      const vRedirect = { glob: redirect.source, location: redirect.destination };
+      const vRedirect = extractPattern("redirect", redirect);
+      vRedirect.location = redirect.destination;
       if (redirect.type) {
         vRedirect.statusCode = redirect.type;
       }
@@ -42,7 +64,7 @@ module.exports = function(config) {
   // headers
   if (_.isArray(config.headers)) {
     out.headers = config.headers.map(function(header) {
-      const vHeader = { glob: header.source };
+      const vHeader = extractPattern("header", header);
       vHeader.headers = {};
       (header.headers || []).forEach(function(h) {
         vHeader.headers[h.key] = h.value;


### PR DESCRIPTION
### Description

The Firebase Hosting API now allows you to specify RE2-based regular expressions instead of node-style glob paths when configuring custom headers, rewrites, and redirects in `firebase.json`. This CL allows users of the CLI to take advantage of the feature.
