### PR TITLE
Fixes checkMinRequiredVersion so that it can be called from before

### DIFF
--- a/src/checkMinRequiredVersion.ts
+++ b/src/checkMinRequiredVersion.ts
@@ -8,9 +8,10 @@ const pkg = require("../package.json"); // eslint-disable-line @typescript-eslin
 /**
  * Checks if the CLI is on a recent enough version to use a command.
  * Errors if a min version is found and the CLI is below the minimum required version.
+ * @param options
  * @param key the motd key to that contains semver for the min version for a command.
  */
-export function checkMinRequiredVersion(key: string) {
+export function checkMinRequiredVersion(options: any, key: string) {
   const minVersion = configstore.get(`motd.${key}`);
   if (minVersion && semver.gt(minVersion, pkg.version)) {
     throw new FirebaseError(

--- a/src/test/checkMinRequiredVersion.spec.ts
+++ b/src/test/checkMinRequiredVersion.spec.ts
@@ -1,0 +1,34 @@
+import { expect } from "chai";
+import { configstore } from "../configstore";
+import * as sinon from "sinon";
+
+import { checkMinRequiredVersion } from "../checkMinRequiredVersion";
+import Sinon from "sinon";
+
+describe("checkMinRequiredVersion", () => {
+  let configstoreStub: Sinon.SinonStub;
+
+  beforeEach(() => {
+    configstoreStub = sinon.stub(configstore, "get");
+  });
+
+  afterEach(() => {
+    configstoreStub.restore();
+  });
+
+  it("should error if installed version is below the min required version", () => {
+    configstoreStub.withArgs("motd.key").returns("1000.1000.1000");
+
+    expect(() => {
+      checkMinRequiredVersion({}, "key");
+    }).to.throw;
+  });
+
+  it("should not error if installed version is above the min required version", () => {
+    configstoreStub.withArgs("motd.key").returns("0.0.0");
+
+    expect(() => {
+      checkMinRequiredVersion({}, "key");
+    }).not.to.throw;
+  });
+});


### PR DESCRIPTION
### Description
Adds options as a first argument to checkMinRequiredVersion, so that it can be called from before().

### Scenarios Tested
Manually set extMinVersion in ~/config/configstore/firebase-tools.json, confirmed that the command errors:
<img width="1440" alt="Screen Shot 2021-04-22 at 11 04 49 AM" src="https://user-images.githubusercontent.com/4635763/115764630-a70d8f80-a35a-11eb-9d84-54d2f55201f4.png">

