### PR TITLE
Add root: true to eslintrc

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   env: {
     browser: true,
     es6: true,


### PR DESCRIPTION
Set `root: true` in the .eslintrc template, so that ESLint doesn't try to combine the configuration in the `functions` directory with the configuration in an `.eslintrc` file in the parent app directory.