### PR TITLE
Fix missing return when sending errors

### DIFF
--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -58,6 +58,7 @@ export function createApp(
     const path = req.body.path;
     if (!path) {
       res.status(400).send("Export request body must include 'path'.");
+      return;
     }
 
     await storageLayer.export(path);
@@ -97,6 +98,7 @@ export function createApp(
       res.status(400).json({
         message: "There was an error updating rules, see logs for more details",
       });
+      return;
     }
 
     res.status(200).json({


### PR DESCRIPTION
### Description

In both cases there was no fall through leading to an `Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client`.

### Scenarios Tested

Run a script that throws these errors and led to the "headers already sent"-error now don't through it anymore.

### Sample Commands

```
firebase emulators:exec --only storage 'jest --runInBand'
```
