### PR TITLE
Don't require trivial @returns per style guide

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
 
         // Google style guide allows us to omit trivial parameters and returns
         "jsdoc/require-param": "off",
-        "jsdoc/require-return": "off",
+        "jsdoc/require-returns": "off",
 
         "no-invalid-this": "off", // Turned off in favor of @typescript-eslint/no-invalid-this.
         "@typescript-eslint/no-invalid-this": ["error"],


### PR DESCRIPTION
Linter had a typo in the rule name. it's "returns" not "return" per https://github.com/gajus/eslint-plugin-jsdoc/blob/master/.README/rules/require-returns.md
