### PR TITLE
Fix incorrect databaseUrl in Functions emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Allow more than 100 concurrent connections to the Realtime Database emulator.
+- Fixes incorrect `databaseURL` inside the Cloud Functions emulator for new projects (#2965).

--- a/src/emulator/adminSdkConfig.ts
+++ b/src/emulator/adminSdkConfig.ts
@@ -1,0 +1,77 @@
+import { firebaseApiOrigin } from "../api";
+import * as apiv2 from "../apiv2";
+import { configstore } from "../configstore";
+import { FirebaseError } from "../error";
+import * as logger from "../logger";
+
+export type AdminSdkConfig = {
+  projectId: string;
+  databaseURL?: string;
+  storageBucket?: string;
+  locationId?: string;
+};
+
+const _CONFIGSTORE_KEY = "adminsdkconfig";
+
+/**
+ * When all else fails we can "guess" the AdminSdkConfig, although this is likely to
+ * be incorrect.
+ */
+export function constructDefaultAdminSdkConfig(projectId: string): AdminSdkConfig {
+  // Do our best to provide reasonable FIREBASE_CONFIG, based on firebase-functions implementation
+  // https://github.com/firebase/firebase-functions/blob/59d6a7e056a7244e700dc7b6a180e25b38b647fd/src/setup.ts#L45
+  return {
+    projectId: projectId,
+    databaseURL: process.env.DATABASE_URL || `https://${projectId}.firebaseio.com`,
+    storageBucket: process.env.STORAGE_BUCKET_URL || `${projectId}.appspot.com`,
+  };
+}
+
+/**
+ * Get the Admin SDK configuration associated with a project, falling back to a cache when offline.
+ */
+export async function getProjectAdminSdkConfigOrCached(
+  projectId: string
+): Promise<AdminSdkConfig | undefined> {
+  try {
+    const config = await getProjectAdminSdkConfig(projectId);
+    setCacheAdminSdkConfig(projectId, config);
+    return config;
+  } catch (e) {
+    logger.debug(`Failed to get Admin SDK config for ${projectId}, falling back to cache`, e);
+    return getCachedAdminSdkConfig(projectId);
+  }
+}
+
+/**
+ * Gets the Admin SDK configuration associated with a project.
+ */
+export async function getProjectAdminSdkConfig(projectId: string): Promise<AdminSdkConfig> {
+  const apiClient = new apiv2.Client({
+    auth: true,
+    apiVersion: "v1beta1",
+    urlPrefix: firebaseApiOrigin,
+  });
+
+  try {
+    const res = await apiClient.get<AdminSdkConfig>(`projects/${projectId}/adminSdkConfig`);
+    return res.body;
+  } catch (err) {
+    throw new FirebaseError(
+      `Failed to get Admin SDK for Firebase project ${projectId}. ` +
+        "Please make sure the project exists and your account has permission to access it.",
+      { exit: 2, original: err }
+    );
+  }
+}
+
+function setCacheAdminSdkConfig(projectId: string, config: AdminSdkConfig) {
+  const allConfigs = configstore.get(_CONFIGSTORE_KEY) || {};
+  allConfigs[projectId] = config;
+  configstore.set(_CONFIGSTORE_KEY, allConfigs);
+}
+
+function getCachedAdminSdkConfig(projectId: string): AdminSdkConfig | undefined {
+  const allConfigs = configstore.get(_CONFIGSTORE_KEY) || {};
+  return allConfigs[projectId];
+}

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -663,7 +663,7 @@ async function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): Pr
       ns = asUrl.hostname.split(".")[0];
     }
 
-    emulatedDatabaseURL = `http://${formatHost(frb.emulators.database)}?ns=${ns}`;
+    emulatedDatabaseURL = `http://${formatHost(frb.emulators.database)}/?ns=${ns}`;
   }
 
   process.env.FIREBASE_CONFIG = JSON.stringify({

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -654,20 +654,22 @@ async function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): Pr
   const functionsGt380 = compareVersionStrings(functionsResolution.version, "3.8.0") >= 0;
   let emulatedDatabaseURL = undefined;
   if (frb.emulators.database && functionsGt380) {
-    emulatedDatabaseURL = `http://${formatHost(frb.emulators.database)}?ns=${
-      process.env.GCLOUD_PROJECT
-    }`;
+    // Database URL will look like one of:
+    //  - https://${namespace}.firebaseio.com
+    //  - https://${namespace}.${location}.firebasedatabase.app
+    let ns = frb.projectId;
+    if (frb.adminSdkConfig.databaseURL) {
+      const asUrl = new URL(frb.adminSdkConfig.databaseURL);
+      ns = asUrl.hostname.split(".")[0];
+    }
+
+    emulatedDatabaseURL = `http://${formatHost(frb.emulators.database)}?ns=${ns}`;
   }
 
-  // Do our best to provide reasonable FIREBASE_CONFIG, based on firebase-functions implementation
-  // https://github.com/firebase/firebase-functions/blob/59d6a7e056a7244e700dc7b6a180e25b38b647fd/src/setup.ts#L45
   process.env.FIREBASE_CONFIG = JSON.stringify({
-    databaseURL:
-      process.env.DATABASE_URL ||
-      emulatedDatabaseURL ||
-      `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`,
-    storageBucket: process.env.STORAGE_BUCKET_URL || `${process.env.GCLOUD_PROJECT}.appspot.com`,
-    projectId: process.env.GCLOUD_PROJECT,
+    storageBucket: frb.adminSdkConfig.storageBucket,
+    databaseURL: emulatedDatabaseURL || frb.adminSdkConfig.databaseURL,
+    projectId: frb.projectId,
   });
 
   if (frb.triggerId) {

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -66,6 +66,10 @@ export interface FunctionsRuntimeBundle {
       port: number;
     };
   };
+  adminSdkConfig: {
+    databaseURL?: string;
+    storageBucket?: string;
+  };
   socketPath?: string;
   disabled_features?: FunctionsRuntimeFeatures;
   nodeMajorVersion?: number;

--- a/src/test/emulators/fixtures.ts
+++ b/src/test/emulators/fixtures.ts
@@ -4,8 +4,12 @@ export const TIMEOUT_LONG = 10000;
 export const TIMEOUT_MED = 5000;
 
 export const MODULE_ROOT = findModuleRoot("firebase-tools", __dirname);
-export const FunctionRuntimeBundles = {
+export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } = {
   onCreate: {
+    adminSdkConfig: {
+      databaseURL: "https://fake-project-id-default-rtdb.firebaseio.com",
+      storageBucket: "fake-project-id.appspot.com",
+    },
     emulators: {
       firestore: {
         host: "localhost",
@@ -39,9 +43,12 @@ export const FunctionRuntimeBundles = {
     },
     triggerId: "function_id",
     projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-
+  },
   onWrite: {
+    adminSdkConfig: {
+      databaseURL: "https://fake-project-id-default-rtdb.firebaseio.com",
+      storageBucket: "fake-project-id.appspot.com",
+    },
     emulators: {
       firestore: {
         host: "localhost",
@@ -75,9 +82,12 @@ export const FunctionRuntimeBundles = {
     },
     triggerId: "function_id",
     projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-
+  },
   onDelete: {
+    adminSdkConfig: {
+      databaseURL: "https://fake-project-id-default-rtdb.firebaseio.com",
+      storageBucket: "fake-project-id.appspot.com",
+    },
     emulators: {
       firestore: {
         host: "localhost",
@@ -111,9 +121,12 @@ export const FunctionRuntimeBundles = {
     },
     triggerId: "function_id",
     projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-
+  },
   onUpdate: {
+    adminSdkConfig: {
+      databaseURL: "https://fake-project-id-default-rtdb.firebaseio.com",
+      storageBucket: "fake-project-id.appspot.com",
+    },
     emulators: {
       firestore: {
         host: "localhost",
@@ -159,9 +172,12 @@ export const FunctionRuntimeBundles = {
     },
     triggerId: "function_id",
     projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
-
+  },
   onRequest: {
+    adminSdkConfig: {
+      databaseURL: "https://fake-project-id-default-rtdb.firebaseio.com",
+      storageBucket: "fake-project-id.appspot.com",
+    },
     emulators: {
       firestore: {
         host: "localhost",
@@ -171,5 +187,5 @@ export const FunctionRuntimeBundles = {
     cwd: MODULE_ROOT,
     triggerId: "function_id",
     projectId: "fake-project-id",
-  } as FunctionsRuntimeBundle,
+  },
 };

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -417,7 +417,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
-        expect(info.databaseURL).to.eql(`http://localhost:9090?ns=fake-project-id-default-rtdb`);
+        expect(info.databaseURL).to.eql(`http://localhost:9090?/ns=fake-project-id-default-rtdb`);
       }).timeout(TIMEOUT_MED);
 
       it("should return a real databaseURL when RTDB emulator is not running", async () => {

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -236,7 +236,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should expose Firestore prod when the emulator is not running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         frb.emulators = {};
 
         const worker = invokeRuntimeWithFunctions(frb, () => {
@@ -260,7 +260,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should set FIRESTORE_EMULATOR_HOST when the emulator is running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         frb.emulators = {
           firestore: {
             host: "localhost",
@@ -286,7 +286,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should expose a stubbed Firestore when the emulator is running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         frb.emulators = {
           firestore: {
             host: "localhost",
@@ -315,7 +315,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should expose RTDB prod when the emulator is not running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         frb.emulators = {};
 
         const worker = invokeRuntimeWithFunctions(frb, () => {
@@ -337,11 +337,11 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
-        expect(info.url).to.eql("https://fake-project-id.firebaseio.com/");
+        expect(info.url).to.eql("https://fake-project-id-default-rtdb.firebaseio.com/");
       }).timeout(TIMEOUT_MED);
 
       it("should set FIREBASE_DATABASE_EMULATOR_HOST when the emulator is running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         frb.emulators = {
           database: {
             host: "localhost",
@@ -366,7 +366,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should expose a stubbed RTDB when the emulator is running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         frb.emulators = {
           database: {
             host: "localhost",
@@ -396,7 +396,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should return an emulated databaseURL when RTDB emulator is running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         frb.emulators = {
           database: {
             host: "localhost",
@@ -417,11 +417,11 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
-        expect(info.databaseURL).to.eql(`http://localhost:9090?ns=${frb.projectId}`);
+        expect(info.databaseURL).to.eql(`http://localhost:9090?ns=fake-project-id-default-rtdb`);
       }).timeout(TIMEOUT_MED);
 
       it("should return a real databaseURL when RTDB emulator is not running", async () => {
-        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+        const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
         const worker = invokeRuntimeWithFunctions(frb, () => {
           const admin = require("firebase-admin");
           admin.initializeApp();
@@ -435,12 +435,12 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
-        expect(info.databaseURL).to.eql(`https://${frb.projectId}.firebaseio.com`);
+        expect(info.databaseURL).to.eql(frb.adminSdkConfig.databaseURL!);
       }).timeout(TIMEOUT_MED);
     });
 
     it("should set FIREBASE_AUTH_EMULATOR_HOST when the emulator is running", async () => {
-      const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest) as FunctionsRuntimeBundle;
+      const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
       frb.emulators = {
         auth: {
           host: "localhost",

--- a/src/test/emulators/functionsEmulatorRuntime.spec.ts
+++ b/src/test/emulators/functionsEmulatorRuntime.spec.ts
@@ -417,7 +417,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
         const data = await callHTTPSFunction(worker, frb);
         const info = JSON.parse(data);
-        expect(info.databaseURL).to.eql(`http://localhost:9090?/ns=fake-project-id-default-rtdb`);
+        expect(info.databaseURL).to.eql(`http://localhost:9090/?ns=fake-project-id-default-rtdb`);
       }).timeout(TIMEOUT_MED);
 
       it("should return a real databaseURL when RTDB emulator is not running", async () => {

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -94,6 +94,11 @@ class MockRuntimeBundle implements FunctionsRuntimeBundle {
   triggerType = EmulatedTriggerType.HTTPS;
   cwd = "/home/users/dir";
   emulators = {};
+  adminSdkConfig = {
+    projectId: "project-1234",
+    datbaseURL: "https://project-1234-default-rtdb.firebaseio.com",
+    storageBucket: "project-1234.appspot.com",
+  };
 
   constructor(public triggerId: string) {}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2965

Due to the new location support in Realtime Database it is no longer safe to assume that `https://<PROJECT-ID>.firebaseio.com` is the default RTDB instance location.  This PR uses the `getAdminSdkConfig` REST endpoint to fetch the real database URL and pass it down to the Functions emulator.

In order to make this behavior work offline there are two fallbacks:

  - Successful fetches populate a local cache which can be used when offline.
  - If the cache is empty we can try and guess the Admin SDK config using the old (and not so good) method.

This fallback behavior is based on what we do with web config in the Hosting emulator. 

### Scenarios Tested

See the setup in https://github.com/firebase/firebase-tools/issues/2965.  I created a brand new project and created the defalt RTDB through `firebase init`.

First add a message using the Cloud Function:
```
$ http http://localhost:5001/fir-tools-2965/us-central1/addMessage?text="hello"
HTTP/1.1 200 OK
connection: keep-alive
content-length: 57
content-type: application/json; charset=utf-8
date: Mon, 28 Dec 2020 18:14:23 GMT
etag: W/"39-bGCJNRIDTzsIri/GyVcXPXLVrbs"
x-powered-by: Express

{
    "result": "Message with ID: -MPeYivLKiIxoGNp2Eil added."
}
```

I can see that the data goes to the right place in the Emulator UI:
![Screen Shot 2020-12-28 at 6 15 19 PM](https://user-images.githubusercontent.com/8466666/103234890-c77a8f80-490e-11eb-8773-0271cf74bfe3.png)

Finally if I load the hosting emulator I can see the correct logs:
![Screen Shot 2020-12-28 at 6 16 21 PM](https://user-images.githubusercontent.com/8466666/103234953-e4af5e00-490e-11eb-83d2-0eb48682dd30.png)


### Sample Commands

N/A