### PR TITLE
Remove Auth Domain on Channel Delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Updates Cloud Functions for Firebase templates to better support function development.
 - Release Firestore emulator v1.11.9: Fixes != and not-in operators.
 - Add endpoints to enable/disable background triggers in the Cloud Functions emulator.
+- Updates `firebase hosting:channel:delete` to remove the channel from the authorized domains list.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,3 @@
 - Add endpoints to enable/disable background triggers in the Cloud Functions emulator.
 - Fixes `TypeError` that arises when trying to deploy with Firebase Hosting targets that don't exist in the project's firebase.json (#1232).
 - Updates `firebase hosting:channel:delete` to remove the channel from the authorized domains list.
-

--- a/src/commands/hosting-channel-delete.ts
+++ b/src/commands/hosting-channel-delete.ts
@@ -1,7 +1,7 @@
 import { bold, underline } from "cli-color";
 
 import { Command } from "../command";
-import { deleteChannel, normalizeName } from "../hosting/api";
+import { deleteChannel, normalizeName, getChannel, removeAuthDomain } from "../hosting/api";
 import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as requireConfig from "../requireConfig";
@@ -33,6 +33,7 @@ export default new Command("hosting:channel:delete <channelId>")
       const siteId = options.site || (await getInstanceId(options));
 
       channelId = normalizeName(channelId);
+      const channel = await getChannel(projectId, siteId, channelId);
 
       let confirmed = Boolean(options.force);
       if (!confirmed) {
@@ -50,6 +51,9 @@ export default new Command("hosting:channel:delete <channelId>")
       }
 
       await deleteChannel(projectId, siteId, channelId);
+      if (channel) {
+        await removeAuthDomain(projectId, channel.url);
+      }
 
       logLabeledSuccess(
         "hosting:channels",

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -380,18 +380,12 @@ export async function addAuthDomain(project: string, url: string): Promise<strin
  */
 export async function removeAuthDomain(project: string, url: string): Promise<string[]> {
   const domains = await getAuthDomains(project);
-  if (domains.length < 1) {
+  if (!domains.length) {
     return domains;
   }
   const targetDomain = url.replace("https://", "");
-  const authDomains: string[] = [];
-  domains.forEach((domain: string) => {
-    if (domain == targetDomain) {
-      return;
-    }
-    authDomains.push(domain);
-  });
-  return await updateAuthDomains(project, authDomains);
+  const authDomains = domains.filter((domain: string) => domain != targetDomain)
+  return updateAuthDomains(project, authDomains);
 }
 
 /**

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -384,7 +384,7 @@ export async function removeAuthDomain(project: string, url: string): Promise<st
     return domains;
   }
   const targetDomain = url.replace("https://", "");
-  const authDomains = domains.filter((domain: string) => domain != targetDomain)
+  const authDomains = domains.filter((domain: string) => domain != targetDomain);
   return updateAuthDomains(project, authDomains);
 }
 

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -385,12 +385,12 @@ export async function removeAuthDomain(project: string, url: string): Promise<st
   }
   const targetDomain = url.replace("https://", "");
   const authDomains: string[] = [];
-  domains.forEach((domain : string) => {
+  domains.forEach((domain: string) => {
     if (domain == targetDomain) {
       return;
     }
     authDomains.push(domain);
-  }) 
+  });
   return await updateAuthDomains(project, authDomains);
 }
 

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -374,6 +374,27 @@ export async function addAuthDomain(project: string, url: string): Promise<strin
 }
 
 /**
+ * Removes channel domain from Firebase Auth list.
+ * @param project the project ID.
+ * @param url the url of the channel.
+ */
+export async function removeAuthDomain(project: string, url: string): Promise<string[]> {
+  const domains = await getAuthDomains(project);
+  if (domains.length < 1) {
+    return domains;
+  }
+  const targetDomain = url.replace("https://", "");
+  const authDomains: string[] = [];
+  domains.forEach((domain : string) => {
+    if (domain == targetDomain) {
+      return;
+    }
+    authDomains.push(domain);
+  }) 
+  return await updateAuthDomains(project, authDomains);
+}
+
+/**
  * Constructs a list of "clean domains"
  * by including all existing auth domains
  * with the exception of domains that belong to


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Removes the channel from the authorized domains when the channel is deleted.

Fixes #2676.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
