### PR TITLE
Fix header forwarding in Hosting emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where emulated functions were not receiving all expected headers.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When proxying to Run|Functions, we need to pass along any headers that were in the original request. The move from `request` to `node-fetch` dropped this because `request` allowed "piping the headers", so to speak, when it was piped through. This explicitly copies the headers over and sends them along.

Fixes #2910 

### Scenarios Tested

I have a Function that echos the headers sent to it. When I run the emulator without this fix, I don't see my custom headers in the request. With this patch, things are working as expected.