### PR TITLE
Fix auth handler styling for mobile devices

### DIFF
--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -341,6 +341,7 @@ button {
   box-sizing: border-box;
   margin: 16px auto;
   max-width: 515px;
+  min-width: 300px;
 }
 
 .content-wrapper, .mdc-list--avatar-list .mdc-list-item {

--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -339,8 +339,8 @@ button {
 
 #content {
   box-sizing: border-box;
-  width: 515px;
   margin: 16px auto;
+  max-width: 515px;
 }
 
 .content-wrapper, .mdc-list--avatar-list .mdc-list-item {


### PR DESCRIPTION
Turns out it was as simple as going from `width` -> `max-width`