### PR TITLE
Make default Firestore rules in the CLI expiring

### DIFF
--- a/src/init/features/firestore/rules.ts
+++ b/src/init/features/firestore/rules.ts
@@ -53,7 +53,7 @@ export function initRules(setup: any, config: any): Promise<any> {
       }
 
       if (!setup.projectId) {
-        return config.writeProjectFile(setup.config.firestore.rules, RULES_TEMPLATE);
+        return config.writeProjectFile(setup.config.firestore.rules, getDefaultRules());
       }
 
       return getRulesFromConsole(setup.projectId).then((contents: any) => {
@@ -62,13 +62,19 @@ export function initRules(setup: any, config: any): Promise<any> {
     });
 }
 
+function getDefaultRules(): string {
+  const date = utils.thirtyDaysFromNow();
+  const formattedForRules = `${date.getFullYear()}, ${date.getMonth() + 1}, ${date.getDate()}`;
+  return RULES_TEMPLATE.replace(/{{IN_30_DAYS}}/g, formattedForRules);
+}
+
 function getRulesFromConsole(projectId: string): Promise<any> {
   return gcp.rules
     .getLatestRulesetName(projectId, "cloud.firestore")
     .then((name) => {
       if (!name) {
         logger.debug("No rulesets found, using default.");
-        return [{ name: DEFAULT_RULES_FILE, content: RULES_TEMPLATE }];
+        return [{ name: DEFAULT_RULES_FILE, content: getDefaultRules() }];
       }
 
       logger.debug("Found ruleset: " + name);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,7 @@ import { Socket } from "net";
 const IS_WINDOWS = process.platform === "win32";
 const SUCCESS_CHAR = IS_WINDOWS ? "+" : "✔";
 const WARNING_CHAR = IS_WINDOWS ? "!" : "⚠";
+const THIRTY_DAYS_IN_MILLISECONDS = 30 * 24 * 60 * 60 * 1000;
 
 export const envOverrides: string[] = [];
 
@@ -505,4 +506,11 @@ export function isCloudEnvironment() {
  */
 export function isRunningInWSL(): boolean {
   return !!process.env.WSL_DISTRO_NAME;
+}
+
+/**
+ * Generates a date that is 30 days from Date.now()
+ */
+export function thirtyDaysFromNow(): Date {
+  return new Date(Date.now() + THIRTY_DAYS_IN_MILLISECONDS);
 }

--- a/templates/init/firestore/firestore.rules
+++ b/templates/init/firestore/firestore.rules
@@ -7,9 +7,9 @@ service cloud.firestore {
       // leaves your app open to attackers. At that time, all client
       // requests to your database will be denied.
       //
-      // Make sure to write security rules for your app before that time, or else
-      // all client requests to your database will be denied until you update
-      // your rules.
+      // Make sure to write security rules for your app before that time, or
+      // else all client requests to your database will be denied until you
+      // update your rules.
       allow read, write: if request.time < timestamp.date({{IN_30_DAYS}});
     }
   }

--- a/templates/init/firestore/firestore.rules
+++ b/templates/init/firestore/firestore.rules
@@ -1,7 +1,16 @@
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write;
+      // This rule allows anyone with your database reference to view, edit,
+      // and delete all data in your database. It is useful for getting
+      // started, but it is configured to expire after 30 days because it
+      // leaves your app open to attackers. At that time, all client
+      // requests to your database will be denied.
+      //
+      // Make sure to write security rules for your app before that time, or else
+      // all client requests to your database will be denied until you update
+      // your rules.
+      allow read, write: if request.time < timestamp.date({{IN_30_DAYS}});
     }
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
Bringing the Firestore default rules into line with the Console (rules now expire after 30 days instead of being `read, write: true`)

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Tested init flow with a new project, an existing project (so that the existing rules _don't_ get overwritten), and with no project.
