### PR TITLE
Add support for vpcConnector and vpcConnectorEgressSettings customization for functions

### DIFF
--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -217,6 +217,8 @@ module.exports = function(context, options, payload) {
                   timeout: functionInfo.timeout,
                   maxInstances: functionInfo.maxInstances,
                   environmentVariables: defaultEnvVariables,
+                  vpcConnector: functionInfo.vpcConnector,
+                  vpcConnectorEgressSettings: functionInfo.vpcConnectorEgressSettings,
                 })
                 .then((createRes) => {
                   if (_.has(functionTrigger, "httpsTrigger")) {
@@ -292,6 +294,8 @@ module.exports = function(context, options, payload) {
               timeout: functionInfo.timeout,
               runtime: runtime,
               maxInstances: functionInfo.maxInstances,
+              vpcConnector: functionInfo.vpcConnector,
+              vpcConnectorEgressSettings: functionInfo.vpcConnectorEgressSettings,
               environmentVariables: _.assign(
                 {},
                 existingFunction.environmentVariables,

--- a/src/gcp/cloudfunctions.js
+++ b/src/gcp/cloudfunctions.js
@@ -65,6 +65,7 @@ function _createFunction(options) {
   const location = "projects/" + options.projectId + "/locations/" + options.region;
   const func = location + "/functions/" + options.functionName;
   const endpoint = "/" + API_VERSION + "/" + location + "/functions";
+
   const data = {
     sourceUploadUrl: options.sourceUploadUrl,
     name: func,
@@ -72,6 +73,17 @@ function _createFunction(options) {
     labels: options.labels,
     runtime: options.runtime,
   };
+
+  if (options.vpcConnector) {
+    data.vpcConnector = options.vpcConnector;
+    // use implied project/location if only given connector id
+    if (!data.vpcConnector.includes("/")) {
+      data.vpcConnector = `${location}/connectors/${data.vpcConnector}`;
+    }
+  }
+  if (options.vpcConnectorEgressSettings) {
+    data.vpcConnectorEgressSettings = options.vpcConnectorEgressSettings;
+  }
   if (options.availableMemoryMb) {
     data.availableMemoryMb = options.availableMemoryMb;
   }
@@ -143,6 +155,7 @@ function _updateFunction(options) {
   const location = "projects/" + options.projectId + "/locations/" + options.region;
   const func = location + "/functions/" + options.functionName;
   const endpoint = "/" + API_VERSION + "/" + func;
+
   const data = _.assign(
     {
       sourceUploadUrl: options.sourceUploadUrl,
@@ -153,6 +166,18 @@ function _updateFunction(options) {
   );
   let masks = ["sourceUploadUrl", "name", "labels"];
 
+  if (options.vpcConnector) {
+    data.vpcConnector = options.vpcConnector;
+    // use implied project/location if only given connector id
+    if (!data.vpcConnector.includes("/")) {
+      data.vpcConnector = `${location}/connectors/${data.vpcConnector}`;
+    }
+    masks.push("vpcConnector");
+  }
+  if (options.vpcConnectorEgressSettings) {
+    data.vpcConnectorEgressSettings = options.vpcConnectorEgressSettings;
+    masks.push("vpcConnectorEgressSettings");
+  }
   if (options.runtime) {
     data.runtime = options.runtime;
     masks = _.concat(masks, "runtime");


### PR DESCRIPTION
### Description

Supports firebase-functions SDK feature in https://github.com/firebase/firebase-functions/pull/752

```js
functions
      .runWith({
        vpcConnector: 'test-connector',
        vpcConnectorEgressSettings: 'PRIVATE_RANGES_ONLY'
      })
      .auth.user()
      .onCreate((user) => user);

```

It's an important feature for people who want to do a lot more with their firebase cloud functions. For instance connecting their cloud functions to a cloudSQL database.  
Check issue [#552 in firebase-functions](https://github.com/firebase/firebase-functions/issues/552) to see that I'm not the only one in need for that feature. Sadly that ticket got closed.

### Scenarios Tested

I tested creating a new cloud function with the vpcConnector and the vpcConnectorEgressSettings, it works. I also tried updating a function and works fine too. I also tested without mentioning the vpcConnectorEgressSettings setting and it worked too (will be set as ALL_TRAFFIC by default.)


### Sample Commands

No actual change in CLI options. Simply configure the vpcConnector inside your firebase.json file.
