### PR TITLE
Create Pub/Sub topic where necessary in Function deploys

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -114,6 +114,8 @@ export function memoryOptionDisplayName(option: MemoryOptions): string {
   }[option];
 }
 
+export const SCHEDULED_FUNCTION_LABEL = Object.freeze({ deployment: "firebase-schedule" });
+
 /** Supported runtimes for new Cloud Functions. */
 export type Runtime = "nodejs10" | "nodejs12" | "nodejs14";
 
@@ -623,7 +625,7 @@ async function loadExistingBackend(ctx: Context & PrivateContextFields): Promise
       ctx.existingBackend.topics.push({
         id,
         project: specFunction.project,
-        labels: { deployment: "firebase-schedule" },
+        labels: SCHEDULED_FUNCTION_LABEL,
         targetService: {
           id: specFunction.id,
           region: specFunction.region,
@@ -659,7 +661,7 @@ async function loadExistingBackend(ctx: Context & PrivateContextFields): Promise
       ctx.existingBackend.topics.push({
         id,
         project: specFunction.project,
-        labels: { deployment: "firebase-schedule" },
+        labels: SCHEDULED_FUNCTION_LABEL,
         targetService: {
           id: specFunction.id,
           region: specFunction.region,

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -21,6 +21,7 @@ export interface ScheduleRetryConfig {
 export interface PubSubSpec {
   id: string;
   project: string;
+  labels?: Record<string, string>;
 
   // What we're actually planning to invoke with this topic
   targetService: TargetIds;
@@ -622,6 +623,7 @@ async function loadExistingBackend(ctx: Context & PrivateContextFields): Promise
       ctx.existingBackend.topics.push({
         id,
         project: specFunction.project,
+        labels: { deployment: "firebase-schedule" },
         targetService: {
           id: specFunction.id,
           region: specFunction.region,
@@ -657,6 +659,7 @@ async function loadExistingBackend(ctx: Context & PrivateContextFields): Promise
       ctx.existingBackend.topics.push({
         id,
         project: specFunction.project,
+        labels: { deployment: "firebase-schedule" },
         targetService: {
           id: specFunction.id,
           region: specFunction.region,

--- a/src/deploy/functions/discovery/jsexports/parseTriggers.ts
+++ b/src/deploy/functions/discovery/jsexports/parseTriggers.ts
@@ -217,6 +217,9 @@ export function addResourcesToBackend(
       const topic: backend.PubSubSpec = {
         id,
         project: projectId,
+        labels: {
+          deployment: "firebase-schedule",
+        },
         targetService: cloudFunctionName,
       };
       want.topics.push(topic);

--- a/src/deploy/functions/discovery/jsexports/parseTriggers.ts
+++ b/src/deploy/functions/discovery/jsexports/parseTriggers.ts
@@ -217,9 +217,7 @@ export function addResourcesToBackend(
       const topic: backend.PubSubSpec = {
         id,
         project: projectId,
-        labels: {
-          deployment: "firebase-schedule",
-        },
+        labels: backend.SCHEDULED_FUNCTION_LABEL,
         targetService: cloudFunctionName,
       };
       want.topics.push(topic);

--- a/src/gcp/pubsub.ts
+++ b/src/gcp/pubsub.ts
@@ -62,6 +62,7 @@ export function topicFromSpec(spec: backend.PubSubSpec): Topic {
 
 // NOTE: We currently don't need or have specFromTopic.
 // backend.ExistingBackend infers actual topics by the fact that it sees a function
-// with a scheduled annotation. This may not be good enough when we're doing the actual
-// using Run, because we'll have to create topics there. Topic specs have a "target service"
-// which is hard to deduce generally.
+// with a scheduled annotation. This may not be good enough when we're
+// using Run, because we'll have to to query multiple resources (e.g. triggers)
+// Were we to get a standalone Topic, we wouldn't have any idea how to set the
+// "target service" since that is part of the subscription.

--- a/src/gcp/pubsub.ts
+++ b/src/gcp/pubsub.ts
@@ -1,18 +1,67 @@
-import * as api from "../api";
+import { Client } from "../apiv2";
+import { pubsubOrigin } from "../api";
+import * as backend from "../deploy/functions/backend";
+import * as proto from "./proto";
 
-const VERSION = "v1";
+const API_VERSION = "v1";
 
-export function createTopic(name: string): Promise<void> {
-  return api.request("PUT", `/${VERSION}/${name}`, {
-    auth: true,
-    origin: api.pubsubOrigin,
-    data: { labels: { deployment: "firebase-schedule" } },
-  });
+const client = new Client({
+  urlPrefix: pubsubOrigin,
+  auth: true,
+  apiVersion: API_VERSION,
+});
+
+export type Encoding = "JSON" | "BINARY";
+
+export interface MessageStoragePolicy {
+  allowedPersistenceRegions: string[];
 }
 
-export function deleteTopic(name: string): Promise<void> {
-  return api.request("DELETE", `/${VERSION}/${name}`, {
-    auth: true,
-    origin: api.pubsubOrigin,
-  });
+export interface SchemaSettings {
+  schema: string;
+  encoding: Encoding;
 }
+
+export interface Topic {
+  name: string;
+  labels?: Record<string, string>;
+  messageStoragePolicy?: MessageStoragePolicy;
+  kmsKeyName?: string;
+  schemaSettings?: SchemaSettings;
+  messageRetentionDuration?: proto.Duration;
+}
+
+export async function createTopic(topic: Topic): Promise<Topic> {
+  const result = await client.put<Topic, Topic>(topic.name, topic);
+  return result.body;
+}
+
+export async function getTopic(name: string): Promise<Topic> {
+  const result = await client.get<Topic>(name);
+  return result.body;
+}
+
+export async function updateTopic(topic: Topic): Promise<Topic> {
+  const queryParams = {
+    updateMask: proto.fieldMasks(topic).join(","),
+  };
+  const result = await client.patch<Topic, Topic>(topic.name, topic, { queryParams });
+  return result.body;
+}
+
+export async function deleteTopic(name: string): Promise<void> {
+  await client.delete(name);
+}
+
+export function topicFromSpec(spec: backend.PubSubSpec): Topic {
+  return {
+    name: backend.topicName(spec),
+    labels: { ...spec.labels },
+  };
+}
+
+// NOTE: We currently don't need or have specFromTopic.
+// backend.ExistingBackend infers actual topics by the fact that it sees a function
+// with a scheduled annotation. This may not be good enough when we're doing the actual
+// using Run, because we'll have to create topics there. Topic specs have a "target service"
+// which is hard to deduce generally.

--- a/src/test/deploy/functions/backend.spec.ts
+++ b/src/test/deploy/functions/backend.spec.ts
@@ -81,6 +81,7 @@ describe("Backend", () => {
   const TOPIC: backend.PubSubSpec = {
     id: backend.scheduleIdForFunction(FUNCTION_SPEC),
     project: "project",
+    labels: { deployment: "firebase-schedule" },
     targetService: FUNCTION_NAME,
   };
 

--- a/src/test/deploy/functions/discovery/jsexports/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/discovery/jsexports/parseTriggers.spec.ts
@@ -300,13 +300,13 @@ describe("addResourcesToBackend", () => {
         {
           id: "firebase-schedule-func-us-central1",
           project: "project",
-          labels: { deployment: "firebase-schedule" },
+          labels: backend.SCHEDULED_FUNCTION_LABEL,
           targetService: BASIC_FUNCTION_NAME,
         },
         {
           id: "firebase-schedule-func-europe-west1",
           project: "project",
-          labels: { deployment: "firebase-schedule" },
+          labels: backend.SCHEDULED_FUNCTION_LABEL,
           targetService: europeFunctionName,
         },
       ],

--- a/src/test/deploy/functions/discovery/jsexports/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/discovery/jsexports/parseTriggers.spec.ts
@@ -300,11 +300,13 @@ describe("addResourcesToBackend", () => {
         {
           id: "firebase-schedule-func-us-central1",
           project: "project",
+          labels: { deployment: "firebase-schedule" },
           targetService: BASIC_FUNCTION_NAME,
         },
         {
           id: "firebase-schedule-func-europe-west1",
           project: "project",
+          labels: { deployment: "firebase-schedule" },
           targetService: europeFunctionName,
         },
       ],


### PR DESCRIPTION
V2 doesn't currently create Pub/Sub topics. There's an outstanding bug to decide if it should. In the meantime, this papers over the issue by creating one on demand.

While we're at it, I defined a fuller Pub/Sub library in `gcp/` and made `labels` an explicit thing in PubSubSpec so we aren't stuck creating topics w/ the `"deployment": "firebase-scheduled"` label annotation.