### PR TITLE
Fix NaN when using Emulator UI defaut port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes issue where the ESLint config file would not be added to version control for new Typescript Cloud Functions projects (#2645)
+- Fixues issue where the CLI displayed `NaN` when choosing the default port for the Emulator UI.

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -90,11 +90,6 @@ export async function doSetup(setup: any, config: any) {
         // Parse the input as a number
         const portNum = Number.parseInt(ui.port);
         ui.port = isNaN(portNum) ? undefined : portNum;
-
-        if (!ui.port) {
-          // Don't write `port: ""` into the config file.
-          delete ui.port;
-        }
       }
     }
 

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -79,13 +79,18 @@ export async function doSetup(setup: any, config: any) {
       if (ui.enabled) {
         await prompt(ui, [
           {
-            type: "number",
+            type: "input",
             name: "port",
             message: `Which port do you want to use for the ${clc.underline(
               uiDesc
             )} (leave empty to use any available port)?`,
           },
         ]);
+
+        // Parse the input as a number
+        const portNum = Number.parseInt(ui.port);
+        ui.port = isNaN(portNum) ? undefined : portNum;
+
         if (!ui.port) {
           // Don't write `port: ""` into the config file.
           delete ui.port;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2627 

### Scenarios Tested

  * Init with empty port
  * Init with custom port
  * Init with invalid port

### Sample Commands

N/A