### PR TITLE
[Codespaces] Set --no-localhost by default when logging in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Change default runtime for Firebase Extensions template to nodejs10.
 - Modify messages for Firebase Extensions Node.js 10 migration.
 - Stop creating, updating and deleting service accounts during extension installation, update, and uninstallation.
+- Defaults `firebase login` to use an authorization code in Codespaces environments.

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -9,6 +9,7 @@ import { FirebaseError } from "../error";
 import { prompt } from "../prompt";
 
 import * as auth from "../auth";
+import { isCloudEnvironment } from "../utils";
 
 module.exports = new Command("login")
   .description("log the CLI into Firebase")
@@ -53,7 +54,13 @@ module.exports = new Command("login")
         );
       }
     }
-    const result = await auth.login(options.localhost, _.get(user, "email"));
+
+    // Default to using the authorization code flow when the end
+    // user is within a cloud-based environment, and therefore,
+    // the authorization callback couldn't redirect to localhost.
+    const useLocalhost = isCloudEnvironment() ? false : options.localhost;
+
+    const result = await auth.login(useLocalhost, _.get(user, "email"));
     configstore.set("user", result.user);
     configstore.set("tokens", result.tokens);
     // store login scopes in case mandatory scopes grow over time

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,7 +3,7 @@ import * as url from "url";
 import * as http from "http";
 import * as clc from "cli-color";
 import * as ora from "ora";
-import { env } from "process";
+import * as process from "process";
 import { Readable } from "stream";
 import * as winston from "winston";
 import { SPLAT } from "triple-beam";
@@ -453,5 +453,5 @@ export function createDestroyer(server: http.Server): () => Promise<void> {
  * Indicates whether the end-user is running the CLI from a cloud-based environment.
  */
 export function isCloudEnvironment() {
-  return !!env.CODESPACES;
+  return !!process.env.CODESPACES;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import * as url from "url";
 import * as http from "http";
 import * as clc from "cli-color";
 import * as ora from "ora";
+import { env } from "process";
 import { Readable } from "stream";
 import * as winston from "winston";
 import { SPLAT } from "triple-beam";
@@ -446,4 +447,11 @@ export function createDestroyer(server: http.Server): () => Promise<void> {
     }
     return destroyPromise;
   };
+}
+
+/**
+ * Indicates whether the end-user is running the CLI from a cloud-based environment.
+ */
+export function isCloudEnvironment() {
+  return !!env.CODESPACES;
 }


### PR DESCRIPTION
# Description

In order to make it simpler to use the Firebase CLI within [Codespaces](https://github.com/features/codespaces), this PR simply updates the `firebase login` command to set `--no-localhost` by default, and prevent potential [user confusion](https://twitter.com/shellen/status/1298824809061601280). This change is likely beneficial in other cloud contexts, and so I implemented a new `isCloudEnvironment` util that currently checks for a Codespaces-based environment, but could be easily augmented for others scenarios as well 👍 

### Scenarios Tested

1. ✅ Ran `firebase login` outside of Codespaces, and correctly received the auth callback flow _(Existing behavior)_
1. ✅ Ran `firebase login --no-localhost` outside of Codespaces, and correctly received the auth code flow _(Existing behavior)_
1. ✅ Ran `firebase login` inside of Codespaces, and correctly received the auth callback flow _(New behavior)_
1. ✅ Ran `firebase login --no-localhost` inside of Codespaces, and correctly received the auth callback flow _(Existing behavior)_

### Sample Commands

This change simply updates `firebase login` to set `--no-localhost` by default, when run in the context of a Codespaces.