### PR TITLE
normalize channel names on hosting:channel:create and remove hashes

### DIFF
--- a/src/commands/hosting-channel-create.ts
+++ b/src/commands/hosting-channel-create.ts
@@ -1,6 +1,6 @@
 import { bold, yellow } from "cli-color";
 
-import { Channel, createChannel, addAuthDomain } from "../hosting/api";
+import { Channel, createChannel, addAuthDomain, normalizeName } from "../hosting/api";
 import { Command } from "../command";
 import { DEFAULT_DURATION, calculateChannelExpireTTL } from "../hosting/expireUtils";
 import { FirebaseError } from "../error";
@@ -55,6 +55,8 @@ export default new Command("hosting:channel:create [channelId]")
       if (!channelId) {
         throw new FirebaseError(`"channelId" must not be empty`);
       }
+
+      channelId = normalizeName(channelId);
 
       let channel: Channel;
       try {

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -160,7 +160,7 @@ export interface Version {
  */
 export function normalizeName(s: string): string {
   // Using a regex replaces *all* bad characters.
-  return s.replace(/[/:_]/g, "-");
+  return s.replace(/[/:_#]/g, "-");
 }
 
 const apiClient = new Client({

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -153,13 +153,13 @@ export interface Version {
 
 /**
  * normalizeName normalizes a name given to it. Most useful for normalizing
- * user provided names. This removes any `/`, ':', or '_' characters and
+ * user provided names. This removes any `/`, ':', '_', or '#' characters and
  * replaces them with dashes (`-`).
  * @param s the name to normalize.
  * @return the normalized name.
  */
 export function normalizeName(s: string): string {
-  // Using a regex replaces *all* bad characters.
+  // Using a regex replaces *all* specified characters at once.
   return s.replace(/[/:_#]/g, "-");
 }
 

--- a/src/test/hosting/api.spec.ts
+++ b/src/test/hosting/api.spec.ts
@@ -77,6 +77,7 @@ describe("normalizeName", () => {
     { in: "happyBranch", out: "happyBranch" },
     { in: "happy:branch", out: "happy-branch" },
     { in: "happy_branch", out: "happy-branch" },
+    { in: "happy#branch", out: "happy-branch" },
   ];
 
   for (const t of tests) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2783

`hosting:channel:deploy` does normalizing of the channel ID provided. `:create` was not. Further, the normalization wasn't removing `#` from the provided IDs and causing issues when passed into a URL.

### Scenarios Tested

- `firebase hosting:channel:create test#bar`
- `firebase hosting:channel:deploy test#bar`