### PR TITLE
Send unknown event when there is no auth event.

### DIFF
--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -265,8 +265,7 @@ export function registerHandlers(
   function sendAuthEvent(authEvent) {
     parentContainer.send('authEvent', {
       type: authEvent ? 'authEvent' : 'unknown',
-      authEvent: authEvent || {},
-      error: authEvent ? undefined : {code: 'auth/no-auth-event'},
+      authEvent: authEvent || { error: { code: 'auth/no-auth-event' } },
     }, function(responses) {
       if (!responses || !responses.length ||
           !responses[responses.length - 1].status === 'ACK') {

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -264,8 +264,8 @@ export function registerHandlers(
 
   function sendAuthEvent(authEvent) {
     parentContainer.send('authEvent', {
-      type: authEvent ? 'authEvent' : 'unknown',
-      authEvent: authEvent || { error: { code: 'auth/no-auth-event' } },
+      type: 'authEvent',
+      authEvent: authEvent || { type: 'unknown', error: { code: 'auth/no-auth-event' } },
     }, function(responses) {
       if (!responses || !responses.length ||
           !responses[responses.length - 1].status === 'ACK') {

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -265,7 +265,8 @@ export function registerHandlers(
   function sendAuthEvent(authEvent) {
     parentContainer.send('authEvent', {
       type: authEvent ? 'authEvent' : 'unknown',
-      authEvent: authEvent || {},
+      authEvent: authEvent,
+      error: {code: 'auth/no-auth-event'},
     }, function(responses) {
       if (!responses || !responses.length ||
           !responses[responses.length - 1].status === 'ACK') {

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -265,7 +265,7 @@ export function registerHandlers(
   function sendAuthEvent(authEvent) {
     parentContainer.send('authEvent', {
       type: authEvent ? 'authEvent' : 'unknown',
-      authEvent: authEvent,
+      authEvent: authEvent || {},
       error: authEvent ? undefined : {code: 'auth/no-auth-event'},
     }, function(responses) {
       if (!responses || !responses.length ||

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -268,7 +268,7 @@ export function registerHandlers(
       authEvent: authEvent || {},
     }, function(responses) {
       if (!responses || !responses.length ||
-          responses[responses.length - 1].status !== 'ACK') {
+          !responses[responses.length - 1].status === 'ACK') {
         return alert("Auth Emulator Internal Error: Sending authEvent failed.");
       }
     }, gapi.iframes.CROSS_ORIGIN_IFRAMES_FILTER);

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -232,7 +232,7 @@ export function registerHandlers(
       }
       var authEvent = e.data.data.authEvent;
       if (parentContainer) {
-        sendAuthEvent(parentContainer, authEvent);
+        sendAuthEvent(authEvent);
       } else {
         // Store it first, and initFrameMessaging() below will pick it up.
         sessionStorage['firebase:redirectEvent:' + storageKey] =
@@ -249,28 +249,26 @@ export function registerHandlers(
       return { status: 'ACK', webStorageSupport: true };
     }, gapi.iframes.CROSS_ORIGIN_IFRAMES_FILTER);
 
+    var authEvent = null;
     var storedEvent = sessionStorage['firebase:redirectEvent:' + storageKey];
     if (storedEvent) {
-      var authEvent = null;
       try {
         authEvent = JSON.parse(storedEvent);
       } catch (_) {
         return alert('Auth Emulator Internal Error: Invalid stored event.');
       }
-      if (authEvent) {
-        sendAuthEvent(parentContainer, authEvent);
-      }
-      delete sessionStorage['firebase:redirectEvent:' + storageKey];
     }
+    sendAuthEvent(authEvent);
+    delete sessionStorage['firebase:redirectEvent:' + storageKey];
   }
 
-  function sendAuthEvent(parentContainer, authEvent) {
+  function sendAuthEvent(authEvent) {
     parentContainer.send('authEvent', {
-      type: 'authEvent',
-      authEvent: authEvent,
+      type: authEvent ? 'authEvent' : 'unknown',
+      authEvent: authEvent || {},
     }, function(responses) {
       if (!responses || !responses.length ||
-          !responses[responses.length - 1].status === 'ACK') {
+          responses[responses.length - 1].status !== 'ACK') {
         return alert("Auth Emulator Internal Error: Sending authEvent failed.");
       }
     }, gapi.iframes.CROSS_ORIGIN_IFRAMES_FILTER);

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -266,7 +266,7 @@ export function registerHandlers(
     parentContainer.send('authEvent', {
       type: authEvent ? 'authEvent' : 'unknown',
       authEvent: authEvent,
-      error: {code: 'auth/no-auth-event'},
+      error: authEvent ? undefined : {code: 'auth/no-auth-event'},
     }, function(responses) {
       if (!responses || !responses.length ||
           !responses[responses.length - 1].status === 'ACK') {


### PR DESCRIPTION
### Description

This brings Auth Emulator iframe a bit closer to production, where it always sends something on start (which may be an `unknown` event if there is nothing stored).

If using iframe messaging, it may send `unknown` first then immediately followed by an `authEvent`. I have no idea whether this works with the JS/TS SDK.

### Scenarios Tested

NOT TESTED YET

### Sample Commands

N/A