### PR TITLE
fix: prevent crash in cases when file not uploaded

### DIFF
--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -200,7 +200,7 @@ export class StorageLayer {
       return undefined;
     }
     upload.status = UploadStatus.CANCELLED;
-    this._persistence.deleteFile(upload.fileLocation);
+    this._persistence.deleteFile(upload.fileLocation, true);
   }
 
   public uploadBytes(uploadId: string, bytes: Buffer): ResumableUpload | undefined {


### PR DESCRIPTION
### Description

Fix the storage emulator, in cases where user does not have permission to upload, currently it will crash with

```
[debug] [2021-09-05T03:43:12.268Z] Error: ENOENT: no such file or directory, unlink '/var/folders/v4/8jyh3pp92x58b6gkspmqv7z00000gn/T/firebase/storage/blobs/de35c131-db18-40df-8d6d-9dcd52e569cf_b_a.appspot.com_o_users%2FcIxTOUyrm8ZlXs8v9aVPKcy12JFA%2Fbca69a4b-f814-402f-a5d8-a9992bd3fb8c.jpg'
    at Object.unlinkSync (node:fs:1718:3)
    at Persistence.deleteFile (/usr/local/lib/node_modules/firebase-tools/lib/emulator/storage/files.js:478:18)
    at StorageLayer.cancelUpload (/usr/local/lib/node_modules/firebase-tools/lib/emulator/storage/files.js:152:27)
    at handleUpload (/usr/local/lib/node_modules/firebase-tools/lib/emulator/storage/apis/firebase.js:366:45)
    at /usr/local/lib/node_modules/firebase-tools/lib/emulator/storage/apis/firebase.js:443:24
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/layer.js:95:5)
    at /usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:281:22
    at param (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:354:14)
    at param (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:365:14)
    at param (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:365:14)
    at Function.process_params (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:410:3)
    at next (/usr/local/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:275:10)
    at /usr/local/lib/node_modules/firebase-tools/lib/emulator/storage/apis/firebase.js:89:9
[error]
[error] Error: An unexpected error has occurred.
```

### Scenarios Tested

Start emulator, use iOS SDK to post to a location that current user doesn't have access to

