### PR TITLE
check instance exists before prompting for params

### DIFF
--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -55,7 +55,6 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
     const roles = spec.roles ? spec.roles.map((role: extensionsApi.Role) => role.role) : [];
     await askUserForConsent.prompt(spec.displayName || spec.name, projectId, roles);
 
-    const params = await paramHelper.getParams(projectId, _.get(spec, "params", []), paramFilePath);
     let instanceId = spec.name;
     const anotherInstanceExists = await instanceIdExists(projectId, instanceId);
     if (anotherInstanceExists) {
@@ -71,6 +70,8 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
       }
       instanceId = await promptForValidInstanceId(`${instanceId}-${getRandomString(4)}`);
     }
+    const params = await paramHelper.getParams(projectId, _.get(spec, "params", []), paramFilePath);
+
     spinner.start();
     let serviceAccountEmail;
     while (!serviceAccountEmail) {


### PR DESCRIPTION
### Description

Check for existing Instance ID before prompting user for params - this is a more intuitive flow as advised by @rachelsaunders , as users are stopped early in case they are accidentally installing two copies of the same Extension. 

### Scenarios Tested

Installing with an existing Instance of the same ID, prompting the user for a new instance name:

```
$ firebase ext:install --project my-project -i storage-resize-images
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: information about storage-resize-images:
Name: Resize Images
Author: Firebase (https://firebase.google.com)
Description: Resizes images uploaded to Cloud Storage to a specified size, and optionally keeps or deletes the original image.

i  extensions: Resize Images will be granted the following access to project my-project
- Storage Admin (Full control of GCS resources.)
? Would you like to continue? Yes
? An extension with the ID storage-resize-images already exists in the project my-project.
Do you wish to proceed with installing another instance of storage-resize-images in this project? Yes
? Please enter a new name for this instance: cookies
i  extensions: answer the questions below to configure your extension:
```

Installing with an existing Instance with the same ID, user denies wanting to install the Extension again:

```
$ firebase ext:install --project my-project -i storage-resize-images
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: information about storage-resize-images:
Name: Resize Images
Author: Firebase (https://firebase.google.com)
Description: Resizes images uploaded to Cloud Storage to a specified size, and optionally keeps or deletes the original image.

i  extensions: Resize Images will be granted the following access to project my-project
- Storage Admin (Full control of GCS resources.)
? Would you like to continue? Yes
? An extension with the ID storage-resize-images already exists in the project my-project.
Do you wish to proceed with installing another instance of storage-resize-images in this project? No
Installation cancelled. For a list of all available Firebase Extensions commands, run firebase ext.
```