### PR TITLE
Remove momentJS dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6729,11 +6729,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
-    },
     "morgan": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,6 @@
     "marked": "^0.7.0",
     "marked-terminal": "^3.3.0",
     "minimatch": "^3.0.4",
-    "moment": "^2.27.0",
     "morgan": "^1.10.0",
     "open": "^6.3.0",
     "ora": "^3.4.0",

--- a/src/extensions/listExtensions.ts
+++ b/src/extensions/listExtensions.ts
@@ -5,8 +5,8 @@ import Table = require("cli-table");
 import { ExtensionInstance, listInstances } from "./extensionsApi";
 import { logPrefix } from "./extensionsHelper";
 import * as utils from "../utils";
+import * as extensionsUtils from "./utils";
 import * as logger from "../logger";
-import * as moment from "moment";
 
 export async function listExtensions(
   projectId: string
@@ -32,7 +32,7 @@ export async function listExtensions(
       _.get(instance, "config.source.spec.author.authorName", ""),
       instance.state,
       _.get(instance, "config.source.spec.version", ""),
-      instance.updateTime ? moment(instance.updateTime).format("YYYY-MM-DD [T]HH:mm:ss") : "",
+      instance.updateTime ? extensionsUtils.formatTimestamp(instance.updateTime) : "",
     ]);
   });
 

--- a/src/extensions/listExtensions.ts
+++ b/src/extensions/listExtensions.ts
@@ -8,6 +8,11 @@ import * as utils from "../utils";
 import * as extensionsUtils from "./utils";
 import * as logger from "../logger";
 
+/**
+ * Lists the extensions installed under a project
+ * @param projectId ID of the project we're querying
+ * @return mapping that contains a list of instances under the "instances" key
+ */
 export async function listExtensions(
   projectId: string
 ): Promise<{ instances: ExtensionInstance[] }> {
@@ -32,7 +37,7 @@ export async function listExtensions(
       _.get(instance, "config.source.spec.author.authorName", ""),
       instance.state,
       _.get(instance, "config.source.spec.version", ""),
-      instance.updateTime ? extensionsUtils.formatTimestamp(instance.updateTime) : "",
+      extensionsUtils.formatTimestamp(instance.updateTime),
     ]);
   });
 

--- a/src/extensions/utils.ts
+++ b/src/extensions/utils.ts
@@ -66,5 +66,5 @@ export function formatTimestamp(timestamp: string): string {
     return "";
   }
   const withoutMs = timestamp.split(".")[0];
-  return withoutMs.replace("T", " T");
+  return withoutMs.replace("T", " ");
 }

--- a/src/extensions/utils.ts
+++ b/src/extensions/utils.ts
@@ -55,3 +55,13 @@ export function getRandomString(length: number): string {
   }
   return result;
 }
+
+/**
+ * Formats a timestamp from API into something more readable. 
+ * @param timestamp with this format: 2020-05-11T03:45:13.583677Z
+ * returns a timestamp with this format: 2020-05-11 T03:45:13
+ */
+export function formatTimestamp(timestamp: string): string {
+  const withoutMs = timestamp.split(".")[0]
+  return withoutMs.replace("T", " T")
+}

--- a/src/extensions/utils.ts
+++ b/src/extensions/utils.ts
@@ -59,9 +59,12 @@ export function getRandomString(length: number): string {
 /**
  * Formats a timestamp from the Extension backend into something more readable
  * @param timestamp with this format: 2020-05-11T03:45:13.583677Z
- * returns a timestamp with this format: 2020-05-11 T03:45:13
+ * @return a timestamp with this format: 2020-05-11 T03:45:13
  */
 export function formatTimestamp(timestamp: string): string {
+  if (!timestamp) {
+    return "";
+  }
   const withoutMs = timestamp.split(".")[0];
   return withoutMs.replace("T", " T");
 }

--- a/src/extensions/utils.ts
+++ b/src/extensions/utils.ts
@@ -57,11 +57,11 @@ export function getRandomString(length: number): string {
 }
 
 /**
- * Formats a timestamp from API into something more readable. 
+ * Formats a timestamp from the Extension backend into something more readable
  * @param timestamp with this format: 2020-05-11T03:45:13.583677Z
  * returns a timestamp with this format: 2020-05-11 T03:45:13
  */
 export function formatTimestamp(timestamp: string): string {
-  const withoutMs = timestamp.split(".")[0]
-  return withoutMs.replace("T", " T")
+  const withoutMs = timestamp.split(".")[0];
+  return withoutMs.replace("T", " T");
 }

--- a/src/test/extensions/utils.spec.ts
+++ b/src/test/extensions/utils.spec.ts
@@ -5,7 +5,7 @@ import * as utils from "../../extensions/utils";
 describe("extensions utils", () => {
   describe("formatTimestamp", () => {
     it("should format timestamp correctly", () => {
-      expect(utils.formatTimestamp("2020-05-11T03:45:13.583677Z")).to.equal("2020-05-11 T03:45:13");
+      expect(utils.formatTimestamp("2020-05-11T03:45:13.583677Z")).to.equal("2020-05-11 03:45:13");
     });
   });
 });

--- a/src/test/extensions/utils.spec.ts
+++ b/src/test/extensions/utils.spec.ts
@@ -1,0 +1,11 @@
+import { expect } from "chai";
+
+import * as utils from "../../extensions/utils";
+
+describe("extensions utils", () => {
+  describe("formatTimestamp", () => {
+    it("should format timestamp correctly", () => {
+      expect(utils.formatTimestamp("2020-05-11T03:45:13.583677Z")).to.equal("2020-05-11 T03:45:13");
+    });
+  });
+});


### PR DESCRIPTION
### Description
A recent PR used MomentJS to format a timestamp from the Extensions backend. Since we want to minimize 3rd-party dependencies, this PR replaces MomentJS with a helper function to format the timestamp.

### Scenarios Tested
I tested manually:
<img width="666" alt="Screen Shot 2020-06-26 at 11 19 56 AM" src="https://user-images.githubusercontent.com/64040981/85888709-fae13380-b79e-11ea-84ca-0275092cd50d.png">
