### PR TITLE
Fix lookup empty results in Auth Emulator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes Cloud Function inspection when using standalone binary release (#2740)
 - Release RTDB emulator v4.6.1: Fix emulator crash on invalid `.validate` rules (#2734)
+- Fixes lookup empty results using Admin SDK in Auth Emulator.

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -215,10 +215,6 @@ function lookup(
         }
       }
     }
-    return {
-      kind: "identitytoolkit#GetAccountInfoResponse",
-      users,
-    };
   } else {
     assert(reqBody.idToken, "MISSING_ID_TOKEN");
     const { user } = parseIdToken(state, reqBody.idToken);
@@ -226,7 +222,10 @@ function lookup(
   }
   return {
     kind: "identitytoolkit#GetAccountInfoResponse",
-    users,
+
+    // Drop users property if no users are found. This is needed for Node.js
+    // Admin SDK: https://github.com/firebase/firebase-admin-node/issues/1078
+    users: users.length ? users : undefined,
   };
 }
 

--- a/src/test/emulators/auth.spec.ts
+++ b/src/test/emulators/auth.spec.ts
@@ -3334,6 +3334,33 @@ describe("Auth emulator", () => {
     });
   });
 
+  describe("accounts:lookup", () => {
+    it("should return user by localId when privileged", async () => {
+      const { localId } = await registerAnonUser(authApp);
+
+      await supertest(authApp)
+        .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:lookup`)
+        .set("Authorization", "Bearer owner")
+        .send({ localId: [localId] })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.users).to.have.length(1);
+          expect(res.body.users[0].localId).to.equal(localId);
+        });
+    });
+
+    it("should return empty result when localId is not found", async () => {
+      await supertest(authApp)
+        .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:lookup`)
+        .set("Authorization", "Bearer owner")
+        .send({ localId: ["noSuchId"] })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body).not.to.have.property("users");
+        });
+    });
+  });
+
   describe("accounts:query", () => {
     it("should return count of accounts when returnUserInfo is false", async () => {
       await registerAnonUser(authApp);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes https://github.com/firebase/firebase-admin-node/issues/1078

Similar things can potentially happen to other fields that are `repeated` in proto definition, but I'd like to quick fix this one and we can look into solutions if this comes up again.

### Scenarios Tested

See tests added.

### Sample Commands

N/A