### PR TITLE
Fix failure policy deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes a bug where all deploys asked about failure policies.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixes a bug where all deploys asked about failure policies.
+- Fixes a bug where all Cloud Functions for Firebase deploys asked about failure policies.

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -158,7 +158,7 @@ module.exports = function(context, options, payload) {
   });
 
   let proceedPrompt = Promise.resolve(true);
-  if (failurePolicyFunctions.length > 0) {
+  if (failurePolicyFunctions.length) {
     var failurePolicyFunctionLabels = failurePolicyFunctions.map((fn) => {
       return helper.getFunctionLabel(_.get(fn, "name"));
     });

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -157,30 +157,32 @@ module.exports = function(context, options, payload) {
     return !!fn.failurePolicy;
   });
 
-  var failurePolicyFunctionLabels = failurePolicyFunctions.map((fn) => {
-    return helper.getFunctionLabel(_.get(fn, "name"));
-  });
-  var retryMessage =
-    "The following functions will be retried in case of failure: " +
-    clc.bold(failurePolicyFunctionLabels.join(", ")) +
-    ". " +
-    "Retried executions are billed as any other execution, and functions are retried repeatedly until they either successfully execute or the maximum retry period has elapsed, which can be up to 7 days. " +
-    "For safety, you might want to ensure that your functions are idempotent; see https://firebase.google.com/docs/functions/retries to learn more.";
-
-  utils.logLabeledWarning("functions", retryMessage);
-
   let proceedPrompt = Promise.resolve(true);
-  if (options.nonInteractive && !options.force) {
-    throw new FirebaseError("Pass the --force option to deploy functions with a failure policy", {
-      exit: 1,
+  if (failurePolicyFunctions.length > 0) {
+    var failurePolicyFunctionLabels = failurePolicyFunctions.map((fn) => {
+      return helper.getFunctionLabel(_.get(fn, "name"));
     });
-  } else if (!options.nonInteractive) {
-    proceedPrompt = promptOnce({
-      type: "confirm",
-      name: "confirm",
-      default: false,
-      message: "Would you like to proceed with deployment?",
-    });
+    var retryMessage =
+      "The following functions will be retried in case of failure: " +
+      clc.bold(failurePolicyFunctionLabels.join(", ")) +
+      ". " +
+      "Retried executions are billed as any other execution, and functions are retried repeatedly until they either successfully execute or the maximum retry period has elapsed, which can be up to 7 days. " +
+      "For safety, you might want to ensure that your functions are idempotent; see https://firebase.google.com/docs/functions/retries to learn more.";
+
+    utils.logLabeledWarning("functions", retryMessage);
+
+    if (options.nonInteractive && !options.force) {
+      throw new FirebaseError("Pass the --force option to deploy functions with a failure policy", {
+        exit: 1,
+      });
+    } else if (!options.nonInteractive) {
+      proceedPrompt = promptOnce({
+        type: "confirm",
+        name: "confirm",
+        default: false,
+        message: "Would you like to proceed with deployment?",
+      });
+    }
   }
 
   delete payload.functions;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Spotted by @armordog ... the failure policy PR makes **ALL** deploys go through the warning step.

### Scenarios Tested

1):
```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp();

exports.helloworld = functions.https.onRequest(async (req, res) => {
  res.json({ ok: true });
});
```

2)
```js
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp();

exports.helloworld = functions.https.onRequest(async (req, res) => {
  res.json({ ok: true });
});

exports.policyEmptyObject = functions
  .runWith({
    failurePolicy: { retry: {} }
  })  
  .pubsub.topic("retry-topic")
  .onPublish((msg, ctx) => {
    return true;
  });
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
