### PR TITLE
emulator: Remove superfluous INFO log

### DIFF
--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -149,11 +149,8 @@ function getFunctionSourceDirectory(functionResources: Resource[]): string {
   let sourceDirectory;
   for (const r of functionResources) {
     let dir = _.get(r, "properties.sourceDirectory");
+    // If not specified, default sourceDirectory to "functions"
     if (!dir) {
-      EmulatorLogger.forEmulator(Emulators.FUNCTIONS).log(
-        "INFO",
-        `No sourceDirectory was specified for function ${r.name}, defaulting to 'functions'`
-      );
       dir = "functions";
     }
     if (!sourceDirectory) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Emulator does not log about the default being used for any other option. Why log about default used for `sourceDirectory`? Seems unnecessary.

### Scenarios Tested

Tested locally.

### Sample Commands

N/A