### PR TITLE
Fixes manipulated location header in Hosting emulator proxy logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where proxied requests to dynamic content through the Hosting emulator would return unexpected `location` headers. (#3097)

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -153,8 +153,12 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
       // our emulator.
       try {
         const locationURL = new URL(location);
-        const unborkedLocation = location.replace(locationURL.origin, "");
-        proxyRes.response.headers.set("location", unborkedLocation);
+        // Only assume we can fix the location header if the origin of the
+        // "fixed" header is the same as the origin of the outbound request.
+        if (locationURL.origin == u.origin) {
+          const unborkedLocation = location.replace(locationURL.origin, "");
+          proxyRes.response.headers.set("location", unborkedLocation);
+        }
       } catch (e) {
         logger.debug(
           `[hosting] had trouble parsing location header, but this may be okay: "${location}"`

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -141,6 +141,8 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
 
     proxyRes.response.headers.set("vary", makeVary(proxyRes.response.headers.get("vary")));
 
+    // Fix the location header that `node-fetch` attempts to helpfully fix:
+    // https://github.com/node-fetch/node-fetch/blob/4abbfd231f4bce7dbe65e060a6323fc6917fd6d9/src/index.js#L117-L120
     const location = proxyRes.response.headers.get("location");
     if (location) {
       const locationURL = new URL(location);

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -175,7 +175,6 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
 /**
  * Returns an Express RequestHandler that will both log out the error and
  * return an internal HTTP error response.
- * @param error
  */
 export function errorRequestHandler(error: string): RequestHandler {
   return (req: Request, res: Response, next: () => void): any => {

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -38,8 +38,6 @@ function makeVary(vary: string | null = ""): string {
  * when writing out logs or errors.  This makes some minor changes to headers,
  * cookies, and caching similar to the behavior of the production version of
  * the Firebase Hosting origin.
- * @param url
- * @param rewriteIdentifier
  */
 export function proxyRequestHandler(url: string, rewriteIdentifier: string): RequestHandler {
   return async (req: IncomingMessage, res: ServerResponse, next: () => void): Promise<void> => {
@@ -167,7 +165,7 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
     }
 
     for (const [key, value] of Object.entries(proxyRes.response.headers.raw())) {
-      res.setHeader(key, value);
+      res.setHeader(key, value as string[]);
     }
     res.statusCode = proxyRes.status;
     proxyRes.response.body.pipe(res);

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -141,6 +141,13 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
 
     proxyRes.response.headers.set("vary", makeVary(proxyRes.response.headers.get("vary")));
 
+    const location = proxyRes.response.headers.get("location");
+    if (location) {
+      const locationURL = new URL(location);
+      const unborkedLocation = location.replace(locationURL.origin, "");
+      proxyRes.response.headers.set("location", unborkedLocation);
+    }
+
     for (const [key, value] of Object.entries(proxyRes.response.headers.raw())) {
       res.setHeader(key, value as string[]);
     }

--- a/src/hosting/proxy.ts
+++ b/src/hosting/proxy.ts
@@ -143,6 +143,8 @@ export function proxyRequestHandler(url: string, rewriteIdentifier: string): Req
 
     // Fix the location header that `node-fetch` attempts to helpfully fix:
     // https://github.com/node-fetch/node-fetch/blob/4abbfd231f4bce7dbe65e060a6323fc6917fd6d9/src/index.js#L117-L120
+    // Filed a bug in `node-fetch` to either document the change or fix it:
+    // https://github.com/node-fetch/node-fetch/issues/1086
     const location = proxyRes.response.headers.get("location");
     if (location) {
       // If parsing the URL fails, it may be because the location header

--- a/src/test/hosting/functionsProxy.spec.ts
+++ b/src/test/hosting/functionsProxy.spec.ts
@@ -67,6 +67,27 @@ describe("functionsProxy", () => {
       });
   });
 
+  it("should maintain the location header as returned by the function", async () => {
+    nock("http://localhost:7778")
+      .get("/project-foo/us-central1/bar/")
+      .reply(301, "", { location: "/over-here" });
+
+    const options = cloneDeep(fakeOptions);
+    options.targets = ["functions"];
+
+    const mwGenerator = functionsProxy(options);
+    const mw = await mwGenerator(fakeRewrite);
+    const spyMw = sinon.spy(mw);
+
+    return supertest(spyMw)
+      .get("/")
+      .expect(301)
+      .then((res) => {
+        expect(res.header["location"]).to.equal("/over-here");
+        expect(spyMw.calledOnce).to.be.true;
+      });
+  });
+
   it("should proxy a request body on a POST request", async () => {
     nock("http://localhost:7778")
       .post("/project-foo/us-central1/bar/", "data")

--- a/src/test/hosting/functionsProxy.spec.ts
+++ b/src/test/hosting/functionsProxy.spec.ts
@@ -88,7 +88,7 @@ describe("functionsProxy", () => {
       });
   });
 
-  it("should allow location headers that don't redirect to itself", async () => {
+  it("should allow location headers that wouldn't redirect to itself", async () => {
     nock("http://localhost:7778")
       .get("/project-foo/us-central1/bar/")
       .reply(301, "", { location: "https://example.com/foo" });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #3097

Node fetch attempts to make life easier, but in fact changes behavior that's defined in the spec and doesn't currently document it: https://github.com/node-fetch/node-fetch/blob/4abbfd231f4bce7dbe65e060a6323fc6917fd6d9/src/index.js#L117-L120

I've filed a bug with them: https://github.com/node-fetch/node-fetch/issues/1086

For now, the best we can do is attempt to fix the `location` header that comes back if it's a resolved URL and that URL points us to the same origin as our original proxy request. This allows valid URLs to come back from the proxy target and only strips the origin if it's a redirect to the same origin.

### Scenarios Tested

I have a manual setup where a redirect is returned. I see now that the `location` header is what I expect:

before:

```
» curl -I http://localhost:5000/start
HTTP/1.1 302 Found
x-powered-by: Express
location: http://localhost:5001/somewhereelse
```

after:

```
» curl -I http://localhost:5000/start
HTTP/1.1 302 Found
x-powered-by: Express
location: /somewhereelse
```
