### PR TITLE
quote eslint glob with escaped double quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
-- Fixes issue where the ESLint config file would not be added to version control for new Typescript Cloud Functions projects (#2645)
-- Fixues issue where the CLI displayed `NaN` when choosing the default port for the Emulator UI.
+- Fixes issue where the ESLint config file would not be added to version control for new Typescript Cloud Functions projects (#2645).
+- Fixes issue where the CLI displayed `NaN` when choosing the default port for the Emulator UI.
+- Fixes the `npm run lint` (`eslint`) command in newly initalized Cloud Functions for Firebase directories on Windows (#2644).

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "lint": "eslint 'src/**/*'",
+    "lint": "eslint \"src/**/*\"",
     "build": "tsc",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

On Windows, the glob must be quoted for it to work. This works on macOS just fine as well.

Fixes #2644