### PR TITLE
Remove duplication of gitignore

### DIFF
--- a/src/commands/ext-dev-init.ts
+++ b/src/commands/ext-dev-init.ts
@@ -90,10 +90,6 @@ async function javascriptSelected(config: Config): Promise<void> {
     path.join(TEMPLATE_ROOT, "javascript", "package.nolint.json"),
     "utf8"
   );
-  const gitignoreTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "javascript", "_gitignore"),
-    "utf8"
-  );
   const eslintTemplate = fs.readFileSync(
     path.join(FUNCTIONS_ROOT, "javascript", "_eslintrc"),
     "utf8"
@@ -116,7 +112,6 @@ async function javascriptSelected(config: Config): Promise<void> {
   } else {
     await config.askWriteProjectFile("functions/package.json", packageNoLintingTemplate);
   }
-  await config.askWriteProjectFile("functions/.gitignore", gitignoreTemplate);
 }
 
 /**

--- a/src/commands/ext-dev-init.ts
+++ b/src/commands/ext-dev-init.ts
@@ -43,10 +43,6 @@ async function typescriptSelected(config: Config): Promise<void> {
     "utf8"
   );
   const indexTemplate = fs.readFileSync(path.join(TEMPLATE_ROOT, "typescript", "index.ts"), "utf8");
-  const gitignoreTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "_gitignore"),
-    "utf8"
-  );
   const eslintTemplate = fs.readFileSync(
     path.join(FUNCTIONS_ROOT, "typescript", "_eslintrc"),
     "utf8"
@@ -73,7 +69,6 @@ async function typescriptSelected(config: Config): Promise<void> {
   if (lint) {
     await config.askWriteProjectFile("functions/tsconfig.dev.json", tsconfigDevTemplate);
   }
-  await config.askWriteProjectFile("functions/.gitignore", gitignoreTemplate);
 }
 
 /**

--- a/src/init/features/functions/javascript.js
+++ b/src/init/features/functions/javascript.js
@@ -18,7 +18,6 @@ var PACKAGE_NO_LINTING_TEMPLATE = fs.readFileSync(
   "utf8"
 );
 var ESLINT_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_eslintrc"), "utf8");
-var GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
 
 module.exports = function (setup, config) {
   return prompt(setup.functions, [
@@ -42,9 +41,6 @@ module.exports = function (setup, config) {
     })
     .then(function () {
       return config.askWriteProjectFile("functions/index.js", INDEX_TEMPLATE);
-    })
-    .then(function () {
-      return config.askWriteProjectFile("functions/.gitignore", GITIGNORE_TEMPLATE);
     })
     .then(function () {
       return npmDependencies.askInstallDependencies(setup.functions, config);

--- a/src/init/features/functions/typescript.js
+++ b/src/init/features/functions/typescript.js
@@ -20,7 +20,6 @@ var ESLINT_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_eslintrc"), "ut
 var TSCONFIG_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "tsconfig.json"), "utf8");
 var TSCONFIG_DEV_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "tsconfig.dev.json"), "utf8");
 var INDEX_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "index.ts"), "utf8");
-var GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
 
 module.exports = function (setup, config) {
   return prompt(setup.functions, [
@@ -56,9 +55,6 @@ module.exports = function (setup, config) {
     })
     .then(function () {
       return config.askWriteProjectFile("functions/src/index.ts", INDEX_TEMPLATE);
-    })
-    .then(function () {
-      return config.askWriteProjectFile("functions/.gitignore", GITIGNORE_TEMPLATE);
     })
     .then(function () {
       return npmDependencies.askInstallDependencies(setup.functions, config);

--- a/templates/_gitignore
+++ b/templates/_gitignore
@@ -17,6 +17,13 @@ firebase-debug.*.log*
 # it commented so all members can deploy to the same project(s) in .firebaserc.
 # .firebaserc
 
+# Compiled JavaScript files
+functions/lib/**/*.js
+functions/lib/**/*.js.map
+
+# TypeScript v1 declaration files
+typings/
+
 # Runtime data
 pids
 *.pid

--- a/templates/init/functions/javascript/_gitignore
+++ b/templates/init/functions/javascript/_gitignore
@@ -1,1 +1,0 @@
-node_modules/

--- a/templates/init/functions/typescript/_gitignore
+++ b/templates/init/functions/typescript/_gitignore
@@ -1,9 +1,0 @@
-# Compiled JavaScript files
-lib/**/*.js
-lib/**/*.js.map
-
-# TypeScript v1 declaration files
-typings/
-
-# Node.js dependency directory
-node_modules/


### PR DESCRIPTION
### Description

- Fixes #3236 to better optimise `.gitignore` management.
- Removed duplicate `.gitignore` in JavaScript Cloud Functions
- Removed duplicate `.gitignore` in TypeScript Cloud Functions and merged into `.gitignore` at root

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Yet to test, I'll edit this message to update once I do.
