### PR TITLE
Fixes #2931 - Support multiple Set-Cookie headers

### DIFF
--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -139,7 +139,7 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
 
     proxyRes.response.headers.set("vary", makeVary(proxyRes.response.headers.get("vary")));
 
-    for (const [key, value] of proxyRes.response.headers) {
+    for (const [key, value] of Object.entries(proxyRes.response.headers.raw())) {
       res.setHeader(key, value);
     }
     res.statusCode = proxyRes.status;


### PR DESCRIPTION
apiv2.js uses node-fetch under the hood, which will concatenate duplicate headers with ', '. This is invalid for Set-Cookie headers.
The solution is to grab the raw headers (which will be an array) and call `res.setHeader()` with that value.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixing #2931. I've not run npm test yet.

### Scenarios Tested

I've tested that this solves the Set-Cookie problem locally. I haven't tested any potential edge cases (what might they be? Is there a case where the raw value is dangerous?)

### Sample Commands

No changes to commands.
