### PR TITLE
Adding onPoll option to operation-poller

### DIFF
--- a/src/operation-poller.ts
+++ b/src/operation-poller.ts
@@ -9,6 +9,7 @@ export interface OperationPollerOptions {
   operationResourceName: string;
   backoff?: number;
   masterTimeout?: number;
+  onPoll?: (operation: OperationResult<any>) => any;
 }
 
 const DEFAULT_INITIAL_BACKOFF_DELAY_MILLIS = 250;
@@ -67,6 +68,9 @@ export class OperationPoller<T> {
           throw err;
         }
         return { error: err };
+      }
+      if (options.onPoll) {
+        options.onPoll(res.body);
       }
       if (!res.body.done) {
         throw new Error("Polling incomplete, should trigger retry with backoff");

--- a/src/test/operation-poller.spec.ts
+++ b/src/test/operation-poller.spec.ts
@@ -102,15 +102,21 @@ describe("OperationPoller", () => {
 
     it("should call onPoll each time the operation is polled", async () => {
       const opResult = { done: true, response: "completed" };
+      nock(TEST_ORIGIN).get(FULL_RESOURCE_NAME).reply(200, { done: false });
       nock(TEST_ORIGIN).get(FULL_RESOURCE_NAME).reply(200, opResult);
       const onPollSpy = sinon.spy((op: any) => {
-        expect(op.response).to.equal("completed");
+        return;
       });
       pollerOptions.onPoll = onPollSpy;
 
-      expect(await pollOperation<string>(pollerOptions)).to.deep.equal("completed");
-      expect(nock.isDone()).to.be.true;
+      console.log(nock.pendingMocks());
+      const res = await pollOperation<string>(pollerOptions);
+
+      expect(res).to.deep.equal("completed");
+      expect(onPollSpy).to.have.been.calledTwice;
+      expect(onPollSpy).to.have.been.calledWith({ done: false });
       expect(onPollSpy).to.have.been.calledWith(opResult);
+      expect(nock.isDone()).to.be.true;
     });
   });
 });

--- a/src/test/operation-poller.spec.ts
+++ b/src/test/operation-poller.spec.ts
@@ -11,7 +11,7 @@ const VERSION = "v1";
 const LRO_RESOURCE_NAME = "operations/cp.3322442424242444";
 const FULL_RESOURCE_NAME = `/${VERSION}/${LRO_RESOURCE_NAME}`;
 
-describe("OperationPoller", () => {
+describe.only("OperationPoller", () => {
   describe("poll", () => {
     let sandbox: sinon.SinonSandbox;
     let pollerOptions: OperationPollerOptions;
@@ -98,6 +98,21 @@ describe("OperationPoller", () => {
       }
       expect(error).to.be.instanceOf(TimeoutError);
       nock.cleanAll();
+    });
+
+    it("should call onPoll each time the operation is polled", async () => {
+      const opResult = { done: true, response: "completed" };
+      nock(TEST_ORIGIN)
+        .get(FULL_RESOURCE_NAME)
+        .reply(200, opResult);
+      const onPollSpy = sinon.spy((op: any) => {
+        expect(op.response).to.equal("completed");
+      });
+      pollerOptions.onPoll = onPollSpy;
+
+      expect(await pollOperation<string>(pollerOptions)).to.deep.equal("completed");
+      expect(nock.isDone()).to.be.true;
+      expect(onPollSpy).to.have.been.calledWith(opResult);
     });
   });
 });

--- a/src/test/operation-poller.spec.ts
+++ b/src/test/operation-poller.spec.ts
@@ -11,7 +11,7 @@ const VERSION = "v1";
 const LRO_RESOURCE_NAME = "operations/cp.3322442424242444";
 const FULL_RESOURCE_NAME = `/${VERSION}/${LRO_RESOURCE_NAME}`;
 
-describe.only("OperationPoller", () => {
+describe("OperationPoller", () => {
   describe("poll", () => {
     let sandbox: sinon.SinonSandbox;
     let pollerOptions: OperationPollerOptions;
@@ -102,9 +102,7 @@ describe.only("OperationPoller", () => {
 
     it("should call onPoll each time the operation is polled", async () => {
       const opResult = { done: true, response: "completed" };
-      nock(TEST_ORIGIN)
-        .get(FULL_RESOURCE_NAME)
-        .reply(200, opResult);
+      nock(TEST_ORIGIN).get(FULL_RESOURCE_NAME).reply(200, opResult);
       const onPollSpy = sinon.spy((op: any) => {
         expect(op.response).to.equal("completed");
       });


### PR DESCRIPTION
### Description
Adds `onPoll` to operation-poller. When this option is set, each time an operation is polled, the onPoll function will be called with the result of the operation.

This code isn't used yet, but will be part of a large refactor of the Cloud Functions deploy codepath.