### PR TITLE
Allow reusing existing IDP accounts for real.

### DIFF
--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -271,6 +271,25 @@ export class ProjectState {
     return this.getUserByLocalIdAssertingExists(localId);
   }
 
+  listProviderInfosByProviderId(provider: string): ProviderUserInfo[] {
+    const users = this.userIdForProviderRawId.get(provider);
+    if (!users) {
+      return [];
+    }
+    const infos: ProviderUserInfo[] = [];
+    for (const localId of users.values()) {
+      const user = this.getUserByLocalIdAssertingExists(localId);
+      const info = user.providerUserInfo?.find((info) => info.providerId === provider);
+      if (!info) {
+        throw new Error(
+          `Internal assertion error: User ${localId} does not have providerInfo ${provider}.`
+        );
+      }
+      infos.push(info);
+    }
+    return infos;
+  }
+
   getUserByLocalId(localId: string): UserInfo | undefined {
     return this.users.get(localId);
   }


### PR DESCRIPTION
### Description

Now you can reuse existing IDP accounts with one click.

I promise I won't do the templating thing again. There's no need to do that again anyway -- I believe this is the only information needed from the backend.

### Scenarios Tested

Sign-in with credentials first and then sign-in with popup. Verify old accounts shows up in the popup window.

### Sample Commands

N/A