### PR TITLE
Fix storage emulator for file.download() API

### DIFF
--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -122,7 +122,7 @@ function createRandomFile(filename: string, sizeInBytes: number): string {
  * Resets the storage layer of the Storage Emulator.
  */
 async function resetStorageEmulator(emulatorHost: string) {
-  await new Promise((resolve) => {
+  await new Promise<void>((resolve) => {
     request.post(`${emulatorHost}/internal/reset`, () => {
       resolve();
     });
@@ -250,7 +250,7 @@ describe("Storage emulator", () => {
           const [downloadContent] = await testBucket
             .file(smallFilePath.split("/").slice(-1)[0])
             .download();
-          
+
           const actualContent = fs.readFileSync(smallFilePath);
           expect(downloadContent).to.deep.equal(actualContent);
         });

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -244,6 +244,18 @@ describe("Storage emulator", () => {
         });
       });
 
+      describe("#download()", () => {
+        it("should return the content of the file", async () => {
+          await testBucket.upload(smallFilePath);
+          const [downloadContent] = await testBucket
+            .file(smallFilePath.split("/").slice(-1)[0])
+            .download();
+          
+          const actualContent = fs.readFileSync(smallFilePath);
+          expect(downloadContent).to.deep.equal(actualContent);
+        });
+      });
+
       describe("#getMetadata()", () => {
         it("should throw on non-existing file", async () => {
           let err: any;

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -42,7 +42,7 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
         res.sendStatus(404);
         return;
       }
-      
+
       const isGZipped = md.contentEncoding == "gzip";
       if (isGZipped) {
         data = gunzipSync(data);
@@ -155,7 +155,7 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
       bufs.push(data);
     });
 
-    await new Promise((resolve) => {
+    await new Promise<void>((resolve) => {
       req.on("end", () => {
         req.body = Buffer.concat(bufs);
         resolve();

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import { gunzipSync } from "zlib";
 import { EmulatorLogger } from "../../emulatorLogger";
 import { Emulators } from "../../types";
 import { CloudStorageObjectMetadata } from "../metadata";
@@ -32,6 +33,40 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
 
     if (!md) {
       res.sendStatus(404);
+      return;
+    }
+
+    if (req.query.alt == "media") {
+      let data = storageLayer.getBytes(req.params.bucketId, req.params.objectId);
+      if (!data) {
+        res.sendStatus(404);
+        return;
+      }
+      
+      const isGZipped = md.contentEncoding == "gzip";
+      if (isGZipped) {
+        data = gunzipSync(data);
+      }
+
+      res.setHeader("Accept-Ranges", "bytes");
+      res.setHeader("Content-Type", md.contentType);
+      res.setHeader("Content-Disposition", md.contentDisposition);
+      res.setHeader("Content-Encoding", "identity");
+
+      const byteRange = [...(req.header("range") || "").split("bytes="), "", ""];
+
+      const [rangeStart, rangeEnd] = byteRange[1].split("-");
+
+      if (rangeStart) {
+        const range = {
+          start: parseInt(rangeStart),
+          end: rangeEnd ? parseInt(rangeEnd) : data.byteLength,
+        };
+        res.setHeader("Content-Range", `bytes ${range.start}-${range.end - 1}/${data.byteLength}`);
+        res.status(206).end(data.slice(range.start, range.end));
+      } else {
+        res.end(data);
+      }
       return;
     }
 


### PR DESCRIPTION
### Description

The current storage emulator doesn't support using `@google-cloud/storage`'s API to download a file directly.
Instead, it returns the metadata of the file.

This PR fixes this by supporting the `alt=media` query in the `gcloud` emulator API, like this is already done for the `firebase` API.

### Scenarios Tested

```ts
import { Storage } from '@google-cloud/storage';

const storage = new Storage({
    credentials: // ...
});

const bucket = storage.bucket('my-bucket');

const file = bucket.file('path/to/my/file');

file.download().then(([content]) => {
    // content is the metadata of the file instead of the actual content of the file
}));
```

I added a test that failed before updating the `gcloud` API with the error:
```
Error: The downloaded data did not match the data from the server. To be sure the content is the same, you should download the file again.
```

After the update, it passes properly 👌 
