### PR TITLE
Implement session cookies in Auth Emulator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Adds support for uploading Android App Bundles (AABs) to App Distribution.
 - Adds support for batchDelete in Auth Emulator (#3091).
+- Adds support for createSessionCookie in Auth Emulator (#3094).

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -534,15 +534,15 @@ function createSessionCookie(
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1CreateSessionCookieResponse"] {
   assert(reqBody.idToken, "MISSING_ID_TOKEN");
-  const validSince = Number(reqBody.validDuration) || SESSION_COOKIE_MAX_VALID_DURATION;
+  const validDuration = Number(reqBody.validDuration) || SESSION_COOKIE_MAX_VALID_DURATION;
   assert(
-    validSince >= SESSION_COOKIE_MIN_VALID_DURATION &&
-      validSince <= SESSION_COOKIE_MAX_VALID_DURATION,
+    validDuration >= SESSION_COOKIE_MIN_VALID_DURATION &&
+      validDuration <= SESSION_COOKIE_MAX_VALID_DURATION,
     "INVALID_DURATION"
   );
   const { payload } = parseIdToken(state, reqBody.idToken);
   const issuedAt = toUnixTimestamp(new Date());
-  const expiresAt = issuedAt + validSince;
+  const expiresAt = issuedAt + validDuration;
   const sessionCookie = signJwt(
     {
       ...payload,

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { UserInfo } from "../../../emulator/auth/state";
 import { PROJECT_ID, signInWithPhoneNumber, TEST_PHONE_NUMBER } from "./helpers";
 import { describeAuthEmulator } from "./setup";
@@ -9,6 +10,11 @@ import {
   updateAccountByLocalId,
   expectUserNotExistsForIdToken,
 } from "./helpers";
+import {
+  FirebaseJwtPayload,
+  SESSION_COOKIE_MAX_VALID_DURATION,
+} from "../../../emulator/auth/operations";
+import { toUnixTimestamp } from "../../../emulator/auth/utils";
 
 describeAuthEmulator("token refresh", ({ authApi }) => {
   it("should exchange refresh token for new tokens", async () => {
@@ -45,6 +51,109 @@ describeAuthEmulator("token refresh", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error.message).to.equal("USER_DISABLED");
+      });
+  });
+});
+
+describeAuthEmulator("createSessionCookie", ({ authApi }) => {
+  it("should return a valid sessionCookie", async () => {
+    const { idToken } = await registerAnonUser(authApi());
+    const validDuration = 7777; /* seconds */
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}:createSessionCookie`)
+      .set("Authorization", "Bearer owner")
+      .send({ idToken, validDuration: validDuration.toString() })
+      .then((res) => {
+        expectStatusCode(200, res);
+        const sessionCookie = res.body.sessionCookie;
+        expect(sessionCookie).to.be.a("string");
+
+        const decoded = decodeJwt(sessionCookie, { complete: true }) as {
+          header: JwtHeader;
+          payload: FirebaseJwtPayload;
+        } | null;
+        expect(decoded, "session cookie is invalid").not.to.be.null;
+        expect(decoded!.header.alg).to.eql("none");
+        expect(decoded!.payload.iat).to.equal(toUnixTimestamp(new Date()));
+        expect(decoded!.payload.exp).to.equal(toUnixTimestamp(new Date()) + validDuration);
+        expect(decoded!.payload.iss).to.equal(`https://session.firebase.google.com/${PROJECT_ID}`);
+
+        const idTokenProps = decodeJwt(idToken) as Partial<FirebaseJwtPayload>;
+        delete idTokenProps.iss;
+        delete idTokenProps.iat;
+        delete idTokenProps.exp;
+        expect(decoded!.payload).to.deep.contain(idTokenProps);
+      });
+  });
+
+  it("should throw if idToken is missing", async () => {
+    const validDuration = 7777; /* seconds */
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}:createSessionCookie`)
+      .set("Authorization", "Bearer owner")
+      .send({ validDuration: validDuration.toString() /* no idToken */ })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.equal("MISSING_ID_TOKEN");
+      });
+  });
+
+  it("should throw if idToken is invalid", async () => {
+    const validDuration = 7777; /* seconds */
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}:createSessionCookie`)
+      .set("Authorization", "Bearer owner")
+      .send({ idToken: "invalid", validDuration: validDuration.toString() })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.equal("INVALID_ID_TOKEN");
+      });
+  });
+
+  it("should use default session cookie validDuration if not specified", async () => {
+    const { idToken } = await registerAnonUser(authApi());
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}:createSessionCookie`)
+      .set("Authorization", "Bearer owner")
+      .send({ idToken })
+      .then((res) => {
+        expectStatusCode(200, res);
+        const sessionCookie = res.body.sessionCookie;
+        expect(sessionCookie).to.be.a("string");
+
+        const decoded = decodeJwt(sessionCookie, { complete: true }) as {
+          header: JwtHeader;
+          payload: FirebaseJwtPayload;
+        } | null;
+        expect(decoded, "session cookie is invalid").not.to.be.null;
+        expect(decoded!.header.alg).to.eql("none");
+        expect(decoded!.payload.exp).to.equal(
+          toUnixTimestamp(new Date()) + SESSION_COOKIE_MAX_VALID_DURATION
+        );
+      });
+  });
+
+  it("should throw if validDuration is too short or too long", async () => {
+    const { idToken } = await registerAnonUser(authApi());
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}:createSessionCookie`)
+      .set("Authorization", "Bearer owner")
+      .send({ idToken, validDuration: "1" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.equal("INVALID_DURATION");
+      });
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}:createSessionCookie`)
+      .set("Authorization", "Bearer owner")
+      .send({ idToken, validDuration: "999999999999" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.equal("INVALID_DURATION");
       });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR adds support for the `createSessionCookie` API.

### Scenarios Tested

See tests added

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
