### PR TITLE
Remove dead code that creates database through the private API.

### DIFF
--- a/src/gcp/firedata.ts
+++ b/src/gcp/firedata.ts
@@ -24,28 +24,7 @@ function _handleErrorResponse(response: any): any {
  * @param projectId Project from which you want to get the ruleset.
  * @param instanceName The name for the new Realtime Database instance.
  */
-export async function createDatabaseInstance(
-  projectNumber: number,
-  instanceName: string
-): Promise<any> {
-  const response = await api.request("POST", `/v1/projects/${projectNumber}/databases`, {
-    auth: true,
-    origin: api.firedataOrigin,
-    json: {
-      instance: instanceName,
-    },
-  });
-  if (response.status === 200) {
-    return response.body.instance;
-  }
-  return _handleErrorResponse(response);
-}
 
-/**
- * Create a new Realtime Database instance
- * @param projectId Project from which you want to get the ruleset.
- * @param instanceName The name for the new Realtime Database instance.
- */
 export async function listDatabaseInstances(projectNumber: string): Promise<DatabaseInstance[]> {
   const response = await api.request("GET", `/v1/projects/${projectNumber}/databases`, {
     auth: true,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

In an effort to migrate away from using Firedata's private API, this is cleaning up dead code that is no longer used (but calls the Firedata private API). The command to create a database instance is already using the public API instead. 

### Scenarios Tested

None.

### Sample Commands

None.
