### PR TITLE
remove request module from database helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where `database:get` would not completely finish writing to the output file.

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -110,6 +110,6 @@ describe("database:set|get|remove", () => {
     await client.database.remove(path, Object.assign({ confirm: true }, opts));
 
     await client.database.get(path, Object.assign({ output: file.name }, opts));
-    expect(JSON.parse(readFileSync(file.name, 'utf-8'))).to.equal(null);
+    expect(JSON.parse(readFileSync(file.name, "utf-8"))).to.equal(null);
   }).timeout(10 * 1e3);
 });

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -110,6 +110,6 @@ describe("database:set|get|remove", () => {
     await client.database.remove(path, Object.assign({ confirm: true }, opts));
 
     await client.database.get(path, Object.assign({ output: file.name }, opts));
-    expect(JSON.parse(readFileSync(file.name).toString())).to.equal(null);
+    expect(JSON.parse(readFileSync(file.name, 'utf-8'))).to.equal(null);
   }).timeout(10 * 1e3);
 });

--- a/scripts/client-integration-tests/tests.ts
+++ b/scripts/client-integration-tests/tests.ts
@@ -1,8 +1,12 @@
 import { expect } from "chai";
 import { join } from "path";
-import { writeFileSync, unlinkSync } from "fs";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import * as uuid from "uuid";
+import * as tmp from "tmp";
 
 import firebase = require("../../src");
+
+tmp.setGracefulCleanup();
 
 // Typescript doesn't like calling functions on `firebase`.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -84,4 +88,28 @@ describe("apps:sdkconfig", () => {
     expect(config.sdkConfig).to.exist;
     expect(config.sdkConfig.appId).to.equal(appID);
   });
+});
+
+describe("database:set|get|remove", () => {
+  it("should be able to interact with the database", async () => {
+    const opts = { project: process.env.FBTOOLS_TARGET_PROJECT };
+    const path = `/${uuid()}`;
+    const data = { foo: "bar" };
+
+    await client.database.set(
+      path,
+      Object.assign({ data: JSON.stringify(data), confirm: true }, opts)
+    );
+
+    // Have to read to a file in order to get data.
+    const file = tmp.fileSync();
+
+    await client.database.get(path, Object.assign({ output: file.name }, opts));
+    expect(JSON.parse(readFileSync(file.name).toString())).to.deep.equal(data);
+
+    await client.database.remove(path, Object.assign({ confirm: true }, opts));
+
+    await client.database.get(path, Object.assign({ output: file.name }, opts));
+    expect(JSON.parse(readFileSync(file.name).toString())).to.equal(null);
+  }).timeout(10 * 1e3);
 });

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -143,6 +143,7 @@ export default new Command("database:get <path>")
           outStream.close();
         } else {
           logger.debug("[database:get] Could not write line break to outStream");
+          resolve();
         }
       });
     });

--- a/src/database/listRemote.ts
+++ b/src/database/listRemote.ts
@@ -1,10 +1,7 @@
-import * as request from "request";
-import { Response } from "request";
-import * as responseToError from "../responseToError";
-import * as utils from "../utils";
-import { FirebaseError } from "../error";
+import { Client } from "../apiv2";
+import { URL } from "url";
 import * as logger from "../logger";
-import * as api from "../api";
+import * as utils from "../utils";
 
 export interface ListRemote {
   /**
@@ -24,7 +21,12 @@ export interface ListRemote {
 }
 
 export class RTDBListRemote implements ListRemote {
-  constructor(private instance: string, private host: string) {}
+  private apiClient: Client;
+
+  constructor(private instance: string, private host: string) {
+    const url = new URL(`${utils.addSubdomain(this.host, this.instance)}`);
+    this.apiClient = new Client({ urlPrefix: url.origin, auth: true });
+  }
 
   async listPath(
     path: string,
@@ -32,7 +34,7 @@ export class RTDBListRemote implements ListRemote {
     startAfter?: string,
     timeout?: number
   ): Promise<string[]> {
-    const url = `${utils.addSubdomain(this.host, this.instance)}${path}.json`;
+    const url = new URL(`${utils.addSubdomain(this.host, this.instance)}${path}.json`);
 
     const params: any = {
       shallow: true,
@@ -46,37 +48,8 @@ export class RTDBListRemote implements ListRemote {
     }
 
     const t0 = Date.now();
-    const reqOptionsWithToken = await api.addRequestHeaders({ url });
-    reqOptionsWithToken.qs = params;
-    const paths = await new Promise<string[]>((resolve, reject) => {
-      request.get(reqOptionsWithToken, (err: Error, res: Response, body: any) => {
-        if (err) {
-          return reject(
-            new FirebaseError("Unexpected error while listing subtrees", {
-              exit: 2,
-              original: err,
-            })
-          );
-        } else if (res.statusCode >= 400) {
-          return reject(responseToError(res, body));
-        }
-        let data;
-        try {
-          data = JSON.parse(body);
-        } catch (e) {
-          return reject(
-            new FirebaseError("Malformed JSON response in shallow get ", {
-              exit: 2,
-              original: e,
-            })
-          );
-        }
-        if (data) {
-          return resolve(Object.keys(data));
-        }
-        return resolve([]);
-      });
-    });
+    const res = await this.apiClient.get<{ [key: string]: unknown }>(url.pathname, { queryParams: params });
+    const paths = Object.keys(res.body);
     const dt = Date.now() - t0;
     logger.debug(`[database] sucessfully fetched ${paths.length} path at ${path} ${dt}`);
     return paths;

--- a/src/database/listRemote.ts
+++ b/src/database/listRemote.ts
@@ -48,7 +48,9 @@ export class RTDBListRemote implements ListRemote {
     }
 
     const t0 = Date.now();
-    const res = await this.apiClient.get<{ [key: string]: unknown }>(url.pathname, { queryParams: params });
+    const res = await this.apiClient.get<{ [key: string]: unknown }>(url.pathname, {
+      queryParams: params,
+    });
     const paths = Object.keys(res.body);
     const dt = Date.now() - t0;
     logger.debug(`[database] sucessfully fetched ${paths.length} path at ${path} ${dt}`);

--- a/src/database/removeRemote.ts
+++ b/src/database/removeRemote.ts
@@ -47,16 +47,21 @@ export class RTDBRemoveRemote implements RemoveRemote {
     const t0 = Date.now();
     const url = new URL(utils.getDatabaseUrl(this.host, this.instance, path + ".json"));
     const queryParams = { print: "silent", writeSizeLimit: "tiny" };
-    try {
-      await this.apiClient.patch(url.pathname, body, { queryParams });
-    } catch (e) {
-      const dt = Date.now() - t0;
+    const res = await this.apiClient.request({
+      method: "PATCH",
+      path: url.pathname,
+      body,
+      queryParams,
+      responseType: "stream",
+      resolveOnHTTPError: true,
+    });
+    const dt = Date.now() - t0;
+    if (res.status >= 400) {
       logger.debug(
         `[database] Failed to remove ${note} at ${path} time: ${dt}ms, will try recursively chunked deletes.`
       );
       return false;
     }
-    const dt = Date.now() - t0;
     logger.debug(`[database] Sucessfully removed ${note} at ${path} time: ${dt}ms`);
     return true;
   }

--- a/src/test/database/listRemote.spec.ts
+++ b/src/test/database/listRemote.spec.ts
@@ -2,14 +2,14 @@ import { expect } from "chai";
 import * as nock from "nock";
 
 import * as utils from "../../utils";
-import * as api from "../../api";
+import { realtimeOrigin } from "../../api";
 import { RTDBListRemote } from "../../database/listRemote";
 const HOST = "https://firebaseio.com";
 
 describe("ListRemote", () => {
   const instance = "fake-db";
   const remote = new RTDBListRemote(instance, HOST);
-  const serverUrl = utils.addSubdomain(api.realtimeOrigin, instance);
+  const serverUrl = utils.addSubdomain(realtimeOrigin, instance);
 
   afterEach(() => {
     nock.cleanAll();


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`request` is deprecated. replacing usages of it with the new `apiv2` client.

I also found some interesting cases where `databse:get` wouldn't write to the output file correctly, so I re-vamped the logic to make sure that the command only exits when the streams fully complete.

I also added some client-integration tests for the `database:*` commands, which helped debug & fix.

### Scenarios Tested

- `database:get`
- `database:set`
- `database:remove`

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
