### PR TITLE
Export custom claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes issue where database export does not work if database is empty (#2634).
+- Add custom claims to auth:export and auth:import

--- a/src/accountExporter.js
+++ b/src/accountExporter.js
@@ -19,6 +19,7 @@ var EXPORTED_JSON_KEYS = [
   "createdAt",
   "phoneNumber",
   "disabled",
+  "customAttributes",
 ];
 var EXPORTED_JSON_KEYS_RENAMING = {
   lastLoginAt: "lastSignedInAt",
@@ -69,6 +70,7 @@ var _transUserToArray = function(user) {
   arr[24] = user.lastLoginAt;
   arr[25] = user.phoneNumber;
   arr[26] = user.disabled;
+  arr[27] = user.customAttributes;
   return arr;
 };
 

--- a/src/accountImporter.js
+++ b/src/accountImporter.js
@@ -20,6 +20,7 @@ var ALLOWED_JSON_KEYS = [
   "providerUserInfo",
   "phoneNumber",
   "disabled",
+  "customAttributes",
 ];
 var ALLOWED_JSON_KEYS_RENAMING = {
   lastSignedInAt: "lastLoginAt",
@@ -122,6 +123,7 @@ var transArrayToUser = function(arr) {
     phoneNumber: arr[25],
     providerUserInfo: [],
     disabled: arr[26],
+    customAttributes: arr[27],
   };
   _addProviderUserInfo(user, "google.com", arr.slice(7, 11));
   _addProviderUserInfo(user, "facebook.com", arr.slice(11, 15));

--- a/src/test/accountExporter.spec.js
+++ b/src/test/accountExporter.spec.js
@@ -133,7 +133,7 @@ describe("accountExporter", function() {
             userList[j].displayName +
             Array(22).join(",") + // A lot of empty fields...
             userList[j].disabled;
-          expect(spyWrite.getCall(j).args[0]).to.eq(expectedEntry + "," + os.EOL);
+          expect(spyWrite.getCall(j).args[0]).to.eq(expectedEntry + ",," + os.EOL);
         }
       });
     });
@@ -181,7 +181,7 @@ describe("accountExporter", function() {
           '"' +
           Array(22).join(",") + // A lot of empty fields.
           singleUser.disabled;
-        expect(spyWrite.getCall(0).args[0]).to.eq(expectedEntry + "," + os.EOL);
+        expect(spyWrite.getCall(0).args[0]).to.eq(expectedEntry + ",," + os.EOL);
       });
     });
 


### PR DESCRIPTION
### Description

When exporting and importing users, preserve any custom claims for each user.

### Scenarios Tested

Tested export of users with custom claims, and re-import of exported user file to ensure custom claims are imported to new project successfully.

### Sample Commands
No changes to commands or flags
