### PR TITLE
Bump firebase-functions in devDeps to 3.11.0.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4995,9 +4995,9 @@
       }
     },
     "firebase-functions": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.10.0.tgz",
-      "integrity": "sha512-1KsZ7vlD6AaWjza++zga8sRwXn9J1YrVcq/gUeEJLL7+WZ1MIVB7ojKsyb3+C1YzpkhlL6iXP/KFN7EvpfvLNA==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.11.0.tgz",
+      "integrity": "sha512-i1uMhZ/M6i5SCI3ulKo7EWX0/LD+I5o6N+sk0HbOWfzyWfOl0iJTvQkR3BVDcjrlhPVC4xG1bDTLxd+DTkLqaw==",
       "dev": true,
       "requires": {
         "@types/express": "4.17.3",

--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "eslint-plugin-prettier": "^3.1.0",
     "firebase": "^7.14.0",
     "firebase-admin": "^8.9.0",
-    "firebase-functions": "^3.8.0",
+    "firebase-functions": "^3.11.0",
     "google-discovery-to-swagger": "^2.1.0",
     "mocha": "^7.1.1",
     "nock": "^9.3.3",


### PR DESCRIPTION
This just bumps that one dev dependency to the latest version. I somehow downgraded this by mistake when merging.

I don't think this broke anything though.