### PR TITLE
Fix #2880 - generating email link from Admin SDK fails with Auth Emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Shows missing documents in Emulator UI Firestore viewer.
 - Better supports paths with special characters in Emulator UI Firestore viewer.
+- Fixes generating email link from Admin SDK failing with Auth Emulator (#2933).


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2880.

### Scenarios Tested

See tests added.

### Sample Commands

N/A