### PR TITLE
Work around Java emulators + WSL connectivity issues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Work around Java emulators + WSL connectivity issues.

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -41,9 +41,19 @@ import { FLAG_EXPORT_ON_EXIT_NAME } from "./commandUtils";
 import { fileExistsSync } from "../fsutils";
 
 async function getAndCheckAddress(emulator: Emulators, options: any): Promise<Address> {
-  const host = Constants.normalizeHost(
+  let host = Constants.normalizeHost(
     options.config.get(Constants.getHostKey(emulator), Constants.getDefaultHost(emulator))
   );
+
+  if (host === "localhost" && utils.isRunningInWSL()) {
+    // HACK(https://github.com/firebase/firebase-tools-ui/issues/332): Use IPv4
+    // 127.0.0.1 instead of localhost. This, combined with the hack in
+    // downloadableEmulators.ts, forces the emulator to listen on IPv4 ONLY.
+    // The CLI (including the hub) will also consistently report 127.0.0.1,
+    // causing clients to connect via IPv4 only (which mitigates the problem of
+    // some clients resolving localhost to IPv6 and get connection refused).
+    host = "127.0.0.1";
+  }
 
   const portVal = options.config.get(Constants.getPortKey(emulator), undefined);
   let port;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -478,3 +478,11 @@ export function datetimeString(d: Date): string {
 export function isCloudEnvironment() {
   return !!process.env.CODESPACES;
 }
+
+/**
+ * Indicates whether or not this process is likely to be running in WSL.
+ * @return true if we're likely in WSL, false otherwise
+ */
+export function isRunningInWSL(): boolean {
+  return !!process.env.WSL_DISTRO_NAME;
+}


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes https://github.com/firebase/firebase-tools-ui/issues/332

This affects Firebase CLI running on WSL only. It has an undesirable side effect of breaking IPv6 use cases, but this is arguably better than not being able to use it at all from the host. I don't think we have a way to serve both IPv4 and IPv6 from host until https://github.com/microsoft/WSL/issues/4851 is fixed. See https://github.com/microsoft/WSL/issues/4851#issuecomment-722003091 for the root cause of the issue.

### Scenarios Tested

Manually tested by crwilcox@ on WSL2. Verified that Firestore Viewer in host can successfully list and edit data in Firestore emulator in subsystem.

### Sample Commands

* `firebase emulators:start` in WSL2.
* `curl http://127.0.0.1:8080/` from host to verify (it fails with connection refused without this patch).