### PR TITLE
Wait for functions to exit before exiting functions emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Includes latest features and improvements from production in the Firestore Emulator.
 - Fixes issue where all database functions triggered on the default namespace (#2501)
 - Fixes issue where rules paths were not normalized before reading (#2544)
+- Functions emulator waits for all functions to finish before exiting (#1813)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -651,10 +651,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     const childProcess = spawn(opts.nodeBinary, args, {
       env: { node: opts.nodeBinary, ...opts.env, ...process.env },
       cwd: frb.cwd,
-      // By running as detached the child proccesses don't pick up
-      // kill signals to the host. This allows functions to finish
-      // running in workqueue.flush()
-      detached: true,
       stdio: ["pipe", "pipe", "pipe", "ipc"],
     });
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -381,7 +381,9 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     this.workQueue.stop();
     this.workerPool.exit();
-    this.destroyServer && this.destroyServer();
+    if (this.destroyServer) {
+      await this.destroyServer();
+    }
   }
 
   addRealtimeDatabaseTrigger(

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1088,6 +1088,25 @@ async function handleMessage(message: string) {
 }
 
 async function main(): Promise<void> {
+  // Since the functions run as attached processes they naturally inherit SIGINT
+  // sent to the functions emulator. We want them to ignore the first signal
+  // to allow for a clean shutdown.
+  let lastSignal = new Date().getTime();
+  let signalCount = 0;
+  process.on("SIGINT", () => {
+    const now = new Date().getTime();
+    if (now - lastSignal < 100) {
+      return;
+    }
+
+    signalCount = signalCount + 1;
+    lastSignal = now;
+
+    if (signalCount >= 2) {
+      process.exit(1);
+    }
+  });
+
   logDebug("Functions runtime initialized.", {
     cwd: process.cwd(),
     node_version: process.versions.node,

--- a/src/emulator/workQueue.ts
+++ b/src/emulator/workQueue.ts
@@ -95,11 +95,40 @@ export class WorkQueue {
     this.stopped = true;
   }
 
+  async flush(timeoutMs: number = 30000) {
+    if (!this.isWorking()) {
+      return;
+    }
+
+    this.logger.logLabeled("BULLET", "functions", "Waiting for all functions to finish...");
+    return new Promise((res, rej) => {
+      const delta = 100;
+      let elapsed = 0;
+
+      const interval = setInterval(() => {
+        elapsed += delta;
+        if (elapsed >= timeoutMs) {
+          rej(new Error(`Functions work queue not empty after ${timeoutMs}ms`));
+        }
+
+        if (!this.isWorking()) {
+          clearInterval(interval);
+          res();
+        }
+      }, delta);
+    });
+  }
+
   getState() {
     return {
       queueLength: this.queue.length,
       workRunningCount: this.workRunningCount,
     };
+  }
+
+  private isWorking() {
+    const state = this.getState();
+    return state.queueLength > 0 || state.workRunningCount > 0;
   }
 
   private async runNext() {
@@ -111,7 +140,7 @@ export class WorkQueue {
       try {
         await next();
       } catch (e) {
-        EmulatorLogger.forEmulator(Emulators.FUNCTIONS).log("DEBUG", e);
+        this.logger.log("DEBUG", e);
       } finally {
         this.workRunningCount--;
         this.notifyWorkFinish();

--- a/src/emulator/workQueue.ts
+++ b/src/emulator/workQueue.ts
@@ -95,7 +95,7 @@ export class WorkQueue {
     this.stopped = true;
   }
 
-  async flush(timeoutMs: number = 30000) {
+  async flush(timeoutMs: number = 60000) {
     if (!this.isWorking()) {
       return;
     }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #1813

Changes made:
  * Defines a consistent emulator stopping order
  * Waits up to 60s for the functions work queue to "flush" before killing them

### Scenarios Tested

I wrote a long-running function:
```js
exports.slowFunction = functions.https.onRequest(async (request, response) => {
  functions.logger.info("Hello logs!");
  await new Promise(res => setTimeout(res, 10 * 1000));
  functions.logger.info("Finished running");
  response.send("Hello from Firebase!");
});
```

And this is what it looks like if you kill while it's running:
```
i  functions: Beginning execution of "slowFunction"
>  {"severity":"INFO","message":"Hello logs!"}
^C 
i  emulators: Received SIGINT (Ctrl-C) for the first time. Starting a clean shutdown.
i  emulators: Please wait for a clean shutdown or send the SIGINT (Ctrl-C) signal again to stop right now.
i  emulators: Shutting down emulators.
i  ui: Stopping Emulator UI
⚠  Emulator UI has exited upon receiving signal: SIGINT
i  functions: Stopping Functions Emulator
i  functions: Waiting for all functions to finish...
>  {"severity":"INFO","message":"Finished running"}
i  functions: Finished "slowFunction" in ~9s
i  firestore: Stopping Firestore Emulator
i  hub: Stopping emulator hub
i  logging: Stopping Logging Emulator
```

### Sample Commands

N/A