### PR TITLE
Make max backoff configurable in OperationPoller

### DIFF
--- a/src/operation-poller.ts
+++ b/src/operation-poller.ts
@@ -8,6 +8,7 @@ export interface OperationPollerOptions {
   apiVersion: string;
   operationResourceName: string;
   backoff?: number;
+  maxBackoff?: number;
   masterTimeout?: number;
   onPoll?: (operation: OperationResult<any>) => any;
 }
@@ -39,6 +40,7 @@ export class OperationPoller<T> {
       name: options.pollerName || "LRO Poller",
       concurrency: 1,
       retries: Number.MAX_SAFE_INTEGER,
+      maxBackoff: options.maxBackoff,
       backoff: options.backoff || DEFAULT_INITIAL_BACKOFF_DELAY_MILLIS,
     });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

https://github.com/firebase/firebase-tools/pull/3670 uses the OperationPoller to poll for the status of an uploaded distribution. The default 60 second max backoff is too long for this purpose, since customers could have to wait up to an additional minute while their binary is processed: https://github.com/firebase/firebase-tools/blob/037b7ea3499a2a7b4aed8ea6b248be977491027a/src/throttler/throttler.ts#L77

Making this parameter configurable is a precondition to shipping that PR.

This is a replacement for https://github.com/firebase/firebase-tools/pull/3685 which set the max backoff to 10 seconds globally. This leaves the default as 60 seconds and therefore does not change any existing behavior.

### Scenarios Tested

Tested project creation, which uses the OperationPoller:

```
firebase projects:create lee-tests-project-creation --folder 261046259366
```
