### PR TITLE
Update extensions init linter to ESLint.

### DIFF
--- a/src/commands/ext-dev-init.ts
+++ b/src/commands/ext-dev-init.ts
@@ -43,15 +43,15 @@ async function typescriptSelected(config: Config): Promise<void> {
     path.join(TEMPLATE_ROOT, "typescript", "_gitignore"),
     "utf8"
   );
-  const tslintTemplate = fs.readFileSync(
-    path.join(FUNCTIONS_ROOT, "typescript", "tslint.json"),
+  const eslintTemplate = fs.readFileSync(
+    path.join(FUNCTIONS_ROOT, "typescript", "_eslintrc"),
     "utf8"
   );
 
   const lint = await promptOnce({
     name: "lint",
     type: "confirm",
-    message: "Do you want to use TSLint to catch probable bugs and enforce style?",
+    message: "Do you want to use ESLint to catch probable bugs and enforce style?",
     default: true,
   });
 
@@ -61,7 +61,7 @@ async function typescriptSelected(config: Config): Promise<void> {
   await config.askWriteProjectFile("functions/src/index.ts", indexTemplate);
   if (lint) {
     await config.askWriteProjectFile("functions/package.json", packageLintingTemplate);
-    await config.askWriteProjectFile("functions/tslint.json", tslintTemplate);
+    await config.askWriteProjectFile("functions/.eslintrc.js", eslintTemplate);
   } else {
     await config.askWriteProjectFile("functions/package.json", packageNoLintingTemplate);
   }

--- a/templates/extensions/typescript/package.lint.json
+++ b/templates/extensions/typescript/package.lint.json
@@ -1,7 +1,7 @@
 {
   "name": "functions",
   "scripts": {
-    "lint": "tslint --project tsconfig.json",
+    "lint": "eslint \"src/**/*\"",
     "build": "tsc"
   },
   "main": "lib/index.js",
@@ -10,7 +10,8 @@
     "firebase-functions": "^3.6.1"
   },
   "devDependencies": {
-    "tslint": "^5.12.0",
+    "eslint": "^7.6.0",
+    "eslint-plugin-import": "^2.22.0",
     "typescript": "^3.8.0"
   },
   "private": true

--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -28,7 +28,7 @@ module.exports = {
     "@typescript-eslint/prefer-for-of": "warn",
     "@typescript-eslint/triple-slash-reference": "error",
     "@typescript-eslint/unified-signatures": "warn",
-    "comma-dangle": "warn",
+    "comma-dangle": ["error", "always-multiline"],
     "constructor-super": "error",
     eqeqeq: ["warn", "always"],
     "import/no-deprecated": "warn",


### PR DESCRIPTION
The functions linter was recently changed to ESLint for TypeScript, reflecting that here.