### PR TITLE
Update action-hosting-deploy workflow template

### DIFF
--- a/src/init/features/hosting/github.ts
+++ b/src/init/features/hosting/github.ts
@@ -148,6 +148,7 @@ export async function initGitHub(setup: Setup, config: any, options: any): Promi
       YML_FULL_PATH_PULL_REQUEST,
       githubSecretName,
       setup.projectId,
+      repo,
       script
     );
 
@@ -269,6 +270,7 @@ type GitHubWorkflowConfig = {
   on: string | { [key: string]: { [key: string]: string[] } };
   jobs: {
     [key: string]: {
+      if: string;
       "runs-on": string;
       steps: {
         uses?: string;
@@ -284,6 +286,7 @@ function writeChannelActionYMLFile(
   ymlPath: string,
   secretName: string,
   projectId: string,
+  repo: string,
   script?: string
 ): void {
   const workflowConfig: GitHubWorkflowConfig = {
@@ -291,6 +294,7 @@ function writeChannelActionYMLFile(
     on: "pull_request",
     jobs: {
       ["build_and_preview"]: {
+        if: `github.repository == "${repo}"`, // secrets aren't accessible on PRs from forks
         "runs-on": "ubuntu-latest",
         steps: [{ uses: CHECKOUT_GITHUB_ACTION_NAME }],
       },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Update the default workflow template for the [Deploy to Firebase Hosting](https://github.com/marketplace/actions/deploy-to-firebase-hosting) action so that it doesn't run on forks.

Github secrets aren't available to forks, so the action will always fail on a PR from a fork.

### Scenarios Tested

`firebase init hosting:github`

Here's the diff between the old output and the new one:

```diff
# This file was auto-generated by the Firebase CLI
# https://github.com/firebase/firebase-tools

name: Deploy to Firebase Hosting on PR
'on': pull_request
jobs:
  build_and_preview:
+    if: github.repository == "jhuleatt/hosting-deploy-sample"
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - uses: FirebaseExtended/action-hosting-deploy@v0
        with:
          repoToken: '${{ secrets.GITHUB_TOKEN }}'
          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_MY_PROJECT }}'
          projectId: jeff-test-699d3
-        env:
-          FIREBASE_CLI_PREVIEWS: hostingchannels
```
