### PR TITLE
pass through compressed content in hosting proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Improves handling of compressed content when proxying through the Hosting emulator. (#3052, #3055)

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -19,6 +19,7 @@ interface BaseRequestOptions<T> extends VerbOptions<T> {
   body?: T | string | NodeJS.ReadableStream;
   responseType?: "json" | "stream";
   redirect?: "error" | "follow" | "manual";
+  compress?: boolean;
 }
 
 interface RequestOptionsWithSignal<T> extends BaseRequestOptions<T> {
@@ -291,6 +292,7 @@ export class Client {
       headers: options.headers,
       method: options.method,
       redirect: options.redirect,
+      compress: options.compress,
     };
 
     if (this.opts.proxy) {

--- a/src/hosting/initMiddleware.ts
+++ b/src/hosting/initMiddleware.ts
@@ -29,6 +29,7 @@ export function initMiddleware(init: TemplateServerResponse): RequestHandler {
         path: u.pathname,
         responseType: "stream",
         resolveOnHTTPError: true,
+        compress: false,
       })
         .then((sdkRes) => {
           if (sdkRes.status === 404) {

--- a/src/hosting/initMiddleware.ts
+++ b/src/hosting/initMiddleware.ts
@@ -24,9 +24,15 @@ export function initMiddleware(init: TemplateServerResponse): RequestHandler {
       const sdkName = match[2];
       const u = new url.URL(`https://www.gstatic.com/firebasejs/${version}/${sdkName}`);
       const c = new Client({ urlPrefix: u.origin, auth: false });
+      const headers: { [key: string]: string } = {};
+      const acceptEncoding = req.headers["accept-encoding"];
+      if (typeof acceptEncoding === "string" && acceptEncoding) {
+        headers["accept-encoding"] = acceptEncoding;
+      }
       c.request<unknown, NodeJS.ReadableStream>({
         method: "GET",
         path: u.pathname,
+        headers,
         responseType: "stream",
         resolveOnHTTPError: true,
         compress: false,

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -99,6 +99,7 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
         redirect: "manual",
         body: passThrough,
         timeout: 60000,
+        compress: false,
       });
     } catch (err) {
       const isAbortError =

--- a/src/test/hosting/initMiddleware.spec.ts
+++ b/src/test/hosting/initMiddleware.spec.ts
@@ -1,0 +1,162 @@
+import { createGunzip, createGzip } from "zlib";
+import { expect } from "chai";
+import * as express from "express";
+import * as http from "http";
+import * as nock from "nock";
+import * as portfinder from "portfinder";
+import * as supertest from "supertest";
+
+import { initMiddleware } from "../../hosting/initMiddleware";
+import { streamToString, stringToStream } from "../../utils";
+import { TemplateServerResponse } from "../../hosting/implicitInit";
+
+const templateServerRes: TemplateServerResponse = {
+  js: "here is some js",
+  emulatorsJs: "emulator js",
+  json: JSON.stringify({ id: "foo" }),
+};
+
+describe("initMiddleware", () => {
+  it("should be able to proxy a basic sdk request", async () => {
+    nock("https://www.gstatic.com").get("/firebasejs/v2.2.2/sample-sdk.js").reply(200, "content");
+
+    const mw = initMiddleware(templateServerRes);
+
+    await supertest(mw)
+      .get("/__/firebase/v2.2.2/sample-sdk.js")
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal("content");
+        expect(nock.isDone()).to.be.true;
+      });
+  });
+
+  it("should provide the init.js file", async () => {
+    const mw = initMiddleware(templateServerRes);
+
+    await supertest(mw)
+      .get("/__/firebase/init.js")
+      .expect(200, templateServerRes.js)
+      .expect("content-type", "application/javascript");
+  });
+
+  it("should provide the emulator init.js file when appropriate", async () => {
+    const mw = initMiddleware(templateServerRes);
+
+    await supertest(mw)
+      .get("/__/firebase/init.js")
+      .query({ useEmulator: true })
+      .expect(200, templateServerRes.emulatorsJs)
+      .expect("content-type", "application/javascript");
+  });
+
+  it("should provide the firebase config (init.json)", async () => {
+    const mw = initMiddleware(templateServerRes);
+
+    await supertest(mw)
+      .get("/__/firebase/init.json")
+      .expect(200, { id: "foo" })
+      .expect("content-type", "application/json");
+  });
+
+  it("should pass (call next) if the sdk file doesn't exit", async () => {
+    nock("https://www.gstatic.com").get("/firebasejs/v2.2.2/sample-sdk.js").reply(404, "no sdk");
+
+    const app = express();
+    const mw = initMiddleware(templateServerRes);
+    app.use(mw);
+    app.use((req: unknown, res: express.Response) => {
+      res.status(200).send("index");
+    });
+
+    await supertest(app)
+      .get("/__/firebase/v2.2.2/sample-sdk.js")
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal("index");
+        expect(nock.isDone()).to.be.true;
+      });
+  });
+
+  it("should ignore any other request path (200)", async () => {
+    const app = express();
+    const mw = initMiddleware(templateServerRes);
+    app.use(mw);
+    app.use((req, res) => {
+      res.status(200).send("index");
+    });
+
+    await supertest(app)
+      .get("/anything.else")
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal("index");
+      });
+  });
+
+  it("should ignore any other request path (403)", async () => {
+    const app = express();
+    const mw = initMiddleware(templateServerRes);
+    app.use(mw);
+    app.use((req, res) => {
+      res.status(403).send("not here");
+    });
+
+    await supertest(app)
+      .get("/anything.else")
+      .expect(403)
+      .then((res) => {
+        expect(res.text).to.equal("not here");
+      });
+  });
+
+  describe("when dealing with compressed data", () => {
+    // This needs to be done using a running server. All the testing libraries
+    // automatically handle compressed data, so a real request against a real
+    // server is the easiest way to confirm this behavior.
+    const content = "this should be compressed";
+    const contentStream = stringToStream(content);
+    const compressedStream = contentStream?.pipe(createGzip());
+
+    const app = express();
+    app.use(initMiddleware(templateServerRes));
+
+    let server: http.Server;
+    let port: number;
+
+    beforeEach(async () => {
+      port = await portfinder.getPortPromise();
+      await new Promise((resolve) => (server = app.listen(port, resolve)));
+    });
+
+    afterEach(async () => {
+      await new Promise((resolve) => server.close(resolve));
+    });
+
+    it("should return compressed data if it is returned compressed", async () => {
+      nock("https://www.gstatic.com")
+        .get("/firebasejs/v2.2.2/sample-sdk.js")
+        .reply(200, () => compressedStream, { "content-encoding": "gzip" });
+
+      const res = await new Promise<http.IncomingMessage>((resolve, reject) => {
+        const req = http.request(
+          {
+            method: "GET",
+            port,
+            path: `/__/firebase/v2.2.2/sample-sdk.js`,
+          },
+          resolve
+        );
+        req.on("error", reject);
+        req.end();
+      });
+
+      // The response should be gzipped, so piping it here should decompress it.
+      const gunzip = createGunzip();
+      const uncompressed = res.pipe(gunzip);
+      const c = await streamToString(uncompressed);
+      expect(c).to.equal(content);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});

--- a/src/test/hosting/initMiddleware.spec.ts
+++ b/src/test/hosting/initMiddleware.spec.ts
@@ -31,6 +31,24 @@ describe("initMiddleware", () => {
       });
   });
 
+  it("should be able to proxy with the correct accept-encoding", async () => {
+    nock("https://www.gstatic.com")
+      .get("/firebasejs/v2.2.2/sample-sdk.js")
+      .matchHeader("accept-encoding", "brrr")
+      .reply(200, "content");
+
+    const mw = initMiddleware(templateServerRes);
+
+    await supertest(mw)
+      .get("/__/firebase/v2.2.2/sample-sdk.js")
+      .set("accept-encoding", "brrr")
+      .expect(200)
+      .then((res) => {
+        expect(res.text).to.equal("content");
+        expect(nock.isDone()).to.be.true;
+      });
+  });
+
   it("should provide the init.js file", async () => {
     const mw = initMiddleware(templateServerRes);
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When using the Hosting emulator, we insert middleware for two cases:
1. fetching javascript SDK files from gstatic and providing initialization helpers, and
2. proxying to CF3, either locally emulated functions or live functions.

In both of these cases, we send along most of the original request through `node-fetch` and receive a response. Now, `node-fetch` (in apiv2) "helpfully" will automatically decompress the response if it is a recognized compression (via `content-encoding` headers) and return to our proxy logic the decompressed content. When we take that response and pass it (along with the original headers) along to the originating response, we sometimes _lose_ content because the compressed response is not re-compressed automatically and the `content-length` header can cause the response to look truncated.

This PR adds support for the `compress` flag, which originates from `node-fetch`. The `compress` flag indicates to `apiv2` (and `node-fetch`) that it (a) should not add an `accept-encoding` header to the response if one does not exist and (b) should not decompress the response if it recognizes the encoding. With that in place, our proxies correctly return compressed content as appropriate and the requests don't throw errors in browsers any longer.

Fixes #3052
Fixes #3055

### Scenarios Tested

I was able to replicate this behavior fairly reliably for (1) by initializing a new Hosting directory and loading it up in the emulator. Looking at the network tab of the inspector, I see no more "failed" responses.

#3055 provided a repro case that I was able to use for (2). Their `/test` endpoint would fail to load, but with this fix, it is successfully loading again.

I also added a test that verifies that the middleware powering (1) doesn't decompress the request when it's being proxied. This was slightly tricky to write because I have to use more basic Node tools, but I believe the test to be valid (and it breaks if `compress` is removed).

I guess this goes into the pile of "things `request` used to do automatically". This was a bugger to track down, but I feel more confident in it now.