### PR TITLE
Implement IDP login POC for widget+iframe for web.

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -37,6 +37,7 @@ export type Schemas = schema.components["schemas"];
  */
 export const authOperations: AuthOps = {
   identitytoolkit: {
+    getProjects,
     getRecaptchaParams,
 
     accounts: {
@@ -316,6 +317,18 @@ function deleteAccount(
 
   return {
     kind: "identitytoolkit#DeleteAccountResponse",
+  };
+}
+
+function getProjects(
+  state: ProjectState
+): Schemas["GoogleCloudIdentitytoolkitV1GetProjectConfigResponse"] {
+  return {
+    projectId: state.projectNumber,
+    authorizedDomains: [
+      "localhost",
+      // TODO: Shall we allow more domains?
+    ],
   };
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This adds a proof of concept for IDP sign-ins for the web. The UI and account picker is just a stub for now, but the communication between iframe / popup / redirect should be considered fully implemented and final. Please review assuming `iframe` code will stay, and most of `handler` code will not be changed (except HTML and DOM obviously, and mobile support soon).

Mobile flows will be implemented later.

### Scenarios Tested

ONLY tested with the existing Auth JS SDK (auth-emulator branch).
Please help testing auth-exp if you have time.

Flows tested:

* Sign-in with redirect on the web
* Sign-in with popup on the web

### Sample Commands

N/A