### PR TITLE
Add logging to auth emulator when import directory is invalid

### DIFF
--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -77,7 +77,7 @@ export class AuthEmulator implements EmulatorInstance {
       logger.logLabeled(
         "WARN",
         "auth",
-        `Error importing config from ${configPath}. Skipping config import`
+        `Skipped importing config because ${configPath} does not exist.`
       );
     }
 
@@ -105,7 +105,7 @@ export class AuthEmulator implements EmulatorInstance {
       logger.logLabeled(
         "WARN",
         "auth",
-        `Error importing accounts from ${accountsPath}. Skipping accounts import`
+        `Skipped importing accounts because ${accountsPath} does not exist.`
       );
     }
   }

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -73,6 +73,12 @@ export class AuthEmulator implements EmulatorInstance {
         },
         configPath
       );
+    } else {
+      logger.logLabeled(
+        "WARN",
+        "auth",
+        `Error importing config from ${configPath}. Skipping config import`
+      );
     }
 
     const accountsPath = path.join(authExportDir, "accounts.json");
@@ -94,6 +100,12 @@ export class AuthEmulator implements EmulatorInstance {
         accountsPath,
         // Ignore the error when there are no users. No action needed.
         { ignoreErrors: ["MISSING_USER_ACCOUNT"] }
+      );
+    } else {
+      logger.logLabeled(
+        "WARN",
+        "auth",
+        `Error importing accounts from ${accountsPath}. Skipping accounts import`
       );
     }
   }


### PR DESCRIPTION
### Description

Addresses Issue #3022 by adding more logs when auth import files cannot be loaded.

### Scenarios Tested
- `firebase emulators:exec` with `import` flag and valid auth import directory
- `firebase emulators:exec` with `import` flag and invalid auth import directory
- `firebase emulators:exec` without `import` flag

### Sample Commands
`firebase emulators:exec "./test.sh" --import=./emulator-data/ --only auth --project=my-test-project`