### PR TITLE
Change ESLint no-invalid-this to error.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
         "@typescript-eslint/no-inferrable-types": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/no-misused-promises": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/no-unnecessary-type-assertion": "warn", // TODO(bkendall): remove, allow to error.
-        "@typescript-eslint/no-use-before-define": ["warn", { "functions": false, "typedefs": false }], // TODO(bkendall): change to error.
+        "@typescript-eslint/no-use-before-define": ["warn", { functions: false, typedefs: false }], // TODO(bkendall): change to error.
         "@typescript-eslint/no-var-requires": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/prefer-includes": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/prefer-regexp-exec": "warn", // TODO(bkendall): remove, allow to error.
@@ -48,6 +48,11 @@ module.exports = {
         "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
         "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
         "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.
+
+        // Use the TS version of the rule which allows `function foo(this) ...`.
+        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-invalid-this.md
+        "no-invalid-this": "off",
+        "@typescript-eslint/no-invalid-this": ["error"],
       },
     },
     {
@@ -64,7 +69,6 @@ module.exports = {
         "@typescript-eslint/prefer-regexp-exec": "off",
         "@typescript-eslint/unbound-method": "off",
 
-        "no-invalid-this": "warn", // TODO(bkendall): remove, allow to error.
         "no-var": "off", // TODO(bkendall): remove, allow to error.
         "prefer-arrow-callback": "off", // TODO(bkendall): remove, allow to error.
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,8 @@ module.exports = {
       rules: {
         "jsdoc/require-param-type": "off",
         "jsdoc/require-returns-type": "off",
+        "no-invalid-this": "off", // Turned off in favor of @typescript-eslint/no-invalid-this.
+        "@typescript-eslint/no-invalid-this": ["error"],
 
         "@typescript-eslint/camelcase": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/explicit-function-return-type": ["warn", { allowExpressions: true }], // TODO(bkendall): SET to error.
@@ -48,11 +50,6 @@ module.exports = {
         "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
         "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
         "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.
-
-        // Use the TS version of the rule which allows `function foo(this) ...`.
-        // https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/no-invalid-this.md
-        "no-invalid-this": "off",
-        "@typescript-eslint/no-invalid-this": ["error"],
       },
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2547,27 +2547,35 @@
       }
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.0.tgz",
-      "integrity": "sha512-QgO/qmNye+rKsU7dan6pkBTSfpbyrHJidsw9bR3gZCrQNTB9eWQ5+UDkrrev/fu9xg6Qh7ebbx03IVuGnGRmEw==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.34.0.tgz",
+      "integrity": "sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.3.0",
-        "eslint-utils": "^1.4.2",
+        "@typescript-eslint/experimental-utils": "2.34.0",
         "functional-red-black-tree": "^1.0.1",
-        "regexpp": "^2.0.1",
+        "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
+      },
+      "dependencies": {
+        "regexpp": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+          "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+          "dev": true
+        }
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.0.tgz",
-      "integrity": "sha512-ry+fgd0Hh33LyzS30bIhX/a1HJpvtnecjQjWxxsZTavrRa1ymdmX7tz+7lPrPAxB018jnNzwNtog6s3OhxPTAg==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
+      "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.3.0",
-        "eslint-scope": "^5.0.0"
+        "@typescript-eslint/typescript-estree": "2.34.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
@@ -2656,21 +2664,53 @@
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.0.tgz",
-      "integrity": "sha512-WBxfwsTeCOsmQ7cLjow7lgysviBKUW34npShu7dxJYUQCbSG5nfZWZTgmQPKEc+3flpbSM7tjXjQOgETYp+njQ==",
+      "version": "2.34.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
+      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.4",
+        "debug": "^4.1.1",
+        "eslint-visitor-keys": "^1.1.0",
+        "glob": "^7.1.6",
         "is-glob": "^4.0.1",
-        "lodash.unescape": "4.0.1",
-        "semver": "^6.3.0"
+        "lodash": "^4.17.15",
+        "semver": "^7.3.2",
+        "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
       }
@@ -4831,12 +4871,12 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
-      "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
-        "eslint-visitor-keys": "^1.0.0"
+        "eslint-visitor-keys": "^1.1.0"
       }
     },
     "eslint-visitor-keys": {
@@ -7471,12 +7511,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
       "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
-    },
-    "lodash.unescape": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
-      "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
-      "dev": true
     },
     "lodash.union": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "@types/uuid": "^3.4.4",
     "@types/winston": "^2.4.4",
     "@types/ws": "^7.2.3",
-    "@typescript-eslint/eslint-plugin": "^2.3.0",
+    "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/scripts/extensions-emulator-tests/tests.ts
+++ b/scripts/extensions-emulator-tests/tests.ts
@@ -28,8 +28,8 @@ function readConfig(): FrameworkOptions {
 describe("extension emulator", () => {
   let test: TriggerEndToEndTest;
 
-  before(async function() {
-    this.timeout(TEST_SETUP_TIMEOUT); // eslint-disable-line no-invalid-this
+  before(async function(this) {
+    this.timeout(TEST_SETUP_TIMEOUT);
 
     expect(FIREBASE_PROJECT).to.exist.and.not.be.empty;
 
@@ -46,13 +46,13 @@ describe("extension emulator", () => {
     ]);
   });
 
-  after(async function() {
-    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS); // eslint-disable-line no-invalid-this
+  after(async function(this) {
+    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
     await test.stopEmulators();
   });
 
-  it("should execute an HTTP function", async function() {
-    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS); // eslint-disable-line no-invalid-this
+  it("should execute an HTTP function", async function(this) {
+    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
 
     const res = await test.invokeHttpFunction(TEST_FUNCTION_NAME, FIREBASE_PROJECT_ZONE);
 

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -52,8 +52,7 @@ describe("database and firestore emulator function triggers", () => {
   let firestore: admin.firestore.Firestore | undefined;
   const firestoreUnsub: Array<() => void> = [];
 
-  before(async function() {
-    // eslint-disable-next-line no-invalid-this
+  before(async function(this) {
     this.timeout(TEST_SETUP_TIMEOUT);
 
     expect(FIREBASE_PROJECT).to.exist.and.not.be.empty;
@@ -123,8 +122,7 @@ describe("database and firestore emulator function triggers", () => {
     firestoreUnsub.push(unsub);
   });
 
-  after(async function() {
-    // eslint-disable-next-line no-invalid-this
+  after(async function(this) {
     this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
     database?.goOffline();
     for (const fn of firestoreUnsub) fn();
@@ -132,16 +130,14 @@ describe("database and firestore emulator function triggers", () => {
     await test.stopEmulators();
   });
 
-  it("should write to the database emulator", async function() {
-    // eslint-disable-next-line no-invalid-this
+  it("should write to the database emulator", async function(this) {
     this.timeout(EMULATOR_TEST_TIMEOUT);
 
     const response = await test.writeToRtdb();
     expect(response.status).to.equal(200);
   });
 
-  it("should write to the firestore emulator", async function() {
-    // eslint-disable-next-line no-invalid-this
+  it("should write to the firestore emulator", async function(this) {
     this.timeout(EMULATOR_TEST_TIMEOUT);
 
     const response = await test.writeToFirestore();
@@ -171,8 +167,7 @@ describe("database and firestore emulator function triggers", () => {
 describe("pubsub emulator function triggers", () => {
   let test: TriggerEndToEndTest;
 
-  before(async function() {
-    // eslint-disable-next-line no-invalid-this
+  before(async function(this) {
     this.timeout(TEST_SETUP_TIMEOUT);
 
     expect(FIREBASE_PROJECT).to.exist.and.not.be.empty;
@@ -182,14 +177,12 @@ describe("pubsub emulator function triggers", () => {
     await test.startEmulators(["--only", "functions,pubsub"]);
   });
 
-  after(async function() {
-    // eslint-disable-next-line no-invalid-this
+  after(async function(this) {
     this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
     await test.stopEmulators();
   });
 
-  it("should write to the pubsub emulator", async function() {
-    // eslint-disable-next-line no-invalid-this
+  it("should write to the pubsub emulator", async function(this) {
     this.timeout(EMULATOR_TEST_TIMEOUT);
 
     const response = await test.writeToPubsub();
@@ -201,8 +194,7 @@ describe("pubsub emulator function triggers", () => {
     expect(test.pubsubTriggerCount).to.equal(1);
   });
 
-  it("should write to the scheduled pubsub emulator", async function() {
-    // eslint-disable-next-line no-invalid-this
+  it("should write to the scheduled pubsub emulator", async function(this) {
     this.timeout(EMULATOR_TEST_TIMEOUT);
 
     const response = await test.writeToScheduledPubsub();
@@ -218,8 +210,7 @@ describe("pubsub emulator function triggers", () => {
 describe("auth emulator function triggers", () => {
   let test: TriggerEndToEndTest;
 
-  before(async function() {
-    // eslint-disable-next-line no-invalid-this
+  before(async function(this) {
     this.timeout(TEST_SETUP_TIMEOUT);
 
     expect(FIREBASE_PROJECT).to.exist.and.not.be.empty;
@@ -229,19 +220,16 @@ describe("auth emulator function triggers", () => {
     await test.startEmulators(["--only", "functions,auth"]);
   });
 
-  after(async function() {
-    // eslint-disable-next-line no-invalid-this
+  after(async function(this) {
     this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
     await test.stopEmulators();
   });
 
-  it("should write to the auth emulator", async function() {
-    // eslint-disable-next-line no-invalid-this
+  it("should write to the auth emulator", async function(this) {
     this.timeout(EMULATOR_TEST_TIMEOUT);
 
     // This test only works on Node 10+
     if (NODE_VERSION < 10) {
-      // eslint-disable-next-line no-invalid-this
       this.skip();
     }
 
@@ -250,10 +238,9 @@ describe("auth emulator function triggers", () => {
     await new Promise((resolve) => setTimeout(resolve, EMULATORS_WRITE_DELAY_MS));
   });
 
-  it("should have have triggered cloud functions", function() {
+  it("should have have triggered cloud functions", function(this) {
     // This test only works on Node 10+
     if (NODE_VERSION < 10) {
-      // eslint-disable-next-line no-invalid-this
       this.skip();
     }
 
@@ -262,8 +249,7 @@ describe("auth emulator function triggers", () => {
 });
 
 describe("import/export end to end", () => {
-  it("should be able to import/export firestore data", async function() {
-    // eslint-disable-next-line no-invalid-this
+  it("should be able to import/export firestore data", async function(this) {
     this.timeout(2 * TEST_SETUP_TIMEOUT);
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
@@ -314,8 +300,7 @@ describe("import/export end to end", () => {
     expect(true).to.be.true;
   });
 
-  it("should be able to import/export rtdb data", async function() {
-    // eslint-disable-next-line no-invalid-this
+  it("should be able to import/export rtdb data", async function(this) {
     this.timeout(2 * TEST_SETUP_TIMEOUT);
     await new Promise((resolve) => setTimeout(resolve, 2000));
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -34,7 +34,9 @@ export class Command {
   private descriptionText = "";
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private options: any[][] = [];
-  private actionFn: ActionFunction = (): void => {};
+  private actionFn: ActionFunction = (): void => {
+    // noop by default, unless overwritten by `.action(fn)`.
+  };
   private befores: BeforeFunction[] = [];
   private helpText = "";
   private client?: CLIClient;

--- a/src/commands/help.js
+++ b/src/commands/help.js
@@ -9,7 +9,8 @@ var utils = require("../utils");
 module.exports = new Command("help [command]")
   .description("display help information")
   .action(function(commandName) {
-    var cmd = this.client.getCommand(commandName);
+    var client = this.client; // eslint-disable-line no-invalid-this
+    var cmd = client.getCommand(commandName);
     if (cmd) {
       cmd.outputHelp();
     } else if (commandName) {
@@ -17,9 +18,9 @@ module.exports = new Command("help [command]")
       utils.logWarning(
         clc.bold(commandName) + " is not a valid command. See below for valid commands"
       );
-      this.client.cli.outputHelp();
+      client.cli.outputHelp();
     } else {
-      this.client.cli.outputHelp();
+      client.cli.outputHelp();
       logger.info();
       logger.info(
         "  To get help with a specific command, type",

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -207,10 +207,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     // A trigger named "foo" needs to respond at "foo" as well as "foo/*" but not "fooBar".
     const httpsFunctionRoutes = [httpsFunctionRoute, `${httpsFunctionRoute}/*`];
 
-    const backgroundHandler: express.RequestHandler = async (
-      req: express.Request,
-      res: express.Response
-    ) => {
+    const backgroundHandler: express.RequestHandler = (req, res) => {
       const triggerId = req.params.trigger_name;
       const projectId = req.params.project_id;
       const reqBody = (req as RequestWithRawBody).rawBody;
@@ -240,19 +237,13 @@ export class FunctionsEmulator implements EmulatorInstance {
       });
     };
 
-    const httpsHandler: express.RequestHandler = async (
-      req: express.Request,
-      res: express.Response
-    ) => {
+    const httpsHandler: express.RequestHandler = (req, res) => {
       this.workQueue.submit(() => {
         return this.handleHttpsTrigger(req, res);
       });
     };
 
-    const multicastHandler: express.RequestHandler = async (
-      req: express.Request,
-      res: express.Response
-    ) => {
+    const multicastHandler: express.RequestHandler = (req, res) => {
       const reqBody = (req as RequestWithRawBody).rawBody;
       const proto = JSON.parse(reqBody.toString());
       const triggers = this.multicastTriggers[`${this.args.projectId}:${proto.eventType}`] || [];

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1123,7 +1123,7 @@ async function handleMessage(message: string) {
   }
 }
 
-async function main(): Promise<void> {
+function main(): void {
   // Since the functions run as attached processes they naturally inherit SIGINT
   // sent to the functions emulator. We want them to ignore the first signal
   // to allow for a clean shutdown.

--- a/src/emulator/workQueue.ts
+++ b/src/emulator/workQueue.ts
@@ -24,9 +24,13 @@ export class WorkQueue {
 
   private queue: Array<Work> = [];
   private workRunningCount: number = 0;
-  private notifyQueue: () => void = () => {};
-  private notifyWorkFinish: () => void = () => {};
-  private stopped: boolean = true;
+  private notifyQueue: () => void = () => {
+    // Noop by default, will be set by .start() when queue is empty.
+  };
+  private notifyWorkFinish: () => void = () => {
+    // Noop by default, will be set by .start() when there are too many jobs.
+  };
+  private stopped = true;
 
   constructor(
     private mode: FunctionsExecutionMode = FunctionsExecutionMode.AUTO,

--- a/src/firestore/delete.js
+++ b/src/firestore/delete.js
@@ -396,7 +396,7 @@ FirestoreDelete.prototype._deletePath = function() {
       }
 
       // For a shallow delete, this error is fatal.
-      return utils.reject("Unable to delete " + clc.cyan(this.path));
+      return utils.reject("Unable to delete " + clc.cyan(self.path));
     });
   } else {
     initialDelete = Promise.resolve();

--- a/src/test/command.spec.ts
+++ b/src/test/command.spec.ts
@@ -21,7 +21,9 @@ describe("Command", () => {
         ["foo", "bar"]
       );
       command.help("here's how!");
-      command.action(() => {});
+      command.action(() => {
+        // do nothing
+      });
     }).not.to.throw;
   });
 

--- a/src/test/emulators/auth/setup.ts
+++ b/src/test/emulators/auth/setup.ts
@@ -16,11 +16,9 @@ export function describeAuthEmulator(
   title: string,
   fn: (this: Suite, utils: AuthTestUtils) => void
 ): Suite {
-  // Avoid arrow functions in order to pass Mocha `this` properly in:
-  return describe(`Auth Emulator: ${title}`, function() {
+  return describe(`Auth Emulator: ${title}`, function(this) {
     let authApp: Express.Application;
-    beforeEach("setup or reuse auth server", async function() {
-      // eslint-disable-next-line no-invalid-this
+    beforeEach("setup or reuse auth server", async function(this) {
       this.timeout(10000);
       authApp = await createOrReuseApp();
     });
@@ -30,7 +28,6 @@ export function describeAuthEmulator(
       clock = useFakeTimers();
     });
     afterEach(() => clock.restore());
-    // eslint-disable-next-line no-invalid-this
     return fn.call(this, { authApi: () => supertest(authApp), getClock: () => clock });
   });
 }

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -12,6 +12,10 @@ import { InvokeRuntimeOpts, FunctionsEmulator } from "../../emulator/functionsEm
 import { RuntimeWorker } from "../../emulator/functionsRuntimeWorker";
 import { streamToString } from "../../utils";
 
+const DO_NOTHING = () => {
+  // do nothing.
+};
+
 const functionsEmulator = new FunctionsEmulator({
   projectId: "fake-project-id",
   functionsDir: MODULE_ROOT,
@@ -156,7 +160,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(() => {}),
+              .onCreate(DO_NOTHING),
           };
         });
 
@@ -172,7 +176,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(() => {}),
+              .onCreate(DO_NOTHING),
           };
         });
 
@@ -197,7 +201,7 @@ describe("FunctionsEmulator-Runtime", () => {
           return {
             function_id: require("firebase-functions")
               .firestore.document("test/test")
-              .onCreate(() => {}),
+              .onCreate(DO_NOTHING),
           };
         });
         const logs = await countLogEntries(worker);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR changes ESLint `no-invalid-this` to error (instead of warning) and fixes the errors.

All changes are noop except one real error caught by the rule, as commented below.

### How to fix the error

If you get `no-invalid-this` error in TypeScript, first see if your use of `this` is safe. If you meant to use `this` from the enclosing scope, change the inner function to an arrow function instead. In rare occasions where you do want to use the `this` passed into the current function (e.g. mocha context), DO NOT `eslint-disable` this rule. Instead, explicitly declare that you're using `this`:

```typescript
    beforeEach("setup", async function(this) {  // <---- add this to enclosing function
      this.timeout(10000); // <---- now safe to use, no eslint errors :)
      // ...
    });
```

In this case, the library already has the correct typing on `beforeEach` callback so you don't need to declare the type of `this`. In case the library typing is funky, use explicit typing like `function(this: MyContextType)`. Obviously, `this` won't work for arrow functions and TypeScript won't let you write `(this) => foo`.

If you get `no-invalid-this` error in JavaScript (plain `.js`), first check to see if you're missing `var self = this;`. If you really meant to use `this` passed into the current function, your only real choice is `// eslint-disable-line no-invalid-this` (and friends).

### Scenarios Tested

`npm test`.

### Sample Commands

N/A
