### PR TITLE
Add MFA support for Auth Emulator

### DIFF
--- a/src/emulator/auth/apiSpec.js
+++ b/src/emulator/auth/apiSpec.js
@@ -2981,6 +2981,52 @@ export default {
   },
   components: {
     schemas: {
+      GoogleCloudIdentitytoolkitV1Argon2Parameters: {
+        description: "The parameters for Argon2 hashing algorithm.",
+        properties: {
+          associatedData: {
+            description:
+              "The additional associated data, if provided, is appended to the hash value to provide an additional layer of security. A base64-encoded string if specified via JSON.",
+            format: "byte",
+            type: "string",
+          },
+          hashLengthBytes: {
+            description:
+              "Required. The desired hash length in bytes. Minimum is 4 and maximum is 1024.",
+            format: "int32",
+            type: "integer",
+          },
+          hashType: {
+            description: "Required. Must not be HASH_TYPE_UNSPECIFIED.",
+            enum: ["HASH_TYPE_UNSPECIFIED", "ARGON2_D", "ARGON2_ID", "ARGON2_I"],
+            type: "string",
+          },
+          iterations: {
+            description:
+              "Required. The number of iterations to perform. Minimum is 1, maximum is 16.",
+            format: "int32",
+            type: "integer",
+          },
+          memoryCostKib: {
+            description: "Required. The memory cost in kibibytes. Maximum is 32768.",
+            format: "int32",
+            type: "integer",
+          },
+          parallelism: {
+            description:
+              "Required. The degree of parallelism, also called threads or lanes. Minimum is 1, maximum is 16.",
+            format: "int32",
+            type: "integer",
+          },
+          version: {
+            description:
+              "The version of the Argon2 algorithm. This defaults to VERSION_13 if not specified.",
+            enum: ["VERSION_UNSPECIFIED", "VERSION_10", "VERSION_13"],
+            type: "string",
+          },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitV1AutoRetrievalInfo: {
         description: "The information required to auto-retrieve an SMS.",
         properties: {
@@ -4784,6 +4830,9 @@ export default {
               "Whether to overwrite an existing account in Identity Platform with a matching `local_id` in the request. If true, the existing account will be overwritten. If false, an error will be returned.",
             type: "boolean",
           },
+          argon2Parameters: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitV1Argon2Parameters",
+          },
           blockSize: {
             description:
               "The block size parameter used by the STANDARD_SCRYPT hashing function. This parameter, along with parallelization and cpu_mem_cost help tune the resources needed to hash a password, and should be tuned as processor speeds and memory technologies advance.",
@@ -4810,7 +4859,7 @@ export default {
           },
           hashAlgorithm: {
             description:
-              "Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT",
+              "Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT * ARGON2",
             type: "string",
           },
           memoryCost: {
@@ -5200,6 +5249,17 @@ export default {
         },
         type: "object",
       },
+      GoogleCloudIdentitytoolkitAdminV2Inheritance: {
+        description: "Settings that the tenants will inherit from project level.",
+        properties: {
+          emailSendingConfig: {
+            description:
+              "Whether to allow the tenant to inherit custom domains, email templates, and custom SMTP settings. If true, email sent from tenant will follow the project level email sending configurations. If false (by default), emails will go with the default settings with no customizations.",
+            type: "boolean",
+          },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitAdminV2ListDefaultSupportedIdpConfigsResponse: {
         description: "Response for DefaultSupportedIdpConfigs",
         properties: {
@@ -5332,7 +5392,7 @@ export default {
       },
       GoogleCloudIdentitytoolkitAdminV2OAuthResponseType: {
         description:
-          "The multiple response type to request for in the OAuth authorization flow. This can possibly be a combination of set bits (e.g. {id_token, token}).",
+          "The response type to request for in the OAuth authorization flow. You can set either `id_token` or `code` to true, but not both. Setting both types to be simultaneously true (`{code: true, id_token: true}`) is not yet supported. See https://openid.net/specs/openid-connect-core-1_0.html#Authentication for a mapping of response type to OAuth 2.0 flow.",
         properties: {
           code: {
             description:
@@ -5344,7 +5404,7 @@ export default {
             type: "boolean",
           },
           token: {
-            description: "If true, access token is returned from IdP's authorization endpoint.",
+            description: "Do not use. The `token` response type is not supported at the moment.",
             type: "boolean",
           },
         },
@@ -5404,6 +5464,9 @@ export default {
             type: "boolean",
           },
           hashConfig: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2HashConfig" },
+          inheritance: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Inheritance",
+          },
           mfaConfig: {
             $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig",
           },
@@ -5731,7 +5794,7 @@ export default {
       },
       GoogleIamV1Policy: {
         description:
-          'An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members` to a single `role`. Members can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** { "bindings": [ { "role": "roles/resourcemanager.organizationAdmin", "members": [ "user:mike@example.com", "group:admins@example.com", "domain:google.com", "serviceAccount:my-project-id@appspot.gserviceaccount.com" ] }, { "role": "roles/resourcemanager.organizationViewer", "members": [ "user:eve@example.com" ], "condition": { "title": "expirable access", "description": "Does not grant access after Sep 2020", "expression": "request.time < timestamp(\'2020-10-01T00:00:00.000Z\')", } } ], "etag": "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp(\'2020-10-01T00:00:00.000Z\') - etag: BwWWja0YfJA= - version: 3 For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).',
+          'An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members` to a single `role`. Members can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** { "bindings": [ { "role": "roles/resourcemanager.organizationAdmin", "members": [ "user:mike@example.com", "group:admins@example.com", "domain:google.com", "serviceAccount:my-project-id@appspot.gserviceaccount.com" ] }, { "role": "roles/resourcemanager.organizationViewer", "members": [ "user:eve@example.com" ], "condition": { "title": "expirable access", "description": "Does not grant access after Sep 2020", "expression": "request.time < timestamp(\'2020-10-01T00:00:00.000Z\')", } } ], "etag": "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp(\'2020-10-01T00:00:00.000Z\') etag: BwWWja0YfJA= version: 3 For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).',
         properties: {
           auditConfigs: {
             description: "Specifies cloud audit logging configuration for this policy.",
@@ -6069,7 +6132,7 @@ export default {
             authorizationUrl: "https://accounts.google.com/o/oauth2/auth",
             scopes: {
               "https://www.googleapis.com/auth/cloud-platform":
-                "See, edit, configure, and delete your Google Cloud Platform data",
+                "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account.",
               "https://www.googleapis.com/auth/firebase":
                 "View and administer all your Firebase data and settings",
             },
@@ -6079,7 +6142,7 @@ export default {
             tokenUrl: "https://accounts.google.com/o/oauth2/token",
             scopes: {
               "https://www.googleapis.com/auth/cloud-platform":
-                "See, edit, configure, and delete your Google Cloud Platform data",
+                "See, edit, configure, and delete your Google Cloud data and see the email address for your Google Account.",
               "https://www.googleapis.com/auth/firebase":
                 "View and administer all your Firebase data and settings",
             },

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -919,8 +919,6 @@ export function setAccountInfoImpl(
   const unimplementedFields: (keyof typeof reqBody)[] = [
     "provider",
     "upgradeToFederatedLogin",
-    "captchaChallenge",
-    "captchaResponse",
     "linkProviderUserInfo",
   ];
   for (const field of unimplementedFields) {
@@ -1531,7 +1529,6 @@ function signInWithPhoneNumber(
   }
 
   let user = state.getUserByPhoneNumber(phoneNumber);
-  // TODO: Throw if account has MFA enabled.
   let isNewUser = false;
   const updates = {
     phoneNumber,

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -612,8 +612,10 @@ function getProjects(
   return {
     projectId: state.projectNumber,
     authorizedDomains: [
+      // This list is just a placeholder -- the JS SDK will NOT validate the
+      // domain at all when connecting to the emulator. Google-internal context:
+      // http://go/firebase-auth-emulator-dd#heading=h.3r9cilur7s46
       "localhost",
-      // TODO: Shall we allow more domains?
     ],
   };
 }

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -10,6 +10,39 @@
 export interface components {
   schemas: {
     /**
+     * The parameters for Argon2 hashing algorithm.
+     */
+    GoogleCloudIdentitytoolkitV1Argon2Parameters: {
+      /**
+       * The additional associated data, if provided, is appended to the hash value to provide an additional layer of security. A base64-encoded string if specified via JSON.
+       */
+      associatedData?: string;
+      /**
+       * Required. The desired hash length in bytes. Minimum is 4 and maximum is 1024.
+       */
+      hashLengthBytes?: number;
+      /**
+       * Required. Must not be HASH_TYPE_UNSPECIFIED.
+       */
+      hashType?: "HASH_TYPE_UNSPECIFIED" | "ARGON2_D" | "ARGON2_ID" | "ARGON2_I";
+      /**
+       * Required. The number of iterations to perform. Minimum is 1, maximum is 16.
+       */
+      iterations?: number;
+      /**
+       * Required. The memory cost in kibibytes. Maximum is 32768.
+       */
+      memoryCostKib?: number;
+      /**
+       * Required. The degree of parallelism, also called threads or lanes. Minimum is 1, maximum is 16.
+       */
+      parallelism?: number;
+      /**
+       * The version of the Argon2 algorithm. This defaults to VERSION_13 if not specified.
+       */
+      version?: "VERSION_UNSPECIFIED" | "VERSION_10" | "VERSION_13";
+    };
+    /**
      * The information required to auto-retrieve an SMS.
      */
     GoogleCloudIdentitytoolkitV1AutoRetrievalInfo: {
@@ -1614,6 +1647,7 @@ export interface components {
        * Whether to overwrite an existing account in Identity Platform with a matching `local_id` in the request. If true, the existing account will be overwritten. If false, an error will be returned.
        */
       allowOverwrite?: boolean;
+      argon2Parameters?: components["schemas"]["GoogleCloudIdentitytoolkitV1Argon2Parameters"];
       /**
        * The block size parameter used by the STANDARD_SCRYPT hashing function. This parameter, along with parallelization and cpu_mem_cost help tune the resources needed to hash a password, and should be tuned as processor speeds and memory technologies advance.
        */
@@ -1631,7 +1665,7 @@ export interface components {
        */
       dkLen?: number;
       /**
-       * Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT
+       * Required. The hashing function used to hash the account passwords. Must be one of the following: * HMAC_SHA256 * HMAC_SHA1 * HMAC_MD5 * SCRYPT * PBKDF_SHA1 * MD5 * HMAC_SHA512 * SHA1 * BCRYPT * PBKDF2_SHA256 * SHA256 * SHA512 * STANDARD_SCRYPT * ARGON2
        */
       hashAlgorithm?: string;
       /**
@@ -1968,6 +2002,15 @@ export interface components {
       spConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SpConfig"];
     };
     /**
+     * Settings that the tenants will inherit from project level.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Inheritance: {
+      /**
+       * Whether to allow the tenant to inherit custom domains, email templates, and custom SMTP settings. If true, email sent from tenant will follow the project level email sending configurations. If false (by default), emails will go with the default settings with no customizations.
+       */
+      emailSendingConfig?: boolean;
+    };
+    /**
      * Response for DefaultSupportedIdpConfigs
      */
     GoogleCloudIdentitytoolkitAdminV2ListDefaultSupportedIdpConfigsResponse: {
@@ -2076,7 +2119,7 @@ export interface components {
       responseType?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2OAuthResponseType"];
     };
     /**
-     * The multiple response type to request for in the OAuth authorization flow. This can possibly be a combination of set bits (e.g. {id_token, token}).
+     * The response type to request for in the OAuth authorization flow. You can set either `id_token` or `code` to true, but not both. Setting both types to be simultaneously true (`{code: true, id_token: true}`) is not yet supported. See https://openid.net/specs/openid-connect-core-1_0.html#Authentication for a mapping of response type to OAuth 2.0 flow.
      */
     GoogleCloudIdentitytoolkitAdminV2OAuthResponseType: {
       /**
@@ -2088,7 +2131,7 @@ export interface components {
        */
       idToken?: boolean;
       /**
-       * If true, access token is returned from IdP's authorization endpoint.
+       * Do not use. The `token` response type is not supported at the moment.
        */
       token?: boolean;
     };
@@ -2147,6 +2190,7 @@ export interface components {
        */
       enableEmailLinkSignin?: boolean;
       hashConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2HashConfig"];
+      inheritance?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Inheritance"];
       mfaConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig"];
       /**
        * Output only. Resource name of a tenant. For example: "projects/{project-id}/tenants/{tenant-id}"
@@ -2429,7 +2473,7 @@ export interface components {
       requestedPolicyVersion?: number;
     };
     /**
-     * An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members` to a single `role`. Members can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** { "bindings": [ { "role": "roles/resourcemanager.organizationAdmin", "members": [ "user:mike@example.com", "group:admins@example.com", "domain:google.com", "serviceAccount:my-project-id@appspot.gserviceaccount.com" ] }, { "role": "roles/resourcemanager.organizationViewer", "members": [ "user:eve@example.com" ], "condition": { "title": "expirable access", "description": "Does not grant access after Sep 2020", "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } ], "etag": "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') - etag: BwWWja0YfJA= - version: 3 For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).
+     * An Identity and Access Management (IAM) policy, which specifies access controls for Google Cloud resources. A `Policy` is a collection of `bindings`. A `binding` binds one or more `members` to a single `role`. Members can be user accounts, service accounts, Google groups, and domains (such as G Suite). A `role` is a named list of permissions; each `role` can be an IAM predefined role or a user-created custom role. For some types of Google Cloud resources, a `binding` can also specify a `condition`, which is a logical expression that allows access to a resource only if the expression evaluates to `true`. A condition can add constraints based on attributes of the request, the resource, or both. To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies). **JSON example:** { "bindings": [ { "role": "roles/resourcemanager.organizationAdmin", "members": [ "user:mike@example.com", "group:admins@example.com", "domain:google.com", "serviceAccount:my-project-id@appspot.gserviceaccount.com" ] }, { "role": "roles/resourcemanager.organizationViewer", "members": [ "user:eve@example.com" ], "condition": { "title": "expirable access", "description": "Does not grant access after Sep 2020", "expression": "request.time < timestamp('2020-10-01T00:00:00.000Z')", } } ], "etag": "BwWWja0YfJA=", "version": 3 } **YAML example:** bindings: - members: - user:mike@example.com - group:admins@example.com - domain:google.com - serviceAccount:my-project-id@appspot.gserviceaccount.com role: roles/resourcemanager.organizationAdmin - members: - user:eve@example.com role: roles/resourcemanager.organizationViewer condition: title: expirable access description: Does not grant access after Sep 2020 expression: request.time < timestamp('2020-10-01T00:00:00.000Z') etag: BwWWja0YfJA= version: 3 For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).
      */
     GoogleIamV1Policy: {
       /**

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -381,7 +381,7 @@ export class ProjectState {
       secondFactor,
     }: {
       extraClaims?: Record<string, unknown>;
-      secondFactor?: { identifier: string; provider: string };
+      secondFactor?: SecondFactorRecord;
     } = {}
   ): string {
     const localId = userInfo.localId;
@@ -403,7 +403,7 @@ export class ProjectState {
         user: UserInfo;
         provider: string;
         extraClaims: Record<string, unknown>;
-        secondFactor?: { identifier: string; provider: string };
+        secondFactor?: SecondFactorRecord;
       }
     | undefined {
     const record = this.refreshTokens.get(refreshToken);
@@ -580,7 +580,12 @@ interface RefreshTokenRecord {
   localId: string;
   provider: string;
   extraClaims: Record<string, unknown>;
-  secondFactor?: { identifier: string; provider: string };
+  secondFactor?: SecondFactorRecord;
+}
+
+export interface SecondFactorRecord {
+  identifier: string;
+  provider: string;
 }
 
 export type OobRequestType = NonNullable<

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -8,12 +8,13 @@ import {
 import { MakeRequired } from "./utils";
 import { AuthCloudFunction } from "./cloudFunctions";
 import { assert } from "./errors";
-import { MfaEnrollment, MfaEnrollments, Schemas } from "./types";
+import { MfaEnrollments, Schemas } from "./types";
 
 export const PROVIDER_PASSWORD = "password";
 export const PROVIDER_PHONE = "phone";
 export const PROVIDER_ANONYMOUS = "anonymous";
 export const PROVIDER_CUSTOM = "custom";
+export const PROVIDER_GAME_CENTER = "gc.apple.com"; // Not yet implemented
 
 export const SIGNIN_METHOD_EMAIL_LINK = "emailLink";
 

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -538,7 +538,6 @@ export class ProjectState {
     if (!record || record.phoneNumber !== phoneNumber) {
       return undefined;
     }
-    // TODO: Find some way to enforce record.temporaryProofExpiresIn.
     return record;
   }
 
@@ -605,6 +604,8 @@ interface TemporaryProofRecord {
   phoneNumber: string;
   temporaryProof: string;
   temporaryProofExpiresIn: string;
+  // Temporary proofs in emulator never expire to make interactive debugging
+  // a bit easier. Therefore, there's no need to record createdAt timestamps.
 }
 
 function getProviderEmailsForUser(user: UserInfo): Set<string> {

--- a/src/emulator/auth/types.ts
+++ b/src/emulator/auth/types.ts
@@ -2,4 +2,3 @@ import * as schema from "./schema";
 export type Schemas = schema.components["schemas"];
 export type MfaEnrollment = Schemas["GoogleCloudIdentitytoolkitV1MfaEnrollment"];
 export type MfaEnrollments = MfaEnrollment[];
-export type CreateMfaEnrollmentsRequest = Schemas["GoogleCloudIdentitytoolkitV1MfaFactor"][];

--- a/src/test/emulators/auth/batch.spec.ts
+++ b/src/test/emulators/auth/batch.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { decode as decodeJwt } from "jsonwebtoken";
 import { describeAuthEmulator } from "./setup";
 import {
+  enrollPhoneMfa,
   expectStatusCode,
   getAccountInfoByIdToken,
   getAccountInfoByLocalId,
@@ -36,6 +37,25 @@ describeAuthEmulator("accounts:batchGet", ({ authApi }) => {
 
         // No more accounts after this, so no page token returned.
         expect(res.body).not.to.have.property("nextPageToken");
+      });
+  });
+
+  it("should return MFA info", async () => {
+    const user1 = await signInWithEmailLink(authApi(), "test@example.com");
+    await enrollPhoneMfa(authApi(), user1.idToken, TEST_PHONE_NUMBER);
+
+    await authApi()
+      .get(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchGet`)
+      .set("Authorization", "Bearer owner")
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.users).to.have.length(1);
+        const user = res.body.users[0] as UserInfo;
+        expect(user.mfaInfo![0]).to.contain({
+          enrolledAt: "1970-01-01T00:00:00.000Z",
+          phoneInfo: TEST_PHONE_NUMBER,
+          unobfuscatedPhoneInfo: TEST_PHONE_NUMBER,
+        });
       });
   });
 
@@ -412,6 +432,17 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
           { localId: "test8", providerUserInfo: [{ rawId: "012345" /* missing providerId */ }] },
           // federatedId without rawId / providerId is supported in production but not Auth Emulator.
           { localId: "test9", providerUserInfo: [{ federatedId: "foo-bar" }] },
+          {
+            // MFA without email
+            localId: "test10",
+            mfaInfo: [{ phoneInfo: TEST_PHONE_NUMBER }],
+          },
+          {
+            // MFA but email is unverified
+            localId: "test11",
+            email: "someone@example.com",
+            mfaInfo: [{ phoneInfo: TEST_PHONE_NUMBER }],
+          },
         ],
       })
       .then((res) => {
@@ -453,6 +484,14 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
             index: 9,
             message:
               "((Parsing federatedId is not implemented in Auth Emulator; please specify providerId AND rawId as a workaround.))",
+          },
+          {
+            index: 10,
+            message: "Second factor account requires email to be presented.",
+          },
+          {
+            index: 11,
+            message: "Second factor account requires email to be verified.",
           },
         ]);
       });
@@ -533,6 +572,39 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
       sub: rawId,
     });
     expect(user1SignIn.localId).to.equal(user1.localId);
+  });
+
+  it("should import MFA info", async () => {
+    const email = "foo@example.com";
+    const user1 = {
+      localId: "foo",
+      email,
+      emailVerified: true,
+      mfaInfo: [
+        {
+          enrolledAt: "2123-04-05T06:07:28.990Z",
+          phoneInfo: TEST_PHONE_NUMBER,
+        },
+      ],
+    };
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({ users: [user1] })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.error || []).to.have.length(0);
+      });
+
+    const user1Info = await getAccountInfoByLocalId(authApi(), user1.localId);
+    expect(user1Info.mfaInfo).to.have.length(1);
+    expect(user1Info.mfaInfo![0]).to.contain({
+      enrolledAt: user1.mfaInfo[0].enrolledAt,
+      phoneInfo: TEST_PHONE_NUMBER,
+      unobfuscatedPhoneInfo: TEST_PHONE_NUMBER,
+    });
+    // A mfaEnrollmentId should be automatically generated if not provided.
+    expect(user1Info.mfaInfo![0].mfaEnrollmentId).to.be.a("string").and.not.empty;
   });
 });
 

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -8,8 +8,6 @@ import {
   getAccountInfoByIdToken,
   updateAccountByLocalId,
   signInWithEmailLink,
-  registerUser,
-  TEST_MFA_INFO,
 } from "./helpers";
 
 describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
@@ -231,26 +229,6 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equal("USER_DISABLED");
-      });
-  });
-
-  it("should error if user has MFA", async () => {
-    const user = {
-      email: "alice@example.com",
-      password: "notasecret",
-      mfaInfo: [TEST_MFA_INFO],
-    };
-    const { localId } = await registerUser(authApi(), user);
-
-    const claims = { abc: "def", ultimate: { answer: 42 } };
-    const token = JSON.stringify({ uid: localId, claims });
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
-      .query({ key: "fake-api-key" })
-      .send({ token })
-      .then((res) => {
-        expectStatusCode(501, res);
-        expect(res.body.error.message).to.equal("MFA Login not yet implemented.");
       });
   });
 });

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -203,7 +203,7 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
       });
   });
 
-  it("should error if user has MFA", async () => {
+  it("should return pending credential if user has MFA", async () => {
     const user = {
       email: "alice@example.com",
       password: "notasecret",
@@ -217,8 +217,11 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
       .query({ key: "fake-api-key" })
       .send({ email, oobCode, idToken })
       .then((res) => {
-        expectStatusCode(501, res);
-        expect(res.body.error.message).to.equal("MFA Login not yet implemented.");
+        expectStatusCode(200, res);
+        expect(res.body).not.to.have.property("idToken");
+        expect(res.body).not.to.have.property("refreshToken");
+        expect(res.body.mfaPendingCredential).to.be.a("string");
+        expect(res.body.mfaInfo).to.be.an("array").with.lengthOf(1);
       });
   });
 });

--- a/src/test/emulators/auth/helpers.ts
+++ b/src/test/emulators/auth/helpers.ts
@@ -9,6 +9,7 @@ import { MfaEnrollments } from "../../../emulator/auth/types";
 
 export { PROJECT_ID };
 export const TEST_PHONE_NUMBER = "+15555550100";
+export const TEST_PHONE_NUMBER_OBFUSCATED = "+*******0100";
 export const TEST_PHONE_NUMBER_2 = "+15555550101";
 export const TEST_PHONE_NUMBER_3 = "+15555550102";
 export const TEST_MFA_INFO = {
@@ -336,5 +337,34 @@ export function updateAccountByLocalId(
     .send({ localId, ...fields })
     .then((res) => {
       expectStatusCode(200, res);
+    });
+}
+
+export async function enrollPhoneMfa(
+  testAgent: TestAgent,
+  idToken: string,
+  phoneNumber: string
+): Promise<{ idToken: string; refreshToken: string }> {
+  const sessionInfo = await testAgent
+    .post("/identitytoolkit.googleapis.com/v2/accounts/mfaEnrollment:start")
+    .query({ key: "fake-api-key" })
+    .send({ idToken, phoneEnrollmentInfo: { phoneNumber } })
+    .then((res) => {
+      expectStatusCode(200, res);
+      expect(res.body.phoneSessionInfo.sessionInfo).to.be.a("string");
+      return res.body.phoneSessionInfo.sessionInfo as string;
+    });
+
+  const code = (await inspectVerificationCodes(testAgent))[0].code;
+
+  return testAgent
+    .post("/identitytoolkit.googleapis.com/v2/accounts/mfaEnrollment:finalize")
+    .query({ key: "fake-api-key" })
+    .send({ idToken, phoneVerificationInfo: { code, sessionInfo } })
+    .then((res) => {
+      expectStatusCode(200, res);
+      expect(res.body.idToken).to.be.a("string");
+      expect(res.body.refreshToken).to.be.a("string");
+      return { idToken: res.body.idToken, refreshToken: res.body.refreshToken };
     });
 }

--- a/src/test/emulators/auth/idp.spec.ts
+++ b/src/test/emulators/auth/idp.spec.ts
@@ -19,11 +19,13 @@ import {
   FAKE_GOOGLE_ACCOUNT,
   REAL_GOOGLE_ACCOUNT,
   TEST_MFA_INFO,
+  enrollPhoneMfa,
+  getAccountInfoByLocalId,
 } from "./helpers";
 
 // Many JWT fields from IDPs use snake_case and we need to match that.
 
-describeAuthEmulator("sign-in with credential", ({ authApi }) => {
+describeAuthEmulator("sign-in with credential", ({ authApi, getClock }) => {
   it("should create new account with IDP from unsigned ID token", async () => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")
@@ -667,32 +669,79 @@ describeAuthEmulator("sign-in with credential", ({ authApi }) => {
       });
   });
 
-  it("should error if user to be linked is an MFA user", async () => {
-    const user = {
-      email: "alice@example.com",
-      password: "notasecret",
-      mfaInfo: [TEST_MFA_INFO],
-    };
-    const { idToken } = await registerUser(authApi(), user);
-
+  it("should return pending credential for MFA-enabled user", async () => {
     const claims = fakeClaims({
       sub: "123456789012345678901",
       name: "Foo",
+      email: "foo@example.com",
+      email_verified: true,
     });
+    const { idToken, localId } = await signInWithFakeClaims(authApi(), "google.com", claims);
+    await enrollPhoneMfa(authApi(), idToken, TEST_PHONE_NUMBER);
+    const beforeSignIn = await getAccountInfoByLocalId(authApi(), localId);
+
+    getClock().tick(3333);
+
     const fakeIdToken = JSON.stringify(claims);
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")
       .query({ key: "fake-api-key" })
       .send({
-        idToken,
         postBody: `providerId=google.com&id_token=${encodeURIComponent(fakeIdToken)}`,
         requestUri: "http://localhost",
         returnIdpCredential: true,
       })
       .then((res) => {
-        expectStatusCode(501, res);
-        expect(res.body.error.message).to.equal("MFA Login not yet implemented.");
+        expectStatusCode(200, res);
+        expect(res.body).not.to.have.property("idToken");
+        expect(res.body).not.to.have.property("refreshToken");
+        const mfaPendingCredential = res.body.mfaPendingCredential as string;
+        expect(mfaPendingCredential).to.be.a("string");
+        expect(res.body.mfaInfo).to.be.an("array").with.lengthOf(1);
       });
+
+    // Login / refresh timestamps should not change until MFA was successful.
+    const afterFirstFactor = await getAccountInfoByLocalId(authApi(), localId);
+    expect(afterFirstFactor.lastLoginAt).to.equal(beforeSignIn.lastLoginAt);
+    expect(afterFirstFactor.lastRefreshAt).to.equal(beforeSignIn.lastRefreshAt);
+  });
+
+  it("should link IDP for existing MFA-enabled user", async () => {
+    const email = "alice@example.com";
+    const { idToken, localId } = await signInWithEmailLink(authApi(), email);
+    await enrollPhoneMfa(authApi(), idToken, TEST_PHONE_NUMBER);
+
+    const claims = fakeClaims({
+      sub: "123456789012345678901",
+      name: "Foo",
+      email,
+      email_verified: true,
+    });
+
+    const fakeIdToken = JSON.stringify(claims);
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")
+      .query({ key: "fake-api-key" })
+      .send({
+        postBody: `providerId=google.com&id_token=${encodeURIComponent(fakeIdToken)}`,
+        requestUri: "http://localhost",
+        returnIdpCredential: true,
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body).not.to.have.property("idToken");
+        expect(res.body).not.to.have.property("refreshToken");
+        const mfaPendingCredential = res.body.mfaPendingCredential as string;
+        expect(mfaPendingCredential).to.be.a("string");
+        expect(res.body.mfaInfo).to.be.an("array").with.lengthOf(1);
+      });
+
+    // IDP sign-in should be linked even before second factor is verified.
+    expect(await getSigninMethods(authApi(), email)).to.have.members(["google.com", "emailLink"]);
+
+    // Similarly, user information from IDP should be added to account.
+    const info = await getAccountInfoByLocalId(authApi(), localId);
+    expect(info.displayName).to.equal(claims.name);
   });
 
   it("should return error if IDP account is already linked to the same user", async () => {

--- a/src/test/emulators/auth/idp.spec.ts
+++ b/src/test/emulators/auth/idp.spec.ts
@@ -106,7 +106,6 @@ describeAuthEmulator("sign-in with credential", ({ authApi }) => {
 
         // The ID Token used above does NOT contain name or photo, so the
         // account created won't have those attributes either.
-        // TODO: Shall we fetch more profile info from IDP via API calls?
         expect(res.body).not.to.have.property("displayName");
         expect(res.body).not.to.have.property("photoUrl");
 

--- a/src/test/emulators/auth/mfa.spec.ts
+++ b/src/test/emulators/auth/mfa.spec.ts
@@ -1,0 +1,109 @@
+import { expect } from "chai";
+import { describeAuthEmulator } from "./setup";
+import {
+  enrollPhoneMfa,
+  expectStatusCode,
+  getAccountInfoByIdToken,
+  inspectVerificationCodes,
+  registerUser,
+  signInWithEmailLink,
+  TEST_PHONE_NUMBER,
+  TEST_PHONE_NUMBER_OBFUSCATED,
+} from "./helpers";
+import { MfaEnrollment } from "../../../emulator/auth/types";
+
+// Many JWT fields from IDPs use snake_case and we need to match that.
+
+describeAuthEmulator("mfa enrollment", ({ authApi }) => {
+  it("should allow phone enrollment for an existing account", async () => {
+    const phoneNumber = TEST_PHONE_NUMBER;
+    const { idToken } = await signInWithEmailLink(authApi(), "foo@example.com");
+    const sessionInfo = await authApi()
+      .post("/identitytoolkit.googleapis.com/v2/accounts/mfaEnrollment:start")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, phoneEnrollmentInfo: { phoneNumber } })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.phoneSessionInfo.sessionInfo).to.be.a("string");
+        return res.body.phoneSessionInfo.sessionInfo as string;
+      });
+
+    const codes = await inspectVerificationCodes(authApi());
+    expect(codes).to.have.length(1);
+    expect(codes[0].phoneNumber).to.equal(phoneNumber);
+    expect(codes[0].sessionInfo).to.equal(sessionInfo);
+    expect(codes[0].code).to.be.a("string");
+    const { code } = codes[0];
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v2/accounts/mfaEnrollment:finalize")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, phoneVerificationInfo: { code, sessionInfo } })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.idToken).to.be.a("string");
+        expect(res.body.refreshToken).to.be.a("string");
+      });
+
+    const userInfo = await getAccountInfoByIdToken(authApi(), idToken);
+    expect(userInfo.mfaInfo).to.be.an("array").with.lengthOf(1);
+    expect(userInfo.mfaInfo![0].phoneInfo).to.equal(phoneNumber);
+  });
+
+  it("should allow sign-in with pending credential for MFA-enabled user", async () => {
+    const email = "foo@example.com";
+    const password = "abcdef";
+    const { idToken } = await registerUser(authApi(), { email, password });
+    await enrollPhoneMfa(authApi(), idToken, TEST_PHONE_NUMBER);
+
+    const { mfaPendingCredential, enrollment } = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
+      .query({ key: "fake-api-key" })
+      .send({ email, password })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body).not.to.have.property("idToken");
+        expect(res.body).not.to.have.property("refreshToken");
+        const mfaPendingCredential = res.body.mfaPendingCredential as string;
+        const mfaInfo = res.body.mfaInfo as MfaEnrollment[];
+        expect(mfaPendingCredential).to.be.a("string");
+        expect(mfaInfo).to.be.an("array").with.lengthOf(1);
+        expect(mfaInfo[0]?.phoneInfo).to.equal(TEST_PHONE_NUMBER_OBFUSCATED);
+
+        // This must not be exposed right after first factor login.
+        expect(mfaInfo[0]?.phoneInfo).not.to.have.property("unobfuscatedPhoneInfo");
+        return { mfaPendingCredential, enrollment: mfaInfo[0] };
+      });
+
+    const sessionInfo = await authApi()
+      .post("/identitytoolkit.googleapis.com/v2/accounts/mfaSignIn:start")
+      .query({ key: "fake-api-key" })
+      .send({
+        mfaEnrollmentId: enrollment.mfaEnrollmentId,
+        mfaPendingCredential,
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.phoneResponseInfo.sessionInfo).to.be.a("string");
+        return res.body.phoneResponseInfo.sessionInfo as string;
+      });
+
+    const code = (await inspectVerificationCodes(authApi()))[0].code;
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v2/accounts/mfaSignIn:finalize")
+      .query({ key: "fake-api-key" })
+      .send({
+        mfaPendingCredential,
+        phoneVerificationInfo: {
+          sessionInfo,
+          code: code,
+        },
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.idToken).to.be.a("string");
+        expect(res.body.refreshToken).to.be.a("string");
+      });
+  });
+});

--- a/src/test/emulators/auth/password.spec.ts
+++ b/src/test/emulators/auth/password.spec.ts
@@ -134,7 +134,7 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
       });
   });
 
-  it("should error if user has MFA", async () => {
+  it("should return pending credential if user has MFA", async () => {
     const user = {
       email: "alice@example.com",
       password: "notasecret",
@@ -147,8 +147,11 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
       .query({ key: "fake-api-key" })
       .send({ email: user.email, password: user.password })
       .then((res) => {
-        expectStatusCode(501, res);
-        expect(res.body.error.message).to.equal("MFA Login not yet implemented.");
+        expectStatusCode(200, res);
+        expect(res.body).not.to.have.property("idToken");
+        expect(res.body).not.to.have.property("refreshToken");
+        expect(res.body.mfaPendingCredential).to.be.a("string");
+        expect(res.body.mfaInfo).to.be.an("array").with.lengthOf(1);
       });
   });
 });

--- a/src/test/emulators/auth/phone.spec.ts
+++ b/src/test/emulators/auth/phone.spec.ts
@@ -11,6 +11,8 @@ import {
   registerUser,
   TEST_MFA_INFO,
   TEST_PHONE_NUMBER,
+  enrollPhoneMfa,
+  TEST_PHONE_NUMBER_2,
 } from "./helpers";
 
 describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
@@ -251,13 +253,13 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
       });
   });
 
-  it("should error if user has MFA", async () => {
+  it("should error when linking phone number to existing user with MFA", async () => {
     const user = {
       email: "alice@example.com",
       password: "notasecret",
       mfaInfo: [TEST_MFA_INFO],
     };
-    const { localId, idToken } = await registerUser(authApi(), user);
+    const { idToken } = await registerUser(authApi(), user);
 
     const phoneNumber = TEST_PHONE_NUMBER;
     const sessionInfo = await authApi()
@@ -266,7 +268,7 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
       .send({ phoneNumber, recaptchaToken: "ignored" })
       .then((res) => {
         expectStatusCode(200, res);
-        return res.body.sessionInfo;
+        return res.body.sessionInfo as string;
       });
 
     const codes = await inspectVerificationCodes(authApi());
@@ -277,9 +279,39 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
       .query({ key: "fake-api-key" })
       .send({ sessionInfo, code, idToken })
       .then((res) => {
-        expectStatusCode(501, res);
-        expect(res.body.error.message).to.equal("MFA Login not yet implemented.");
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.equal(
+          "UNSUPPORTED_FIRST_FACTOR : A phone number cannot be set as a first factor on an SMS based MFA user."
+        );
       });
+  });
+
+  it("should error if user has MFA", async () => {
+    const phoneNumber = TEST_PHONE_NUMBER;
+    let { idToken, localId } = await registerUser(authApi(), {
+      email: "alice@example.com",
+      password: "notasecret",
+    });
+    await updateAccountByLocalId(authApi(), localId, {
+      emailVerified: true,
+      phoneNumber,
+    });
+    ({ idToken } = await enrollPhoneMfa(authApi(), idToken, TEST_PHONE_NUMBER_2));
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendVerificationCode")
+      .query({ key: "fake-api-key" })
+      .send({ phoneNumber })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.equal(
+          "UNSUPPORTED_FIRST_FACTOR : A phone number cannot be set as a first factor on an SMS based MFA user."
+        );
+        return res.body.sessionInfo;
+      });
+
+    const codes = await inspectVerificationCodes(authApi());
+    expect(codes).to.be.empty;
   });
 
   it("should return temporaryProof if phone number already belongs to another account", async () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This adds partial MFA support for password sign-in etc. Error messages are NOT yet done (strings in double braces may not match production) and signInWithIdp + MFA doesn't work right now.

Many tests for edge cases (especially error strings) TBD.

### Scenarios Tested

See tests added

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
