### PR TITLE
remove `request` from emulators folder

### DIFF
--- a/src/emulator/auth/cloudFunctions.ts
+++ b/src/emulator/auth/cloudFunctions.ts
@@ -1,15 +1,17 @@
-import { EmulatorRegistry } from "../registry";
+import { Client } from "../../apiv2";
+
 import { EmulatorInfo, Emulators } from "../types";
-import { UserInfo } from "./state";
-import * as request from "request";
 import { EmulatorLogger } from "../emulatorLogger";
+import { EmulatorRegistry } from "../registry";
+import { UserInfo } from "./state";
 
 type AuthCloudFunctionAction = "create" | "delete";
 
 export class AuthCloudFunction {
   private logger = EmulatorLogger.forEmulator(Emulators.AUTH);
   private functionsEmulatorInfo?: EmulatorInfo;
-  private multicastEndpoint = "";
+  private multicastOrigin = "";
+  private multicastPath = "";
   private enabled = false;
 
   constructor(private projectId: string) {
@@ -18,38 +20,43 @@ export class AuthCloudFunction {
     if (functionsEmulator) {
       this.enabled = true;
       this.functionsEmulatorInfo = functionsEmulator.getInfo();
-      this.multicastEndpoint = `http://${this.functionsEmulatorInfo?.host}:${this.functionsEmulatorInfo?.port}/functions/projects/${projectId}/trigger_multicast`;
+      this.multicastOrigin = `http://${this.functionsEmulatorInfo?.host}:${this.functionsEmulatorInfo?.port}`;
+      this.multicastPath = `/functions/projects/${projectId}/trigger_multicast`;
     }
   }
 
-  public dispatch(action: AuthCloudFunctionAction, user: UserInfo): void {
+  public async dispatch(action: AuthCloudFunctionAction, user: UserInfo): Promise<void> {
     if (!this.enabled) return;
 
     const userInfoPayload = this.createUserInfoPayload(user);
     const multicastEventBody = this.createEventRequestBody(action, userInfoPayload);
 
-    request.post(this.multicastEndpoint, {
-      body: multicastEventBody,
-      callback: (error, response) => {
-        if (error || response.statusCode != 200) {
-          this.logger.logLabeled(
-            "WARN",
-            "functions",
-            `Firebase Authentication function was not triggered due to emulation error. Please file a bug.`
-          );
-        }
-      },
-    });
+    const c = new Client({ urlPrefix: this.multicastOrigin, auth: false });
+    let res;
+    let err: Error | undefined;
+    try {
+      res = await c.post(this.multicastPath, multicastEventBody);
+    } catch (e) {
+      err = e;
+    }
+
+    if (err || res?.status != 200) {
+      this.logger.logLabeled(
+        "WARN",
+        "functions",
+        `Firebase Authentication function was not triggered due to emulation error. Please file a bug.`
+      );
+    }
   }
 
   private createEventRequestBody(
     action: AuthCloudFunctionAction,
     userInfoPayload: UserInfoPayload
-  ): string {
-    return JSON.stringify({
+  ): { eventType: string; data: UserInfoPayload } {
+    return {
       eventType: `providers/firebase.auth/eventTypes/user.${action}`,
       data: userInfoPayload,
-    });
+    };
   }
 
   private createUserInfoPayload(user: UserInfo): UserInfoPayload {

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -13,6 +13,7 @@ import {
 import { FirebaseError } from "../../error";
 import * as api from "../../api";
 import { Distribution } from "../../appdistribution/distribution";
+import { mockAuth } from "../helpers";
 
 tmp.setGracefulCleanup();
 
@@ -26,6 +27,7 @@ describe("distribution", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    mockAuth(sandbox);
     sandbox.useFakeTimers();
   });
 

--- a/src/test/emulators/cloudFunctions.spec.ts
+++ b/src/test/emulators/cloudFunctions.spec.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as sinon from "sinon";
+
+import { AuthCloudFunction } from "../../emulator/auth/cloudFunctions";
+import { EmulatorRegistry } from "../../emulator/registry";
+import { Emulators } from "../../emulator/types";
+import { FakeEmulator } from "./fakeEmulator";
+
+describe("cloudFunctions", () => {
+  describe("dispatch", () => {
+    let sandbox: sinon.SinonSandbox;
+    const fakeEmulator = new FakeEmulator(Emulators.FUNCTIONS, "1.1.1.1", 4);
+    before(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(EmulatorRegistry, "get").returns(fakeEmulator);
+    });
+
+    after(() => {
+      sandbox.restore();
+      nock.cleanAll();
+    });
+
+    it("should make a request to the functions emulator", async () => {
+      nock("http://1.1.1.1:4")
+        .post("/functions/projects/project-foo/trigger_multicast", {
+          eventType: `providers/firebase.auth/eventTypes/user.create`,
+          data: { uid: "foobar", metadata: {}, customClaims: {} },
+        })
+        .reply(200, {});
+
+      const cf = new AuthCloudFunction("project-foo");
+      await cf.dispatch("create", { localId: "foobar" });
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});

--- a/src/test/gcp/cloudscheduler.spec.ts
+++ b/src/test/gcp/cloudscheduler.spec.ts
@@ -1,10 +1,12 @@
-import * as _ from "lodash";
 import { expect } from "chai";
+import * as _ from "lodash";
 import * as nock from "nock";
-import * as api from "../../api";
+import * as sinon from "sinon";
 
-import { FirebaseError } from "../../error";
 import { cloudscheduler } from "../../gcp";
+import { FirebaseError } from "../../error";
+import { mockAuth } from "../helpers";
+import * as api from "../../api";
 
 const VERSION = "v1beta1";
 
@@ -21,7 +23,14 @@ const TEST_JOB = {
 
 describe("cloudscheduler", () => {
   describe("createOrUpdateJob", () => {
+    let sandbox: sinon.SinonSandbox;
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      mockAuth(sandbox);
+    });
+
     afterEach(() => {
+      sandbox.restore();
       nock.cleanAll();
     });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Migrating some of the emulators logic that depended on `request` to `apiv2`. Cleaned up a bit of the logic where I could.

### Scenarios Tested

- [x] deleted all emulators from `~/.cache` and started the Firestore emulator to trigger the download
- [x] trigger the dispatch in the emulator