### PR TITLE
Triggers from multiple RTDB instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,1 @@
-- Fixes issue where `Authorization` header was missing from callable functions in the emulator (#2459).
-- Improve support for the Node.js 12 (Beta) runtime in the Functions emulator.
-- Allow specifying the config (`firebase.json`) file using the `--config`/`-c` flag.
-- Fixes issue where `emulators:exec` could fail to shut down cleanly (#2477).
-- Fixes issue where database emulator did not properly load initial rules (#2483).
-- Allow starting the UI with `emulators:exec` using the `--ui` flag.
-- Fixes issue where multiple CLI instances compete for the same log (#2464).
-- Fixes issue where emulators run from `npm` scripts could not be shut down cleanly (#2507).
-- Makes it easier to import data from production databases.
+- Fixes issue where all database functions triggered on the default namespace (#2501)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -193,7 +193,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     // all events.
     hub.post(backgroundFunctionRoute, dataMiddleware, backgroundHandler);
     hub.all(httpsFunctionRoutes, dataMiddleware, httpsHandler);
-    hub.all('*', dataMiddleware, async (req, res) => {
+    hub.all("*", dataMiddleware, (req, res) => {
       logger.debug(`Functions emulator received unknown request at path ${req.path}`);
       res.sendStatus(501);
     });

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -195,7 +195,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     hub.all(httpsFunctionRoutes, dataMiddleware, httpsHandler);
     hub.all("*", dataMiddleware, (req, res) => {
       logger.debug(`Functions emulator received unknown request at path ${req.path}`);
-      res.sendStatus(501);
+      res.sendStatus(404);
     });
     return hub;
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2501, right now all triggers are registered on the default namespace.

### Scenarios Tested

I am now able to add the function trigger to the correct namespace:
```
>>> HTTP REQUEST POST http://localhost:9000/.settings/functionTriggers.json?ns=secondary  
 {"name":"projects/fir-dumpster/locations/_/functions/triggerTwo","path":"/foo/bar","event":"providers/google.firebase.database/eventTypes/ref.write","topic":"projects/fir-dumpster/topics/triggerTwo"}
```

Each function properly triggers:
```
i  functions: Beginning execution of "writeOne"
i  functions: Finished "writeOne" in ~1s
i  functions: Beginning execution of "triggerOne"
>  triggerOne
i  functions: Finished "triggerOne" in ~1s
i  functions: Beginning execution of "writeTwo"
i  functions: Finished "writeTwo" in ~1s
i  functions: Beginning execution of "triggerTwo"
>  triggerTwo
i  functions: Finished "triggerTwo" in ~1s
```

**Functions**
```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
const { app } = require('firebase-admin');

exports.writeOne = functions.https.onRequest(async (req, res) => {
  if (admin.apps.length === 0) {
    admin.initializeApp();
  }
  
  const db1 = admin.database();
  await db1.ref('/foo/bar').set({
    date: new Date().toISOString(),
  });

  res.send('ok');
});

exports.writeTwo = functions.https.onRequest(async (req, res) => {
  if (admin.apps.length === 0) {
    admin.initializeApp({
      databaseURL: 'https://secondary.firebaseio.com',
      credential: admin.credential.applicationDefault()
    });
  }

  const db2 = admin.database();
  await db2.ref('/foo/bar').set({
    date: new Date().toISOString(),
  });

  res.send('ok');
});

exports.triggerOne = functions.database.ref('/foo/bar').onWrite(() => {
  console.log('triggerOne');
  return true;
});

exports.triggerTwo = functions.database.instance('secondary').ref('/foo/bar').onWrite(() => {
  console.log('triggerTwo');
  return true;
});
```

### Sample Commands

N/A