### PR TITLE
Fix grouped HTTPS functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Allow more than 100 concurrent connections to the Realtime Database emulator.
+- Fixes function URLs when emulating namespaced/grouped Cloud Functions (#2966).

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -421,7 +421,7 @@ export class FunctionsEmulator implements EmulatorInstance {
           host,
           port,
           this.args.projectId,
-          definition.entryPoint,
+          definition.name,
           region
         );
       } else if (definition.eventTrigger) {
@@ -956,8 +956,19 @@ export class FunctionsEmulator implements EmulatorInstance {
   private async handleHttpsTrigger(req: express.Request, res: express.Response) {
     const method = req.method;
     const triggerId = req.params.trigger_name;
-    const trigger = this.getTriggerDefinitionByKey(triggerId);
 
+    if (!this.triggers[triggerId]) {
+      res
+        .status(404)
+        .send(
+          `Function ${triggerId} does not exist, valid triggers are: ${Object.keys(
+            this.triggers
+          ).join(", ")}`
+        );
+      return;
+    }
+
+    const trigger = this.getTriggerDefinitionByKey(triggerId);
     logger.debug(`Accepted request ${method} ${req.url} --> ${triggerId}`);
 
     const reqBody = (req as RequestWithRawBody).rawBody;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fix #2966

### Scenarios Tested

✅   Unit tests added
✅   Manual testing

functions/index.js
```js
const functions = require('firebase-functions');

const helloWorld = functions.https.onRequest((request, response) => {
  response.send("Hello from Firebase!");
});

exports.functions = {
  helloWorld
};
```

Start emulators
```
$ firebase emulators:start
i  emulators: Starting emulators: functions
⚠  functions: The following emulators are not running, calls to these services from the Functions emulator will affect production: auth, firestore, database, hosting, pubsub
⚠  Your requested "node" version "12" doesn't match your global version "10"
i  ui: Emulator UI logging to ui-debug.log
i  functions: Watching "/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.4l0amrGc/functions" for Cloud Functions...
✔  functions[functions-helloWorld]: http function initialized (http://localhost:5001/fir-dumpster/us-central1/functions-helloWorld).

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://localhost:4000                │
└─────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Functions │ localhost:5001 │ http://localhost:4000/functions │
└───────────┴────────────────┴─────────────────────────────────┘
  Emulator Hub running at localhost:4400
  Other reserved ports: 4500
```

200 Request
```
$ http http://localhost:5001/fir-dumpster/us-central1/functions-helloWorld
HTTP/1.1 200 OK
connection: keep-alive
content-length: 20
content-type: text/html; charset=utf-8
date: Mon, 28 Dec 2020 15:50:38 GMT
etag: W/"14-z3iZXchEt5DVWZKsMncy8Wl4KSQ"
x-powered-by: Express

Hello from Firebase!
```

400 Request:
```
$ http http://localhost:5001/fir-dumpster/us-central1/functions.helloWorld
HTTP/1.1 404 Not Found
Connection: keep-alive
Content-Length: 86
Content-Type: text/html; charset=utf-8
Date: Mon, 28 Dec 2020 15:50:58 GMT
ETag: W/"56-o2lBSK2ZagofGuWRTO91r8ShW5M"
X-Powered-By: Express

Function functions.helloWorld does not exist, valid triggers are: functions-helloWorld
```


### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
