### PR TITLE
Update the Site API commands

### DIFF
--- a/src/commands/hosting-channel-create.ts
+++ b/src/commands/hosting-channel-create.ts
@@ -102,7 +102,7 @@ export default new Command("hosting:channel:create [channelId]")
       logLabeledSuccess(LOG_TAG, `Channel URL: ${channel.url}`);
       logger.info();
       logger.info(
-        `To deploy to this channel, use \`firebase hosting:channel:deploy ${channelId}\`.`
+        `To deploy to this channel, use${yellow(`firebase hosting:channel:deploy ${channelId}`)}.`
       );
 
       return channel;

--- a/src/commands/hosting-channel-create.ts
+++ b/src/commands/hosting-channel-create.ts
@@ -102,7 +102,7 @@ export default new Command("hosting:channel:create [channelId]")
       logLabeledSuccess(LOG_TAG, `Channel URL: ${channel.url}`);
       logger.info();
       logger.info(
-        `To deploy to this channel, use${yellow(`firebase hosting:channel:deploy ${channelId}`)}.`
+        `To deploy to this channel, use ${yellow(`firebase hosting:channel:deploy ${channelId}`)}.`
       );
 
       return channel;

--- a/src/commands/hosting-channel-create.ts
+++ b/src/commands/hosting-channel-create.ts
@@ -62,7 +62,7 @@ export default new Command("hosting:channel:create [channelId]")
       try {
         channel = await createChannel(projectId, site, channelId, expireTTL);
       } catch (e) {
-        if (e.status == 409) {
+        if (e.status === 409) {
           throw new FirebaseError(
             `Channel ${bold(channelId)} already exists on site ${bold(site)}. Deploy to ${bold(
               channelId

--- a/src/commands/hosting-site-create.ts
+++ b/src/commands/hosting-site-create.ts
@@ -68,7 +68,9 @@ export default new Command("hosting:site:create [siteName]")
       }
       logLabeledSuccess(LOG_TAG, `Site URL: ${site.defaultUrl}`);
       logger.info();
-      logger.info(`To deploy to this site, use \`firebase deploy --only hosting:${siteName}\`.`);
+      logger.info(
+        `To deploy to this site, use ${yellow(`firebase deploy --only hosting:${siteName}`)}.`
+      );
       return site;
     }
   );

--- a/src/commands/hosting-site-create.ts
+++ b/src/commands/hosting-site-create.ts
@@ -2,7 +2,7 @@ import { bold, yellow } from "cli-color";
 
 import { logLabeledSuccess } from "../utils";
 import { Command } from "../command";
-import { createSite } from "../hosting/api";
+import { Site, createSite } from "../hosting/api";
 import { promptOnce } from "../prompt";
 import { FirebaseError } from "../error";
 import { requirePermissions } from "../requirePermissions";
@@ -15,55 +15,60 @@ export default new Command("hosting:site:create [siteName]")
   .description("create a Firebase Hosting site")
   .option("--app <appId>", "specify an existing Firebase Web App AppID")
   .before(requirePermissions, ["firebasehosting.sites.update"])
-  .action(async (siteName: string, options) => {
-    const projectId = getProjectId(options);
-    const appId = options.app;
-    if (!siteName) {
-      if (options.nonInteractive) {
-        throw new FirebaseError(
-          `"siteName" argument must be provided in a non-interactive environment`
+  .action(
+    async (
+      siteName: string,
+      options: any // eslint-disable-line @typescript-eslint/no-explicit-any
+    ): Promise<Site> => {
+      const projectId = getProjectId(options);
+      const appId = options.app;
+      if (!siteName) {
+        if (options.nonInteractive) {
+          throw new FirebaseError(
+            `"siteName" argument must be provided in a non-interactive environment`
+          );
+        }
+        siteName = await promptOnce(
+          {
+            type: "input",
+            message: "Please provide a URL-friendly name for the site:",
+            validate: (s) => s.length > 0,
+          } // Prevents an empty string from being submitted!
         );
       }
-      siteName = await promptOnce(
-        {
-          type: "input",
-          message: "Please provide a URL-friendly name for the site:",
-          validate: (s) => s.length > 0,
-        } // Prevents an empty string from being submitted!
-      );
-    }
-    if (!siteName) {
-      throw new FirebaseError(`"siteName" must not be empty`);
-    }
-
-    let site: Site;
-    try {
-      site = await createSite(projectId, siteName, appId);
-    } catch (e) {
-      if (e.status == 409) {
-        throw new FirebaseError(
-          `Site ${bold(siteName)} already exists on project ${bold(projectId)}. Deploy to ${bold(
-            siteName
-          )} with: ${yellow(`firebase deploy --only hosting:${siteName}`)}`,
-          { original: e }
-        );
+      if (!siteName) {
+        throw new FirebaseError(`"siteName" must not be empty`);
       }
-      throw e;
-    }
 
-    logger.info();
-    logLabeledSuccess(
-      LOG_TAG,
-      `Site ${bold(siteName)} has been created in project ${bold(projectId)}.`
-    );
-    if (appId) {
+      let site: Site;
+      try {
+        site = await createSite(projectId, siteName, appId);
+      } catch (e) {
+        if (e.status == 409) {
+          throw new FirebaseError(
+            `Site ${bold(siteName)} already exists on project ${bold(projectId)}. Deploy to ${bold(
+              siteName
+            )} with: ${yellow(`firebase deploy --only hosting:${siteName}`)}`,
+            { original: e }
+          );
+        }
+        throw e;
+      }
+
+      logger.info();
       logLabeledSuccess(
         LOG_TAG,
-        `Site ${bold(siteName)} has been linked to web app ${bold(appId)}`
+        `Site ${bold(siteName)} has been created in project ${bold(projectId)}.`
       );
+      if (appId) {
+        logLabeledSuccess(
+          LOG_TAG,
+          `Site ${bold(siteName)} has been linked to web app ${bold(appId)}`
+        );
+      }
+      logLabeledSuccess(LOG_TAG, `Site URL: ${site.defaultUrl}`);
+      logger.info();
+      logger.info(`To deploy to this site, use \`firebase deploy --only hosting:${siteName}\`.`);
+      return site;
     }
-    logLabeledSuccess(LOG_TAG, `Site URL: ${site.defaultUrl}`);
-    logger.info();
-    logger.info(`To deploy to this site, use \`firebase deploy --only hosting:${siteName}\`.`);
-    return site;
-  });
+  );

--- a/src/commands/hosting-site-create.ts
+++ b/src/commands/hosting-site-create.ts
@@ -3,6 +3,7 @@ import { bold, yellow } from "cli-color";
 import { logLabeledSuccess } from "../utils";
 import { Command } from "../command";
 import { createSite } from "../hosting/api";
+import { promptOnce } from "../prompt";
 import { FirebaseError } from "../error";
 import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";

--- a/src/commands/hosting-site-create.ts
+++ b/src/commands/hosting-site-create.ts
@@ -13,7 +13,7 @@ const LOG_TAG = "hosting:site";
 
 export default new Command("hosting:site:create [siteName]")
   .description("create a Firebase Hosting site")
-  .option("--app <appId>", "specify an existing Firebase Web App AppID")
+  .option("--app <appId>", "specify an existing Firebase Web App ID")
   .before(requirePermissions, ["firebasehosting.sites.update"])
   .action(
     async (

--- a/src/commands/hosting-site-create.ts
+++ b/src/commands/hosting-site-create.ts
@@ -11,24 +11,24 @@ import * as logger from "../logger";
 
 const LOG_TAG = "hosting:site";
 
-export default new Command("hosting:site:create [siteName]")
+export default new Command("hosting:site:create [siteId]")
   .description("create a Firebase Hosting site")
   .option("--app <appId>", "specify an existing Firebase Web App ID")
   .before(requirePermissions, ["firebasehosting.sites.update"])
   .action(
     async (
-      siteName: string,
+      siteId: string,
       options: any // eslint-disable-line @typescript-eslint/no-explicit-any
     ): Promise<Site> => {
       const projectId = getProjectId(options);
       const appId = options.app;
-      if (!siteName) {
+      if (!siteId) {
         if (options.nonInteractive) {
           throw new FirebaseError(
-            `"siteName" argument must be provided in a non-interactive environment`
+            `"siteId" argument must be provided in a non-interactive environment`
           );
         }
-        siteName = await promptOnce(
+        siteId = await promptOnce(
           {
             type: "input",
             message: "Please provide a URL-friendly name for the site:",
@@ -36,19 +36,19 @@ export default new Command("hosting:site:create [siteName]")
           } // Prevents an empty string from being submitted!
         );
       }
-      if (!siteName) {
-        throw new FirebaseError(`"siteName" must not be empty`);
+      if (!siteId) {
+        throw new FirebaseError(`"siteId" must not be empty`);
       }
 
       let site: Site;
       try {
-        site = await createSite(projectId, siteName, appId);
+        site = await createSite(projectId, siteId, appId);
       } catch (e) {
         if (e.status === 409) {
           throw new FirebaseError(
-            `Site ${bold(siteName)} already exists on project ${bold(projectId)}. Deploy to ${bold(
-              siteName
-            )} with: ${yellow(`firebase deploy --only hosting:${siteName}`)}`,
+            `Site ${bold(siteId)} already exists on project ${bold(projectId)}. Deploy to ${bold(
+              siteId
+            )} with: ${yellow(`firebase deploy --only hosting:${siteId}`)}`,
             { original: e }
           );
         }
@@ -58,18 +58,18 @@ export default new Command("hosting:site:create [siteName]")
       logger.info();
       logLabeledSuccess(
         LOG_TAG,
-        `Site ${bold(siteName)} has been created in project ${bold(projectId)}.`
+        `Site ${bold(siteId)} has been created in project ${bold(projectId)}.`
       );
       if (appId) {
         logLabeledSuccess(
           LOG_TAG,
-          `Site ${bold(siteName)} has been linked to web app ${bold(appId)}`
+          `Site ${bold(siteId)} has been linked to web app ${bold(appId)}`
         );
       }
       logLabeledSuccess(LOG_TAG, `Site URL: ${site.defaultUrl}`);
       logger.info();
       logger.info(
-        `To deploy to this site, use ${yellow(`firebase deploy --only hosting:${siteName}`)}.`
+        `To deploy to this site, use ${yellow(`firebase deploy --only hosting:${siteId}`)}.`
       );
       return site;
     }

--- a/src/commands/hosting-site-create.ts
+++ b/src/commands/hosting-site-create.ts
@@ -44,7 +44,7 @@ export default new Command("hosting:site:create [siteName]")
       try {
         site = await createSite(projectId, siteName, appId);
       } catch (e) {
-        if (e.status == 409) {
+        if (e.status === 409) {
           throw new FirebaseError(
             `Site ${bold(siteName)} already exists on project ${bold(projectId)}. Deploy to ${bold(
               siteName

--- a/src/commands/hosting-site-delete.ts
+++ b/src/commands/hosting-site-delete.ts
@@ -7,7 +7,6 @@ import { promptOnce } from "../prompt";
 import { FirebaseError } from "../error";
 import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
-import * as logger from "../logger";
 import * as requireConfig from "../requireConfig";
 
 const LOG_TAG = "hosting:site";
@@ -17,31 +16,36 @@ export default new Command("hosting:site:delete <siteName>")
   .option("-f, --force", "delete without confirmation")
   .before(requireConfig)
   .before(requirePermissions, ["firebasehosting.sites.delete"])
-  .action(async (siteName: string, options) => {
-    const projectId = getProjectId(options);
-    if (!siteName) {
-      throw new FirebaseError("siteName is required");
-    }
+  .action(
+    async (
+      siteName: string,
+      options: any // eslint-disable-line @typescript-eslint/no-explicit-any
+    ): Promise<void> => {
+      const projectId = getProjectId(options);
+      if (!siteName) {
+        throw new FirebaseError("siteName is required");
+      }
 
-    let confirmed = Boolean(options.force);
-    if (!confirmed) {
-      confirmed = await promptOnce({
-        message: `Are you sure you want to delete the Hosting Site ${underline(
-          siteName
-        )} for project ${underline(projectId)}?`,
-        type: "confirm",
-        default: false,
-      });
-    }
-    if (!confirmed) {
-      return;
-    }
+      let confirmed = Boolean(options.force);
+      if (!confirmed) {
+        confirmed = await promptOnce({
+          message: `Are you sure you want to delete the Hosting Site ${underline(
+            siteName
+          )} for project ${underline(projectId)}?`,
+          type: "confirm",
+          default: false,
+        });
+      }
+      if (!confirmed) {
+        return;
+      }
 
-    // Check that the site exists first, to avoid giving a sucessesful message on a non-existant site.
-    await getSite(projectId, siteName);
-    await deleteSite(projectId, siteName);
-    logLabeledSuccess(
-      LOG_TAG,
-      `Successfully deleted site ${bold(siteName)} for project ${bold(projectId)}`
-    );
-  });
+      // Check that the site exists first, to avoid giving a sucessesful message on a non-existant site.
+      await getSite(projectId, siteName);
+      await deleteSite(projectId, siteName);
+      logLabeledSuccess(
+        LOG_TAG,
+        `Successfully deleted site ${bold(siteName)} for project ${bold(projectId)}`
+      );
+    }
+  );

--- a/src/commands/hosting-site-delete.ts
+++ b/src/commands/hosting-site-delete.ts
@@ -1,15 +1,20 @@
-import { bold } from "cli-color";
+import { bold, underline } from "cli-color";
 
 import { Command } from "../command";
-import { deleteSite } from "../hosting/api";
+import { logLabeledSuccess } from "../utils";
+import { getSite, deleteSite } from "../hosting/api";
+import { promptOnce } from "../prompt";
 import { FirebaseError } from "../error";
 import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
 import * as requireConfig from "../requireConfig";
 
+const LOG_TAG = "hosting:site";
+
 export default new Command("hosting:site:delete <siteName>")
   .description("delete a Firebase Hosting site")
+  .option("-f, --force", "delete without confirmation")
   .before(requireConfig)
   .before(requirePermissions, ["firebasehosting.sites.delete"])
   .action(async (siteName: string, options) => {
@@ -18,6 +23,25 @@ export default new Command("hosting:site:delete <siteName>")
       throw new FirebaseError("siteName is required");
     }
 
+    let confirmed = Boolean(options.force);
+    if (!confirmed) {
+      confirmed = await promptOnce({
+        message: `Are you sure you want to delete the Hosting Site ${underline(
+          siteName
+        )} for project ${underline(projectId)}?`,
+        type: "confirm",
+        default: false,
+      });
+    }
+    if (!confirmed) {
+      return;
+    }
+
+    // Check that the site exists first, to avoid giving a sucessesful message on a non-existant site.
+    await getSite(projectId, siteName);
     await deleteSite(projectId, siteName);
-    logger.info(`Site ${bold(siteName)} deleted.`);
+    logLabeledSuccess(
+      LOG_TAG,
+      `Successfully deleted site ${bold(siteName)} for project ${bold(projectId)}`
+    );
   });

--- a/src/commands/hosting-site-delete.ts
+++ b/src/commands/hosting-site-delete.ts
@@ -11,26 +11,26 @@ import * as requireConfig from "../requireConfig";
 
 const LOG_TAG = "hosting:site";
 
-export default new Command("hosting:site:delete <siteName>")
+export default new Command("hosting:site:delete <siteId>")
   .description("delete a Firebase Hosting site")
   .option("-f, --force", "delete without confirmation")
   .before(requireConfig)
   .before(requirePermissions, ["firebasehosting.sites.delete"])
   .action(
     async (
-      siteName: string,
+      siteId: string,
       options: any // eslint-disable-line @typescript-eslint/no-explicit-any
     ): Promise<void> => {
       const projectId = getProjectId(options);
-      if (!siteName) {
-        throw new FirebaseError("siteName is required");
+      if (!siteId) {
+        throw new FirebaseError("siteId is required");
       }
 
       let confirmed = Boolean(options.force);
       if (!confirmed) {
         confirmed = await promptOnce({
           message: `Are you sure you want to delete the Hosting Site ${underline(
-            siteName
+            siteId
           )} for project ${underline(projectId)}?`,
           type: "confirm",
           default: false,
@@ -41,11 +41,11 @@ export default new Command("hosting:site:delete <siteName>")
       }
 
       // Check that the site exists first, to avoid giving a sucessesful message on a non-existant site.
-      await getSite(projectId, siteName);
-      await deleteSite(projectId, siteName);
+      await getSite(projectId, siteId);
+      await deleteSite(projectId, siteId);
       logLabeledSuccess(
         LOG_TAG,
-        `Successfully deleted site ${bold(siteName)} for project ${bold(projectId)}`
+        `Successfully deleted site ${bold(siteId)} for project ${bold(projectId)}`
       );
     }
   );

--- a/src/commands/hosting-site-get.ts
+++ b/src/commands/hosting-site-get.ts
@@ -7,16 +7,16 @@ import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
 import { FirebaseError } from "../error";
 
-export default new Command("hosting:site:get <siteName>")
+export default new Command("hosting:site:get <siteId>")
   .description("print info about a Firebase Hosting site")
   .before(requirePermissions, ["firebasehosting.sites.get"])
   .action(
-    async (siteName: string, options): Promise<Site> => {
+    async (siteId: string, options): Promise<Site> => {
       const projectId = getProjectId(options);
-      if (!siteName) {
-        throw new FirebaseError("<siteName> must be specified");
+      if (!siteId) {
+        throw new FirebaseError("<siteId> must be specified");
       }
-      const site = await getSite(projectId, siteName);
+      const site = await getSite(projectId, siteId);
       const table = new Table();
       table.push(["Name:", site.name.split("/").pop()]);
       table.push(["Default URL:", site.defaultUrl]);

--- a/src/commands/hosting-site-get.ts
+++ b/src/commands/hosting-site-get.ts
@@ -1,7 +1,7 @@
 import Table = require("cli-table");
 
 import { Command } from "../command";
-import { getSite } from "../hosting/api";
+import { Site, getSite } from "../hosting/api";
 import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
@@ -10,18 +10,22 @@ import { FirebaseError } from "../error";
 export default new Command("hosting:site:get <siteName>")
   .description("print info about a Firebase Hosting site")
   .before(requirePermissions, ["firebasehosting.sites.get"])
-  .action(async (siteName: string, options) => {
-    const projectId = getProjectId(options);
-    if (!siteName) {
-      throw new FirebaseError("<siteName> must be specified");
-    }
-    const site = await getSite(projectId, siteName);
-    const table = new Table();
-    table.push(["Name:", site.name.split("/").pop()]);
-    table.push(["Default URL:", site.defaultUrl]);
-    table.push(["App ID:", site.appId || ""]);
-    // table.push(["Labels:", JSON.stringify(site.labels)]);
+  .action(
+    async (siteName: string, options): Promise<Site> => {
+      const projectId = getProjectId(options);
+      if (!siteName) {
+        throw new FirebaseError("<siteName> must be specified");
+      }
+      const site = await getSite(projectId, siteName);
+      const table = new Table();
+      table.push(["Name:", site.name.split("/").pop()]);
+      table.push(["Default URL:", site.defaultUrl]);
+      table.push(["App ID:", site.appId || ""]);
+      // table.push(["Labels:", JSON.stringify(site.labels)]);
 
-    logger.info();
-    logger.info(table.toString());
-  });
+      logger.info();
+      logger.info(table.toString());
+
+      return site;
+    }
+  );

--- a/src/commands/hosting-site-list.ts
+++ b/src/commands/hosting-site-list.ts
@@ -7,7 +7,7 @@ import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
 
-const TABLE_HEAD = ["Site ID", "Default URL", "Created At", "App ID (if set)"];
+const TABLE_HEAD = ["Site ID", "Default URL", "App ID (if set)"];
 
 export default new Command("hosting:site:list")
   .description("list Firebase Hosting sites")

--- a/src/commands/hosting-site-list.ts
+++ b/src/commands/hosting-site-list.ts
@@ -7,7 +7,7 @@ import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
 
-const TABLE_HEAD = ["Site", "Default URL", "App ID (if set)"];
+const TABLE_HEAD = ["Site ID", "Default URL", "Created At", "App ID (if set)"];
 
 export default new Command("hosting:site:list")
   .description("list Firebase Hosting sites")

--- a/src/commands/hosting-site-list.ts
+++ b/src/commands/hosting-site-list.ts
@@ -2,7 +2,7 @@ import { bold } from "cli-color";
 import Table = require("cli-table");
 
 import { Command } from "../command";
-import { listSites } from "../hosting/api";
+import { Site, listSites } from "../hosting/api";
 import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
@@ -12,17 +12,23 @@ const TABLE_HEAD = ["Site", "Default URL", "App ID (if set)"];
 export default new Command("hosting:site:list")
   .description("list Firebase Hosting sites")
   .before(requirePermissions, ["firebasehosting.sites.get"])
-  .action(async (options) => {
-    const projectId = getProjectId(options);
-    const sites = await listSites(projectId);
-    const table = new Table({ head: TABLE_HEAD, style: { head: ["green"] } });
-    for (const site of sites) {
-      const siteId = site.name.split("/").pop();
-      table.push([siteId, site.defaultUrl, site.appId || "--"]);
-    }
+  .action(
+    async (
+      options: any // eslint-disable-line @typescript-eslint/no-explicit-any
+    ): Promise<{ sites: Site[] }> => {
+      const projectId = getProjectId(options);
+      const sites = await listSites(projectId);
+      const table = new Table({ head: TABLE_HEAD, style: { head: ["green"] } });
+      for (const site of sites) {
+        const siteId = site.name.split("/").pop();
+        table.push([siteId, site.defaultUrl, site.appId || "--"]);
+      }
 
-    logger.info();
-    logger.info(`Sites for project ${bold(projectId)}`);
-    logger.info();
-    logger.info(table.toString());
-  });
+      logger.info();
+      logger.info(`Sites for project ${bold(projectId)}`);
+      logger.info();
+      logger.info(table.toString());
+
+      return { sites };
+    }
+  );

--- a/src/commands/hosting-site-list.ts
+++ b/src/commands/hosting-site-list.ts
@@ -22,7 +22,7 @@ export default new Command("hosting:site:list")
     }
 
     logger.info();
-    logger.info(`Channels for site ${bold(projectId)}`);
+    logger.info(`Sites for project ${bold(projectId)}`);
     logger.info();
     logger.info(table.toString());
   });

--- a/src/commands/hosting-sites-create.ts
+++ b/src/commands/hosting-sites-create.ts
@@ -46,9 +46,7 @@ export default new Command("hosting:sites:create [siteId]")
       } catch (e) {
         if (e.status === 409) {
           throw new FirebaseError(
-            `Site ${bold(siteId)} already exists on project ${bold(projectId)}. Deploy to ${bold(
-              siteId
-            )} with: ${yellow(`firebase deploy --only hosting:${siteId}`)}`,
+            `Site ${bold(siteId)} already exists on project ${bold(projectId)}.`,
             { original: e }
           );
         }
@@ -69,7 +67,7 @@ export default new Command("hosting:sites:create [siteId]")
       logLabeledSuccess(LOG_TAG, `Site URL: ${site.defaultUrl}`);
       logger.info();
       logger.info(
-        `To deploy to this site, use ${yellow(`firebase deploy --only hosting:${siteId}`)}.`
+        `To deploy to this site, follow the guide at https://firebase.google.com/docs/hosting/multisites.`
       );
       return site;
     }

--- a/src/commands/hosting-sites-create.ts
+++ b/src/commands/hosting-sites-create.ts
@@ -31,7 +31,7 @@ export default new Command("hosting:sites:create [siteId]")
         siteId = await promptOnce(
           {
             type: "input",
-            message: "Please provide a uniqueURL-friendly name for the site:",
+            message: "Please provide an unique, URL-friendly id for the site (<id>.web.app):",
             validate: (s) => s.length > 0,
           } // Prevents an empty string from being submitted!
         );

--- a/src/commands/hosting-sites-create.ts
+++ b/src/commands/hosting-sites-create.ts
@@ -9,9 +9,9 @@ import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
 
-const LOG_TAG = "hosting:site";
+const LOG_TAG = "hosting:sites";
 
-export default new Command("hosting:site:create [siteId]")
+export default new Command("hosting:sites:create [siteId]")
   .description("create a Firebase Hosting site")
   .option("--app <appId>", "specify an existing Firebase Web App ID")
   .before(requirePermissions, ["firebasehosting.sites.update"])

--- a/src/commands/hosting-sites-create.ts
+++ b/src/commands/hosting-sites-create.ts
@@ -31,7 +31,7 @@ export default new Command("hosting:sites:create [siteId]")
         siteId = await promptOnce(
           {
             type: "input",
-            message: "Please provide a URL-friendly name for the site:",
+            message: "Please provide a uniqueURL-friendly name for the site:",
             validate: (s) => s.length > 0,
           } // Prevents an empty string from being submitted!
         );
@@ -46,7 +46,7 @@ export default new Command("hosting:sites:create [siteId]")
       } catch (e) {
         if (e.status === 409) {
           throw new FirebaseError(
-            `Site ${bold(siteId)} already exists on project ${bold(projectId)}.`,
+            `Site ${bold(siteId)} already exists in project ${bold(projectId)}.`,
             { original: e }
           );
         }

--- a/src/commands/hosting-sites-delete.ts
+++ b/src/commands/hosting-sites-delete.ts
@@ -9,9 +9,9 @@ import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as requireConfig from "../requireConfig";
 
-const LOG_TAG = "hosting:site";
+const LOG_TAG = "hosting:sites";
 
-export default new Command("hosting:site:delete <siteId>")
+export default new Command("hosting:sites:delete <siteId>")
   .description("delete a Firebase Hosting site")
   .option("-f, --force", "delete without confirmation")
   .before(requireConfig)

--- a/src/commands/hosting-sites-delete.ts
+++ b/src/commands/hosting-sites-delete.ts
@@ -51,7 +51,7 @@ export default new Command("hosting:sites:delete <siteId>")
       await deleteSite(projectId, siteId);
       logLabeledSuccess(
         LOG_TAG,
-        `Successfully deleted site ${bold(siteId)} for project ${bold(projectId)}`
+        `Successfully deleted site ${bold(siteId)} from project ${bold(projectId)}`
       );
     }
   );

--- a/src/commands/hosting-sites-delete.ts
+++ b/src/commands/hosting-sites-delete.ts
@@ -1,5 +1,4 @@
 import { bold, underline } from "cli-color";
-
 import { Command } from "../command";
 import { logLabeledSuccess } from "../utils";
 import { getSite, deleteSite } from "../hosting/api";
@@ -8,6 +7,7 @@ import { FirebaseError } from "../error";
 import { requirePermissions } from "../requirePermissions";
 import * as getProjectId from "../getProjectId";
 import * as requireConfig from "../requireConfig";
+import * as logger from "../logger";
 
 const LOG_TAG = "hosting:sites";
 
@@ -25,13 +25,19 @@ export default new Command("hosting:sites:delete <siteId>")
       if (!siteId) {
         throw new FirebaseError("siteId is required");
       }
+      logger.info(
+        `Deleting a site is a permanent action. If you delete a site, Firebase doesn't maintain records of deployed files or deployment history, and the site ${underline(
+          siteId
+        )} cannot be reactivated by you or anyone else.`
+      );
+      logger.info();
 
       let confirmed = Boolean(options.force);
       if (!confirmed) {
         confirmed = await promptOnce({
-          message: `Are you sure you want to delete the Hosting Site ${underline(
+          message: `Are you sure you want to delete the Hosting site ${underline(
             siteId
-          )} for project ${underline(projectId)}?`,
+          )} for project ${underline(projectId)}? `,
           type: "confirm",
           default: false,
         });

--- a/src/commands/hosting-sites-get.ts
+++ b/src/commands/hosting-sites-get.ts
@@ -18,7 +18,7 @@ export default new Command("hosting:sites:get <siteId>")
       }
       const site = await getSite(projectId, siteId);
       const table = new Table();
-      table.push(["Name:", site.name.split("/").pop()]);
+      table.push(["Site ID:", site.name.split("/").pop()]);
       table.push(["Default URL:", site.defaultUrl]);
       table.push(["App ID:", site.appId || ""]);
       // table.push(["Labels:", JSON.stringify(site.labels)]);

--- a/src/commands/hosting-sites-get.ts
+++ b/src/commands/hosting-sites-get.ts
@@ -7,7 +7,7 @@ import * as getProjectId from "../getProjectId";
 import * as logger from "../logger";
 import { FirebaseError } from "../error";
 
-export default new Command("hosting:site:get <siteId>")
+export default new Command("hosting:sites:get <siteId>")
   .description("print info about a Firebase Hosting site")
   .before(requirePermissions, ["firebasehosting.sites.get"])
   .action(

--- a/src/commands/hosting-sites-list.ts
+++ b/src/commands/hosting-sites-list.ts
@@ -9,7 +9,7 @@ import * as logger from "../logger";
 
 const TABLE_HEAD = ["Site ID", "Default URL", "App ID (if set)"];
 
-export default new Command("hosting:site:list")
+export default new Command("hosting:sites:list")
   .description("list Firebase Hosting sites")
   .before(requirePermissions, ["firebasehosting.sites.get"])
   .action(

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -101,11 +101,11 @@ module.exports = function (client) {
   client.hosting.clone = loadCommand("hosting-clone");
   client.hosting.disable = loadCommand("hosting-disable");
   if (previews.hostingsites) {
-    client.hosting.site = {};
-    client.hosting.site.create = loadCommand("hosting-site-create");
-    client.hosting.site.delete = loadCommand("hosting-site-delete");
-    client.hosting.site.get = loadCommand("hosting-site-get");
-    client.hosting.site.list = loadCommand("hosting-site-list");
+    client.hosting.sites = {};
+    client.hosting.sites.create = loadCommand("hosting-sites-create");
+    client.hosting.sites.delete = loadCommand("hosting-sites-delete");
+    client.hosting.sites.get = loadCommand("hosting-sites-get");
+    client.hosting.sites.list = loadCommand("hosting-sites-list");
   }
   client.init = loadCommand("init");
   client.login = loadCommand("login");

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -420,12 +420,13 @@ export async function getSite(project: string, site: string): Promise<Site> {
  * Create a Hosting site.
  * @param project project name or number.
  * @param site the site name to create.
+ * @param appId the Firebase Web App AppID
  * @return site information.
  */
-export async function createSite(project: string, site: string): Promise<Site> {
-  const res = await apiClient.post<unknown, Site>(
+export async function createSite(project: string, site: string, appId = ""): Promise<Site> {
+  const res = await apiClient.post<{ appId: string }, Site>(
     `/projects/${project}/sites`,
-    {},
+    { appId: appId },
     { queryParams: { site_id: site } }
   );
   return res.body;

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -420,7 +420,7 @@ export async function getSite(project: string, site: string): Promise<Site> {
  * Create a Hosting site.
  * @param project project name or number.
  * @param site the site name to create.
- * @param appId the Firebase Web App AppID
+ * @param appId the Firebase Web Application ID
  * @return site information.
  */
 export async function createSite(project: string, site: string, appId = ""): Promise<Site> {

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -420,7 +420,7 @@ export async function getSite(project: string, site: string): Promise<Site> {
  * Create a Hosting site.
  * @param project project name or number.
  * @param site the site name to create.
- * @param appId the Firebase Web Application ID
+ * @param appId the Firebase Web App ID (https://firebase.google.com/docs/projects/learn-more#config-files-objects)
  * @return site information.
  */
 export async function createSite(project: string, site: string, appId = ""): Promise<Site> {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

- Changes command from hosting:site to hosting:sites. 
- Improves formatting for site api to align with channels. 
- Adds the app-id option when creating a site
- Adds the prompt/force interaction for deleting sites
- Adds the ability to prompt for site name when creating new site.

### Scenarios Tested

```
▶ firebase hosting:sites:create

? Please provide an unique, URL-friendly id for the site (<id>.web.app):

Error: HTTP Error: 400, Invalid name: `my-test-site` is reserved by another project; try something like `my-test-site-dd769` instead

Having trouble? Try firebase [command] --help

```
```
▶ firebase hosting:sites:create my-test-site-dd769


✔  hosting:sites: Site my-test-site-dd769 has been created in project kiana-rest-api.
✔  hosting:sites: Site URL: https://my-test-site-dd769.web.app

To deploy to this site, follow the guide at https://firebase.google.com/docs/hosting/multisites.

```
```
▶ firebase hosting:sites:create a-test-site


✔  hosting:sites: Site a-test-site has been created in project kiana-rest-api.
✔  hosting:sites: Site URL: https://a-test-site.web.app

To deploy to this site, follow the guide at https://firebase.google.com/docs/hosting/multisites.

```
```
▶ firebase hosting:sites:create used-test-site


Error: HTTP Error: 400, Invalid name: `used-test-site` is reserved by another project; try something like `used-test-site-924dc` instead

```
```
▶ firebase hosting:sites:create another-test-site


✔  hosting:sites: Site another-test-site has been created in project kiana-rest-api.
✔  hosting:sites: Site URL: https://another-test-site.web.app

To deploy to this site, follow the guide at https://firebase.google.com/docs/hosting/multisites.

```
```
▶ firebase hosting:sites:create this.is.an.illegal.firebase.test.site.that.really.won't.work

◀
◀ `
◀ `
◀ '

Error: HTTP Error: 400, Invalid name: "this.is.an.illegal.firebase.test.site.that.really.wont.work\n\n\n`\n`\n" is invalid; try something like `this-is-an-illegal-firebase-test-site-that-really-wont-work` instead


▶

```
```
▶ firebase hosting:sites:create another-test-site2 --app="1:789349071652:web:3940e5bd0eeb1c216c51b1"


Error: HTTP Error: 429, Web app [1:789349071652:web:3940e5bd0eeb1c216c51b1] is already linked to hosting sites: [StoredHostingSite{namespace=test-site-new4, projectNumber=Optional[789349071652], siteType=Optional[USER_HOSTING_SITE], creationTime=Optional[1614275129316], deletionTime=Optional.empty, webAppId=Optional[1:789349071652:web:3940e5bd0eeb1c216c51b1]}]

Having trouble? Try firebase [command] --help

```
```
▶ firebase hosting:sites:delete test-site-new4

Deleting a site is a permanent action. If you delete a site, Firebase doesn't maintain records of deployed files or deployment history, and the site test-site-new4 cannot be reactivated by you or anyone else.

? Are you sure you want to delete the Hosting site test-site-new4 for project kiana-res
t-api?  Yes
✔  hosting:sites: Successfully deleted site test-site-new4 from project kiana-rest-api

```
```
▶ firebase hosting:sites:create another-test-site3 --app="1:789349071652:web:3940e5bd0eeb1c216c51b1"


✔  hosting:sites: Site another-test-site3 has been created in project kiana-rest-api.
✔  hosting:sites: Site another-test-site3 has been linked to web app 1:789349071652:web:3940e5bd0eeb1c216c51b1
✔  hosting:sites: Site URL: https://another-test-site3.web.app

To deploy to this site, follow the guide at https://firebase.google.com/docs/hosting/multisites.

```
```
▶ firebase hosting:sites:get a-test-site


┌──────────────┬─────────────────────────────┐
│ Site ID:     │ a-test-site                 │
├──────────────┼─────────────────────────────┤
│ Default URL: │ https://a-test-site.web.app │
├──────────────┼─────────────────────────────┤
│ App ID:      │                             │
└──────────────┴─────────────────────────────┘

```
```
▶ firebase hosting:sites:get used-test-site


Error: could not find site "used-test-site" for project "kiana-rest-api"

```
```
▶ firebase hosting:sites:list


Sites for project kiana-rest-api

┌────────────────────┬────────────────────────────────────┬───────────────────────────────────────────┐
│ Site ID            │ Default URL                        │ App ID (if set)                           │
├────────────────────┼────────────────────────────────────┼───────────────────────────────────────────┤
│ a-test-site        │ https://a-test-site.web.app        │ --                                        │
├────────────────────┼────────────────────────────────────┼───────────────────────────────────────────┤
│ another-test-site  │ https://another-test-site.web.app  │ --                                        │
├────────────────────┼────────────────────────────────────┼───────────────────────────────────────────┤
│ another-test-site3 │ https://another-test-site3.web.app │ 1:789349071652:web:3940e5bd0eeb1c216c51b1 │
├────────────────────┼────────────────────────────────────┼───────────────────────────────────────────┤
│ my-test-site-dd769 │ https://my-test-site-dd769.web.app │ --                                        │
└────────────────────┴────────────────────────────────────┴───────────────────────────────────────────┘

```
```
▶ firebase hosting:sites:delete a-test-site

Deleting a site is a permanent action. If you delete a site, Firebase doesn't maintain records of deployed files or deployment history, and the site a-test-site cannot be reactivated by you or anyone else.

? Are you sure you want to delete the Hosting site a-test-site for project kiana-rest-a
pi?  Yes
✔  hosting:sites: Successfully deleted site a-test-site from project kiana-rest-api

```
```
▶ firebase hosting:sites:delete used-test-site

Deleting a site is a permanent action. If you delete a site, Firebase doesn't maintain records of deployed files or deployment history, and the site used-test-site cannot be reactivated by you or anyone else.

? Are you sure you want to delete the Hosting site used-test-site for project kiana-res
t-api?  Yes

Error: could not find site "used-test-site" for project "kiana-rest-api"

```
```
▶ firebase hosting:sites:delete another-test-site -f

Deleting a site is a permanent action. If you delete a site, Firebase doesn't maintain records of deployed files or deployment history, and the site another-test-site cannot be reactivated by you or anyone else.

✔  hosting:sites: Successfully deleted site another-test-site from project kiana-rest-api

```
### Sample Commands

`hosting:sites:delete <site> -f`
`hosting:sites:list`
`hosting:sites:get <site>`
`hosting:sites:create <site> --app=<appid>` - note that this app id must be already created in the console `hosting:sites:create` - prompts for site name 