### PR TITLE
fix: sync firebase config with #3351

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -705,9 +705,6 @@
                             "type": "boolean"
                         }
                     },
-                    "required": [
-                        "public"
-                    ],
                     "type": "object"
                 },
                 {
@@ -1057,7 +1054,6 @@
                                     }
                                 },
                                 "required": [
-                                    "public",
                                     "target"
                                 ],
                                 "type": "object"
@@ -1406,7 +1402,6 @@
                                     }
                                 },
                                 "required": [
-                                    "public",
                                     "site"
                                 ],
                                 "type": "object"

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -58,7 +58,7 @@ type HostingHeaders = HostingSource & {
 };
 
 type HostingBase = {
-  public: string;
+  public?: string;
   ignore?: string[];
   appAssociation?: string;
   cleanUrls?: boolean;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

#3351 allows Hosting deploys with no `public` dir if they had a rewrite rule.

While the Hosting Config is validated during deployment, if-this-than-that requirements makes this configuration schema of very little use as all fields will eventually be represented as optional and the schema itself not represent the schema of the API. I've no idea if there is a solution to this with such flexible config requirements. I guess at worst it documents all field names :shrug: 