### PR TITLE
fix use of normalizedHostingConfigs when it is called repeatedly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue in `hosting:channel` commands where a Firebase Hosting target may cause configuration parsing issues (#2746).

--- a/scripts/hosting-tests/run.sh
+++ b/scripts/hosting-tests/run.sh
@@ -13,7 +13,7 @@ echo "Running with Application Creds: ${GOOGLE_APPLICATION_CREDENTIALS}"
 
 echo "Target project: ${FBTOOLS_TARGET_PROJECT}"
 
-echo "Initalizing some variables..."
+echo "Initializing some variables..."
 DATE="$(date)"
 echo "Variables initalized..."
 
@@ -25,7 +25,7 @@ echo "Installing firebase-tools..."
 npm link
 echo "Installed firebase-tools: $(which firebase)"
 
-echo "Initalizing temp directory..."
+echo "Initializing temp directory..."
 cd "${TEMP_DIR}"
 cat > "firebase.json" <<- EOM
 {
@@ -42,7 +42,7 @@ EOM
 mkdir "public"
 touch "public/${TARGET_FILE}"
 echo "${DATE}" > "public/${TARGET_FILE}"
-echo "Initalized temp directory."
+echo "Initialized temp directory."
 
 echo "Testing local serve..."
 PORT=8685
@@ -72,3 +72,53 @@ sleep 5
 VALUE="$(curl https://${FBTOOLS_TARGET_PROJECT}.web.app/${TARGET_FILE})"
 test "${DATE}" = "${VALUE}" || (echo "Expected ${VALUE} to equal ${DATE}." && false)
 echo "Tested hosting deployment."
+
+# Test more complex scenarios:
+echo "Creating second temp directory..."
+TEMP_DIR="$(mktemp -d)"
+echo "Created second temp directory: ${TEMP_DIR}"
+
+echo "Initializing a new date..."
+DATE="$(date)"
+echo "Initialized a new date."
+
+echo "Initializing second temp directory..."
+cd "${TEMP_DIR}"
+cat > "firebase.json" <<- EOM
+{
+  "hosting": [
+    {
+      "target": "customtarget",
+      "public": "public",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ]
+    }
+  ]
+}
+EOM
+mkdir "public"
+touch "public/${TARGET_FILE}"
+echo "${DATE}" > "public/${TARGET_FILE}"
+echo "Setting targets..."
+firebase use --add "${FBTOOLS_TARGET_PROJECT}"
+firebase target:apply hosting customtarget "${FBTOOLS_TARGET_PROJECT}"
+echo "Set targets."
+echo "Initialized second temp directory."
+
+echo "Testing hosting deployment by target..."
+firebase deploy --only hosting:customtarget --project "${FBTOOLS_TARGET_PROJECT}"
+sleep 5
+VALUE="$(curl https://${FBTOOLS_TARGET_PROJECT}.web.app/${TARGET_FILE})"
+test "${DATE}" = "${VALUE}" || (echo "Expected ${VALUE} to equal ${DATE}." && false)
+echo "Tested hosting deployment by target."
+
+echo "Testing hosting channel deployment by target..."
+firebase hosting:channel:deploy mychannel --only customtarget --project "${FBTOOLS_TARGET_PROJECT}" --json | tee output.json
+sleep 5
+CHANNEL_URL=$(cat output.json | jq -r ".result.customtarget.url")
+VALUE="$(curl ${CHANNEL_URL}/${TARGET_FILE})"
+test "${DATE}" = "${VALUE}" || (echo "Expected ${VALUE} to equal ${DATE}." && false)
+echo "Tested hosting channel deployment by target."

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -1,4 +1,5 @@
 import { bold } from "cli-color";
+import { cloneDeep } from "lodash";
 
 import { FirebaseError } from "../error";
 
@@ -65,7 +66,7 @@ export function normalizedHostingConfigs(
   cmdOptions: any, // eslint-disable-line @typescript-eslint/no-explicit-any
   options: { resolveTargets?: boolean } = {}
 ): HostingConfig[] {
-  let configs = cmdOptions.config.get("hosting");
+  let configs = cloneDeep(cmdOptions.config.get("hosting"));
   if (!configs) {
     return [];
   }

--- a/src/test/hosting/normalizedHostingConfigs.spec.ts
+++ b/src/test/hosting/normalizedHostingConfigs.spec.ts
@@ -26,6 +26,17 @@ describe("normalizedHostingConfigs", () => {
     );
   });
 
+  it("should not modify the config when resolving targets", () => {
+    const singleHostingConfig = { target: "target" };
+    const cmdConfig = {
+      site: "default-site",
+      config: { get: () => singleHostingConfig },
+      rc: { requireTarget: () => ["default-site"] },
+    };
+    normalizedHostingConfigs(cmdConfig, { resolveTargets: true });
+    expect(singleHostingConfig).to.deep.equal({ target: "target" });
+  });
+
   describe("without an only parameter", () => {
     const DEFAULT_SITE = "default-hosting-site";
     const baseConfig = { public: "public", ignore: ["firebase.json"] };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2746

The `hosting:channel:deploy` path normalizes the configs once before going through the normal deploy path. Unfortunately, the normalizing process modified the underlying config which ended up causing issues when the normalize method was called a second time. Deep cloning the config fixes this issue.

Also, added some functional tests for deploying to a target and deploying to a channel!