### PR TITLE
Expose errors returned by Hosting when deploys fail to upload files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes error where Hosting gets in an undeployable state due to the hash cache having incorrect entries.
+- Improves error handling for the throttler queue, to better diagnose Hosting deploys that fail during the file upload step.

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -251,12 +251,13 @@ export class Uploader {
       logger.debug("[hosting][upload]", this.uploadQueue.stats());
     }
     if (res.status !== 200) {
+      const errorMessage = await res.response.text();
       logger.debug(
-        `[hosting][upload] ${this.hashMap[toUpload]} (${toUpload}) HTTP ERROR ${res.status}: ${
-          res.response.headers
-        } ${await res.response.text()}`
+        `[hosting][upload] ${this.hashMap[toUpload]} (${toUpload}) HTTP ERROR ${
+          res.status
+        }: headers=${JSON.stringify(res.response.headers)} ${errorMessage}`
       );
-      throw new Error("Unexpected error while uploading file.");
+      throw new Error(`Unexpected error while uploading file: ${errorMessage}`);
     }
   }
 

--- a/src/test/throttler/throttler.spec.ts
+++ b/src/test/throttler/throttler.spec.ts
@@ -109,7 +109,9 @@ const throttlerTest = (ThrottlerConstructor: ThrottlerConstructorType): void => 
       .catch((err: TaskError) => {
         expect(err).to.be.an.instanceof(RetriesExhaustedError);
         expect(err.original).to.equal(TEST_ERROR);
-        expect(err.message).to.equal("Task index 0 failed: retries exhausted after 1 attempts");
+        expect(err.message).to.equal(
+          "Task index 0 failed: retries exhausted after 1 attempts, with error: foobar"
+        );
       })
       .then(() => {
         expect(handler.callCount).to.equal(1);
@@ -140,7 +142,9 @@ const throttlerTest = (ThrottlerConstructor: ThrottlerConstructorType): void => 
       .catch((err: TaskError) => {
         expect(err).to.be.an.instanceof(RetriesExhaustedError);
         expect(err.original).to.equal(TEST_ERROR);
-        expect(err.message).to.equal("Task index 0 failed: retries exhausted after 4 attempts");
+        expect(err.message).to.equal(
+          "Task index 0 failed: retries exhausted after 4 attempts, with error: foobar"
+        );
       })
       .then(() => {
         expect(handler.callCount).to.equal(4);
@@ -300,7 +304,9 @@ const throttlerTest = (ThrottlerConstructor: ThrottlerConstructorType): void => 
     }
     expect(err).to.be.instanceOf(RetriesExhaustedError);
     expect(err.original).to.equal(TEST_ERROR);
-    expect(err.message).to.equal("Task index 0 failed: retries exhausted after 3 attempts");
+    expect(err.message).to.equal(
+      "Task index 0 failed: retries exhausted after 3 attempts, with error: foobar"
+    );
     expect(handler.callCount).to.equal(3);
     expect(q.complete).to.equal(1);
     expect(q.success).to.equal(0);
@@ -383,7 +389,9 @@ const throttlerTest = (ThrottlerConstructor: ThrottlerConstructorType): void => 
       err = e;
     }
     expect(err).to.be.instanceOf(RetriesExhaustedError);
-    expect(err.message).to.equal("Task index 1 failed: retries exhausted after 2 attempts");
+    expect(err.message).to.equal(
+      "Task index 1 failed: retries exhausted after 2 attempts, with error: foobar"
+    );
     expect(handler.callCount).to.equal(3);
     expect(q.complete).to.equal(2);
     expect(q.success).to.equal(1);

--- a/src/throttler/errors/retries-exhausted-error.ts
+++ b/src/throttler/errors/retries-exhausted-error.ts
@@ -2,8 +2,12 @@ import TaskError from "./task-error";
 
 export default class RetriesExhaustedError extends TaskError {
   constructor(taskName: string, totalRetries: number, lastTrialError: Error) {
-    super(taskName, `retries exhausted after ${totalRetries + 1} attempts`, {
-      original: lastTrialError,
-    });
+    super(
+      taskName,
+      `retries exhausted after ${totalRetries + 1} attempts, with error: ${lastTrialError.message}`,
+      {
+        original: lastTrialError,
+      }
+    );
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Allow quicker debugging of Hosting upload errors, by exposing the final error message returned by the server without the --debug flag.

This would help issue like #2126 from being lumped into a single issue report, when they are separate problems.

This will also expose the final error returned after the maximum retries during a failed function deploy.
### Scenarios Tested

- Deploy a hosting site
- Go to .firebase/hosting.<sitehash>.cache
- Modify the hash for any file
- Re-deploy the site (`firebase deploy --only hosting`).  
 
Observe the error returned:
`Error: Task <hash> failed: retries exhausted after 6 attempts, with error: Unexpected error while uploading file: Couldn't process request (status=400): content hash doesn't match content`

Previously, this was 
`Error: Task <hash> failed: retries exhausted after 6 attempts`
