### PR TITLE
Fix linter error with linter config file

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -10,7 +10,7 @@ module.exports = {
     "plugin:import/warnings",
     "plugin:import/typescript",
     "google",
-    "plugin:@typescript-eslint/recommended"
+    "plugin:@typescript-eslint/recommended",
   ],
   parser: "@typescript-eslint/parser",
   parserOptions: {


### PR DESCRIPTION
When trying to deploy a "hello world" project, I got the error:

```
=== Deploying to 'inlined-junkdrawer'...

i  deploying functions
Running command: npm --prefix "$RESOURCE_DIR" run lint

> lint
> eslint --ext .js,.ts .


/Users/inlined/git/junkdrawer/functions/.eslintrc.js
  13:44  error  Missing trailing comma  comma-dangle

✖ 1 problem (1 error, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.


Error: functions predeploy error: Command terminated with non-zero exit code1
```

This should fix the linter error in `.eslintrc.js`