### PR TITLE
docs(emulator): remove extra `-` in `---project` from missing project ID warning

### DIFF
--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -598,7 +598,7 @@ export async function startAll(options: any, showUI: boolean = true): Promise<vo
     EmulatorLogger.forEmulator(Emulators.HUB).logLabeled(
       "WARN",
       "emulators",
-      "The Emulator UI requires a project ID to start. Configure your default project with 'firebase use' or pass the ---project flag."
+      "The Emulator UI requires a project ID to start. Configure your default project with 'firebase use' or pass the --project flag."
     );
   }
 


### PR DESCRIPTION
### Description

If you run the emulator you get a warning that you need to set a project ID and can use the `---project` flag, but it had an extra `-` so if you use it as documented you get this...

```
error: unknown option '---project'
```

### Scenarios Tested

I just created a simple project, added firebase with `firebase init` and never assigned a project. Then I went to run the emulator, etc, etc...