### PR TITLE
use apiv2 in operation-poller

### DIFF
--- a/src/operation-poller.ts
+++ b/src/operation-poller.ts
@@ -1,6 +1,6 @@
-import { Queue } from "./throttler/queue";
-import * as api from "./api";
+import { Client, ClientResponse } from "./apiv2";
 import { FirebaseError } from "./error";
+import { Queue } from "./throttler/queue";
 
 export interface OperationPollerOptions {
   pollerName?: string;
@@ -15,6 +15,7 @@ const DEFAULT_INITIAL_BACKOFF_DELAY_MILLIS = 250;
 const DEFAULT_MASTER_TIMEOUT_MILLIS = 30000;
 
 interface OperationResult<T> {
+  done?: boolean;
   response?: T;
   error?: {
     message: string;
@@ -27,6 +28,7 @@ export class OperationPoller<T> {
    * Returns a promise that resolves when the operation is completed with a successful response.
    * Rejects the promise if the masterTimeout runs out before the operation is "done", or when it is
    * "done" with an error response, or when the api request rejects with an unrecoverable error.
+   * @param options poller options.
    */
   async poll(options: OperationPollerOptions): Promise<T> {
     const queue: Queue<() => Promise<OperationResult<T>>, OperationResult<T>> = new Queue({
@@ -45,34 +47,31 @@ export class OperationPoller<T> {
         ? error
         : new FirebaseError(error.message, { status: error.code });
     }
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return response!;
   }
 
   private getPollingTask(options: OperationPollerOptions): () => Promise<OperationResult<T>> {
-    const { apiOrigin, apiVersion, operationResourceName } = options;
-    const requestOptions = { auth: true, origin: apiOrigin };
+    const apiClient = new Client({
+      urlPrefix: options.apiOrigin,
+      apiVersion: options.apiVersion,
+      auth: true,
+    });
     return async () => {
-      let apiResponse;
-
+      let res: ClientResponse<OperationResult<T>>;
       try {
-        apiResponse = await api.request(
-          "GET",
-          `/${apiVersion}/${operationResourceName}`,
-          requestOptions
-        );
+        res = await apiClient.get(options.operationResourceName);
       } catch (err) {
-        // Responses with 500 or 503 status code are treated as retriable errors
+        // Responses with 500 or 503 status code are treated as retriable errors.
         if (err.status === 500 || err.status === 503) {
           throw err;
         }
         return { error: err };
       }
-
-      if (!apiResponse.body || !apiResponse.body.done) {
+      if (!res.body.done) {
         throw new Error("Polling incomplete, should trigger retry with backoff");
       }
-
-      return apiResponse.body as OperationResult<T>;
+      return res.body;
     };
   }
 }

--- a/src/operation-poller.ts
+++ b/src/operation-poller.ts
@@ -1,4 +1,4 @@
-import { Client, ClientResponse } from "./apiv2";
+import { Client } from "./apiv2";
 import { FirebaseError } from "./error";
 import { Queue } from "./throttler/queue";
 
@@ -58,9 +58,9 @@ export class OperationPoller<T> {
       auth: true,
     });
     return async () => {
-      let res: ClientResponse<OperationResult<T>>;
+      let res;
       try {
-        res = await apiClient.get(options.operationResourceName);
+        res = await apiClient.get<OperationResult<T>>(options.operationResourceName);
       } catch (err) {
         // Responses with 500 or 503 status code are treated as retriable errors.
         if (err.status === 500 || err.status === 503) {

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -205,7 +205,7 @@ describe("extensions", () => {
         .reply(200, { name: "operations/abc123" });
       nock(api.extensionsOrigin)
         .get(`/${VERSION}/operations/abc123`)
-        .reply(502);
+        .reply(502, {});
 
       await expect(
         extensionsApi.createInstance(
@@ -442,7 +442,7 @@ describe("extensions", () => {
         .reply(200, { name: "operations/abc123" });
       nock(api.extensionsOrigin)
         .get(`/${VERSION}/operations/abc123`)
-        .reply(502);
+        .reply(502, {});
 
       await expect(extensionsApi.createSource(PROJECT_ID, PACKAGE_URI, "./")).to.be.rejectedWith(
         FirebaseError,

--- a/src/test/hosting/cloudRunProxy.spec.ts
+++ b/src/test/hosting/cloudRunProxy.spec.ts
@@ -9,6 +9,7 @@ import cloudRunProxy, {
   CloudRunProxyOptions,
   CloudRunProxyRewrite,
 } from "../../hosting/cloudRunProxy";
+import { mockAuth } from "../helpers";
 
 describe("cloudRunProxy", () => {
   const fakeOptions: CloudRunProxyOptions = {
@@ -17,8 +18,15 @@ describe("cloudRunProxy", () => {
   const fakeRewrite: CloudRunProxyRewrite = { run: { serviceId: "helloworld" } };
   const cloudRunServiceOrigin = "https://helloworld-hash-uc.a.run.app";
 
+  let sandbox: sinon.SinonSandbox;
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    mockAuth(sandbox);
+  });
+
   afterEach(() => {
     nock.cleanAll();
+    sandbox.restore();
   });
 
   it("should error when not provided a valid Cloud Run service ID", async () => {

--- a/src/test/operation-poller.spec.ts
+++ b/src/test/operation-poller.spec.ts
@@ -1,28 +1,25 @@
 import { expect } from "chai";
+import * as nock from "nock";
 import * as sinon from "sinon";
 
-import * as api from "../api";
 import { FirebaseError } from "../error";
+import { mockAuth } from "./helpers";
 import { OperationPollerOptions, pollOperation } from "../operation-poller";
 import TimeoutError from "../throttler/errors/timeout-error";
-import { mockAuth } from "./helpers";
 
 const TEST_ORIGIN = "https://firebasedummy.googleapis.com.com";
 const VERSION = "v1";
 const LRO_RESOURCE_NAME = "operations/cp.3322442424242444";
 const FULL_RESOURCE_NAME = `/${VERSION}/${LRO_RESOURCE_NAME}`;
-const API_OPTIONS = { auth: true, origin: TEST_ORIGIN };
 
 describe("OperationPoller", () => {
   describe("poll", () => {
     let sandbox: sinon.SinonSandbox;
-    let stubApiRequest: sinon.SinonStub;
     let pollerOptions: OperationPollerOptions;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
       mockAuth(sandbox);
-      stubApiRequest = sandbox.stub(api, "request");
       pollerOptions = {
         apiOrigin: TEST_ORIGIN,
         apiVersion: VERSION,
@@ -36,30 +33,24 @@ describe("OperationPoller", () => {
     });
 
     it("should return result with response field if polling succeeds", async () => {
-      const successfulResponse = {
-        done: true,
-        response: "completed",
-      };
-
-      stubApiRequest
-        .withArgs("GET", FULL_RESOURCE_NAME, API_OPTIONS)
-        .resolves({ body: successfulResponse });
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(200, { done: true, response: "completed" });
 
       expect(await pollOperation<string>(pollerOptions)).to.deep.equal("completed");
-      expect(stubApiRequest.callCount).to.equal(1);
+      expect(nock.isDone()).to.be.true;
     });
 
     it("should return result with error field if polling operation returns failure response", async () => {
-      const failedResponse = {
-        done: true,
-        error: {
-          message: "failed",
-          code: 7,
-        },
-      };
-      stubApiRequest
-        .withArgs("GET", FULL_RESOURCE_NAME, API_OPTIONS)
-        .resolves({ body: failedResponse });
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(200, {
+          done: true,
+          error: {
+            message: "failed",
+            code: 7,
+          },
+        });
 
       let err;
       try {
@@ -69,63 +60,55 @@ describe("OperationPoller", () => {
       }
       expect(err.message).to.equal("failed");
       expect(err.status).to.equal(7);
-      expect(stubApiRequest.callCount).to.equal(1);
+      expect(nock.isDone()).to.be.true;
     });
 
     it("should return result with error field if api call rejects with unrecoverable error", async () => {
-      const unrecoverableError = new FirebaseError("poll failed", { status: 404 });
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(404, { message: "poll failed" });
 
-      stubApiRequest.withArgs("GET", FULL_RESOURCE_NAME, API_OPTIONS).rejects(unrecoverableError);
-
-      let err;
-      try {
-        await pollOperation<string>(pollerOptions);
-      } catch (e) {
-        err = e;
-      }
-      expect(err).to.equal(unrecoverableError);
-      expect(stubApiRequest.callCount).to.equal(1);
+      await expect(pollOperation<string>(pollerOptions)).to.eventually.be.rejectedWith(
+        FirebaseError,
+        "404"
+      );
+      expect(nock.isDone()).to.be.true;
     });
 
     it("should retry polling if http request responds with 500 or 503 status code", async () => {
-      const retriableError1 = new FirebaseError("poll failed", { status: 500 });
-      const retriableError2 = new FirebaseError("poll failed", { status: 503 });
-      const successfulResponse = {
-        done: true,
-        response: "completed",
-      };
-
-      stubApiRequest
-        .withArgs("GET", FULL_RESOURCE_NAME, API_OPTIONS)
-        .onFirstCall()
-        .rejects(retriableError1)
-        .onSecondCall()
-        .rejects(retriableError2)
-        .onThirdCall()
-        .resolves({ body: successfulResponse });
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(500, {});
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(503, {});
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(200, { done: true, response: "completed" });
 
       expect(await pollOperation<string>(pollerOptions)).to.deep.equal("completed");
-      expect(stubApiRequest.callCount).to.equal(3);
+      expect(nock.isDone()).to.be.true;
     });
 
     it("should retry polling until the LRO is done", async () => {
-      const successfulResponse = {
-        done: true,
-        response: "completed",
-      };
-      stubApiRequest
-        .withArgs("GET", FULL_RESOURCE_NAME, API_OPTIONS)
-        .resolves({ done: false })
-        .onThirdCall()
-        .resolves({ body: successfulResponse });
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .twice()
+        .reply(200, { done: false });
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(200, { done: true, response: "completed" });
 
       expect(await pollOperation<string>(pollerOptions)).to.deep.equal("completed");
-      expect(stubApiRequest.callCount).to.equal(3);
+      expect(nock.isDone()).to.be.true;
     });
 
     it("should reject with TimeoutError when timed out after failed retries", async () => {
       pollerOptions.masterTimeout = 200;
-      stubApiRequest.withArgs("GET", FULL_RESOURCE_NAME, API_OPTIONS).resolves({ done: false });
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(200, { done: false })
+        .persist();
 
       let error;
       try {
@@ -134,7 +117,7 @@ describe("OperationPoller", () => {
         error = err;
       }
       expect(error).to.be.instanceOf(TimeoutError);
-      expect(stubApiRequest.callCount).to.be.at.least(3);
+      nock.cleanAll();
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Swap out `api` for `apiv2` in the operation poller. AFAIK, since these clients are incredibly similar, this should work pretty well.

While updating the tests, I removed "stubbing the API client" for "stubbing the http responses" with nock. This means that the APIv2 client is being fully utilized and not just stubbed away. This gives me more confidence that the tests are actually validating the interaction between the two.

### Scenarios Tested

- `hosting:clone`
- `ext:uninstall`