### PR TITLE
fix: bail out of `firebase init hosting:github` early with helpful message if Hosting isn't set up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Fixes issue with filtering on a specific storage bucket using functions in the emulator (#3893)
 - Fixes check in Cloud Functions for Firebase initialization to check for API enablement before trying to enable them. (#2574)
 - No longer tries to clean up function build images from Artifact Registry when Artifact Registry is not enabled (#3943)
+- Show error message when running `firebase init hosting:github` with no Hosting config in `firebase.json` (#3113)

--- a/src/init/features/hosting/github.ts
+++ b/src/init/features/hosting/github.ts
@@ -54,6 +54,12 @@ export async function initGitHub(setup: Setup, config: any, options: any): Promi
     return reject("Could not determine Project ID, can't set up GitHub workflow.", { exit: 1 });
   }
 
+  if (!setup.config.hosting) {
+    return reject(
+      `Didn't find a Hosting config in firebase.json. Run ${bold("firebase init hosting")} instead.`
+    );
+  }
+
   logger.info();
 
   // Find existing Git/Github config


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

#3113 

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1. Create an empty project
2. Run `firebase init hosting:github`
3. The CLI should bail out before the authentication process with Firebase and Github

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
