### PR TITLE
Ml i18n support

### DIFF
--- a/src/deploy/hosting/convertConfig.js
+++ b/src/deploy/hosting/convertConfig.js
@@ -89,7 +89,7 @@ module.exports = function(config) {
   if (_.has(config, "appAssociation")) {
     out.appAssociation = config.appAssociation;
   }
-  
+
   // i18n config
   if (_.has(config, "i18n")) {
     out.i18n = config.i18n;

--- a/src/deploy/hosting/convertConfig.js
+++ b/src/deploy/hosting/convertConfig.js
@@ -92,7 +92,7 @@ module.exports = function(config) {
   
   // i18n config
   if (_.has(config, "i18n")) {
-    out.i18N = config.i18n;
+    out.i18n = config.i18n;
   }
 
   return out;

--- a/src/deploy/hosting/convertConfig.js
+++ b/src/deploy/hosting/convertConfig.js
@@ -89,6 +89,11 @@ module.exports = function(config) {
   if (_.has(config, "appAssociation")) {
     out.appAssociation = config.appAssociation;
   }
+  
+  // i18n config
+  if (_.has(config, "i18n")) {
+    out.i18N = config.i18n;
+  }
 
   return out;
 };


### PR DESCRIPTION
### Description

This change passes i18n info from firebase.json through to the serving config, so that it can be accessed by internal code that has already been submitted as a part of a new feature.

### Scenarios Tested

Tested with a sample project to make sure that the i18n information successfully passes through to the serving config. Ran tests & linter.

### Sample Commands

n/a
