### PR TITLE
Support emulators:export and import for auth.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Improves error handling for `firestore:delete` when deleting very large documents.
 - Support batchCreate API in Auth Emulator (#2947).
+- Support emulators:export and import for Auth Emulator (#2955).

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -512,4 +512,63 @@ describe("import/export end to end", () => {
       delete process.env.FIREBASE_AUTH_EMULATOR_HOST;
     }
   });
+
+  it("should be able to export / import auth data with no users", async function(this) {
+    this.timeout(2 * TEST_SETUP_TIMEOUT);
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+
+    // Start up emulator suite
+    const project = FIREBASE_PROJECT || "example";
+    const emulatorsCLI = new CLIProcess("1", __dirname);
+
+    await emulatorsCLI.start("emulators:start", project, ["--only", "auth"], (data: unknown) => {
+      if (typeof data != "string" && !Buffer.isBuffer(data)) {
+        throw new Error(`data is not a string or buffer (${typeof data})`);
+      }
+      return data.includes(ALL_EMULATORS_STARTED_LOG);
+    });
+
+    // Ask for export (with no users)
+    const exportCLI = new CLIProcess("2", __dirname);
+    const exportPath = fs.mkdtempSync(path.join(os.tmpdir(), "emulator-data"));
+    await exportCLI.start("emulators:export", project, [exportPath], (data: unknown) => {
+      if (typeof data != "string" && !Buffer.isBuffer(data)) {
+        throw new Error(`data is not a string or buffer (${typeof data})`);
+      }
+      return data.includes("Export complete");
+    });
+    await exportCLI.stop();
+
+    // Stop the suite
+    await emulatorsCLI.stop();
+
+    // Confirm the data is exported as expected
+    const configPath = path.join(exportPath, "auth_export", "config.json");
+    const configData = JSON.parse(fs.readFileSync(configPath).toString());
+    expect(configData).to.deep.equal({
+      signIn: {
+        allowDuplicateEmails: false,
+      },
+    });
+
+    const accountsPath = path.join(exportPath, "auth_export", "accounts.json");
+    const accountsData = JSON.parse(fs.readFileSync(accountsPath).toString());
+    expect(accountsData.users).to.have.length(0);
+
+    // Attempt to import
+    const importCLI = new CLIProcess("3", __dirname);
+    await importCLI.start(
+      "emulators:start",
+      project,
+      ["--only", "auth", "--import", exportPath],
+      (data: unknown) => {
+        if (typeof data != "string" && !Buffer.isBuffer(data)) {
+          throw new Error(`data is not a string or buffer (${typeof data})`);
+        }
+        return data.includes(ALL_EMULATORS_STARTED_LOG);
+      }
+    );
+
+    await importCLI.stop();
+  });
 });

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -450,7 +450,7 @@ describe("import/export end to end", () => {
     await emulatorsCLI.stop();
 
     // Confirm the data is exported as expected
-    const configPath = path.join(exportPath, "auth_export", `${project}.config.json`);
+    const configPath = path.join(exportPath, "auth_export", "config.json");
     const configData = JSON.parse(fs.readFileSync(configPath).toString());
     expect(configData).to.deep.equal({
       signIn: {
@@ -458,7 +458,7 @@ describe("import/export end to end", () => {
       },
     });
 
-    const accountsPath = path.join(exportPath, "auth_export", `${project}.accounts.json`);
+    const accountsPath = path.join(exportPath, "auth_export", "accounts.json");
     const accountsData = JSON.parse(fs.readFileSync(accountsPath).toString());
     expect(accountsData.users).to.have.length(1);
     expect(accountsData.users[0]).to.deep.contain({

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -55,7 +55,7 @@ export class AuthEmulator implements EmulatorInstance {
 
     // TODO: In the future when we support import on demand, clear data first.
 
-    const configPath = path.join(authExportDir, `${projectId}.config.json`);
+    const configPath = path.join(authExportDir, "config.json");
     const configStat = await stat(configPath);
     if (configStat.isFile()) {
       logger.logLabeled("BULLET", "auth", `Importing config from ${configPath}`);
@@ -75,7 +75,7 @@ export class AuthEmulator implements EmulatorInstance {
       );
     }
 
-    const accountsPath = path.join(authExportDir, `${projectId}.accounts.json`);
+    const accountsPath = path.join(authExportDir, "accounts.json");
     const accountsStat = await stat(accountsPath);
     if (accountsStat.isFile()) {
       logger.logLabeled("BULLET", "auth", `Importing accounts from ${accountsPath}`);

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -57,7 +57,7 @@ export class AuthEmulator implements EmulatorInstance {
 
     const configPath = path.join(authExportDir, "config.json");
     const configStat = await stat(configPath);
-    if (configStat.isFile()) {
+    if (configStat?.isFile()) {
       logger.logLabeled("BULLET", "auth", `Importing config from ${configPath}`);
 
       await importFromFile(
@@ -77,7 +77,7 @@ export class AuthEmulator implements EmulatorInstance {
 
     const accountsPath = path.join(authExportDir, "accounts.json");
     const accountsStat = await stat(accountsPath);
-    if (accountsStat.isFile()) {
+    if (accountsStat?.isFile()) {
       logger.logLabeled("BULLET", "auth", `Importing accounts from ${accountsPath}`);
 
       await importFromFile(
@@ -99,13 +99,16 @@ export class AuthEmulator implements EmulatorInstance {
   }
 }
 
-function stat(path: fs.PathLike): Promise<fs.Stats> {
+function stat(path: fs.PathLike): Promise<fs.Stats | undefined> {
   return new Promise((resolve, reject) =>
     fs.stat(path, (err, stats) => {
       if (err) {
-        reject(err);
+        if (err.code === "ENOENT") {
+          return resolve(undefined);
+        }
+        return reject(err);
       } else {
-        resolve(stats);
+        return resolve(stats);
       }
     })
   );

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -1,7 +1,12 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as http from "http";
 import * as utils from "../../utils";
 import { Constants } from "../constants";
+import { EmulatorLogger } from "../emulatorLogger";
 import { Emulators, EmulatorInstance, EmulatorInfo } from "../types";
 import { createApp } from "./server";
+import { FirebaseError } from "../../error";
 
 export interface AuthEmulatorArgs {
   projectId: string;
@@ -43,4 +48,91 @@ export class AuthEmulator implements EmulatorInstance {
   getName(): Emulators {
     return Emulators.AUTH;
   }
+
+  async importData(authExportDir: string, projectId: string): Promise<void> {
+    const logger = EmulatorLogger.forEmulator(Emulators.DATABASE);
+    const { host, port } = this.getInfo();
+
+    // TODO: In the future when we support import on demand, clear data first.
+
+    const configPath = path.join(authExportDir, `${projectId}.config.json`);
+    const configStat = await stat(configPath);
+    if (configStat.isFile()) {
+      logger.logLabeled("BULLET", "auth", `Importing config from ${configPath}`);
+
+      await importFromFile(
+        {
+          method: "PATCH",
+          host,
+          port,
+          path: `/emulator/v1/projects/${projectId}/config`,
+          headers: {
+            Authorization: "Bearer owner",
+            "Content-Type": "application/json",
+          },
+        },
+        configPath
+      );
+    }
+
+    const accountsPath = path.join(authExportDir, `${projectId}.accounts.json`);
+    const accountsStat = await stat(accountsPath);
+    if (accountsStat.isFile()) {
+      logger.logLabeled("BULLET", "auth", `Importing accounts from ${accountsPath}`);
+
+      await importFromFile(
+        {
+          method: "POST",
+          host,
+          port,
+          path: `/identitytoolkit.googleapis.com/v1/projects/${projectId}/accounts:batchCreate`,
+          headers: {
+            Authorization: "Bearer owner",
+            "Content-Type": "application/json",
+          },
+        },
+        accountsPath
+      );
+    }
+  }
+}
+
+function stat(configPath: string): Promise<fs.Stats> {
+  return new Promise((resolve, reject) =>
+    fs.stat(configPath, (err, stats) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(stats);
+      }
+    })
+  );
+}
+
+function importFromFile(options: http.RequestOptions, path: fs.PathLike): Promise<void> {
+  const readStream = fs.createReadStream(path);
+
+  return new Promise<void>((resolve, reject) => {
+    const req = http.request(options, (response) => {
+      if (response.statusCode === 200) {
+        resolve();
+      } else {
+        let data = `Received HTTP status code: ${response.statusCode}\n`;
+        response
+          .on("data", (d) => {
+            data += d.toString();
+          })
+          .on("error", reject)
+          .on("end", () => reject(new FirebaseError(data)));
+      }
+    });
+
+    req.on("error", reject);
+    readStream.pipe(req, { end: true });
+  }).catch((e) => {
+    throw new FirebaseError(`Error during Auth Emulator import: ${e.message}`, {
+      original: e,
+      exit: 1,
+    });
+  });
 }

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -401,14 +401,15 @@ function batchGet(
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1DownloadAccountResponse"] {
   const limit = Math.min(Math.floor(ctx.params.query.maxResults) || 20, 1000);
-  assert(limit >= 0, "((Auth Emulator: maxResults must not be negative.))");
 
   const users = state.queryUsers(
     {},
     { sortByField: "localId", order: "ASC", startToken: ctx.params.query.nextPageToken }
   );
   let newPageToken: string | undefined = undefined;
-  if (users.length > limit) {
+
+  // As a non-standard behavior, passing in limit=-1 will return all users.
+  if (limit >= 0 && users.length > limit) {
     users.length = limit;
     if (users.length) {
       newPageToken = users[users.length - 1].localId;

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -549,6 +549,13 @@ export async function startAll(options: any, noUi: boolean = false): Promise<voi
       projectId,
     });
     await startEmulator(authEmulator);
+
+    if (exportMetadata.auth) {
+      const importDirAbsPath = path.resolve(options.import);
+      const authExportDir = path.resolve(importDirAbsPath, exportMetadata.auth.path);
+
+      await authEmulator.importData(authExportDir, projectId);
+    }
   }
 
   if (shouldStart(options, Emulators.PUBSUB)) {

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -91,7 +91,7 @@ export class HubExport {
   }
 
   private async exportFirestore(metadata: ExportMetadata): Promise<void> {
-    const firestoreInfo = EmulatorRegistry.get(Emulators.FIRESTORE)!!.getInfo();
+    const firestoreInfo = EmulatorRegistry.get(Emulators.FIRESTORE)!.getInfo();
     const firestoreHost = `http://${EmulatorRegistry.getInfoHostString(firestoreInfo)}`;
 
     const firestoreExportBody = {
@@ -167,7 +167,7 @@ export class HubExport {
   }
 
   private async exportAuth(metadata: ExportMetadata): Promise<void> {
-    const { host, port } = EmulatorRegistry.get(Emulators.AUTH)!!.getInfo();
+    const { host, port } = EmulatorRegistry.get(Emulators.AUTH)!.getInfo();
 
     const authExportPath = path.join(this.exportPath, metadata.auth!.path);
     if (!fs.existsSync(authExportPath)) {

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -174,7 +174,9 @@ export class HubExport {
       fs.mkdirSync(authExportPath);
     }
 
-    const accountsFile = path.join(authExportPath, `${this.projectId}.accounts.json`);
+    // TODO: Shall we support exporting other projects too?
+
+    const accountsFile = path.join(authExportPath, "accounts.json");
     logger.debug(`Exporting auth users in Project ${this.projectId} to ${accountsFile}`);
     await fetchToFile(
       {
@@ -186,7 +188,7 @@ export class HubExport {
       accountsFile
     );
 
-    const configFile = path.join(authExportPath, `${this.projectId}.config.json`);
+    const configFile = path.join(authExportPath, "config.json");
     logger.debug(`Exporting project config in Project ${this.projectId} to ${accountsFile}`);
     await fetchToFile(
       {

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -26,7 +26,7 @@ export const DOWNLOADABLE_EMULATORS = [
 ];
 
 export type ImportExportEmulators = Emulators.FIRESTORE | Emulators.DATABASE;
-export const IMPORT_EXPORT_EMULATORS = [Emulators.FIRESTORE, Emulators.DATABASE];
+export const IMPORT_EXPORT_EMULATORS = [Emulators.FIRESTORE, Emulators.DATABASE, Emulators.AUTH];
 
 export const ALL_SERVICE_EMULATORS = [
   Emulators.AUTH,

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -25,7 +25,7 @@ export const DOWNLOADABLE_EMULATORS = [
   Emulators.UI,
 ];
 
-export type ImportExportEmulators = Emulators.FIRESTORE | Emulators.DATABASE;
+export type ImportExportEmulators = Emulators.FIRESTORE | Emulators.DATABASE | Emulators.AUTH;
 export const IMPORT_EXPORT_EMULATORS = [Emulators.FIRESTORE, Emulators.DATABASE, Emulators.AUTH];
 
 export const ALL_SERVICE_EMULATORS = [


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Adds support for `emulators:export` and `emulators:start --import`.

### Scenarios Tested

See end to end test added

### Sample Commands

```bash
firebase emulators:start
# on separate terminal
firebase emulators:export my-dump
```

Later: `firebase emulators:start --import my-dump`.

`--export-on-exit` should also work, although I didn't test it.

Fixes #2749.