### PR TITLE
fix: move runtime libraries to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "cross-spawn": "^7.0.1",
     "csv-streamify": "^3.0.4",
     "dotenv": "^6.1.0",
+    "exegesis": "^2.5.6",
     "exegesis-express": "^2.0.0",
     "exit-code": "^1.0.2",
     "express": "^4.16.4",
@@ -134,6 +135,7 @@
     "update-notifier": "^4.1.0",
     "uuid": "^3.0.0",
     "winston": "^3.0.0",
+    "winston-transport": "^4.4.0",
     "ws": "^7.2.3"
   },
   "devDependencies": {
@@ -184,7 +186,6 @@
     "eslint-config-prettier": "^7.1.0",
     "eslint-plugin-jsdoc": "^30.7.13",
     "eslint-plugin-prettier": "^3.3.1",
-    "exegesis": "^2.5.6",
     "firebase": "^7.24.0",
     "firebase-admin": "^9.4.2",
     "firebase-functions": "^3.11.0",
@@ -201,7 +202,6 @@
     "supertest": "^3.3.0",
     "swagger2openapi": "^6.0.3",
     "ts-node": "^9.1.1",
-    "typescript": "^3.9.5",
-    "winston-transport": "^4.4.0"
+    "typescript": "^3.9.5"
   }
 }


### PR DESCRIPTION
### Description

Close #2974
Actually, my previous PR (#2975) didn't solve #2974 (sorry) and I confirmed this follow-up PR solves #2974 for sure.
To fix errors in yarn berry, this PR makes `firebase-tools` depend on `exegesis` and `winston-transport` as `dependencies` instead of `devDependencies`.

### Scenarios Tested

`Steps to reproduce` in #2974

### Sample Commands

No change to commands or flags.
