### PR TITLE
Allow optional extension params to be omitted (#3126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fixes issue where proxied requests to dynamic content through the Hosting emulator would return unexpected `location` headers. (#3097)
-- Fixes issue where optional extension parameters could not be omitted (#3126)
+- Fixes issue where optional extension parameters could not be omitted. (#3126)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes issue where proxied requests to dynamic content through the Hosting emulator would return unexpected `location` headers. (#3097)
+- Fixes issue where optional extension parameters could not be omitted (#3126)

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -144,7 +144,7 @@ export function populateDefaultParams(paramVars: any, paramSpec: any): any {
     if (!paramVars[env.param]) {
       if (env.default) {
         newParams[env.param] = env.default;
-      } else {
+      } else if (env.required) {
         throw new FirebaseError(
           `${env.param} has not been set in the given params file` +
             " and there is no default available. Please set this variable before installing again."

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -6,17 +6,18 @@ import * as fs from "fs-extra";
 
 import { FirebaseError } from "../../error";
 import * as logger from "../../logger";
-import { ExtensionInstance, ParamType } from "../../extensions/extensionsApi";
+import { ExtensionInstance, Param, ParamType } from "../../extensions/extensionsApi";
 import * as extensionsHelper from "../../extensions/extensionsHelper";
 import * as paramHelper from "../../extensions/paramHelper";
 import * as prompt from "../../prompt";
 
 const PROJECT_ID = "test-proj";
-const TEST_PARAMS = [
+const TEST_PARAMS: Param[] = [
   {
     param: "A_PARAMETER",
     label: "Param",
     type: ParamType.STRING,
+    required: true,
   },
   {
     param: "ANOTHER_PARAMETER",
@@ -26,7 +27,7 @@ const TEST_PARAMS = [
   },
 ];
 
-const TEST_PARAMS_2 = [
+const TEST_PARAMS_2: Param[] = [
   {
     param: "ANOTHER_PARAMETER",
     label: "Another Param",
@@ -46,7 +47,7 @@ const TEST_PARAMS_2 = [
     default: "default",
   },
 ];
-const TEST_PARAMS_3 = [
+const TEST_PARAMS_3: Param[] = [
   {
     param: "A_PARAMETER",
     label: "Param",
@@ -115,7 +116,23 @@ describe("paramHelper", () => {
       });
     });
 
-    it("should throw if a param without a default is not in envFilePath", async () => {
+    it("should omit optional params that are not in envFilePath", async () => {
+      dotenvStub.returns({
+        ANOTHER_PARAMETER: "aValue",
+      });
+
+      const params = await paramHelper.getParams(
+        PROJECT_ID,
+        TEST_PARAMS_3,
+        "./a/path/to/a/file.env"
+      );
+
+      expect(params).to.eql({
+        ANOTHER_PARAMETER: "aValue",
+      });
+    });
+
+    it("should throw if a required param without a default is not in envFilePath", async () => {
       dotenvStub.returns({
         ANOTHER_PARAMETER: "aValue",
       });
@@ -217,6 +234,7 @@ describe("paramHelper", () => {
             label: "Param",
             default: "new default",
             type: ParamType.STRING,
+            required: true,
           },
           {
             param: "ANOTHER_PARAMETER",
@@ -244,6 +262,7 @@ describe("paramHelper", () => {
           label: "Param",
           default: "new default",
           type: ParamType.STRING,
+          required: true,
         },
         {
           param: "ANOTHER_PARAMETER",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fix for (#3126): allow optional extension params to be omitted when installing with env file

### Scenarios Tested

* Install firestore-send-email with optional parameters omitted (see Sample Commands).
* Try to install firestore-send-email with required parameter missing (still fails as expected).

### Sample Commands

```shell
# create params file
echo 'LOCATION=europe-west3
SMTP_CONNECTION_URI=smtps://user:pass@example.org
MAIL_COLLECTION=mail
DEFAULT_FROM=test@example.org' > send-email.env

# try to install extension
firebase ext:install firestore-send-email --params='send-email.env'
```