### PR TITLE
Update function deploys to default to node 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 - Updates the Google Cloud Run proxy API calls to `v1` (from `v1alpha1`) (#2695).
 - Release RTDB emulator v4.6.0: Get wire protocol with optional query.
-- Updates Cloud Functions for Firebase templates to better support function development.
+- Updates Cloud Functions for Firebase templates to use Node 12 and better support function development.
 - Release Firestore emulator v1.11.9: Fixes != and not-in operators.
 - Add endpoints to enable/disable background triggers in the Cloud Functions emulator.
 - Fixes `TypeError` that arises when trying to deploy with Firebase Hosting targets that don't exist in the project's firebase.json (#1232).

--- a/scripts/test-project/functions/package.json
+++ b/scripts/test-project/functions/package.json
@@ -6,6 +6,6 @@
     "firebase-functions": "^3.2.0"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   }
 }

--- a/scripts/triggers-end-to-end-tests/functions/package.json
+++ b/scripts/triggers-end-to-end-tests/functions/package.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "dependencies": {
     "@google-cloud/pubsub": "^1.1.5",

--- a/src/deploy/functions/checkRuntimeDependencies.ts
+++ b/src/deploy/functions/checkRuntimeDependencies.ts
@@ -82,6 +82,11 @@ function isPermissionError(e: { context?: { body?: { error?: { status?: string }
   return e.context?.body?.error?.status === "PERMISSION_DENIED";
 }
 
+/**
+ * Warns users about pending deprecation dates if a node 8 function was deployed.
+ *
+ * @param runtime The runtime as declared in package.json, e.g. `nodejs10`.
+ */
 export function checkForNode8(runtime: string): void {
   if (runtime === "nodejs8") {
     node8DeprecationWarning();

--- a/src/deploy/functions/checkRuntimeDependencies.ts
+++ b/src/deploy/functions/checkRuntimeDependencies.ts
@@ -14,7 +14,7 @@ function node8DeprecationWarning(): void {
   logger.warn();
   logLabeledWarning(
     "functions",
-    `Warning: Node.js 8 functions are deprecated and will stop running on 2021-03-15. Please upgrade to Node.js 10 or greater by adding an entry like this to your package.json:
+    `${bold(`${yellow("Warning:")} Node.js 8 functions are deprecated and will stop running on 2021-03-15.`)} Please upgrade to Node.js 10 or greater by adding an entry like this to your package.json:
     
     {
       "engines": {
@@ -22,7 +22,7 @@ function node8DeprecationWarning(): void {
       }
     }
 
-    The Firebase CLI will stop deploying Node.js 8 functions in new versions beginning 2020-12-15, and deploys from all CLI versions will halt on 2021-02-15. For additional information, see: ${FAQ_URL}`
+The Firebase CLI will stop deploying Node.js 8 functions in new versions beginning ${bold("2020-12-15")}, and deploys from all CLI versions will halt on ${bold("2021-02-15")}. For additional information, see: ${FAQ_URL}`
   );
   logger.warn();
 }

--- a/src/deploy/functions/checkRuntimeDependencies.ts
+++ b/src/deploy/functions/checkRuntimeDependencies.ts
@@ -96,15 +96,17 @@ export function checkForNode8(runtime: string): void {
  * @param runtime The runtime as declared in package.json, e.g. `nodejs10`.
  */
 export async function checkRuntimeDependencies(projectId: string, runtime: string): Promise<void> {
-  try {
-    await ensure(projectId, CLOUD_BUILD_API, "functions");
-  } catch (e) {
-    if (isBillingError(e)) {
-      throw nodeBillingError(projectId);
-    } else if (isPermissionError(e)) {
-      throw nodePermissionError(projectId);
-    }
+  if (runtime !== "nodejs8") {
+    try {
+      await ensure(projectId, CLOUD_BUILD_API, "functions");
+    } catch (e) {
+      if (isBillingError(e)) {
+        throw nodeBillingError(projectId);
+      } else if (isPermissionError(e)) {
+        throw nodePermissionError(projectId);
+      }
 
-    throw e;
+      throw e;
+    }
   }
 }

--- a/src/deploy/functions/checkRuntimeDependencies.ts
+++ b/src/deploy/functions/checkRuntimeDependencies.ts
@@ -1,4 +1,4 @@
-import { bold } from "cli-color";
+import { bold, yellow } from "cli-color";
 
 import * as track from "../../track";
 import * as logger from "../../logger";
@@ -14,7 +14,11 @@ function node8DeprecationWarning(): void {
   logger.warn();
   logLabeledWarning(
     "functions",
-    `${bold(`${yellow("Warning:")} Node.js 8 functions are deprecated and will stop running on 2021-03-15.`)} Please upgrade to Node.js 10 or greater by adding an entry like this to your package.json:
+    `${bold(
+      `${yellow(
+        "Warning:"
+      )} Node.js 8 functions are deprecated and will stop running on 2021-03-15.`
+    )} Please upgrade to Node.js 10 or greater by adding an entry like this to your package.json:
     
     {
       "engines": {
@@ -22,7 +26,11 @@ function node8DeprecationWarning(): void {
       }
     }
 
-The Firebase CLI will stop deploying Node.js 8 functions in new versions beginning ${bold("2020-12-15")}, and deploys from all CLI versions will halt on ${bold("2021-02-15")}. For additional information, see: ${FAQ_URL}`
+The Firebase CLI will stop deploying Node.js 8 functions in new versions beginning ${bold(
+      "2020-12-15"
+    )}, and deploys from all CLI versions will halt on ${bold(
+      "2021-02-15"
+    )}. For additional information, see: ${FAQ_URL}`
   );
   logger.warn();
 }

--- a/src/deploy/functions/release.js
+++ b/src/deploy/functions/release.js
@@ -17,6 +17,7 @@ var friendlyRuntimeName = require("../../parseRuntimeAndValidateSDK").getHumanFr
 var { getAppEngineLocation } = require("../../functionsConfig");
 var { promptOnce } = require("../../prompt");
 var { createOrUpdateSchedulesAndTopics } = require("./createOrUpdateSchedulesAndTopics");
+var { checkForNode8 } = require("./checkRuntimeDependencies");
 
 var deploymentTool = require("../../deploymentTool");
 var timings = {};
@@ -565,6 +566,7 @@ module.exports = function(context, options, payload) {
               deployments.length - failedDeployments.length
             );
           }
+          checkForNode8(runtime);
           if (failedDeployments.length > 0) {
             logger.info("\n\nFunctions deploy had errors with the following functions:");
             const sortedFailedDeployments = failedDeployments.sort();

--- a/src/test/deploy/functions/checkRuntimeDependencies.spec.ts
+++ b/src/test/deploy/functions/checkRuntimeDependencies.spec.ts
@@ -76,7 +76,7 @@ describe("checkRuntimeDependencies()", () => {
       stubTimes(Date.now() - 10000, Date.now() - 5000);
 
       await expect(checkRuntimeDependencies("test-project", "nodejs8")).to.eventually.be.fulfilled;
-      expect(logStub?.callCount).to.be.gt(0);
+      expect(logStub?.callCount).to.eq(0);
     });
   });
 

--- a/src/test/parseRuntimeAndValidateSDK.spec.ts
+++ b/src/test/parseRuntimeAndValidateSDK.spec.ts
@@ -52,6 +52,13 @@ describe("getRuntimeChoice", () => {
       expect(warningSpy).not.called;
     });
 
+    it("should return node 12 if runtime field is set to node 12", () => {
+      SDKVersionStub.returns("3.4.0");
+
+      expect(runtime.getRuntimeChoice("path/to/source", "nodejs12")).to.equal("nodejs12");
+      expect(warningSpy).not.called;
+    });
+
     it("should print warning when firebase-functions version is below 2.0.0", () => {
       SDKVersionStub.returns("0.5.0");
 

--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -10,12 +10,12 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^8.10.0",
-    "firebase-functions": "^3.6.1"
+    "firebase-admin": "^9.2.0",
+    "firebase-functions": "^3.11.0"
   },
   "devDependencies": {
     "eslint": "^5.12.0",

--- a/templates/init/functions/javascript/package.nolint.json
+++ b/templates/init/functions/javascript/package.nolint.json
@@ -9,12 +9,12 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^8.10.0",
-    "firebase-functions": "^3.6.1"
+    "firebase-admin": "^9.2.0",
+    "firebase-functions": "^3.11.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -10,12 +10,12 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^8.10.0",
-    "firebase-functions": "^3.6.1"
+    "firebase-admin": "^9.2.0",
+    "firebase-functions": "^3.11.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^3.9.1",

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -9,12 +9,12 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "10"
+    "node": "12"
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^8.10.0",
-    "firebase-functions": "^3.6.1"
+    "firebase-admin": "^9.2.0",
+    "firebase-functions": "^3.11.0"
   },
   "devDependencies": {
     "typescript": "^3.8.0",


### PR DESCRIPTION
### Description
Updates `firebase init` to use node 12 as the default for functions, and updates the other firebase dependencies  in to their latest versions. Also adds more in depth warning message for node 8 deploys laying out the full timeline of when deploys/executions will stop working.

### Scenarios Tested
Deploying a node 8 function:
<img width="1310" alt="Screen Shot 2020-10-14 at 12 46 10 PM" src="https://user-images.githubusercontent.com/4635763/96040006-6e768180-0e1e-11eb-822c-80e7e9294fb2.png">

I also deployed the default helloWorld function from 'firebase init' with the new dependencies, and it is working correctly.
