### PR TITLE
Add passthrough mode to auth emulator

### DIFF
--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -295,6 +295,7 @@ function addEmulatorOperations(openapi3: any): void {
       signIn: {
         properties: {
           allowDuplicateEmails: { type: "boolean" },
+          usageMode: { type: "string" },
         },
         type: "object",
       },

--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -295,9 +295,12 @@ function addEmulatorOperations(openapi3: any): void {
       signIn: {
         properties: {
           allowDuplicateEmails: { type: "boolean" },
-          usageMode: { type: "string" },
         },
         type: "object",
+      },
+      usageMode: {
+        enum: ["DEFAULT", "PASSTHROUGH"],
+        type: "string",
       },
     },
   };

--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -299,7 +299,7 @@ function addEmulatorOperations(openapi3: any): void {
         type: "object",
       },
       usageMode: {
-        enum: ["DEFAULT", "PASSTHROUGH"],
+        enum: ["USAGE_MODE_UNSPECIFIED", "DEFAULT", "PASSTHROUGH"],
         type: "string",
       },
     },

--- a/src/emulator/auth/apiSpec.js
+++ b/src/emulator/auth/apiSpec.js
@@ -5945,7 +5945,7 @@ export default {
         description: "Emulator-specific configuration.",
         properties: {
           signIn: { properties: { allowDuplicateEmails: { type: "boolean" } }, type: "object" },
-          usageMode: { enum: ["DEFAULT", "PASSTHROUGH"], type: "string" },
+          usageMode: { enum: ["USAGE_MODE_UNSPECIFIED", "DEFAULT", "PASSTHROUGH"], type: "string" },
         },
       },
       EmulatorV1ProjectsOobCodes: {

--- a/src/emulator/auth/apiSpec.js
+++ b/src/emulator/auth/apiSpec.js
@@ -2981,6 +2981,52 @@ export default {
   },
   components: {
     schemas: {
+      GoogleCloudIdentitytoolkitV1Argon2Parameters: {
+        description: "The parameters for Argon2 hashing algorithm.",
+        properties: {
+          associatedData: {
+            description:
+              "The additional associated data, if provided, is appended to the hash value to provide an additional layer of security. A base64-encoded string if specified via JSON.",
+            format: "byte",
+            type: "string",
+          },
+          hashLengthBytes: {
+            description:
+              "Required. The desired hash length in bytes. Minimum is 4 and maximum is 1024.",
+            format: "int32",
+            type: "integer",
+          },
+          hashType: {
+            description: "Required. Must not be HASH_TYPE_UNSPECIFIED.",
+            enum: ["HASH_TYPE_UNSPECIFIED", "ARGON2_D", "ARGON2_ID", "ARGON2_I"],
+            type: "string",
+          },
+          iterations: {
+            description:
+              "Required. The number of iterations to perform. Minimum is 1, maximum is 16.",
+            format: "int32",
+            type: "integer",
+          },
+          memoryCostKib: {
+            description: "Required. The memory cost in kibibytes. Maximum is 32768.",
+            format: "int32",
+            type: "integer",
+          },
+          parallelism: {
+            description:
+              "Required. The degree of parallelism, also called threads or lanes. Minimum is 1, maximum is 16.",
+            format: "int32",
+            type: "integer",
+          },
+          version: {
+            description:
+              "The version of the Argon2 algorithm. This defaults to VERSION_13 if not specified.",
+            enum: ["VERSION_UNSPECIFIED", "VERSION_10", "VERSION_13"],
+            type: "string",
+          },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitV1AutoRetrievalInfo: {
         description: "The information required to auto-retrieve an SMS.",
         properties: {
@@ -4784,6 +4830,9 @@ export default {
               "Whether to overwrite an existing account in Identity Platform with a matching `local_id` in the request. If true, the existing account will be overwritten. If false, an error will be returned.",
             type: "boolean",
           },
+          argon2Parameters: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitV1Argon2Parameters",
+          },
           blockSize: {
             description:
               "The block size parameter used by the STANDARD_SCRYPT hashing function. This parameter, along with parallelization and cpu_mem_cost help tune the resources needed to hash a password, and should be tuned as processor speeds and memory technologies advance.",
@@ -4810,7 +4859,7 @@ export default {
           },
           hashAlgorithm: {
             description:
-              "Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT",
+              "Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT * ARGON2",
             type: "string",
           },
           memoryCost: {
@@ -5200,6 +5249,17 @@ export default {
         },
         type: "object",
       },
+      GoogleCloudIdentitytoolkitAdminV2Inheritance: {
+        description: "Settings that the tenants will inherit from project level.",
+        properties: {
+          emailSendingConfig: {
+            description:
+              "Whether to allow the tenant to inherit custom domains, email templates, and custom SMTP settings. If true, email sent from tenant will follow the project level email sending configurations. If false (by default), emails will go with the default settings with no customizations.",
+            type: "boolean",
+          },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitAdminV2ListDefaultSupportedIdpConfigsResponse: {
         description: "Response for DefaultSupportedIdpConfigs",
         properties: {
@@ -5332,7 +5392,7 @@ export default {
       },
       GoogleCloudIdentitytoolkitAdminV2OAuthResponseType: {
         description:
-          "The multiple response type to request for in the OAuth authorization flow. This can possibly be a combination of set bits (e.g. {id_token, token}).",
+          "The response type to request for in the OAuth authorization flow. You can set either `id_token` or `code` to true, but not both. Setting both types to be simultaneously true (`{code: true, id_token: true}`) is not yet supported. See https://openid.net/specs/openid-connect-core-1_0.html#Authentication for a mapping of response type to OAuth 2.0 flow.",
         properties: {
           code: {
             description:
@@ -5344,7 +5404,7 @@ export default {
             type: "boolean",
           },
           token: {
-            description: "If true, access token is returned from IdP's authorization endpoint.",
+            description: "Do not use. The `token` response type is not supported at the moment.",
             type: "boolean",
           },
         },
@@ -5404,6 +5464,9 @@ export default {
             type: "boolean",
           },
           hashConfig: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2HashConfig" },
+          inheritance: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Inheritance",
+          },
           mfaConfig: {
             $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig",
           },
@@ -5882,6 +5945,7 @@ export default {
         description: "Emulator-specific configuration.",
         properties: {
           signIn: { properties: { allowDuplicateEmails: { type: "boolean" } }, type: "object" },
+          usageMode: { enum: ["DEFAULT", "PASSTHROUGH"], type: "string" },
         },
       },
       EmulatorV1ProjectsOobCodes: {
@@ -6069,7 +6133,7 @@ export default {
             authorizationUrl: "https://accounts.google.com/o/oauth2/auth",
             scopes: {
               "https://www.googleapis.com/auth/cloud-platform":
-                "See, edit, configure, and delete your Google Cloud Platform data",
+                "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account.",
               "https://www.googleapis.com/auth/firebase":
                 "View and administer all your Firebase data and settings",
             },
@@ -6079,7 +6143,7 @@ export default {
             tokenUrl: "https://accounts.google.com/o/oauth2/token",
             scopes: {
               "https://www.googleapis.com/auth/cloud-platform":
-                "See, edit, configure, and delete your Google Cloud Platform data",
+                "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account.",
               "https://www.googleapis.com/auth/firebase":
                 "View and administer all your Firebase data and settings",
             },

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -10,6 +10,39 @@
 export interface components {
   schemas: {
     /**
+     * The parameters for Argon2 hashing algorithm.
+     */
+    GoogleCloudIdentitytoolkitV1Argon2Parameters: {
+      /**
+       * The additional associated data, if provided, is appended to the hash value to provide an additional layer of security. A base64-encoded string if specified via JSON.
+       */
+      associatedData?: string;
+      /**
+       * Required. The desired hash length in bytes. Minimum is 4 and maximum is 1024.
+       */
+      hashLengthBytes?: number;
+      /**
+       * Required. Must not be HASH_TYPE_UNSPECIFIED.
+       */
+      hashType?: "HASH_TYPE_UNSPECIFIED" | "ARGON2_D" | "ARGON2_ID" | "ARGON2_I";
+      /**
+       * Required. The number of iterations to perform. Minimum is 1, maximum is 16.
+       */
+      iterations?: number;
+      /**
+       * Required. The memory cost in kibibytes. Maximum is 32768.
+       */
+      memoryCostKib?: number;
+      /**
+       * Required. The degree of parallelism, also called threads or lanes. Minimum is 1, maximum is 16.
+       */
+      parallelism?: number;
+      /**
+       * The version of the Argon2 algorithm. This defaults to VERSION_13 if not specified.
+       */
+      version?: "VERSION_UNSPECIFIED" | "VERSION_10" | "VERSION_13";
+    };
+    /**
      * The information required to auto-retrieve an SMS.
      */
     GoogleCloudIdentitytoolkitV1AutoRetrievalInfo: {
@@ -1614,6 +1647,7 @@ export interface components {
        * Whether to overwrite an existing account in Identity Platform with a matching `local_id` in the request. If true, the existing account will be overwritten. If false, an error will be returned.
        */
       allowOverwrite?: boolean;
+      argon2Parameters?: components["schemas"]["GoogleCloudIdentitytoolkitV1Argon2Parameters"];
       /**
        * The block size parameter used by the STANDARD_SCRYPT hashing function. This parameter, along with parallelization and cpu_mem_cost help tune the resources needed to hash a password, and should be tuned as processor speeds and memory technologies advance.
        */
@@ -1631,7 +1665,7 @@ export interface components {
        */
       dkLen?: number;
       /**
-       * Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT
+       * Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT * ARGON2
        */
       hashAlgorithm?: string;
       /**
@@ -1968,6 +2002,15 @@ export interface components {
       spConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SpConfig"];
     };
     /**
+     * Settings that the tenants will inherit from project level.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Inheritance: {
+      /**
+       * Whether to allow the tenant to inherit custom domains, email templates, and custom SMTP settings. If true, email sent from tenant will follow the project level email sending configurations. If false (by default), emails will go with the default settings with no customizations.
+       */
+      emailSendingConfig?: boolean;
+    };
+    /**
      * Response for DefaultSupportedIdpConfigs
      */
     GoogleCloudIdentitytoolkitAdminV2ListDefaultSupportedIdpConfigsResponse: {
@@ -2076,7 +2119,7 @@ export interface components {
       responseType?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2OAuthResponseType"];
     };
     /**
-     * The multiple response type to request for in the OAuth authorization flow. This can possibly be a combination of set bits (e.g. {id_token, token}).
+     * The response type to request for in the OAuth authorization flow. You can set either `id_token` or `code` to true, but not both. Setting both types to be simultaneously true (`{code: true, id_token: true}`) is not yet supported. See https://openid.net/specs/openid-connect-core-1_0.html#Authentication for a mapping of response type to OAuth 2.0 flow.
      */
     GoogleCloudIdentitytoolkitAdminV2OAuthResponseType: {
       /**
@@ -2088,7 +2131,7 @@ export interface components {
        */
       idToken?: boolean;
       /**
-       * If true, access token is returned from IdP's authorization endpoint.
+       * Do not use. The `token` response type is not supported at the moment.
        */
       token?: boolean;
     };
@@ -2147,6 +2190,7 @@ export interface components {
        */
       enableEmailLinkSignin?: boolean;
       hashConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2HashConfig"];
+      inheritance?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Inheritance"];
       mfaConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig"];
       /**
        * Output only. Resource name of a tenant. For example: "projects/{project-id}/tenants/{tenant-id}"
@@ -2549,7 +2593,10 @@ export interface components {
     /**
      * Emulator-specific configuration.
      */
-    EmulatorV1ProjectsConfig: { signIn?: { allowDuplicateEmails?: boolean; usageMode?: string } };
+    EmulatorV1ProjectsConfig: {
+      signIn?: { allowDuplicateEmails?: boolean };
+      usageMode?: "DEFAULT" | "PASSTHROUGH";
+    };
     /**
      * Details of all pending confirmation codes.
      */

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -2549,7 +2549,7 @@ export interface components {
     /**
      * Emulator-specific configuration.
      */
-    EmulatorV1ProjectsConfig: { signIn?: { allowDuplicateEmails?: boolean } };
+    EmulatorV1ProjectsConfig: { signIn?: { allowDuplicateEmails?: boolean; usageMode?: string } };
     /**
      * Details of all pending confirmation codes.
      */

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -2595,7 +2595,7 @@ export interface components {
      */
     EmulatorV1ProjectsConfig: {
       signIn?: { allowDuplicateEmails?: boolean };
-      usageMode?: "DEFAULT" | "PASSTHROUGH";
+      usageMode?: "USAGE_MODE_UNSPECIFIED" | "DEFAULT" | "PASSTHROUGH";
     };
     /**
      * Details of all pending confirmation codes.

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -31,6 +31,7 @@ export class ProjectState {
   private temporaryProofs: Map<string, TemporaryProofRecord> = new Map();
   public oneAccountPerEmail = true;
   private authCloudFunction: AuthCloudFunction;
+  public usageMode: UsageMode = UsageMode.DEFAULT;
 
   constructor(public readonly projectId: string) {
     this.authCloudFunction = new AuthCloudFunction(projectId);
@@ -599,4 +600,9 @@ function getProviderEmailsForUser(user: UserInfo): Set<string> {
     }
   });
   return emails;
+}
+
+export enum UsageMode {
+  DEFAULT = "DEFAULT",
+  PASSTHROUGH = "PASSTHROUGH",
 }

--- a/src/test/emulators/auth/batch.spec.ts
+++ b/src/test/emulators/auth/batch.spec.ts
@@ -144,22 +144,6 @@ describeAuthEmulator("accounts:batchGet", ({ authApi }) => {
         expect(res.body).not.to.have.property("nextPageToken");
       });
   });
-
-  it("should error if usageMode is passthrough", async () => {
-    const user = await registerAnonUser(authApi());
-    await deleteAccount(authApi(), { idToken: user.idToken });
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
-
-    await authApi()
-      .get(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchGet`)
-      .set("Authorization", "Bearer owner")
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
-  });
 });
 
 describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
@@ -559,7 +543,7 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
       phoneNumber: TEST_PHONE_NUMBER,
       customAttributes: '{"hello": "world"}',
     };
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
@@ -695,21 +679,6 @@ describeAuthEmulator("accounts:batchDelete", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error.message).to.equal("LOCAL_ID_LIST_EXCEEDS_LIMIT");
-      });
-  });
-
-  it("should error if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
-
-    await authApi()
-      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchDelete`)
-      .set("Authorization", "Bearer owner")
-      .send({ localIds: ["nosuch", "nosuch2"] })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 });

--- a/src/test/emulators/auth/createAuthUri.spec.ts
+++ b/src/test/emulators/auth/createAuthUri.spec.ts
@@ -184,7 +184,7 @@ describeAuthEmulator("accounts:createAuthUri", ({ authApi }) => {
   });
 
   it("should error if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:createAuthUri")

--- a/src/test/emulators/auth/createAuthUri.spec.ts
+++ b/src/test/emulators/auth/createAuthUri.spec.ts
@@ -182,4 +182,19 @@ describeAuthEmulator("accounts:createAuthUri", ({ authApi }) => {
         expect(res.body.error).to.have.property("message").equals("INVALID_CONTINUE_URI");
       });
   });
+
+  it("should error if usageMode is passthrough", async () => {
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:createAuthUri")
+      .send({ continueUri: "http://example.com/", identifier: "notregistered@example.com" })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
+  });
 });

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -128,7 +128,7 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
       issuer: "fake-service-account@example.com",
       audience: CUSTOM_TOKEN_AUDIENCE,
     });
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
@@ -137,8 +137,7 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(200, res);
         expect(res.body.isNewUser).to.equal(true);
-        expect(res.body).to.have.property("refreshToken").that.is.a("string");
-        expect(res.body.refreshToken).to.equal("");
+        expect(res.body).not.to.have.property("refreshToken");
 
         const idToken = res.body.idToken as string;
         const decoded = decodeJwt(idToken, { complete: true }) as {

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -10,6 +10,7 @@ import {
   signInWithEmailLink,
   registerUser,
   TEST_MFA_INFO,
+  updateProjectConfig,
 } from "./helpers";
 
 describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
@@ -113,6 +114,45 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
           ...customClaims,
           ...claims,
         });
+      });
+  });
+
+  it("should not issue a refresh token in passthrough mode", async () => {
+    const uid = "someuid";
+    const claims = { abc: "def", ultimate: { answer: 42 } };
+    const token = signJwt({ uid, claims }, "", {
+      algorithm: "none",
+      expiresIn: 3600,
+
+      subject: "fake-service-account@example.com",
+      issuer: "fake-service-account@example.com",
+      audience: CUSTOM_TOKEN_AUDIENCE,
+    });
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
+      .query({ key: "fake-api-key" })
+      .send({ token })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.isNewUser).to.equal(true);
+        expect(res.body).to.have.property("refreshToken").that.is.a("string");
+        expect(res.body.refreshToken).to.equal("");
+
+        const idToken = res.body.idToken as string;
+        const decoded = decodeJwt(idToken, { complete: true }) as {
+          header: JwtHeader;
+          payload: FirebaseJwtPayload;
+        } | null;
+        expect(decoded, "JWT returned by emulator is invalid").not.to.be.null;
+        expect(decoded!.header.alg).to.eql("none");
+        expect(decoded!.payload).not.to.have.property("provider_id");
+        expect(decoded!.payload.firebase)
+          .to.have.property("sign_in_provider")
+          .equals(PROVIDER_CUSTOM);
+        expect(decoded!.payload).deep.include(claims);
+        return idToken;
       });
   });
 

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -117,6 +117,7 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
       });
   });
 
+  // TODO: update
   it("should not issue a refresh token in passthrough mode", async () => {
     const uid = "someuid";
     const claims = { abc: "def", ultimate: { answer: 42 } };
@@ -136,7 +137,7 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
       .send({ token })
       .then((res) => {
         expectStatusCode(200, res);
-        expect(res.body.isNewUser).to.equal(true);
+        expect(res.body.isNewUser).to.equal(false);
         expect(res.body).not.to.have.property("refreshToken");
 
         const idToken = res.body.idToken as string;
@@ -150,6 +151,7 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
         expect(decoded!.payload.firebase)
           .to.have.property("sign_in_provider")
           .equals(PROVIDER_CUSTOM);
+        expect(decoded!.payload.firebase).to.have.property("usage_mode").equals("passthrough");
         expect(decoded!.payload).deep.include(claims);
         return idToken;
       });

--- a/src/test/emulators/auth/deleteAccount.spec.ts
+++ b/src/test/emulators/auth/deleteAccount.spec.ts
@@ -126,18 +126,13 @@ describeAuthEmulator("accounts:delete", ({ authApi }) => {
       });
   });
 
-  it("should error on delete with localId if usageMode is passthrough", async () => {
-    const { localId, idToken } = await registerUser(authApi(), {
-      email: "alice@example.com",
-      password: "notasecret",
-    });
-    await deleteAccount(authApi(), { idToken });
+  it("should return not found on delete with localId if usageMode is passthrough", async () => {
     await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:delete")
       .set("Authorization", "Bearer owner")
-      .send({ localId })
+      .send({ localId: "does-not-exist" })
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equals("USER_NOT_FOUND");

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -85,30 +85,12 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
   it("should error on signInWithEmailLink if usageMode is passthrough", async () => {
     const user = { email: "bob@example.com", password: "notasecret" };
     const { oobCode } = await createEmailSignInOob(authApi(), user.email);
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
       .query({ key: "fake-api-key" })
       .send({ email: user.email, oobCode })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
-  });
-
-  it("should error on lookup if usageMode is passthrough", async () => {
-    const user = { email: "bob@example.com", password: "notasecret" };
-    const { idToken } = await registerUser(authApi(), user);
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:lookup")
-      .query({ key: "fake-api-key" })
-      .send({ idToken })
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error)

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -12,6 +12,8 @@ import {
   createEmailSignInOob,
   TEST_PHONE_NUMBER,
   TEST_MFA_INFO,
+  deleteAccount,
+  updateProjectConfig,
 } from "./helpers";
 
 describeAuthEmulator("email link sign-in", ({ authApi }) => {
@@ -78,6 +80,41 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
       "password",
       "emailLink",
     ]);
+  });
+
+  it("should error on signInWithEmailLink if usageMode is passthrough", async () => {
+    const user = { email: "bob@example.com", password: "notasecret" };
+    const { oobCode } = await createEmailSignInOob(authApi(), user.email);
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ email: user.email, oobCode })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
+  });
+
+  it("should error on lookup if usageMode is passthrough", async () => {
+    const user = { email: "bob@example.com", password: "notasecret" };
+    const { idToken } = await registerUser(authApi(), user);
+    await deleteAccount(authApi(), { idToken });
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:lookup")
+      .query({ key: "fake-api-key" })
+      .send({ idToken })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
   });
 
   it("should error on invalid oobCode", async () => {

--- a/src/test/emulators/auth/helpers.ts
+++ b/src/test/emulators/auth/helpers.ts
@@ -338,3 +338,15 @@ export function updateAccountByLocalId(
       expectStatusCode(200, res);
     });
 }
+
+export function deleteAccount(testAgent: TestAgent, reqBody: {}): Promise<string> {
+  return testAgent
+    .post("/identitytoolkit.googleapis.com/v1/accounts:delete")
+    .send(reqBody)
+    .query({ key: "fake-api-key" })
+    .then((res) => {
+      expectStatusCode(200, res);
+      expect(res.body).not.to.have.property("error");
+      return res.body.kind;
+    });
+}

--- a/src/test/emulators/auth/idp.spec.ts
+++ b/src/test/emulators/auth/idp.spec.ts
@@ -851,4 +851,24 @@ describeAuthEmulator("sign-in with credential", ({ authApi }) => {
         expect(res.body.localId).to.equal(localId);
       });
   });
+
+  it("should error if usageMode is passthrough", async () => {
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")
+      .query({ key: "fake-api-key" })
+      .send({
+        postBody: `providerId=google.com&id_token=${FAKE_GOOGLE_ACCOUNT.idToken}`,
+        requestUri: "http://localhost",
+        returnIdpCredential: true,
+        returnSecureToken: true,
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
+  });
 });

--- a/src/test/emulators/auth/idp.spec.ts
+++ b/src/test/emulators/auth/idp.spec.ts
@@ -853,7 +853,7 @@ describeAuthEmulator("sign-in with credential", ({ authApi }) => {
   });
 
   it("should error if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -432,6 +432,26 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
       });
   });
 
+  it("should default to DEFAULT usageMode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
+    await authApi()
+      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
+      .send({ usageMode: undefined })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body).to.have.property("usageMode").equals("DEFAULT");
+      });
+  });
+
+  it("should error for unspecified usageMode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
+    await authApi()
+      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
+      .send({ usageMode: "USAGE_MODE_UNSPECIFIED" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("Invalid usage mode provided");
+      });
+  });
+
   it("should error for invalid usageMode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
     await authApi()
       .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)

--- a/src/test/emulators/auth/oob.spec.ts
+++ b/src/test/emulators/auth/oob.spec.ts
@@ -214,7 +214,7 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
     const user = { email: "alice@example.com", password: "notasecret" };
     const { idToken } = await registerUser(authApi(), user);
     await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
@@ -332,7 +332,7 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
       });
     const oobs = await inspectOobs(authApi());
     await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:resetPassword")

--- a/src/test/emulators/auth/oob.spec.ts
+++ b/src/test/emulators/auth/oob.spec.ts
@@ -7,6 +7,8 @@ import {
   updateAccountByLocalId,
   expectIdTokenExpired,
   inspectOobs,
+  updateProjectConfig,
+  deleteAccount,
 } from "./helpers";
 
 describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
@@ -208,6 +210,24 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
     expect(oobs).to.have.length(0);
   });
 
+  it("should error if usageMode is passthrough", async () => {
+    const user = { email: "alice@example.com", password: "notasecret" };
+    const { idToken } = await registerUser(authApi(), user);
+    await deleteAccount(authApi(), { idToken });
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, requestType: "VERIFY_EMAIL" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
+  });
+
   it("should generate OOB code for reset password", async () => {
     const user = { email: "alice@example.com", password: "notasecret" };
     const { idToken } = await registerUser(authApi(), user);
@@ -297,5 +317,32 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
     // OOB codes are not consumed by the lookup above.
     const oobs2 = await inspectOobs(authApi());
     expect(oobs2).to.have.length(3);
+  });
+
+  it("should error on resetPassword endpoint if usageMode is passthrough", async () => {
+    const user = { email: "alice@example.com", password: "notasecret" };
+    const { idToken } = await registerUser(authApi(), user);
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({ requestType: "PASSWORD_RESET", email: user.email })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.email).to.equal(user.email);
+      });
+    const oobs = await inspectOobs(authApi());
+    await deleteAccount(authApi(), { idToken });
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:resetPassword")
+      .query({ key: "fake-api-key" })
+      .send({ oobCode: oobs[0].oobCode, newPassword: "notasecret2" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
   });
 });

--- a/src/test/emulators/auth/password.spec.ts
+++ b/src/test/emulators/auth/password.spec.ts
@@ -135,7 +135,7 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi }) => {
     const user = { email: "alice@example.com", password: "notasecret" };
     const { localId, idToken } = await registerUser(authApi(), user);
     await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")

--- a/src/test/emulators/auth/password.spec.ts
+++ b/src/test/emulators/auth/password.spec.ts
@@ -3,11 +3,12 @@ import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
 import { describeAuthEmulator } from "./setup";
 import {
+  deleteAccount,
   expectStatusCode,
   registerUser,
   TEST_MFA_INFO,
-  TEST_PHONE_NUMBER,
   updateAccountByLocalId,
+  updateProjectConfig,
 } from "./helpers";
 
 describeAuthEmulator("accounts:signInWithPassword", ({ authApi }) => {
@@ -127,6 +128,24 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(501, res);
         expect(res.body.error.message).to.equal("MFA Login not yet implemented.");
+      });
+  });
+
+  it("should error if usageMode is passthrough", async () => {
+    const user = { email: "alice@example.com", password: "notasecret" };
+    const { localId, idToken } = await registerUser(authApi(), user);
+    await deleteAccount(authApi(), { idToken });
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
+      .query({ key: "fake-api-key" })
+      .send({ email: user.email, password: user.password })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 });

--- a/src/test/emulators/auth/phone.spec.ts
+++ b/src/test/emulators/auth/phone.spec.ts
@@ -75,7 +75,7 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
 
   it("should error on sendVerificationMode if usageMode is passthrough", async () => {
     const phoneNumber = TEST_PHONE_NUMBER;
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     const sessionInfo = await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:sendVerificationCode")
@@ -357,7 +357,7 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
       });
     const codes = await inspectVerificationCodes(authApi());
     const code = codes[0].code;
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPhoneNumber")

--- a/src/test/emulators/auth/phone.spec.ts
+++ b/src/test/emulators/auth/phone.spec.ts
@@ -11,6 +11,7 @@ import {
   registerUser,
   TEST_MFA_INFO,
   TEST_PHONE_NUMBER,
+  updateProjectConfig,
 } from "./helpers";
 
 describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
@@ -69,6 +70,22 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
         expect(res.body.error)
           .to.have.property("message")
           .equals("INVALID_PHONE_NUMBER : Invalid format.");
+      });
+  });
+
+  it("should error on sendVerificationMode if usageMode is passthrough", async () => {
+    const phoneNumber = TEST_PHONE_NUMBER;
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    const sessionInfo = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendVerificationCode")
+      .query({ key: "fake-api-key" })
+      .send({ phoneNumber, recaptchaToken: "ignored" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 
@@ -325,6 +342,32 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equals("PHONE_NUMBER_EXISTS");
+      });
+  });
+
+  it("should error on signInWithPhoneNumber if usageMode is passthrough", async () => {
+    const phoneNumber = TEST_PHONE_NUMBER;
+    const sessionInfo = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendVerificationCode")
+      .query({ key: "fake-api-key" })
+      .send({ phoneNumber, recaptchaToken: "ignored" })
+      .then((res) => {
+        expectStatusCode(200, res);
+        return res.body.sessionInfo;
+      });
+    const codes = await inspectVerificationCodes(authApi());
+    const code = codes[0].code;
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPhoneNumber")
+      .query({ key: "fake-api-key" })
+      .send({ sessionInfo, code })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 });

--- a/src/test/emulators/auth/setAccountInfo.spec.ts
+++ b/src/test/emulators/auth/setAccountInfo.spec.ts
@@ -20,6 +20,8 @@ import {
   TEST_PHONE_NUMBER_2,
   TEST_PHONE_NUMBER_3,
   TEST_INVALID_PHONE_NUMBER,
+  deleteAccount,
+  updateProjectConfig,
 } from "./helpers";
 
 describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
@@ -1134,6 +1136,25 @@ describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error.message).to.equal("CLAIMS_TOO_LARGE");
+      });
+  });
+
+  it("should error if usageMode is passthrough", async () => {
+    const user = { email: "alice@example.com", password: "notasecret" };
+    const { idToken } = await registerUser(authApi(), user);
+    const newPassword = "notasecreteither";
+    await deleteAccount(authApi(), { idToken });
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, password: newPassword })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 });

--- a/src/test/emulators/auth/setAccountInfo.spec.ts
+++ b/src/test/emulators/auth/setAccountInfo.spec.ts
@@ -1144,7 +1144,7 @@ describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
     const { idToken } = await registerUser(authApi(), user);
     const newPassword = "notasecreteither";
     await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:update")

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -16,6 +16,7 @@ import {
   TEST_PHONE_NUMBER,
   TEST_PHONE_NUMBER_2,
   TEST_INVALID_PHONE_NUMBER,
+  updateProjectConfig,
 } from "./helpers";
 
 describeAuthEmulator("accounts:signUp", ({ authApi }) => {
@@ -514,5 +515,20 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
     expect(savedMfaInfo).to.include(TEST_MFA_INFO);
     expect(savedMfaInfo.mfaEnrollmentId).to.be.a("string").and.not.empty;
     expect([mfaEnrollmentId1, mfaEnrollmentId2]).not.to.include(savedMfaInfo.mfaEnrollmentId);
+  });
+
+  it("should error on signInWithPhoneNumber if usageMode is passthrough", async () => {
+    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .send({ returnSecureToken: true })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
   });
 });

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -517,8 +517,8 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
     expect([mfaEnrollmentId1, mfaEnrollmentId2]).not.to.include(savedMfaInfo.mfaEnrollmentId);
   });
 
-  it("should error on signInWithPhoneNumber if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { signIn: { usageMode: "PASSTHROUGH" } });
+  it("should error on signUp if usageMode is passthrough", async () => {
+    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Added UsageMode to ProjectState. When usage mode is set to PASSTHROUGH, Auth endpoints will throw UNSUPPORTED_PASSTHROUGH_OPERATION error. This error is thrown before any other checks are performed. Toggling the usage mode can be done by hitting the endpoint: `/emulator/v1/projects/{targetProjectId}/config`.

Corresponding internal bug: b/192387797

**Some things to highlight:**
1. Left out assert for emulator endpoints

2. For updateEmulatorProjectConfig(), setting the default behavior to error if providing a string that does not map to one of the UsageMode enums; LMK if it would make more sense to default to "DEFAULT"

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

`npm test` passes

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

N/A

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
