### PR TITLE
Fix database:remove bug

### DIFF
--- a/src/database/listRemote.ts
+++ b/src/database/listRemote.ts
@@ -51,7 +51,7 @@ export class RTDBListRemote implements ListRemote {
     const res = await this.apiClient.get<{ [key: string]: unknown }>(url.pathname, {
       queryParams: params,
     });
-    const paths = res.body ? [] : Object.keys(res.body);
+    const paths = res.body ? Object.keys(res.body) : [];
     const dt = Date.now() - t0;
     logger.debug(`[database] sucessfully fetched ${paths.length} path at ${path} ${dt}`);
     return paths;

--- a/src/database/listRemote.ts
+++ b/src/database/listRemote.ts
@@ -51,7 +51,7 @@ export class RTDBListRemote implements ListRemote {
     const res = await this.apiClient.get<{ [key: string]: unknown }>(url.pathname, {
       queryParams: params,
     });
-    const paths = Object.keys(res.body);
+    const paths = res.body ? [] : Object.keys(res.body);
     const dt = Date.now() - t0;
     logger.debug(`[database] sucessfully fetched ${paths.length} path at ${path} ${dt}`);
     return paths;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,15 +89,11 @@ export function getDatabaseViewDataUrl(
   pathname: string
 ): string {
   const urlObj = new url.URL(origin);
-  if (
-    urlObj.hostname.includes("firebaseio.com") ||
-    urlObj.hostname.includes("firebasedatabase.app")
-  ) {
+  if (urlObj.hostname.includes("firebase")) {
     return consoleUrl(project, `/database/${namespace}/data${pathname}`);
-  } else {
-    // TODO(samstern): View in Emulator UI
-    return getDatabaseUrl(origin, namespace, pathname + ".json");
   }
+  // TODO(samstern): View in Emulator UI
+  return getDatabaseUrl(origin, namespace, pathname + ".json");
 }
 
 /**
@@ -110,15 +106,11 @@ export function addDatabaseNamespace(origin: string, namespace: string): string 
   if (urlObj.hostname.includes(namespace)) {
     return urlObj.href;
   }
-  if (
-    urlObj.hostname.includes("firebaseio.com") ||
-    urlObj.hostname.includes("firebasedatabase.app")
-  ) {
+  if (urlObj.hostname.includes("firebase")) {
     return addSubdomain(origin, namespace);
-  } else {
-    urlObj.searchParams.set("ns", namespace);
-    return urlObj.href;
   }
+  urlObj.searchParams.set("ns", namespace);
+  return urlObj.href;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,7 @@ export function getDatabaseViewDataUrl(
   pathname: string
 ): string {
   const urlObj = new url.URL(origin);
-  if (urlObj.hostname.includes("firebase")) {
+  if (urlObj.hostname.includes("firebaseio") || urlObj.hostname.includes("firebasedatabase")) {
     return consoleUrl(project, `/database/${namespace}/data${pathname}`);
   }
   // TODO(samstern): View in Emulator UI
@@ -106,7 +106,7 @@ export function addDatabaseNamespace(origin: string, namespace: string): string 
   if (urlObj.hostname.includes(namespace)) {
     return urlObj.href;
   }
-  if (urlObj.hostname.includes("firebase")) {
+  if (urlObj.hostname.includes("firebaseio") || urlObj.hostname.includes("firebasedatabase")) {
     return addSubdomain(origin, namespace);
   }
   urlObj.searchParams.set("ns", namespace);


### PR DESCRIPTION
In `listRemove.ts`, `const paths = Object.keys(res.body);` fails if `res.body` is null.
This is causing errors when listing a path already deleted.

This bug was introduced in https://github.com/firebase/firebase-tools/pull/2828.