### PR TITLE
Fix expires time parsing; re-enable all tests

### DIFF
--- a/src/hosting/expireUtils.ts
+++ b/src/hosting/expireUtils.ts
@@ -3,7 +3,7 @@ import { FirebaseError } from "../error";
 /**
  * A regex to test for valid duration strings.
  */
-export const DURATION_REGEX = /^\d+[hdm]$/;
+export const DURATION_REGEX = /^(\d+)([hdm])$/;
 
 /**
  * Basic durations in milliseconds.

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -219,7 +219,7 @@ describe("utils", () => {
     });
   });
 
-  describe.only("datetimeString", () => {
+  describe("datetimeString", () => {
     it("should output the date in the correct format", () => {
       // Don't worry about the hour since timezones screw everything up.
       expect(utils.datetimeString(new Date("February 22, 2020 11:35:45-07:00"))).to.match(


### PR DESCRIPTION
### Description

Expires time parsing was broken, but the tests were still "passing". Strange.

There was a `.only` committed into `master` that prevented _all_ tests from running.

Thankfully, removing that allows all the tests to run and they still all pass (with the parsing fix).