### PR TITLE
Add .git to standard functions ignore

### DIFF
--- a/src/prepareFunctionsUpload.js
+++ b/src/prepareFunctionsUpload.js
@@ -63,7 +63,7 @@ var _packageSource = function(options, sourceDir, configValues) {
   // you're in the public dir when you deploy.
   // We ignore any CONFIG_DEST_FILE that already exists, and write another one
   // with current config values into the archive in the "end" handler for reader
-  var ignore = options.config.get("functions.ignore", ["node_modules", ".git", ]);
+  var ignore = options.config.get("functions.ignore", ["node_modules", ".git"]);
   ignore.push("firebase-debug.log", CONFIG_DEST_FILE /* .runtimeconfig.json */);
   return fsAsync
     .readdirRecursive({ path: sourceDir, ignore: ignore })

--- a/src/prepareFunctionsUpload.js
+++ b/src/prepareFunctionsUpload.js
@@ -63,7 +63,7 @@ var _packageSource = function(options, sourceDir, configValues) {
   // you're in the public dir when you deploy.
   // We ignore any CONFIG_DEST_FILE that already exists, and write another one
   // with current config values into the archive in the "end" handler for reader
-  var ignore = options.config.get("functions.ignore", ["node_modules"]);
+  var ignore = options.config.get("functions.ignore", ["node_modules", ".git", ]);
   ignore.push("firebase-debug.log", CONFIG_DEST_FILE /* .runtimeconfig.json */);
   return fsAsync
     .readdirRecursive({ path: sourceDir, ignore: ignore })


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

If a functions-only developer chooses to put their functions source in the root folder, this could be a source of longer deploy times.  See #536

### Scenarios Tested

N/A

### Sample Commands

N/A