### PR TITLE
feat(serve): add --inspect flag

### DIFF
--- a/src/commands/serve.js
+++ b/src/commands/serve.js
@@ -41,6 +41,7 @@ module.exports = new Command("serve")
     "--except <targets>",
     "serve all except specified targets (valid targets are: " + VALID_TARGETS.join(", ") + ")"
   )
+  .option("--inspect [port]", "attach the node.js debugger")
   .before((options) => {
     if (
       options.only &&

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -23,6 +23,12 @@ module.exports = {
       projectId,
       functionsDir,
       nodeMajorVersion: parseRuntimeVersion(options.config.get("functions.runtime")),
+      debugPort:
+        typeof options.inspect === "string"
+          ? Number(options.inspect)
+          : options.inspect
+          ? 9229
+          : undefined,
 
       ...(args as object),
     };


### PR DESCRIPTION
### Description

Add an `--inspect` flag to `firebase serve`.

When defined, the `debugPort` of `FunctionsEmulator` becomes 9229 or the specified port (eg: `--inspect=9230`).

### Scenarios Tested

N/A

### Sample Commands

```sh
firebase serve --inspect
firebase serve --inspect=9230
```