### PR TITLE
Remove any inspect options when forking process to parse function triggers

### DIFF
--- a/src/parseTriggers.js
+++ b/src/parseTriggers.js
@@ -8,6 +8,16 @@ var _ = require("lodash");
 
 var TRIGGER_PARSER = path.resolve(__dirname, "./triggerParser.js");
 
+/**
+ * Removes any inspect options (`inspect` or `inspect-brk`) from options so the forked process is able to run (otherwise
+ * it'll inherit process values and will use the same port).
+ * @param {string[]} options From either `process.execArgv` or `NODE_OPTIONS` envar (which is a space separated string)
+ * @return {string[]} `options` without any `inspect` or `inspect-brk` values
+ */
+function removeInspectOptions(options) {
+  return options.filter((opt) => !opt.startsWith("--inspect"));
+}
+
 module.exports = function(projectId, sourceDir, configValues, firebaseConfig) {
   return new Promise(function(resolve, reject) {
     var env = _.cloneDeep(process.env);
@@ -28,7 +38,13 @@ module.exports = function(projectId, sourceDir, configValues, firebaseConfig) {
       // is loaded, which would normally set FIREBASE_CONFIG.
       env.FIREBASE_CONFIG = firebaseConfig;
     }
-    var parser = fork(TRIGGER_PARSER, [sourceDir], { silent: true, env: env });
+
+    var execArgv = removeInspectOptions(process.execArgv);
+    if (env.NODE_OPTIONS) {
+      env.NODE_OPTIONS = removeInspectOptions(env.NODE_OPTIONS.split(" ")).join(" ");
+    }
+
+    var parser = fork(TRIGGER_PARSER, [sourceDir], { silent: true, env: env, execArgv: execArgv });
 
     parser.on("message", function(message) {
       if (message.triggers) {


### PR DESCRIPTION
As per comments - fixes #2865

Also applied to [`NODE_OPTIONS`](https://nodejs.org/api/cli.html#cli_node_options_options) as that is a "space-separated list of command-line options".