### PR TITLE
Added typescript import plugin to eslintrc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes issue where database export does not work if database is empty (#2634).
+- Updates Cloud Functions for Firebase templates to better support function development.

--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -7,6 +7,7 @@ module.exports = {
   extends: [
     "plugin:import/errors",
     "plugin:import/warnings",
+    "plugin:import/typescript",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {


### PR DESCRIPTION
As outlined from [Using eslint with typescript - Unable to resolve path to module](https://stackoverflow.com/a/56696478/195969), added the _typescript import plugin_ to avoid `Unable to resolve path to module` errors.

This impacted my firebase project that initially was setup with TSLint, but then I updated it, based on the latest templates, to migrate to ESLint.  There were 2 issues -- this one, and another issue that I can see has already been fixed.  This symptom is related to typescript code being in multiple files.

Note that I am using TypeScript 4, ESLint 7.10, and @typescript-eslint 4.4.0 (latest versions).
