### PR TITLE
RTDB emulator v4.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes Cloud Function inspection when using standalone binary release (#2740)
+- Release RTDB emulator v4.6.1: Fix emulator crash on invalid `.validate` rules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fixes Cloud Function inspection when using standalone binary release (#2740)
-- Release RTDB emulator v4.6.1: Fix emulator crash on invalid `.validate` rules.
+- Release RTDB emulator v4.6.1: Fix emulator crash on invalid `.validate` rules (#2734)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -28,14 +28,14 @@ const CACHE_DIR =
 
 const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails } = {
   database: {
-    downloadPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.6.0.jar"),
-    version: "4.6.0",
+    downloadPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.6.1.jar"),
+    version: "4.6.1",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.6.0.jar",
-      expectedSize: 28458498,
-      expectedChecksum: "2b061fa9ba9f34d0d534f12caecddf3d",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.6.1.jar",
+      expectedSize: 28924850,
+      expectedChecksum: "ca90f222978277517c03161d2f7b4476",
       namePrefix: "firebase-database-emulator",
     },
   },


### PR DESCRIPTION
### Description

Contains a fix for a longstanding emulator bug that caused https://github.com/firebase/firebase-tools/issues/2734

### Scenarios Tested

Ran npm install and node lib/bin/firebase.js emulators:start --only database

```
curl -H "Authorization: Bearer owner" -X PUT -d @bad.rules.json localhost:9000/.settings/rules.json?ns=test-ns
```

Where `bad.rules.json` contains the example rules from the issue:
```
{
  "rules": {
      "$offering_id": {
          ".validate": "newData.hasChildren(['timestamp', 'text']"
      }
  }
}
```