### PR TITLE
Improve node runtime version parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Improve support for the Node.js 12 (Beta) runtime in the Functions emulator.

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -19,6 +19,7 @@ import {
 } from "./types";
 import { Constants, FIND_AVAILBLE_PORT_BY_DEFAULT } from "./constants";
 import { FunctionsEmulator } from "./functionsEmulator";
+import { parseRuntimeVersion } from "./functionsEmulatorUtils";
 import { DatabaseEmulator, DatabaseEmulatorArgs } from "./databaseEmulator";
 import { FirestoreEmulator, FirestoreEmulatorArgs } from "./firestoreEmulator";
 import { HostingEmulator } from "./hostingEmulator";
@@ -372,7 +373,9 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
         ...options.extensionEnv,
       },
       predefinedTriggers: options.extensionTriggers,
-      nodeMajorVersion: options.extensionNodeVersion || options.config.get("functions.runtime"),
+      nodeMajorVersion: parseRuntimeVersion(
+        options.extensionNodeVersion || options.config.get("functions.runtime")
+      ),
     });
     await startEmulator(functionsEmulator);
   }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -568,7 +568,9 @@ export class FunctionsEmulator implements EmulatorInstance {
     }
 
     const hostMajorVersion = process.versions.node.split(".")[0];
-    const requestedMajorVersion: string = nodeMajorVersion ? `${nodeMajorVersion}` : pkg.engines.node;
+    const requestedMajorVersion: string = nodeMajorVersion
+      ? `${nodeMajorVersion}`
+      : pkg.engines.node;
     let localMajorVersion = "0";
     const localNodePath = path.join(cwd, "node_modules/.bin/node");
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -568,7 +568,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     }
 
     const hostMajorVersion = process.versions.node.split(".")[0];
-    const requestedMajorVersion: string = `${nodeMajorVersion}` || pkg.engines.node;
+    const requestedMajorVersion: string = nodeMajorVersion ? `${nodeMajorVersion}` : pkg.engines.node;
     let localMajorVersion = "0";
     const localNodePath = path.join(cwd, "node_modules/.bin/node");
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -61,7 +61,7 @@ export interface FunctionsEmulatorArgs {
   env?: { [key: string]: string };
   remoteEmulators?: { [key: string]: EmulatorInfo };
   predefinedTriggers?: EmulatedTriggerDefinition[];
-  nodeMajorVersion?: string; // Lets us specify the node version when emulating extensions.
+  nodeMajorVersion?: number; // Lets us specify the node version when emulating extensions.
 }
 
 // FunctionsRuntimeInstance is the handler for a running function invocation
@@ -555,7 +555,7 @@ export class FunctionsEmulator implements EmulatorInstance {
    *  specified in extension.yaml. This will ALWAYS be populated when emulating extensions, even if they
    *  are using the default version.
    */
-  askInstallNodeVersion(cwd: string, nodeMajorVersion?: string): string {
+  askInstallNodeVersion(cwd: string, nodeMajorVersion?: number): string {
     const pkg = require(path.join(cwd, "package.json"));
     // If the developer hasn't specified a Node to use, inform them that it's an option and use default
     if ((!pkg.engines || !pkg.engines.node) && !nodeMajorVersion) {
@@ -568,7 +568,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     }
 
     const hostMajorVersion = process.versions.node.split(".")[0];
-    const requestedMajorVersion = nodeMajorVersion || pkg.engines.node;
+    const requestedMajorVersion: string = `${nodeMajorVersion}` || pkg.engines.node;
     let localMajorVersion = "0";
     const localNodePath = path.join(cwd, "node_modules/.bin/node");
 
@@ -600,10 +600,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       return localNodePath;
     }
 
-    /*
-    Otherwise we'll begin the conversational flow to install the correct version locally
-   */
-
+    // Otherwise we'll begin the conversational flow to install the correct version locally
     this.logger.log(
       "WARN",
       `Your requested "node" version "${requestedMajorVersion}" doesn't match your global version "${hostMajorVersion}"`

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -67,7 +67,7 @@ export interface FunctionsRuntimeBundle {
   };
   socketPath?: string;
   disabled_features?: FunctionsRuntimeFeatures;
-  nodeMajorVersion?: string;
+  nodeMajorVersion?: number;
   cwd: string;
 }
 

--- a/src/emulator/functionsEmulatorUtils.ts
+++ b/src/emulator/functionsEmulatorUtils.ts
@@ -74,6 +74,24 @@ export function removePathSegments(path: string, count: number): string {
 }
 
 /**
+ * Parse a runtime string like "nodejs10" or "10" into a single number.
+ * Returns undefined if the string does not match the expected pattern.
+ */
+export function parseRuntimeVersion(runtime?: string): number | undefined {
+  if (!runtime) {
+    return undefined;
+  }
+
+  const runtimeRe = /(nodejs)?([0-9]+)/;
+  const match = runtime.match(runtimeRe);
+  if (match) {
+    return Number.parseInt(match[2]);
+  }
+
+  return undefined;
+}
+
+/**
  * Parse a semver version string into parts, filling in 0s where empty.
  */
 export function parseVersionString(version?: string): ModuleVersion {

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -1,6 +1,7 @@
 import * as path from "path";
 import { FunctionsEmulator, FunctionsEmulatorArgs } from "../emulator/functionsEmulator";
 import { EmulatorServer } from "../emulator/emulatorServer";
+import { parseRuntimeVersion } from "../emulator/functionsEmulatorUtils";
 import * as getProjectId from "../getProjectId";
 
 // TODO(samstern): It would be better to convert this to an EmulatorServer
@@ -21,7 +22,7 @@ module.exports = {
       // default values for those tests to work properly.
       projectId,
       functionsDir,
-      nodeMajorVersion: options.config.get("functions.runtime"),
+      nodeMajorVersion: parseRuntimeVersion(options.config.get("functions.runtime")),
 
       ...(args as object),
     };

--- a/src/test/emulators/functionsEmulatorUtils.spec.ts
+++ b/src/test/emulators/functionsEmulatorUtils.spec.ts
@@ -4,6 +4,7 @@ import {
   isValidWildcardMatch,
   trimSlashes,
   compareVersionStrings,
+  parseRuntimeVersion,
 } from "../../emulator/functionsEmulatorUtils";
 
 describe("FunctionsEmulatorUtils", () => {
@@ -115,6 +116,26 @@ describe("FunctionsEmulatorUtils", () => {
       expect(compareVersionStrings("4.0.0", "4.0.0")).to.eql(0);
       expect(compareVersionStrings("4.0", "4.0.0")).to.eql(0);
       expect(compareVersionStrings("4", "4.0.0")).to.eql(0);
+    });
+  });
+
+  describe("parseRuntimeVerson", () => {
+    it("should parse fully specified runtime strings", () => {
+      expect(parseRuntimeVersion("nodejs6")).to.eql(10);
+      expect(parseRuntimeVersion("nodejs8")).to.eql(10);
+      expect(parseRuntimeVersion("nodejs10")).to.eql(10);
+      expect(parseRuntimeVersion("nodejs12")).to.eql(10);
+    });
+
+    it("should parse plain number strings", () => {
+      expect(parseRuntimeVersion("6")).to.eql(10);
+      expect(parseRuntimeVersion("8")).to.eql(10);
+      expect(parseRuntimeVersion("10")).to.eql(10);
+      expect(parseRuntimeVersion("12")).to.eql(10);
+    });
+
+    it("should ignore unknown", () => {
+      expect(parseRuntimeVersion("banana")).to.eql(undefined);
     });
   });
 });

--- a/src/test/emulators/functionsEmulatorUtils.spec.ts
+++ b/src/test/emulators/functionsEmulatorUtils.spec.ts
@@ -121,17 +121,17 @@ describe("FunctionsEmulatorUtils", () => {
 
   describe("parseRuntimeVerson", () => {
     it("should parse fully specified runtime strings", () => {
-      expect(parseRuntimeVersion("nodejs6")).to.eql(10);
-      expect(parseRuntimeVersion("nodejs8")).to.eql(10);
+      expect(parseRuntimeVersion("nodejs6")).to.eql(6);
+      expect(parseRuntimeVersion("nodejs8")).to.eql(8);
       expect(parseRuntimeVersion("nodejs10")).to.eql(10);
-      expect(parseRuntimeVersion("nodejs12")).to.eql(10);
+      expect(parseRuntimeVersion("nodejs12")).to.eql(12);
     });
 
     it("should parse plain number strings", () => {
-      expect(parseRuntimeVersion("6")).to.eql(10);
-      expect(parseRuntimeVersion("8")).to.eql(10);
+      expect(parseRuntimeVersion("6")).to.eql(6);
+      expect(parseRuntimeVersion("8")).to.eql(8);
       expect(parseRuntimeVersion("10")).to.eql(10);
-      expect(parseRuntimeVersion("12")).to.eql(10);
+      expect(parseRuntimeVersion("12")).to.eql(12);
     });
 
     it("should ignore unknown", () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

I started to work on http://b/160000969 but realized that it would be better to first clean up how/where we parse the runtime versions.

cc @quentinvernot 

### Scenarios Tested

Used this function for testing, these Node vars should only be set on Node10+:
```js
exports.checkEnv = functions.https.onRequest((req, res) => {
  res.json({
    FUNCTION_SIGNATURE_TYPE: process.env.FUNCTION_SIGNATURE_TYPE,
    K_SERVICE: process.env.FUNCTION_SIGNATURE_TYPE
  });
});
```

I use Node 10 on my machine, here are the results from setting `functions.runtime` to `nodejs12` in `firebase.json`:
```
$ firebase emulators:start
i  emulators: Starting emulators: functions
⚠  functions: The following emulators are not running, calls to these services from the Functions emulator will affect production: firestore, database, hosting, pubsub
⚠  Your requested "node" version "12" doesn't match your global version "10"
```
```
$ http http://localhost:5001/fir-dumpster/us-central1/checkEnv
HTTP/1.1 200 OK
connection: keep-alive
content-length: 53
content-type: application/json; charset=utf-8
date: Thu, 16 Jul 2020 11:11:01 GMT
etag: W/"35-jLEAhYb67wxcijkJhmEpq2yWteI"
x-powered-by: Express

{
    "FUNCTION_SIGNATURE_TYPE": "http",
    "K_SERVICE": "http"
}
```

And the results were the same when using "engines" in package.json

### Sample Commands

N/A