### PR TITLE
Remove @types/filesize stub types definition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2109,14 +2109,6 @@
         "@types/range-parser": "*"
       }
     },
-    "@types/filesize": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/filesize/-/filesize-5.0.0.tgz",
-      "integrity": "sha512-zgn1Kmm6VfqruG9STpwpZiSnpzHjF9hlvHVw+5hhM20xRCOIgjxnXJxOoLuZ/aWS6v/M5d6fvXFbbVQfBe4cMg==",
-      "requires": {
-        "filesize": "*"
-      }
-    },
     "@types/fs-extra": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   "dependencies": {
     "@google-cloud/pubsub": "^2.7.0",
     "@types/archiver": "^5.1.0",
-    "@types/filesize": "^5.0.0",
+    "JSONStream": "^1.2.1",
     "abort-controller": "^3.0.0",
     "archiver": "^5.0.0",
     "body-parser": "^1.19.0",
@@ -106,7 +106,6 @@
     "inquirer": "~6.3.1",
     "js-yaml": "^3.13.1",
     "jsonschema": "^1.0.2",
-    "JSONStream": "^1.2.1",
     "jsonwebtoken": "^8.2.1",
     "leven": "^3.1.0",
     "lodash": "^4.17.19",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Remove stub types definition of package `filesize` as it's not necessary anymore since version > 5.0.0. This will remove the following warning when installing firebase-tools:

```
warning firebase-tools > @types/filesize@5.0.0: This is a stub types definition. filesize provides its own type definitions, so you do not need this installed.
```