### PR TITLE
Added validation for protected function names on package.json

### DIFF
--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -134,9 +134,9 @@ function assertFunctionsSourcePresent(data: any, sourceDir: string, projectDir: 
  */
 function checkForProtectedNpmScriptNames(data: any): void {
   const protectedScriptNames = ["prepare"];
-  if (Object.prototype.hasOwnProperty.call(data, "scripts")) {
+  if (data?.scripts) {
     for (const scriptName of protectedScriptNames) {
-      if (Object.prototype.hasOwnProperty.call(data.scripts, scriptName)) {
+      if (data.scripts.[scriptName]) {
         const msg = `package.json contains script with protected name ${scriptName}`;
         throw new FirebaseError(msg);
       }

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -72,6 +72,7 @@ export function packageJsonIsValid(
     data = cjson.load(packageJsonFile);
     logger.debug("> [functions] package.json contents:", JSON.stringify(data, null, 2));
     assertFunctionsSourcePresent(data, sourceDir, projectDir);
+    checkForProtectedNpmScriptNames(data);
   } catch (e) {
     const msg = `There was an error reading ${sourceDirName}${path.sep}package.json:\n\n ${e.message}`;
     throw new FirebaseError(msg);
@@ -123,6 +124,23 @@ function assertFunctionsSourcePresent(data: any, sourceDir: string, projectDir: 
       indexJsFile
     )} does not exist, can't deploy Cloud Functions`;
     throw new FirebaseError(msg);
+  }
+}
+
+/**
+ * Asserts that package.json does not include any scripts with invalid names
+ * @param data Object representing package.json file.
+ * @throws { FirebaseError } package.json must not contain scripts with protected names
+ */
+function checkForProtectedNpmScriptNames(data: any): void {
+  const protectedScriptNames = ["prepare"];
+  if (Object.prototype.hasOwnProperty.call(data, "scripts")) {
+    for (const scriptName of protectedScriptNames) {
+      if (Object.prototype.hasOwnProperty.call(data.scripts, scriptName)) {
+        const msg = `package.json contains script with protected name ${scriptName}`;
+        throw new FirebaseError(msg);
+      }
+    }
   }
 }
 

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -245,6 +245,16 @@ describe("validate", () => {
       }).to.throw(FirebaseError, "does not exist, can't deploy");
     });
 
+    it("should throw error if script with protected name is defined", () => {
+      cjsonLoadStub.returns({ name: "my-project", scripts: { prepare: "my-script" } });
+      fileExistsStub.withArgs("sourceDir/package.json").returns(true);
+      fileExistsStub.withArgs("sourceDir/index.js").returns(true);
+
+      expect(() => {
+        validate.packageJsonIsValid("sourceDirName", "sourceDir", "projectDir", true);
+      }).to.throw(FirebaseError, "contains script with protected name");
+    });
+
     it("should not throw error if runtime is set in the config and the engines field is not set", () => {
       cjsonLoadStub.returns({ name: "my-project" });
       fileExistsStub.withArgs("sourceDir/package.json").returns(true);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Whenever the `package.json` file that accompanies the Cloud Functions project contains a script named "prepare", a deploy will fail with no proper error message. I believe this happens because the `npm ci` is run, it attempt to run a script named "prepare" that conflicts with the user-defined one.

To avoid this I have added an extra step on the `package.json` verification prior to deploy to ensure that any scripts with _protected_ names (for now, just "prepare") are identified and a proper error is thrown.

### Scenarios Tested

As far as I can see, the only test that really made sense here was to check for a failure if the `package.json` file contained a script named "prepare". Which passes properly. This will have to be extended for other protected (conflicting?) names.

### Sample Commands

N/A
