### PR TITLE
Fix crash when deploying zero functions.

### DIFF
--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -56,7 +56,7 @@ export async function deploy(
   }
 
   try {
-    const want = options.config.get("functions.backend") as backend.Backend;
+    const want = payload.functions!.backend;
     const uploads: Promise<void>[] = [];
     if (want.cloudFunctions.some((fn) => fn.apiVersion === 1)) {
       uploads.push(uploadSourceV1(context));

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -54,7 +54,7 @@ export async function prepare(
 
   logger.debug(`Analyzing ${runtimeDelegate.name} backend spec`);
   const wantBackend = await runtimeDelegate.discoverSpec(runtimeConfig, env);
-  options.config.set("functions.backend", wantBackend);
+  payload.functions = { backend: wantBackend };
   if (backend.isEmptyBackend(wantBackend)) {
     return;
   }
@@ -86,11 +86,6 @@ export async function prepare(
       );
     })
   );
-
-  // Build a regionMap, and duplicate functions for each region they are being deployed to.
-  payload.functions = {
-    backend: wantBackend,
-  };
 
   // Validate the function code that is being deployed.
   validate.functionIdsAreValid(wantBackend.cloudFunctions);


### PR DESCRIPTION
Previously most code read the desired backend from `options.config.get("functions.backend")` which was set to the empty backend correctly. Code that depended on `payload.functions.backend` crashed because `payload.functions` was null when the backend was empty.

Since `options.config` should be firebase.json data, this change normalizes on payload.functions.backend and ensures that it is never null while `options.config.get('functions')` is present (i.e. when the customer has functions to deploy).

Should fix #3512 and #3517