### PR TITLE
Set publish cloud build timeout to 20 minutes

### DIFF
--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -109,6 +109,8 @@ steps:
     entrypoint: "node"
     args: ["/usr/src/app/pipeline.js", "--package=firebase-tools@latest", "--publish"]
 
+timeout: 1200s # 20 minutes
+
 options:
   volumes:
     - name: "ssh"


### PR DESCRIPTION
The runtime of our our publish script (which invokes a cloud build with the config I changed) is getting close to the default 10 minute timeout. Let's bump it up to 20 minutes by explicitly specifying the timeout in the config yaml.