### PR TITLE
Default timeout is 60s + user define custom timeout per emulator

### DIFF
--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -12,7 +12,7 @@ export interface AuthEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
-  timeout: number;
+  timeout?: number;
 }
 
 export class AuthEmulator implements EmulatorInstance {

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -12,6 +12,7 @@ export interface AuthEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
+  timeout: number;
 }
 
 export class AuthEmulator implements EmulatorInstance {
@@ -37,11 +38,13 @@ export class AuthEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.AUTH);
     const port = this.args.port || Constants.getDefaultPort(Emulators.AUTH);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.AUTH);
 
     return {
       name: this.getName(),
       host,
       port,
+      timeout,
     };
   }
 

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -42,6 +42,7 @@ export const EMULATOR_DESCRIPTION: Record<Emulators, string> = {
 };
 
 const DEFAULT_HOST = "localhost";
+const DEFAULT_TIMEOUT = 60000;
 
 export class Constants {
   // GCP projects cannot start with 'demo' so we use 'demo-' as a prefix to denote
@@ -115,12 +116,20 @@ export class Constants {
     return DEFAULT_PORTS[emulator];
   }
 
+  static getDefaultTimeout(emulator: Emulators): number {
+    return DEFAULT_TIMEOUT;
+  }
+
   static getHostKey(emulator: Emulators): string {
     return `emulators.${emulator.toString()}.host`;
   }
 
   static getPortKey(emulator: Emulators): string {
     return `emulators.${emulator.toString()}.port`;
+  }
+
+  static getTimeoutKey(emulator: Emulators): string {
+    return `emulators.${emulator.toString()}.timeout`;
   }
 
   static description(name: Emulators): string {

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -16,7 +16,7 @@ import * as parseBoltRules from "../parseBoltRules";
 export interface DatabaseEmulatorArgs {
   port?: number;
   host?: string;
-  timeout: number;
+  timeout?: number;
   projectId?: string;
   rules?: { rules: string; instance: string }[];
   functions_emulator_port?: number;

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -16,6 +16,7 @@ import * as parseBoltRules from "../parseBoltRules";
 export interface DatabaseEmulatorArgs {
   port?: number;
   host?: string;
+  timeout: number;
   projectId?: string;
   rules?: { rules: string; instance: string }[];
   functions_emulator_port?: number;
@@ -96,12 +97,14 @@ export class DatabaseEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.DATABASE);
     const port = this.args.port || Constants.getDefaultPort(Emulators.DATABASE);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.DATABASE);
 
     return {
       name: this.getName(),
       host,
       port,
       pid: downloadableEmulators.getPID(Emulators.DATABASE),
+      timeout,
     };
   }
 

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -14,7 +14,7 @@ import { Issue } from "./types";
 export interface FirestoreEmulatorArgs {
   port?: number;
   host?: string;
-  timeout: number;
+  timeout?: number;
   projectId?: string;
   rules?: string;
   functions_emulator?: string;

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -14,6 +14,7 @@ import { Issue } from "./types";
 export interface FirestoreEmulatorArgs {
   port?: number;
   host?: string;
+  timeout: number;
   projectId?: string;
   rules?: string;
   functions_emulator?: string;
@@ -77,12 +78,14 @@ export class FirestoreEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.FIRESTORE);
     const port = this.args.port || Constants.getDefaultPort(Emulators.FIRESTORE);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.FIRESTORE);
 
     return {
       name: this.getName(),
       host,
       port,
       pid: downloadableEmulators.getPID(Emulators.FIRESTORE),
+      timeout,
     };
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -71,6 +71,7 @@ export interface FunctionsEmulatorArgs {
   account?: Account;
   port?: number;
   host?: string;
+  timeout?: number;
   quiet?: boolean;
   disabledRuntimeFeatures?: FunctionsRuntimeFeatures;
   debugPort?: number;
@@ -664,11 +665,13 @@ export class FunctionsEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.FUNCTIONS);
     const port = this.args.port || Constants.getDefaultPort(Emulators.FUNCTIONS);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.FUNCTIONS);
 
     return {
       name: this.getName(),
       host,
       port,
+      timeout,
     };
   }
 
@@ -1117,6 +1120,9 @@ export class FunctionsEmulator implements EmulatorInstance {
         socketPath: worker.lastArgs.frb.socketPath,
       },
       (runtimeRes: http.IncomingMessage) => {
+        /**
+         *
+         */
         function forwardStatusAndHeaders(): void {
           res.status(runtimeRes.statusCode || 200);
           if (!res.headersSent) {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1120,9 +1120,6 @@ export class FunctionsEmulator implements EmulatorInstance {
         socketPath: worker.lastArgs.frb.socketPath,
       },
       (runtimeRes: http.IncomingMessage) => {
-        /**
-         *
-         */
         function forwardStatusAndHeaders(): void {
           res.status(runtimeRes.statusCode || 200);
           if (!res.headersSent) {

--- a/src/emulator/hostingEmulator.ts
+++ b/src/emulator/hostingEmulator.ts
@@ -6,6 +6,7 @@ interface HostingEmulatorArgs {
   options: any;
   port?: number;
   host?: string;
+  timeout: number;
 }
 
 export class HostingEmulator implements EmulatorInstance {
@@ -29,11 +30,13 @@ export class HostingEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.HOSTING);
     const port = this.args.port || Constants.getDefaultPort(Emulators.HOSTING);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.HOSTING);
 
     return {
       name: this.getName(),
       host,
       port,
+      timeout,
     };
   }
 

--- a/src/emulator/hostingEmulator.ts
+++ b/src/emulator/hostingEmulator.ts
@@ -6,7 +6,7 @@ interface HostingEmulatorArgs {
   options: any;
   port?: number;
   host?: string;
-  timeout: number;
+  timeout?: number;
 }
 
 export class HostingEmulator implements EmulatorInstance {

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -26,6 +26,7 @@ export interface EmulatorHubArgs {
   projectId: string;
   port?: number;
   host?: string;
+  timeout?: number;
 }
 
 export type GetEmulatorsResponse = Record<string, EmulatorInfo>;
@@ -164,11 +165,13 @@ export class EmulatorHub implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.HUB);
     const port = this.args.port || Constants.getDefaultPort(Emulators.HUB);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.HUB);
 
     return {
       name: this.getName(),
       host,
       port,
+      timeout,
     };
   }
 

--- a/src/emulator/loggingEmulator.ts
+++ b/src/emulator/loggingEmulator.ts
@@ -10,7 +10,7 @@ const ansiStrip = require("cli-color/strip");
 export interface LoggingEmulatorArgs {
   port?: number;
   host?: string;
-  timeout: number;
+  timeout?: number;
 }
 
 export interface LogData {

--- a/src/emulator/loggingEmulator.ts
+++ b/src/emulator/loggingEmulator.ts
@@ -10,6 +10,7 @@ const ansiStrip = require("cli-color/strip");
 export interface LoggingEmulatorArgs {
   port?: number;
   host?: string;
+  timeout: number;
 }
 
 export interface LogData {
@@ -56,11 +57,13 @@ export class LoggingEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.LOGGING);
     const port = this.args.port || Constants.getDefaultPort(Emulators.LOGGING);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.LOGGING);
 
     return {
       name: this.getName(),
       host,
       port,
+      timeout,
     };
   }
 

--- a/src/emulator/portUtils.ts
+++ b/src/emulator/portUtils.ts
@@ -109,7 +109,7 @@ export function suggestUnrestricted(port: number): number {
 export async function findAvailablePort(
   host: string,
   start: number,
-  avoidRestricted: boolean = true
+  avoidRestricted = true
 ): Promise<number> {
   const openPort = await pf.getPortPromise({ host, port: start });
 
@@ -137,9 +137,12 @@ export async function checkPortOpen(port: number, host: string): Promise<boolean
 /**
  * Wait for a port to close on the given host. Checks every 250ms for up to 30s.
  */
-export async function waitForPortClosed(port: number, host: string): Promise<void> {
+export async function waitForPortClosed(
+  port: number,
+  host: string,
+  timeout: number
+): Promise<void> {
   const interval = 250;
-  const timeout = 30000;
   try {
     await tcpport.waitUntilUsedOnHost(port, host, interval, timeout);
   } catch (e) {

--- a/src/emulator/pubsubEmulator.ts
+++ b/src/emulator/pubsubEmulator.ts
@@ -14,6 +14,7 @@ export interface PubsubEmulatorArgs {
   port?: number;
   host?: string;
   auto_download?: boolean;
+  timeout: number;
 }
 
 export class PubsubEmulator implements EmulatorInstance {
@@ -53,12 +54,14 @@ export class PubsubEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.PUBSUB);
     const port = this.args.port || Constants.getDefaultPort(Emulators.PUBSUB);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.STORAGE);
 
     return {
       name: this.getName(),
       host,
       port,
       pid: downloadableEmulators.getPID(Emulators.PUBSUB),
+      timeout,
     };
   }
 

--- a/src/emulator/pubsubEmulator.ts
+++ b/src/emulator/pubsubEmulator.ts
@@ -13,8 +13,8 @@ export interface PubsubEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
+  timeout?: number;
   auto_download?: boolean;
-  timeout: number;
 }
 
 export class PubsubEmulator implements EmulatorInstance {

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -24,7 +24,7 @@ export class EmulatorRegistry {
     await instance.start();
 
     const info = instance.getInfo();
-    await portUtils.waitForPortClosed(info.port, info.host);
+    await portUtils.waitForPortClosed(info.port, info.host, info.timeout);
   }
 
   static async stop(name: Emulators): Promise<void> {

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -17,9 +17,9 @@ export interface StorageEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
+  timeout?: number;
   rules: Source | string;
   auto_download?: boolean;
-  timeout: number;
 }
 
 export class StorageEmulator implements EmulatorInstance {

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -19,6 +19,7 @@ export interface StorageEmulatorArgs {
   host?: string;
   rules: Source | string;
   auto_download?: boolean;
+  timeout: number;
 }
 
 export class StorageEmulator implements EmulatorInstance {
@@ -160,11 +161,13 @@ export class StorageEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost(Emulators.STORAGE);
     const port = this.args.port || Constants.getDefaultPort(Emulators.STORAGE);
+    const timeout = this.args.timeout || Constants.getDefaultTimeout(Emulators.STORAGE);
 
     return {
       name: this.getName(),
       host,
       port,
+      timeout,
     };
   }
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -45,7 +45,7 @@ export const ALL_SERVICE_EMULATORS = [
   Emulators.HOSTING,
   Emulators.PUBSUB,
   Emulators.STORAGE,
-].filter((v) => v) as Emulators[];
+].filter((v) => v);
 
 export const EMULATORS_SUPPORTED_BY_FUNCTIONS = [
   Emulators.FIRESTORE,
@@ -128,6 +128,7 @@ export interface EmulatorInfo {
   host: string;
   port: number;
   pid?: number;
+  timeout: number;
 }
 
 export interface DownloadableEmulatorCommand {
@@ -171,9 +172,10 @@ export interface DownloadableEmulatorDetails {
   stdout: any | null;
 }
 
-export interface Address {
+export interface UserConfig {
   host: string;
   port: number;
+  timeout: number;
 }
 
 export enum FunctionsExecutionMode {

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -127,8 +127,8 @@ export interface EmulatorInfo {
   name: Emulators;
   host: string;
   port: number;
-  pid?: number;
   timeout: number;
+  pid?: number;
 }
 
 export interface DownloadableEmulatorCommand {

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -7,9 +7,9 @@ import { Constants } from "./constants";
 export interface EmulatorUIOptions {
   port: number;
   host: string;
+  timeout: number;
   projectId: string;
   auto_download?: boolean;
-  timeout: number;
 }
 
 export class EmulatorUI implements EmulatorInstance {

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -9,6 +9,7 @@ export interface EmulatorUIOptions {
   host: string;
   projectId: string;
   auto_download?: boolean;
+  timeout: number;
 }
 
 export class EmulatorUI implements EmulatorInstance {
@@ -48,6 +49,7 @@ export class EmulatorUI implements EmulatorInstance {
       host: this.args.host,
       port: this.args.port,
       pid: downloadableEmulators.getPID(Emulators.UI),
+      timeout: this.args.timeout,
     };
   }
 

--- a/src/hosting/implicitInit.ts
+++ b/src/hosting/implicitInit.ts
@@ -6,7 +6,7 @@ import { fetchWebSetup, getCachedWebSetup } from "../fetchWebSetup";
 import * as utils from "../utils";
 import { logger } from "../logger";
 import { EmulatorRegistry } from "../emulator/registry";
-import { EMULATORS_SUPPORTED_BY_USE_EMULATOR, Address, Emulators } from "../emulator/types";
+import { EMULATORS_SUPPORTED_BY_USE_EMULATOR, UserConfig, Emulators } from "../emulator/types";
 
 const INIT_TEMPLATE = fs.readFileSync(__dirname + "/../../templates/hosting/init.js", "utf8");
 
@@ -63,7 +63,7 @@ export async function implicitInit(options: any): Promise<TemplateServerResponse
 
   const configJson = JSON.stringify(config, null, 2);
 
-  const emulators: { [e in Emulators]?: Address } = {};
+  const emulators: { [e in Emulators]?: UserConfig } = {};
   for (const e of EMULATORS_SUPPORTED_BY_USE_EMULATOR) {
     const info = EmulatorRegistry.getInfo(e);
 
@@ -82,6 +82,7 @@ export async function implicitInit(options: any): Promise<TemplateServerResponse
       emulators[e] = {
         host,
         port: info.port,
+        timeout: info.timeout,
       };
     }
   }

--- a/src/test/emulators/cloudFunctions.spec.ts
+++ b/src/test/emulators/cloudFunctions.spec.ts
@@ -10,7 +10,7 @@ import { FakeEmulator } from "./fakeEmulator";
 describe("cloudFunctions", () => {
   describe("dispatch", () => {
     let sandbox: sinon.SinonSandbox;
-    const fakeEmulator = new FakeEmulator(Emulators.FUNCTIONS, "1.1.1.1", 4);
+    const fakeEmulator = new FakeEmulator(Emulators.FUNCTIONS, "1.1.1.1", 4, 60000);
     before(() => {
       sandbox = sinon.createSandbox();
       sandbox.stub(EmulatorRegistry, "get").returns(fakeEmulator);

--- a/src/test/emulators/controller.spec.ts
+++ b/src/test/emulators/controller.spec.ts
@@ -14,7 +14,7 @@ describe("EmulatorController", () => {
 
     expect(EmulatorRegistry.isRunning(name)).to.be.false;
 
-    await startEmulator(new FakeEmulator(name, "localhost", 7777));
+    await startEmulator(new FakeEmulator(name, "localhost", 7777, 60000));
 
     expect(EmulatorRegistry.isRunning(name)).to.be.true;
     expect(EmulatorRegistry.getPort(name)).to.eql(7777);

--- a/src/test/emulators/emulatorServer.spec.ts
+++ b/src/test/emulators/emulatorServer.spec.ts
@@ -7,7 +7,7 @@ import { EmulatorServer } from "../../emulator/emulatorServer";
 describe("EmulatorServer", () => {
   it("should correctly start and stop an emulator", async () => {
     const name = Emulators.FUNCTIONS;
-    const emulator = new FakeEmulator(name, "localhost", 5000);
+    const emulator = new FakeEmulator(name, "localhost", 5000, 60000);
     const server = new EmulatorServer(emulator);
 
     await server.start();

--- a/src/test/emulators/fakeEmulator.ts
+++ b/src/test/emulators/fakeEmulator.ts
@@ -9,7 +9,12 @@ export class FakeEmulator implements EmulatorInstance {
   private exp: express.Express;
   private destroyServer?: () => Promise<void>;
 
-  constructor(public name: Emulators, public host: string, public port: number) {
+  constructor(
+    public name: Emulators,
+    public host: string,
+    public port: number,
+    public timeout: number
+  ) {
     this.exp = express();
   }
 
@@ -29,6 +34,7 @@ export class FakeEmulator implements EmulatorInstance {
       name: this.getName(),
       host: this.host,
       port: this.port,
+      timeout: this.timeout,
     };
   }
   getName(): Emulators {

--- a/src/test/emulators/registry.spec.ts
+++ b/src/test/emulators/registry.spec.ts
@@ -18,7 +18,7 @@ describe("EmulatorRegistry", () => {
 
   it("should correctly return information about a running emulator", async () => {
     const name = Emulators.FUNCTIONS;
-    const emu = new FakeEmulator(name, "localhost", 5000);
+    const emu = new FakeEmulator(name, "localhost", 5000, 60000);
 
     expect(EmulatorRegistry.isRunning(name)).to.be.false;
 
@@ -32,7 +32,7 @@ describe("EmulatorRegistry", () => {
 
   it("once stopped, an emulator is no longer running", async () => {
     const name = Emulators.FUNCTIONS;
-    const emu = new FakeEmulator(name, "localhost", 5000);
+    const emu = new FakeEmulator(name, "localhost", 5000, 60000);
 
     expect(EmulatorRegistry.isRunning(name)).to.be.false;
     await EmulatorRegistry.start(emu);

--- a/src/test/hosting/functionsProxy.spec.ts
+++ b/src/test/hosting/functionsProxy.spec.ts
@@ -23,7 +23,7 @@ describe("functionsProxy", () => {
   const fakeRewrite: FunctionProxyRewrite = { function: "bar" };
 
   beforeEach(async () => {
-    const fakeFunctionsEmulator = new FakeEmulator(Emulators.FUNCTIONS, "localhost", 7778);
+    const fakeFunctionsEmulator = new FakeEmulator(Emulators.FUNCTIONS, "localhost", 7778, 60000);
     await EmulatorRegistry.start(fakeFunctionsEmulator);
   });
 


### PR DESCRIPTION
### Description

Fix #2379 
Firestore is failing to start in the hardcoded timeout of 30 secs.
This PR:
- increase the default timeout to 60 secs
- leave open to the user the configuration of the timeout for each emulator in the same pattern of host and port

### Scenarios Tested

GIVEN a user does not provide a timeout
WHEN `firebase emulators:start` is called
THEN firestore emulator will fail to run with `Error: TIMEOUT: Port 8081 on localhost was not active within 60000ms`

GIVEN a user provides a timeout in `firebase.json` for firestore of 10ms
WHEN `firebase emulators:start --only firestore` is called
THEN firestore emulator will fail to run with `Error: TIMEOUT: Port 8081 on localhost was not active within 10ms`

GIVEN a user provides a timeout in `firebase.json` for hosting of 10ms
WHEN `firebase emulators:start --only firestore` is called
THEN firestore emulator will fail to run  with `Error: TIMEOUT: Port 8081 on localhost was not active within 60000ms`*

*I understand these is a bit flacky - couldn't think any better at midnight 😛 
I actually tested them with the old value of 30 secs

### Sample Commands

In `firebase.json`:
```
{
  //...
  "emulators": {
    "auth": {
      "port": 9099
    },
    "firestore": {
      "timeout": 60000,
      "port": 8081
    },
    "hosting": {
      "port": 5000
    },
    "ui": {
      "enabled": true
    }
  }
}
```