### PR TITLE
Populate the "properties" property of an extension resource.

### DIFF
--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -1,5 +1,7 @@
+import * as yaml from "js-yaml";
 import * as _ from "lodash";
 import * as api from "../api";
+import * as logger from "../logger";
 import * as operationPoller from "../operation-poller";
 
 const VERSION = "v1beta";
@@ -66,6 +68,7 @@ export interface Resource {
   type: string;
   description?: string;
   properties?: { [key: string]: any };
+  propertiesYaml?: string;
 }
 
 export interface Author {
@@ -284,6 +287,21 @@ async function patchInstance(
   return pollRes;
 }
 
+function populateResourceProperties(source: ExtensionSource): void {
+  const spec: ExtensionSpec = source.spec;
+  if (spec) {
+    spec.resources.forEach((r) => {
+      try {
+        if (r.propertiesYaml) {
+          r.properties = yaml.safeLoad(r.propertiesYaml);
+        }
+      } catch (err) {
+        logger.debug(`[ext] failed to parse resource properties yaml: ${err}`);
+      }
+    });
+  }
+}
+
 /**
  * Create a new extension source
  *
@@ -310,6 +328,7 @@ export async function createSource(
     operationResourceName: createRes.body.name,
     masterTimeout: 600000,
   });
+  populateResourceProperties(pollRes);
   return pollRes;
 }
 
@@ -324,6 +343,7 @@ export function getSource(sourceName: string): Promise<ExtensionSource> {
       origin: api.extensionsOrigin,
     })
     .then((res) => {
+      populateResourceProperties(res.body);
       return res.body;
     });
 }

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -45,6 +45,35 @@ TEST_INSTANCES_RESPONSE_NEXT_PAGE_TOKEN.nextPageToken = "abc123";
 const PROJECT_ID = "test-project";
 const INSTANCE_ID = "test-extensions-instance";
 
+const PACKAGE_URI = "https://storage.googleapis.com/ABCD.zip";
+const SOURCE_NAME = "projects/firebasemods/sources/abcd";
+const TEST_SOURCE = {
+  name: SOURCE_NAME,
+  packageUri: PACKAGE_URI,
+  hash: "deadbeef",
+  spec: {
+    name: "test",
+    displayName: "Old",
+    description: "descriptive",
+    version: "1.0.0",
+    license: "MIT",
+    resources: [
+      {
+        name: "resource1",
+        type: "firebaseextensions.v1beta.function",
+        description: "desc",
+        propertiesYaml:
+          "eventTrigger:\n  eventType: providers/cloud.firestore/eventTypes/document.write\n  resource: projects/${PROJECT_ID}/databases/(default)/documents/${COLLECTION_PATH}/{documentId}\nlocation: ${LOCATION}",
+      },
+    ],
+    author: { authorName: "Tester" },
+    contributors: [{ authorName: "Tester 2" }],
+    billingRequired: true,
+    sourceUrl: "test.com",
+    params: [],
+  },
+};
+
 describe("extensions", () => {
   beforeEach(() => {
     helpers.mockAuth(sinon);
@@ -348,6 +377,79 @@ describe("extensions", () => {
 
       await expect(extensionsApi.getInstance(PROJECT_ID, INSTANCE_ID)).to.be.rejectedWith(
         FirebaseError
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("getSource", () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it("should make a GET call to the correct endpoint", async () => {
+      nock(api.extensionsOrigin)
+        .get(`/${VERSION}/${SOURCE_NAME}`)
+        .reply(200, TEST_SOURCE);
+
+      const source = await extensionsApi.getSource(SOURCE_NAME);
+      expect(nock.isDone()).to.be.true;
+      expect(source.spec.resources).to.have.lengthOf(1);
+      expect(source.spec.resources[0]).to.have.property("properties");
+    });
+
+    it("should throw a FirebaseError if the endpoint returns an error response", async () => {
+      nock(api.extensionsOrigin)
+        .get(`/${VERSION}/${SOURCE_NAME}`)
+        .reply(404);
+
+      await expect(extensionsApi.getSource(SOURCE_NAME)).to.be.rejectedWith(FirebaseError);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("createSource", () => {
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it("should make a POST call to the correct endpoint, and then poll on the returned operation", async () => {
+      nock(api.extensionsOrigin)
+        .post(`/${VERSION}/projects/${PROJECT_ID}/sources/`)
+        .reply(200, { name: "operations/abc123" });
+      nock(api.extensionsOrigin)
+        .get(`/${VERSION}/operations/abc123`)
+        .reply(200, { done: true, response: TEST_SOURCE });
+
+      const source = await extensionsApi.createSource(PROJECT_ID, PACKAGE_URI, ",./");
+      expect(nock.isDone()).to.be.true;
+      expect(source.spec.resources).to.have.lengthOf(1);
+      expect(source.spec.resources[0]).to.have.property("properties");
+    });
+
+    it("should throw a FirebaseError if create returns an error response", async () => {
+      nock(api.extensionsOrigin)
+        .post(`/${VERSION}/projects/${PROJECT_ID}/sources/`)
+        .reply(500);
+
+      await expect(extensionsApi.createSource(PROJECT_ID, PACKAGE_URI, "./")).to.be.rejectedWith(
+        FirebaseError,
+        "HTTP Error: 500, Unknown Error"
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("stop polling and throw if the operation call throws an unexpected error", async () => {
+      nock(api.extensionsOrigin)
+        .post(`/${VERSION}/projects/${PROJECT_ID}/sources/`)
+        .reply(200, { name: "operations/abc123" });
+      nock(api.extensionsOrigin)
+        .get(`/${VERSION}/operations/abc123`)
+        .reply(502);
+
+      await expect(extensionsApi.createSource(PROJECT_ID, PACKAGE_URI, "./")).to.be.rejectedWith(
+        FirebaseError,
+        "HTTP Error: 502, Unknown Error"
       );
       expect(nock.isDone()).to.be.true;
     });


### PR DESCRIPTION
Today, response from Extensions API's `GetSource` and `CreateSource` returns a source spec with `propertiesYAML` E.g.

```
{
  name: "my-ext-source",
    resources: [
      {
        name: "resource1",
        type: "firebaseextensions.v1beta.function",
        description: "desc",
        propertiesYaml:
          "eventTrigger:\n  eventType: providers/cloud.firestore/eventTypes/document.write\n  resource: projects/${PROJECT_ID}/databases/(default)/documents/${COLLECTION_PATH}/{documentId}\nlocation: ${LOCATION}",
      },
    ],
...
  },
}
```

With this PR, we load the `propertiesYAML` and populate the `properties` property of each resource after we receive a response from the Extensions API to make it simpler to access resource properties (e.g. Cloud Functions runtime) in other parts of our codebase.