### PR TITLE
Enable a function to be emulated in multiple regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Enable running functions in multiple regions in the emulator.

--- a/scripts/emulator-tests/fixtures.ts
+++ b/scripts/emulator-tests/fixtures.ts
@@ -41,7 +41,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         },
       },
     },
-    triggerId: "function_id",
+    triggerId: "us-central1-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onWrite: {
@@ -80,7 +81,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         },
       },
     },
-    triggerId: "function_id",
+    triggerId: "us-central1-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onDelete: {
@@ -119,7 +121,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         },
       },
     },
-    triggerId: "function_id",
+    triggerId: "us-central1-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onUpdate: {
@@ -170,7 +173,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         timestamp: "2019-05-15T16:21:15.148831Z",
       },
     },
-    triggerId: "function_id",
+    triggerId: "us-central1-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onRequest: {
@@ -185,7 +189,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
       },
     },
     cwd: MODULE_ROOT,
-    triggerId: "function_id",
+    triggerId: "us-central1-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
 };

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -35,12 +35,24 @@ functionsEmulator.nodeBinary = process.execPath;
 functionsEmulator.setTriggersForTesting([
   {
     name: "function_id",
+    id: "us-central1-function_id",
+    region: "us-central1",
+    entryPoint: "function_id",
+    httpsTrigger: {},
+    labels: {},
+  },
+  {
+    name: "function_id",
+    id: "europe-west2-function_id",
+    region: "europe-west2",
     entryPoint: "function_id",
     httpsTrigger: {},
     labels: {},
   },
   {
     name: "callable_function_id",
+    id: "us-central1-callable_function_id",
+    region: "us-central1",
     entryPoint: "callable_function_id",
     httpsTrigger: {},
     labels: {
@@ -49,6 +61,8 @@ functionsEmulator.setTriggersForTesting([
   },
   {
     name: "nested-function_id",
+    id: "us-central1-nested-function_id",
+    region: "us-central1",
     entryPoint: "nested.function_id",
     httpsTrigger: {},
     labels: {},
@@ -63,11 +77,12 @@ function useFunctions(triggers: () => {}): void {
   // eslint-disable-next-line @typescript-eslint/unbound-method
   functionsEmulator.startFunctionRuntime = (
     triggerId: string,
+    targetName: string,
     triggerType: EmulatedTriggerType,
     proto?: any,
     runtimeOpts?: InvokeRuntimeOpts
   ): RuntimeWorker => {
-    return startFunctionRuntime(triggerId, triggerType, proto, {
+    return startFunctionRuntime(triggerId, targetName, triggerType, proto, {
       nodeBinary: process.execPath,
       serializedTriggers,
     });
@@ -93,6 +108,43 @@ describe("FunctionsEmulator-Hub", () => {
       .then((res) => {
         expect(res.body.path).to.deep.equal("/");
       });
+  }).timeout(TIMEOUT_LONG);
+
+  it("should route requests to /:project_id/:other-region/:trigger_id to the region's HTTPS Function", async () => {
+    useFunctions(() => {
+      require("firebase-admin").initializeApp();
+      return {
+        function_id: require("firebase-functions").https.onRequest(
+          (req: express.Request, res: express.Response) => {
+            res.json({ path: req.path });
+          }
+        ),
+      };
+    });
+
+    await supertest(functionsEmulator.createHubServer())
+      .get("/fake-project-id/europe-west2/function_id")
+      .expect(200)
+      .then((res) => {
+        expect(res.body.path).to.deep.equal("/");
+      });
+  }).timeout(TIMEOUT_LONG);
+
+  it("should 404 when a function doesn't exist in the region", async () => {
+    useFunctions(() => {
+      require("firebase-admin").initializeApp();
+      return {
+        function_id: require("firebase-functions").https.onRequest(
+          (req: express.Request, res: express.Response) => {
+            res.json({ path: req.path });
+          }
+        ),
+      };
+    });
+
+    await supertest(functionsEmulator.createHubServer())
+      .get("/fake-project-id/us-east1/function_id")
+      .expect(404);
   }).timeout(TIMEOUT_LONG);
 
   it("should route requests to /:project_id/:region/:trigger_id/ to HTTPS Function", async () => {

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -50,6 +50,14 @@ functionsEmulator.setTriggersForTesting([
     labels: {},
   },
   {
+    name: "function_id",
+    id: "europe-west3-function_id",
+    region: "europe-west3",
+    entryPoint: "function_id",
+    httpsTrigger: {},
+    labels: {},
+  },
+  {
     name: "callable_function_id",
     id: "us-central1-callable_function_id",
     region: "us-central1",
@@ -90,7 +98,7 @@ function useFunctions(triggers: () => {}): void {
 }
 
 describe("FunctionsEmulator-Hub", () => {
-  it("should route requests to /:project_id/:region/:trigger_id to HTTPS Function", async () => {
+  it("should route requests to /:project_id/us-central1/:trigger_id to default region HTTPS Function", async () => {
     useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
@@ -114,11 +122,11 @@ describe("FunctionsEmulator-Hub", () => {
     useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
-        function_id: require("firebase-functions").https.onRequest(
-          (req: express.Request, res: express.Response) => {
+        function_id: require("firebase-functions")
+          .region("us-central1", "europe-west2")
+          .https.onRequest((req: express.Request, res: express.Response) => {
             res.json({ path: req.path });
-          }
-        ),
+          }),
       };
     });
 
@@ -134,11 +142,11 @@ describe("FunctionsEmulator-Hub", () => {
     useFunctions(() => {
       require("firebase-admin").initializeApp();
       return {
-        function_id: require("firebase-functions").https.onRequest(
-          (req: express.Request, res: express.Response) => {
+        function_id: require("firebase-functions")
+          .region("us-central1", "europe-west2")
+          .https.onRequest((req: express.Request, res: express.Response) => {
             res.json({ path: req.path });
-          }
-        ),
+          }),
       };
     });
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -222,10 +222,8 @@ export class FunctionsEmulator implements EmulatorInstance {
     const httpsFunctionRoutes = [httpsFunctionRoute, `${httpsFunctionRoute}/*`];
 
     const backgroundHandler: express.RequestHandler = (req, res) => {
-      const triggerName = req.params.trigger_name;
-      const region = req.params.region;
+      const triggerId = req.params.trigger_name;
       const projectId = req.params.project_id;
-      const triggerId = `${region}-${triggerName}`;
 
       const reqBody = (req as RequestWithRawBody).rawBody;
       const proto = JSON.parse(reqBody.toString());
@@ -1094,7 +1092,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     // req.url = /:projectId/:region/:trigger_name/*
     const url = new URL(`${req.protocol}://${req.hostname}${req.url}`);
     const path = `${url.pathname}${url.search}`.replace(
-      new RegExp(`\/${this.args.projectId}\/[^\/]*\/${triggerId}\/?`),
+      new RegExp(`\/${this.args.projectId}\/[^\/]*\/${triggerName}\/?`),
       "/"
     );
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -285,6 +285,7 @@ export class FunctionsEmulator implements EmulatorInstance {
 
   startFunctionRuntime(
     triggerId: string,
+    targetName: string,
     triggerType: EmulatedTriggerType,
     proto?: any,
     runtimeOpts?: InvokeRuntimeOpts
@@ -302,6 +303,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       nodeMajorVersion: this.args.nodeMajorVersion,
       proto,
       triggerId,
+      targetName,
       triggerType,
     };
     const opts = runtimeOpts || {
@@ -713,6 +715,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       cwd: this.args.functionsDir,
       projectId: this.args.projectId,
       triggerId: "",
+      targetName: "",
       triggerType: undefined,
       emulators: {
         firestore: EmulatorRegistry.getInfo(Emulators.FIRESTORE),
@@ -922,7 +925,12 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     const trigger = this.getTriggerDefinitionByKey(triggerKey);
     const service = getFunctionService(trigger);
-    const worker = this.startFunctionRuntime(trigger.id, EmulatedTriggerType.BACKGROUND, proto);
+    const worker = this.startFunctionRuntime(
+      trigger.id,
+      trigger.name,
+      EmulatedTriggerType.BACKGROUND,
+      proto
+    );
 
     return new Promise((resolve, reject) => {
       if (projectId !== this.args.projectId) {
@@ -1059,7 +1067,12 @@ export class FunctionsEmulator implements EmulatorInstance {
         );
       }
     }
-    const worker = this.startFunctionRuntime(trigger.id, EmulatedTriggerType.HTTPS, undefined);
+    const worker = this.startFunctionRuntime(
+      trigger.id,
+      trigger.name,
+      EmulatedTriggerType.HTTPS,
+      undefined
+    );
 
     worker.onLogs((el: EmulatorLog) => {
       if (el.level === "FATAL") {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -681,7 +681,7 @@ async function initializeEnvironmentalVariables(frb: FunctionsRuntimeBundle): Pr
   if (frb.triggerId) {
     // Runtime values are based on information from the bundle. Proper information for this is
     // available once the target code has been loaded, which is too late.
-    const service = frb.triggerId || "";
+    const service = frb.targetName || "";
     const target = service.replace(/-/g, ".");
     const mode = frb.triggerType === EmulatedTriggerType.BACKGROUND ? "event" : "http";
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -11,7 +11,7 @@ import {
   emulatedFunctionsByRegion,
   getEmulatedTriggersFromDefinitions,
   FunctionsRuntimeArgs,
-  HttpConstants
+  HttpConstants,
 } from "./functionsEmulatorShared";
 import { Constants } from "./constants";
 import { parseVersionString, compareVersionStrings } from "./functionsEmulatorUtils";

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -8,9 +8,10 @@ import {
   findModuleRoot,
   FunctionsRuntimeBundle,
   FunctionsRuntimeFeatures,
+  emulatedFunctionsByRegion,
   getEmulatedTriggersFromDefinitions,
   FunctionsRuntimeArgs,
-  HttpConstants,
+  HttpConstants
 } from "./functionsEmulatorShared";
 import { Constants } from "./constants";
 import { parseVersionString, compareVersionStrings } from "./functionsEmulatorUtils";

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -8,7 +8,6 @@ import {
   findModuleRoot,
   FunctionsRuntimeBundle,
   FunctionsRuntimeFeatures,
-  emulatedFunctionsByRegion,
   getEmulatedTriggersFromDefinitions,
   FunctionsRuntimeArgs,
   HttpConstants,

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1,7 +1,9 @@
 import { EmulatorLog } from "./types";
 import { CloudFunction, DeploymentOptions, https } from "firebase-functions";
 import {
+  ParsedTriggerDefinition,
   EmulatedTrigger,
+  emulatedFunctionsByRegion,
   EmulatedTriggerDefinition,
   EmulatedTriggerMap,
   EmulatedTriggerType,
@@ -36,10 +38,11 @@ function noOp(): false {
   return false;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function requireAsync(moduleName: string, opts?: { paths: string[] }): Promise<any> {
   return new Promise((res, rej) => {
     try {
-      res(require(require.resolve(moduleName, opts)));
+      res(require(require.resolve(moduleName, opts))); // eslint-disable-line @typescript-eslint/no-var-requires
     } catch (e) {
       rej(e);
     }
@@ -58,8 +61,8 @@ function requireResolveAsync(moduleName: string, opts?: { paths: string[] }): Pr
 
 interface PackageJSON {
   engines?: { node?: string };
-  dependencies: { [name: string]: any };
-  devDependencies: { [name: string]: any };
+  dependencies: { [name: string]: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
+  devDependencies: { [name: string]: any }; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 interface ModuleResolution {
@@ -77,7 +80,7 @@ interface SuccessfulModuleResolution {
 }
 
 interface ProxyTarget extends Object {
-  [key: string]: any;
+  [key: string]: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
 /*
@@ -1031,7 +1034,7 @@ async function invokeTrigger(
 async function initializeRuntime(
   frb: FunctionsRuntimeBundle,
   serializedFunctionTrigger?: string,
-  extensionTriggers?: EmulatedTriggerDefinition[]
+  extensionTriggers?: ParsedTriggerDefinition[]
 ): Promise<EmulatedTriggerMap | undefined> {
   logDebug(`Disabled runtime features: ${JSON.stringify(frb.disabled_features)}`);
 
@@ -1052,7 +1055,7 @@ async function initializeRuntime(
   await initializeFirebaseFunctionsStubs(frb);
   await initializeFirebaseAdminStubs(frb);
 
-  let triggerDefinitions: EmulatedTriggerDefinition[] = [];
+  let parsedDefinitions: ParsedTriggerDefinition[] = [];
   let triggerModule;
 
   if (serializedFunctionTrigger) {
@@ -1067,10 +1070,13 @@ async function initializeRuntime(
     }
   }
   if (extensionTriggers) {
-    triggerDefinitions = extensionTriggers;
+    parsedDefinitions = extensionTriggers;
   } else {
-    require("../extractTriggers")(triggerModule, triggerDefinitions);
+    require("../extractTriggers")(triggerModule, parsedDefinitions);
   }
+  const triggerDefinitions: EmulatedTriggerDefinition[] = emulatedFunctionsByRegion(
+    parsedDefinitions
+  );
 
   const triggers = getEmulatedTriggersFromDefinitions(triggerDefinitions, triggerModule);
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -8,7 +8,7 @@ import { InvokeRuntimeOpts } from "./functionsEmulator";
 
 export enum EmulatedTriggerType {
   BACKGROUND = "BACKGROUND",
-  HTTPS = "HTTPS"
+  HTTPS = "HTTPS",
 }
 
 export interface EmulatedTriggerDefinition {
@@ -148,7 +148,7 @@ export function emulatedFunctionsByRegion(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const defDeepCopy: EmulatedTriggerDefinition = JSON.parse(JSON.stringify(def));
       defDeepCopy.regions = [region];
-      defDeepCopy.id =`${region}-${defDeepCopy.name}`;
+      defDeepCopy.id = `${region}-${defDeepCopy.name}`;
 
       regionDefinitions.push(defDeepCopy);
     }

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -52,6 +52,7 @@ export interface FunctionsRuntimeBundle {
   projectId: string;
   proto?: any;
   triggerId?: string;
+  targetName?: string;
   triggerType?: EmulatedTriggerType;
   emulators: {
     firestore?: {

--- a/src/emulator/functionsEmulatorShell.ts
+++ b/src/emulator/functionsEmulatorShell.ts
@@ -1,10 +1,6 @@
 import * as uuid from "uuid";
 import { FunctionsEmulator } from "./functionsEmulator";
-import {
-  EmulatedTriggerDefinition,
-  EmulatedTriggerType,
-  getFunctionRegion,
-} from "./functionsEmulatorShared";
+import { EmulatedTriggerDefinition, EmulatedTriggerType } from "./functionsEmulatorShared";
 import * as utils from "../utils";
 import { logger } from "../logger";
 import { FirebaseError } from "../error";
@@ -21,33 +17,31 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
 
   constructor(private emu: FunctionsEmulator) {
     this.triggers = emu.getTriggerDefinitions();
-    this.emulatedFunctions = this.triggers.map((t) => t.name);
+    this.emulatedFunctions = this.triggers.map((t) => t.id);
 
     const entryPoints = this.triggers.map((t) => t.entryPoint);
     utils.logLabeledBullet("functions", `Loaded functions: ${entryPoints.join(", ")}`);
 
     for (const trigger of this.triggers) {
-      const id = trigger.id ? trigger.id : trigger.name;
-
       if (trigger.httpsTrigger) {
-        this.urls[id] = FunctionsEmulator.getHttpFunctionUrl(
+        this.urls[trigger.id] = FunctionsEmulator.getHttpFunctionUrl(
           this.emu.getInfo().host,
           this.emu.getInfo().port,
           this.emu.getProjectId(),
           trigger.name,
-          getFunctionRegion(trigger)
+          trigger.region
         );
       }
     }
   }
 
-  call(name: string, data: any, opts: any): void {
-    const trigger = this.getTrigger(name);
-    logger.debug(`shell:${name}: trigger=${JSON.stringify(trigger)}`);
-    logger.debug(`shell:${name}: opts=${JSON.stringify(opts)}, data=${JSON.stringify(data)}`);
+  call(id: string, data: any, opts: any): void {
+    const trigger = this.getTrigger(id);
+    logger.debug(`shell:${id}: trigger=${JSON.stringify(trigger)}`);
+    logger.debug(`shell:${id}: opts=${JSON.stringify(opts)}, data=${JSON.stringify(data)}`);
 
     if (!trigger.eventTrigger) {
-      throw new FirebaseError(`Function ${name} is not a background function`);
+      throw new FirebaseError(`Function ${id} is not a background function`);
     }
 
     const eventType = trigger.eventTrigger.eventType;
@@ -70,16 +64,16 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
       data,
     };
 
-    this.emu.startFunctionRuntime(name, EmulatedTriggerType.BACKGROUND, proto);
+    this.emu.startFunctionRuntime(id, EmulatedTriggerType.BACKGROUND, proto);
   }
 
-  private getTrigger(name: string): EmulatedTriggerDefinition {
+  private getTrigger(id: string): EmulatedTriggerDefinition {
     const result = this.triggers.find((trigger) => {
-      return trigger.name === name;
+      return trigger.id === id;
     });
 
     if (!result) {
-      throw new FirebaseError(`Could not find trigger ${name}`);
+      throw new FirebaseError(`Could not find trigger ${id}`);
     }
 
     return result;

--- a/src/emulator/functionsEmulatorShell.ts
+++ b/src/emulator/functionsEmulatorShell.ts
@@ -27,14 +27,14 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
     utils.logLabeledBullet("functions", `Loaded functions: ${entryPoints.join(", ")}`);
 
     for (const trigger of this.triggers) {
-      const name = trigger.name;
+      const id = trigger.id ? trigger.id : trigger.name;
 
       if (trigger.httpsTrigger) {
-        this.urls[name] = FunctionsEmulator.getHttpFunctionUrl(
+        this.urls[id] = FunctionsEmulator.getHttpFunctionUrl(
           this.emu.getInfo().host,
           this.emu.getInfo().port,
           this.emu.getProjectId(),
-          name,
+          trigger.name,
           getFunctionRegion(trigger)
         );
       }

--- a/src/emulator/functionsEmulatorShell.ts
+++ b/src/emulator/functionsEmulatorShell.ts
@@ -64,7 +64,7 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
       data,
     };
 
-    this.emu.startFunctionRuntime(id, EmulatedTriggerType.BACKGROUND, proto);
+    this.emu.startFunctionRuntime(id, trigger.name, EmulatedTriggerType.BACKGROUND, proto);
   }
 
   private getTrigger(id: string): EmulatedTriggerDefinition {

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs-extra";
 import * as _ from "lodash";
+import { ParsedTriggerDefinition } from "../../emulator/functionsEmulatorShared";
 import * as path from "path";
 import * as paramHelper from "../paramHelper";
 import * as specHelper from "./specHelper";
@@ -37,7 +38,7 @@ export async function buildOptions(options: any): Promise<any> {
   }
   options.config = buildConfig(functionResources, testConfig);
   options.extensionEnv = params;
-  const functionEmuTriggerDefs = functionResources.map((r) =>
+  const functionEmuTriggerDefs: ParsedTriggerDefinition[] = functionResources.map((r) =>
     triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
   );
   options.extensionTriggers = functionEmuTriggerDefs;

--- a/src/extensions/emulator/triggerHelper.ts
+++ b/src/extensions/emulator/triggerHelper.ts
@@ -1,13 +1,11 @@
 import * as _ from "lodash";
-import { EmulatedTriggerDefinition } from "../../emulator/functionsEmulatorShared";
+import { ParsedTriggerDefinition } from "../../emulator/functionsEmulatorShared";
 import { Constants } from "../../emulator/constants";
 import { EmulatorLogger } from "../../emulator/emulatorLogger";
 import { Emulators } from "../../emulator/types";
 
-export function functionResourceToEmulatedTriggerDefintion(
-  resource: any
-): EmulatedTriggerDefinition {
-  const etd: EmulatedTriggerDefinition = {
+export function functionResourceToEmulatedTriggerDefintion(resource: any): ParsedTriggerDefinition {
+  const etd: ParsedTriggerDefinition = {
     name: resource.name,
     entryPoint: resource.name,
   };

--- a/src/extractTriggers.js
+++ b/src/extractTriggers.js
@@ -5,7 +5,7 @@
 
 /**
  * @param {Object} mod module, usually the result of require(functions/index.js)
- * @param {Array<object>} triggers array of EmulatedTriggerDefinitions to extend (in-place).
+ * @param {Array<object>} triggers array of ParsedTriggerDefinition to extend (in-place).
  * @param {string=} prefix optional function name prefix, for example when using grouped functions.
  */
 var extractTriggers = function (mod, triggers, prefix) {

--- a/src/test/emulators/fixtures.ts
+++ b/src/test/emulators/fixtures.ts
@@ -41,7 +41,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         },
       },
     },
-    triggerId: "function_id",
+    triggerId: "region-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onWrite: {
@@ -80,7 +81,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         },
       },
     },
-    triggerId: "function_id",
+    triggerId: "region-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onDelete: {
@@ -119,7 +121,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         },
       },
     },
-    triggerId: "function_id",
+    triggerId: "region-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onUpdate: {
@@ -170,7 +173,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
         timestamp: "2019-05-15T16:21:15.148831Z",
       },
     },
-    triggerId: "function_id",
+    triggerId: "region-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
   onRequest: {
@@ -185,7 +189,8 @@ export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } =
       },
     },
     cwd: MODULE_ROOT,
-    triggerId: "function_id",
+    triggerId: "region-function_id",
+    targetName: "function_id",
     projectId: "fake-project-id",
   },
 };

--- a/src/types/extractTriggers.d.ts
+++ b/src/types/extractTriggers.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Extracts trigger definitions from a function file.
+ * @param {Object} mod module, usually the result of require(functions/index.js)
+ * @param {ParsedTriggerDefinition[]} triggers array of EmulatedTriggerDefinitions to extend (in-place).
+ * @param {string=} prefix optional function name prefix, for example when using grouped functions.
+ */
+import { ParsedTriggerDefinition } from "../emulator/functionsEmulatorShared";
+
+export declare function extractTriggers(
+  mod: Array<object>, // eslint-disable-line @typescript-eslint/ban-types
+  triggers: ParsedTriggerDefinition[],
+  prefix?: string
+): void;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Enable function emulation for all the regions listed in the `.region('us-central1','europe-west1')` config (not just the first one)

### Scenarios Tested

- Hosting function rewrites
- Firestore background trigger
- Directly calling function url

### Changed output

```
✔  functions[us-central1-express]: http function initialized (http://localhost:5001/test-project/us-central1/express).
✔  functions[europe-west1-test]: http function initialized (http://localhost:5001/test-project/europe-west1/test).
✔  functions[europe-west2-test]: http function initialized (http://localhost:5001/test-project/europe-west2/test).
✔  functions[europe-west1-fire3]: firestore function initialized.
✔  functions[europe-west2-fire3]: firestore function initialized.
✔  functions[us-central1-fire4]: firestore function initialized.
✔  functions[europe-west2-fire4]: firestore function initialized.
```