### PR TITLE
Rename apiVersion to platform

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -131,11 +131,11 @@ export interface TargetIds {
   project: string;
 }
 
-export type FunctionsApiVersion = 1 | 2;
+export type FunctionsPlatform = "gcfv1" | "gcfv2";
 
 /** An API agnostic definition of a Cloud Function. */
 export interface FunctionSpec extends TargetIds {
-  apiVersion: FunctionsApiVersion;
+  platform: FunctionsPlatform;
   entryPoint: string;
   trigger: HttpsTrigger | EventTrigger;
   runtime: runtimes.Runtime | runtimes.DeprecatedRuntime;
@@ -405,7 +405,7 @@ export async function checkAvailability(context: Context, want: Backend): Promis
   const gcfV1Regions = new Set();
   const gcfV2Regions = new Set();
   for (const fn of want.cloudFunctions) {
-    if (fn.apiVersion === 1) {
+    if (fn.platform == "gcfv1") {
       gcfV1Regions.add(fn.region);
     } else {
       gcfV2Regions.add(fn.region);

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -60,10 +60,10 @@ export async function deploy(
   try {
     const want = payload.functions!.backend;
     const uploads: Promise<void>[] = [];
-    if (want.cloudFunctions.some((fn) => fn.apiVersion === 1)) {
+    if (want.cloudFunctions.some((fn) => fn.platform === "gcfv1")) {
       uploads.push(uploadSourceV1(context));
     }
-    if (want.cloudFunctions.some((fn) => fn.apiVersion === 2)) {
+    if (want.cloudFunctions.some((fn) => fn.platform === "gcfv2")) {
       uploads.push(uploadSourceV2(context));
     }
     await Promise.all(uploads);

--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -115,7 +115,7 @@ export async function printTriggerUrls(context: args.Context) {
     // TODO: way to filter out extensions deployed on GCFv2. May have to just replace
     // the existing backend with operation results as functions deploy rather than
     // calling existingBackend twice.
-    if (fn.apiVersion == 1 && fn.sourceUploadUrl !== context.uploadUrl) {
+    if (fn.platform == "gcfv1" && fn.sourceUploadUrl !== context.uploadUrl) {
       return false;
     }
     return !backend.isEventTrigger(fn.trigger) && deploymentTool.isFirebaseManaged(fn.labels || {});

--- a/src/deploy/functions/prompts.ts
+++ b/src/deploy/functions/prompts.ts
@@ -14,8 +14,8 @@ import { Options } from "../../options";
 // Future versions might want to compare regions by GCF/Run pricing tier before
 // location.
 function compareFunctions(left: backend.FunctionSpec, right: backend.FunctionSpec): number {
-  if (left.apiVersion != right.apiVersion) {
-    return right.apiVersion - left.apiVersion;
+  if (left.platform != right.platform) {
+    return right.platform < left.platform ? -1 : 1;
   }
   if (left.region < right.region) {
     return -1;
@@ -217,7 +217,7 @@ export async function promptForMinInstances(
     costLine = `With these options, your minimum bill will be $${cost} in a 30-day month`;
   }
   let cudAnnotation = "";
-  if (want.some((fn) => fn.apiVersion == 2 && fn.minInstances)) {
+  if (want.some((fn) => fn.platform == "gcfv2" && fn.minInstances)) {
     cudAnnotation =
       "\nThis bill can be lowered with a one year commitment. See https://cloud.google.com/run/cud for more";
   }

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -29,9 +29,9 @@ function tryValidate(typed: backend.Backend) {
   for (let ndx = 0; ndx < typed.cloudFunctions.length; ndx++) {
     const prefix = `cloudFunctions[${ndx}]`;
     const func = typed.cloudFunctions[ndx];
-    requireKeys(prefix, func, "apiVersion", "id", "entryPoint", "trigger");
+    requireKeys(prefix, func, "platform", "id", "entryPoint", "trigger");
     assertKeyTypes(prefix, func, {
-      apiVersion: "number",
+      platform: "string",
       id: "string",
       region: "string",
       project: "string",

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -32,8 +32,7 @@ export interface ScheduleAnnotation {
 // Defined in firebase-functions/src/cloud-function.ts
 export interface TriggerAnnotation {
   name: string;
-  // HACK HACK HACK. Will not be the way we do this by the time customers have their hands on it.
-  apiVersion?: 1 | 2;
+  platform?: "gcfv1" | "gcfv2";
   labels?: Record<string, string>;
   entryPoint: string;
   vpcConnector?: string;
@@ -172,7 +171,7 @@ export function addResourcesToBackend(
       project: projectId,
     };
     const cloudFunction: backend.FunctionSpec = {
-      apiVersion: annotation.apiVersion || 1,
+      platform: annotation.platform || "gcfv1",
       ...cloudFunctionName,
       entryPoint: annotation.entryPoint,
       runtime: runtime,

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -66,14 +66,14 @@ export function checkForInvalidChangeOfTrigger(
       )}] Changing from an HTTPS function to an background triggered function is not allowed. Please delete your function and create a new one instead.`
     );
   }
-  if (fn.apiVersion == 2 && exFn.apiVersion == 1) {
+  if (fn.platform == "gcfv2" && exFn.platform == "gcfv1") {
     throw new FirebaseError(
       `[${getFunctionLabel(
         fn
       )}] Upgrading from GCFv1 to GCFv2 is not yet supported. Please delete your old function or wait for this feature to be ready.`
     );
   }
-  if (fn.apiVersion == 1 && exFn.apiVersion == 2) {
+  if (fn.platform == "gcfv1" && exFn.platform == "gcfv2") {
     throw new FirebaseError(
       `[${getFunctionLabel(fn)}] Functions cannot be downgraded from GCFv2 to GCFv1`
     );

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -397,7 +397,7 @@ export function specFromFunction(gcfFunction: CloudFunction): backend.FunctionSp
   }
 
   const cloudFunction: backend.FunctionSpec = {
-    apiVersion: 1,
+    platform: "gcfv1",
     id,
     project,
     region,
@@ -434,7 +434,7 @@ export function functionFromSpec(
   cloudFunction: backend.FunctionSpec,
   sourceUploadUrl: string
 ): Omit<CloudFunction, OutputOnlyFields> {
-  if (cloudFunction.apiVersion != 1) {
+  if (cloudFunction.platform != "gcfv1") {
     throw new FirebaseError(
       "Trying to create a v1 CloudFunction with v2 API. This should never happen"
     );

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -327,7 +327,7 @@ export async function deleteFunction(cloudFunction: string): Promise<Operation> 
 }
 
 export function functionFromSpec(cloudFunction: backend.FunctionSpec, source: StorageSource) {
-  if (cloudFunction.apiVersion != 2) {
+  if (cloudFunction.platform != "gcfv2") {
     throw new FirebaseError(
       "Trying to create a v2 CloudFunction with v1 API. This should never happen"
     );
@@ -435,7 +435,7 @@ export function specFromFunction(gcfFunction: CloudFunction): backend.FunctionSp
   }
 
   const cloudFunction: backend.FunctionSpec = {
-    apiVersion: 2,
+    platform: "gcfv2",
     id,
     project,
     region,

--- a/src/test/deploy/functions/backend.spec.ts
+++ b/src/test/deploy/functions/backend.spec.ts
@@ -17,7 +17,7 @@ describe("Backend", () => {
   };
 
   const FUNCTION_SPEC: backend.FunctionSpec = {
-    apiVersion: 1,
+    platform: "gcfv1",
     ...FUNCTION_NAME,
     trigger: {
       allowInsecure: false,
@@ -228,7 +228,7 @@ describe("Backend", () => {
           cloudFunctions: [
             {
               ...FUNCTION_SPEC,
-              apiVersion: 2,
+              platform: "gcfv2",
               uri: HAVE_CLOUD_FUNCTION_V2.serviceConfig.uri,
             },
           ],
@@ -382,7 +382,7 @@ describe("Backend", () => {
           cloudFunctions: [
             {
               ...FUNCTION_SPEC,
-              apiVersion: 2,
+              platform: "gcfv2",
             },
           ],
         };
@@ -431,7 +431,7 @@ describe("Backend", () => {
           cloudFunctions: [
             {
               ...FUNCTION_SPEC,
-              apiVersion: 2,
+              platform: "gcfv2",
             },
           ],
         };

--- a/src/test/deploy/functions/containerCleaner.spec.ts
+++ b/src/test/deploy/functions/containerCleaner.spec.ts
@@ -112,7 +112,7 @@ describe("DockerHelper", () => {
 
 describe("ContainerRegistryCleaner", () => {
   const FUNCTION: backend.FunctionSpec = {
-    apiVersion: 1,
+    platform: "gcfv1",
     project: "project",
     region: "us-central1",
     id: "id",

--- a/src/test/deploy/functions/deploymentPlanner.spec.ts
+++ b/src/test/deploy/functions/deploymentPlanner.spec.ts
@@ -6,7 +6,7 @@ import * as deploymentTool from "../../../deploymentTool";
 
 describe("deploymentPlanner", () => {
   const CLOUD_FUNCTION: Omit<backend.FunctionSpec, "id" | "region"> = {
-    apiVersion: 1,
+    platform: "gcfv1",
     project: "project",
     runtime: "nodejs14",
     trigger: { allowInsecure: true },

--- a/src/test/deploy/functions/functionsDeployHelper.spec.ts
+++ b/src/test/deploy/functions/functionsDeployHelper.spec.ts
@@ -6,7 +6,7 @@ import { Options } from "../../../options";
 
 describe("functionsDeployHelper", () => {
   const CLOUD_FUNCTION: Omit<backend.FunctionSpec, "id"> = {
-    apiVersion: 1,
+    platform: "gcfv1",
     project: "project",
     region: "us-central1",
     runtime: "nodejs14",

--- a/src/test/deploy/functions/pricing.spec.ts
+++ b/src/test/deploy/functions/pricing.spec.ts
@@ -4,7 +4,7 @@ import { v1 } from "uuid";
 import * as backend from "../../../deploy/functions/backend";
 import * as pricing from "../../../deploy/functions/pricing";
 
-const FUNCTION_FRAGMENT: Omit<backend.FunctionSpec, "apiVersion" | "region"> = {
+const FUNCTION_FRAGMENT: Omit<backend.FunctionSpec, "platform" | "region"> = {
   id: "function",
   project: "project",
   entryPoint: "foobar",
@@ -21,7 +21,7 @@ describe("Functions Pricing", () => {
       expect(
         pricing.canCalculateMinInstanceCost({
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
         })
       ).to.be.true;
@@ -29,7 +29,7 @@ describe("Functions Pricing", () => {
       expect(
         pricing.canCalculateMinInstanceCost({
           ...FUNCTION_FRAGMENT,
-          apiVersion: 2,
+          platform: "gcfv2",
           ...INVALID_REGION,
         })
       ).to.be.true;
@@ -39,7 +39,7 @@ describe("Functions Pricing", () => {
       expect(
         pricing.canCalculateMinInstanceCost({
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 10,
         })
@@ -50,7 +50,7 @@ describe("Functions Pricing", () => {
       expect(
         pricing.canCalculateMinInstanceCost({
           ...FUNCTION_FRAGMENT,
-          apiVersion: 2,
+          platform: "gcfv2",
           region: "us-central1",
           minInstances: 10,
         })
@@ -61,7 +61,7 @@ describe("Functions Pricing", () => {
       expect(
         pricing.canCalculateMinInstanceCost({
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 10,
           availableMemoryMb: 0xdeadbeef as backend.MemoryOptions,
@@ -74,7 +74,7 @@ describe("Functions Pricing", () => {
         pricing.canCalculateMinInstanceCost({
           ...FUNCTION_FRAGMENT,
           ...INVALID_REGION,
-          apiVersion: 1,
+          platform: "gcfv1",
           minInstances: 10,
         })
       ).to.be.false;
@@ -100,7 +100,7 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 1,
           availableMemoryMb: 256,
@@ -118,14 +118,14 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 1,
           availableMemoryMb: 256,
         },
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 0,
         },
@@ -142,7 +142,7 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 2,
           availableMemoryMb: 256,
@@ -160,14 +160,14 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 1,
           availableMemoryMb: 256,
         },
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 1,
         },
@@ -184,7 +184,7 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "europe-west3",
           minInstances: 1,
           availableMemoryMb: 256,
@@ -202,7 +202,7 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "europe-west3",
           minInstances: 1,
           availableMemoryMb: 8192,
@@ -220,7 +220,7 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 2,
+          platform: "gcfv2",
           region: "us-central1",
           minInstances: 1,
           availableMemoryMb: 256,
@@ -238,7 +238,7 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 2,
+          platform: "gcfv2",
           region: "europe-west3",
           minInstances: 1,
           availableMemoryMb: 256,
@@ -256,7 +256,7 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 2,
+          platform: "gcfv2",
           region: "europe-west3",
           minInstances: 1,
           availableMemoryMb: 4096,
@@ -274,13 +274,13 @@ describe("Functions Pricing", () => {
       const cost = pricing.monthlyMinInstanceCost([
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 1,
+          platform: "gcfv1",
           region: "us-central1",
           minInstances: 1,
         },
         {
           ...FUNCTION_FRAGMENT,
-          apiVersion: 2,
+          platform: "gcfv2",
           region: "us-central1",
           minInstances: 1,
         },

--- a/src/test/deploy/functions/prompts.spec.ts
+++ b/src/test/deploy/functions/prompts.spec.ts
@@ -17,7 +17,7 @@ const SAMPLE_EVENT_TRIGGER: backend.EventTrigger = {
 };
 
 const SAMPLE_FUNC: backend.FunctionSpec = {
-  apiVersion: 1,
+  platform: "gcfv1",
   id: "c",
   region: "us-central1",
   project: "a",
@@ -394,7 +394,7 @@ describe("promptForMinInstances", () => {
       {
         ...SAMPLE_FUNC,
         region: "fillory",
-        apiVersion: 2,
+        platform: "gcfv2",
         minInstances: 2,
       },
     ];

--- a/src/test/deploy/functions/runtimes/discovery/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/index.spec.ts
@@ -11,7 +11,7 @@ import * as discovery from "../../../../../deploy/functions/runtimes/discovery";
 import * as backend from "../../../../../deploy/functions/backend";
 
 const MIN_FUNCTION = {
-  apiVersion: 1 as backend.FunctionsApiVersion,
+  platform: "gcfv1" as backend.FunctionsPlatform,
   id: "function",
   entryPoint: "entrypoint",
   trigger: {

--- a/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -9,7 +9,7 @@ const PROJECT = "project";
 const REGION = "region";
 const RUNTIME: Runtime = "node14";
 const MIN_FUNC: Partial<backend.FunctionSpec> = {
-  apiVersion: 1,
+  platform: "gcfv1",
   id: "id",
   entryPoint: "entryPoint",
   trigger: {

--- a/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -27,7 +27,7 @@ describe("addResourcesToBackend", () => {
   });
 
   const BASIC_FUNCTION: Omit<backend.FunctionSpec, "trigger"> = Object.freeze({
-    apiVersion: 1,
+    platform: "gcfv1",
     ...BASIC_FUNCTION_NAME,
     runtime: "nodejs14",
     entryPoint: "func",

--- a/src/test/deploy/functions/tasks.spec.ts
+++ b/src/test/deploy/functions/tasks.spec.ts
@@ -9,7 +9,7 @@ import * as tasks from "../../../deploy/functions/tasks";
 
 describe("Function Deployment tasks", () => {
   const CLOUD_FUNCTION: backend.FunctionSpec = {
-    apiVersion: 1,
+    platform: "gcfv1",
     id: "id",
     region: "region",
     project: "project",

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -97,7 +97,7 @@ describe("validate", () => {
 
   describe("checkForInvalidChangeOfTrigger", () => {
     const CLOUD_FUNCTION: Omit<FunctionSpec, "trigger"> = {
-      apiVersion: 1,
+      platform: "gcfv1",
       id: "my-func",
       region: "us-central1",
       project: "project",

--- a/src/test/gcp/cloudfunctions.spec.ts
+++ b/src/test/gcp/cloudfunctions.spec.ts
@@ -11,7 +11,7 @@ describe("cloudfunctions", () => {
   };
 
   const FUNCTION_SPEC: backend.FunctionSpec = {
-    apiVersion: 1,
+    platform: "gcfv1",
     ...FUNCTION_NAME,
     trigger: {
       allowInsecure: false,
@@ -38,7 +38,7 @@ describe("cloudfunctions", () => {
     const UPLOAD_URL = "https://storage.googleapis.com/projects/-/buckets/sample/source.zip";
     it("should guard against version mixing", () => {
       expect(() => {
-        cloudfunctions.functionFromSpec({ ...FUNCTION_SPEC, apiVersion: 2 }, UPLOAD_URL);
+        cloudfunctions.functionFromSpec({ ...FUNCTION_SPEC, platform: "gcfv2" }, UPLOAD_URL);
       }).to.throw;
     });
 

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -11,7 +11,7 @@ describe("cloudfunctionsv2", () => {
   };
 
   const FUNCTION_SPEC: backend.FunctionSpec = {
-    apiVersion: 2,
+    platform: "gcfv2",
     ...FUNCTION_NAME,
     trigger: {
       allowInsecure: false,
@@ -57,7 +57,7 @@ describe("cloudfunctionsv2", () => {
     it("should guard against version mixing", () => {
       expect(() => {
         cloudfunctionsv2.functionFromSpec(
-          { ...FUNCTION_SPEC, apiVersion: 1 },
+          { ...FUNCTION_SPEC, platform: "gcfv1" },
           CLOUD_FUNCTION_V2_SOURCE
         );
       }).to.throw;
@@ -68,7 +68,7 @@ describe("cloudfunctionsv2", () => {
         cloudfunctionsv2.functionFromSpec(
           {
             ...FUNCTION_SPEC,
-            apiVersion: 2,
+            platform: "gcfv2",
           },
           CLOUD_FUNCTION_V2_SOURCE
         )
@@ -76,7 +76,7 @@ describe("cloudfunctionsv2", () => {
 
       const eventFunction: backend.FunctionSpec = {
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         trigger: {
           eventType: "google.cloud.audit.log.v1.written",
           eventFilters: {
@@ -113,7 +113,7 @@ describe("cloudfunctionsv2", () => {
     it("should copy trival fields", () => {
       const fullFunction: backend.FunctionSpec = {
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         availableMemoryMb: 128,
         vpcConnector: "connector",
         vpcConnectorEgressSettings: "ALL_TRAFFIC",
@@ -156,7 +156,7 @@ describe("cloudfunctionsv2", () => {
     it("should calculate non-trivial fields", () => {
       const complexFunction: backend.FunctionSpec = {
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         trigger: {
           eventType: cloudfunctionsv2.PUBSUB_PUBLISH_EVENT,
           eventFilters: {
@@ -196,7 +196,7 @@ describe("cloudfunctionsv2", () => {
     it("should copy a minimal version", () => {
       expect(cloudfunctionsv2.specFromFunction(HAVE_CLOUD_FUNCTION_V2)).to.deep.equal({
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         uri: RUN_URI,
       });
     });
@@ -212,7 +212,7 @@ describe("cloudfunctionsv2", () => {
         })
       ).to.deep.equal({
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         uri: RUN_URI,
         trigger: {
           eventType: cloudfunctionsv2.PUBSUB_PUBLISH_EVENT,
@@ -243,7 +243,7 @@ describe("cloudfunctionsv2", () => {
         })
       ).to.deep.equal({
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         uri: RUN_URI,
         trigger: {
           eventType: "google.cloud.audit.log.v1.written",
@@ -280,7 +280,7 @@ describe("cloudfunctionsv2", () => {
         })
       ).to.deep.equal({
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         uri: RUN_URI,
         ...extraFields,
         labels: {
@@ -312,7 +312,7 @@ describe("cloudfunctionsv2", () => {
         })
       ).to.deep.equal({
         ...FUNCTION_SPEC,
-        apiVersion: 2,
+        platform: "gcfv2",
         uri: RUN_URI,
         ...extraFields,
       });


### PR DESCRIPTION
I know the whole point of having an "entity" API is that you can make public API changes without changing the internal details, but I figure this one was only a small amount of work to avoid tech debt where new team members need to learn the field transformation.

This will break the Go SDK until we update it. That's not a big worry since nobody uses the Go SDK and we need to rewrite it to target GCFv2 before we give it to anyone anyway.

Bonus fix: a few tests were missing "spec" in the filename.