### PR TITLE
Release Firestore Emulator v1.11.5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,5 @@
 
 - Fixes an issue where the suggested redeploy command for Firebase Functions was incorrect for names with dashes.
 - Adds the `--export-on-exit` flag to `emulators:start` and `emulators:exec` to automatically export emulator data on command exit (#2224)
-- Fixes support for camel case query parameters in Firestore Emulator.
+- Fixes support for camel-case query parameters in Firestore Emulator.
 - Adds support for `!=` style queries in Firestore Emulator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,5 @@
 
 - Fixes an issue where the suggested redeploy command for Firebase Functions was incorrect for names with dashes.
 - Adds the `--export-on-exit` flag to `emulators:start` and `emulators:exec` to automatically export emulator data on command exit (#2224)
+- Fixes support for camel case query parameters in Firestore Emulator.
+- Adds support for `!=` style queries in Firestore Emulator.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -40,14 +40,14 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.4.jar"),
-    version: "1.11.4",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.5.jar"),
+    version: "1.11.5",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.4.jar",
-      expectedSize: 63915084,
-      expectedChecksum: "53a1e2ee7b8a2b26a46f50167dcf4962",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.5.jar",
+      expectedSize: 63287761,
+      expectedChecksum: "badd7007623ce51761d7a8ec2be42f8f",
       namePrefix: "cloud-firestore-emulator",
     },
   },


### PR DESCRIPTION
### Description

This PR updates Firestore Emulator to v1.11.5.

### Scenarios Tested

Started emulators and it downloads and verifies the checksum correctly.

```bash
$ node /path/to/firebase-tools/lib/bin/firebase.js emulators:start
i  emulators: Starting emulators: functions, firestore, database, hosting
⚠  functions: The following emulators are not running, calls to these services from the Functions emulator will affect production: pubsub
⚠  Your requested "node" version "8" doesn't match your global version "12"
i  firestore: downloading cloud-firestore-emulator-v1.11.5.jar...
Progress: ==================================> (100% of 64MB
i  firestore: Removing outdated emulator files: cloud-firestore-emulator-v1.11.4.jar
i  firestore: Firestore Emulator logging to firestore-debug.log
```
