### PR TITLE
Adds support for dash notation in --only functions: flag

### DIFF
--- a/src/functionsDeployHelper.js
+++ b/src/functionsDeployHelper.js
@@ -31,7 +31,10 @@ function getFilterGroups(options) {
       return opts[0] === "functions" && opts[1];
     })
     .map(function(filter) {
-      return filter.split(":")[1].replace("-",".").split(".");
+      return filter
+        .split(":")[1]
+        .replace("-", ".")
+        .split(".");
     })
     .value();
 }

--- a/src/functionsDeployHelper.js
+++ b/src/functionsDeployHelper.js
@@ -33,8 +33,7 @@ function getFilterGroups(options) {
     .map(function(filter) {
       return filter
         .split(":")[1]
-        .replace("-", ".")
-        .split(".");
+        .split(/[.-]/);
     })
     .value();
 }

--- a/src/functionsDeployHelper.js
+++ b/src/functionsDeployHelper.js
@@ -31,9 +31,7 @@ function getFilterGroups(options) {
       return opts[0] === "functions" && opts[1];
     })
     .map(function(filter) {
-      return filter
-        .split(":")[1]
-        .split(/[.-]/);
+      return filter.split(":")[1].split(/[.-]/);
     })
     .value();
 }

--- a/src/functionsDeployHelper.js
+++ b/src/functionsDeployHelper.js
@@ -31,7 +31,7 @@ function getFilterGroups(options) {
       return opts[0] === "functions" && opts[1];
     })
     .map(function(filter) {
-      return filter.split(":")[1].split(".");
+      return filter.split(":")[1].replace("-",".").split(".");
     })
     .value();
 }


### PR DESCRIPTION
### Description
Supports dash notation (`group-fnName`) in the `--only functions:` flag. Previously, this only supported dot notation (`group.fnName`). This is confusing (https://github.com/firebase/firebase-tools/issues/2166), because function names are displayed in dot notation on the Firebase console and in other contexts.

Original intent in the internal bug (b/160148195) was to only allow this for functions that have already been deployed. However, I think that will be an unintuitive experience for users - imagine this scenario: I'm writing a new function, and changing an existing function to work with my new one, and I only want to deploy these 2 functions. It would be unintuitive for `--only functions:group-oldFn,group-newFn` not to deploy both functions.