### PR TITLE
Fix adding testers from a file

### DIFF
--- a/src/commands/appdistribution-testers-add.ts
+++ b/src/commands/appdistribution-testers-add.ts
@@ -13,7 +13,7 @@ module.exports = new Command("appdistribution:testers:add [emails...]")
   .action(async (emails: string[], options?: any) => {
     const projectName = await getProjectName(options);
     const appDistroClient = new AppDistributionClient();
-    const emailsArr = getEmails(emails, options.file);
-    utils.logBullet(`Adding ${emailsArr.length} testers to project`);
-    await appDistroClient.addTesters(projectName, emails);
+    const emailsToAdd = getEmails(emails, options.file);
+    utils.logBullet(`Adding ${emailsToAdd.length} testers to project`);
+    await appDistroClient.addTesters(projectName, emailsToAdd);
   });


### PR DESCRIPTION
Figured I'd try and fix this since it was probably something simple. Confirmed that this fixes it:

```
$ firebase appdistribution:testers:add --file testers.txt --project ...
i  Adding 3 testers to project
✔  Testers created successfully
```

This was the error: http://go/paste/6521938970148864