### PR TITLE
fix: emulator auth_time (#3608)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Makes auth_time emulator behavior match production (auth_time is now set to user's last sign in time). (#3608)
 - Fixes Auth Emulator errors when importing many users. (#3577)
 - Fixes support for `--except` flag when used for deploying Hosting. (#3397)

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1726,11 +1726,12 @@ function generateJwt(
     // This field is only set for anonymous sign-in but not for any other
     // provider (such as email or Google) in production. Let's match that.
     provider_id: signInProvider === "anonymous" ? signInProvider : undefined,
-    auth_time: user.lastLoginAt != null
-      ? toUnixTimestamp(new Date(user.lastLoginAt))
-      : user.lastRefreshAt != null
-      ? toUnixTimestamp(new Date(user.lastRefreshAt))
-      : toUnixTimestamp(new Date()),
+    auth_time:
+      user.lastLoginAt != null
+        ? toUnixTimestamp(new Date(user.lastLoginAt))
+        : user.lastRefreshAt != null
+        ? toUnixTimestamp(new Date(user.lastRefreshAt))
+        : toUnixTimestamp(new Date()),
     user_id: user.localId,
     firebase: {
       identities,

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1726,9 +1726,9 @@ function generateJwt(
     // This field is only set for anonymous sign-in but not for any other
     // provider (such as email or Google) in production. Let's match that.
     provider_id: signInProvider === "anonymous" ? signInProvider : undefined,
-    auth_time: user.lastLoginAt
+    auth_time: user.lastLoginAt != null
       ? toUnixTimestamp(new Date(user.lastLoginAt))
-      : user.lastRefreshAt
+      : user.lastRefreshAt != null
       ? toUnixTimestamp(new Date(user.lastRefreshAt))
       : toUnixTimestamp(new Date()),
     user_id: user.localId,

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1726,7 +1726,11 @@ function generateJwt(
     // This field is only set for anonymous sign-in but not for any other
     // provider (such as email or Google) in production. Let's match that.
     provider_id: signInProvider === "anonymous" ? signInProvider : undefined,
-    auth_time: toUnixTimestamp(new Date()),
+    auth_time: user.lastLoginAt
+      ? toUnixTimestamp(new Date(user.lastLoginAt))
+      : user.lastRefreshAt
+      ? toUnixTimestamp(new Date(user.lastRefreshAt))
+      : toUnixTimestamp(new Date()),
     user_id: user.localId,
     firebase: {
       identities,
@@ -2122,6 +2126,7 @@ export interface FirebaseJwtPayload {
   exp: number; // expiresAt (in seconds since epoch)
   iss: string; // issuer
   aud: string; // audience (=projectId)
+  auth_time: number; // lastLoginAt (in seconds since epoch)
   // ...and other fields that we don't care for now.
 
   // Firebase-specific fields:

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -21,7 +21,7 @@ import {
 } from "../../../emulator/auth/operations";
 import { toUnixTimestamp } from "../../../emulator/auth/utils";
 
-describeAuthEmulator("token refresh", ({ authApi }) => {
+describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
   it("should exchange refresh token for new tokens", async () => {
     const { refreshToken, localId } = await registerAnonUser(authApi());
     await authApi()
@@ -47,6 +47,8 @@ describeAuthEmulator("token refresh", ({ authApi }) => {
   it("should populate auth_time to match lastLoginAt (in seconds since epoch)", async () => {
     const emailUser = { email: "alice@example.com", password: "notasecret" };
     const { refreshToken } = await registerUser(authApi(), emailUser);
+
+    getClock().tick(2000); // Wait for idToken to be issued in the past.
 
     const res = await authApi()
       .post("/securetoken.googleapis.com/v1/token")

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -59,9 +59,8 @@ describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
 
     const idToken = res.body.id_token;
     const user = await getAccountInfoByIdToken(authApi(), idToken);
-    const lastLoginAtSeconds = user.lastLoginAt
-      ? toUnixTimestamp(new Date(user.lastLoginAt))
-      : undefined;
+    expect(user.lastLoginAt).not.to.be.undefined;
+    const lastLoginAtSeconds = toUnixTimestamp(new Date(user.lastLoginAt!));
     const decoded = decodeJwt(idToken, { complete: true }) as {
       header: JwtHeader;
       payload: FirebaseJwtPayload;

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -48,7 +48,7 @@ describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
     const emailUser = { email: "alice@example.com", password: "notasecret" };
     const { refreshToken } = await registerUser(authApi(), emailUser);
 
-    getClock().tick(2000); // Wait for idToken to be issued in the past.
+    getClock().tick(2000); // Wait 2 seconds before refreshing.
 
     const res = await authApi()
       .post("/securetoken.googleapis.com/v1/token")
@@ -67,6 +67,7 @@ describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
     } | null;
     expect(decoded, "JWT returned by emulator is invalid").not.to.be.null;
     expect(decoded!.header.alg).to.eql("none");
+    // This should match login time, not token refresh time.
     expect(decoded!.payload.auth_time).to.equal(lastLoginAtSeconds);
   });
 


### PR DESCRIPTION
### Description

Fixes #3608 so that emulator sets auth_time the same way production does (auth_time should match lastLoginAt in seconds)

### Scenarios Tested

Added unit test to src/test/emulators/auth/misc.spec.ts called `"should populate auth_time to match lastLoginAt (in seconds since epoch)"`

This unit test...
1. Registers a user
2. Exchanges a refresh token for a new token
3. Checks that the new token's auth_time matches the user's lastLoginAt in seconds.
