### PR TITLE
Clarify error message for unrecognized param types in emulator

### DIFF
--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -11,14 +11,7 @@ import { checkResponse } from "./askUserForParam";
 import { ensure } from "../ensureApiEnabled";
 import { deleteObject, uploadObject } from "../gcp/storage";
 import * as getProjectId from "../getProjectId";
-import {
-  createSource,
-  getInstance,
-  ExtensionSource,
-  getSource,
-  Param,
-  ParamType,
-} from "./extensionsApi";
+import { createSource, getInstance, ExtensionSource, getSource, Param } from "./extensionsApi";
 import { promptOnce } from "../prompt";
 import * as logger from "../logger";
 import { envOverride } from "../utils";
@@ -210,7 +203,7 @@ export function validateSpec(spec: any) {
       errors.push(
         `Invalid type ${param.type} for param${
           param.param ? ` ${param.param}` : ""
-        }. Valid types are ${_.values(ParamType).join(", ")}`
+        }. Valid types are ${_.values(SpecParamType).join(", ")}`
       );
     }
     if (!param.type || param.type == SpecParamType.STRING) {


### PR DESCRIPTION
Display the correct (all lowercase) param types in the error message for invalid param types. Previously, we were displaying the (all caps) output only param types.