### PR TITLE
Fix functions emulator url on console

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -121,7 +121,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     name: string,
     region: string
   ): string {
-    return `http://${host}:${port}/${projectId}/${region}/${name}`;
+    return `http://${host}:${port}/${projectId}/${region}/${name.replace(".", "-")}`;
   }
 
   nodeBinary = "";


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When I emulated organized function, console shows wrong local emulated functions url.

Ex) code
``` javascript
// index.js

import * as admin from 'firebase-admin';
import * as functions from 'firebase-functions';

const aFunction = functions.https.onRequest((req, res) => { ... some codes... });

export const group  = {
  function1: aFunction
}
```

When emulator shows emulated functions local url in console
```
✔  functions[group-function1]: http function initialized (http://localhost:5001/{projectId}/{region}/group.function1).
```

But it should be
```
✔  functions[group-function1]: http function initialized (http://localhost:5001/{projectId}/{region}/group-function1).
```

The functions should be grouped by symbol `-` not `.` !!

### Scenarios Tested

Set my firebase cli to this developing code and tested on my project. It worked very well.

### Sample Commands

```
firebase emulators:start --only functions
```
