### PR TITLE
Add kill signal logic to exec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes issue where `Authorization` header was missing from callable functions in the emulator (#2459).
 - Improve support for the Node.js 12 (Beta) runtime in the Functions emulator.
 - Allow specifying the config (`firebase.json`) file using the `--config`/`-c` flag.
+- Fixes issue where `emulators:exec` could fail to shut down cleanly (#2477).

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -374,6 +374,7 @@ async function runScript(script: string, extraEnv: Record<string, string>): Prom
  *  @param options: A Commander options object.
  */
 export async function emulatorExec(script: string, options: any) {
+  const killSignalPromise = shutdownWhenKilled(options);
   const projectId = getProjectId(options, true);
   const extraEnv: Record<string, string> = {};
   if (projectId) {

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -374,7 +374,7 @@ async function runScript(script: string, extraEnv: Record<string, string>): Prom
  *  @param options: A Commander options object.
  */
 export async function emulatorExec(script: string, options: any) {
-  const killSignalPromise = shutdownWhenKilled(options);
+  shutdownWhenKilled(options);
   const projectId = getProjectId(options, true);
   const extraEnv: Record<string, string> = {};
   if (projectId) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2477

### Scenarios Tested

```
$ firebase emulators:exec "cat"
i  emulators: Starting emulators: firestore
⚠  firestore: Did not find a Cloud Firestore rules file specified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  firestore: Firestore Emulator logging to firestore-debug.log
^C 
i  emulators: Received SIGINT (Ctrl-C) for the first time. Starting a clean shutdown.
i  emulators: Please wait for a clean shutdown or send the SIGINT (Ctrl-C) signal again to stop right now.
i  emulators: Shutting down emulators.
i  hub: Stopping emulator hub
i  firestore: Stopping Firestore Emulator
```

### Sample Commands

N/A