### PR TITLE
Respect TimeZone in scheduled functions

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -546,7 +546,7 @@ export function toJob(schedule: ScheduleSpec, appEngineLocation: string): clouds
     name: scheduleName(schedule, appEngineLocation),
     schedule: schedule.schedule!,
   };
-  proto.copyIfPresent(job, schedule, "retryConfig");
+  proto.copyIfPresent(job, schedule, "timeZone", "retryConfig");
   if (schedule.transport === "https") {
     throw new FirebaseError("HTTPS transport for scheduled functions is not yet supported");
   }

--- a/src/test/deploy/functions/backend.spec.ts
+++ b/src/test/deploy/functions/backend.spec.ts
@@ -640,6 +640,7 @@ describe("Backend", () => {
         backend.toJob(
           {
             ...SCHEDULE,
+            timeZone: "America/Los_Angeles",
             retryConfig: {
               maxDoublings: 2,
               maxBackoffDuration: "20s",
@@ -652,6 +653,7 @@ describe("Backend", () => {
       ).to.deep.equal({
         name: "projects/project/locations/appEngineLocation/jobs/firebase-schedule-id-region",
         schedule: "every 1 minutes",
+        timeZone: "America/Los_Angeles",
         retryConfig: {
           maxDoublings: 2,
           maxBackoffDuration: "20s",


### PR DESCRIPTION
In scheduler spec to job we weren't copying timezones which caused the CLI to fall back to the default timezone (America/Los_Angeles)