### PR TITLE
Ask before overwriting storage.rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Ask before overwriting `storage.rules` during `firebase init` (#1833)

--- a/src/init/features/storage.ts
+++ b/src/init/features/storage.ts
@@ -27,5 +27,5 @@ export async function doSetup(setup: any, config: any): Promise<void> {
     default: "storage.rules",
   });
   setup.config.storage.rules = storageRulesFile;
-  config.writeProjectFile(setup.config.storage.rules, RULES_TEMPLATE);
+  await config.askWriteProjectFile(setup.config.storage.rules, RULES_TEMPLATE);
 }

--- a/src/test/init/features/storage.spec.ts
+++ b/src/test/init/features/storage.spec.ts
@@ -9,11 +9,11 @@ import * as prompt from "../../../prompt";
 
 describe("storage", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
-  let writeProjectFileStub: sinon.SinonStub;
+  let askWriteProjectFileStub: sinon.SinonStub;
   let promptStub: sinon.SinonStub;
 
   beforeEach(() => {
-    writeProjectFileStub = sandbox.stub(Config.prototype, "writeProjectFile");
+    askWriteProjectFileStub = sandbox.stub(Config.prototype, "askWriteProjectFile");
     promptStub = sandbox.stub(prompt, "promptOnce");
   });
 
@@ -30,7 +30,7 @@ describe("storage", () => {
         projectLocation: "us-central",
       };
       promptStub.returns("storage.rules");
-      writeProjectFileStub.resolves();
+      askWriteProjectFileStub.resolves();
 
       await doSetup(setup, new Config("/path/to/src", {}));
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #1833

### Scenarios Tested

No overwrite
```
samstern@samstern-macbookpro3 tmp.CYaoYYpQ 
$ echo 'cat' > storage.rules
samstern@samstern-macbookpro3 tmp.CYaoYYpQ 
$ firebase init storage

     ######## #### ########  ######## ########     ###     ######  ########
     ##        ##  ##     ## ##       ##     ##  ##   ##  ##       ##
     ######    ##  ########  ######   ########  #########  ######  ######
     ##        ##  ##    ##  ##       ##     ## ##     ##       ## ##
     ##       #### ##     ## ######## ########  ##     ##  ######  ########

You're about to initialize a Firebase project in this directory:

  /private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.CYaoYYpQ

Before we get started, keep in mind:

  * You are currently outside your home directory
  * You are initializing within an existing Firebase project directory


=== Project Setup

First, let's associate this project directory with a Firebase project.
You can create multiple project aliases by running firebase use --add, 
but for now we'll just set up a default project.

i  .firebaserc already has a default project, using fir-dumpster.

=== Storage Setup

Firebase Storage Security Rules allow you to define how and when to allow
uploads and downloads. You can keep these rules in your project directory
and publish them with firebase deploy.

? What file should be used for Storage Rules? storage.rule
s
? File storage.rules already exists. Overwrite? No
i  Skipping write of storage.rules

i  Writing configuration info to firebase.json...
i  Writing project information to .firebaserc...

✔  Firebase initialization complete!
samstern@samstern-macbookpro3 tmp.CYaoYYpQ 
$ cat storage.rules 
cat
```

Overwrite:
```
samstern@samstern-macbookpro3 tmp.CYaoYYpQ 
$ firebase init storage

     ######## #### ########  ######## ########     ###     ######  ########
     ##        ##  ##     ## ##       ##     ##  ##   ##  ##       ##
     ######    ##  ########  ######   ########  #########  ######  ######
     ##        ##  ##    ##  ##       ##     ## ##     ##       ## ##
     ##       #### ##     ## ######## ########  ##     ##  ######  ########

You're about to initialize a Firebase project in this directory:

  /private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.CYaoYYpQ

Before we get started, keep in mind:

  * You are currently outside your home directory
  * You are initializing within an existing Firebase project directory


=== Project Setup

First, let's associate this project directory with a Firebase project.
You can create multiple project aliases by running firebase use --add, 
but for now we'll just set up a default project.

i  .firebaserc already has a default project, using fir-dumpster.

=== Storage Setup

Firebase Storage Security Rules allow you to define how and when to allow
uploads and downloads. You can keep these rules in your project directory
and publish them with firebase deploy.

? What file should be used for Storage Rules? storage.rule
s
? File storage.rules already exists. Overwrite? Yes
✔  Wrote storage.rules

i  Writing configuration info to firebase.json...
i  Writing project information to .firebaserc...

✔  Firebase initialization complete!
samstern@samstern-macbookpro3 tmp.CYaoYYpQ 
$ cat storage.rules 
rules_version = '2';
service firebase.storage {
  match /b/{bucket}/o {
    match /{allPaths=**} {
      allow read, write: if request.auth!=null;
    }
  }
}
```

### Sample Commands

N/A
