### PR TITLE
Don't accept param on RTDB commands without flag

### DIFF
--- a/src/commands/database-instances-create.ts
+++ b/src/commands/database-instances-create.ts
@@ -9,12 +9,9 @@ import { previews } from "../previews";
 import { createInstance, DatabaseLocation, parseDatabaseLocation } from "../management/database";
 import getProjectId = require("../getProjectId");
 
-export default new Command("database:instances:create <instanceName>")
+let cmd = new Command("database:instances:create <instanceName>")
   .description("create a realtime database instance")
-  .option(
-    "-l, --location <location>",
-    "(optional) location for the database instance, defaults to us-central1"
-  )
+
   .before(requirePermissions, ["firebasedatabase.instances.create"])
   .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (instanceName: string, options: any) => {
@@ -30,3 +27,10 @@ export default new Command("database:instances:create <instanceName>")
     logger.info(`created database instance ${instance.instance}`);
     return instance;
   });
+if (previews.rtdbmanagement) {
+  cmd = cmd.option(
+    "-l, --location <location>",
+    "(optional) location for the database instance, defaults to us-central1"
+  );
+}
+export default cmd;

--- a/src/commands/database-instances-list.ts
+++ b/src/commands/database-instances-list.ts
@@ -40,12 +40,8 @@ function logInstancesCount(count = 0): void {
   logger.info(`${count} database instance(s) total.`);
 }
 
-export default new Command("database:instances:list")
+let cmd = new Command("database:instances:list")
   .description("list realtime database instances, optionally filtered by a specified location")
-  .option(
-    "-l, --location <location>",
-    "(optional) location for the database instance, defaults to us-central1"
-  )
   .before(requirePermissions, ["firebasedatabase.instances.list"])
   .before(warnEmulatorNotSupported, Emulators.DATABASE)
   .action(async (options: any) => {
@@ -83,3 +79,11 @@ export default new Command("database:instances:list")
     logger.info(`Project ${options.project} has ${instances.length} database instances`);
     return instances;
   });
+
+if (previews.rtdbmanagement) {
+  cmd = cmd.option(
+    "-l, --location <location>",
+    "(optional) location for the database instance, defaults to us-central1"
+  );
+}
+export default cmd;


### PR DESCRIPTION
### Description
Earlier, RTDB `database:instances:create` and `database:instances:list` command would accept (and ignore) `location` param without the `FIREBASE_CLI_PREVIEWS=rtdbmanagement` flag set.

This PR makes these commands accept the `location` param only when the flag is set.
### Scenarios Tested
```
firebase database:instances:create <instance> --project=<project> --location
FIREBASE_CLI_PREVIEWS=rtdbmanagement firebase database:instances:create <instance> --project=<project> --location
firebase database:instances:list --project=<project> --location
FIREBASE_CLI_PREVIEWS=rtdbmanagement firebase database:instances:list --project=<project> --location
```