### PR TITLE
Add warning for certain generic IDP flows.

### DIFF
--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -38,6 +38,17 @@ assert(
   'Missing one of appName / clientId / appId / apn / ibi query params.'
 );
 
+// Warn the developer of a few flows only available in Auth Emulator.
+if ((providerId === 'facebook.com' && appIdentifier) || (providerId === 'apple.com' && ibi)) {
+  var providerName = (providerId === 'facebook.com') ? 'Facebook' : 'Apple';
+  var productionMethod = providerName + (apn ? ' Android SDK' : ' iOS SDK');
+  var warningEl = document.querySelector('.js-signin-warning');
+  warningEl.querySelector('.content').textContent =
+    'Sign-in with ' + providerName + ' via generic IDP is only supported in the Auth Emulator; ' +
+    'remember to switch to ' + productionMethod + ' for production Firebase projects.';
+  warningEl.style.display = 'flex';
+}
+
 function saveAuthEvent(authEvent) {
   if (/popup/i.test(authType)) {
     sendAuthEventViaIframeRelay(authEvent, function (err) {
@@ -393,6 +404,11 @@ button {
   padding: 12px 24px;
 }
 
+.callout-warning {
+  background: #fff3e0;
+  color: #bf360c;
+}
+
 .callout .content {
   flex: 1;
   font-size: 14px;
@@ -473,6 +489,10 @@ export const WIDGET_UI = `
   </div>
   <div id="accounts-list">
     <div class="content-wrapper">
+      <div class="callout callout-warning vs js-signin-warning" style="display:none">
+        <i class="material-icons">error</i>
+        <div class="content"></div>
+      </div>
       <p class="subtitle">Please select an existing account in the Auth Emulator or add a new one:</p>
     </div>
     <ul class="mdc-list list mdc-list--two-line mdc-list--avatar-list">

--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -396,7 +396,6 @@ button {
 }
 
 .callout {
-  align-items: center;
   background: #e5eaf0;
   color: #476282;
   display: flex;
@@ -411,6 +410,7 @@ button {
 
 .callout .content {
   flex: 1;
+  align-self: center;
   font-size: 14px;
   font-weight: 500;
   margin-left: 8px;


### PR DESCRIPTION
This shows a warning banner for some flows supported in Auth Emulator only but not in production. We will still let the developer proceed for testing though.

cc'd a few folks for print and UX.

<img width="487" alt="Screen Shot 2020-10-12 at 12 53 18 PM" src="https://user-images.githubusercontent.com/22875286/95785143-1149c700-0c8a-11eb-8b57-c4e4ea9610c1.png">
