### PR TITLE
Forcibly destroy emulator servers on closing.

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -113,7 +113,7 @@ export class FunctionsEmulator implements EmulatorInstance {
   }
 
   nodeBinary = "";
-  private destoryServer?: () => Promise<void>;
+  private destroyServer?: () => Promise<void>;
   private triggers: EmulatedTriggerDefinition[] = [];
   private knownTriggerIDs: { [triggerId: string]: boolean } = {};
 
@@ -228,7 +228,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     const { host, port } = this.getInfo();
     this.workQueue.start();
     const server = this.createHubServer().listen(port, host);
-    this.destoryServer = createDestroyer(server);
+    this.destroyServer = createDestroyer(server);
     return Promise.resolve();
   }
 
@@ -363,7 +363,7 @@ export class FunctionsEmulator implements EmulatorInstance {
   stop(): Promise<void> {
     this.workQueue.stop();
     this.workerPool.exit();
-    return this.destoryServer ? this.destoryServer() : Promise.resolve();
+    return this.destroyServer ? this.destroyServer() : Promise.resolve();
   }
 
   addRealtimeDatabaseTrigger(

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -64,7 +64,7 @@ export class EmulatorHub implements EmulatorInstance {
   }
 
   private hub: express.Express;
-  private server?: http.Server;
+  private destroyServer?: () => Promise<void>;
 
   constructor(private args: EmulatorHubArgs) {
     this.hub = express();
@@ -106,7 +106,8 @@ export class EmulatorHub implements EmulatorInstance {
 
   async start(): Promise<void> {
     const { host, port } = this.getInfo();
-    this.server = this.hub.listen(port, host);
+    const server = this.hub.listen(port, host);
+    this.destroyServer = utils.createDestroyer(server);
     await this.writeLocatorFile();
   }
 
@@ -115,7 +116,7 @@ export class EmulatorHub implements EmulatorInstance {
   }
 
   async stop(): Promise<void> {
-    this.server && this.server.close();
+    if (this.destroyServer) await this.destroyServer();
     await this.deleteLocatorFile();
   }
 

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -1,4 +1,3 @@
-import * as http from "http";
 import * as express from "express";
 import * as os from "os";
 import * as fs from "fs";
@@ -116,7 +115,9 @@ export class EmulatorHub implements EmulatorInstance {
   }
 
   async stop(): Promise<void> {
-    if (this.destroyServer) await this.destroyServer();
+    if (this.destroyServer) {
+      await this.destroyServer();
+    }
     await this.deleteLocatorFile();
   }
 

--- a/src/emulator/loggingEmulator.ts
+++ b/src/emulator/loggingEmulator.ts
@@ -48,17 +48,7 @@ export class LoggingEmulator implements EmulatorInstance {
   stop(): Promise<void> {
     logger.remove(this.transport);
 
-    if (this.transport?.wss) {
-      const wss = this.transport.wss;
-      return new Promise((resolve, reject) => {
-        wss.close((err) => {
-          if (err) reject(err);
-          else resolve();
-        });
-      });
-    }
-
-    return Promise.resolve();
+    return this.transport ? this.transport.stop() : Promise.resolve();
   }
 
   getInfo(): EmulatorInfo {
@@ -85,7 +75,7 @@ type LogEntry = {
 
 class WebSocketTransport extends TransportStream {
   wss?: WebSocket.Server;
-  connections: WebSocket[] = [];
+  connections = new Set<WebSocket>();
   history: LogEntry[] = [];
 
   constructor(options = {}) {
@@ -96,10 +86,22 @@ class WebSocketTransport extends TransportStream {
   start(options: EmulatorInfo) {
     this.wss = new WebSocket.Server(options);
     this.wss.on("connection", (ws) => {
-      this.connections.push(ws);
+      this.connections.add(ws);
+      ws.once("close", () => this.connections.delete(ws));
       this.history.forEach((bundle) => {
         ws.send(JSON.stringify(bundle));
       });
+    });
+  }
+
+  stop(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      if (!this.wss) return resolve();
+      this.wss.close((err) => {
+        if (err) return reject(err);
+        resolve();
+      });
+      this.connections.forEach((socket) => socket.terminate());
     });
   }
 

--- a/src/emulator/loggingEmulator.ts
+++ b/src/emulator/loggingEmulator.ts
@@ -96,7 +96,9 @@ class WebSocketTransport extends TransportStream {
 
   stop(): Promise<void> {
     return new Promise((resolve, reject) => {
-      if (!this.wss) return resolve();
+      if (!this.wss) {
+        return resolve();
+      }
       this.wss.close((err) => {
         if (err) return reject(err);
         resolve();

--- a/src/serve/hosting.ts
+++ b/src/serve/hosting.ts
@@ -14,10 +14,11 @@ import { NextFunction, Request, Response } from "express";
 import { Writable } from "stream";
 import { EmulatorLogger } from "../emulator/emulatorLogger";
 import { Emulators } from "../emulator/types";
+import { createDestroyer } from "../utils";
 
 const MAX_PORT_ATTEMPTS = 10;
 let attempts = 0;
-let server: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+let destroyServer: undefined | (() => Promise<void>) = undefined;
 
 const logger = EmulatorLogger.forEmulator(Emulators.HOSTING);
 
@@ -42,7 +43,7 @@ function startServer(options: any, config: any, port: number, init: TemplateServ
     stream: morganStream,
   });
 
-  server = superstatic({
+  const server = superstatic({
     debug: false,
     port: port,
     host: options.host,
@@ -78,6 +79,8 @@ function startServer(options: any, config: any, port: number, init: TemplateServ
     );
   });
 
+  destroyServer = createDestroyer(server);
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   server.on("error", (err: any) => {
     if (err.code === "EADDRINUSE") {
@@ -105,10 +108,8 @@ function startServer(options: any, config: any, port: number, init: TemplateServ
 /**
  * Stop the Hosting server.
  */
-export async function stop(): Promise<void> {
-  if (server) {
-    await server.close();
-  }
+export function stop(): Promise<void> {
+  return destroyServer ? destroyServer() : Promise.resolve();
 }
 
 /**

--- a/src/test/emulators/fakeEmulator.ts
+++ b/src/test/emulators/fakeEmulator.ts
@@ -1,31 +1,28 @@
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../../emulator/types";
 import * as express from "express";
-import * as http from "http";
+import { createDestroyer } from "../../utils";
 
 /**
  * A thing that acts like an emulator by just occupying a port.
  */
 export class FakeEmulator implements EmulatorInstance {
   private exp: express.Express;
-  private server?: http.Server;
+  private destroyServer?: () => Promise<void>;
 
   constructor(public name: Emulators, public host: string, public port: number) {
     this.exp = express();
   }
 
   start(): Promise<void> {
-    this.server = this.exp.listen(this.port);
+    const server = this.exp.listen(this.port);
+    this.destroyServer = createDestroyer(server);
     return Promise.resolve();
   }
   connect(): Promise<void> {
     return Promise.resolve();
   }
   stop(): Promise<void> {
-    if (this.server) {
-      this.server.close();
-      this.server = undefined;
-    }
-    return Promise.resolve();
+    return this.destroyServer ? this.destroyServer() : Promise.resolve();
   }
   getInfo(): EmulatorInfo {
     return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -421,11 +421,9 @@ export async function promiseWithSpinner<T>(action: () => Promise<T>, message: s
 export function createDestroyer(server: http.Server): () => Promise<void> {
   const connections = new Set<Socket>();
 
-  server.on("connection", function(conn) {
+  server.on("connection", (conn) => {
     connections.add(conn);
-    conn.once("close", function() {
-      connections.delete(conn);
-    });
+    conn.once("close", () => connections.delete(conn));
   });
 
   // Make calling destroyer again just noop but return the same promise.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import * as _ from "lodash";
 import * as url from "url";
+import * as http from "http";
 import * as clc from "cli-color";
 import * as ora from "ora";
 import { Readable } from "stream";
@@ -11,6 +12,7 @@ import { configstore } from "./configstore";
 import { FirebaseError } from "./error";
 import * as logger from "./logger";
 import { LogDataOrUndefined } from "./emulator/loggingEmulator";
+import { Socket } from "net";
 
 const IS_WINDOWS = process.platform === "win32";
 const SUCCESS_CHAR = IS_WINDOWS ? "+" : "✔";
@@ -406,4 +408,38 @@ export async function promiseWithSpinner<T>(action: () => Promise<T>, message: s
   }
 
   return data;
+}
+
+/**
+ * Return a "destroy" function for a Node.js HTTP server. MUST be called on
+ * server creation (e.g. right after `.listen`), BEFORE any connections.
+ *
+ * Inspired by https://github.com/isaacs/server-destroy/blob/master/index.js
+ *
+ * @returns a function that destroys all connections and closes the server
+ */
+export function createDestroyer(server: http.Server): () => Promise<void> {
+  const connections = new Set<Socket>();
+
+  server.on("connection", function(conn) {
+    connections.add(conn);
+    conn.once("close", function() {
+      connections.delete(conn);
+    });
+  });
+
+  // Make calling destroyer again just noop but return the same promise.
+  let destroyPromise: Promise<void> | undefined = undefined;
+  return function destroyer() {
+    if (!destroyPromise) {
+      destroyPromise = new Promise((resolve, reject) => {
+        server.close((err) => {
+          if (err) return reject(err);
+          resolve();
+        });
+        connections.forEach((socket) => socket.destroy());
+      });
+    }
+    return destroyPromise;
+  };
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR makes `SomeEmulator#stop()` forcibly close the server by destroying all connections. This fixes Ctrl-C not killing emulators (e.g. hosting emulator, logging) when a keep-alive connection is still open, commonly seen in browsers.

Note that this has the potential to interrupt connections that are still sending / reading data, but I think this is fine for emulators. I believe developers will understand once they kill the emulators, things can go wrong. (I've tested that Emulator UI is still okay when connection breaks.)

### Scenarios Tested

Started emulators via `emulators:start` and tried opening up Emulator UI etc. Then killed the CLI with the browser tab still open on logging. Both hub and logging stopped with no problem. Pressing `Ctrl-C` twice in a row also works fine.
