### PR TITLE
Fix bug where ESM module load fails on windows.

### DIFF
--- a/src/deploy/functions/runtimes/node/triggerParser.js
+++ b/src/deploy/functions/runtimes/node/triggerParser.js
@@ -2,6 +2,7 @@
 // from a functions package directory.
 "use strict";
 
+var url = require("url");
 var extractTriggers = require("./extractTriggers");
 var EXIT = function () {
   process.exit(0);
@@ -21,8 +22,10 @@ async function loadModule(packageDir) {
     return require(packageDir);
   } catch (e) {
     if (e.code === "ERR_REQUIRE_ESM") {
-      const mod = await dynamicImport(require.resolve(packageDir));
-      return mod;
+      const modulePath = require.resolve(packageDir);
+      // Resolve module path to file:// URL. Required for windows support.
+      const moduleURL = url.pathToFileURL(modulePath).href;
+      return await dynamicImport(moduleURL);
     }
     throw e;
   }


### PR DESCRIPTION
Patch allows Windows users to deploy Firebase Functions packaged as ES module.

We apply the same fix we made for Windows ES module support in the Functions Emulator (https://github.com/firebase/firebase-tools/pull/3574) to the triggerParser script t
Fixes https://github.com/firebase/firebase-tools/issues/3689