### PR TITLE
emulators:exec support for Storage emulator

### DIFF
--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -331,6 +331,15 @@ async function runScript(script: string, extraEnv: Record<string, string>): Prom
     env[FirestoreEmulator.FIRESTORE_EMULATOR_ENV_ALT] = address;
   }
 
+  const storageInstance = EmulatorRegistry.get(Emulators.STORAGE);
+  if (storageInstance) {
+    const info = storageInstance.getInfo();
+    const address = EmulatorRegistry.getInfoHostString(info);
+
+    env[Constants.FIREBASE_STORAGE_EMULATOR_HOST] = address;
+    env[Constants.CLOUD_STORAGE_EMULATOR_HOST] = `http://${address}`;
+  }
+
   const authInstance = EmulatorRegistry.get(Emulators.AUTH);
   if (authInstance) {
     const info = authInstance.getInfo();

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -63,7 +63,8 @@ export class Constants {
   static FIREBASE_STORAGE_EMULATOR_HOST = "FIREBASE_STORAGE_EMULATOR_HOST";
 
   // Environment variable to override SDK/CLI to point at the Firebase Storage emulator
-  // for firebase-admin <= 9.6.0
+  // for firebase-admin <= 9.6.0. Unlike the FIREBASE_STORAGE_EMULATOR_HOST variable
+  // this one must start with 'http://'.
   static CLOUD_STORAGE_EMULATOR_HOST = "STORAGE_EMULATOR_HOST";
 
   // Environment variable to discover the Emulator HUB


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Make `emulators:exec` set the storage emulator environment variables.

### Scenarios Tested

```
$ firebase emulators:exec 'echo $FIREBASE_STORAGE_EMULATOR_HOST; echo $STORAGE_EMULATOR_HOST'
i  emulators: Starting emulators: storage
i  Running script: echo $FIREBASE_STORAGE_EMULATOR_HOST; echo $STORAGE_EMULATOR_HOST
localhost:9199
http://localhost:9199
✔  Script exited successfully (code 0)
i  emulators: Shutting down emulators.
i  storage: Stopping Storage Emulator
i  hub: Stopping emulator hub
```

### Sample Commands

N/A