### PR TITLE
Increase waitForPortClosed timeout to 60s

### DIFF
--- a/src/emulator/portUtils.ts
+++ b/src/emulator/portUtils.ts
@@ -109,7 +109,7 @@ export function suggestUnrestricted(port: number): number {
 export async function findAvailablePort(
   host: string,
   start: number,
-  avoidRestricted: boolean = true
+  avoidRestricted = true
 ): Promise<number> {
   const openPort = await pf.getPortPromise({ host, port: start });
 
@@ -139,7 +139,7 @@ export async function checkPortOpen(port: number, host: string): Promise<boolean
  */
 export async function waitForPortClosed(port: number, host: string): Promise<void> {
   const interval = 250;
-  const timeout = 30000;
+  const timeout = 60000;
   try {
     await tcpport.waitUntilUsedOnHost(port, host, interval, timeout);
   } catch (e) {


### PR DESCRIPTION
### Description

See #2379 
Firestore is failing to start in the hardcoded timeout of 30 secs.
This PR increase the default timeout to 60 secs

I initially opened #3482 - this is a simpler iteration.

### Scenarios Tested

Firestore doesn't fail anymore when taking more than 30 secs to launch.
