### PR TITLE
refactor(templates): add link to Firebase support on login failure

### DIFF
--- a/templates/loginFailure.html
+++ b/templates/loginFailure.html
@@ -11,6 +11,7 @@
       #message h2 { color: #f44336; font-weight: bold; font-size: 16px; margin: 0 0 8px; }
       #message h1 { font-size: 22px; font-weight: 300; color: rgba(0,0,0,0.6); margin: 0 0 16px;}
       #message p { line-height: 140%; margin: 16px 0 24px; font-size: 14px; }
+      #message p a { background: none; display: inline; box-shadow: none; color:#039BE5; text-transform: none; padding: 0}
       #message a { display: block; text-align: center; background: #039be5; text-transform: uppercase; text-decoration: none; color: white; padding: 16px; border-radius: 4px; }
       #message, #message a { box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24); }
       #load { color: rgba(0,0,0,0.4); text-align: center; font-size: 13px; }
@@ -26,7 +27,7 @@
       <h2>Oops!</h2>
       <h1>Firebase CLI Login Failed</h1>
       <p>The Firebase CLI login request was rejected or an error occurred. Please
-      run <code>firebase login</code> again or contact support if you continue
+      run <code>firebase login</code> again or <a href="https://firebase.google.com/support/troubleshooter/access" target="_blank" title="Firebase Support">contact support </a> if you continue
       to have difficulty logging in.</p>
     </div>
   </body>


### PR DESCRIPTION
Alternative PR for #2436 with no format changes and updated codebase as the original author hadn't responded to the request (https://github.com/firebase/firebase-tools/pull/2436#discussion_r581384940 / https://github.com/firebase/firebase-tools/pull/2436#discussion_r452250782) in a long while.

Just thought I'll help speed things up as the PR has been open since 9th July 2020 without being merged or closed.