### PR TITLE
Improve concurrency during functions deploys

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -140,6 +140,7 @@ export interface FunctionSpec extends TargetIds {
   trigger: HttpsTrigger | EventTrigger;
   runtime: runtimes.Runtime | runtimes.DeprecatedRuntime;
 
+  concurrency?: number;
   labels?: Record<string, string>;
   environmentVariables?: Record<string, string>;
   availableMemoryMb?: MemoryOptions;

--- a/src/deploy/functions/deploymentPlanner.ts
+++ b/src/deploy/functions/deploymentPlanner.ts
@@ -83,7 +83,13 @@ export function calculateRegionalFunctionChanges(
     .filter((fn) => isFirebaseManaged(fn.labels || {}));
 
   if (upgradedToGCFv2WithoutSettingConcurrency) {
-    logLabeledBullet("functions", "You are updating one or more functions to Google Cloud Functions v2, which introduces support for concurrent execution. New functions default to 80 concurrent executions, but existing functions keep the old default of 1. You can change this with the 'concurrency' option.")
+    logLabeledBullet(
+      "functions",
+      "You are updating one or more functions to Google Cloud Functions v2, " +
+        "which introduces support for concurrent execution. New functions " +
+        "default to 80 concurrent executions, but existing functions keep the " +
+        "old default of 1. You can change this with the 'concurrency' option."
+    );
   }
   return { functionsToCreate, functionsToUpdate, functionsToDelete };
 }

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -40,6 +40,7 @@ function tryValidate(typed: backend.Backend) {
       availableMemoryMb: "number",
       maxInstances: "number",
       minInstances: "number",
+      concurrency: "number",
       serviceAccountEmail: "string",
       timeout: "string",
       trigger: "object",

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -54,6 +54,7 @@ export interface TriggerAnnotation {
   schedule?: ScheduleAnnotation;
   timeZone?: string;
   regions?: string[];
+  concurrency?: number;
 }
 
 /**
@@ -187,6 +188,7 @@ export function addResourcesToBackend(
     proto.copyIfPresent(
       cloudFunction,
       annotation,
+      "concurrency",
       "serviceAccountEmail",
       "labels",
       "vpcConnectorEgressSettings",

--- a/src/deploy/functions/tasks.ts
+++ b/src/deploy/functions/tasks.ts
@@ -122,8 +122,8 @@ export function createFunctionTask(
       // GCFv2 has a default concurrency of 1, but CF3 has a default concurrency of 80.
       await setConcurrency(
         (cloudFunction as gcfV2.CloudFunction).serviceConfig.service!,
-        fn.concurrency || 80,
-      )
+        fn.concurrency || 80
+      );
     }
   };
   return {
@@ -174,7 +174,7 @@ export function updateFunctionTask(
       } else {
         await setConcurrency(
           (cloudFunction as gcfV2.CloudFunction).serviceConfig.service!,
-          fn.concurrency || 80,
+          fn.concurrency || 80
         );
       }
     }
@@ -216,7 +216,7 @@ export function deleteFunctionTask(params: TaskParams, fn: backend.FunctionSpec)
 }
 
 async function setConcurrency(name: string, concurrency: number) {
-  const service = await cloudrun.getService(name)
+  const service = await cloudrun.getService(name);
 
   delete service.spec.template.spec.containerConcurrency;
 


### PR DESCRIPTION
Though the method is a bit obtuse, this will enable concurrency.

We recognize concurrency as a field in the trigger annotations
and plumb it through to a ReplaceService call. Unfortuantely
GCFv2 doesn't have a direct concurrency option and Run doesn't
have a PATCH option so...