### PR TITLE
Normalize rules paths before reading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes an issue where immutable params were not sent during ext:configure.
 - Includes latest features and improvements from production in the Firestore Emulator.
 - Fixes issue where all database functions triggered on the default namespace (#2501)
+- Fixes issue where rules paths were not normalized before reading (#2544)

--- a/src/database/rulesConfig.ts
+++ b/src/database/rulesConfig.ts
@@ -1,4 +1,5 @@
 import { FirebaseError } from "../error";
+import * as Config from "../config";
 import * as logger from "../logger";
 
 export interface RulesInstanceConfig {
@@ -10,6 +11,22 @@ interface DatabaseConfig {
   rules: string;
   target?: string;
   instance?: string;
+}
+
+/**
+ * Convert the relative paths in the config into absolute paths ready to be read.
+ */
+export function normalizeRulesConfig(
+  rulesConfig: RulesInstanceConfig[],
+  options: any
+): RulesInstanceConfig[] {
+  const config = options.config as Config;
+  return rulesConfig.map((rc) => {
+    return {
+      instance: rc.instance,
+      rules: config.path(rc.rules),
+    };
+  });
 }
 
 export function getRulesConfig(projectId: string, options: any): RulesInstanceConfig[] {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -4,6 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as http from "http";
 
+import * as Config from "../config";
 import * as logger from "../logger";
 import * as track from "../track";
 import * as utils from "../utils";
@@ -457,10 +458,11 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
       args.seed_from_export = exportMetadataFilePath;
     }
 
-    const rulesLocalPath = options.config.get("firestore.rules");
+    const config = options.config as Config;
+    const rulesLocalPath = config.get("firestore.rules");
     let rulesFileFound = false;
     if (rulesLocalPath) {
-      const rules: string = path.join(options.projectRoot, rulesLocalPath);
+      const rules: string = config.path(rulesLocalPath);
       rulesFileFound = fs.existsSync(rules);
       if (rulesFileFound) {
         args.rules = rules;
@@ -502,7 +504,10 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
       auto_download: true,
     };
 
-    const rc = dbRulesConfig.getRulesConfig(projectId, options);
+    const rc = dbRulesConfig.normalizeRulesConfig(
+      dbRulesConfig.getRulesConfig(projectId, options),
+      options
+    );
     logger.debug("database rules config: ", JSON.stringify(rc));
 
     args.rules = rc;

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -520,7 +520,7 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
       );
     } else {
       for (const c of rc) {
-        const rules: string = path.join(options.projectRoot, c.rules);
+        const rules: string = c.rules;
         if (!fs.existsSync(rules)) {
           databaseLogger.logLabeled(
             "WARN",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2544 by making sure rules paths are always absolute

### Scenarios Tested

```
# Choose functions, database, and emulators
firebase init

cd functions
firebase emulators:start
```

### Sample Commands

N/A