### PR TITLE
adds withForce to command, to standardize the --force flag

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -77,6 +77,17 @@ export class Command {
   }
 
   /**
+   * Sets up --force flag for the command.
+   *
+   * @param message overrides the description for --force for this command
+   * @returns the command, for chaining
+   */
+  withForce(message?: string): Command {
+    this.options.push(["-f, --force", message || "automatically accept all interactive prompts"]);
+    return this;
+  }
+
+  /**
    * Attaches a function to run before the command's action function.
    * @param fn the function to run.
    * @param args arguments, as an array, for the function.

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -40,12 +40,11 @@ const TARGET_PERMISSIONS = {
 
 module.exports = new Command("deploy")
   .description("deploy code and assets to your Firebase project")
-  .option("-p, --public <path>", "override the Hosting public directory specified in firebase.json")
-  .option("-m, --message <message>", "an optional message describing this deploy")
-  .option(
-    "-f, --force",
+  .withForce(
     "delete Cloud Functions missing from the current working directory without confirmation"
   )
+  .option("-p, --public <path>", "override the Hosting public directory specified in firebase.json")
+  .option("-m, --message <message>", "an optional message describing this deploy")
   .option(
     "--only <targets>",
     'only deploy to specified, comma-separated targets (e.g. "hosting,storage"). For functions, ' +

--- a/src/commands/emulators-export.ts
+++ b/src/commands/emulators-export.ts
@@ -4,6 +4,6 @@ import * as commandUtils from "../emulator/commandUtils";
 
 module.exports = new Command("emulators:export <path>")
   .description("export data from running emulators")
+  .withForce("overwrite any export data in the target directory")
   .option(commandUtils.FLAG_ONLY, commandUtils.DESC_ONLY)
-  .option("--force", "Overwrite any export data in the target directory.")
   .action(controller.exportEmulatorData);

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -42,7 +42,7 @@ function consoleUninstallOnly(projectId: string, instanceId: string): Promise<vo
 
 export default new Command("ext:uninstall <extensionInstanceId>")
   .description("uninstall an extension that is installed in your Firebase project by instance ID")
-  .option("-f, --force", "No confirmation. Otherwise, a confirmation prompt will appear.")
+  .withForce()
   .before(requirePermissions, ["firebaseextensions.instances.delete"])
   .before(ensureExtensionsApiEnabled)
   .before(checkMinRequiredVersion, "extMinVersion")

--- a/src/commands/functions-delete.ts
+++ b/src/commands/functions-delete.ts
@@ -18,7 +18,7 @@ export default new Command("functions:delete [filters...]")
     "Specify region of the function to be deleted. " +
       "If omitted, functions from all regions whose names match the filters will be deleted. "
   )
-  .option("-f, --force", "No confirmation. Otherwise, a confirmation prompt will appear.")
+  .withForce()
   .before(requirePermissions, ["cloudfunctions.functions.list", "cloudfunctions.functions.delete"])
   .action(async (filters: string[], options: { force: boolean; region?: string } & Options) => {
     if (!filters.length) {

--- a/src/commands/hosting-channel-delete.ts
+++ b/src/commands/hosting-channel-delete.ts
@@ -13,8 +13,8 @@ import { logger } from "../logger";
 
 export default new Command("hosting:channel:delete <channelId>")
   .description("delete a Firebase Hosting channel")
+  .withForce()
   .option("--site <siteId>", "site in which the channel exists")
-  .option("-f, --force", "delete without confirmation")
   .before(requireConfig)
   .before(requirePermissions, ["firebasehosting.sites.update"])
   .before(requireHostingSite)

--- a/src/commands/hosting-sites-delete.ts
+++ b/src/commands/hosting-sites-delete.ts
@@ -13,7 +13,7 @@ const LOG_TAG = "hosting:sites";
 
 export default new Command("hosting:sites:delete <siteId>")
   .description("delete a Firebase Hosting site")
-  .option("-f, --force", "delete without confirmation")
+  .withForce()
   .before(requireConfig)
   .before(requirePermissions, ["firebasehosting.sites.delete"])
   .action(

--- a/src/commands/remoteconfig-rollback.ts
+++ b/src/commands/remoteconfig-rollback.ts
@@ -18,7 +18,7 @@ module.exports = new Command("remoteconfig:rollback")
     "-v, --version-number <versionNumber>",
     "rollback to the specified version of the template"
   )
-  .option("--force", "rollback template to the specified version without confirmation")
+  .withForce()
   .action(async (options) => {
     const templateVersion = await getVersions(needProjectId(options), 1);
     let targetVersion = 0;

--- a/src/test/command.spec.ts
+++ b/src/test/command.spec.ts
@@ -14,7 +14,8 @@ describe("Command", () => {
   it("should allow all basic behavior", () => {
     expect(() => {
       command.description("description!");
-      command.option("-f, --foobar", "description", "value");
+      command.option("-x, --foobar", "description", "value");
+      command.withForce();
       command.before(
         (arr: string[]) => {
           return arr;


### PR DESCRIPTION
### Description
Adds command.withForce(), which standardizes the `--force` flag.

### Scenarios Tested
ext:uninstall (with the default message):
<img width="612" alt="Screen Shot 2021-08-23 at 3 14 33 PM" src="https://user-images.githubusercontent.com/4635763/130526821-e5995d03-f0e5-4fd6-898f-68f4c9cd5d3c.png">
deploy (with a custom message):
<img width="1124" alt="Screen Shot 2021-08-23 at 3 10 58 PM" src="https://user-images.githubusercontent.com/4635763/130526855-cd7497d8-58b2-440a-8eb6-ada6b1e71f23.png">

