### PR TITLE
Disable Node.js 8 deploys for Cloud Functions.

### DIFF
--- a/src/deploy/functions/checkRuntimeDependencies.ts
+++ b/src/deploy/functions/checkRuntimeDependencies.ts
@@ -1,39 +1,11 @@
-import { bold, yellow } from "cli-color";
+import { bold } from "cli-color";
 
 import * as track from "../../track";
-import * as logger from "../../logger";
 import { ensure } from "../../ensureApiEnabled";
-import { logLabeledWarning } from "../../utils";
 import { FirebaseError, isBillingError } from "../../error";
 
 const FAQ_URL = "https://firebase.google.com/support/faq#functions-runtime";
 const CLOUD_BUILD_API = "cloudbuild.googleapis.com";
-
-function node8DeprecationWarning(): void {
-  track("functions_runtime_notices", "nodejs8_deprecation_warning");
-  logger.warn();
-  logLabeledWarning(
-    "functions",
-    `${bold(
-      `${yellow(
-        "Warning:"
-      )} Node.js 8 functions are deprecated and will stop running on 2021-03-15.`
-    )} Please upgrade to Node.js 10 or greater by adding an entry like this to your package.json:
-    
-    {
-      "engines": {
-        "node": "12"
-      }
-    }
-
-The Firebase CLI will stop deploying Node.js 8 functions in new versions beginning ${bold(
-      "2020-12-15"
-    )}, and deploys from all CLI versions will halt on ${bold(
-      "2021-02-15"
-    )}. For additional information, see: ${FAQ_URL}`
-  );
-  logger.warn();
-}
 
 function nodeBillingError(projectId: string): FirebaseError {
   track("functions_runtime_notices", "nodejs10_billing_error");
@@ -69,17 +41,6 @@ function isPermissionError(e: { context?: { body?: { error?: { status?: string }
 }
 
 /**
- * Warns users about pending deprecation dates if a node 8 function was deployed.
- *
- * @param runtime The runtime as declared in package.json, e.g. `nodejs10`.
- */
-export function checkForNode8(runtime: string): void {
-  if (runtime === "nodejs8") {
-    node8DeprecationWarning();
-    return;
-  }
-}
-/**
  * Checks for various warnings and API enablements needed based on the runtime
  * of the deployed functions.
  *
@@ -87,17 +48,15 @@ export function checkForNode8(runtime: string): void {
  * @param runtime The runtime as declared in package.json, e.g. `nodejs10`.
  */
 export async function checkRuntimeDependencies(projectId: string, runtime: string): Promise<void> {
-  if (runtime !== "nodejs8") {
-    try {
-      await ensure(projectId, CLOUD_BUILD_API, "functions");
-    } catch (e) {
-      if (isBillingError(e)) {
-        throw nodeBillingError(projectId);
-      } else if (isPermissionError(e)) {
-        throw nodePermissionError(projectId);
-      }
-
-      throw e;
+  try {
+    await ensure(projectId, CLOUD_BUILD_API, "functions");
+  } catch (e) {
+    if (isBillingError(e)) {
+      throw nodeBillingError(projectId);
+    } else if (isPermissionError(e)) {
+      throw nodePermissionError(projectId);
     }
+
+    throw e;
   }
 }

--- a/src/parseRuntimeAndValidateSDK.ts
+++ b/src/parseRuntimeAndValidateSDK.ts
@@ -50,6 +50,12 @@ export const UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG = clc.bold(
     )}.`
 );
 
+export const DEPRECATED_NODE_VERSION_INFO =
+  `\n\nDeploys to runtimes below Node.js 10 are now disabled in the Firebase CLI. ` +
+  `${clc.bold(
+    `Existing Node.js 8 functions ${clc.underline("will stop executing on 2021-03-15")}`
+  )}. Update existing functions to Node.js 10 or greater as soon as possible.`;
+
 export const FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING =
   clc.bold.yellow("functions: ") +
   "You must have a " +
@@ -107,17 +113,18 @@ function getRuntimeChoiceFromPackageJson(sourceDir: string): string {
  */
 export function getRuntimeChoice(sourceDir: string, runtimeFromConfig?: string): string {
   const runtime = runtimeFromConfig || getRuntimeChoiceFromPackageJson(sourceDir);
-  const errorMessage = runtimeFromConfig
-    ? UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG
-    : UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG;
+  const errorMessage =
+    (runtimeFromConfig
+      ? UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG
+      : UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG) + DEPRECATED_NODE_VERSION_INFO;
 
   if (!runtime || !ENGINE_RUNTIMES_NAMES.includes(runtime)) {
     track("functions_runtime_notices", "package_missing_runtime");
     throw new FirebaseError(errorMessage, { exit: 1 });
   }
 
-  if (runtime === "nodejs6") {
-    track("functions_runtime_notices", "nodejs6_deploy_prohibited");
+  if (["nodejs6", "nodejs8"].includes(runtime)) {
+    track("functions_runtime_notices", `${runtime}_deploy_prohibited`);
     throw new FirebaseError(errorMessage, { exit: 1 });
   }
 

--- a/src/test/deploy/functions/checkRuntimeDependencies.spec.ts
+++ b/src/test/deploy/functions/checkRuntimeDependencies.spec.ts
@@ -71,15 +71,6 @@ describe("checkRuntimeDependencies()", () => {
     timeStub.withArgs("motd.cloudBuildErrorAfter").returns(errorAfter);
   }
 
-  describe("with nodejs8", () => {
-    it("should print warning", async () => {
-      stubTimes(Date.now() - 10000, Date.now() - 5000);
-
-      await expect(checkRuntimeDependencies("test-project", "nodejs8")).to.eventually.be.fulfilled;
-      expect(logStub?.callCount).to.eq(0);
-    });
-  });
-
   ["nodejs10", "nodejs12", "nodejs14"].forEach((runtime) => {
     describe(`with ${runtime}`, () => {
       describe("with cloudbuild service enabled", () => {

--- a/src/test/parseRuntimeAndValidateSDK.spec.ts
+++ b/src/test/parseRuntimeAndValidateSDK.spec.ts
@@ -39,10 +39,12 @@ describe("getRuntimeChoice", () => {
       }).to.throw(runtime.UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG);
     });
 
-    it("should return node 8 if runtime field is set to node 8", () => {
+    it("should error if runtime field is set to node 8", () => {
       SDKVersionStub.returns("2.0.0");
 
-      expect(runtime.getRuntimeChoice("path/to/source", "nodejs8")).to.equal("nodejs8");
+      expect(() => {
+        runtime.getRuntimeChoice("path/to/source", "nodejs8");
+      }).to.throw(runtime.UNSUPPORTED_NODE_VERSION_FIREBASE_JSON_MSG);
     });
 
     it("should return node 10 if runtime field is set to node 10", () => {
@@ -91,11 +93,13 @@ describe("getRuntimeChoice", () => {
       }).to.throw(runtime.UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG);
     });
 
-    it("should return node 8 if engines field is set to node 8", () => {
+    it("should error if engines field is set to node 8", () => {
       cjsonStub.returns({ engines: { node: "8" } });
       SDKVersionStub.returns("2.0.0");
 
-      expect(runtime.getRuntimeChoice("path/to/source", "")).to.equal("nodejs8");
+      expect(() => {
+        runtime.getRuntimeChoice("path/to/source", "");
+      }).to.throw(runtime.UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG);
     });
 
     it("should return node 10 if engines field is set to node 10", () => {


### PR DESCRIPTION
Turns warnings about Node.js 8 deploys into explicit errors.

Screenshot:

![image](https://user-images.githubusercontent.com/1022/102154553-7d81ac00-3e2e-11eb-806e-403a6be1b34c.png)
