### PR TITLE
Delete hash cache after uploads fail with content-hash error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes error where Hosting gets in an undeployable state due to the hash cache having incorrect entries.

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -123,6 +123,15 @@ export class Uploader {
         this.uploadQueue.close();
       });
 
+    this.uploadQueue.wait().catch((err: Error) => {
+      if (err.message.includes("content hash")) {
+        logger.debug(
+          "[hosting][upload queue] upload failed with content hash error. Deleting hash cache"
+        );
+        hashcache.dump(this.projectRoot, this.hashcacheName(), new Map());
+      }
+    });
+
     const fin = (err: unknown): void => {
       logger.debug("[hosting][upload queue][FINAL]", this.uploadQueue.stats());
       if (err) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

If the content-hash cache gets corrupted somehow, the files uploaded will not have the same sha256 hash as we are expecting, and the upload will fail.  To prevent this, if an upload fails with an error containing "content hash" (the current error is `content hash doesn't match content`), delete all the cached gziped file hashes.  Then the user will be able to re-gzip-hash and deploy successfully next time.

This fixes one of the reported issues in #2126

### Scenarios Tested

- Deploy a hosting site
- Go to .firebase/hosting.<sitehash>.cache
- Modify the hash for any file
- Re-deploy the site (`firebase deploy --only hosting`).  Observe it fails.
- Re-deploy the site again (`firebase deploy --only hosting`).  The deploy should now succeed.

