### PR TITLE
💡 setup:emulators:ui

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -120,6 +120,7 @@ module.exports = function (client) {
   client.setup.emulators.database = loadCommand("setup-emulators-database");
   client.setup.emulators.firestore = loadCommand("setup-emulators-firestore");
   client.setup.emulators.pubsub = loadCommand("setup-emulators-pubsub");
+  client.setup.emulators.ui = loadCommand("setup-emulators-ui");
   client.target = loadCommand("target");
   client.target.apply = loadCommand("target-apply");
   client.target.clear = loadCommand("target-clear");

--- a/src/commands/setup-emulators-ui.js
+++ b/src/commands/setup-emulators-ui.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const { Command } = require("../command");
+const { Emulators } = require("../emulator/types");
+const { downloadEmulator } = require("../emulator/download");
+
+const NAME = Emulators.UI;
+
+module.exports = new Command(`setup:emulators:${NAME}`)
+  .description(`downloads the ${NAME} emulator`)
+  .action((options) => {
+    return downloadEmulator(NAME);
+  });


### PR DESCRIPTION
fixes #3151

**Motivation:** to build docker image with firestore emulator and ui we can prefetch firestore emulator with help of `setup:emulators:firestore` but there is no such command for ui, so it is being downloaded each time container starts.

**Workaround:** meanwhile workaround is to

```
ADD https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.4.1.zip /root/.cache/firebase/emulators/ui-v1.4.1.zip
RUN unzip /root/.cache/firebase/emulators/ui-v1.4.1.zip -d /root/.cache/firebase/emulators/ui-v1.4.1
```

**What was done:**

If I understood everything correctly all we need is add 

**src/commands/setup-emulators-ui.js**

```js
"use strict";

const { Command } = require("../command");
const { Emulators } = require("../emulator/types");
const { downloadEmulator } = require("../emulator/download");

const NAME = Emulators.UI;

module.exports = new Command(`setup:emulators:${NAME}`)
  .description(`downloads the ${NAME} emulator`)
  .action((options) => {
    return downloadEmulator(NAME);
  });
```

And add it to `src/commands/index.js`

