### PR TITLE
Revert "Remove import eslint module"

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -22,6 +22,7 @@ module.exports = {
   ],
   plugins: [
     "@typescript-eslint",
+    "import",
   ],
   rules: {
     quotes: ["error", "double"],


### PR DESCRIPTION
This reverts commit 413fbc46d8641da2d9e96f8561ccb1cbe46976d9.

Per offline conversation, I'm going to reenable the imports linter and add dummy files in the SDK to silence the linter.