### PR TITLE
migrate database:get to new apiv2 client (with stream support!)

### DIFF
--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -144,6 +144,15 @@ export class Client {
       reqOptions.responseType = "json";
     }
 
+    // TODO(bkendall): stream + !resolveOnHTTPError makes for difficult handling.
+    //   Figure out if there's a better way to handle streamed >=400 responses.
+    if (reqOptions.responseType === "stream" && !reqOptions.resolveOnHTTPError) {
+      throw new FirebaseError(
+        "apiv2 will not handle HTTP errors while streaming and you must set `resolveOnHTTPError` and check for res.status >= 400 on your own",
+        { exit: 2 }
+      );
+    }
+
     reqOptions = this.addRequestHeaders(reqOptions);
 
     if (this.opts.auth) {

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -9,6 +9,7 @@ import { populateInstanceDetails } from "../management/database";
 import { printNoticeIfEmulated } from "../emulator/commandUtils";
 import { realtimeOriginOrEmulatorOrCustomUrl } from "../database/api";
 import { requirePermissions } from "../requirePermissions";
+import * as logger from "../logger";
 import * as requireInstance from "../requireInstance";
 import * as responseToError from "../responseToError";
 import * as utils from "../utils";
@@ -116,12 +117,13 @@ export default new Command("database:get <path>")
     const outStream = fileOut ? fs.createWriteStream(options.output) : process.stdout;
 
     if (res.status >= 400) {
+      // TODO(bkendall): consider moving stream-handling logic to responseToError.
       const r = await utils.streamToString(res.body);
       let d;
       try {
         d = JSON.parse(r);
       } catch (e) {
-        throw new FirebaseError("Malformed JSON response", { original: e, exit: 2 });
+        logger.debug("Malformed JSON response:", e, r);
       }
       throw responseToError({ statusCode: res.status }, d);
     }

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -2,40 +2,49 @@ import * as _ from "lodash";
 import * as fs from "fs";
 import * as url from "url";
 
+import { Client } from "../apiv2";
 import { Command } from "../command";
-import * as requireInstance from "../requireInstance";
-import { requirePermissions } from "../requirePermissions";
-import * as request from "request";
-import * as api from "../api";
-import * as responseToError from "../responseToError";
-import * as logger from "../logger";
-import { FirebaseError } from "../error";
 import { Emulators } from "../emulator/types";
-import { printNoticeIfEmulated } from "../emulator/commandUtils";
+import { FirebaseError } from "../error";
 import { populateInstanceDetails } from "../management/database";
+import { printNoticeIfEmulated } from "../emulator/commandUtils";
 import { realtimeOriginOrEmulatorOrCustomUrl } from "../database/api";
+import { requirePermissions } from "../requirePermissions";
+import * as requireInstance from "../requireInstance";
+import * as responseToError from "../responseToError";
 import * as utils from "../utils";
 
-function applyStringOpts(dest: any, src: any, keys: string[], jsonKeys: string[]): void {
-  _.forEach(keys, (key) => {
+/**
+ * Copies any `keys` from `src` to `dest`. Then copies any `jsonKeys` from
+ * `src` as JSON strings to `dest`. Modifies `dest`.
+ * @param dest destination object.
+ * @param src source to read from for `keys` and `jsonKeys`.
+ * @param keys keys to copy from `src`.
+ * @param jsonKeys keys to copy as JSON strings from `src`.
+ */
+function applyStringOpts(
+  dest: { [key: string]: string },
+  src: { [key: string]: string },
+  keys: string[],
+  jsonKeys: string[]
+): void {
+  for (const key of keys) {
     if (src[key]) {
       dest[key] = src[key];
     }
-  });
-
+  }
   // some keys need JSON encoding of the querystring value
-  _.forEach(jsonKeys, (key) => {
+  for (const key of jsonKeys) {
     let jsonVal;
     try {
       jsonVal = JSON.parse(src[key]);
-    } catch (e) {
+    } catch (_) {
       jsonVal = src[key];
     }
-
     if (src[key]) {
       dest[key] = JSON.stringify(jsonVal);
     }
-  });
+  }
 }
 
 export default new Command("database:get <path>")
@@ -60,13 +69,13 @@ export default new Command("database:get <path>")
   .before(requireInstance)
   .before(populateInstanceDetails)
   .before(printNoticeIfEmulated, Emulators.DATABASE)
-  .action((path, options) => {
+  .action(async (path, options) => {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });
     }
 
     const dbHost = realtimeOriginOrEmulatorOrCustomUrl(options);
-    let dbUrl = utils.getDatabaseUrl(dbHost, options.instance, path + ".json");
+    const dbUrl = utils.getDatabaseUrl(dbHost, options.instance, path + ".json");
     const query: { [key: string]: string } = {};
     if (options.shallow) {
       query.shallow = "true";
@@ -91,70 +100,50 @@ export default new Command("database:get <path>")
     );
 
     const urlObj = new url.URL(dbUrl);
-    Object.keys(query).forEach((key) => {
-      urlObj.searchParams.set(key, query[key]);
+    const client = new Client({
+      urlPrefix: urlObj.origin,
+      auth: true,
+    });
+    const res = await client.request<unknown, NodeJS.ReadableStream>({
+      method: "GET",
+      path: urlObj.pathname,
+      queryParams: query,
+      responseType: "stream",
+      resolveOnHTTPError: true,
     });
 
-    dbUrl = urlObj.href;
+    const fileOut = !!options.output;
+    const outStream = fileOut ? fs.createWriteStream(options.output) : process.stdout;
 
-    logger.debug("Query URL: ", dbUrl);
-    const reqOptions = {
-      url: dbUrl,
-    };
+    if (res.status >= 400) {
+      const r = await streamToString(res.body);
+      let d;
+      try {
+        d = JSON.parse(r);
+      } catch (e) {
+        throw new FirebaseError("Malformed JSON response", { original: e, exit: 2 });
+      }
+      throw responseToError(res, d);
+    }
 
-    return api.addRequestHeaders(reqOptions).then((reqOptionsWithToken) => {
-      return new Promise((resolve, reject) => {
-        const fileOut = !!options.output;
-        const outStream = fileOut ? fs.createWriteStream(options.output) : process.stdout;
-        const writeOut = (s: Buffer | string, cb?: Function): void => {
-          if (outStream === process.stdout) {
-            outStream.write(s, cb);
-          } else if (outStream instanceof fs.WriteStream) {
-            outStream.write(s, (err) => {
-              if (cb) {
-                cb(err);
-              }
-            });
-          }
-        };
-        let erroring = false;
-        let errorResponse = "";
-        let response: any;
-
-        request
-          .get(reqOptionsWithToken)
-          .on("response", (res) => {
-            response = res;
-            if (response.statusCode >= 400) {
-              erroring = true;
-            }
-          })
-          .on("data", (chunk) => {
-            if (erroring) {
-              errorResponse += chunk;
-            } else {
-              writeOut(chunk);
-            }
-          })
-          .on("end", () => {
-            writeOut("\n", () => {
-              resolve();
-            });
-            if (erroring) {
-              try {
-                const data = JSON.parse(errorResponse);
-                return reject(responseToError(response, data));
-              } catch (e) {
-                return reject(
-                  new FirebaseError("Malformed JSON response", {
-                    exit: 2,
-                    original: e,
-                  })
-                );
-              }
-            }
-          })
-          .on("error", reject);
-      });
+    res.body.pipe(outStream);
+    // Tack on a single newline at the end of the stream.
+    res.body.once("end", () => {
+      if (outStream === process.stdout) {
+        outStream.write("\n");
+      } else if (outStream instanceof fs.WriteStream) {
+        outStream.write("\n");
+      } else {
+        throw new FirebaseError("Could not write line break", { status: 2 });
+      }
     });
   });
+
+function streamToString(s: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let b = "";
+    s.on("error", reject);
+    s.on("data", (d) => (b += `${d}`));
+    s.once("end", () => resolve(b));
+  });
+}

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash";
 import * as fs from "fs";
 import * as url from "url";
 
@@ -69,8 +68,9 @@ export default new Command("database:get <path>")
   .before(requireInstance)
   .before(populateInstanceDetails)
   .before(printNoticeIfEmulated, Emulators.DATABASE)
-  .action(async (path, options) => {
-    if (!_.startsWith(path, "/")) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  .action(async (path: string, options: any) => {
+    if (!path.startsWith("/")) {
       return utils.reject("Path must begin with /", { exit: 1 });
     }
 

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -123,7 +123,7 @@ export default new Command("database:get <path>")
       try {
         d = JSON.parse(r);
       } catch (e) {
-        logger.debug("Malformed JSON response:", e, r);
+        throw new FirebaseError("Malformed JSON response", { original: e, exit: 2 });
       }
       throw responseToError({ statusCode: res.status }, d);
     }
@@ -140,7 +140,7 @@ export default new Command("database:get <path>")
         s.write("\n");
         s.close();
       } else {
-        throw new FirebaseError("Could not write line break", { status: 2 });
+        logger.debug("[database:get] Could not write line break to outStream");
       }
     });
   });

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -118,7 +118,7 @@ export default new Command("database:get <path>")
 
     if (res.status >= 400) {
       // TODO(bkendall): consider moving stream-handling logic to responseToError.
-      const r = await utils.streamToString(res.body);
+      const r = await res.response.text();
       let d;
       try {
         d = JSON.parse(r);

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -130,9 +130,13 @@ export default new Command("database:get <path>")
     // Tack on a single newline at the end of the stream.
     res.body.once("end", () => {
       if (outStream === process.stdout) {
+        // `stdout` can simply be written to.
         outStream.write("\n");
       } else if (outStream instanceof fs.WriteStream) {
-        outStream.write("\n");
+        // .pipe closes the output file stream, so we need to re-open the file.
+        const s = fs.createWriteStream(options.output, { flags: "a" });
+        s.write("\n");
+        s.close();
       } else {
         throw new FirebaseError("Could not write line break", { status: 2 });
       }

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -116,14 +116,14 @@ export default new Command("database:get <path>")
     const outStream = fileOut ? fs.createWriteStream(options.output) : process.stdout;
 
     if (res.status >= 400) {
-      const r = await streamToString(res.body);
+      const r = await utils.streamToString(res.body);
       let d;
       try {
         d = JSON.parse(r);
       } catch (e) {
         throw new FirebaseError("Malformed JSON response", { original: e, exit: 2 });
       }
-      throw responseToError(res, d);
+      throw responseToError({ statusCode: res.status }, d);
     }
 
     res.body.pipe(outStream);
@@ -142,12 +142,3 @@ export default new Command("database:get <path>")
       }
     });
   });
-
-function streamToString(s: NodeJS.ReadableStream): Promise<string> {
-  return new Promise((resolve, reject) => {
-    let b = "";
-    s.on("error", reject);
-    s.on("data", (d) => (b += `${d}`));
-    s.once("end", () => resolve(b));
-  });
-}

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -233,4 +233,14 @@ describe("utils", () => {
       );
     });
   });
+
+  describe("streamToString/stringToStream", () => {
+    it("should be able to create and read streams", async () => {
+      const stream = utils.stringToStream("hello world");
+      if (!stream) {
+        throw new Error("stream came back undefined");
+      }
+      await expect(utils.streamToString(stream)).to.eventually.equal("hello world");
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -215,7 +215,9 @@ export function explainStdin(): void {
 }
 
 /**
- * Convert text input to a Readable stream.
+ * Converts text input to a Readable stream.
+ * @param text string to turn into a stream.
+ * @return Readable stream, or undefined if text is empty.
  */
 export function stringToStream(text: string): Readable | undefined {
   if (!text) {
@@ -225,6 +227,20 @@ export function stringToStream(text: string): Readable | undefined {
   s.push(text);
   s.push(null);
   return s;
+}
+
+/**
+ * Converts a Readable stream into a string.
+ * @param s a readable stream.
+ * @return a promise resolving to the string'd contents of the stream.
+ */
+export function streamToString(s: NodeJS.ReadableStream): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let b = "";
+    s.on("error", reject);
+    s.on("data", (d) => (b += `${d}`));
+    s.once("end", () => resolve(b));
+  });
 }
 
 /**


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

1. Adds streaming response support to the apiv2 client.
2. Migrates the `database:get` command to the new apiv2 `Client`.

### Scenarios Tested

`database:get`
- with a valid path
- with no auth (code change - tests the `4xx` response path)
- with an invalid path (returns `null`, same as head).
- to a file