### PR TITLE
Preserve existing environment variables when deploying functions.

### DIFF
--- a/src/deploy/functions/deploymentPlanner.ts
+++ b/src/deploy/functions/deploymentPlanner.ts
@@ -147,6 +147,11 @@ export function createDeploymentPlan(
       if (matchingExistingFunction) {
         // Check if this is an invalid change of trigger type.
         checkForInvalidChangeOfTrigger(fn, matchingExistingFunction);
+        // Preserve existing environment variables.
+        fn.environmentVariables = {
+          ...matchingExistingFunction.environmentVariables,
+          ...fn.environmentVariables,
+        };
         regionalDeployment.functionsToUpdate.push(fn);
         existingFnsCopy = existingFnsCopy.filter((exFn: CloudFunctionTrigger) => {
           return exFn.name !== fn.name;


### PR DESCRIPTION
### Description

Today, we unexpectedly delete environment variables on existing Cloud Functions when updating functions via `firebase deploy --only functions` command #3226. This regression was introduced in #3132.

### Scenarios Tested
1. Manually setup an environment variable using Google Cloud Console on a firebase function.
2. Run `firebase deploy --only functions` to update the existing function.
3. Notice that existing environment variable isn't wiped out as a result of the new deploy.


