### PR TITLE
adds filterExcept to normalizedHostingConfigs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-- Fix Auth Emulator errors when importing many users (#3577).
+- Fixes Auth Emulator errors when importing many users. (#3577)
+- Fixes support for `--except` flag when used for deploying Hosting. (#3397)

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -56,34 +56,23 @@ function filterOnly(configs: HostingConfig[], onlyString: string): HostingConfig
   return filteredConfigs;
 }
 
-function filterExcept(configs: HostingConfig[], exceptString: string): HostingConfig[] {
-  if (!exceptString) {
+function filterExcept(configs: HostingConfig[], exceptOption: string): HostingConfig[] {
+  if (!exceptOption) {
     return configs;
   }
 
-  const exceptTargets = exceptString.split(",");
+  const exceptTargets = exceptOption.split(",");
   if (exceptTargets.includes("hosting")) {
     return [];
   }
 
-  const exceptSet = new Set(
+  const exceptValues = new Set(
     exceptTargets.filter((t) => t.startsWith("hosting:")).map((t) => t.replace("hosting:", ""))
   );
 
-  const configsBySite = new Map<string, HostingConfig>();
-  const configsByTarget = new Map<string, HostingConfig>();
-  for (const c of configs) {
-    if (c.site) {
-      configsBySite.set(c.site, c);
-    }
-    if (c.target) {
-      configsByTarget.set(c.target, c);
-    }
-  }
-
   const filteredConfigs: HostingConfig[] = [];
   for (const c of configs) {
-    if (!(exceptSet.has(c.site) || exceptSet.has(c.target))) {
+    if (!(exceptValues.has(c.site) || exceptValues.has(c.target))) {
       filteredConfigs.push(c);
     }
   }

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -125,7 +125,7 @@ export function normalizedHostingConfigs(
   }
 
   let hostingConfigs: HostingConfig[] = filterOnly(configs, cmdOptions.only);
-  hostingConfigs = filterExcept(configs, cmdOptions.except);
+  hostingConfigs = filterExcept(hostingConfigs, cmdOptions.except);
 
   if (options.resolveTargets) {
     for (const cfg of hostingConfigs) {

--- a/src/hosting/normalizedHostingConfigs.ts
+++ b/src/hosting/normalizedHostingConfigs.ts
@@ -124,6 +124,7 @@ export function normalizedHostingConfigs(
     }
   }
 
+  // filter* functions check if the strings are empty for us.
   let hostingConfigs: HostingConfig[] = filterOnly(configs, cmdOptions.only);
   hostingConfigs = filterExcept(hostingConfigs, cmdOptions.except);
 

--- a/src/test/hosting/normalizedHostingConfigs.spec.ts
+++ b/src/test/hosting/normalizedHostingConfigs.spec.ts
@@ -185,7 +185,7 @@ describe("normalizedHostingConfigs", () => {
     }
   });
 
-  describe.only("with an except parameter, resolving targets", () => {
+  describe("with an except parameter, resolving targets", () => {
     const DEFAULT_SITE = "default-hosting-site";
     const TARGETED_SITE = "targeted-site";
     const baseConfig = { public: "public", ignore: ["firebase.json"] };

--- a/src/test/hosting/normalizedHostingConfigs.spec.ts
+++ b/src/test/hosting/normalizedHostingConfigs.spec.ts
@@ -184,4 +184,104 @@ describe("normalizedHostingConfigs", () => {
       });
     }
   });
+
+  describe.only("with an except parameter, resolving targets", () => {
+    const DEFAULT_SITE = "default-hosting-site";
+    const TARGETED_SITE = "targeted-site";
+    const baseConfig = { public: "public", ignore: ["firebase.json"] };
+    const tests = [
+      {
+        desc: "a normal hosting config, omitting the default site",
+        cfg: Object.assign({}, baseConfig),
+        except: `hosting:${DEFAULT_SITE}`,
+        want: [],
+      },
+      {
+        desc: "a hosting config with multiple sites, no targets, omitting the second site",
+        cfg: [
+          Object.assign({}, baseConfig, { site: DEFAULT_SITE }),
+          Object.assign({}, baseConfig, { site: "different-site" }),
+        ],
+        except: `hosting:different-site`,
+        want: [Object.assign({}, baseConfig, { site: DEFAULT_SITE })],
+      },
+      {
+        desc: "a normal hosting config with a target, omitting the target",
+        cfg: Object.assign({}, baseConfig, { target: "main" }),
+        except: "hosting:main",
+        want: [],
+      },
+      {
+        desc: "a hosting config with multiple targets, omitting one",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+        except: "hosting:t-two",
+        want: [Object.assign({}, baseConfig, { target: "t-one", site: TARGETED_SITE })],
+      },
+      {
+        desc: "a hosting config with multiple targets, omitting all hosting",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+        except: "hosting",
+        want: [],
+      },
+      {
+        desc: "a hosting config with multiple targets, omitting an invalid target",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-two" }),
+        ],
+        except: "hosting:t-three",
+        want: [
+          Object.assign({}, baseConfig, { target: "t-one", site: TARGETED_SITE }),
+          Object.assign({}, baseConfig, { target: "t-two", site: TARGETED_SITE }),
+        ],
+      },
+      {
+        desc: "a hosting config with multiple targets, with multiple matching targets",
+        cfg: [
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-one" }),
+          Object.assign({}, baseConfig, { target: "t-other" }),
+        ],
+        except: "hosting:t-other",
+        targetedSites: [TARGETED_SITE, TARGETED_SITE],
+        wantErr: /Hosting target.+t-one.+linked to multiple sites/,
+      },
+      {
+        desc: "a hosting config with multiple sites but no targets, only all hosting",
+        cfg: [Object.assign({}, baseConfig), Object.assign({}, baseConfig)],
+        except: "hosting:site",
+        wantErr: /Must supply either "site" or "target"/,
+      },
+    ];
+
+    for (const t of tests) {
+      it(`should be able to parse ${t.desc}`, () => {
+        if (!Array.isArray(t.targetedSites)) {
+          t.targetedSites = [TARGETED_SITE];
+        }
+        const cmdConfig = {
+          site: DEFAULT_SITE,
+          except: t.except,
+          config: { get: () => t.cfg },
+          rc: { requireTarget: () => t.targetedSites },
+        };
+
+        if (t.wantErr) {
+          expect(() => normalizedHostingConfigs(cmdConfig, { resolveTargets: true })).to.throw(
+            FirebaseError,
+            t.wantErr
+          );
+        } else {
+          const got = normalizedHostingConfigs(cmdConfig, { resolveTargets: true });
+          expect(got).to.deep.equal(t.want);
+        }
+      });
+    }
+  });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Adds support for `--except` when deploying to Firebase Hosting.

fixes #3397

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

```
» firebase deploy --only hosting

=== Deploying to 'site'...

i  deploying hosting
i  hosting[site]: beginning deploy...
i  hosting[site]: found 17 files in public/
✔  hosting[site]: file upload complete
i  hosting[OTHER-SITE]: beginning deploy...
i  hosting[OTHER-SITE]: found 16 files in public/
✔  hosting[OTHER-SITE]: file upload complete
i  hosting[site]: finalizing version...
i  hosting[OTHER-SITE]: finalizing version...
✔  hosting[OTHER-SITE]: version finalized
i  hosting[OTHER-SITE]: releasing new version...
✔  hosting[site]: version finalized
i  hosting[site]: releasing new version...
✔  hosting[OTHER-SITE]: release complete
✔  hosting[site]: release complete

✔  Deploy complete!
```

`other` is the target for `OTHER-SITE`. I also have some functions...

```
» firebase deploy --except functions,hosting:other

=== Deploying to 'site'...

i  deploying hosting
i  hosting[site]: beginning deploy...
i  hosting[site]: found 17 files in public/
✔  hosting[site]: file upload complete
i  hosting[site]: finalizing version...
✔  hosting[site]: version finalized
i  hosting[site]: releasing new version...
✔  hosting[site]: release complete

✔  Deploy complete!
```

