### PR TITLE
Fix console URL for RTDB commands

### DIFF
--- a/src/commands/database-push.js
+++ b/src/commands/database-push.js
@@ -67,6 +67,7 @@ module.exports = new Command("database:push <path> [infile]")
 
             var consoleUrl = utils.getDatabaseViewDataUrl(
               origin,
+              options.project,
               options.instance,
               path + body.name
             );

--- a/src/commands/database-set.js
+++ b/src/commands/database-set.js
@@ -83,7 +83,7 @@ module.exports = new Command("database:set <path> [infile]")
               logger.info();
               logger.info(
                 clc.bold("View data at:"),
-                utils.getDatabaseViewDataUrl(origin, options.instance, path)
+                utils.getDatabaseViewDataUrl(origin, options.project, options.instance, path)
               );
               return resolve();
             })

--- a/src/commands/database-update.js
+++ b/src/commands/database-update.js
@@ -81,7 +81,7 @@ module.exports = new Command("database:update <path> [infile]")
               logger.info();
               logger.info(
                 clc.bold("View data at:"),
-                utils.getDatabaseViewDataUrl(origin, options.project, path)
+                utils.getDatabaseViewDataUrl(origin, options.project, options.instance, path)
               );
               return resolve();
             })

--- a/src/test/utils.spec.ts
+++ b/src/test/utils.spec.ts
@@ -110,16 +110,31 @@ describe("utils", () => {
   });
 
   describe("getDatabaseViewDataUrl", () => {
-    it("should get a view data url for prod", () => {
+    it("should get a view data url for legacy prod URL", () => {
       expect(
-        utils.getDatabaseViewDataUrl("https://firebaseio.com", "fir-proj", "/foo/bar")
-      ).to.equal("https://console.firebase.google.com/project/fir-proj/database/data/foo/bar");
+        utils.getDatabaseViewDataUrl("https://firebaseio.com", "fir-proj", "fir-ns", "/foo/bar")
+      ).to.equal(
+        "https://console.firebase.google.com/project/fir-proj/database/fir-ns/data/foo/bar"
+      );
+    });
+
+    it("should get a view data url for new prod URL", () => {
+      expect(
+        utils.getDatabaseViewDataUrl(
+          "https://firebasedatabase.app",
+          "fir-proj",
+          "fir-ns",
+          "/foo/bar"
+        )
+      ).to.equal(
+        "https://console.firebase.google.com/project/fir-proj/database/fir-ns/data/foo/bar"
+      );
     });
 
     it("should get a view data url for the emulator", () => {
       expect(
-        utils.getDatabaseViewDataUrl("http://localhost:9000", "fir-proj", "/foo/bar")
-      ).to.equal("http://localhost:9000/foo/bar.json?ns=fir-proj");
+        utils.getDatabaseViewDataUrl("http://localhost:9000", "fir-proj", "fir-ns", "/foo/bar")
+      ).to.equal("http://localhost:9000/foo/bar.json?ns=fir-ns");
     });
   });
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -83,12 +83,16 @@ export function getDatabaseUrl(origin: string, namespace: string, pathname: stri
  */
 export function getDatabaseViewDataUrl(
   origin: string,
+  project: string,
   namespace: string,
   pathname: string
 ): string {
   const urlObj = new url.URL(origin);
-  if (urlObj.hostname.includes("firebaseio.com")) {
-    return consoleUrl(namespace, "/database/data" + pathname);
+  if (
+    urlObj.hostname.includes("firebaseio.com") ||
+    urlObj.hostname.includes("firebasedatabase.app")
+  ) {
+    return consoleUrl(project, `/database/${namespace}/data${pathname}`);
   } else {
     // TODO(samstern): View in Emulator UI
     return getDatabaseUrl(origin, namespace, pathname + ".json");


### PR DESCRIPTION
### Description
For `database:set|update|push`, display the correct console URL. 
This accounts for two things:-
1. New RTDB URLs
2. Projects with multiple instances
### Scenarios Tested
```
firebase database:push /path/ --instance <instance> --project=<project> -d `"hello123"'
firebase database:set /path/ --instance <instance> --project=<project> -d `"hello123"'
firebase database:update /path/ --instance <instance> --project=<project> -d '{"cliKey":"hello123"}'
```
both with and without `FIREBASE_CLI_PREVIEWS=rtdbmanagement`

Screenshot for reviewers: https://screenshot.googleplex.com/3vrk348acHuPdTd