### PR TITLE
nock out API call to extensions registry

### DIFF
--- a/src/test/extensions/updateHelper.spec.ts
+++ b/src/test/extensions/updateHelper.spec.ts
@@ -135,7 +135,7 @@ const REGISTRY_INSTANCE = {
   },
 };
 
-describe.only("updateHelper", () => {
+describe("updateHelper", () => {
   describe("updateFromLocalSource", () => {
     let promptStub: sinon.SinonStub;
     let createSourceStub: sinon.SinonStub;

--- a/src/test/extensions/updateHelper.spec.ts
+++ b/src/test/extensions/updateHelper.spec.ts
@@ -1,12 +1,14 @@
 import { expect } from "chai";
+import * as nock from "nock";
 import * as sinon from "sinon";
 
 import { FirebaseError } from "../../error";
-import * as updateHelper from "../../extensions/updateHelper";
-import * as prompt from "../../prompt";
-import * as extensionsHelper from "../../extensions/extensionsHelper";
-import * as resolveSource from "../../extensions/resolveSource";
+import { firebaseExtensionsRegistryOrigin } from "../../api";
 import * as extensionsApi from "../../extensions/extensionsApi";
+import * as extensionsHelper from "../../extensions/extensionsHelper";
+import * as prompt from "../../prompt";
+import * as resolveSource from "../../extensions/resolveSource";
+import * as updateHelper from "../../extensions/updateHelper";
 
 const SPEC = {
   name: "test",
@@ -133,7 +135,7 @@ const REGISTRY_INSTANCE = {
   },
 };
 
-describe("updateHelper", () => {
+describe.only("updateHelper", () => {
   describe("updateFromLocalSource", () => {
     let promptStub: sinon.SinonStub;
     let createSourceStub: sinon.SinonStub;
@@ -143,12 +145,17 @@ describe("updateHelper", () => {
       promptStub = sinon.stub(prompt, "promptOnce");
       createSourceStub = sinon.stub(extensionsHelper, "createSourceFromLocation");
       getInstanceStub = sinon.stub(extensionsApi, "getInstance").resolves(INSTANCE);
+
+      // The logic will fetch the extensions registry, but it doesn't need to receive anything.
+      nock(firebaseExtensionsRegistryOrigin).get("/extensions.json").reply(200, {});
     });
 
     afterEach(() => {
       promptStub.restore();
       createSourceStub.restore();
       getInstanceStub.restore();
+
+      nock.cleanAll();
     });
 
     it("should return the correct source name for a valid local source", async () => {
@@ -190,12 +197,17 @@ describe("updateHelper", () => {
       promptStub = sinon.stub(prompt, "promptOnce");
       createSourceStub = sinon.stub(extensionsHelper, "createSourceFromLocation");
       getInstanceStub = sinon.stub(extensionsApi, "getInstance").resolves(INSTANCE);
+
+      // The logic will fetch the extensions registry, but it doesn't need to receive anything.
+      nock(firebaseExtensionsRegistryOrigin).get("/extensions.json").reply(200, {});
     });
 
     afterEach(() => {
       promptStub.restore();
       createSourceStub.restore();
       getInstanceStub.restore();
+
+      nock.cleanAll();
     });
 
     it("should return the correct source name for a valid url source", async () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

In the tests, the logic eventually would call to the extensions registry which would slow them down. I've nocked out those calls so that they are not made any more, bringing the tests down from 500ms to next to nothing.