### PR TITLE
remove request module from database commands

### DIFF
--- a/src/commands/database-set.ts
+++ b/src/commands/database-set.ts
@@ -1,20 +1,20 @@
-import { Command } from "../command";
-import * as requireInstance from "../requireInstance";
-import { requirePermissions } from "../requirePermissions";
-import * as request from "request";
-import * as api from "../api";
-import * as responseToError from "../responseToError";
-import { FirebaseError } from "../error";
-import { Emulators } from "../emulator/types";
-import { printNoticeIfEmulated } from "../emulator/commandUtils";
-import { populateInstanceDetails } from "../management/database";
-import * as utils from "../utils";
-import { realtimeOriginOrEmulatorOrCustomUrl } from "../database/api";
-import * as clc from "cli-color";
-import * as logger from "../logger";
-import * as fs from "fs";
-import { prompt } from "../prompt";
 import * as _ from "lodash";
+import * as clc from "cli-color";
+import * as fs from "fs";
+
+import { Client } from "../apiv2";
+import { Command } from "../command";
+import { Emulators } from "../emulator/types";
+import { FirebaseError } from "../error";
+import { populateInstanceDetails } from "../management/database";
+import { printNoticeIfEmulated } from "../emulator/commandUtils";
+import { promptOnce } from "../prompt";
+import { realtimeOriginOrEmulatorOrCustomUrl } from "../database/api";
+import { requirePermissions } from "../requirePermissions";
+import { URL } from "url";
+import * as logger from "../logger";
+import * as requireInstance from "../requireInstance";
+import * as utils from "../utils";
 
 export default new Command("database:set <path> [infile]")
   .description("store JSON data at the specified path via STDIN, arg, or file")
@@ -28,66 +28,49 @@ export default new Command("database:set <path> [infile]")
   .before(requireInstance)
   .before(populateInstanceDetails)
   .before(printNoticeIfEmulated, Emulators.DATABASE)
-  .action((path, infile, options) => {
+  .action(async (path, infile, options) => {
     if (!_.startsWith(path, "/")) {
-      return utils.reject("Path must begin with /", { exit: 1 });
+      throw new FirebaseError("Path must begin with /");
     }
     const origin = realtimeOriginOrEmulatorOrCustomUrl(options.instanceDetails.databaseUrl);
     const dbPath = utils.getDatabaseUrl(origin, options.instance, path);
-    const dbJsonPath = utils.getDatabaseUrl(origin, options.instance, path + ".json");
+    const dbJsonURL = new URL(utils.getDatabaseUrl(origin, options.instance, path + ".json"));
 
-    return prompt(options, [
-      {
+    if (!options.confirm) {
+      const confirm = await promptOnce({
         type: "confirm",
         name: "confirm",
         default: false,
         message: "You are about to overwrite all data at " + clc.cyan(dbPath) + ". Are you sure?",
-      },
-    ]).then(() => {
-      if (!options.confirm) {
-        return utils.reject("Command aborted.", { exit: 1 });
-      }
-
-      const inStream =
-        utils.stringToStream(options.data) ||
-        (infile ? fs.createReadStream(infile) : process.stdin);
-
-      if (!infile && !options.data) {
-        utils.explainStdin();
-      }
-
-      const reqOptions = {
-        url: dbJsonPath,
-        json: true,
-      };
-
-      return api.addRequestHeaders(reqOptions).then((reqOptionsWithToken) => {
-        return new Promise((resolve, reject) => {
-          inStream.pipe(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            request.put(reqOptionsWithToken, (err: Error, res: any, body: any) => {
-              logger.info();
-              if (err) {
-                logger.debug(err);
-                return reject(
-                  new FirebaseError("Unexpected error while setting data", {
-                    exit: 2,
-                  })
-                );
-              } else if (res.statusCode >= 400) {
-                return reject(responseToError(res, body));
-              }
-
-              utils.logSuccess("Data persisted successfully");
-              logger.info();
-              logger.info(
-                clc.bold("View data at:"),
-                utils.getDatabaseViewDataUrl(origin, options.project, options.instance, path)
-              );
-              return resolve();
-            })
-          );
-        });
       });
-    });
+      if (!confirm) {
+        throw new FirebaseError("Command aborted.");
+      }
+    }
+
+    const inStream =
+      utils.stringToStream(options.data) || (infile ? fs.createReadStream(infile) : process.stdin);
+
+    if (!infile && !options.data) {
+      utils.explainStdin();
+    }
+
+    const c = new Client({ urlPrefix: dbJsonURL.origin, auth: true });
+    try {
+      await c.request({
+        method: "PUT",
+        path: dbJsonURL.pathname,
+        body: inStream,
+      });
+    } catch (err) {
+      logger.debug(err);
+      throw new FirebaseError(`Unexpected error while setting data: ${err}`, { exit: 2 });
+    }
+
+    utils.logSuccess("Data persisted successfully");
+    logger.info();
+    logger.info(
+      clc.bold("View data at:"),
+      utils.getDatabaseViewDataUrl(origin, options.project, options.instance, path)
+    );
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`request` is deprecated. Long live `apiv2`.

### Scenarios Tested

- `database:push` with `--data` and with a file
- `database:set` success, and not confirming (which errored)