### PR TITLE
Track functions deploys

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -96,6 +96,29 @@ export function isEventTrigger(trigger: HttpsTrigger | EventTrigger): trigger is
   return "eventType" in trigger;
 }
 
+/** Friendly name to label a function in stats */
+export function triggerTag(fn: FunctionSpec) {
+  if (fn.labels?.["deployment-scheduled"]) {
+    if (fn.platform === "gcfv1") {
+      return "v1.scheduled";
+    }
+    return "v2.scheduled";
+  }
+  if (fn.labels?.["deployment-callable"]) {
+    if (fn.platform === "gcfv1") {
+      return "v1.callable";
+    }
+    return "v2.callable";
+  }
+  if (!isEventTrigger(fn.trigger)) {
+    if (fn.platform === "gcfv1") {
+      return "v1.https";
+    }
+    return "v2.https";
+  }
+  return fn.trigger.eventType;
+}
+
 // TODO(inlined): Enum types should be singularly named
 export type VpcEgressSettings = "PRIVATE_RANGES_ONLY" | "ALL_TRAFFIC";
 export type IngressSettings = "ALLOW_ALL" | "ALLOW_INTERNAL_ONLY" | "ALLOW_INTERNAL_AND_GCLB";

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -97,7 +97,7 @@ export function isEventTrigger(trigger: HttpsTrigger | EventTrigger): trigger is
 }
 
 /** Friendly name to label a function in stats */
-export function triggerTag(fn: FunctionSpec) {
+export function triggerTag(fn: FunctionSpec): string {
   if (fn.labels?.["deployment-scheduled"]) {
     if (fn.platform === "gcfv1") {
       return "v1.scheduled";
@@ -124,6 +124,7 @@ export type VpcEgressSettings = "PRIVATE_RANGES_ONLY" | "ALL_TRAFFIC";
 export type IngressSettings = "ALLOW_ALL" | "ALLOW_INTERNAL_ONLY" | "ALLOW_INTERNAL_AND_GCLB";
 export type MemoryOptions = 128 | 256 | 512 | 1024 | 2048 | 4096 | 8192;
 
+/** Returns a human-readable name with MB or GB suffix for a MemoryOption (MB). */
 export function memoryOptionDisplayName(option: MemoryOptions): string {
   return {
     128: "128MB",

--- a/src/deploy/functions/deploymentTimer.ts
+++ b/src/deploy/functions/deploymentTimer.ts
@@ -13,10 +13,10 @@ export class DeploymentTimer {
     this.timings[name] = { type: type, t0: process.hrtime() };
   }
 
-  endTimer(name: string) {
+  endTimer(name: string): number {
     if (!this.timings[name]) {
       logger.debug("[functions] no timer initialized for", name);
-      return;
+      return 0;
     }
 
     // hrtime returns a duration as an array of [seconds, nanos]
@@ -26,5 +26,7 @@ export class DeploymentTimer {
       this.timings[name].type,
       duration[0] * 1000 + Math.round(duration[1] * 1e-6)
     );
+
+    return duration[0] * 1000 * Math.round(duration[1] * 1e-6);
   }
 }

--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -129,7 +129,6 @@ export async function getRuntimeDelegate(
   }
 
   throw new FirebaseError(
-    "Could not detect language for functions at",
-    options.config.get("functions.source")
+    `Could not detect language for functions at ${options.config.get("functions.source")}`
   );
 }

--- a/src/deploy/functions/tasks.ts
+++ b/src/deploy/functions/tasks.ts
@@ -18,7 +18,7 @@ import * as helper from "./functionsDeployHelper";
 import * as pubsub from "../../gcp/pubsub";
 import * as utils from "../../utils";
 import { FirebaseError } from "../../error";
-import { cloudfunctions } from "../../gcp";
+import { track } from "../../track";
 
 interface PollerOptions {
   apiOrigin: string;
@@ -53,9 +53,9 @@ export type OperationType =
   | "delete topic"
   | "make public";
 
-export interface DeploymentTask {
+export interface DeploymentTask<T> {
   run: () => Promise<void>;
-  fn: backend.TargetIds;
+  data: T;
   operationType: OperationType;
 }
 
@@ -75,7 +75,7 @@ export function createFunctionTask(
   fn: backend.FunctionSpec,
   sourceToken?: string,
   onPoll?: (op: OperationResult<backend.FunctionSpec>) => void
-): DeploymentTask {
+): DeploymentTask<backend.FunctionSpec> {
   const fnName = backend.functionName(fn);
   const run = async () => {
     utils.logBullet(
@@ -145,7 +145,7 @@ export function createFunctionTask(
   };
   return {
     run,
-    fn,
+    data: fn,
     operationType: "create",
   };
 }
@@ -155,7 +155,7 @@ export function updateFunctionTask(
   fn: backend.FunctionSpec,
   sourceToken?: string,
   onPoll?: (op: OperationResult<gcf.CloudFunction>) => void
-): DeploymentTask {
+): DeploymentTask<backend.FunctionSpec> {
   const fnName = backend.functionName(fn);
   const run = async () => {
     utils.logBullet(
@@ -205,12 +205,15 @@ export function updateFunctionTask(
   };
   return {
     run,
-    fn,
+    data: fn,
     operationType: "update",
   };
 }
 
-export function deleteFunctionTask(params: TaskParams, fn: backend.FunctionSpec): DeploymentTask {
+export function deleteFunctionTask(
+  params: TaskParams,
+  fn: backend.FunctionSpec
+): DeploymentTask<backend.FunctionSpec> {
   const fnName = backend.functionName(fn);
   const run = async () => {
     utils.logBullet(
@@ -234,7 +237,7 @@ export function deleteFunctionTask(params: TaskParams, fn: backend.FunctionSpec)
   };
   return {
     run,
-    fn,
+    data: fn,
     operationType: "delete",
   };
 }
@@ -265,22 +268,25 @@ async function setConcurrency(name: string, concurrency: number) {
 export function functionsDeploymentHandler(
   timer: DeploymentTimer,
   errorHandler: ErrorHandler
-): (task: DeploymentTask) => Promise<any | undefined> {
-  return async (task: DeploymentTask) => {
+): (task: DeploymentTask<backend.FunctionSpec>) => Promise<any | undefined> {
+  return async (task: DeploymentTask<backend.FunctionSpec>) => {
     let result;
-    const fnName = backend.functionName(task.fn);
+    const fnName = backend.functionName(task.data);
     try {
       timer.startTimer(fnName, task.operationType);
       result = await task.run();
-      helper.printSuccess(task.fn, task.operationType);
+      helper.printSuccess(task.data, task.operationType);
+      const duration = timer.endTimer(fnName);
+      track("function_deploy_success", backend.triggerTag(task.data), duration);
     } catch (err) {
       if (err.original?.context?.response?.statusCode === 429) {
         // Throw quota errors so that throttler retries them.
         throw err;
       }
       errorHandler.record("error", fnName, task.operationType, err.original?.message || "");
+      const duration = timer.endTimer(fnName);
+      track("function_deploy_failure", backend.triggerTag(task.data), duration);
     }
-    timer.endTimer(fnName);
     return result;
   };
 }
@@ -292,7 +298,7 @@ export async function runRegionalFunctionDeployment(
   params: TaskParams,
   region: string,
   regionalDeployment: RegionalFunctionChanges,
-  queue: Queue<DeploymentTask, void>
+  queue: Queue<DeploymentTask<backend.FunctionSpec>, void>
 ): Promise<void> {
   let resolveToken: (token: string | undefined) => void;
   const getRealToken = new Promise<string | undefined>((resolve) => (resolveToken = resolve));
@@ -324,7 +330,7 @@ export async function runRegionalFunctionDeployment(
       ...(functionSpec.labels || {}),
       ...deploymentTool.labels(),
     };
-    let task: DeploymentTask;
+    let task: DeploymentTask<backend.FunctionSpec>;
     // GCF v2 doesn't support tokens yet. If we were to pass onPoll to a GCFv2 function, then
     // it would complete deployment and resolve the getRealToken promies as undefined.
     if (functionSpec.platform == "gcfv2") {
@@ -371,14 +377,14 @@ export function upsertScheduleTask(
   params: TaskParams,
   schedule: backend.ScheduleSpec,
   appEngineLocation: string
-): DeploymentTask {
+): DeploymentTask<backend.ScheduleSpec> {
   const run = async () => {
     const job = cloudscheduler.jobFromSpec(schedule, appEngineLocation);
     await cloudscheduler.createOrReplaceJob(job);
   };
   return {
     run,
-    fn: schedule.targetService,
+    data: schedule,
     operationType: "upsert schedule",
   };
 }
@@ -387,36 +393,39 @@ export function deleteScheduleTask(
   params: TaskParams,
   schedule: backend.ScheduleSpec,
   appEngineLocation: string
-): DeploymentTask {
+): DeploymentTask<backend.ScheduleSpec> {
   const run = async () => {
     const jobName = backend.scheduleName(schedule, appEngineLocation);
     await cloudscheduler.deleteJob(jobName);
   };
   return {
     run,
-    fn: schedule.targetService,
+    data: schedule,
     operationType: "delete schedule",
   };
 }
 
-export function deleteTopicTask(params: TaskParams, topic: backend.PubSubSpec): DeploymentTask {
+export function deleteTopicTask(
+  params: TaskParams,
+  topic: backend.PubSubSpec
+): DeploymentTask<backend.PubSubSpec> {
   const run = async () => {
     const topicName = backend.topicName(topic);
     await pubsub.deleteTopic(topicName);
   };
   return {
     run,
-    fn: topic.targetService,
+    data: topic,
     operationType: "delete topic",
   };
 }
 
 export const schedulerDeploymentHandler = (errorHandler: ErrorHandler) => async (
-  task: DeploymentTask
+  task: DeploymentTask<backend.ScheduleSpec | backend.PubSubSpec>
 ): Promise<void> => {
   try {
     const result = await task.run();
-    helper.printSuccess(task.fn, task.operationType);
+    helper.printSuccess(task.data.targetService, task.operationType);
     return result;
   } catch (err) {
     if (err.status === 429) {
@@ -426,7 +435,7 @@ export const schedulerDeploymentHandler = (errorHandler: ErrorHandler) => async 
       // Ignore 404 errors from scheduler calls since they may be deleted out of band.
       errorHandler.record(
         "error",
-        backend.functionName(task.fn),
+        backend.functionName(task.data.targetService),
         task.operationType,
         err.message || ""
       );

--- a/src/functionsDelete.ts
+++ b/src/functionsDelete.ts
@@ -14,17 +14,17 @@ export async function deleteFunctions(
 ): Promise<void> {
   const timer = new DeploymentTimer();
   const errorHandler = new ErrorHandler();
-  const cloudFunctionsQueue = new Queue<tasks.DeploymentTask, void>({
+  const cloudFunctionsQueue = new Queue<tasks.DeploymentTask<backend.FunctionSpec>, void>({
     handler: tasks.functionsDeploymentHandler(timer, errorHandler),
     retries: 30,
     backoff: 10000,
     concurrency: 40,
     maxBackoff: 40000,
   });
-  const schedulerQueue = new Queue<tasks.DeploymentTask, void>({
+  const schedulerQueue = new Queue<tasks.DeploymentTask<backend.ScheduleSpec>, void>({
     handler: tasks.schedulerDeploymentHandler(errorHandler),
   });
-  const topicQueue = new Queue<tasks.DeploymentTask, void>({
+  const topicQueue = new Queue<tasks.DeploymentTask<backend.PubSubSpec>, void>({
     handler: tasks.schedulerDeploymentHandler(errorHandler),
   });
 

--- a/src/test/deploy/functions/backend.spec.ts
+++ b/src/test/deploy/functions/backend.spec.ts
@@ -147,6 +147,122 @@ describe("Backend", () => {
     });
   });
 
+  describe("triggerTag", () => {
+    it("detects v1.https", () => {
+      expect(
+        backend.triggerTag({
+          ...FUNCTION_NAME,
+          platform: "gcfv1",
+          entryPoint: "id",
+          runtime: "node14",
+          trigger: {
+            allowInsecure: false,
+          },
+        })
+      ).to.equal("v1.https");
+    });
+
+    it("detects v2.https", () => {
+      expect(
+        backend.triggerTag({
+          ...FUNCTION_NAME,
+          platform: "gcfv2",
+          entryPoint: "id",
+          runtime: "node14",
+          trigger: {
+            allowInsecure: false,
+          },
+        })
+      ).to.equal("v2.https");
+    });
+
+    it("detects v1.callable", () => {
+      expect(
+        backend.triggerTag({
+          ...FUNCTION_NAME,
+          platform: "gcfv1",
+          entryPoint: "id",
+          runtime: "node14",
+          trigger: {
+            allowInsecure: false,
+          },
+          labels: {
+            "deployment-callable": "true",
+          },
+        })
+      ).to.equal("v1.callable");
+    });
+
+    it("detects v2.callable", () => {
+      expect(
+        backend.triggerTag({
+          ...FUNCTION_NAME,
+          platform: "gcfv2",
+          entryPoint: "id",
+          runtime: "node14",
+          trigger: {
+            allowInsecure: false,
+          },
+          labels: {
+            "deployment-callable": "true",
+          },
+        })
+      ).to.equal("v2.callable");
+    });
+
+    it("detects v1.scheduled", () => {
+      expect(
+        backend.triggerTag({
+          ...FUNCTION_NAME,
+          platform: "gcfv1",
+          entryPoint: "id",
+          runtime: "node14",
+          trigger: {
+            eventType: "google.pubsub.topoic.publish",
+            eventFilters: {},
+            retry: false,
+          },
+          labels: {
+            "deployment-scheduled": "true",
+          },
+        })
+      ).to.equal("v1.scheduled");
+    });
+
+    it("detects v2.scheduled", () => {
+      expect(
+        backend.triggerTag({
+          ...FUNCTION_NAME,
+          platform: "gcfv2",
+          entryPoint: "id",
+          runtime: "node14",
+          trigger: {
+            allowInsecure: false,
+          },
+          labels: {
+            "deployment-scheduled": "true",
+          },
+        })
+      ).to.equal("v2.scheduled");
+    });
+
+    it("detects others", () => {
+      expect(
+        backend.triggerTag({
+          ...FUNCTION_NAME,
+          platform: "gcfv2",
+          entryPoint: "id",
+          runtime: "node14",
+          trigger: {
+            eventType: "google.pubsub.topic.publish",
+            eventFilters: {},
+            retry: false,
+          },
+        })
+      ).to.equal("google.pubsub.topic.publish");
+    });
+  });
+
   describe("existing backend", () => {
     let listAllFunctions: sinon.SinonStub;
     let listAllFunctionsV2: sinon.SinonStub;

--- a/src/track.js
+++ b/src/track.js
@@ -23,7 +23,7 @@ visitor.set("cd1", process.platform); // Platform
 visitor.set("cd2", process.version); // NodeVersion
 visitor.set("cd3", process.env.FIREPIT_VERSION || "none"); // FirepitVersion
 
-module.exports = function (action, label, duration) {
+function track(action, label, duration) {
   return new Promise(function (resolve) {
     if (!_.isString(action) || !_.isString(label)) {
       logger.debug("track received non-string arguments:", action, label);
@@ -40,4 +40,9 @@ module.exports = function (action, label, duration) {
       resolve();
     }
   });
-};
+}
+
+// New code should import track by name so that it can be stubbed
+// in unit tests. Legacy code still imports as default.
+track.track = track;
+module.exports = track;


### PR DESCRIPTION
Per offline conversation, this now tracks individual function deploy timing by trigger "tag".

We also track overall codebase deploys, tagged by API type.