### PR TITLE
Add more actionable error message for billing errors when enabling apis

### DIFF
--- a/src/deploy/functions/checkRuntimeDependencies.ts
+++ b/src/deploy/functions/checkRuntimeDependencies.ts
@@ -4,7 +4,7 @@ import * as track from "../../track";
 import * as logger from "../../logger";
 import { ensure } from "../../ensureApiEnabled";
 import { logLabeledWarning } from "../../utils";
-import { FirebaseError } from "../../error";
+import { FirebaseError, isBillingError } from "../../error";
 
 const FAQ_URL = "https://firebase.google.com/support/faq#functions-runtime";
 const CLOUD_BUILD_API = "cloudbuild.googleapis.com";
@@ -48,20 +48,6 @@ https://console.cloud.google.com/apis/library/cloudbuild.googleapis.com?project=
 For additional information about this requirement, see Firebase FAQs:
 ${FAQ_URL}
 `);
-}
-
-function isBillingError(e: {
-  context?: {
-    body?: {
-      error?: {
-        details?: { type: string; violations?: { type: string }[] }[];
-      };
-    };
-  };
-}): boolean {
-  return !!e.context?.body?.error?.details?.find((d) =>
-    d.violations?.find((v) => v.type === "serviceusage/billing-enabled")
-  );
 }
 
 function isPermissionError(e: { context?: { body?: { error?: { status?: string } } } }): boolean {

--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -4,7 +4,7 @@ import { bold } from "cli-color";
 import * as track from "./track";
 import * as api from "./api";
 import * as utils from "./utils";
-import { FirebaseError } from "./error";
+import { FirebaseError, isBillingError } from "./error";
 
 export const POLL_SETTINGS = {
   pollInterval: 10000,
@@ -43,10 +43,23 @@ export async function check(
  * @param apiName The name of the API e.g. `someapi.googleapis.com`.
  */
 export async function enable(projectId: string, apiName: string): Promise<void> {
-  return api.request("POST", `/v1/projects/${projectId}/services/${apiName}:enable`, {
-    auth: true,
-    origin: api.serviceUsageOrigin,
-  });
+  return api
+    .request("POST", `/v1/projects/${projectId}/services/${apiName}:enable`, {
+      auth: true,
+      origin: api.serviceUsageOrigin,
+    })
+    .catch((err) => {
+      if (isBillingError(err)) {
+        throw new FirebaseError(`Your project ${bold(
+          projectId
+        )} must be on the Blaze (pay-as-you-go) plan to complete this command. Required API ${bold(
+          apiName
+        )} can't be enabled until the upgrade is complete. To upgrade, visit the following URL:
+
+https://console.firebase.google.com/project/${projectId}/usage/details`);
+      }
+      throw err;
+    });
 }
 
 async function pollCheckEnabled(

--- a/src/error.ts
+++ b/src/error.ts
@@ -32,3 +32,28 @@ export class FirebaseError extends Error {
     this.status = defaultTo(options.status, DEFAULT_STATUS);
   }
 }
+
+/**
+ * Checks if a FirebaseError is caused by attempting something
+ * that requires billing enabled while billing is not enabled.
+ */
+export function isBillingError(e: {
+  context?: {
+    body?: {
+      error?: {
+        details?: {
+          type: string;
+          reason?: string;
+          violations?: { type: string }[];
+        }[];
+      };
+    };
+  };
+}): boolean {
+  return !!e.context?.body?.error?.details?.find((d) => {
+    return (
+      d.violations?.find((v) => v.type === "serviceusage/billing-enabled") ||
+      d.reason == "UREQ_PROJECT_BILLING_NOT_FOUND"
+    );
+  });
+}


### PR DESCRIPTION
### Description
Adds a more actionable error message when a user tries to enable an API that requires billing, without billing enabled on that project.

### Scenarios Tested
Trying to deploy a Node 12 Cloud Function that requires billing when billing is not enabled.
<img width="1241" alt="Screen Shot 2020-10-15 at 12 37 03 PM" src="https://user-images.githubusercontent.com/4635763/96178436-42bdcf00-0ee4-11eb-8a3d-88893515af8a.png">
