### PR TITLE
fix:  auth_time emulator behavior should match production (auth_time is now set to user's last sign in time). (#3608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Makes auth_time emulator behavior match production (auth_time is now set to user's last sign in time). (#3608)
 - Fixes Auth Emulator errors when importing many users. (#3577)
 - Fixes support for `--except` flag when used for deploying Hosting. (#3397)

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1726,7 +1726,11 @@ function generateJwt(
     // This field is only set for anonymous sign-in but not for any other
     // provider (such as email or Google) in production. Let's match that.
     provider_id: signInProvider === "anonymous" ? signInProvider : undefined,
-    auth_time: toUnixTimestamp(new Date()),
+    auth_time: user.lastLoginAt
+      ? toUnixTimestamp(new Date(user.lastLoginAt))
+      : user.lastRefreshAt
+      ? toUnixTimestamp(new Date(user.lastRefreshAt))
+      : toUnixTimestamp(new Date()),
     user_id: user.localId,
     firebase: {
       identities,
@@ -2122,6 +2126,7 @@ export interface FirebaseJwtPayload {
   exp: number; // expiresAt (in seconds since epoch)
   iss: string; // issuer
   aud: string; // audience (=projectId)
+  auth_time: number; // lastLoginAt (in seconds since epoch)
   // ...and other fields that we don't care for now.
 
   // Firebase-specific fields:


### PR DESCRIPTION
### Description

Fixes #3608 so that emulator sets auth_time the same way production does (auth_time should match lastLoginAt in seconds)

### Scenarios Tested

Added unit test to src/test/emulators/auth/misc.spec.ts called `"should populate auth_time to match lastLoginAt (in seconds since epoch)"`

This unit test...
1. Registers a user
2. Exchanges a refresh token for a new token
3. Checks that the new token's auth_time matches the user's lastLoginAt in seconds.
