### PR TITLE
fix database:settings:get/set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,1 @@
 - Fixes issue in `database:settings:get` where the value wasn't being properly displayed.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Fixes issue in `database:settings:get` where the value wasn't being properly displayed.
+

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -245,7 +245,7 @@ export class Client {
       method: options.method,
     };
 
-    if (options.json) {
+    if (options.json !== undefined) {
       fetchOptions.body = JSON.stringify(options.json);
     }
 

--- a/src/commands/database-settings-get.ts
+++ b/src/commands/database-settings-get.ts
@@ -44,6 +44,12 @@ export default new Command("database:settings:get <path>")
           original: err,
         });
       }
+      // strictTriggerValidation returns an object, not a single string.
+      // Check for an object and get the `value` from it.
+      if (typeof res.body === "object") {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        res.body = (res.body as any).value;
+      }
       utils.logSuccess(`For database instance ${options.instance}\n\t ${path} = ${res.body}`);
     }
   );


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`database:settings:get` was returning an object instead of a string, so I've added a check to parse the returned object when necessary.

`database:settings:set` was failing when `false` was provided as the json PUT body because of a falsey check.

### Scenarios Tested

all the combos of `database:settings:get` and `:set`