### PR TITLE
Release Cloud Firestore Emulator v1.11.9.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Updates the Google Cloud Run proxy API calls to `v1` (from `v1alpha1`) (#2695).
 - Release RTDB emulator v4.6.0: Get wire protocol with optional query.
 - Updates Cloud Functions for Firebase templates to better support function development.
+- Release Firestore emulator v1.11.9: Fixes != and not-in operators.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -41,14 +41,14 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.7.jar"),
-    version: "1.11.7",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.9.jar"),
+    version: "1.11.9",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.7.jar",
-      expectedSize: 63857175,
-      expectedChecksum: "fd8577f82d42ee1c03ae9d12b888049c",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.9.jar",
+      expectedSize: 64448827,
+      expectedChecksum: "0b841d928e1d0877e789010301b265a4",
       namePrefix: "cloud-firestore-emulator",
     },
   },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

See changelog

### Scenarios Tested

`firebase emulators:start` pulls in the latest JAR.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
