### PR TITLE
Avoid emulator data loss when there an error during export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Avoid emulator data loss when there an error during export (#3504)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -774,15 +774,6 @@ export async function exportEmulatorData(exportPath: string, options: any) {
     }
   }
 
-  // Remove all existing data (metadata.json will be overwritten automatically)
-  if (existingMetadata) {
-    if (existingMetadata.firestore) {
-      const firestorePath = path.join(exportAbsPath, existingMetadata.firestore.path);
-      utils.logBullet(`Deleting directory ${firestorePath}`);
-      rimraf.sync(firestorePath);
-    }
-  }
-
   utils.logBullet(`Exporting data to: ${exportAbsPath}`);
   try {
     await hubClient.postExport(exportAbsPath);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #3504

### Scenarios Tested

This should be well covered by unit tests but I also did an end-to-end test of import/export with the Auth emulator to make sure it still works well.

### Sample Commands

N/A