### PR TITLE
Preserve Authorization header in callable requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where `Authorization` header was missing from callable functions in the emulator (#2459).

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -780,7 +780,11 @@ export class FunctionsEmulator implements EmulatorInstance {
           token: token,
         };
 
+        // Stash the "Authorization" header in a temporary place, we will replace it
+        // when invoking the callable handler
+        req.headers[HttpConstants.ORIGINAL_AUTH_HEADER] = req.headers["authorization"];
         delete req.headers["authorization"];
+
         req.headers[HttpConstants.CALLABLE_AUTH_HEADER] = encodeURIComponent(
           JSON.stringify(contextAuth)
         );

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -460,6 +460,7 @@ function wrapCallableHandler(handler: CallableHandler): CallableHandler {
           value: authContext,
         });
         context.auth = JSON.parse(decodeURIComponent(authContext));
+        delete context.rawRequest.headers[HttpConstants.CALLABLE_AUTH_HEADER]
       } else {
         logDebug("No callable functions auth found");
       }
@@ -469,6 +470,7 @@ function wrapCallableHandler(handler: CallableHandler): CallableHandler {
       const originalAuth = context.rawRequest.header(HttpConstants.ORIGINAL_AUTH_HEADER);
       if (originalAuth) {
         context.rawRequest.headers["authorization"] = originalAuth;
+        delete context.rawRequest.headers[HttpConstants.ORIGINAL_AUTH_HEADER];
       }
     }
     return handler(data, context);

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -463,6 +463,13 @@ function wrapCallableHandler(handler: CallableHandler): CallableHandler {
       } else {
         logDebug("No callable functions auth found");
       }
+
+      // Restore the original auth header in case the code relies on parsing it (for
+      // example, the code could forward it to another function or server).
+      const originalAuth = context.rawRequest.header(HttpConstants.ORIGINAL_AUTH_HEADER);
+      if (originalAuth) {
+        context.rawRequest.headers["authorization"] = originalAuth;
+      }
     }
     return handler(data, context);
   };

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -460,7 +460,7 @@ function wrapCallableHandler(handler: CallableHandler): CallableHandler {
           value: authContext,
         });
         context.auth = JSON.parse(decodeURIComponent(authContext));
-        delete context.rawRequest.headers[HttpConstants.CALLABLE_AUTH_HEADER]
+        delete context.rawRequest.headers[HttpConstants.CALLABLE_AUTH_HEADER];
       } else {
         logDebug("No callable functions auth found");
       }

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -85,6 +85,7 @@ const memoryLookup = {
 
 export class HttpConstants {
   static readonly CALLABLE_AUTH_HEADER: string = "x-callable-context-auth";
+  static readonly ORIGINAL_AUTH_HEADER: string = "x-original-auth";
 }
 
 export class EmulatedTrigger {

--- a/src/test/emulators/functionsEmulator.spec.ts
+++ b/src/test/emulators/functionsEmulator.spec.ts
@@ -353,4 +353,37 @@ describe("FunctionsEmulator-Hub", () => {
         });
       });
   }).timeout(TIMEOUT_LONG);
+
+  it("should preserve the Authorization header for callable auth", async () => {
+    useFunctions(() => {
+      return {
+        callable_function_id: require("firebase-functions").https.onCall((data: any, ctx: any) => {
+          return {
+            header: ctx.rawRequest.headers["authorization"],
+          };
+        }),
+      };
+    });
+
+    const authHeader =
+      "Bearer eyJhbGciOiJSUzI1NiIsImtpZCI6IjFmODhiODE0MjljYzQ1MWEzMzVjMmY1Y2RiM2RmYjM0ZWIzYmJjN2YiLCJ0eXAiOiJKV1QifQ.eyJwcm92aWRlcl9pZCI6ImFub255bW91cyIsImlzcyI6Imh0dHBzOi8vc2VjdXJldG9rZW4uZ29vZ2xlLmNvbS9maXItZHVtcHN0ZXIiLCJhdWQiOiJmaXItZHVtcHN0ZXIiLCJhdXRoX3RpbWUiOjE1ODUwNTMyNjQsInVzZXJfaWQiOiJTbW56OE8xcmxkZmptZHg4QVJVdE12WG1tdzYyIiwic3ViIjoiU21uejhPMXJsZGZqbWR4OEFSVXRNdlhtbXc2MiIsImlhdCI6MTU4NTA1MzI2NCwiZXhwIjoxNTg1MDU2ODY0LCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7fSwic2lnbl9pbl9wcm92aWRlciI6ImFub255bW91cyJ9fQ.ujOthXwov9NJAOmJfumkDzMQgj8P1YRWkhFeq_HqHpPmth1BbtrQ_duwFoFmAPGjnGTuozUi0YUl8eKh4p2CqXi-Wf_OLSumxNnJWhj_tm7OvYWjvUy0ZvjilPBrhQ17_lRnhyOVSLSXfneqehYvE85YkBkFy3GtOpN49fRdmBT7B71Yx8E8SM7fohlia-ah7_uSNpuJXzQ9-0rv6HH9uBYCmjUxb9MiuKwkIjDoYtjTuaqG8-4w8bPrKHmg6V7HeDSNItUcfDbALZiTsM5uob_uuVTwjCCQnwryB5Y3bmdksTqCvp8U7ZTU04HS9CJawTa-zuDXIwlOvsC-J8oQQw";
+
+    // For token info:
+    // https://jwt.io/#debugger-io?token=eyJhbGciOiJSUzI1NiIsImtpZCI6IjFmODhiODE0MjljYzQ1MWEzMzVjMmY1Y2RiM2RmYjM0ZWIzYmJjN2YiLCJ0eXAiOiJKV1QifQ.eyJwcm92aWRlcl9pZCI6ImFub255bW91cyIsImlzcyI6Imh0dHBzOi8vc2VjdXJldG9rZW4uZ29vZ2xlLmNvbS9maXItZHVtcHN0ZXIiLCJhdWQiOiJmaXItZHVtcHN0ZXIiLCJhdXRoX3RpbWUiOjE1ODUwNTMyNjQsInVzZXJfaWQiOiJTbW56OE8xcmxkZmptZHg4QVJVdE12WG1tdzYyIiwic3ViIjoiU21uejhPMXJsZGZqbWR4OEFSVXRNdlhtbXc2MiIsImlhdCI6MTU4NTA1MzI2NCwiZXhwIjoxNTg1MDU2ODY0LCJmaXJlYmFzZSI6eyJpZGVudGl0aWVzIjp7fSwic2lnbl9pbl9wcm92aWRlciI6ImFub255bW91cyJ9fQ.ujOthXwov9NJAOmJfumkDzMQgj8P1YRWkhFeq_HqHpPmth1BbtrQ_duwFoFmAPGjnGTuozUi0YUl8eKh4p2CqXi-Wf_OLSumxNnJWhj_tm7OvYWjvUy0ZvjilPBrhQ17_lRnhyOVSLSXfneqehYvE85YkBkFy3GtOpN49fRdmBT7B71Yx8E8SM7fohlia-ah7_uSNpuJXzQ9-0rv6HH9uBYCmjUxb9MiuKwkIjDoYtjTuaqG8-4w8bPrKHmg6V7HeDSNItUcfDbALZiTsM5uob_uuVTwjCCQnwryB5Y3bmdksTqCvp8U7ZTU04HS9CJawTa-zuDXIwlOvsC-J8oQQw
+    await supertest(functionsEmulator.createHubServer())
+      .post("/fake-project-id/us-central1/callable_function_id")
+      .set({
+        "Content-Type": "application/json",
+        Authorization: authHeader,
+      })
+      .send({ data: {} })
+      .expect(200)
+      .then((res) => {
+        expect(res.body).to.deep.equal({
+          result: {
+            header: authHeader,
+          },
+        });
+      });
+  }).timeout(TIMEOUT_LONG);
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2459 

Basically we stash away the `Authorization` header and restore it just before invoking the handler.

### Scenarios Tested

See unit test.

### Sample Commands

N/A