### PR TITLE
Increasing operation poller timeout to prevent unexpected behavior for slow function deployments (#3137)

### DIFF
--- a/src/deploy/functions/release.ts
+++ b/src/deploy/functions/release.ts
@@ -96,7 +96,7 @@ export async function release(context: any, options: any, payload: any) {
   // Wait for all of the deployments to complete.
   await Promise.all(queuePromises);
   helper.logAndTrackDeployStats(cloudFunctionsQueue, errorHandler);
+  helper.printTriggerUrls(projectId, sourceUrl);
   errorHandler.printWarnings();
   errorHandler.printErrors();
-  return helper.printTriggerUrls(projectId, sourceUrl);
 }

--- a/src/deploy/functions/tasks.ts
+++ b/src/deploy/functions/tasks.ts
@@ -19,7 +19,7 @@ import { ErrorHandler } from "./errorHandler";
 const defaultPollerOptions = {
   apiOrigin: functionsOrigin,
   apiVersion: cloudfunctions.API_VERSION,
-  masterTimeout: 300000, // 300000ms = 5 minutes
+  masterTimeout: 900000, // 900000ms = 15 minutes
 };
 
 export interface TaskParams {


### PR DESCRIPTION

### Description
Increasing operation poller timeout to prevent unexpected behavior for slow function deployments (see #3137).

Additionally, in release.ts, I moved the call to printTriggerUrls to before the call to printErrors, to ensure that it gets called even if some functions experience errors.

