### PR TITLE
Simpler prod imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fixes issue where database emulator did not properly load initial rules (#2483).
 - Allow starting the UI with `emulators:exec` using the `--ui` flag.
 - Fixes issue where multiple CLI instances compete for the same log (#2464).
+- Makes it easier to import data from production databases.

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -234,9 +234,7 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
   // If there is an export metadata file, we always prefer that
   const importFilePath = path.join(importPath, HubExport.METADATA_FILE_NAME);
   if (fileExistsSync(importFilePath)) {
-    return JSON.parse(
-      fs.readFileSync(importFilePath, "utf8").toString()
-    ) as ExportMetadata;
+    return JSON.parse(fs.readFileSync(importFilePath, "utf8").toString()) as ExportMetadata;
   }
 
   const fileList = fs.readdirSync(importPath);
@@ -254,7 +252,7 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
     };
 
     EmulatorLogger.forEmulator(Emulators.FIRESTORE).logLabeled(
-      "INFO",
+      "BULLET",
       "firestore",
       `Detected non-emulator Firestore export, creating metadata file ${importFilePath}`
     );
@@ -275,7 +273,7 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
     };
 
     EmulatorLogger.forEmulator(Emulators.DATABASE).logLabeled(
-      "INFO",
+      "BULLET",
       "firestore",
       `Detected non-emulator Database export, creating metadata file ${importFilePath}`
     );

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -225,6 +225,67 @@ export function shouldStart(options: any, name: Emulators): boolean {
   return emulatorInTargets;
 }
 
+function findExportMetadata(importPath: string): ExportMetadata | undefined {
+  const pathIsDirectory = fs.lstatSync(importPath).isDirectory();
+  if (!pathIsDirectory) {
+    return;
+  }
+
+  // If there is an export metadata file, we always prefer that
+  const importFilePath = path.join(importPath, HubExport.METADATA_FILE_NAME);
+  if (fileExistsSync(importFilePath)) {
+    return JSON.parse(
+      fs.readFileSync(importFilePath, "utf8").toString()
+    ) as ExportMetadata;
+  }
+
+  const fileList = fs.readdirSync(importPath);
+
+  // The user might have passed a Firestore export directly
+  const firestoreMetadataFile = fileList.find((f) => f.endsWith(".overall_export_metadata"));
+  if (firestoreMetadataFile) {
+    const metadata: ExportMetadata = {
+      version: EmulatorHub.CLI_VERSION,
+      firestore: {
+        version: "prod",
+        path: importPath,
+        metadata_file: `${importPath}/${firestoreMetadataFile}`,
+      },
+    };
+
+    EmulatorLogger.forEmulator(Emulators.FIRESTORE).logLabeled(
+      "INFO",
+      "firestore",
+      `Detected non-emulator Firestore export, creating metadata file ${importFilePath}`
+    );
+    fs.writeFileSync(importFilePath, JSON.stringify(metadata, undefined, 2));
+
+    return metadata;
+  }
+
+  // The user might haved passed a directory containing RTDB json files
+  const rtdbDataFile = fileList.find((f) => f.endsWith(".json"));
+  if (rtdbDataFile) {
+    const metadata: ExportMetadata = {
+      version: EmulatorHub.CLI_VERSION,
+      database: {
+        version: "prod",
+        path: importPath,
+      },
+    };
+
+    EmulatorLogger.forEmulator(Emulators.DATABASE).logLabeled(
+      "INFO",
+      "firestore",
+      `Detected non-emulator Database export, creating metadata file ${importFilePath}`
+    );
+
+    fs.writeFileSync(importFilePath, JSON.stringify(metadata, undefined, 2));
+
+    return metadata;
+  }
+}
+
 export async function startAll(options: any, noUi: boolean = false): Promise<void> {
   // Emulators config is specified in firebase.json as:
   // "emulators": {
@@ -285,24 +346,15 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
     version: "unknown",
   };
   if (options.import) {
-    const importFilePath = path.join(path.resolve(options.import), HubExport.METADATA_FILE_NAME);
-    if (fileExistsSync(importFilePath)) {
-      exportMetadata = JSON.parse(
-        fs
-          .readFileSync(
-            path.join(path.resolve(options.import), HubExport.METADATA_FILE_NAME),
-            "utf8"
-          )
-          .toString()
-      ) as ExportMetadata;
+    const importDir = path.resolve(options.import);
+    const foundMetadata = await findExportMetadata(importDir);
+    if (foundMetadata) {
+      exportMetadata = foundMetadata;
     } else {
-      // could happen when an export was interrupted mid-export...
       EmulatorLogger.forEmulator(Emulators.HUB).logLabeled(
         "WARN",
         "emulators",
-        `Import/Export metadata file does not exist. ${clc.bold(
-          "Skipping data import!"
-        )} Metadata file location: ${importFilePath}`
+        `Could not find import/export metadata file, ${clc.bold("skipping data import!")}`
       );
     }
   }
@@ -397,7 +449,7 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
 
     if (exportMetadata.firestore) {
       const importDirAbsPath = path.resolve(options.import);
-      const exportMetadataFilePath = path.join(
+      const exportMetadataFilePath = path.resolve(
         importDirAbsPath,
         exportMetadata.firestore.metadata_file
       );
@@ -486,7 +538,7 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
 
     if (exportMetadata.database) {
       const importDirAbsPath = path.resolve(options.import);
-      const databaseExportDir = path.join(importDirAbsPath, exportMetadata.database.path);
+      const databaseExportDir = path.resolve(importDirAbsPath, exportMetadata.database.path);
 
       const files = fs.readdirSync(databaseExportDir).filter((f) => f.endsWith(".json"));
       for (const f of files) {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -254,9 +254,8 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
     EmulatorLogger.forEmulator(Emulators.FIRESTORE).logLabeled(
       "BULLET",
       "firestore",
-      `Detected non-emulator Firestore export, creating metadata file ${importFilePath}`
+      `Detected non-emulator Firestore export at ${importPath}`
     );
-    fs.writeFileSync(importFilePath, JSON.stringify(metadata, undefined, 2));
 
     return metadata;
   }
@@ -275,10 +274,8 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
     EmulatorLogger.forEmulator(Emulators.DATABASE).logLabeled(
       "BULLET",
       "firestore",
-      `Detected non-emulator Database export, creating metadata file ${importFilePath}`
+      `Detected non-emulator Database export at ${importPath}`
     );
-
-    fs.writeFileSync(importFilePath, JSON.stringify(metadata, undefined, 2));
 
     return metadata;
   }

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -10,17 +10,20 @@ import { FirebaseError } from "../error";
 import { EmulatorHub } from "./hub";
 import { getDownloadDetails } from "./downloadableEmulators";
 
+export interface FirestoreExportMetadata {
+  version: string;
+  path: string;
+  metadata_file: string;
+}
+
+export interface DatabaseExportMetadata {
+  version: string;
+  path: string;
+}
 export interface ExportMetadata {
   version: string;
-  firestore?: {
-    version: string;
-    path: string;
-    metadata_file: string;
-  };
-  database?: {
-    version: string;
-    path: string;
-  };
+  firestore?: FirestoreExportMetadata;
+  database?: DatabaseExportMetadata;
 }
 
 export class HubExport {
@@ -68,7 +71,7 @@ export class HubExport {
     }
 
     const metadataPath = path.join(this.exportPath, HubExport.METADATA_FILE_NAME);
-    fs.writeFileSync(metadataPath, JSON.stringify(metadata));
+    fs.writeFileSync(metadataPath, JSON.stringify(metadata, undefined, 2));
   }
 
   private async exportFirestore(metadata: ExportMetadata): Promise<void> {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes https://github.com/firebase/firebase-tools/issues/2175

### Scenarios Tested

I downloaded firestore prod data to `firestore-export` using `gsutil cp -r ...` and I made a fake db export at `database-export/database.json`

**Firestore - First Import**
```
$ firebase emulators:start --import=./firestore-export
i  emulators: Starting emulators: firestore, database
i  firestore: Detected non-emulator Firestore export at file /Users/samstern/Scratch/export-testbed/firestore-export
i  firestore: Importing data from /Users/samstern/Scratch/export-testbed/firestore-export/firestore-export.overall_export_metadata
i  firestore: Firestore Emulator logging to firestore-debug.log
i  database: Database Emulator logging to database-debug.log
⚠  ui: Emulator UI unable to start on port 4000, starting on 4002 instead.
i  ui: Emulator UI logging to ui-debug.log

┌───────────────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! View status and logs at http://localhost:4002 │
└───────────────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Firestore │ localhost:8080 │ http://localhost:4002/firestore │
├───────────┼────────────────┼─────────────────────────────────┤
│ Database  │ localhost:9000 │ http://localhost:4002/database  │
└───────────┴────────────────┴─────────────────────────────────┘
  Other reserved ports: 4400, 4500

Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
```


**Database**
```
$ firebase emulators:start --import=./database-export/
i  emulators: Starting emulators: firestore, database
i  firestore: Detected non-emulator Database export at /Users/samstern/Scratch/export-testbed/database-export
i  firestore: Firestore Emulator logging to firestore-debug.log
i  database: Database Emulator logging to database-debug.log
i  database: Importing data from /Users/samstern/Scratch/export-testbed/database-export/database.json
i  database: Importing data from /Users/samstern/Scratch/export-testbed/database-export/firebase-export-metadata.json
⚠  ui: Emulator UI unable to start on port 4000, starting on 4002 instead.
i  ui: Emulator UI logging to ui-debug.log

┌───────────────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! View status and logs at http://localhost:4002 │
└───────────────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Firestore │ localhost:8080 │ http://localhost:4002/firestore │
├───────────┼────────────────┼─────────────────────────────────┤
│ Database  │ localhost:9000 │ http://localhost:4002/database  │
└───────────┴────────────────┴─────────────────────────────────┘
  Other reserved ports: 4400, 4500

Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
