### PR TITLE
fix: correct typo in operationType

### DIFF
--- a/src/deploy/functions/deploymentPlanner.ts
+++ b/src/deploy/functions/deploymentPlanner.ts
@@ -16,7 +16,7 @@ export interface RegionalFunctionChanges {
 
 export interface DeploymentPlan {
   regionalDeployments: Record<string, RegionalFunctionChanges>;
-  schedulesToUpsert: backend.ScheduleSpec[];
+  schedulesToUpdate: backend.ScheduleSpec[];
   schedulesToDelete: backend.ScheduleSpec[];
 
   // NOTE(inlined):
@@ -131,7 +131,7 @@ export function createDeploymentPlan(
 ): DeploymentPlan {
   const deployment: DeploymentPlan = {
     regionalDeployments: {},
-    schedulesToUpsert: [],
+    schedulesToUpdate: [],
     schedulesToDelete: [],
     topicsToDelete: [],
   };
@@ -144,7 +144,7 @@ export function createDeploymentPlan(
     deployment.regionalDeployments[region] = calculateRegionalFunctionChanges(want, have, options);
   }
 
-  deployment.schedulesToUpsert = want.schedules.filter((schedule) =>
+  deployment.schedulesToUpdate = want.schedules.filter((schedule) =>
     functionMatchesAnyGroup(schedule.targetService, options.filters)
   );
   deployment.schedulesToDelete = have.schedules

--- a/src/deploy/functions/release.ts
+++ b/src/deploy/functions/release.ts
@@ -106,8 +106,8 @@ export async function release(context: args.Context, options: Options, payload: 
     );
   }
 
-  for (const schedule of fullDeployment.schedulesToUpsert) {
-    const task = tasks.upsertScheduleTask(taskParams, schedule, appEngineLocation);
+  for (const schedule of fullDeployment.schedulesToUpdate) {
+    const task = tasks.updateScheduleTask(taskParams, schedule, appEngineLocation);
     void schedulerQueue.run(task);
   }
   for (const schedule of fullDeployment.schedulesToDelete) {

--- a/src/deploy/functions/tasks.ts
+++ b/src/deploy/functions/tasks.ts
@@ -48,7 +48,7 @@ export type OperationType =
   | "create"
   | "update"
   | "delete"
-  | "upsert schedule"
+  | "update schedule"
   | "delete schedule"
   | "delete topic"
   | "set invoker";
@@ -386,7 +386,7 @@ export async function runRegionalFunctionDeployment(
  * Cloud Scheduler Deployments Tasks and Handler
  */
 
-export function upsertScheduleTask(
+export function updateScheduleTask(
   params: TaskParams,
   schedule: backend.ScheduleSpec,
   appEngineLocation: string
@@ -398,7 +398,7 @@ export function upsertScheduleTask(
   return {
     run,
     data: schedule,
-    operationType: "upsert schedule",
+    operationType: "update schedule",
   };
 }
 

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1402,7 +1402,7 @@ function signInWithIdp(
         lastLoginAt: Date.now().toString(),
       },
       {
-        upsertProviders: [providerUserInfo],
+        updateProviders: [providerUserInfo],
       }
     );
   }
@@ -1989,7 +1989,7 @@ function fakeFetchUserInfoFromIdp(
 
 interface AccountUpdates {
   fields?: Omit<Partial<UserInfo>, "localId" | "providerUserInfo">;
-  upsertProviders?: ProviderUserInfo[];
+  updateProviders?: ProviderUserInfo[];
   deleteProviders?: string[];
 }
 

--- a/src/test/deploy/functions/deploymentPlanner.spec.ts
+++ b/src/test/deploy/functions/deploymentPlanner.spec.ts
@@ -100,7 +100,7 @@ describe("deploymentPlanner", () => {
           },
         },
         topicsToDelete: [],
-        schedulesToUpsert: [],
+        schedulesToUpdate: [],
         schedulesToDelete: [],
       };
       expect(deploymentPlan).to.deep.equal(expected);
@@ -147,7 +147,7 @@ describe("deploymentPlanner", () => {
           },
         },
         topicsToDelete: [],
-        schedulesToUpsert: [],
+        schedulesToUpdate: [],
         schedulesToDelete: [],
       };
     });
@@ -189,7 +189,7 @@ describe("deploymentPlanner", () => {
           },
         },
         topicsToDelete: [],
-        schedulesToUpsert: [],
+        schedulesToUpdate: [],
         schedulesToDelete: [],
       };
       expect(deploymentPlan).to.deep.equal(expected);
@@ -251,7 +251,7 @@ describe("deploymentPlanner", () => {
             functionsToDelete: [],
           },
         },
-        schedulesToUpsert: [r1sched1, r1sched2, r2sched1],
+        schedulesToUpdate: [r1sched1, r1sched2, r2sched1],
         schedulesToDelete: [],
         topicsToDelete: [],
       };
@@ -309,7 +309,7 @@ describe("deploymentPlanner", () => {
             functionsToDelete: [],
           },
         },
-        schedulesToUpsert: [],
+        schedulesToUpdate: [],
         schedulesToDelete: [],
         topicsToDelete: [],
       };
@@ -356,7 +356,7 @@ describe("deploymentPlanner", () => {
             functionsToDelete: [f1],
           },
         },
-        schedulesToUpsert: [],
+        schedulesToUpdate: [],
         schedulesToDelete: [schedule1, schedule2],
         topicsToDelete: [topic1],
       };
@@ -416,7 +416,7 @@ describe("deploymentPlanner", () => {
             functionsToDelete: [group1func3, group1func4],
           },
         },
-        schedulesToUpsert: [group1schedule1],
+        schedulesToUpdate: [group1schedule1],
         schedulesToDelete: [group1schedule3],
         topicsToDelete: [group1topic3],
       };

--- a/src/test/deploy/functions/tasks.spec.ts
+++ b/src/test/deploy/functions/tasks.spec.ts
@@ -155,7 +155,7 @@ describe("Function Deployment tasks", () => {
       const testTask: tasks.DeploymentTask<backend.ScheduleSpec> = {
         run,
         data: SCHEDULE,
-        operationType: "upsert schedule",
+        operationType: "update schedule",
       };
 
       const handler = tasks.schedulerDeploymentHandler(errorHandlerStub);
@@ -174,7 +174,7 @@ describe("Function Deployment tasks", () => {
       const testTask: tasks.DeploymentTask<backend.ScheduleSpec> = {
         run,
         data: SCHEDULE,
-        operationType: "upsert schedule",
+        operationType: "update schedule",
       };
 
       const handler = tasks.schedulerDeploymentHandler(errorHandlerStub);
@@ -193,7 +193,7 @@ describe("Function Deployment tasks", () => {
       const testTask: tasks.DeploymentTask<backend.ScheduleSpec> = {
         run,
         data: SCHEDULE,
-        operationType: "upsert schedule",
+        operationType: "update schedule",
       };
 
       const handler = tasks.schedulerDeploymentHandler(errorHandlerStub);
@@ -213,7 +213,7 @@ describe("Function Deployment tasks", () => {
       const testTask: tasks.DeploymentTask<backend.ScheduleSpec> = {
         run,
         data: SCHEDULE,
-        operationType: "upsert schedule",
+        operationType: "upate schedule",
       };
 
       const handler = tasks.schedulerDeploymentHandler(errorHandlerStub);
@@ -223,7 +223,7 @@ describe("Function Deployment tasks", () => {
       expect(errorHandlerStub.record).to.have.been.calledWith(
         "error",
         functionName,
-        "upsert schedule"
+        "update schedule"
       );
     });
   });


### PR DESCRIPTION
### Description

This simply fixes a typo that caught my eye. The firebase cli said 'upsert' instead of 'update' when updating a schedule.
