### PR TITLE
Check for and display CHANGELOG.md during ext:dev:publish

### DIFF
--- a/src/extensions/changelog.ts
+++ b/src/extensions/changelog.ts
@@ -109,11 +109,11 @@ export function parseChangelog(rawChangelog: string): Record<string, string> {
     const matches = line.match(VERSION_LINE_REGEX);
     if (matches) {
       currentVersion = matches[1]; // The first capture group is the SemVer.
-    } else {
+    } else if (currentVersion) {
       // Throw away lines that aren't under a specific version.
-      if (currentVersion && !changelog[currentVersion]) {
+      if (!changelog[currentVersion]) {
         changelog[currentVersion] = line;
-      } else if (currentVersion) {
+      } else {
         changelog[currentVersion] += `\n${line}`;
       }
     }

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -393,7 +393,6 @@ export async function publishExtensionVersionFromLocalSource(
   );
   validateSpec(subbedSpec);
 
-  
   const consent = await confirmExtensionVersion(publisherId, extensionId, extensionSpec.version);
   if (!consent) {
     return;

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -4,6 +4,11 @@ import * as ora from "ora";
 import * as semver from "semver";
 import * as marked from "marked";
 
+const TerminalRenderer = require("marked-terminal");
+marked.setOptions({
+  renderer: new TerminalRenderer(),
+});
+
 import { storageOrigin } from "../api";
 import { archiveDirectory } from "../archiveDirectory";
 import { convertOfficialExtensionsToList } from "./utils";
@@ -29,6 +34,7 @@ import { getLocalExtensionSpec } from "./localHelper";
 import { promptOnce } from "../prompt";
 import { logger } from "../logger";
 import { envOverride } from "../utils";
+import { getLocalChangelog, parseChangelog } from "./changelog";
 
 /**
  * SpecParamType represents the exact strings that the extensions
@@ -393,16 +399,44 @@ export async function publishExtensionVersionFromLocalSource(
   );
   validateSpec(subbedSpec);
 
-  const consent = await confirmExtensionVersion(publisherId, extensionId, extensionSpec.version);
-  if (!consent) {
-    return;
-  }
-
   let extension;
   try {
     extension = await getExtension(`${publisherId}/${extensionId}`);
   } catch (err) {
     // Silently fail and continue the publish flow if extension not found.
+  }
+
+  let notes: string;
+  try {
+    const changes = getLocalChangelog(rootDirectory);
+    notes = changes[extensionSpec.version];
+  } catch (err) {
+    throw new FirebaseError(
+      "No CHANGELOG.md file found. " +
+        "Please create one and add an entry for this version. " +
+        marked(
+          "See https://firebase.google.com/docs/extensions/alpha/create-user-docs#writing-changelog for more details."
+        )
+    );
+  }
+  if (!notes && extension) {
+    // If this is not the first version of this extension, we require release notes
+    throw new FirebaseError(
+      `No entry for version ${extensionSpec.version} found in CHANGELOG.md. ` +
+        "Please add one so users know what has changed in this version. " +
+        marked(
+          "See https://firebase.google.com/docs/extensions/alpha/create-user-docs#writing-changelog for more details."
+        )
+    );
+  }
+  const consent = await confirmExtensionVersion(
+    publisherId,
+    extensionId,
+    extensionSpec.version,
+    notes
+  );
+  if (!consent) {
+    return;
   }
 
   if (
@@ -554,12 +588,16 @@ export async function getExtensionSourceFromName(extensionName: string): Promise
 export async function confirmExtensionVersion(
   publisherId: string,
   extensionId: string,
-  versionId: string
+  versionId: string,
+  releaseNotes?: string
 ): Promise<boolean> {
+  const releaseNotesMessage = releaseNotes
+    ? ` Release notes for this version:\n${marked(releaseNotes)}\n`
+    : "\n";
   const message =
     `You are about to publish version ${clc.green(versionId)} of ${clc.green(
       `${publisherId}/${extensionId}`
-    )} to Firebase's registry of extensions.\n\n` +
+    )} to Firebase's registry of extensions.${releaseNotesMessage}` +
     "Once an extension version is published, it cannot be changed. If you wish to make changes after publishing, you will need to publish a new version.\n\n" +
     "Do you wish to continue?";
   return await promptOnce({

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -393,6 +393,7 @@ export async function publishExtensionVersionFromLocalSource(
   );
   validateSpec(subbedSpec);
 
+  
   const consent = await confirmExtensionVersion(publisherId, extensionId, extensionSpec.version);
   if (!consent) {
     return;

--- a/src/extensions/localHelper.ts
+++ b/src/extensions/localHelper.ts
@@ -9,8 +9,6 @@ import { logger } from "../logger";
 
 const EXTENSIONS_SPEC_FILE = "extension.yaml";
 const EXTENSIONS_PREINSTALL_FILE = "PREINSTALL.md";
-const EXTENSIONS_CHANGELOG = "CHANGELOG.md";
-const VERSION_LINE_REGEX = /##.*(\d+\.\d+\.\d+).*/
 
 /**
  * Retrieves and parses an ExtensionSpec from a local directory
@@ -25,37 +23,6 @@ export async function getLocalExtensionSpec(directory: string): Promise<Extensio
     logger.debug(`No PREINSTALL.md found in directory ${directory}.`);
   }
   return spec;
-}
-
-/**
- * getLocalChangelog checks directory for a CHANGELOG.md, and parses it into a map of
- * version to release notes for that version.
- * @param directory The directory to check for
- * @returns 
- */
-export async function getLocalChangelog(directory: string): Promise<Record<string, string>> {
-  const rawChangelog = readFile(path.resolve(directory, EXTENSIONS_CHANGELOG));
-  return parseChangelog(rawChangelog);
-}
-
-// Exported for testing.
-export function parseChangelog(rawChangelog: string): Record<string,string> {
-  const changelog: Record<string, string> = {};
-  let currentVersion = "";
-  for (const line of rawChangelog.split("\n")) {
-    const matches = line.match(VERSION_LINE_REGEX);
-    if (matches) {
-      currentVersion = matches[1]; // The first capture group is the SemVer.
-    } else {
-      // Throw away lines that aren't under a specific version.
-      if (currentVersion && !changelog[currentVersion]) {
-        changelog[currentVersion] = line
-      } else {
-        changelog[currentVersion] += `\n${line}`
-      }
-    }
-  }
-  return changelog;
 }
 
 /**

--- a/src/test/extensions/changelog.spec.ts
+++ b/src/test/extensions/changelog.spec.ts
@@ -26,7 +26,7 @@ function testExtensionVersion(
   };
 }
 
-describe("changelog", () => {
+describe.only("changelog", () => {
   describe("GetReleaseNotesForUpdate", () => {
     let listExtensionVersionStub: sinon.SinonStub;
 
@@ -104,6 +104,38 @@ describe("changelog", () => {
     for (const testCase of testCases) {
       it(testCase.description, () => {
         const got = changelog.breakingChangesInUpdate(testCase.in);
+
+        expect(got).to.deep.equal(testCase.want);
+      });
+    }
+  });
+
+  describe("parseChangelog", () => {
+    const testCases: {
+      description: string;
+      in: string;
+      want: Record<string, string>;
+    }[] = [
+      {
+        description: "should split changelog by version",
+        in: "## Version 0.1.0\nNotes\n## Version 0.1.1\nNew notes",
+        want: {
+          "0.1.0": "Notes",
+          "0.1.1": "New notes",
+        },
+      },
+      {
+        description: "should ignore text not in a version",
+        in: "Some random words\n## Version 0.1.0\nNotes\n## Version 0.1.1\nNew notes",
+        want: {
+          "0.1.0": "Notes",
+          "0.1.1": "New notes",
+        },
+      },
+    ];
+    for (const testCase of testCases) {
+      it(testCase.description, () => {
+        const got = changelog.parseChangelog(testCase.in);
 
         expect(got).to.deep.equal(testCase.want);
       });

--- a/src/test/extensions/changelog.spec.ts
+++ b/src/test/extensions/changelog.spec.ts
@@ -26,7 +26,7 @@ function testExtensionVersion(
   };
 }
 
-describe.only("changelog", () => {
+describe("changelog", () => {
   describe("GetReleaseNotesForUpdate", () => {
     let listExtensionVersionStub: sinon.SinonStub;
 


### PR DESCRIPTION
### Description
Check for and display CHANGELOG.md during ext:dev:publish.

### Scenarios Tested
Show release notes for the version being released:
<img width="1041" alt="Screen Shot 2021-08-19 at 3 08 35 PM" src="https://user-images.githubusercontent.com/4635763/130152728-19445b63-97be-44a8-b371-1ed6e5e05dcc.png">
Release notes not required for first version of a new extension (but will be displayed if they are there)
<img width="1064" alt="Screen Shot 2021-08-19 at 3 34 14 PM" src="https://user-images.githubusercontent.com/4635763/130153023-4e74b3be-89dc-454d-84b1-4b8befb70793.png">
Error if release notes for the latest version are missing:
<img width="1118" alt="Screen Shot 2021-08-19 at 3 09 53 PM" src="https://user-images.githubusercontent.com/4635763/130153091-0a863019-978b-48f1-998c-6cb050350957.png">
Error if CHANGELOG.md doesn't exist:
<img width="1130" alt="Screen Shot 2021-08-19 at 3 11 53 PM" src="https://user-images.githubusercontent.com/4635763/130153115-2b7e7b96-519b-4e79-acc3-3fa28a41a930.png">

