### PR TITLE
fix(emulator): Hosting emulator should not connect to 0.0.0.0 for emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Fixes issue where proxied requests to dynamic content through the Hosting emulator would return unexpected `location` headers. (#3097)
 - Fixes issue where optional extension parameters could not be omitted. (#3126)
-- Fixes issue where hosting emulator should not connect to 0.0.0.0 for emulators. (#3121)
+- Fixes issue where hosting emulator would connect to 0.0.0.0 for emulators. (#3121)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes issue where proxied requests to dynamic content through the Hosting emulator would return unexpected `location` headers. (#3097)
 - Fixes issue where optional extension parameters could not be omitted. (#3126)
+- Fixes issue where hosting emulator should not connect to 0.0.0.0 for emulators. (#3121)

--- a/src/hosting/implicitInit.ts
+++ b/src/hosting/implicitInit.ts
@@ -68,8 +68,17 @@ export async function implicitInit(options: any): Promise<TemplateServerResponse
     const info = EmulatorRegistry.getInfo(e);
 
     if (info) {
-      // IPv6 hosts need to be quoted using brackets.
-      const host = info.host.includes(":") ? `[${info.host}]` : info.host;
+      let host = info.host;
+
+      if (host === "0.0.0.0") {
+        host = "127.0.0.1";
+      } else if (host === "::") {
+        host = "[::1]";
+      } else if (host.includes(":")) {
+        // IPv6 hosts need to be quoted using brackets.
+        host = `[${host}]`;
+      }
+
       emulators[e] = {
         host,
         port: info.port,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fix for (#3121): Fixed to connect to 127.0.0.1 when host is set to 0.0.0.0 in firebase.json

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

**public/index.html**

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="utf-8" />
    <meta name="viewport" content="width=device-width, initial-scale=1" />
    <title>Welcome to Firebase Hosting</title>

    <script defer src="/__/firebase/8.2.7/firebase-app.js"></script>
    <script defer src="/__/firebase/8.2.7/firebase-firestore.js"></script>
    <script defer src="/__/firebase/init.js?useEmulator=true"></script>
  </head>
  <body>
    <script>
      document.addEventListener("DOMContentLoaded", function () {
        firebase
          .firestore()
          .doc("/foo/bar")
          .get()
          .then((doc) => {
            console.log(doc.exists);
          });
      });
    </script>
  </body>
</html>
```

**firebase.json**

```json
{
  "firestore": {
    "rules": "firestore.rules",
    "indexes": "firestore.indexes.json"
  },
  "hosting": {
    "public": "public",
    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"]
  },
  "emulators": {
    "firestore": {
      "host": "0.0.0.0",
      "port": 8080
    },
    "hosting": {
      "host": "0.0.0.0",
      "port": 5000
    },
    "ui": {
      "enabled": false
    }
  }
}
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
