### PR TITLE
remove `request` from `src/hosting` files (proxy middleware)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Updates Firebase Hosting emulator's code to not use the deprecated `request` module.

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -8,7 +8,7 @@ import * as responseToError from "./responseToError";
 
 const CLI_VERSION = require("../package.json").version;
 
-type HttpMethod = "GET" | "PUT" | "POST" | "DELETE" | "PATCH";
+export type HttpMethod = "GET" | "PUT" | "POST" | "DELETE" | "PATCH";
 
 interface RequestOptions<T> extends VerbOptions<T> {
   method: HttpMethod;

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -16,6 +16,7 @@ interface RequestOptions<T> extends VerbOptions<T> {
   path: string;
   body?: T | string | NodeJS.ReadableStream;
   responseType?: "json" | "stream";
+  redirect?: "error" | "follow" | "manual";
   signal?: AbortSignal;
 }
 
@@ -248,6 +249,7 @@ export class Client {
     const fetchOptions: RequestInit = {
       headers: options.headers,
       method: options.method,
+      redirect: options.redirect,
       signal: options.signal,
     };
 

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -274,7 +274,6 @@ export class Client {
     } else if (options.responseType === "stream") {
       body = (res.body as unknown) as ResT;
     } else {
-      // This is how the linter wants the casting to T to work.
       throw new FirebaseError(`Unable to interpret response. Please set responseType.`, {
         exit: 2,
       });

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -176,7 +176,7 @@ export class Client {
       reqOptions = await this.addAuthHeader(reqOptions);
     }
     try {
-      return this.doRequest<ReqT, ResT>(reqOptions);
+      return await this.doRequest<ReqT, ResT>(reqOptions);
     } catch (err) {
       if (err instanceof FirebaseError) {
         throw err;
@@ -275,7 +275,9 @@ export class Client {
       body = (res.body as unknown) as ResT;
     } else {
       // This is how the linter wants the casting to T to work.
-      body = ((await res.text()) as unknown) as ResT;
+      throw new FirebaseError(`Unable to interpret response. Please set responseType.`, {
+        exit: 2,
+      });
     }
 
     this.logResponse(res, body, options);

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -78,6 +78,7 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
         },
         resolveOnHTTPError: true,
         responseType: "stream",
+        redirect: "manual",
         body: passThrough,
         signal: controller.signal,
       });

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -1,12 +1,14 @@
 import { capitalize, includes } from "lodash";
+import { IncomingMessage, ServerResponse } from "http";
+import { PassThrough } from "stream";
 import { Request, RequestHandler, Response } from "express";
 import { URL } from "url";
 import AbortController from "abort-controller";
-import { ServerResponse } from "http";
 
 import { Client, HttpMethod } from "../apiv2";
-import * as logger from "../logger";
 import { FirebaseError } from "../error";
+import * as logger from "../logger";
+import { FetchError } from "node-fetch";
 
 const REQUIRED_VARY_VALUES = ["Accept-Encoding", "Authorization", "Cookie"];
 
@@ -39,7 +41,7 @@ function makeVary(vary: string | null = ""): string {
  * the Firebase Hosting origin.
  */
 export function proxyRequestHandler(url: string, rewriteIdentifier: string): RequestHandler {
-  return (req: Request, res: ServerResponse, next: () => void): any => {
+  return async (req: IncomingMessage, res: ServerResponse, next: () => void): Promise<void> => {
     logger.info(`[hosting] Rewriting ${req.url} to ${url} for ${rewriteIdentifier}`);
     // Extract the __session cookie from headers to forward it to the
     // functions cookie is not a string[].
@@ -48,69 +50,84 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
       return c.trim().startsWith("__session=");
     });
 
+    // req.url is just the full path (e.g. /foo?key=value; no origin).
     const u = new URL(url + req.url);
     const c = new Client({ urlPrefix: u.origin, auth: false });
     const controller = new AbortController();
-    const timer = setTimeout(controller.abort.bind(controller), 1000);
+    const timer: NodeJS.Timeout = setTimeout(() => controller.abort(), 60000);
 
-    c.request<unknown, NodeJS.ReadableStream>({
-      method: req.method as HttpMethod,
-      path: u.pathname,
-      queryParams: req.query as { [key: string]: string },
-      headers: {
-        "X-Forwarded-Host": req.headers.host || "",
-        "X-Original-Url": req.url,
-        Pragma: "no-cache",
-        "Cache-Control": "no-cache, no-store",
-        // forward the parsed __session cookie if any
-        Cookie: sessionCookie || "",
-      },
-      resolveOnHTTPError: true,
-      responseType: "stream",
-      body: ["GET", "HEAD"].includes(req.method) ? undefined : req,
-      signal: controller.signal,
-    })
-      .then((proxyRes) => {
-        clearTimeout(timer);
-        if (proxyRes.status === 404) {
-          // x-cascade is not a string[].
-          const cascade = proxyRes.response.headers.get("x-cascade");
-          if (cascade && cascade.toUpperCase() === "PASS") {
-            return next();
-          }
-        }
+    let passThrough: PassThrough | undefined;
+    if (req.method && !["GET", "HEAD"].includes(req.method)) {
+      passThrough = new PassThrough();
+      req.pipe(passThrough);
+    }
 
-        // default to private cache
-        if (!proxyRes.response.headers.get("cache-control")) {
-          proxyRes.response.headers.set("cache-control", "private");
-        }
-
-        // don't allow cookies to be set on non-private cached responses
-        const cc = proxyRes.response.headers.get("cache-control");
-        if (cc && !cc.includes("private")) {
-          proxyRes.response.headers.delete("set-cookie");
-        }
-
-        proxyRes.response.headers.set("vary", makeVary(proxyRes.response.headers.get("vary")));
-
-        proxyRes.body.pipe(res);
-      })
-      .catch((err) => {
-        console.error(res instanceof ServerResponse);
-        console.error("error", err);
-        clearTimeout(timer);
-        const isAbortError =
-          err instanceof FirebaseError && err.original?.name.includes("AbortError");
-        console.error("abort", isAbortError);
-        if (isAbortError || err.code === "ETIMEDOUT" || err.code === "ESOCKETTIMEDOUT") {
-          res.statusCode = 504;
-          return res.end("Timed out waiting for function to respond.");
-        }
-
-        console.error("OTHER ERROR");
-        res.statusCode = 500;
-        res.end(`An internal error occurred while proxying for ${rewriteIdentifier}`);
+    let proxyRes;
+    try {
+      proxyRes = await c.request<unknown, NodeJS.ReadableStream>({
+        method: (req.method || "GET") as HttpMethod,
+        path: u.pathname,
+        queryParams: u.searchParams,
+        headers: {
+          "X-Forwarded-Host": req.headers.host || "",
+          "X-Original-Url": req.url || "",
+          Pragma: "no-cache",
+          "Cache-Control": "no-cache, no-store",
+          // forward the parsed __session cookie if any
+          Cookie: sessionCookie || "",
+        },
+        resolveOnHTTPError: true,
+        responseType: "stream",
+        body: passThrough,
+        signal: controller.signal,
       });
+    } catch (err) {
+      clearTimeout(timer);
+      const isAbortError =
+        err instanceof FirebaseError && err.original?.name.includes("AbortError");
+      const isTimeoutError =
+        err instanceof FirebaseError &&
+        err.original instanceof FetchError &&
+        err.original.code === "ETIMEDOUT";
+      const isSocketTimeoutError =
+        err instanceof FirebaseError &&
+        err.original instanceof FetchError &&
+        err.original.code === "ESOCKETTIMEDOUT";
+      if (isAbortError || isTimeoutError || isSocketTimeoutError) {
+        res.statusCode = 504;
+        return res.end("Timed out waiting for function to respond.\n");
+      }
+      res.statusCode = 500;
+      return res.end(`An internal error occurred while proxying for ${rewriteIdentifier}\n`);
+    }
+
+    clearTimeout(timer);
+    if (proxyRes.status === 404) {
+      // x-cascade is not a string[].
+      const cascade = proxyRes.response.headers.get("x-cascade");
+      if (cascade && cascade.toUpperCase() === "PASS") {
+        return next();
+      }
+    }
+
+    // default to private cache
+    if (!proxyRes.response.headers.get("cache-control")) {
+      proxyRes.response.headers.set("cache-control", "private");
+    }
+
+    // don't allow cookies to be set on non-private cached responses
+    const cc = proxyRes.response.headers.get("cache-control");
+    if (cc && !cc.includes("private")) {
+      proxyRes.response.headers.delete("set-cookie");
+    }
+
+    proxyRes.response.headers.set("vary", makeVary(proxyRes.response.headers.get("vary")));
+
+    for (const [key, value] of proxyRes.response.headers) {
+      res.setHeader(key, value);
+    }
+    res.statusCode = proxyRes.status;
+    proxyRes.response.body.pipe(res);
   };
 }
 

--- a/src/test/hosting/functionsProxy.spec.ts
+++ b/src/test/hosting/functionsProxy.spec.ts
@@ -69,6 +69,26 @@ describe("functionsProxy", () => {
       });
   });
 
+  it("should return 3xx responses directly", async () => {
+    nock("http://localhost:7778")
+      .get("/project-foo/us-central1/bar/")
+      .reply(301, "redirected", { Location: "https://example.com" });
+
+    const options = cloneDeep(fakeOptions);
+    options.targets = ["functions"];
+
+    const mwGenerator = functionsProxy(options);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/")
+      .expect(301, "redirected")
+      .then(() => {
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+
   it("should pass through normal 404 errors", async () => {
     nock("https://us-central1-project-foo.cloudfunctions.net")
       .get("/bar/404.html")


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Replaces usage of the `request` library in the `hosting` directory with our new `apiv2`. `apiv2` needed to be extended to support query parameters and not follow redirects - tests have been added for that.

### Scenarios Tested

Tested against the emulator and a real function. Tested with the function taking too long and the abort logic taking effect. Tested both GET and POST requests.