### PR TITLE
Fix storage emulator crash in non-English locales.

### DIFF
--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -150,8 +150,17 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
     joinArgs: false,
   },
   storage: {
+    // This is for the Storage Emulator rules runtime, which is started
+    // separately in ./storage/runtime.ts (not via the start function below).
     binary: "java",
-    args: ["-jar", getExecPath(Emulators.STORAGE), "serve"],
+    args: [
+      "-jar",
+      // Required for rules error/warning messages, which are in English only.
+      // Attempts to fetch the messages in another language leads to crashes.
+      "-Duser.language=en",
+      getExecPath(Emulators.STORAGE),
+      "serve",
+    ],
     optionalArgs: [],
     joinArgs: false,
   },
@@ -186,7 +195,7 @@ export function getLogFileName(name: string): string {
  * @param emulator - string identifier for the emulator to start.
  * @param args - map<string,string> of addittional args
  */
-function _getCommand(
+export function _getCommand(
   emulator: DownloadableEmulators,
   args: { [s: string]: any }
 ): DownloadableEmulatorCommand {

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -34,7 +34,7 @@ export class StorageEmulator implements EmulatorInstance {
 
   constructor(private args: StorageEmulatorArgs) {
     const downloadDetails = getDownloadDetails(Emulators.STORAGE);
-    this._rulesRuntime = new StorageRulesRuntime(downloadDetails.downloadPath);
+    this._rulesRuntime = new StorageRulesRuntime();
     this._storageLayer = new StorageLayer(args.projectId);
   }
 

--- a/src/emulator/storage/rules/runtime.ts
+++ b/src/emulator/storage/rules/runtime.ts
@@ -21,7 +21,7 @@ import * as utils from "../../../utils";
 import { Constants } from "../../constants";
 import { downloadEmulator } from "../../download";
 import * as fs from "fs-extra";
-import { DownloadDetails } from "../../downloadableEmulators";
+import { DownloadDetails, _getCommand } from "../../downloadableEmulators";
 
 export interface RulesetVerificationOpts {
   file: {
@@ -94,15 +94,13 @@ export class StorageRulesRuntime {
   private _childprocess?: ChildProcess;
   private _alive = false;
 
-  constructor(private readonly _jarPath: string) {}
-
   get alive() {
     return this._alive;
   }
 
   async start(auto_download = true) {
-    const hasEmulator = fs.existsSync(this._jarPath);
     const downloadDetails = DownloadDetails[Emulators.STORAGE];
+    const hasEmulator = fs.existsSync(downloadDetails.downloadPath);
 
     if (!hasEmulator) {
       if (auto_download) {
@@ -122,7 +120,8 @@ export class StorageRulesRuntime {
     }
 
     this._alive = true;
-    this._childprocess = spawn("java", ["-jar", this._jarPath, "serve"], {
+    const command = _getCommand(Emulators.STORAGE, {});
+    this._childprocess = spawn(command.binary, command.args, {
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/src/test/emulators/storage.rules.spec.ts
+++ b/src/test/emulators/storage.rules.spec.ts
@@ -49,8 +49,7 @@ describe.skip("Storage Rules", function () {
   before(async () => {
     await downloadIfNecessary(Emulators.STORAGE);
 
-    const storageDownload = getDownloadDetails(Emulators.STORAGE);
-    runtime = new StorageRulesRuntime(storageDownload.downloadPath);
+    runtime = new StorageRulesRuntime();
     (EmulatorLogger as any).prototype.log = console.log.bind(console);
     await runtime.start();
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes a crash when Storage rules have warnings / errors and the Java locale is set to something other than English (e.g. `de`).

### Scenarios Tested

To repro the crash, use rules that parses but don't compile (or compile with warning), e.g.

```
rules_version = '3';
service firebase.storage {
  match /b/{bucket}/o {
    match /{allPaths=**} {
      allow read, write;
    }
  }
}
```

Note the intentional version `3` which leads to version unsupported error. Now run the sample command below.

### Sample Commands

```bash
JAVA_TOOL_OPTIONS=-Duser.language=de firebase emulators:start
```

Before the fix, it crashes with `Exception in thread \"main\" java.util.MissingResourceException: Can't find bundle for base name com.google.firebase.rules.validations.JValidationMessages_messages, locale de` etc. etc.

After the fix, it should not crash but print a warning with `Unsupported rules version 3 in ...`