### PR TITLE
Catch auth channel update on channel deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Catches errors while updating authorized domains when deleting channels, printing a warning instead of failing.

--- a/src/commands/hosting-channel-delete.ts
+++ b/src/commands/hosting-channel-delete.ts
@@ -52,7 +52,7 @@ export default new Command("hosting:channel:delete <channelId>")
           logLabeledWarning(
             "hosting:channel",
             marked(
-              `Unable to remove channel domain to Firebase Auth. Visit the Firebase Console at ${consoleUrl(
+              `Unable to remove channel domain from Firebase Auth. Visit the Firebase Console at ${consoleUrl(
                 projectId,
                 "/authentication/providers"
               )}`

--- a/src/gcp/auth.ts
+++ b/src/gcp/auth.ts
@@ -1,24 +1,34 @@
-import * as api from "../api";
+import { Client } from "../apiv2";
+import { identityOrigin } from "../api";
 
+const apiClient = new Client({ urlPrefix: identityOrigin, auth: true });
+
+/**
+ * Returns the list of authorized domains.
+ * @param project project identifier.
+ * @return authorized domains.
+ */
 export async function getAuthDomains(project: string): Promise<string[]> {
-  const res = await api.request("GET", `/admin/v2/projects/${project}/config`, {
-    auth: true,
-    origin: api.identityOrigin,
-  });
-  return res?.body?.authorizedDomains;
+  const res = await apiClient.get<{ authorizedDomains: string[] }>(
+    `/admin/v2/projects/${project}/config`
+  );
+  return res.body.authorizedDomains;
 }
 
+/**
+ * Updates the list of authorized domains.
+ * @param project project identifier.
+ * @param authDomains full list of authorized domains.
+ * @return authorized domains.
+ */
 export async function updateAuthDomains(project: string, authDomains: string[]): Promise<string[]> {
-  const resp = await api.request(
-    "PATCH",
-    `/admin/v2/projects/${project}/config?update_mask=authorizedDomains`,
-    {
-      auth: true,
-      origin: api.identityOrigin,
-      data: {
-        authorizedDomains: authDomains,
-      },
-    }
+  const res = await apiClient.patch<
+    { authorizedDomains: string[] },
+    { authorizedDomains: string[] }
+  >(
+    `/admin/v2/projects/${project}/config`,
+    { authorizedDomains: authDomains },
+    { queryParams: { update_mask: "authorizedDomains" } }
   );
-  return resp?.body?.authorizedDomains;
+  return res.body.authorizedDomains;
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When we delete channels, if we are unable to update the authorized domains list, we should catch the error and continue, like we do on create.

While I'm here, migrating the api file to apiv2.

### Scenarios Tested

- `hosting:channel:delete` after both a `create` and `deploy` workflow.