### PR TITLE
Fix problem with typescript initial eslint config for functions project

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -10,6 +10,8 @@ module.exports = {
     "plugin:import/warnings",
     "plugin:import/typescript",
     "google",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {


### PR DESCRIPTION
### Description
When setting up a brand new functions project with eslint. I was getting the following linting errors:

![image](https://user-images.githubusercontent.com/9438362/108858705-369cf900-75cb-11eb-84af-635c93b339e6.png)
![image](https://user-images.githubusercontent.com/9438362/108858791-5502f480-75cb-11eb-8164-09b48b6057ca.png)

After some research I found we where missing extending some `@typescript-eslint` options in the eslint config. [link](https://stackoverflow.com/questions/57802057/eslint-configuring-no-unused-vars-for-typescript)