### PR TITLE
Fix bugs in disable background triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Allow more than 100 concurrent connections to the Realtime Database emulator.
 - Fixes incorrect `databaseURL` inside the Cloud Functions emulator for new projects (#2965).
 - Fixes function URLs when emulating namespaced/grouped Cloud Functions (#2966).
+- Fixes issue where Auth triggers were not disabled when background trigges were disabled.

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -875,19 +875,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     });
   }
 
-  enableBackgroundTriggers() {
-    let hasDisabledTrigger = false;
-    Object.values(this.triggers).forEach((record) => {
-      if (record.def.eventTrigger) {
-        hasDisabledTrigger = hasDisabledTrigger || !record.enabled;
-      }
-    });
-
-    if (hasDisabledTrigger) {
-      return this.reloadTriggers();
-    }
-  }
-
   async reloadTriggers() {
     this.triggerGeneration++;
     return this.loadTriggers(false);

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -419,11 +419,10 @@ export class FunctionsEmulator implements EmulatorInstance {
 
       // We want to add a trigger if we don't already have an enabled trigger
       // with the same entryPoint.
-      const matchingTriggers = Object.values(this.triggers)
-        .filter(record => {
-          return record.def.entryPoint === definition.entryPoint;
-        })
-      const anyEnabledMatch = matchingTriggers.some(def => def.enabled);
+      const matchingTriggers = Object.values(this.triggers).filter((record) => {
+        return record.def.entryPoint === definition.entryPoint;
+      });
+      const anyEnabledMatch = matchingTriggers.some((def) => def.enabled);
       return !anyEnabledMatch;
     });
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -359,7 +359,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       return debouncedLoadTriggers();
     });
 
-    return this.loadTriggers(true);
+    return this.loadTriggers(/* force= */true);
   }
 
   async stop(): Promise<void> {
@@ -419,10 +419,9 @@ export class FunctionsEmulator implements EmulatorInstance {
 
       // We want to add a trigger if we don't already have an enabled trigger
       // with the same entryPoint.
-      const matchingTriggers = Object.values(this.triggers).filter((record) => {
-        return record.def.entryPoint === definition.entryPoint;
+      const anyEnabledMatch = Object.values(this.triggers).some((record) => {
+        return record.def.entryPoint === definition.entryPoint && record.enabled;
       });
-      const anyEnabledMatch = matchingTriggers.some((def) => def.enabled);
       return !anyEnabledMatch;
     });
 
@@ -876,7 +875,7 @@ export class FunctionsEmulator implements EmulatorInstance {
 
   async reloadTriggers() {
     this.triggerGeneration++;
-    return this.loadTriggers(false);
+    return this.loadTriggers();
   }
 
   private async handleBackgroundTrigger(projectId: string, triggerKey: string, proto: any) {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -223,15 +223,6 @@ export class FunctionsEmulator implements EmulatorInstance {
       const reqBody = (req as RequestWithRawBody).rawBody;
       const proto = JSON.parse(reqBody.toString());
 
-      // When background triggers are disabled just ignore the request and respond
-      // with 204 "No Content"
-      const record = this.triggers[triggerId];
-      if (record && !record.enabled) {
-        this.logger.log("DEBUG", `Ignoring background trigger: ${req.url}`);
-        res.status(204).send();
-        return;
-      }
-
       this.workQueue.submit(() => {
         this.logger.log("DEBUG", `Accepted request ${req.method} ${req.url} --> ${triggerId}`);
 
@@ -426,7 +417,14 @@ export class FunctionsEmulator implements EmulatorInstance {
         return true;
       }
 
-      return this.getTriggerDefinitionByName(definition.name) === undefined;
+      // We want to add a trigger if we don't already have an enabled trigger
+      // with the same entryPoint.
+      const matchingTriggers = Object.values(this.triggers)
+        .filter(record => {
+          return record.def.entryPoint === definition.entryPoint;
+        })
+      const anyEnabledMatch = matchingTriggers.some(def => def.enabled);
+      return !anyEnabledMatch;
     });
 
     for (const definition of toSetup) {
@@ -877,12 +875,31 @@ export class FunctionsEmulator implements EmulatorInstance {
     });
   }
 
+  enableBackgroundTriggers() {
+    let hasDisabledTrigger = false;
+    Object.values(this.triggers).forEach((record) => {
+      if (record.def.eventTrigger) {
+        hasDisabledTrigger = hasDisabledTrigger || !record.enabled;
+      }
+    });
+
+    if (hasDisabledTrigger) {
+      return this.reloadTriggers();
+    }
+  }
+
   async reloadTriggers() {
     this.triggerGeneration++;
-    return this.loadTriggers(true);
+    return this.loadTriggers(false);
   }
 
   private async handleBackgroundTrigger(projectId: string, triggerKey: string, proto: any) {
+    // If background triggers are disabled, exit early
+    const record = this.triggers[triggerKey];
+    if (record && !record.enabled) {
+      return Promise.reject({ code: 204, body: "Background triggers are curently disabled." });
+    }
+
     const trigger = this.getTriggerDefinitionByKey(triggerKey);
     const service = getFunctionService(trigger);
     const worker = this.startFunctionRuntime(trigger.name, EmulatedTriggerType.BACKGROUND, proto);

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -359,7 +359,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       return debouncedLoadTriggers();
     });
 
-    return this.loadTriggers(/* force= */true);
+    return this.loadTriggers(/* force= */ true);
   }
 
   async stop(): Promise<void> {

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -134,7 +134,7 @@ export class EmulatorHub implements EmulatorInstance {
       }
 
       const emu = instance as FunctionsEmulator;
-      await emu.reloadTriggers();
+      await emu.enableBackgroundTriggers();
       res.status(200).json({ enabled: true });
     });
   }

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -134,7 +134,7 @@ export class EmulatorHub implements EmulatorInstance {
       }
 
       const emu = instance as FunctionsEmulator;
-      await emu.enableBackgroundTriggers();
+      await emu.reloadTriggers();
       res.status(200).json({ enabled: true });
     });
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

@Joeybayld raised two issues recently:

1. `disableBackgroundTriggers` did not work on Auth triggers: https://github.com/firebase/firebase-tools/issues/2749#issuecomment-752964011
2. Repeated `enableBackgroundTriggers` calls can cause duplicate triggers: https://github.com/firebase/firebase-tools/issues/2749#issuecomment-752969886

This fixes both.

### Scenarios Tested

Functions used in testing:
```
const functions = require('firebase-functions');
const admin = require('firebase-admin');
admin.initializeApp();

exports.helloWorld = functions.https.onRequest(async (request, response) => {
  await admin.auth().createUser({
    uid: `user${new Date().getTime()}`
  });
  await admin.firestore().collection('test').add({
    hello: 'world'
  });
  response.send("Hello from Firebase!");
});

exports.onDatabase = functions.firestore.document('/test/{id}').onWrite(async (snap, ctx) => {
  console.log("onDatabase", snap.after.id);
})

exports.onAuth = functions.auth.user().onCreate(async (user) => {
  console.log("onAuth", user.uid);
  return;
});
```

I then did the following sequence.

1. Call helloWorld
2. Disable background triggers
3. Call helloWold
4. Enable background triggers (2x)
5. Call helloworld

Logs below:
```
i  functions: Beginning execution of "helloWorld"
i  functions: Beginning execution of "onAuth"
>  onAuth user1609425025316
i  functions: Finished "onAuth" in ~1s
i  functions: Finished "helloWorld" in ~1s
i  functions: Beginning execution of "onDatabase"
>  onDatabase Fc1j0wdORgW4ssJNfm8S
i  functions: Finished "onDatabase" in ~1s
i  emulators: Disabling Cloud Functions triggers, non-HTTP functions will not execute.
i  functions[onDatabase]: function temporarily disabled.
i  functions[onAuth]: function temporarily disabled.
i  functions: Beginning execution of "helloWorld"
i  functions: Finished "helloWorld" in ~1s
i  emulators: Enabling Cloud Functions triggers, non-HTTP functions will execute.
✔  functions[onDatabase]: firestore function initialized.
✔  functions[onAuth]: auth function initialized.
i  emulators: Enabling Cloud Functions triggers, non-HTTP functions will execute.
i  functions: Beginning execution of "helloWorld"
i  functions: Beginning execution of "onAuth"
>  onAuth user1609425041308
i  functions: Finished "onAuth" in ~1s
i  functions: Finished "helloWorld" in ~1s
i  functions: Beginning execution of "onDatabase"
>  onDatabase YUA4kMqczEUYJsLeipXx
i  functions: Finished "onDatabase" in ~1s
```

### Sample Commands

N/A