### PR TITLE
Apply rules to the correct emulated RTDB instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes issue where OOB flow is not initiated after updating a user's email (#3096)
+- Fixes issue where rules are not applied to the default emulated Realtime Database instance (#3124)

--- a/src/database/rulesConfig.ts
+++ b/src/database/rulesConfig.ts
@@ -41,7 +41,8 @@ export function getRulesConfig(projectId: string, options: any): RulesInstanceCo
 
   if (!Array.isArray(dbConfig)) {
     if (dbConfig && dbConfig.rules) {
-      return [{ rules: dbConfig.rules, instance: options.instance || options.project }];
+      const instance = options.instance || `${options.project}-default-rtdb`;
+      return [{ rules: dbConfig.rules, instance }];
     } else {
       logger.debug("Possibly invalid database config: ", JSON.stringify(dbConfig));
       return [];

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -39,6 +39,7 @@ import { promptOnce } from "../prompt";
 import * as rimraf from "rimraf";
 import { FLAG_EXPORT_ON_EXIT_NAME } from "./commandUtils";
 import { fileExistsSync } from "../fsutils";
+import { getDefaultDatabaseInstance } from "../getDefaultDatabaseInstance";
 
 async function getAndCheckAddress(emulator: Emulators, options: any): Promise<Address> {
   let host = Constants.normalizeHost(
@@ -493,6 +494,16 @@ export async function startAll(options: any, showUI: boolean = true): Promise<vo
       projectId,
       auto_download: true,
     };
+
+    // Try to fetch the default RTDB instance for a project, but don't hard-fail if we
+    // can't because the user may be using a fake project.
+    try {
+      if (!options.instance) {
+        options.instance = await getDefaultDatabaseInstance(options);
+      }
+    } catch (e) {
+      databaseLogger.log("DEBUG", `Failed to retrieve default database instance: ${JSON.stringify(e)}`);
+    }
 
     const rc = dbRulesConfig.normalizeRulesConfig(
       dbRulesConfig.getRulesConfig(projectId, options),

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -502,7 +502,10 @@ export async function startAll(options: any, showUI: boolean = true): Promise<vo
         options.instance = await getDefaultDatabaseInstance(options);
       }
     } catch (e) {
-      databaseLogger.log("DEBUG", `Failed to retrieve default database instance: ${JSON.stringify(e)}`);
+      databaseLogger.log(
+        "DEBUG",
+        `Failed to retrieve default database instance: ${JSON.stringify(e)}`
+      );
     }
 
     const rc = dbRulesConfig.normalizeRulesConfig(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #3124

### Scenarios Tested

Simple firebase.json
```json
{
  "database": {
    "rules": "database.rules.json"
  },
  "emulators": {
    "database": {
      "port": 9000
    },
    "ui": {
      "enabled": true
    }
  }
}
```

Used a newly created project with a single RTDB instance:
```
https://test-rtdb-flow-default-rtdb.europe-west1.firebasedatabase.app/
```

Debug logs from `emulators:start`
```
$ firebase --debug emulators:start
[2021-02-18T15:49:14.664Z] > command requires scopes: ["email","openid","https://www.googleapis.com/auth/cloudplatformprojects.readonly","https://www.googleapis.com/auth/firebase","https://www.googleapis.com/auth/cloud-platform"]
[2021-02-18T15:49:14.666Z] > authorizing via signed-in user
i  emulators: Starting emulators: database {"metadata":{"emulator":{"name":"hub"},"message":"Starting emulators: database"}}
[2021-02-18T15:49:14.686Z] [hub] writing locator at /var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/hub-test-rtdb-flow.json
[2021-02-18T15:49:14.713Z] >>> [apiv2][query] GET https://firebase.googleapis.com/v1beta1/projects/test-rtdb-flow [none]
[2021-02-18T15:49:14.949Z] <<< [apiv2][status] GET https://firebase.googleapis.com/v1beta1/projects/test-rtdb-flow 200
[2021-02-18T15:49:14.950Z] <<< [apiv2][body] GET https://firebase.googleapis.com/v1beta1/projects/test-rtdb-flow {"projectId":"test-rtdb-flow","projectNumber":"163862336985","displayName":"test-rtdb-flow","name":"projects/test-rtdb-flow","resources":{"hostingSite":"test-rtdb-flow","realtimeDatabaseInstance":"test-rtdb-flow-default-rtdb","storageBucket":"test-rtdb-flow.appspot.com","locationId":"us-central"},"state":"ACTIVE"}
[2021-02-18T15:49:14.950Z] database rules config:  [{"instance":"test-rtdb-flow-default-rtdb","rules":"/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.hqsyDEjv/database.rules.json"}]
[2021-02-18T15:49:14.954Z] Ignoring unsupported arg: projectId {"metadata":{"emulator":{"name":"database"},"message":"Ignoring unsupported arg: projectId"}}
[2021-02-18T15:49:14.954Z] Ignoring unsupported arg: auto_download {"metadata":{"emulator":{"name":"database"},"message":"Ignoring unsupported arg: auto_download"}}
[2021-02-18T15:49:14.954Z] Ignoring unsupported arg: rules {"metadata":{"emulator":{"name":"database"},"message":"Ignoring unsupported arg: rules"}}
[2021-02-18T15:49:14.954Z] Starting Database Emulator with command {"binary":"java","args":["-Duser.language=en","-jar","/Users/samstern/.cache/firebase/emulators/firebase-database-emulator-v4.7.2.jar","--host","localhost","--port",9000],"optionalArgs":["port","host","functions_emulator_port","functions_emulator_host"],"joinArgs":false} {"metadata":{"emulator":{"name":"database"},"message":"Starting Database Emulator with command {\"binary\":\"java\",\"args\":[\"-Duser.language=en\",\"-jar\",\"/Users/samstern/.cache/firebase/emulators/firebase-database-emulator-v4.7.2.jar\",\"--host\",\"localhost\",\"--port\",9000],\"optionalArgs\":[\"port\",\"host\",\"functions_emulator_port\",\"functions_emulator_host\"],\"joinArgs\":false}"}}
i  database: Database Emulator logging to database-debug.log {"metadata":{"emulator":{"name":"database"},"message":"Database Emulator logging to \u001b[1mdatabase-debug.log\u001b[22m"}}
[2021-02-18T15:49:16.125Z] WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/Users/samstern/.cache/firebase/emulators/firebase-database-emulator-v4.7.2.jar) to field sun.nio.ch.SelectorImpl.selectedKeys
WARNING: Please consider reporting this to the maintainers of io.netty.util.internal.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release {"metadata":{"emulator":{"name":"database"},"message":"WARNING: An illegal reflective access operation has occurred\nWARNING: Illegal reflective access by io.netty.util.internal.ReflectionUtil (file:/Users/samstern/.cache/firebase/emulators/firebase-database-emulator-v4.7.2.jar) to field sun.nio.ch.SelectorImpl.selectedKeys\nWARNING: Please consider reporting this to the maintainers of io.netty.util.internal.ReflectionUtil\nWARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations\nWARNING: All illegal access operations will be denied in a future release"}}
[2021-02-18T15:49:16.126Z] 
 {"metadata":{"emulator":{"name":"database"},"message":"\n"}}
[2021-02-18T15:49:17.253Z] 15:49:17.252 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started
 {"metadata":{"emulator":{"name":"database"},"message":"15:49:17.252 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO akka.event.slf4j.Slf4jLogger - Slf4jLogger started\n"}}
[2021-02-18T15:49:17.462Z] 15:49:17.462 [main] INFO com.firebase.server.forge.App$ - Listening at localhost:9000
 {"metadata":{"emulator":{"name":"database"},"message":"15:49:17.462 [main] INFO com.firebase.server.forge.App$ - Listening at localhost:9000\n"}}
⚠  ui: Emulator UI unable to start on port 4000, starting on 4001 instead. {"metadata":{"emulator":{"name":"ui"},"message":"Emulator UI unable to start on port 4000, starting on 4001 instead."}}
[2021-02-18T15:49:17.791Z] Ignoring unsupported arg: auto_download {"metadata":{"emulator":{"name":"ui"},"message":"Ignoring unsupported arg: auto_download"}}
[2021-02-18T15:49:17.791Z] Ignoring unsupported arg: port {"metadata":{"emulator":{"name":"ui"},"message":"Ignoring unsupported arg: port"}}
[2021-02-18T15:49:17.791Z] Starting Emulator UI with command {"binary":"node","args":["/Users/samstern/.cache/firebase/emulators/ui-v1.4.1/server.bundle.js"],"optionalArgs":[],"joinArgs":false} {"metadata":{"emulator":{"name":"ui"},"message":"Starting Emulator UI with command {\"binary\":\"node\",\"args\":[\"/Users/samstern/.cache/firebase/emulators/ui-v1.4.1/server.bundle.js\"],\"optionalArgs\":[],\"joinArgs\":false}"}}
i  ui: Emulator UI logging to ui-debug.log {"metadata":{"emulator":{"name":"ui"},"message":"Emulator UI logging to \u001b[1mui-debug.log\u001b[22m"}}
[2021-02-18T15:49:17.915Z] Web / API server started at http://localhost:4001
 {"metadata":{"emulator":{"name":"ui"},"message":"Web / API server started at http://localhost:4001\n"}}
[2021-02-18T15:49:18.056Z] >>> HTTP REQUEST PUT http://localhost:9000/.settings/rules.json?ns=test-rtdb-flow-default-rtdb  
 {
  "rules": {
    ".read": false,
    ".write": false
  }
}

[2021-02-18T15:49:18.569Z] <<< HTTP RESPONSE 200 {"content-length":"15","content-type":"application/json; charset=utf-8","access-control-allow-origin":"*","cache-control":"no-cache","x-firebase-project-id":"test-rtdb-flow-default-rtdb","x-firebase-project-number":"123456789","x-firebase-uuid":"7d0024a6-e744-44ce-b9fe-9fc9a25d90fe"}

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://localhost:4001                │
└─────────────────────────────────────────────────────────────┘

┌──────────┬────────────────┬────────────────────────────────┐
│ Emulator │ Host:Port      │ View in Emulator UI            │
├──────────┼────────────────┼────────────────────────────────┤
│ Database │ localhost:9000 │ http://localhost:4001/database │
└──────────┴────────────────┴────────────────────────────────┘
  Emulator Hub running at localhost:4400
  Other reserved ports: 4500

Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
 
c^C[2021-02-18T15:49:26.823Z] Received signal SIGINT (Ctrl-C) 1
 
i  emulators: Received SIGINT (Ctrl-C) for the first time. Starting a clean shutdown. 
i  emulators: Please wait for a clean shutdown or send the SIGINT (Ctrl-C) signal again to stop right now. 
i  emulators: Shutting down emulators. {"metadata":{"emulator":{"name":"hub"},"message":"Shutting down emulators."}}
i  ui: Stopping Emulator UI {"metadata":{"emulator":{"name":"ui"},"message":"Stopping Emulator UI"}}
⚠  Emulator UI has exited upon receiving signal: SIGINT 
i  database: Stopping Database Emulator {"metadata":{"emulator":{"name":"database"},"message":"Stopping Database Emulator"}}
[2021-02-18T15:49:26.832Z] 15:49:26.832 [Thread-0] INFO com.firebase.server.forge.App$ - Attempting graceful shutdown.
 {"metadata":{"emulator":{"name":"database"},"message":"15:49:26.832 [Thread-0] INFO com.firebase.server.forge.App$ - Attempting graceful shutdown.\n"}}
[2021-02-18T15:49:26.843Z] 15:49:26.843 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO com.firebase.core.namespace.Terminator$Terminator - 1 actors left to terminate: test-rtdb-flow-default-rtdb
 {"metadata":{"emulator":{"name":"database"},"message":"15:49:26.843 [NamespaceSystem-akka.actor.default-dispatcher-4] INFO com.firebase.core.namespace.Terminator$Terminator - 1 actors left to terminate: test-rtdb-flow-default-rtdb\n"}}
[2021-02-18T15:49:26.855Z] 15:49:26.855 [NamespaceSystem-akka.actor.default-dispatcher-7] INFO com.firebase.core.namespace.NamespaceActor - Stopping namespace actor for test-rtdb-flow-default-rtdb
 {"metadata":{"emulator":{"name":"database"},"message":"15:49:26.855 [NamespaceSystem-akka.actor.default-dispatcher-7] INFO com.firebase.core.namespace.NamespaceActor - Stopping namespace actor for test-rtdb-flow-default-rtdb\n"}}
[2021-02-18T15:49:26.856Z] 15:49:26.856 [NamespaceSystem-akka.actor.default-dispatcher-7] INFO com.firebase.core.namespace.NamespaceActor - Gauges removed for test-rtdb-flow-default-rtdb
 {"metadata":{"emulator":{"name":"database"},"message":"15:49:26.856 [NamespaceSystem-akka.actor.default-dispatcher-7] INFO com.firebase.core.namespace.NamespaceActor - Gauges removed for test-rtdb-flow-default-rtdb\n"}}
[2021-02-18T15:49:26.861Z] 15:49:26.861 [Thread-0] INFO com.firebase.server.forge.App$ - Graceful shutdown complete.
 {"metadata":{"emulator":{"name":"database"},"message":"15:49:26.861 [Thread-0] INFO com.firebase.server.forge.App$ - Graceful shutdown complete.\n"}}
i  hub: Stopping emulator hub {"metadata":{"emulator":{"name":"hub"},"message":"Stopping emulator hub"}}
i  logging: Stopping Logging Emulator {"metadata":{"emulator":{"name":"logging"},"message":"Stopping Logging Emulator"}}
```

### Sample Commands

N/A