### PR TITLE
Add linter exceptions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,11 @@ module.exports = {
       rules: {
         "jsdoc/require-param-type": "off",
         "jsdoc/require-returns-type": "off",
+
+        // Google style guide allows us to omit trivial parameters and returns
+        "jsdoc/require-param": "off",
+        "jsdoc/require-return": "off",
+
         "no-invalid-this": "off", // Turned off in favor of @typescript-eslint/no-invalid-this.
         "@typescript-eslint/no-invalid-this": ["error"],
 


### PR DESCRIPTION
Per offline conversation, we're allowing JSDocs to omit @param and @return since the Google style guide allows us to omit them when trivial. Reviewers should still ask for documentation on non-obvious parameters or return types.