### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ repository:
 ```bash
 git clone git@github.com:firebase/firebase-tools.git
 cd firebase-tools
+npm install # must be run the first time you clone
 npm link  # installs dependencies, runs a build, links it into the environment
 ```
 


### PR DESCRIPTION
### Description

The contributing steps didn't work for me since `rimraf` wasn't installed in my global npm modules.

To help future contributors, I would suggest added `npm install` to the contribution steps. Let me know if I'm wrong here!

--

I ran into this error when running `npm link` after cloning:

```
776 verbose argv "/usr/local/bin/node" "/usr/local/bin/npm" "link"
777 verbose node v14.15.4
778 verbose npm  v7.18.1
779 error code 127
780 error path /Users/<user>/firebase-tools
781 error command failed
782 error command sh -c npm run clean && npm run build -- --build tsconfig.publish.json
783 error > firebase-tools@9.13.1 clean
783 error > rimraf lib dev
784 error sh: rimraf: command not found
785 verbose exit 127
```

Since `rimraf` wasn't found, I tried `npm install` first which installed the dependency needed to run `npm link`

### Scenarios Tested

1. delete all global npm modules
2. try to follow new contributing steps
3. it should now work

### Sample Commands
n/a