### PR TITLE
Ml i18n support

### DIFF
--- a/src/deploy/hosting/convertConfig.js
+++ b/src/deploy/hosting/convertConfig.js
@@ -89,7 +89,7 @@ module.exports = function(config) {
   if (_.has(config, "appAssociation")) {
     out.appAssociation = config.appAssociation;
   }
-  
+
   // i18n config
   if (_.has(config, "i18n")) {
     out.i18n = config.i18n;

--- a/src/deploy/hosting/convertConfig.js
+++ b/src/deploy/hosting/convertConfig.js
@@ -92,7 +92,7 @@ module.exports = function(config) {
   
   // i18n config
   if (_.has(config, "i18n")) {
-    out.i18N = config.i18n;
+    out.i18n = config.i18n;
   }
 
   return out;

--- a/src/deploy/hosting/convertConfig.js
+++ b/src/deploy/hosting/convertConfig.js
@@ -89,6 +89,11 @@ module.exports = function(config) {
   if (_.has(config, "appAssociation")) {
     out.appAssociation = config.appAssociation;
   }
+  
+  // i18n config
+  if (_.has(config, "i18n")) {
+    out.i18N = config.i18n;
+  }
 
   return out;
 };

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -7,6 +7,7 @@ const api = require("../../api");
 const convertConfig = require("./convertConfig");
 const deploymentTool = require("../../deploymentTool");
 const { FirebaseError } = require("../../error");
+const utils = require("../../utils");
 const fsutils = require("../../fsutils");
 const { normalizedHostingConfigs } = require("../../hosting/normalizedHostingConfigs");
 const { resolveProjectPath } = require("../../projectPath");
@@ -65,6 +66,15 @@ module.exports = function(context, options) {
           `can't deploy hosting to site ${deploy.site}`,
         { exit: 1 }
       );
+    }
+    
+    if (cfg.i18n) {
+      if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, cfg.public + cfg.i18n.root))) {
+        utils.logLabeledWarning(
+          "hosting",
+          `The I18n Rewrites feature is enabled, but the directory could not be found at root '${cfg.i18n.root}'`
+        );
+      }
     }
 
     versionCreates.push(

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -69,7 +69,11 @@ module.exports = function(context, options) {
     }
     
     if (cfg.i18n) {
-      if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, cfg.public + cfg.i18n.root))) {
+      let i18nPathPrefix = cfg.public;
+      if (!cfg.i18n.root.startsWith("/")) {
+      	i18nPathPrefix += "/";
+      }
+      if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, i18nPathPrefix + cfg.i18n.root))) {
         utils.logLabeledWarning(
           "hosting",
           `The I18n Rewrites feature is enabled, but the directory ` +

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -2,6 +2,7 @@
 
 const _ = require("lodash");
 const clc = require("cli-color");
+const path = require("path");
 
 const api = require("../../api");
 const convertConfig = require("./convertConfig");
@@ -69,11 +70,8 @@ module.exports = function(context, options) {
     }
 
     if (cfg.i18n) {
-      let i18nPathPrefix = cfg.public;
-      if (!cfg.i18n.root.startsWith("/")) {
-        i18nPathPrefix += "/";
-      }
-      if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, i18nPathPrefix + cfg.i18n.root))) {
+      const i18nPath = path.join(cfg.public, cfg.i18n.root);
+      if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, i18nPath))) {
         utils.logLabeledWarning(
           "hosting",
           `The I18n Rewrites feature is enabled, but the directory ` +

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -72,7 +72,8 @@ module.exports = function(context, options) {
       if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, cfg.public + cfg.i18n.root))) {
         utils.logLabeledWarning(
           "hosting",
-          `The I18n Rewrites feature is enabled, but the directory could not be found at root '${cfg.i18n.root}'`
+          `The I18n Rewrites feature is enabled, but the directory ` +
+            `could not be found within '${cfg.public}' at root '${cfg.i18n.root}'.`
         );
       }
     }

--- a/src/deploy/hosting/prepare.js
+++ b/src/deploy/hosting/prepare.js
@@ -67,11 +67,11 @@ module.exports = function(context, options) {
         { exit: 1 }
       );
     }
-    
+
     if (cfg.i18n) {
       let i18nPathPrefix = cfg.public;
       if (!cfg.i18n.root.startsWith("/")) {
-      	i18nPathPrefix += "/";
+        i18nPathPrefix += "/";
       }
       if (!fsutils.dirExistsSync(resolveProjectPath(options.cwd, i18nPathPrefix + cfg.i18n.root))) {
         utils.logLabeledWarning(


### PR DESCRIPTION
### Description

This change adds a warning if the I18n Rewrites feature is enabled, but there's no i18n content directory (at the root specified in firebase.json) within the public folder.
Previous pull request for this feature: https://github.com/firebase/firebase-tools/pull/2414

### Scenarios Tested

Used a sample project to make sure that the warning shows up when it's supposed to (and doesn't show up when it isn't supposed to). Ran tests & linter.

### Sample Commands

N/A
