### PR TITLE
Release Cloud Firestore Emulator v1.11.11.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 - Adds new Cloud Functions regions and new versions of `firebase-functions` and `firebase-admin` to `ext:dev:init` templates.
 - Fixes unclear error messages when trying to enable APIs that require billing on projects without a billing account.
 - Adds support for specifying the service account a Cloud Function should run as, by setting the `serviceAccount` in `functions.runWith()`.
+- Fixes Firestore Emulator listCollectionId not returning collections with nested docs.
+- Fixes Firestore Emulator listDocuments with showMissing returning 500 errors.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -40,14 +40,14 @@ const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails }
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.9.jar"),
-    version: "1.11.9",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.11.11.jar"),
+    version: "1.11.11",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.9.jar",
-      expectedSize: 64448827,
-      expectedChecksum: "0b841d928e1d0877e789010301b265a4",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.11.11.jar",
+      expectedSize: 63886307,
+      expectedChecksum: "398782f4108360434ef9e7cc86df50f6",
       namePrefix: "cloud-firestore-emulator",
     },
   },
@@ -116,7 +116,12 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
   },
   firestore: {
     binary: "java",
-    args: ["-Duser.language=en", "-jar", getExecPath(Emulators.FIRESTORE)],
+    args: [
+      "-Dgoogle.cloud_firestore.debug_log_level=FINE",
+      "-Duser.language=en",
+      "-jar",
+      getExecPath(Emulators.FIRESTORE),
+    ],
     optionalArgs: [
       "port",
       "webchannel_port",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

See changelog.

### Scenarios Tested

Manually started `firebase emulators:start` and used `curl` to verify that the listCollectionIds fix is in.

### Sample Commands

`firebase emulators:start`