### PR TITLE
Hosting proxy: conditionally add user-agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Catches errors while updating authorized domains when deleting channels, printing a warning instead of failing.
 - Fixes issue where `host` header was being incorrectly set when proxying to Cloud Run or Cloud Functions for Firebase from the Hosting emulator. (#3012)
+- Fixes issue where the User-Agent was being overridden when proxying through the Hosting emulator. (#2970)

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -229,7 +229,9 @@ export class Client {
       reqOptions.headers = new Headers();
     }
     reqOptions.headers.set("Connection", "keep-alive");
-    reqOptions.headers.set("User-Agent", `FirebaseCLI/${CLI_VERSION}`);
+    if (!reqOptions.headers.has("User-Agent")) {
+      reqOptions.headers.set("User-Agent", `FirebaseCLI/${CLI_VERSION}`);
+    }
     reqOptions.headers.set("X-Client-Version", `FirebaseCLI/${CLI_VERSION}`);
     if (reqOptions.responseType === "json") {
       reqOptions.headers.set("Content-Type", "application/json");

--- a/src/test/apiv2.spec.ts
+++ b/src/test/apiv2.spec.ts
@@ -223,6 +223,22 @@ describe("apiv2", () => {
       expect(nock.isDone()).to.be.true;
     });
 
+    it("should make a basic GET request and not override the user-agent", async () => {
+      nock("https://example.com")
+        .get("/path/to/foo")
+        .matchHeader("user-agent", "unit tests, silly")
+        .reply(200, { success: true });
+
+      const c = new Client({ urlPrefix: "https://example.com" });
+      const r = await c.request({
+        method: "GET",
+        path: "/path/to/foo",
+        headers: { "user-agent": "unit tests, silly" },
+      });
+      expect(r.body).to.deep.equal({ success: true });
+      expect(nock.isDone()).to.be.true;
+    });
+
     it("should handle a 204 response with no data", async () => {
       nock("https://example.com").get("/path/to/foo").reply(204);
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2970

When the Hosting proxy makes a request, it may set the `user-agent` if one was provided in the original request. This updates `apiv2` to not override the `user-agent` if it was already set by the incoming request (that is being proxied).

### Scenarios Tested

My echo function before and after this change:

```
» curl localhost:5000/echo
{"headers":{"x-forwarded-host":"localhost:5000","x-original-url":"/echo","pragma":"no-cache","cache-control":"no-cache, no-store","cookie":"","user-agent":"FirebaseCLI/9.2.0","accept":"*/*","connection":"keep-alive","x-client-version":"FirebaseCLI/9.2.0","accept-encoding":"gzip,deflate","host":"localhost:5001"},"body":{}}%
» curl localhost:5000/echo
{"headers":{"x-forwarded-host":"localhost:5000","x-original-url":"/echo","pragma":"no-cache","cache-control":"no-cache, no-store","cookie":"","user-agent":"curl/7.64.1","accept":"*/*","connection":"keep-alive","x-client-version":"FirebaseCLI/9.2.0","accept-encoding":"gzip,deflate","host":"localhost:5001"},"body":{}}%
```