### PR TITLE
Add retries for Docker APIs

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -24,6 +24,7 @@ module.exports = {
     "@typescript-eslint",
   ],
   rules: {
-    quotes: ["error", "double"],
+    "quotes": ["error", "double"],
+    "import/no-unresolved": 0,
   },
 };


### PR DESCRIPTION
Blind attempt to fix #3639 before I get debug logs.

Normally I'd worry that we hit a rate limit, but according to [docs](https://cloud.google.com/container-registry/quotas) the rate limit is 50K requests per 10m. Even with an API this chatty it's unlikely to hit the limit...

Without knowing any more info, we can realize that an API as chatty as Docker is likely to fail just through statistics. Deleting 15 functions would probably require 60-75 API calls. If gcr.io is a 3-9s service, that's a 6% chance of failure.
