### PR TITLE
Add support for setting user labels on scheduled functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fixes manually setting download tokens in Storage Emulator. (#3396)
 - Fixes deleting custom metadata in Storage emulator. (#3385)
 - Fixes errors when calling makePublic() with Storage Emulator(#3394)
+- Adds support for setting user labels on scheduled functions.

--- a/src/deploy/functions/discovery/jsexports/parseTriggers.ts
+++ b/src/deploy/functions/discovery/jsexports/parseTriggers.ts
@@ -227,9 +227,10 @@ export function addResourcesToBackend(
         cloudFunction.trigger.eventFilters.resource = `${cloudFunction.trigger.eventFilters.resource}/${id}`;
       }
 
-      cloudFunction.labels = Object.assign(cloudFunction.labels, {
+      cloudFunction.labels = {
+        ...cloudFunction.labels,
         "deployment-scheduled": "true",
-      });
+      };
     }
 
     want.cloudFunctions.push(cloudFunction);

--- a/src/deploy/functions/discovery/jsexports/parseTriggers.ts
+++ b/src/deploy/functions/discovery/jsexports/parseTriggers.ts
@@ -227,7 +227,9 @@ export function addResourcesToBackend(
         cloudFunction.trigger.eventFilters.resource = `${cloudFunction.trigger.eventFilters.resource}/${id}`;
       }
 
-      cloudFunction.labels = { "deployment-scheduled": "true" };
+      cloudFunction.labels = Object.assign(cloudFunction.labels, {
+        "deployment-scheduled": "true",
+      });
     }
 
     want.cloudFunctions.push(cloudFunction);

--- a/src/test/deploy/functions/discovery/jsexports/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/discovery/jsexports/parseTriggers.spec.ts
@@ -126,6 +126,9 @@ describe("addResourcesToBackend", () => {
       vpcConnector: "projects/project/locations/region/connectors/connector",
       ingressSettings: "ALLOW_ALL",
       timeout: "60s",
+      labels: {
+        test: "testing",
+      },
     };
 
     const result = backend.empty();
@@ -146,6 +149,9 @@ describe("addResourcesToBackend", () => {
           vpcConnector: "projects/project/locations/region/connectors/connector",
           ingressSettings: "ALLOW_ALL",
           timeout: "60s",
+          labels: {
+            test: "testing",
+          },
         },
       ],
     };
@@ -260,6 +266,9 @@ describe("addResourcesToBackend", () => {
       httpsTrigger: {},
       regions: ["us-central1", "europe-west1"],
       schedule,
+      labels: {
+        test: "testing",
+      },
     };
 
     const result = backend.empty();
@@ -277,6 +286,7 @@ describe("addResourcesToBackend", () => {
       },
       labels: {
         "deployment-scheduled": "true",
+        test: "testing",
       },
       region: "us-central1",
     };
@@ -288,6 +298,7 @@ describe("addResourcesToBackend", () => {
       },
       labels: {
         "deployment-scheduled": "true",
+        test: "testing",
       },
     };
     const expected: backend.Backend = {


### PR DESCRIPTION
### Description
Adds support for user labels on scheduled functions. 

Turns out we already supported user labels in this code path - except that they were being overwritten on scheduled functions.

### Scenarios Tested
Confirmed that scheduled functions and non-scheduled functions are deployed with labels when firebase-functions passes them through.
