### PR TITLE
Added validation logic to allow selectResource param type in extension.yaml

### DIFF
--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -41,6 +41,7 @@ export enum SpecParamType {
   SELECT = "select",
   MULTISELECT = "multiSelect",
   STRING = "string",
+  SELECTRESOURCE = "selectResource",
 }
 
 export enum SourceOrigin {
@@ -300,6 +301,15 @@ export function validateSpec(spec: any) {
             } is missing required field: value`
           );
         }
+      }
+    }
+    if (param.type && param.type == SpecParamType.SELECTRESOURCE) {
+      if (!param.resourceType) {
+        errors.push(
+          `Param${param.param ? ` ${param.param}` : ""} must have resourceType because it is type ${
+            param.type
+          }`
+        );
       }
     }
   }

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -590,6 +590,26 @@ describe("extensionsHelper", () => {
         extensionsHelper.validateSpec(testSpec);
       }).to.throw(FirebaseError, /default/);
     });
+    it("should error if a param selectResource missing resourceType.", () => {
+      const testSpec = {
+        version: "0.1.0",
+        specVersion: "v1beta",
+        params: [
+          {
+            type: extensionsHelper.SpecParamType.SELECTRESOURCE,
+            validationRegex: "test",
+            default: "fail",
+          },
+        ],
+        resources: [],
+        sourceUrl: "https://test-source.fake",
+        license: "apache-2.0",
+      };
+
+      expect(() => {
+        extensionsHelper.validateSpec(testSpec);
+      }).to.throw(FirebaseError, /must have resourceType/);
+    });
   });
 
   describe("promptForValidInstanceId", () => {


### PR DESCRIPTION
This allows setting extension param type to selectResource. There is currently no askParam logic to handle this type, it will fallback to simple STRING logic.