### PR TITLE
Fix one more sendStatus typo.

### DIFF
--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -118,7 +118,7 @@ export function createApp(
       console.log(req.method, req.url);
       res.json("endpoint not implemented");
     } else {
-      res.sendStatus(404).json("endpoint not implemented");
+      res.sendStatus(404);
     }
   });
 


### PR DESCRIPTION
See #3338 for symptoms and rationale.

Also IMO this catch-all handler should just return plain `Not Found` instead of not implemented since the path may as well not be an API or misspelled. For example, `/favicon.ico` requests from browsers also trigger this.