### PR TITLE
OnRequest Access Policy Invoker - move inside trigger block

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -45,6 +45,7 @@ export interface ScheduleSpec {
 /** API agnostic version of a Cloud Function's HTTPs trigger. */
 export interface HttpsTrigger {
   allowInsecure: boolean;
+  invoker?: string[];
 }
 
 /** Well known keys in the eventFilter attribute of an event trigger */
@@ -175,7 +176,6 @@ export interface FunctionSpec extends TargetIds {
   vpcConnectorEgressSettings?: VpcEgressSettings;
   ingressSettings?: IngressSettings;
   serviceAccountEmail?: "default" | string;
-  invoker?: string[];
 
   // Output only:
 

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -51,7 +51,6 @@ function tryValidate(typed: backend.Backend) {
       environmentVariables: "omit",
       uri: "omit",
       sourceUploadUrl: "omit",
-      invoker: "array",
     });
     if (backend.isEventTrigger(func.trigger)) {
       requireKeys(prefix + ".trigger", func.trigger, "eventType", "eventFilters");
@@ -65,6 +64,7 @@ function tryValidate(typed: backend.Backend) {
     } else {
       assertKeyTypes(prefix + ".trigger", func.trigger, {
         allowInsecure: "boolean",
+        invoker: "array",
       });
     }
   }

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -45,6 +45,7 @@ export interface TriggerAnnotation {
   serviceAccountEmail?: string;
   httpsTrigger?: {
     allowInsecure?: boolean;
+    invoker?: string[];
   };
   eventTrigger?: {
     eventType: string;
@@ -57,7 +58,6 @@ export interface TriggerAnnotation {
   timeZone?: string;
   regions?: string[];
   concurrency?: number;
-  invoker?: string[];
 }
 
 /**
@@ -164,6 +164,7 @@ export function addResourcesToBackend(
       if (annotation.failurePolicy) {
         logger.warn(`Ignoring retry policy for HTTPS function ${annotation.name}`);
       }
+      proto.copyIfPresent(trigger, annotation.httpsTrigger, "invoker", "invoker");
     } else {
       trigger = {
         eventType: annotation.eventTrigger!.eventType,
@@ -203,8 +204,7 @@ export function addResourcesToBackend(
       "timeout",
       "maxInstances",
       "minInstances",
-      "availableMemoryMb",
-      "invoker"
+      "availableMemoryMb"
     );
 
     if (annotation.schedule) {

--- a/src/deploy/functions/tasks.ts
+++ b/src/deploy/functions/tasks.ts
@@ -121,7 +121,7 @@ export function createFunctionTask(
       onPoll,
     });
     if (!backend.isEventTrigger(fn.trigger)) {
-      const invoker = fn.invoker || ["public"];
+      const invoker = fn.trigger.invoker || ["public"];
       if (invoker[0] !== "private") {
         try {
           if (fn.platform === "gcfv1") {
@@ -192,13 +192,13 @@ export function updateFunctionTask(
       onPoll,
     };
     const cloudFunction = await pollOperation<unknown>(pollerOptions);
-    if (!backend.isEventTrigger(fn.trigger) && fn.invoker) {
+    if (!backend.isEventTrigger(fn.trigger) && fn.trigger.invoker) {
       try {
         if (fn.platform === "gcfv1") {
-          await gcf.setInvokerUpdate(params.projectId, fnName, fn.invoker);
+          await gcf.setInvokerUpdate(params.projectId, fnName, fn.trigger.invoker);
         } else {
           const serviceName = (cloudFunction as gcfV2.CloudFunction).serviceConfig.service!;
-          cloudrun.setInvokerUpdate(params.projectId, serviceName, fn.invoker);
+          cloudrun.setInvokerUpdate(params.projectId, serviceName, fn.trigger.invoker);
         }
       } catch (err) {
         params.errorHandler.record("error", fnName, "set invoker", err.message);

--- a/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -89,7 +89,6 @@ describe("backendFromV1Alpha1", () => {
         vpcConnectorEgressSettings: {},
         labels: "yes",
         ingressSettings: true,
-        invoker: true,
       };
       for (const [key, value] of Object.entries(invalidFunctionEntries)) {
         it(`invalid value for CloudFunction key ${key}`, () => {

--- a/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -118,7 +118,9 @@ describe("addResourcesToBackend", () => {
   it("should copy fields", () => {
     const trigger: parseTriggers.TriggerAnnotation = {
       ...BASIC_TRIGGER,
-      httpsTrigger: {},
+      httpsTrigger: {
+        invoker: ["public"],
+      },
       maxInstances: 42,
       minInstances: 1,
       serviceAccountEmail: "inlined@google.com",
@@ -129,7 +131,6 @@ describe("addResourcesToBackend", () => {
       labels: {
         test: "testing",
       },
-      invoker: ["public"],
     };
 
     const result = backend.empty();
@@ -142,6 +143,7 @@ describe("addResourcesToBackend", () => {
           ...BASIC_FUNCTION,
           trigger: {
             allowInsecure: true,
+            invoker: ["public"],
           },
           maxInstances: 42,
           minInstances: 1,
@@ -153,7 +155,6 @@ describe("addResourcesToBackend", () => {
           labels: {
             test: "testing",
           },
-          invoker: ["public"],
         },
       ],
     };


### PR DESCRIPTION
### Description

This is the CLI change that corresponds with [#960](https://github.com/firebase/firebase-functions/pull/960). This change moves the `invoker` into the `HttpsTrigger` type from the root `FunctionSpec`.

### Scenarios Tested

- Parsing trigger correctly

### Sample Commands

`firebase deploy --only functions`
