### PR TITLE
Adding logic to build regional deployments

### DIFF
--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -3,7 +3,11 @@ import { bold } from "cli-color";
 
 import { debug } from "../../logger";
 import * as track from "../../track";
-import { getReleaseNames, getFunctionsInfo, getFilterGroups } from "../../functionsDeployHelper";
+import {
+  getReleaseNames,
+  getFilterGroups,
+  CloudFunctionTrigger,
+} from "../../functionsDeployHelper";
 import { FirebaseError } from "../../error";
 import { testIamPermissions, testResourceIamPermissions } from "../../gcp/iam";
 
@@ -51,13 +55,12 @@ export async function checkServiceAccountIam(projectId: string): Promise<void> {
  * @param payload The deploy payload.
  */
 export async function checkHttpIam(context: any, options: any, payload: any): Promise<void> {
-  const triggers = payload.functions.triggers;
-  const functionsInfo = getFunctionsInfo(triggers, context.projectId);
+  const functionsInfo = payload.functions.triggers;
   const filterGroups = getFilterGroups(options);
 
   const httpFunctionNames: string[] = functionsInfo
-    .filter((f) => has(f, "httpsTrigger"))
-    .map((f) => f.name);
+    .filter((f: CloudFunctionTrigger) => has(f, "httpsTrigger"))
+    .map((f: CloudFunctionTrigger) => f.name);
   const httpFunctionFullNames: string[] = getReleaseNames(httpFunctionNames, [], filterGroups);
   const existingFunctionFullNames: string[] = context.existingFunctions.map(
     (f: { name: string }) => f.name


### PR DESCRIPTION
### Description
Implements the logic to build regional deployments, per the design at go/cf3-deployment-refactor. This will be followed up by another PR to execute these deployments - I separated this chunk so it would be easier to verify that the new logic for what gets deployed matches the old logic.

### Scenarios Tested
I ran some deploys to confirm that deploys weren't broken, but I relied on the unit tests to test createRegionalDeployment, since it's not yet used in the deployment.