### PR TITLE
Increases timeout for function operations.

### DIFF
--- a/src/deploy/functions/tasks.ts
+++ b/src/deploy/functions/tasks.ts
@@ -19,7 +19,7 @@ import { ErrorHandler } from "./errorHandler";
 const defaultPollerOptions = {
   apiOrigin: functionsOrigin,
   apiVersion: cloudfunctions.API_VERSION,
-  masterTimeout: 300000, // 300000ms = 5 minutes
+  masterTimeout: 25 * 60000, // 25 minutes is the maximum build time for a function
 };
 
 export interface TaskParams {


### PR DESCRIPTION
A customer reported issues with deploys timing out. When I asked them to investigate closer, it appears that the CLI is timing out but the build does eventually succeed. Increasing the operation timeout to the actual backend limit to avoid false failures.

Fixes #3147