### PR TITLE
Add support for maxBackoff to throttler

### DIFF
--- a/src/test/throttler/throttler.spec.ts
+++ b/src/test/throttler/throttler.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 
 import Queue from "../../throttler/queue";
 import Stack from "../../throttler/stack";
-import { Throttler, ThrottlerOptions } from "../../throttler/throttler";
+import { Throttler, ThrottlerOptions, timeToWait } from "../../throttler/throttler";
 import TaskError from "../../throttler/errors/task-error";
 import TimeoutError from "../../throttler/errors/timeout-error";
 import RetriesExhaustedError from "../../throttler/errors/retries-exhausted-error";
@@ -399,6 +399,28 @@ describe("Throttler", () => {
   });
   describe("Stack", () => {
     throttlerTest(Stack);
+  });
+});
+
+describe("timeToWait", () => {
+  it("Should wait the base delay on the first attempt", () => {
+    const retryCount = 0;
+    const delay = 100;
+    const maxDelay = 1000;
+    expect(timeToWait(retryCount, delay, maxDelay)).to.equal(delay);
+  });
+  it("Should back off exponentially", () => {
+    const delay = 100;
+    const maxDelay = 1000;
+    expect(timeToWait(1, delay, maxDelay)).to.equal(delay * 2);
+    expect(timeToWait(2, delay, maxDelay)).to.equal(delay * 4);
+    expect(timeToWait(3, delay, maxDelay)).to.equal(delay * 8);
+  });
+  it("Should not wait longer than maxDelay", () => {
+    const retryCount = 2;
+    const delay = 300;
+    const maxDelay = 400;
+    expect(timeToWait(retryCount, delay, maxDelay)).to.equal(maxDelay);
   });
 });
 

--- a/src/test/throttler/throttler.spec.ts
+++ b/src/test/throttler/throttler.spec.ts
@@ -403,20 +403,22 @@ describe("Throttler", () => {
 });
 
 describe("timeToWait", () => {
-  it("Should wait the base delay on the first attempt", () => {
+  it("should wait the base delay on the first attempt", () => {
     const retryCount = 0;
     const delay = 100;
     const maxDelay = 1000;
     expect(timeToWait(retryCount, delay, maxDelay)).to.equal(delay);
   });
-  it("Should back off exponentially", () => {
+
+  it("should back off exponentially", () => {
     const delay = 100;
     const maxDelay = 1000;
     expect(timeToWait(1, delay, maxDelay)).to.equal(delay * 2);
     expect(timeToWait(2, delay, maxDelay)).to.equal(delay * 4);
     expect(timeToWait(3, delay, maxDelay)).to.equal(delay * 8);
   });
-  it("Should not wait longer than maxDelay", () => {
+
+  it("should not wait longer than maxDelay", () => {
     const retryCount = 2;
     const delay = 300;
     const maxDelay = 400;

--- a/src/throttler/throttler.ts
+++ b/src/throttler/throttler.ts
@@ -5,9 +5,13 @@ import TaskError from "./errors/task-error";
 
 function backoff(retryNumber: number, delay: number, maxDelay: number): Promise<void> {
   return new Promise((resolve: () => void) => {
-    const timeToWait = Math.min(delay * Math.pow(2, retryNumber), maxDelay);
-    setTimeout(resolve, timeToWait);
+    setTimeout(resolve, timeToWait(retryNumber, delay, maxDelay));
   });
+}
+
+// Exported for unit testing.
+export function timeToWait(retryNumber: number, delay: number, maxDelay: number): number {
+  return Math.min(delay * Math.pow(2, retryNumber), maxDelay);
 }
 
 function DEFAULT_HANDLER<R>(task: any): Promise<R> {

--- a/src/throttler/throttler.ts
+++ b/src/throttler/throttler.ts
@@ -5,7 +5,7 @@ import TaskError from "./errors/task-error";
 
 function backoff(retryNumber: number, delay: number, maxDelay: number): Promise<void> {
   return new Promise((resolve: () => void) => {
-    const timeToWait = Math.min(delay * Math.pow(2, retryNumber), maxDelay)
+    const timeToWait = Math.min(delay * Math.pow(2, retryNumber), maxDelay);
     setTimeout(resolve, timeToWait);
   });
 }
@@ -261,8 +261,7 @@ export abstract class Throttler<T, R> {
     const t0 = Date.now();
     let result;
     try {
-      if (this.name = "cloudFunctionsDeployment")
-        result = await this.handler(taskData.task);
+      if ((this.name = "cloudFunctionsDeployment")) result = await this.handler(taskData.task);
     } catch (err) {
       if (taskData.retryCount === this.retries) {
         throw new RetriesExhaustedError(this.taskName(cursorIndex), this.retries, err);

--- a/src/throttler/throttler.ts
+++ b/src/throttler/throttler.ts
@@ -261,7 +261,7 @@ export abstract class Throttler<T, R> {
     const t0 = Date.now();
     let result;
     try {
-      if ((this.name = "cloudFunctionsDeployment")) result = await this.handler(taskData.task);
+      result = await this.handler(taskData.task);
     } catch (err) {
       if (taskData.retryCount === this.retries) {
         throw new RetriesExhaustedError(this.taskName(cursorIndex), this.retries, err);

--- a/src/throttler/throttler.ts
+++ b/src/throttler/throttler.ts
@@ -3,9 +3,10 @@ import RetriesExhaustedError from "./errors/retries-exhausted-error";
 import TimeoutError from "./errors/timeout-error";
 import TaskError from "./errors/task-error";
 
-function backoff(retryNumber: number, delay: number): Promise<void> {
+function backoff(retryNumber: number, delay: number, maxDelay: number): Promise<void> {
   return new Promise((resolve: () => void) => {
-    setTimeout(resolve, delay * Math.pow(2, retryNumber));
+    const timeToWait = Math.min(delay * Math.pow(2, retryNumber), maxDelay)
+    setTimeout(resolve, timeToWait);
   });
 }
 
@@ -19,6 +20,7 @@ export interface ThrottlerOptions<T, R> {
   handler?: (task: T) => Promise<R>;
   retries?: number;
   backoff?: number;
+  maxBackoff?: number;
 }
 
 export interface ThrottlerStats {
@@ -68,6 +70,7 @@ export abstract class Throttler<T, R> {
   avg: number = 0;
   retries: number = 0;
   backoff: number = 200;
+  maxBackoff: number = 60000; // 1 minute
   closed: boolean = false;
   finished: boolean = false;
   startTime: number = 0;
@@ -88,8 +91,8 @@ export abstract class Throttler<T, R> {
     if (typeof options.backoff === "number") {
       this.backoff = options.backoff;
     }
-    if (typeof options.backoff === "number") {
-      this.backoff = options.backoff;
+    if (typeof options.maxBackoff === "number") {
+      this.maxBackoff = options.maxBackoff;
     }
   }
 
@@ -258,12 +261,13 @@ export abstract class Throttler<T, R> {
     const t0 = Date.now();
     let result;
     try {
-      result = await this.handler(taskData.task);
+      if (this.name = "cloudFunctionsDeployment")
+        result = await this.handler(taskData.task);
     } catch (err) {
       if (taskData.retryCount === this.retries) {
         throw new RetriesExhaustedError(this.taskName(cursorIndex), this.retries, err);
       }
-      await backoff(taskData.retryCount + 1, this.backoff);
+      await backoff(taskData.retryCount + 1, this.backoff, this.maxBackoff);
       if (taskData.isTimedOut) {
         throw new TimeoutError(this.taskName(cursorIndex), taskData.timeoutMillis!);
       }
@@ -280,7 +284,6 @@ export abstract class Throttler<T, R> {
     this.min = Math.min(dt, this.min);
     this.max = Math.max(dt, this.max);
     this.avg = (this.avg * this.complete + dt) / (this.complete + 1);
-
     return result;
   }
 


### PR DESCRIPTION
### Description
Adds support for setting a max value for backoff in throttler.ts, and set the default maxBackoff to 60 seconds.

While working on retrying quota errors in Cloud Functions deployment, I noticed that the throttler will exponentially backoff to an arbitrary backoff time. For tasks that took many retries, this caused huge backoffs and severe delays

### Scenarios Tested
I manually tested this by adding a log statement that printed out the timeToWait at each attempt of a task, and  confirming that it  never exceeded maxBackoff. I also added some unit tests to ensure that backoff is waiting the appropriate amount of time.
