### PR TITLE
Validate "sub" field in idTokens.

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1433,11 +1433,14 @@ function parseClaims(idTokenOrJsonClaims: string | undefined): IdpJwtPayload | u
     claims = decoded as IdpJwtPayload;
   }
 
-  if (!claims.sub) {
-    throw new BadRequestError(
-      'INVALID_IDP_RESPONSE : Invalid Idp Response: id_token missing required fields. ((Missing "sub" field. This field is required and must be a unique identifier.))'
-    );
-  }
+  assert(
+    claims.sub,
+    'INVALID_IDP_RESPONSE : Invalid Idp Response: id_token missing required fields. ((Missing "sub" field. This field is required and must be a unique identifier.))'
+  );
+  assert(
+    typeof claims.sub === "string",
+    'INVALID_IDP_RESPONSE : ((The "sub" field must be a string.))'
+  );
   return claims;
 }
 

--- a/src/test/emulators/auth.spec.ts
+++ b/src/test/emulators/auth.spec.ts
@@ -2564,6 +2564,34 @@ describe("Auth emulator", () => {
         });
     });
 
+    it("should error when sub is missing or not a string", async () => {
+      await supertest(authApp)
+        .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")
+        .query({ key: "fake-api-key" })
+        .send({
+          // No sub in token.
+          postBody: `providerId=google.com&id_token=${JSON.stringify({})}`,
+          requestUri: "http://localhost",
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.contain("INVALID_IDP_RESPONSE");
+        });
+
+      await supertest(authApp)
+        .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")
+        .query({ key: "fake-api-key" })
+        .send({
+          // sub is not a string
+          postBody: `providerId=google.com&id_token=${JSON.stringify({ sub: 12345 })}`,
+          requestUri: "http://localhost",
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.contain("INVALID_IDP_RESPONSE");
+        });
+    });
+
     it("should link IDP to existing account by idToken", async () => {
       const user = await registerUser(authApp, {
         email: "foo@example.com",


### PR DESCRIPTION
### Description

This fixes a bug where entering sub as numbers will cause Auth Emulator to fail with 500.

### Scenarios Tested

See test cases.

### Sample Commands

N/A