### PR TITLE
Add field mask support to proto.ts

### DIFF
--- a/src/gcp/proto.ts
+++ b/src/gcp/proto.ts
@@ -60,3 +60,44 @@ export function renameIfPresent<Src, Dest>(
   }
   dest[destField] = converter(src[srcField]);
 }
+
+export function fieldMasks(
+  object: Record<string, any>,
+  includeEmptyValues: boolean = false
+): string[] {
+  const masks: string[] = [];
+  for (const key of Object.keys(object)) {
+    fieldMasksHelper(key, object[key], includeEmptyValues, masks);
+  }
+  return masks;
+}
+
+function fieldMasksHelper(
+  prefix: string,
+  cursor: any,
+  includeEmptyValues: boolean,
+  masks: string[]
+) {
+  if (cursor === null || typeof cursor === "undefined") {
+    if (includeEmptyValues) {
+      masks.push(prefix);
+    }
+    return;
+  }
+  if (typeof cursor !== "object" || Array.isArray(cursor)) {
+    masks.push(prefix);
+    return;
+  }
+
+  const cursorKeys = Object.keys(cursor);
+  // An empty object (e.g. CloudFunction.httpsTrigger) is an explicit object.
+  // This is needed for OneOf<A, protobuf.Empty>
+  if (cursorKeys.length === 0) {
+    masks.push(prefix);
+    return;
+  }
+
+  for (const key of cursorKeys) {
+    fieldMasksHelper(`${prefix}.${key}`, cursor[key], includeEmptyValues, masks);
+  }
+}

--- a/src/gcp/proto.ts
+++ b/src/gcp/proto.ts
@@ -63,11 +63,11 @@ export function renameIfPresent<Src, Dest>(
 
 export function fieldMasks(
   object: Record<string, any>,
-  includeEmptyValues: boolean = false
+  includeNullOrUndefinedValues: boolean = false
 ): string[] {
   const masks: string[] = [];
   for (const key of Object.keys(object)) {
-    fieldMasksHelper(key, object[key], includeEmptyValues, masks);
+    fieldMasksHelper(key, object[key], includeNullOrUndefinedValues, masks);
   }
   return masks;
 }
@@ -75,11 +75,11 @@ export function fieldMasks(
 function fieldMasksHelper(
   prefix: string,
   cursor: any,
-  includeEmptyValues: boolean,
+  includeNullOrUndefinedValues: boolean,
   masks: string[]
 ) {
   if (cursor === null || typeof cursor === "undefined") {
-    if (includeEmptyValues) {
+    if (includeNullOrUndefinedValues) {
       masks.push(prefix);
     }
     return;
@@ -98,6 +98,6 @@ function fieldMasksHelper(
   }
 
   for (const key of cursorKeys) {
-    fieldMasksHelper(`${prefix}.${key}`, cursor[key], includeEmptyValues, masks);
+    fieldMasksHelper(`${prefix}.${key}`, cursor[key], includeNullOrUndefinedValues, masks);
   }
 }

--- a/src/test/gcp/proto.spec.ts
+++ b/src/test/gcp/proto.spec.ts
@@ -88,4 +88,46 @@ describe("proto", () => {
     // proto.renameIfPresent(dest, src, "destFoo", "srcccFoo");
     // proto.renameIfPresent(dest, src, "desFoo", "srcFoo");
   });
+
+  describe("fieldMasks", () => {
+    it("should copy simple fields", () => {
+      const obj = {
+        number: 1,
+        string: "foo",
+        array: ["hello", "world"],
+      };
+      expect(proto.fieldMasks(obj).sort()).to.deep.equal(["number", "string", "array"].sort());
+    });
+
+    it("should respect includeEmptyValues", () => {
+      const obj = {
+        present: "foo",
+        empty: undefined,
+      };
+
+      expect(proto.fieldMasks(obj, /* includeEmptyValues=*/ false)).to.deep.equal(["present"]);
+      expect(proto.fieldMasks(obj, /* includeEmptyValues=*/ true).sort()).to.deep.equal(
+        ["present", "empty"].sort()
+      );
+    });
+
+    it("should nest into objects", () => {
+      const obj = {
+        top: "level",
+        nested: {
+          key: "value",
+        },
+      };
+      expect(proto.fieldMasks(obj).sort()).to.deep.equal(["top", "nested.key"].sort());
+    });
+
+    it("should include empty objects", () => {
+      const obj = {
+        failurePolicy: {
+          retry: {},
+        },
+      };
+      expect(proto.fieldMasks(obj)).to.deep.equal(["failurePolicy.retry"]);
+    });
+  });
 });

--- a/src/test/gcp/proto.spec.ts
+++ b/src/test/gcp/proto.spec.ts
@@ -99,14 +99,16 @@ describe("proto", () => {
       expect(proto.fieldMasks(obj).sort()).to.deep.equal(["number", "string", "array"].sort());
     });
 
-    it("should respect includeEmptyValues", () => {
+    it("should respect includeNullOrUndefinedValues", () => {
       const obj = {
         present: "foo",
         empty: undefined,
       };
 
-      expect(proto.fieldMasks(obj, /* includeEmptyValues=*/ false)).to.deep.equal(["present"]);
-      expect(proto.fieldMasks(obj, /* includeEmptyValues=*/ true).sort()).to.deep.equal(
+      expect(proto.fieldMasks(obj, /* includeNullOrUndefinedValues=*/ false)).to.deep.equal([
+        "present",
+      ]);
+      expect(proto.fieldMasks(obj, /* includeNullOrUndefinedValues=*/ true).sort()).to.deep.equal(
         ["present", "empty"].sort()
       );
     });


### PR DESCRIPTION
I found a utility for generating field masks useful in the new version of the GCF APIs. Full disclosure, I have mixed feelings about the empty values flag. I'm considering a design pattern like

```
cloudFunction.eventTrigger.failurePolicy = undefined;
// now includes "eventTrigger.failurePolicy"
const fieldMasks = proto.fieldMasks(cloudFunction, /*includeEmptyValues=*/true);
```

It would serialize correctly (`JSON.stringify` drops keys for undefined values), but I'm reticent to make the codebase have semantic differences between missing and undefined.