### PR TITLE
allow --only hosting:site with bare hosting configs without targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Restores the ability to specify the default Hosting site as a deploy `--only` target.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Restores the ability to specify the default Hosting site as a deploy `--only` target.
+- Restores the ability to specify a Hosting `site` (configured in `firebase.json`) as a deploy `--only` target. (#2731)

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -1,18 +1,13 @@
 import { bold } from "cli-color";
 
 import { FirebaseError } from "../error";
-import logger = require("../logger");
 
 interface HostingConfig {
   site: string;
   target: string;
 }
 
-function filterOnly(
-  configs: HostingConfig[],
-  onlyString: string,
-  defaultSite: string
-): HostingConfig[] {
+function filterOnly(configs: HostingConfig[], onlyString: string): HostingConfig[] {
   if (!onlyString) {
     return configs;
   }
@@ -29,28 +24,35 @@ function filterOnly(
     .filter((target) => target.startsWith("hosting:"))
     .map((target) => target.replace("hosting:", ""));
 
-  // There is a case where users have not set any targets but use --only to
-  // specify the site name. This was working before because we weren't checking
-  // the validity of the target name before doing the final filter below. Since
-  // the case exists where a single (non-array, non-multi-site) config will
-  // have `config.site` set, we are going to short circuit the validity check
-  // of the targets to ensure the site name can be specified in a non-multi-
-  // site setup.
-  const configsHaveTargets = configs.some((c) => c.target);
-  const onlyDefaultSite = onlyTargets.length === 1 && onlyTargets[0] === defaultSite;
-  if (!configsHaveTargets && onlyDefaultSite) {
-    logger.debug("filtering configs down to default site");
-    return configs.filter((c) => c.site === defaultSite);
-  }
-
-  // Check to see that all the hosting deploy targets exist in the hosting config
-  for (const onlyTarget of onlyTargets) {
-    if (!configs.some((config) => config.target === onlyTarget)) {
-      throw new FirebaseError(`Hosting target ${bold(onlyTarget)} not detected in firebase.json`);
+  const configsBySite = new Map<string, HostingConfig>();
+  const configsByTarget = new Map<string, HostingConfig>();
+  for (const c of configs) {
+    if (c.site) {
+      configsBySite.set(c.site, c);
+    }
+    if (c.target) {
+      configsByTarget.set(c.target, c);
     }
   }
 
-  return configs.filter((config) => onlyTargets.includes(config.target));
+  const filteredConfigs: HostingConfig[] = [];
+  // Check to see that all the hosting deploy targets exist in the hosting
+  // config as either `site`s or `target`s.
+  for (const onlyTarget of onlyTargets) {
+    if (configsBySite.has(onlyTarget)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      filteredConfigs.push(configsBySite.get(onlyTarget)!);
+    } else if (configsByTarget.has(onlyTarget)) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      filteredConfigs.push(configsByTarget.get(onlyTarget)!);
+    } else {
+      throw new FirebaseError(
+        `Hosting site or target ${bold(onlyTarget)} not detected in firebase.json`
+      );
+    }
+  }
+
+  return filteredConfigs;
 }
 
 /**
@@ -78,7 +80,7 @@ export function normalizedHostingConfigs(
     configs = [configs];
   }
 
-  const hostingConfigs: HostingConfig[] = filterOnly(configs, cmdOptions.only, cmdOptions.site);
+  const hostingConfigs: HostingConfig[] = filterOnly(configs, cmdOptions.only);
 
   if (options.resolveTargets) {
     for (const cfg of hostingConfigs) {

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -50,8 +50,7 @@ function filterOnly(
     }
   }
 
-  const filtered = configs.filter((config) => onlyTargets.includes(config.target));
-  return filtered;
+  return configs.filter((config) => onlyTargets.includes(config.target));
 }
 
 /**

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -1,13 +1,18 @@
 import { bold } from "cli-color";
 
 import { FirebaseError } from "../error";
+import logger = require("../logger");
 
 interface HostingConfig {
   site: string;
   target: string;
 }
 
-function filterOnly(configs: HostingConfig[], onlyString: string): HostingConfig[] {
+function filterOnly(
+  configs: HostingConfig[],
+  onlyString: string,
+  defaultSite: string
+): HostingConfig[] {
   if (!onlyString) {
     return configs;
   }
@@ -24,16 +29,29 @@ function filterOnly(configs: HostingConfig[], onlyString: string): HostingConfig
     .filter((target) => target.startsWith("hosting:"))
     .map((target) => target.replace("hosting:", ""));
 
+  // There is a case where users have not set any targets but use --only to
+  // specify the site name. This was working before because we weren't checking
+  // the validity of the target name before doing the final filter below. Since
+  // the case exists where a single (non-array, non-multi-site) config will
+  // have `config.site` set, we are going to short circuit the validity check
+  // of the targets to ensure the site name can be specified in a non-multi-
+  // site setup.
+  const configsHaveTargets = configs.some((c) => c.target);
+  const onlyDefaultSite = onlyTargets.length === 1 && onlyTargets[0] === defaultSite;
+  if (!configsHaveTargets && onlyDefaultSite) {
+    logger.debug("filtering configs down to default site");
+    return configs.filter((c) => c.site === defaultSite);
+  }
+
   // Check to see that all the hosting deploy targets exist in the hosting config
-  onlyTargets.forEach((onlyTarget) => {
+  for (const onlyTarget of onlyTargets) {
     if (!configs.some((config) => config.target === onlyTarget)) {
       throw new FirebaseError(`Hosting target ${bold(onlyTarget)} not detected in firebase.json`);
     }
-  });
+  }
 
-  return configs.filter((config: HostingConfig) =>
-    onlyTargets.includes(config.target || config.site)
-  );
+  const filtered = configs.filter((config) => onlyTargets.includes(config.target));
+  return filtered;
 }
 
 /**
@@ -46,6 +64,7 @@ export function normalizedHostingConfigs(
   cmdOptions: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   options: { resolveTargets?: boolean } = {}
 ): HostingConfig[] {
+  let hostingConfigs: HostingConfig[] = [];
   let configs = cmdOptions.config.get("hosting");
   if (!configs) {
     return [];
@@ -61,10 +80,10 @@ export function normalizedHostingConfigs(
     configs = [configs];
   }
 
-  configs = filterOnly(configs, cmdOptions.only);
+  hostingConfigs = filterOnly(configs, cmdOptions.only, cmdOptions.site);
 
   if (options.resolveTargets) {
-    configs.forEach((cfg: HostingConfig) => {
+    for (const cfg of hostingConfigs) {
       if (cfg.target) {
         const matchingTargets = cmdOptions.rc.requireTarget(
           cmdOptions.project,
@@ -82,8 +101,8 @@ export function normalizedHostingConfigs(
       } else if (!cfg.site) {
         throw new FirebaseError('Must supply either "site" or "target" in each "hosting" config.');
       }
-    });
+    }
   }
 
-  return configs;
+  return hostingConfigs;
 }

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -80,6 +80,14 @@ export function normalizedHostingConfigs(
     configs = [configs];
   }
 
+  for (const c of configs) {
+    if (c.target && c.site) {
+      throw new FirebaseError(
+        `Hosting configs should only include either "site" or "target", not both.`
+      );
+    }
+  }
+
   const hostingConfigs: HostingConfig[] = filterOnly(configs, cmdOptions.only);
 
   if (options.resolveTargets) {

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -63,7 +63,6 @@ export function normalizedHostingConfigs(
   cmdOptions: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   options: { resolveTargets?: boolean } = {}
 ): HostingConfig[] {
-  let hostingConfigs: HostingConfig[] = [];
   let configs = cmdOptions.config.get("hosting");
   if (!configs) {
     return [];
@@ -79,7 +78,7 @@ export function normalizedHostingConfigs(
     configs = [configs];
   }
 
-  hostingConfigs = filterOnly(configs, cmdOptions.only, cmdOptions.site);
+  const hostingConfigs: HostingConfig[] = filterOnly(configs, cmdOptions.only, cmdOptions.site);
 
   if (options.resolveTargets) {
     for (const cfg of hostingConfigs) {

--- a/src/test/hosting/normalizedHostingConfigs.spec.ts
+++ b/src/test/hosting/normalizedHostingConfigs.spec.ts
@@ -1,0 +1,145 @@
+import { expect } from "chai";
+import { FirebaseError } from "../../error";
+
+import { normalizedHostingConfigs } from "../../hosting/normalizedHostingConfigs";
+
+describe("normalizedHostingConfigs", () => {
+  describe("without an only parameter", () => {
+    const DEFAULT_SITE = "default-hosting-site";
+    const baseConfig = { public: "public", ignore: ["firebase.json"] };
+    const tests = [
+      {
+        desc: "a normal hosting config",
+        cfg: Object.assign({}, baseConfig),
+        want: [Object.assign({}, baseConfig, { site: DEFAULT_SITE })],
+      },
+      {
+        desc: "no hosting config",
+        want: [],
+      },
+      {
+        desc: "a normal hosting config with a target",
+        cfg: Object.assign({}, baseConfig, { target: "main" }),
+        want: [Object.assign({}, baseConfig, { target: "main" })],
+      },
+      {
+        desc: "a hosting config with multiple targets",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+        want: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+      },
+    ];
+
+    for (const t of tests) {
+      it(`should be able to parse ${t.desc}`, () => {
+        const cmdConfig = {
+          site: DEFAULT_SITE,
+          config: { get: () => t.cfg },
+        };
+        const got = normalizedHostingConfigs(cmdConfig);
+        expect(got).to.deep.equal(t.want);
+      });
+    }
+  });
+
+  describe("with an only parameter, resolving targets", () => {
+    const DEFAULT_SITE = "default-hosting-site";
+    const TARGETED_SITE = "targeted-site";
+    const baseConfig = { public: "public", ignore: ["firebase.json"] };
+    const tests = [
+      {
+        desc: "a normal hosting config, specifying the default site",
+        cfg: Object.assign({}, baseConfig),
+        only: `hosting:${DEFAULT_SITE}`,
+        want: [Object.assign({}, baseConfig, { site: DEFAULT_SITE })],
+      },
+      {
+        desc: "a normal hosting config with a target",
+        cfg: Object.assign({}, baseConfig, { target: "main" }),
+        only: "hosting:main",
+        want: [Object.assign({}, baseConfig, { target: "main", site: TARGETED_SITE })],
+      },
+      {
+        desc: "a hosting config with multiple targets, specifying one",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+        only: "hosting:t-two",
+        want: [Object.assign({}, baseConfig, { target: "t-two", site: TARGETED_SITE })],
+      },
+      {
+        desc: "a hosting config with multiple targets, specifying all hosting",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+        only: "hosting",
+        want: [
+          Object.assign({}, baseConfig, { target: "t-one", site: TARGETED_SITE }),
+          Object.assign({}, baseConfig, { target: "t-two", site: TARGETED_SITE }),
+        ],
+      },
+      {
+        desc: "a hosting config with multiple targets, specifying an invalid target",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+        only: "hosting:t-three",
+        wantErr: /Hosting target.+t-three.+not detected/,
+      },
+      {
+        desc: "a hosting config with multiple targets, with multiple matching targets",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-one" }),
+        ],
+        only: "hosting:t-one",
+        targetedSites: [TARGETED_SITE, TARGETED_SITE],
+        wantErr: /Hosting target.+t-one.+linked to multiple sites/,
+      },
+      {
+        desc: "a hosting config with multiple sites but no targets, only all hosting",
+        cfg: [Object.assign({}, baseConfig), Object.assign({}, baseConfig)],
+        only: "hosting",
+        wantErr: /Must supply either "site" or "target"/,
+      },
+      {
+        desc: "a hosting config with multiple sites but no targets, only an invalid target",
+        cfg: [Object.assign({}, baseConfig), Object.assign({}, baseConfig)],
+        only: "hosting:t-one",
+        wantErr: /Hosting target.+t-one.+not detected/,
+      },
+    ];
+
+    for (const t of tests) {
+      it(`should be able to parse ${t.desc}`, () => {
+        if (!Array.isArray(t.targetedSites)) {
+          t.targetedSites = [TARGETED_SITE];
+        }
+        const cmdConfig = {
+          site: DEFAULT_SITE,
+          only: t.only,
+          config: { get: () => t.cfg },
+          rc: { requireTarget: () => t.targetedSites },
+        };
+
+        if (t.wantErr) {
+          expect(() => normalizedHostingConfigs(cmdConfig, { resolveTargets: true })).to.throw(
+            FirebaseError,
+            t.wantErr
+          );
+        } else {
+          const got = normalizedHostingConfigs(cmdConfig, { resolveTargets: true });
+          expect(got).to.deep.equal(t.want);
+        }
+      });
+    }
+  });
+});

--- a/src/test/hosting/normalizedHostingConfigs.spec.ts
+++ b/src/test/hosting/normalizedHostingConfigs.spec.ts
@@ -59,6 +59,15 @@ describe("normalizedHostingConfigs", () => {
         want: [Object.assign({}, baseConfig, { site: DEFAULT_SITE })],
       },
       {
+        desc: "a hosting config with multiple sites, no targets, specifying the second site",
+        cfg: [
+          Object.assign({}, baseConfig, { site: DEFAULT_SITE }),
+          Object.assign({}, baseConfig, { site: "different-site" }),
+        ],
+        only: `hosting:different-site`,
+        want: [Object.assign({}, baseConfig, { site: "different-site" })],
+      },
+      {
         desc: "a normal hosting config with a target",
         cfg: Object.assign({}, baseConfig, { target: "main" }),
         only: "hosting:main",
@@ -92,7 +101,7 @@ describe("normalizedHostingConfigs", () => {
           Object.assign({}, baseConfig, { target: "t-two" }),
         ],
         only: "hosting:t-three",
-        wantErr: /Hosting target.+t-three.+not detected/,
+        wantErr: /Hosting site or target.+t-three.+not detected/,
       },
       {
         desc: "a hosting config with multiple targets, with multiple matching targets",
@@ -114,7 +123,7 @@ describe("normalizedHostingConfigs", () => {
         desc: "a hosting config with multiple sites but no targets, only an invalid target",
         cfg: [Object.assign({}, baseConfig), Object.assign({}, baseConfig)],
         only: "hosting:t-one",
-        wantErr: /Hosting target.+t-one.+not detected/,
+        wantErr: /Hosting site or target.+t-one.+not detected/,
       },
     ];
 

--- a/src/test/hosting/normalizedHostingConfigs.spec.ts
+++ b/src/test/hosting/normalizedHostingConfigs.spec.ts
@@ -4,6 +4,28 @@ import { FirebaseError } from "../../error";
 import { normalizedHostingConfigs } from "../../hosting/normalizedHostingConfigs";
 
 describe("normalizedHostingConfigs", () => {
+  it("should fail if both site and target are specified", () => {
+    const singleHostingConfig = { site: "site", target: "target" };
+    const cmdConfig = {
+      site: "default-site",
+      config: { get: () => singleHostingConfig },
+    };
+    expect(() => normalizedHostingConfigs(cmdConfig)).to.throw(
+      FirebaseError,
+      /configs should only include either/
+    );
+
+    const hostingConfig = [{ site: "site", target: "target" }];
+    const newCmdConfig = {
+      site: "default-site",
+      config: { get: () => hostingConfig },
+    };
+    expect(() => normalizedHostingConfigs(newCmdConfig)).to.throw(
+      FirebaseError,
+      /configs should only include either/
+    );
+  });
+
   describe("without an only parameter", () => {
     const DEFAULT_SITE = "default-hosting-site";
     const baseConfig = { public: "public", ignore: ["firebase.json"] };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2731 

In `v8.12.1`, we did not do any validation of `target` in `--only hosting:<target>`, but _did_ allow the ability to specify `--only hosting:<site-name>` because of how the filtering logic played out when a user had a single Hosting config (think immediately post `init hosting`).

In #2704, we started validating that `target` was a valid Hosting target, as our documentation states that `target` must match a `target` in `firebase.json`. This is well meaning, but it broke the case where the Hosting site could be specified by name.

Specifying a Hosting `target` is intended for [multi-site setups, described in the documentation](https://firebase.google.com/docs/hosting/multisites#set_up_deploy_targets). However, we also want to maintain support for specifying the `site` in a multisite configuration (rather than `target`).

### Scenarios Tested

`firebase deploy` with
- nothing
  - on a basic config
    - with a `target` specified in firebase.json
  - on a multi-site config
   - with `site` instead of `target`
- `--only hosting`
  - on a basic config
    - with a `target` specified in firebase.json
  - on a multi-site config
   - with `site` instead of `target`
- `--only hosting:<sitename>`
  - on a basic config (works)
    - with a `target` specified in firebase.json (fails)
  - on a multi-site config (fails)
   - with `site` instead of `target` (works, since it's the site)
- `only hosting:<target>`
  - on a basic config (fails, no target)
    - with a `target` specified in firebase.json (works)
  - on a multi-site config (works)
   - with `site` instead of `target` (fails, since it's not a target)

I've also added new tests for `normalizedHostingConfigs` to help solidify this behavior (yay 100% test coverage).

cc @thomasmburke 