### PR TITLE
Increase timeout on detectFromPort to reduce flakes.

### DIFF
--- a/src/test/deploy/functions/runtimes/discovery/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/index.spec.ts
@@ -126,12 +126,12 @@ describe("detectFromPort", () => {
         port,
         "project",
         "nodejs14",
-        /* timeout= */ 9_500
+        /* timeout= */ 15_500
       );
       expect(parsed).to.deep.equal(BACKEND);
     } finally {
       child.kill("SIGKILL");
     }
     await exit;
-  }).timeout(10_000);
+  }).timeout(20_000);
 });


### PR DESCRIPTION
detectFromPort test reliably fails in Cloud Build environment. Increasing timeout to compensate.