### PR TITLE
rewrite database commands in typescript

### DIFF
--- a/src/commands/database-profile.ts
+++ b/src/commands/database-profile.ts
@@ -1,17 +1,15 @@
-"use strict";
+import * as _ from "lodash";
 
-var _ = require("lodash");
+import { Command } from "../command";
+import * as requireInstance from "../requireInstance";
+import { populateInstanceDetails } from "../management/database";
+import { requirePermissions } from "../requirePermissions";
+import * as utils from "../utils";
+import { profiler } from "../profiler";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 
-var { Command } = require("../command");
-var requireInstance = require("../requireInstance");
-var { populateInstanceDetails } = require("../management/database");
-var { requirePermissions } = require("../requirePermissions");
-var utils = require("../utils");
-var { profiler } = require("../profiler");
-var { Emulators } = require("../emulator/types");
-var { warnEmulatorNotSupported } = require("../emulator/commandUtils");
-
-var description = "profile the Realtime Database and generate a usage report";
+const description = "profile the Realtime Database and generate a usage report";
 
 module.exports = new Command("database:profile")
   .description(description)
@@ -35,7 +33,7 @@ module.exports = new Command("database:profile")
   .before(requireInstance)
   .before(populateInstanceDetails)
   .before(warnEmulatorNotSupported, Emulators.DATABASE)
-  .action(function(options) {
+  .action((options) => {
     // Validate options
     if (options.raw && options.input) {
       return utils.reject("Cannot specify both an input file and raw format", {

--- a/src/commands/database-remove.ts
+++ b/src/commands/database-remove.ts
@@ -1,17 +1,15 @@
-"use strict";
-
-var { Command } = require("../command");
-var requireInstance = require("../requireInstance");
-var { requirePermissions } = require("../requirePermissions");
-var DatabaseRemove = require("../database/remove").default;
-var { Emulators } = require("../emulator/types");
-var { warnEmulatorNotSupported } = require("../emulator/commandUtils");
-var { populateInstanceDetails } = require("../management/database");
-var { realtimeOriginOrEmulatorOrCustomUrl } = require("../database/api");
-var utils = require("../utils");
-var { prompt } = require("../prompt");
-var clc = require("cli-color");
-var _ = require("lodash");
+import { Command } from "../command";
+import * as requireInstance from "../requireInstance";
+import { requirePermissions } from "../requirePermissions";
+import DatabaseRemove from "../database/remove";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
+import { populateInstanceDetails } from "../management/database";
+import { realtimeOriginOrEmulatorOrCustomUrl } from "../database/api";
+import * as utils from "../utils";
+import { prompt } from "../prompt";
+import * as clc from "cli-color";
+import * as _ from "lodash";
 
 module.exports = new Command("database:remove <path>")
   .description("remove data from your Firebase at the specified path")
@@ -24,7 +22,7 @@ module.exports = new Command("database:remove <path>")
   .before(requireInstance)
   .before(populateInstanceDetails)
   .before(warnEmulatorNotSupported, Emulators.DATABASE)
-  .action(function(path, options) {
+  .action((path, options) => {
     if (!_.startsWith(path, "/")) {
       return utils.reject("Path must begin with /", { exit: 1 });
     }
@@ -37,13 +35,13 @@ module.exports = new Command("database:remove <path>")
         default: false,
         message: "You are about to remove all data at " + clc.cyan(databaseUrl) + ". Are you sure?",
       },
-    ]).then(function() {
+    ]).then(() => {
       if (!options.confirm) {
         return utils.reject("Command aborted.", { exit: 1 });
       }
 
-      var removeOps = new DatabaseRemove(options.instance, path, origin);
-      return removeOps.execute().then(function() {
+      const removeOps = new DatabaseRemove(options.instance, path, origin);
+      return removeOps.execute().then(() => {
         utils.logSuccess("Data removed successfully");
       });
     });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Rewriting the rest of the `database-*.js` command files into typescript.

(`push` and `set` will have `request` removed next - but I figured I may as well convert all of them since it was easy enough!)

### Scenarios Tested

- `database:profile` while doing the following
- `database:push` twice
- `database:set` overwriting the `push`'d stuff
- `database:remove` cleaning things up!