### PR TITLE
fix: print functions source directory in error message when no language was detected

### DIFF
--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -128,8 +128,5 @@ export async function getRuntimeDelegate(
     }
   }
 
-  throw new FirebaseError(
-    "Could not detect language for functions at",
-    options.config.get("functions.source")
-  );
+  throw new FirebaseError("Could not detect language for functions at " + sourceDirName);
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

When running `firebase deploy --only functions` and no language could be detected, the following message is displayed even though a `functions.source` is configured in `firebase.json`:

```
Error: Could not detect language for functions at
```

The actual location where `firebase-tools` tried to detect the language is not printed. That's because the directory is passed into `FirebaseError` as the second argument which is `options` and different to e.g. `console.log` the arguments are not concatenated.

With this PR the `firebase-tools` correctly print the source directory. In my case:

```
Error: Could not detect language for functions at dist
```

Depending on your preferred error message style, the path could be wrapped in quotes.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

I only ran `firebase deploy --only functions` and the message above was printed.

