### PR TITLE
Set maximum backoff to 10s for OperationPoller

### DIFF
--- a/src/operation-poller.ts
+++ b/src/operation-poller.ts
@@ -13,7 +13,8 @@ export interface OperationPollerOptions {
 }
 
 const DEFAULT_INITIAL_BACKOFF_DELAY_MILLIS = 250;
-const DEFAULT_MASTER_TIMEOUT_MILLIS = 30000;
+const MAX_BACKOFF_MILLIS = 10_000;
+const DEFAULT_MASTER_TIMEOUT_MILLIS = 30_000;
 
 export interface OperationResult<T> {
   done?: boolean;
@@ -39,6 +40,7 @@ export class OperationPoller<T> {
       name: options.pollerName || "LRO Poller",
       concurrency: 1,
       retries: Number.MAX_SAFE_INTEGER,
+      maxBackoff: MAX_BACKOFF_MILLIS,
       backoff: options.backoff || DEFAULT_INITIAL_BACKOFF_DELAY_MILLIS,
     });
 


### PR DESCRIPTION
Previously it used 60s (which is the default).

This change doesn't make much of a difference when using the default timeout of 30s, but for longer timeouts it still makes sense to poll frequently to minimize excessive delays for interactive (human) users.
