### PR TITLE
Fix sendStatus/status typo in Storage emulator

### DIFF
--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -108,7 +108,7 @@ export function createApp(
       });
     }
 
-    res.sendStatus(200).json({
+    res.status(200).json({
       message: "Rules updated successfully",
     });
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Successfully setting Storage rules causes this error:
```
(node:90535) UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at ServerResponse.setHeader (_http_outgoing.js:530:11)
    at ServerResponse.header (/Users/samstern/Projects/firebase-js-sdk/node_modules/express/lib/response.js:771:10)
    at ServerResponse.send (/Users/samstern/Projects/firebase-js-sdk/node_modules/express/lib/response.js:170:12)
    at ServerResponse.json (/Users/samstern/Projects/firebase-js-sdk/node_modules/express/lib/response.js:267:15)
    at /Users/samstern/Projects/firebase-js-sdk/packages/rules-unit-testing/node_modules/firebase-tools/lib/emulator/storage/server.js:73:29
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
```

### Scenarios Tested

Tested manually with `rules-unit-testing` PR.

### Sample Commands

N/A