### PR TITLE
Fixes error when passing project number as flag.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,3 @@
 - `ext:update` now displays release notes for the new Extension Version.
 - `ext:dev:publish` now checks for a CHANGELOG.md file.
 - Fixes error when using a project number as the `--project` flag.
-- 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Adds support for the `nodejs16` runtime for Cloud Functions.
+- Fixes error when using a project number as the `--project` flag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - `ext:update` now displays release notes for the new Extension Version.
 - `ext:dev:publish` now checks for a CHANGELOG.md file.
 - Fixes error when using a project number as the `--project` flag.
+- 

--- a/src/command.ts
+++ b/src/command.ts
@@ -12,6 +12,7 @@ import track = require("./track");
 import clc = require("cli-color");
 import { selectAccount, setActiveAccount } from "./auth";
 import { getFirebaseProject } from "./management/projects";
+import { requireAuth } from "./requireAuth";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type ActionFunction = (...args: any[]) => any;
@@ -256,13 +257,6 @@ export class Command {
       options.configError = e;
     }
 
-    options.projectRoot = detectProjectRoot(options);
-    this.applyRC(options);
-    if (options.project) {
-      await this.resolveProjectIdentifiers(options);
-      validateProjectId(options.projectId);
-    }
-
     const account = getInheritedOption(options, "account");
     options.account = account;
 
@@ -271,6 +265,13 @@ export class Command {
 
     if (activeAccount) {
       setActiveAccount(options, activeAccount);
+    }
+
+    options.projectRoot = detectProjectRoot(options);
+    this.applyRC(options);
+    if (options.project) {
+      await this.resolveProjectIdentifiers(options);
+      validateProjectId(options.projectId);
     }
   }
 
@@ -307,6 +308,7 @@ export class Command {
     projectNumber?: string;
   }): Promise<void> {
     if (options.project?.match(/^\d+$/)) {
+      await requireAuth(options);
       const { projectId, projectNumber } = await getFirebaseProject(options.project);
       options.projectId = projectId;
       options.projectNumber = projectNumber;

--- a/src/test/command.spec.ts
+++ b/src/test/command.spec.ts
@@ -100,7 +100,7 @@ describe("Command", () => {
         })
         .runner();
 
-      const result = await run({ project: "12345678" });
+      const result = await run({ project: "12345678", token: "thisisatoken" });
       expect(result).to.deep.eq({
         projectId: "resolved-project",
         projectNumber: "12345678",


### PR DESCRIPTION
Needed a little order change in `prepare()` but otherwise not too bad. Fixes #3717 

/cc @kaibolay 