### PR TITLE
Fix bug where dotenv file using quotes greedily consumes values.

### DIFF
--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -40,19 +40,19 @@ const RESERVED_KEYS = [
 //   https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/parser.rb
 // prettier-ignore
 const LINE_RE = new RegExp(
-  "^" +                    // begin line
-  "\\s*" +                 //   leading whitespaces
-  "(\\w+)" +               //   key
-  "\\s*=\\s*" +            //   separator (=)
-  "(" +                    //   begin optional value
-  "\\s*'(?:\\'|[^'])*'|" + //     single quoted or
-  '\\s*"(?:\\"|[^"])*"|' + //     double quoted or
-  "[^\\#\\r\\n]+" +        //     unquoted
-  ")?" +                   //   end optional value
-  "\\s*" +                 //   trailing whitespaces
-  "(?:#[^\\n]*)?" +        //   optional comment
-  "$",                     // end line
-  "gms"                    // flags: global, multiline, dotall
+  "^" +                      // begin line
+  "\\s*" +                   //   leading whitespaces
+  "(\\w+)" +                 //   key
+  "\\s*=\\s*" +              //   separator (=)
+  "(" +                      //   begin optional value
+  "\\s*'(?:\\\\'|[^'])*'|" + //     single quoted or
+  '\\s*"(?:\\\\"|[^"])*"|' + //     double quoted or
+  "[^\\#\\r\\n]+" +          //     unquoted
+  ")?" +                     //   end optional value
+  "\\s*" +                   //   trailing whitespaces
+  "(?:#[^\\n]*)?" +          //   optional comment
+  "$",                       // end line
+  "gms"                      // flags: global, multiline, dotall
 );
 
 interface ParseResult {

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -35,6 +35,21 @@ BAR=bar
         want: { FOO: "foo1\nfoo2", BAR: "bar" },
       },
       {
+        description: "should parse many double quoted values",
+        input: 'FOO="foo"\nBAR="bar"',
+        want: { FOO: "foo", BAR: "bar" },
+      },
+      {
+        description: "should parse many single quoted values",
+        input: "FOO='foo'\nBAR='bar'",
+        want: { FOO: "foo", BAR: "bar" },
+      },
+      {
+        description: "should parse mix of double and single quoted values",
+        input: `FOO="foo"\nBAR='bar'`,
+        want: { FOO: "foo", BAR: "bar" },
+      },
+      {
         description: "should parse double quoted with escaped newlines",
         input: 'FOO="foo1\\nfoo2"\nBAR=bar',
         want: { FOO: "foo1\nfoo2", BAR: "bar" },


### PR DESCRIPTION
Our parser for dotenv file format allows values to be wrapped inside single or double quotes.

The regex we have for parsing these value is too greedy as implemented:

```
# .env
A="abc"
B="efg"
```

```
parse(readFileSync(".env"))
=> { A: 'abc\nB="efg"' }
```

The change in regex correctly parses the dotenv file:

```
parse(readFileSync(".env"))
=> { A: "abc", B: "efg"  }
```
