### PR TITLE
Fix default arguments and option when using as a module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Fixes `TypeError` that arises when trying to deploy with Firebase Hosting targets that don't exist in the project's firebase.json (#1232).
 - Updates `firebase hosting:channel:delete` to remove the channel from the authorized domains list.
 - Add custom claims to auth:export and auth:import
+- Fixes incorrect defaults when using commands from Node.js (#2672)

--- a/README.md
+++ b/README.md
@@ -206,50 +206,42 @@ will immediately revoke access for the specified token.
 
 ## Using as a Module
 
-The Firebase CLI can also be used programmatically as a standard Node module. Each command is exposed as a function that takes an options object and returns a Promise. For example:
+The Firebase CLI can also be used programmatically as a standard Node module.
+Each command is exposed as a function that takes positional arguments followed
+by an options object and returns a Promise.
+
+So if we run this command at our command line:
+
+```bash
+$ firebase --project="foo" apps:list ANDROID
+```
+
+That translates to the following in Node:
 
 ```js
-var client = require("firebase-tools");
-client.projects
-  .list()
-  .then(function(data) {
-    console.log(data);
+const client = require("firebase-tools");
+client.apps
+  .list("ANDROID", { project: "foo" })
+  .then((data) => {
+    // ...
   })
-  .catch(function(err) {
-    // handle error
-  });
-
-client
-  .deploy({
-    project: "myfirebase",
-    token: process.env.FIREBASE_TOKEN,
-    force: true,
-    cwd: "/path/to/project/folder",
-  })
-  .then(function() {
-    console.log("Rules have been deployed!");
-  })
-  .catch(function(err) {
-    // handle error
+  .catch((err) => {
+    // ...
   });
 ```
 
-Some commands, such as `firebase use` require both positional arguments and options flags. In this case you first
-provide any positional arguments as strings followed by an object containing the options:
+The options object must be the very last argument and any unspecified
+positional argument will get the default value of `""`. The following
+two invocations are equivalent:
 
 ```js
-var client = require("firebase-tools");
-client
-  .use("projectId", {
-    // Equivalent to --add when using the CLI
-    add: true,
-  })
-  .then(function(data) {
-    console.log(data);
-  })
-  .catch(function(err) {
-    // handle error
-  });
+const client = require("firebase-tools");
+
+// #1 - No arguments or options, defaults will be inferred
+client.apps.list();
+
+// #2 - Explicitly provide "" for all arguments and {} for options
+client.apps.list("", {});
 ```
 
 Note: when used in a limited environment like Cloud Functions, not all `firebase-tools` commands will work programatically

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -58,6 +58,11 @@ describe("apps:list", () => {
       project: process.env.FBTOOLS_TARGET_PROJECT,
     });
     expect(undefinedArgsApps).to.have.length.greaterThan(0);
+
+    const nullArgsApps = await client.apps.list(null, {
+      project: process.env.FBTOOLS_TARGET_PROJECT,
+    });
+    expect(nullArgsApps).to.have.length.greaterThan(0);
   });
 
   it("should list apps configuration", async () => {

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -56,6 +56,9 @@ describe("apps:list", () => {
 
     const undefinedArgsApps = await client.apps.list(undefined, { project: process.env.FBTOOLS_TARGET_PROJECT });
     expect(undefinedArgsApps).to.have.length.greaterThan(0);
+
+    const nullArgsApps = await client.apps.list(null, { project: process.env.FBTOOLS_TARGET_PROJECT });
+    expect(nullArgsApps).to.have.length.greaterThan(0);
   });
 
   it("should list apps configuration", async () => {

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -58,11 +58,6 @@ describe("apps:list", () => {
       project: process.env.FBTOOLS_TARGET_PROJECT,
     });
     expect(undefinedArgsApps).to.have.length.greaterThan(0);
-
-    const nullArgsApps = await client.apps.list(null, {
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-    });
-    expect(nullArgsApps).to.have.length.greaterThan(0);
   });
 
   it("should list apps configuration", async () => {

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -50,6 +50,14 @@ describe("deployHosting", () => {
 });
 
 describe("apps:list", () => {
+  it("should be able to list apps with missing or undefined optional arguments", async () => {
+    const noArgsApps = await client.apps.list({ project: process.env.FBTOOLS_TARGET_PROJECT });
+    expect(noArgsApps).to.have.length.greaterThan(0);
+
+    const undefinedArgsApps = await client.apps.list(undefined, { project: process.env.FBTOOLS_TARGET_PROJECT });
+    expect(undefinedArgsApps).to.have.length.greaterThan(0);
+  });
+
   it("should list apps configuration", async () => {
     const apps = await client.apps.list("web", { project: process.env.FBTOOLS_TARGET_PROJECT });
 

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -54,10 +54,14 @@ describe("apps:list", () => {
     const noArgsApps = await client.apps.list({ project: process.env.FBTOOLS_TARGET_PROJECT });
     expect(noArgsApps).to.have.length.greaterThan(0);
 
-    const undefinedArgsApps = await client.apps.list(undefined, { project: process.env.FBTOOLS_TARGET_PROJECT });
+    const undefinedArgsApps = await client.apps.list(undefined, {
+      project: process.env.FBTOOLS_TARGET_PROJECT,
+    });
     expect(undefinedArgsApps).to.have.length.greaterThan(0);
 
-    const nullArgsApps = await client.apps.list(null, { project: process.env.FBTOOLS_TARGET_PROJECT });
+    const nullArgsApps = await client.apps.list(null, {
+      project: process.env.FBTOOLS_TARGET_PROJECT,
+    });
     expect(nullArgsApps).to.have.length.greaterThan(0);
   });
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -284,11 +284,6 @@ export class Command {
   runner(): (...a: any[]) => Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return async (...args: any[]) => {
-      console.log("==============RUNNER=============");
-      console.log("cmd", this.cmd);
-      console.log("positionalArgs", this.positionalArgs);
-      console.log("options", this.options);
-
       // Make sure the last argument is an object for options, add {} if none
       if (typeof last(args) !== "object" || last(args) === null) {
         args.push({});

--- a/src/command.ts
+++ b/src/command.ts
@@ -38,6 +38,7 @@ export class Command {
   private befores: BeforeFunction[] = [];
   private helpText = "";
   private client?: CLIClient;
+  private positionalArgs: { name: string; required: boolean }[] = [];
 
   /**
    * @param cmd the command to create.
@@ -131,6 +132,9 @@ export class Command {
         console.log(this.helpText);
       });
     }
+
+    // See below about using this private property
+    this.positionalArgs = cmd._args;
 
     // args is an array of all the arguments provided for the command PLUS the
     // options object as provided by Commander (on the end).
@@ -280,10 +284,23 @@ export class Command {
   runner(): (...a: any[]) => Promise<void> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return async (...args: any[]) => {
-      // always provide at least an empty object for options
-      if (args.length === 0) {
+      console.log("==============RUNNER=============");
+      console.log("cmd", this.cmd);
+      console.log("positionalArgs", this.positionalArgs);
+      console.log("options", this.options);
+
+      // Make sure the last argument is an object for options, add {} if none
+      if (typeof last(args) !== "object" || last(args) === null) {
         args.push({});
       }
+
+      // Args should have one entry for each positional arg (even the optional
+      // ones) and end with options.
+      while (args.length < this.positionalArgs.length + 1) {
+        // Add "" for missing args while keeping options at the end
+        args.splice(args.length - 1, 0, "");
+      }
+
       const options = last(args);
       this.prepare(options);
       for (const before of this.befores) {

--- a/src/commands/apps-list.ts
+++ b/src/commands/apps-list.ts
@@ -39,9 +39,9 @@ module.exports = new Command("apps:list [platform]")
   )
   .before(requireAuth)
   .action(
-    async (platform: string = "", options: any): Promise<AppMetadata[]> => {
+    async (platform: string | undefined, options: any): Promise<AppMetadata[]> => {  
       const projectId = getProjectId(options);
-      const appPlatform = getAppPlatform(platform);
+      const appPlatform = getAppPlatform(platform || "");
 
       let apps;
       const spinner = ora(

--- a/src/commands/apps-list.ts
+++ b/src/commands/apps-list.ts
@@ -39,7 +39,7 @@ module.exports = new Command("apps:list [platform]")
   )
   .before(requireAuth)
   .action(
-    async (platform: string | undefined, options: any): Promise<AppMetadata[]> => {  
+    async (platform: string | undefined, options: any): Promise<AppMetadata[]> => {
       const projectId = getProjectId(options);
       const appPlatform = getAppPlatform(platform || "");
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2672
Fixes #322

### Scenarios Tested

```ts
const client = require("firebase-tools");

async function main() {
    await client.use("fir-dumpster", { add: true });

    // This did not previously work!
    const apps = await client.apps.list();
    console.log(apps);
}

main().catch(console.warn);
```

### Sample Commands

N/A