### PR TITLE
Detect changes in eventTrigger definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Firestore Emulator UI now supports deleting documents and collections recursively.
 - Fixes some Storage Emulator UI errors.
 - Fixes some issues when using Emulator UI on a different device.
+- Fixes Emulator issue when function definition changes (#2533).

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -50,7 +50,6 @@ import {
   AdminSdkConfig,
   constructDefaultAdminSdkConfig,
 } from "./adminSdkConfig";
-import { recorder } from "nock/types";
 
 const EVENT_INVOKE = "functions:invoke";
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -50,6 +50,7 @@ import {
   AdminSdkConfig,
   constructDefaultAdminSdkConfig,
 } from "./adminSdkConfig";
+import { recorder } from "nock/types";
 
 const EVENT_INVOKE = "functions:invoke";
 
@@ -432,9 +433,24 @@ export class FunctionsEmulator implements EmulatorInstance {
       }
 
       // We want to add a trigger if we don't already have an enabled trigger
-      // with the same entryPoint.
+      // with the same entryPoint / trigger.
       const anyEnabledMatch = Object.values(this.triggers).some((record) => {
-        return record.def.entryPoint === definition.entryPoint && record.enabled;
+        const sameEntryPoint = record.def.entryPoint === definition.entryPoint;
+
+        // If they both have event triggers, make sure they match
+        const sameEventTrigger =
+          JSON.stringify(record.def.eventTrigger) === JSON.stringify(definition.eventTrigger);
+
+        if (sameEntryPoint && !sameEventTrigger) {
+          this.logger.log(
+            "DEBUG",
+            `Definition for trigger ${definition.entryPoint} changed from ${JSON.stringify(
+              record.def.eventTrigger
+            )} to ${JSON.stringify(definition.eventTrigger)}`
+          );
+        }
+
+        return record.enabled && sameEntryPoint && sameEventTrigger;
       });
       return !anyEnabledMatch;
     });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #2533

### Scenarios Tested

1. Create a function `exports.firestoreFn = functions.firestore.document('/test/{doc}').onWrite(...)`
2. Write a doc in `/test` the emulator UI, see that the function executes
3. Change the trigger to be  functions.firestore.document('/test2/{doc}')
4. Write a doc in `/test`, nothing happens.
5. Write a doc in `/test2`, see exactly one execution.

Logs:

```
$ firebase --project=demo-project-12345  emulators:start
i  emulators: Starting emulators: functions, firestore
i  emulators: Detected demo project ID "demo-project-12345", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  firestore: Firestore Emulator logging to firestore-debug.log
i  ui: Emulator UI logging to ui-debug.log
i  functions: Watching "/private/var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/tmp.bH599aKP/functions" for Cloud Functions...
✔  functions[us-central1-firestoreFn]: firestore function initialized.

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://localhost:4000                │
└─────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Functions │ localhost:5001 │ http://localhost:4000/functions │
├───────────┼────────────────┼─────────────────────────────────┤
│ Firestore │ localhost:8080 │ http://localhost:4000/firestore │
└───────────┴────────────────┴─────────────────────────────────┘
  Emulator Hub running at localhost:4400
  Other reserved ports: 4500

Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
 
i  functions: Beginning execution of "us-central1-firestoreFn"
>  test/qJN4KLuFOJItu0iIUjcK
i  functions: Finished "us-central1-firestoreFn" in ~1s
✔  functions[us-central1-firestoreFn]: firestore function initialized.
i  functions: Beginning execution of "us-central1-firestoreFn"
>  test2/6FyUaaYWMaILYtXwb3vK
i  functions: Finished "us-central1-firestoreFn" in ~1s

```

### Sample Commands

N/A