### PR TITLE
Cut release 1.11.7 for Firestore emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fixes an issue where immutable params were not sent during ext:configure.
-- Includes latest features and improvements from production.
+- Includes latest features and improvements from production in the Firestore Emulator.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes an issue where immutable params were not sent during ext:configure.
+- Includes latest features and improvements from production.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -40,14 +40,14 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.6.jar"),
-    version: "1.11.6",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.7.jar"),
+    version: "1.11.7",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.6.jar",
-      expectedSize: 91311475,
-      expectedChecksum: "b82839f98980ff0c4827f2b7e5c61010",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.7.jar",
+      expectedSize: 63857175,
+      expectedChecksum: "fd8577f82d42ee1c03ae9d12b888049c",
       namePrefix: "cloud-firestore-emulator",
     },
   },

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -40,14 +40,14 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.5.jar"),
-    version: "1.11.5",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.6.jar"),
+    version: "1.11.6",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.5.jar",
-      expectedSize: 63287761,
-      expectedChecksum: "badd7007623ce51761d7a8ec2be42f8f",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.6.jar",
+      expectedSize: 91311475,
+      expectedChecksum: "b82839f98980ff0c4827f2b7e5c61010",
       namePrefix: "cloud-firestore-emulator",
     },
   },


### PR DESCRIPTION
### Description

This PR updates Firestore Emulator to v1.11.7.

### Scenarios Tested

```bash
$ node lib/bin/firebase.js emulators:start --only firestore
⚠  Could not find config (firebase.json) so using defaults.
i  emulators: Starting emulators: firestore
⚠  firestore: Did not find a Cloud Firestore rules file specified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  firestore: downloading cloud-firestore-emulator-v1.11.7.jar...
Progress: ==================================================================================================================> (100% of 64MB)
i  firestore: Removing outdated emulator files: cloud-firestore-emulator-v1.11.6.jar
i  firestore: Firestore Emulator logging to firestore-debug.log
```
