### PR TITLE
Move default credentials setup to inside FunctionsEmulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Fixes issue where all database functions triggered on the default namespace (#2501)
 - Fixes issue where rules paths were not normalized before reading (#2544)
 - Functions emulator waits for all functions to finish before exiting (#1813)
+- Fixes default credentials inside `functions:shell` (#2561)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -8,7 +8,6 @@ import * as Config from "../config";
 import * as logger from "../logger";
 import * as track from "../track";
 import * as utils from "../utils";
-import { getCredentialPathAsync } from "../defaultCredentials";
 import { EmulatorRegistry } from "./registry";
 import {
   Address,
@@ -376,30 +375,6 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
       );
     }
 
-    // Provide default application credentials when appropriate
-    const credentialEnv: Record<string, string> = {};
-    if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
-      functionsLogger.logLabeled(
-        "WARN",
-        "functions",
-        `Your GOOGLE_APPLICATION_CREDENTIALS environment variable points to ${process.env.GOOGLE_APPLICATION_CREDENTIALS}. Non-emulated services will access production using these credentials. Be careful!`
-      );
-    } else {
-      const defaultCredPath = await getCredentialPathAsync();
-      if (defaultCredPath) {
-        functionsLogger.log("DEBUG", `Setting GAC to ${defaultCredPath}`);
-        credentialEnv.GOOGLE_APPLICATION_CREDENTIALS = defaultCredPath;
-      } else {
-        // TODO: It would be safer to set GOOGLE_APPLICATION_CREDENTIALS to /dev/null here but we can't because some SDKs don't work
-        //       without credentials even when talking to the emulator: https://github.com/firebase/firebase-js-sdk/issues/3144
-        functionsLogger.logLabeled(
-          "WARN",
-          "functions",
-          "You are not signed in to the Firebase CLI. If you have authorized this machine using gcloud application-default credentials those may be discovered and used to access production services."
-        );
-      }
-    }
-
     // Warn the developer that the Functions emulator can call out to production.
     const emulatorsNotRunning = ALL_SERVICE_EMULATORS.filter((e) => {
       return e !== Emulators.FUNCTIONS && !shouldStart(options, e);
@@ -421,7 +396,6 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
       port: functionsAddr.port,
       debugPort: inspectFunctions,
       env: {
-        ...credentialEnv,
         ...options.extensionEnv,
       },
       predefinedTriggers: options.extensionTriggers,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -39,6 +39,7 @@ import { PubsubEmulator } from "./pubsubEmulator";
 import { FirebaseError } from "../error";
 import { WorkQueue } from "./workQueue";
 import { createDestroyer } from "../utils";
+import { getCredentialPathAsync } from "../defaultCredentials";
 
 const EVENT_INVOKE = "functions:invoke";
 
@@ -142,6 +143,34 @@ export class FunctionsEmulator implements EmulatorInstance {
     this.workQueue = new WorkQueue(mode);
   }
 
+  private async getCredentialsEnvironment(): Promise<Record<string, string>> {
+    // Provide default application credentials when appropriate
+    const credentialEnv: Record<string, string> = {};
+    if (process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+      this.logger.logLabeled(
+        "WARN",
+        "functions",
+        `Your GOOGLE_APPLICATION_CREDENTIALS environment variable points to ${process.env.GOOGLE_APPLICATION_CREDENTIALS}. Non-emulated services will access production using these credentials. Be careful!`
+      );
+    } else {
+      const defaultCredPath = await getCredentialPathAsync();
+      if (defaultCredPath) {
+        this.logger.log("DEBUG", `Setting GAC to ${defaultCredPath}`);
+        credentialEnv.GOOGLE_APPLICATION_CREDENTIALS = defaultCredPath;
+      } else {
+        // TODO: It would be safer to set GOOGLE_APPLICATION_CREDENTIALS to /dev/null here but we can't because some SDKs don't work
+        //       without credentials even when talking to the emulator: https://github.com/firebase/firebase-js-sdk/issues/3144
+        this.logger.logLabeled(
+          "WARN",
+          "functions",
+          "You are not signed in to the Firebase CLI. If you have authorized this machine using gcloud application-default credentials those may be discovered and used to access production services."
+        );
+      }
+    }
+
+    return credentialEnv;
+  }
+
   createHubServer(): express.Application {
     // TODO(samstern): Should not need this here but some tests are directly calling this method
     // because FunctionsEmulator.start() is not test-safe due to askInstallNodeVersion.
@@ -228,11 +257,18 @@ export class FunctionsEmulator implements EmulatorInstance {
     return worker;
   }
 
-  start(): Promise<void> {
+  async start(): Promise<void> {
     this.nodeBinary = this.askInstallNodeVersion(
       this.args.functionsDir,
       this.args.nodeMajorVersion
     );
+
+    const credentialEnv = await this.getCredentialsEnvironment();
+    this.args.env = {
+      ...credentialEnv,
+      ...this.args.env,
+    };
+
     const { host, port } = this.getInfo();
     this.workQueue.start();
     const server = this.createHubServer().listen(port, host);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2561 

### Scenarios Tested

See test case here:
https://github.com/firebase/firebase-tools/issues/2561#issuecomment-677549864

By moving the credential setting from the controller to the `start()` of the emulator itself, we bring this functionality to all surfaces such as `firebase functions:shell` and `firebase serve`.

### Sample Commands

N/A