### PR TITLE
Debounce kill signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fixes issue where database emulator did not properly load initial rules (#2483).
 - Allow starting the UI with `emulators:exec` using the `--ui` flag.
 - Fixes issue where multiple CLI instances compete for the same log (#2464).
+- Fixes issue where emulators run from `npm` scripts could not be shut down cleanly (#2507).


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This fixes #2507 (which is npm's fault not ours) by debouncing kill signals.

### Scenarios Tested

Was able to successfully `--export-on-exit` from a `npm` script.

### Sample Commands

N/A