### PR TITLE
Add --ui flag to emulators:exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes issue where `Authorization` header was missing from callable functions in the emulator (#2459).
 - Improve support for the Node.js 12 (Beta) runtime in the Functions emulator.
 - Allow specifying the config (`firebase.json`) file using the `--config`/`-c` flag.
+- Allow starting the UI with `emulators:exec` using the `--ui` flag.

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -11,4 +11,5 @@ module.exports = new Command("emulators:exec <script>")
   .option(commandUtils.FLAG_INSPECT_FUNCTIONS, commandUtils.DESC_INSPECT_FUNCTIONS)
   .option(commandUtils.FLAG_IMPORT, commandUtils.DESC_IMPORT)
   .option(commandUtils.FLAG_EXPORT_ON_EXIT, commandUtils.DESC_EXPORT_ON_EXIT)
+  .option(commandUtils.FLAG_UI, commandUtils.DESC_UI)
   .action(commandUtils.emulatorExec);

--- a/src/commands/ext-dev-emulators-exec.ts
+++ b/src/commands/ext-dev-emulators-exec.ts
@@ -11,6 +11,7 @@ module.exports = new Command("ext:dev:emulators:exec <script>")
   .option(commandUtils.FLAG_TEST_PARAMS, commandUtils.DESC_TEST_PARAMS)
   .option(commandUtils.FLAG_IMPORT, commandUtils.DESC_IMPORT)
   .option(commandUtils.FLAG_EXPORT_ON_EXIT, commandUtils.DESC_EXPORT_ON_EXIT)
+  .option(commandUtils.FLAG_UI, commandUtils.DESC_UI)
   .action(async (script: string, options: any) => {
     const emulatorOptions = await optionsHelper.buildOptions(options);
     commandUtils.beforeEmulatorCommand(emulatorOptions);

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -46,6 +46,9 @@ export const EXPORT_ON_EXIT_USAGE_ERROR =
   `"${FLAG_EXPORT_ON_EXIT_NAME}" must be used with "${FLAG_IMPORT}"` +
   ` or provide a dir directly to "${FLAG_EXPORT_ON_EXIT}"`;
 
+export const FLAG_UI = "--ui";
+export const DESC_UI = "run the Emulator UI";
+
 // Flags for the ext:dev:emulators:* commands
 export const FLAG_TEST_CONFIG = "--test-config <firebase.json file>";
 export const DESC_TEST_CONFIG =
@@ -381,7 +384,8 @@ export async function emulatorExec(script: string, options: any) {
   }
   let exitCode = 0;
   try {
-    await controller.startAll(options, /* noUi = */ true);
+    const excludeUi = !options.ui;
+    await controller.startAll(options, excludeUi);
     exitCode = await runScript(script, extraEnv);
     await onExit(options);
   } finally {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Adds `--ui` flag to the `:exec` commands

### Scenarios Tested

```bash
$ firebase emulators:exec "echo 'hello'"
i  emulators: Starting emulators: firestore
⚠  firestore: Did not find a Cloud Firestore rules file sp
ecified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all re
ads and writes. Learn more about this option: https://fire
base.google.com/docs/emulator-suite/install_and_configure#
security_rules_configuration.
i  firestore: Firestore Emulator logging to firestore-debu
g.log
i  Running script: echo 'hello'
hello
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  hub: Stopping emulator hub
i  firestore: Stopping Firestore Emulator
```

```bash
$ firebase emulators:exec --ui "echo 'hello'"
i  emulators: Starting emulators: firestore
⚠  firestore: Did not find a Cloud Firestore rules file specified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  firestore: Firestore Emulator logging to firestore-debug.log
i  ui: Emulator UI logging to ui-debug.log
i  Running script: echo 'hello'
hello
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  hub: Stopping emulator hub
i  ui: Stopping Emulator UI
i  logging: Stopping Logging Emulator
i  firestore: Stopping Firestore Emulator
⚠  Emulator UI has exited upon receiving signal: SIGINT
```

### Sample Commands

N/A