### PR TITLE
fixes issue with hosting emulator targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-* Fixes issue where the Firebase Hosting emulator would fail to start with `--only` filters using targets (#2820).
+- Fixes issue where the Firebase Hosting emulator would fail to start with `--only` filters using targets (#2820).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fixes issue where the Firebase Hosting emulator would fail to start with `--only` filters using targets (#2820).

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -174,8 +174,12 @@ export function filterEmulatorTargets(options: any): Emulators[] {
     return options.config.has(e) || options.config.has(`emulators.${e}`);
   });
 
-  if (options.only) {
-    targets = _.intersection(targets, options.only.split(","));
+  const onlyOptions: string = options.only;
+  if (onlyOptions) {
+    const only = onlyOptions.split(",").map((o) => {
+      return o.split(":")[0];
+    });
+    targets = _.intersection(targets, only as Emulators[]);
   }
 
   return targets;
@@ -321,8 +325,11 @@ export async function startAll(options: any, showUI: boolean = true): Promise<vo
     "emulators",
     `Starting emulators: ${targets.join(", ")}`
   );
-  if (options.only) {
-    const requested: string[] = options.only.split(",");
+  const onlyOptions: string = options.only;
+  if (onlyOptions) {
+    const requested: string[] = onlyOptions.split(",").map((o) => {
+      return o.split(":")[0];
+    });
     const ignored = _.difference(requested, targets);
 
     for (const name of ignored) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2820

### Scenarios Tested

- `emulators:start --only hosting:one`
- `emulators:start --only hosting:two`
- `emulators:start --only hosting` (to see both start)
- `emulators:start --only functions:echo` (to make sure my function still works)