### PR TITLE
Implement validation for changing trigger types, and fixes from bug bash

### DIFF
--- a/src/deploy/functions/deploymentPlanner.ts
+++ b/src/deploy/functions/deploymentPlanner.ts
@@ -1,5 +1,6 @@
 import * as deploymentTool from "../../deploymentTool";
 import { functionMatchesAnyGroup, getTopicName } from "../../functionsDeployHelper";
+import { checkForInvalidChangeOfTrigger } from "./validate";
 
 // TODO: Better name for this?
 // It's really a CloudFuntion, not just a trigger,
@@ -144,6 +145,8 @@ export function createDeploymentPlan(
       }
 
       if (matchingExistingFunction) {
+        // Check if this is an invalid change of trigger type.
+        checkForInvalidChangeOfTrigger(fn, matchingExistingFunction);
         regionalDeployment.functionsToUpdate.push(fn);
         existingFnsCopy = existingFnsCopy.filter((exFn: CloudFunctionTrigger) => {
           return exFn.name !== fn.name;

--- a/src/deploy/functions/errorHandler.ts
+++ b/src/deploy/functions/errorHandler.ts
@@ -1,6 +1,7 @@
 import * as clc from "cli-color";
 
 import * as logger from "../../logger";
+import { getFunctionId, getFunctionLabel } from "../../functionsDeployHelper";
 import { FirebaseError } from "../../error";
 
 type OperationType =
@@ -42,7 +43,7 @@ export class ErrorHandler {
     }
     logger.info("\nFunctions deploy had errors with the following functions:");
     for (const failedDeployment of this.errors) {
-      logger.info(`\t${failedDeployment.functionName}`);
+      logger.info(`\t${getFunctionLabel(failedDeployment.functionName)}`);
     }
     logger.info("\nTo try redeploying those functions, run:");
     logger.info(
@@ -52,7 +53,8 @@ export class ErrorHandler {
         clc.bold(
           this.errors
             .map(
-              (failedDeployment) => `functions:${failedDeployment.functionName.replace(/-/g, ".")}`
+              (failedDeployment) =>
+                `functions:${getFunctionId(failedDeployment.functionName).replace(/-/g, ".")}`
             )
             .join(",")
         ) +

--- a/src/deploy/functions/tasks.ts
+++ b/src/deploy/functions/tasks.ts
@@ -19,7 +19,7 @@ import { ErrorHandler } from "./errorHandler";
 const defaultPollerOptions = {
   apiOrigin: functionsOrigin,
   apiVersion: cloudfunctions.API_VERSION,
-  masterTimeout: 180000, // 180000ms = 3 minutes
+  masterTimeout: 300000, // 300000ms = 5 minutes
 };
 
 export interface TaskParams {

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -86,18 +86,25 @@ export function checkForInvalidChangeOfTrigger(
   fn: CloudFunctionTrigger,
   exFn: CloudFunctionTrigger
 ) {
-  let shouldThrow = false;
   if (fn.httpsTrigger && !exFn.httpsTrigger) {
-    shouldThrow = true;
-  }
-  if (fn.eventTrigger?.service != exFn.eventTrigger?.service) {
-    shouldThrow = true;
-  }
-  if (shouldThrow) {
     throw new FirebaseError(
       `[${getFunctionLabel(
         fn.name
-      )}] Change of function trigger type or event provider is not allowed.`
+      )}] Changing from a background triggered function to an HTTPS function is not allowed. Please delete your function and create a new one instead.`
+    );
+  }
+  if (!fn.httpsTrigger && exFn.httpsTrigger) {
+    throw new FirebaseError(
+      `[${getFunctionLabel(
+        fn.name
+      )}] Changing from an HTTPS function to an background triggered function is not allowed. Please delete your function and create a new one instead.`
+    );
+  }
+  if (fn.eventTrigger?.service != exFn.eventTrigger?.service) {
+    throw new FirebaseError(
+      `[${getFunctionLabel(
+        fn.name
+      )}] Changing to a different type of background trigger is not allowed. Please delete your function and create a new one instead.`
     );
   }
 }

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -6,6 +6,8 @@ import * as logger from "../../logger";
 import * as projectPath from "../../projectPath";
 import * as fsutils from "../../fsutils";
 import { RUNTIME_NOT_SET } from "../../parseRuntimeAndValidateSDK";
+import { getFunctionLabel } from "../../functionsDeployHelper";
+import { CloudFunctionTrigger } from "./deploymentPlanner";
 
 // have to require this because no @types/cjson available
 // tslint:disable-next-line
@@ -80,6 +82,25 @@ export function packageJsonIsValid(
   }
 }
 
+export function checkForInvalidChangeOfTrigger(
+  fn: CloudFunctionTrigger,
+  exFn: CloudFunctionTrigger
+) {
+  let shouldThrow = false;
+  if (fn.httpsTrigger && !exFn.httpsTrigger) {
+    shouldThrow = true;
+  }
+  if (fn.eventTrigger?.service != exFn.eventTrigger?.service) {
+    shouldThrow = true;
+  }
+  if (shouldThrow) {
+    throw new FirebaseError(
+      `[${getFunctionLabel(
+        fn.name
+      )}] Change of function trigger type or event provider is not allowed.`
+    );
+  }
+}
 /**
  * Asserts that functions source directory exists and source file is present.
  * @param data Object representing package.json file.


### PR DESCRIPTION
### Description
Adds validation to throw a clearly worded error before deployment when trying to change a functions trigger type in a way that would cause the deployment to fail. Also cleaning up the error messages printed when a deployment fails, and increasing the timeout on our pollers.

### Scenarios Tested

Trying to change a function from https to Firestore (also tested the other direction, as well as Firestore -> Storage, they look the same):
<img width="971" alt="Screen Shot 2021-02-12 at 11 59 00 AM" src="https://user-images.githubusercontent.com/4635763/107816532-c1f3d000-6d29-11eb-937b-643ed6f2361f.png">

The updated error messages printed when deployment fails - I also tested & confirmed that the redeploy command works as intended.
<img width="443" alt="Screen Shot 2021-02-12 at 12 00 47 PM" src="https://user-images.githubusercontent.com/4635763/107816684-f7002280-6d29-11eb-835e-33f90c48b597.png">

