### PR TITLE
App Distro: Add/remove testers & use v1 public api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 - `ext:install` now supports `--force` and `--non-interactive` flags.
 - Fixes a crash when customers deploy an empty Cloud Functions project (#3705)
 - Fixes (and implements) `--no-authorized-domains`, skipping syncing with Firebase Auth, when deploying to a Firebase Hosting channel (#3740).
+- Uses public v1 AppDistribution API.
+- Adds `appdistribution:testers:add` and `appdistribution:testers:remove` commands (#3072).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 - Fixes a crash when customers deploy an empty Cloud Functions project (#3705)
 - Fixes (and implements) `--no-authorized-domains`, skipping syncing with Firebase Auth, when deploying to a Firebase Hosting channel (#3740).
 - Uses public v1 AppDistribution API.
-- Adds `appdistribution:testers:add` and `appdistribution:testers:remove` commands (#3072).
+- Adds `appdistribution:testers:add` and `appdistribution:testers:remove` commands.

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -195,9 +195,12 @@ export class AppDistributionClient {
       apiVersion: "v1",
       auth: true,
     });
-    let apiResponse: ClientResponse<BatchRemoveTestersResponse>;
+    let apiResponse;
     try {
-      apiResponse = await appDistroV2Client.request({
+      apiResponse = await appDistroV2Client.request<
+        { emails: string[] },
+        BatchRemoveTestersResponse
+      >({
         method: "POST",
         path: `${projectName}/testers:batchRemove`,
         body: { emails: emails },

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -74,10 +74,7 @@ export class AppDistributionClient {
   }
 
   async uploadRelease(appName: string, distribution: Distribution): Promise<string> {
-    const apiResponse = await api.request(
-      "POST",
-      `/upload/v1/${appName}/releases:upload`,
-      {
+    const apiResponse = await api.request("POST", `/upload/v1/${appName}/releases:upload`, {
         auth: true,
         origin: api.appDistributionOrigin,
         headers: {

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -4,7 +4,7 @@ import * as utils from "../utils";
 import * as operationPoller from "../operation-poller";
 import { Distribution } from "./distribution";
 import { FirebaseError } from "../error";
-import { getAppName, getProjectName } from "./options-parser-util";
+import { getAppName } from "./options-parser-util";
 import { Client, ClientResponse } from "../apiv2";
 
 // tslint:disable-next-line:no-var-requires

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -75,17 +75,16 @@ export class AppDistributionClient {
 
   async uploadRelease(appName: string, distribution: Distribution): Promise<string> {
     const apiResponse = await api.request("POST", `/upload/v1/${appName}/releases:upload`, {
-        auth: true,
-        origin: api.appDistributionOrigin,
-        headers: {
-          "X-Goog-Upload-File-Name": distribution.getFileName(),
-          "X-Goog-Upload-Protocol": "raw",
-          "Content-Type": "application/octet-stream",
-        },
-        data: distribution.readStream(),
-        json: false,
-      }
-    );
+      auth: true,
+      origin: api.appDistributionOrigin,
+      headers: {
+        "X-Goog-Upload-File-Name": distribution.getFileName(),
+        "X-Goog-Upload-Protocol": "raw",
+        "Content-Type": "application/octet-stream",
+      },
+      data: distribution.readStream(),
+      json: false,
+    });
 
     return _.get(JSON.parse(apiResponse.body), "name");
   }

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -1,6 +1,7 @@
 import * as _ from "lodash";
 import * as api from "../api";
 import * as utils from "../utils";
+import * as operationPoller from "../operation-poller";
 import { Distribution } from "./distribution";
 import { FirebaseError } from "../error";
 
@@ -10,32 +11,22 @@ const pkg = require("../../package.json");
 /**
  * Helper interface for an app that is provisioned with App Distribution
  */
-export interface AppDistributionApp {
-  projectNumber: string;
-  appId: string;
-  platform: string;
-  bundleId: string;
-  contactEmail: string;
-  aabState: AabState;
-  aabCertificate: AabCertificate | null;
+export interface AabInfo {
+  name: string;
+  integrationState: IntegrationState;
+  testCertificate: TestCertificate | null;
 }
 
-export interface AabCertificate {
-  certificateHashMd5: string;
-  certificateHashSha1: string;
-  certificateHashSha256: string;
-}
-
-export enum UploadStatus {
-  SUCCESS = "SUCCESS",
-  IN_PROGRESS = "IN_PROGRESS",
-  ERROR = "ERROR",
+export interface TestCertificate {
+  hashSha1: string;
+  hashSha256: string;
+  hashMd5: string;
 }
 
 /** Enum representing the App Bundles state for the App */
-export enum AabState {
-  AAB_STATE_UNSPECIFIED = "AAB_STATE_UNSPECIFIED",
-  ACTIVE = "ACTIVE",
+export enum IntegrationState {
+  AAB_INTEGRATION_STATE_UNSPECIFIED = "AAB_INTEGRATION_STATE_UNSPECIFIED",
+  INTEGRATED = "INTEGRATED",
   PLAY_ACCOUNT_NOT_LINKED = "PLAY_ACCOUNT_NOT_LINKED",
   NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT = "NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT",
   APP_NOT_PUBLISHED = "APP_NOT_PUBLISHED",
@@ -43,32 +34,42 @@ export enum AabState {
   PLAY_IAS_TERMS_NOT_ACCEPTED = "PLAY_IAS_TERMS_NOT_ACCEPTED",
 }
 
-export interface UploadStatusResponse {
-  status: UploadStatus;
-  message: string;
-  errorCode: string;
-  release: {
-    id: string;
-  };
+export enum UploadReleaseResult {
+  UPLOAD_RELEASE_RESULT_UNSPECIFIED = "UPLOAD_RELEASE_RESULT_UNSPECIFIED",
+  RELEASE_CREATED = "RELEASE_CREATED",
+  RELEASE_UPDATED = "RELEASE_UPDATED",
+  RELEASE_UNMODIFIED = "RELEASE_UNMODIFIED",
 }
 
-/** Enum for app_view parameter for getApp requests */
-export enum AppView {
-  BASIC = "BASIC",
-  FULL = "FULL",
+export interface Release {
+  name: string;
+  releaseNotes: ReleaseNotes;
+  displayVersion: string;
+  buildVersion: string;
+  createTime: Date;
+}
+
+export interface ReleaseNotes {
+  text: string;
+}
+
+export interface UploadReleaseResponse {
+  result: UploadReleaseResult;
+  release: Release;
 }
 
 /**
- * Proxies HTTPS requests to the App Distribution server backend.
+ * Makes RPCs to the App Distribution server backend.
  */
 export class AppDistributionClient {
-  static MAX_POLLING_RETRIES = 60;
-  static POLLING_INTERVAL_MS = 2000;
+  private readonly appName: string;
 
-  constructor(private readonly appId: string) {}
+  constructor(appId: string) {
+    this.appName = `projects/${appId.split(":")[1]}/apps/${appId}`;
+  }
 
-  async getApp(appView = AppView.BASIC): Promise<AppDistributionApp> {
-    const apiResponse = await api.request("GET", `/v1alpha/apps/${this.appId}?appView=${appView}`, {
+  async getAabInfo(): Promise<AabInfo> {
+    const apiResponse = await api.request("GET", `/v1/${this.appName}/aabInfo`, {
       origin: api.appDistributionOrigin,
       auth: true,
     });
@@ -76,107 +77,82 @@ export class AppDistributionClient {
     return _.get(apiResponse, "body");
   }
 
-  async uploadDistribution(distribution: Distribution): Promise<string> {
-    const apiResponse = await api.request("POST", `/app-binary-uploads?app_id=${this.appId}`, {
+  async uploadRelease(distribution: Distribution): Promise<string> {
+    const apiResponse = await api.request("POST", `/upload/v1/${this.appName}/releases:upload`, {
       auth: true,
       origin: api.appDistributionOrigin,
       headers: {
-        "X-APP-DISTRO-API-CLIENT-ID": pkg.name,
-        "X-APP-DISTRO-API-CLIENT-TYPE": distribution.platform(),
-        "X-APP-DISTRO-API-CLIENT-VERSION": pkg.version,
-        "X-GOOG-UPLOAD-FILE-NAME": distribution.getFileName(),
-        "X-GOOG-UPLOAD-PROTOCOL": "raw",
+        "X-Firebase-Client": `${pkg.name}/${pkg.version}`,
+        "X-Goog-Upload-File-Name": distribution.getFileName(),
+        "X-Goog-Upload-Protocol": "raw",
         "Content-Type": "application/octet-stream",
       },
       data: distribution.readStream(),
       json: false,
     });
 
-    return _.get(JSON.parse(apiResponse.body), "token");
+    return _.get(JSON.parse(apiResponse.body), "name");
   }
 
-  async pollUploadStatus(binaryName: string, retryCount = 0): Promise<string> {
-    const uploadStatus = await this.getUploadStatus(binaryName);
-    if (uploadStatus.status === UploadStatus.IN_PROGRESS) {
-      if (retryCount >= AppDistributionClient.MAX_POLLING_RETRIES) {
-        throw new FirebaseError(
-          "it took longer than expected to process your binary, please try again",
-          { exit: 1 }
-        );
-      }
-      await new Promise((resolve) =>
-        setTimeout(resolve, AppDistributionClient.POLLING_INTERVAL_MS)
-      );
-      return this.pollUploadStatus(binaryName, retryCount + 1);
-    } else if (uploadStatus.status === UploadStatus.SUCCESS) {
-      return uploadStatus.release.id;
-    } else {
-      throw new FirebaseError(
-        `error processing your binary: ${uploadStatus.message} (Code: ${uploadStatus.errorCode})`
-      );
-    }
+  async pollUploadStatus(operationName: string): Promise<UploadReleaseResponse> {
+    return operationPoller.pollOperation<UploadReleaseResponse>({
+      pollerName: "App Distribution Upload Poller",
+      apiOrigin: api.appDistributionOrigin,
+      apiVersion: "v1",
+      operationResourceName: operationName,
+      masterTimeout: 5 * 60 * 1000,
+      backoff: 1000,
+      maxBackoff: 10 * 1000,
+    });
   }
 
-  async getUploadStatus(binaryName: string): Promise<UploadStatusResponse> {
-    const encodedBinaryName = encodeURIComponent(binaryName);
-    const apiResponse = await api.request(
-      "GET",
-      `/v1alpha/apps/${this.appId}/upload_status/${encodedBinaryName}`,
-      {
-        origin: api.appDistributionOrigin,
-        auth: true,
-      }
-    );
-
-    return _.get(apiResponse, "body");
-  }
-
-  async addReleaseNotes(releaseId: string, releaseNotes: string): Promise<void> {
+  async updateReleaseNotes(releaseName: string, releaseNotes: string): Promise<void> {
     if (!releaseNotes) {
       utils.logWarning("no release notes specified, skipping");
       return;
     }
 
-    utils.logBullet("adding release notes...");
+    utils.logBullet("updating release notes...");
 
     const data = {
+      name: releaseName,
       releaseNotes: {
-        releaseNotes,
+        text: releaseNotes,
       },
     };
 
     try {
-      await api.request("POST", `/v1alpha/apps/${this.appId}/releases/${releaseId}/notes`, {
+      await api.request("PATCH", `/v1/${releaseName}?updateMask=release_notes.text`, {
         origin: api.appDistributionOrigin,
         auth: true,
         data,
       });
     } catch (err) {
-      throw new FirebaseError(`failed to add release notes with ${err.message}`, { exit: 1 });
+      throw new FirebaseError(`failed to update release notes with ${err.message}`, { exit: 1 });
     }
 
     utils.logSuccess("added release notes successfully");
   }
 
-  async enableAccess(
-    releaseId: string,
-    emails: string[] = [],
-    groupIds: string[] = []
+  async distribute(
+    releaseName: string,
+    testerEmails: string[] = [],
+    groupAliases: string[] = []
   ): Promise<void> {
-    if (emails.length === 0 && groupIds.length === 0) {
+    if (testerEmails.length === 0 && groupAliases.length === 0) {
       utils.logWarning("no testers or groups specified, skipping");
       return;
     }
 
-    utils.logBullet("adding testers/groups...");
+    utils.logBullet("distributing to testers/groups...");
 
     const data = {
-      emails,
-      groupIds,
+      testerEmails,
+      groupAliases,
     };
 
     try {
-      await api.request("POST", `/v1alpha/apps/${this.appId}/releases/${releaseId}/enable_access`, {
+      await api.request("POST", `/v1/${releaseName}:distribute`, {
         origin: api.appDistributionOrigin,
         auth: true,
         data,
@@ -191,9 +167,11 @@ export class AppDistributionClient {
           errorMessage = "invalid groups";
         }
       }
-      throw new FirebaseError(`failed to add testers/groups: ${errorMessage}`, { exit: 1 });
+      throw new FirebaseError(`failed to distribute to testers/groups: ${errorMessage}`, {
+        exit: 1,
+      });
     }
 
-    utils.logSuccess("added testers/groups successfully");
+    utils.logSuccess("distributed to testers/groups successfully");
   }
 }

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -4,11 +4,7 @@ import * as utils from "../utils";
 import * as operationPoller from "../operation-poller";
 import { Distribution } from "./distribution";
 import { FirebaseError } from "../error";
-import { getAppName } from "./options-parser-util";
 import { Client, ClientResponse } from "../apiv2";
-
-// tslint:disable-next-line:no-var-requires
-const pkg = require("../../package.json");
 
 /**
  * Helper interface for an app that is provisioned with App Distribution
@@ -68,8 +64,8 @@ export interface BatchRemoveTestersResponse {
  * Makes RPCs to the App Distribution server backend.
  */
 export class AppDistributionClient {
-  async getAabInfo(appId: string): Promise<AabInfo> {
-    const apiResponse = await api.request("GET", `/v1/${getAppName(appId)}/aabInfo`, {
+  async getAabInfo(appName: string): Promise<AabInfo> {
+    const apiResponse = await api.request("GET", `/v1/${appName}/aabInfo`, {
       origin: api.appDistributionOrigin,
       auth: true,
     });
@@ -77,15 +73,14 @@ export class AppDistributionClient {
     return _.get(apiResponse, "body");
   }
 
-  async uploadRelease(appId: string, distribution: Distribution): Promise<string> {
+  async uploadRelease(appName: string, distribution: Distribution): Promise<string> {
     const apiResponse = await api.request(
       "POST",
-      `/upload/v1/${getAppName(appId)}/releases:upload`,
+      `/upload/v1/${appName}/releases:upload`,
       {
         auth: true,
         origin: api.appDistributionOrigin,
         headers: {
-          "X-Firebase-Client": `${pkg.name}/${pkg.version}`,
           "X-Goog-Upload-File-Name": distribution.getFileName(),
           "X-Goog-Upload-Protocol": "raw",
           "Content-Type": "application/octet-stream",
@@ -189,7 +184,6 @@ export class AppDistributionClient {
       await appDistroV2Client.request({
         method: "POST",
         path: `${projectName}/testers:batchAdd`,
-        headers: { "X-Client-Version": `${pkg.name}/${pkg.version}` },
         body: { emails: emails },
       });
     } catch (err) {
@@ -210,7 +204,6 @@ export class AppDistributionClient {
       apiResponse = await appDistroV2Client.request({
         method: "POST",
         path: `${projectName}/testers:batchRemove`,
-        headers: { "X-Client-Version": `${pkg.name}/${pkg.version}` },
         body: { emails: emails },
       });
     } catch (err) {

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -64,6 +64,11 @@ export interface BatchRemoveTestersResponse {
  * Makes RPCs to the App Distribution server backend.
  */
 export class AppDistributionClient {
+  appDistroV2Client = new Client({
+    urlPrefix: api.appDistributionOrigin,
+    apiVersion: "v1",
+  });
+
   async getAabInfo(appName: string): Promise<AabInfo> {
     const apiResponse = await api.request("GET", `/v1/${appName}/aabInfo`, {
       origin: api.appDistributionOrigin,
@@ -171,13 +176,8 @@ export class AppDistributionClient {
   }
 
   async addTesters(projectName: string, emails: string[]) {
-    const appDistroV2Client = new Client({
-      urlPrefix: api.appDistributionOrigin,
-      apiVersion: "v1",
-      auth: true,
-    });
     try {
-      await appDistroV2Client.request({
+      await this.appDistroV2Client.request({
         method: "POST",
         path: `${projectName}/testers:batchAdd`,
         body: { emails: emails },
@@ -190,14 +190,9 @@ export class AppDistributionClient {
   }
 
   async removeTesters(projectName: string, emails: string[]): Promise<BatchRemoveTestersResponse> {
-    const appDistroV2Client = new Client({
-      urlPrefix: api.appDistributionOrigin,
-      apiVersion: "v1",
-      auth: true,
-    });
     let apiResponse;
     try {
-      apiResponse = await appDistroV2Client.request<
+      apiResponse = await this.appDistroV2Client.request<
         { emails: string[] },
         BatchRemoveTestersResponse
       >({

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs-extra";
+import { FirebaseError } from "../error";
+import { needProjectNumber } from "../projectUtils";
+
+/**
+ * Takes in comma separated string or a path to a comma/new line separated file
+ * and converts the input into an string[] of testers or groups. Value takes precedent
+ * over file.
+ */
+export function getTestersOrGroups(value: string, file: string): string[] {
+  // If there is no value then the file gets parsed into a string to be split
+  if (!value && file) {
+    ensureFileExists(file);
+    value = fs.readFileSync(file, "utf8");
+  }
+
+  // The value is split into a string[]
+  if (value) {
+    return splitter(value);
+  }
+  return [];
+}
+
+/**
+ * Takes in a string[] or a path to a comma/new line separated file of testers emails and
+ * returns a string[] of emails.
+ */
+export function getEmails(emails: string[], file: string): string[] {
+  if (emails.length == 0) {
+    ensureFileExists(file);
+    const readFile = fs.readFileSync(file, "utf8");
+    return splitter(readFile);
+  }
+  return emails;
+}
+
+// Ensures a the file path that the user input is valid
+export function ensureFileExists(file: string, message = ""): void {
+  if (!fs.existsSync(file)) {
+    throw new FirebaseError(`File ${file} does not exist: ${message}`);
+  }
+}
+
+// Splits string by either comma or new line
+function splitter(value: string): string[] {
+  return value
+    .split(/[,\n]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => !!entry);
+}
+// Gets project name from project number
+export async function getProjectName(options: any): Promise<string> {
+  const projectNumber = await needProjectNumber(options);
+  return `projects/${projectNumber}`;
+}
+
+// Gets app name from appId
+export function getAppName(appId: string): string {
+  return `projects/${appId.split(":")[1]}/apps/${appId}`;
+}

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -55,6 +55,10 @@ export async function getProjectName(options: any): Promise<string> {
 }
 
 // Gets app name from appId
-export function getAppName(appId: string): string {
+export function getAppName(options: any): string {
+  if (!options.app) {
+    throw new FirebaseError("set the --app option to a valid Firebase app id and try again");
+  }
+  const appId = options.app;
   return `projects/${appId.split(":")[1]}/apps/${appId}`;
 }

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -7,17 +7,11 @@ import {
   AabInfo,
   IntegrationState,
   AppDistributionClient,
-  UploadReleaseResponse,
   UploadReleaseResult,
 } from "../appdistribution/client";
 import { FirebaseError } from "../error";
 import { Distribution, DistributionFileType } from "../appdistribution/distribution";
-
-function ensureFileExists(file: string, message = ""): void {
-  if (!fs.existsSync(file)) {
-    throw new FirebaseError(`File ${file} does not exist: ${message}`);
-  }
-}
+import { ensureFileExists, getTestersOrGroups } from "../appdistribution/options-parser-util";
 
 function getAppId(appId: string): string {
   if (!appId) {
@@ -35,22 +29,6 @@ function getReleaseNotes(releaseNotes: string, releaseNotesFile: string): string
     return fs.readFileSync(releaseNotesFile, "utf8");
   }
   return "";
-}
-
-function getTestersOrGroups(value: string, file: string): string[] {
-  if (!value && file) {
-    ensureFileExists(file);
-    value = fs.readFileSync(file, "utf8");
-  }
-
-  if (value) {
-    return value
-      .split(/,|\n/)
-      .map((entry) => entry.trim())
-      .filter((entry) => !!entry);
-  }
-
-  return [];
 }
 
 module.exports = new Command("appdistribution:distribute <release-binary-file>")
@@ -75,12 +53,12 @@ module.exports = new Command("appdistribution:distribute <release-binary-file>")
     const releaseNotes = getReleaseNotes(options.releaseNotes, options.releaseNotesFile);
     const testers = getTestersOrGroups(options.testers, options.testersFile);
     const groups = getTestersOrGroups(options.groups, options.groupsFile);
-    const requests = new AppDistributionClient(appId);
+    const requests = new AppDistributionClient();
     let aabInfo: AabInfo | undefined;
 
     if (distribution.distributionFileType() === DistributionFileType.AAB) {
       try {
-        aabInfo = await requests.getAabInfo();
+        aabInfo = await requests.getAabInfo(appId);
       } catch (err) {
         if (err.status === 404) {
           throw new FirebaseError(
@@ -127,7 +105,7 @@ module.exports = new Command("appdistribution:distribute <release-binary-file>")
     utils.logBullet("uploading binary...");
     let releaseName;
     try {
-      const operationName = await requests.uploadRelease(distribution);
+      const operationName = await requests.uploadRelease(appId, distribution);
 
       // The upload process is asynchronous, so poll to figure out when the upload has finished successfully
       const uploadResponse = await requests.pollUploadStatus(operationName);
@@ -171,7 +149,7 @@ module.exports = new Command("appdistribution:distribute <release-binary-file>")
     // If this is an app bundle and the certificate was originally blank fetch the updated
     // certificate and print
     if (aabInfo && !aabInfo.testCertificate) {
-      aabInfo = await requests.getAabInfo();
+      aabInfo = await requests.getAabInfo(appId);
       if (aabInfo.testCertificate) {
         utils.logBullet(
           "After you upload an AAB for the first time, App Distribution " +

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -4,11 +4,11 @@ import { Command } from "../command";
 import * as utils from "../utils";
 import { requireAuth } from "../requireAuth";
 import {
-  AabState,
-  AppDistributionApp,
+  AabInfo,
+  IntegrationState,
   AppDistributionClient,
-  AppView,
-  UploadStatus,
+  UploadReleaseResponse,
+  UploadReleaseResult,
 } from "../appdistribution/client";
 import { FirebaseError } from "../error";
 import { Distribution, DistributionFileType } from "../appdistribution/distribution";
@@ -53,14 +53,11 @@ function getTestersOrGroups(value: string, file: string): string[] {
   return [];
 }
 
-module.exports = new Command("appdistribution:distribute <distribution-file>")
-  .description("upload a distribution")
+module.exports = new Command("appdistribution:distribute <release-binary-file>")
+  .description("upload a release binary")
   .option("--app <app_id>", "the app id of your Firebase app")
-  .option("--release-notes <string>", "release notes to include with this distribution")
-  .option(
-    "--release-notes-file <file>",
-    "path to file with release notes to include with this distribution"
-  )
+  .option("--release-notes <string>", "release notes to include")
+  .option("--release-notes-file <file>", "path to file with release notes")
   .option("--testers <string>", "a comma separated list of tester emails to distribute to")
   .option(
     "--testers-file <file>",
@@ -79,14 +76,85 @@ module.exports = new Command("appdistribution:distribute <distribution-file>")
     const testers = getTestersOrGroups(options.testers, options.testersFile);
     const groups = getTestersOrGroups(options.groups, options.groupsFile);
     const requests = new AppDistributionClient(appId);
-    let app: AppDistributionApp;
+    let aabInfo: AabInfo | undefined;
 
+    if (distribution.distributionFileType() === DistributionFileType.AAB) {
+      try {
+        aabInfo = await requests.getAabInfo();
+      } catch (err) {
+        if (err.status === 404) {
+          throw new FirebaseError(
+            `App Distribution could not find your app ${appId}. ` +
+              `Make sure to onboard your app by pressing the "Get started" ` +
+              "button on the App Distribution page in the Firebase console: " +
+              "https://console.firebase.google.com/project/_/appdistribution",
+            { exit: 1 }
+          );
+        }
+        throw new FirebaseError(`failed to determine AAB info. ${err.message}`, { exit: 1 });
+      }
+
+      if (
+        aabInfo.integrationState !== IntegrationState.INTEGRATED &&
+        aabInfo.integrationState !== IntegrationState.AAB_STATE_UNAVAILABLE
+      ) {
+        switch (aabInfo.integrationState) {
+          case IntegrationState.PLAY_ACCOUNT_NOT_LINKED: {
+            throw new FirebaseError("This project is not linked to a Google Play account.");
+          }
+          case IntegrationState.APP_NOT_PUBLISHED: {
+            throw new FirebaseError('"This app is not published in the Google Play console.');
+          }
+          case IntegrationState.NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT: {
+            throw new FirebaseError(
+              "App with matching package name does not exist in Google Play."
+            );
+          }
+          case IntegrationState.PLAY_IAS_TERMS_NOT_ACCEPTED: {
+            throw new FirebaseError(
+              "You must accept the Play Internal App Sharing (IAS) terms to upload AABs."
+            );
+          }
+          default: {
+            throw new FirebaseError(
+              "App Distribution failed to process the AAB: " + aabInfo.integrationState
+            );
+          }
+        }
+      }
+    }
+
+    utils.logBullet("uploading binary...");
+    let releaseName;
     try {
-      const appView =
-        distribution.distributionFileType() === DistributionFileType.AAB
-          ? AppView.FULL
-          : AppView.BASIC;
-      app = await requests.getApp(appView);
+      const operationName = await requests.uploadRelease(distribution);
+
+      // The upload process is asynchronous, so poll to figure out when the upload has finished successfully
+      const uploadResponse = await requests.pollUploadStatus(operationName);
+
+      const release = uploadResponse.release;
+      switch (uploadResponse.result) {
+        case UploadReleaseResult.RELEASE_CREATED:
+          utils.logSuccess(
+            `uploaded new release ${release.displayVersion} (${release.buildVersion}) successfully!`
+          );
+          break;
+        case UploadReleaseResult.RELEASE_UPDATED:
+          utils.logSuccess(
+            `uploaded update to existing release ${release.displayVersion} (${release.buildVersion}) successfully!`
+          );
+          break;
+        case UploadReleaseResult.RELEASE_UNMODIFIED:
+          utils.logSuccess(
+            `re-uploaded already existing release ${release.displayVersion} (${release.buildVersion}) successfully!`
+          );
+          break;
+        default:
+          utils.logSuccess(
+            `uploaded release ${release.displayVersion} (${release.buildVersion}) successfully!`
+          );
+      }
+      releaseName = uploadResponse.release.name;
     } catch (err) {
       if (err.status === 404) {
         throw new FirebaseError(
@@ -97,85 +165,27 @@ module.exports = new Command("appdistribution:distribute <distribution-file>")
           { exit: 1 }
         );
       }
-      throw new FirebaseError(`failed to fetch app information. ${err.message}`, { exit: 1 });
-    }
-
-    if (!app.contactEmail) {
-      throw new FirebaseError(
-        `We could not find a contact email for app ${appId}. Please visit App Distribution within ` +
-          "the Firebase Console to set one up.",
-        { exit: 1 }
-      );
-    }
-
-    if (
-      distribution.distributionFileType() === DistributionFileType.AAB &&
-      app.aabState !== AabState.ACTIVE &&
-      app.aabState !== AabState.AAB_STATE_UNAVAILABLE
-    ) {
-      switch (app.aabState) {
-        case AabState.PLAY_ACCOUNT_NOT_LINKED: {
-          throw new FirebaseError("This project is not linked to a Google Play account.");
-        }
-        case AabState.APP_NOT_PUBLISHED: {
-          throw new FirebaseError('"This app is not published in the Google Play console.');
-        }
-        case AabState.NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT: {
-          throw new FirebaseError("App with matching package name does not exist in Google Play.");
-        }
-        case AabState.PLAY_IAS_TERMS_NOT_ACCEPTED: {
-          throw new FirebaseError(
-            "You must accept the Play Internal App Sharing (IAS) terms to upload AABs."
-          );
-        }
-        default: {
-          throw new FirebaseError("App Distribution failed to process the AAB: " + app.aabState);
-        }
-      }
-    }
-
-    let binaryName = await distribution.binaryName(app);
-
-    // Upload the distribution if it hasn't been uploaded before
-    let releaseId: string;
-    const uploadStatus = await requests.getUploadStatus(binaryName);
-
-    if (uploadStatus.status === UploadStatus.SUCCESS) {
-      utils.logWarning("this distribution has been uploaded before, skipping upload");
-      releaseId = uploadStatus.release.id;
-    } else {
-      // If there's an error, we know that the distribution hasn't been uploaded before
-      utils.logBullet("uploading distribution...");
-
-      try {
-        binaryName = await requests.uploadDistribution(distribution);
-
-        // The upload process is asynchronous, so poll to figure out when the upload has finished successfully
-        releaseId = await requests.pollUploadStatus(binaryName);
-        utils.logSuccess("uploaded distribution successfully!");
-      } catch (err) {
-        throw new FirebaseError(`failed to upload distribution. ${err.message}`, { exit: 1 });
-      }
+      throw new FirebaseError(`failed to upload release. ${err.message}`, { exit: 1 });
     }
 
     // If this is an app bundle and the certificate was originally blank fetch the updated
     // certificate and print
-    if (distribution.distributionFileType() === DistributionFileType.AAB && !app.aabCertificate) {
-      const updatedApp = await requests.getApp();
-      if (updatedApp.aabCertificate) {
+    if (aabInfo && !aabInfo.testCertificate) {
+      aabInfo = await requests.getAabInfo();
+      if (aabInfo.testCertificate) {
         utils.logBullet(
           "After you upload an AAB for the first time, App Distribution " +
             "generates a new test certificate. All AAB uploads are re-signed with this test " +
             "certificate. Use the certificate fingerprints below to register your app " +
             "signing key with API providers, such as Google Sign-In and Google Maps.\n" +
-            `MD-1 certificate fingerprint: ${updatedApp.aabCertificate.certificateHashMd5}\n` +
-            `SHA-1 certificate fingerprint: ${updatedApp.aabCertificate.certificateHashSha1}\n` +
-            `SHA-256 certificate fingerprint: ${updatedApp.aabCertificate.certificateHashSha256}`
+            `MD-1 certificate fingerprint: ${aabInfo.testCertificate.hashMd5}\n` +
+            `SHA-1 certificate fingerprint: ${aabInfo.testCertificate.hashSha1}\n` +
+            `SHA-256 certificate fingerprint: ${aabInfo.testCertificate.hashSha256}`
         );
       }
     }
 
-    // Add release notes and testers/groups
-    await requests.addReleaseNotes(releaseId, releaseNotes);
-    await requests.enableAccess(releaseId, testers, groups);
+    // Add release notes and distribute to testers/groups
+    await requests.updateReleaseNotes(releaseName, releaseNotes);
+    await requests.distribute(releaseName, testers, groups);
   });

--- a/src/commands/appdistribution-testers-add.ts
+++ b/src/commands/appdistribution-testers-add.ts
@@ -13,7 +13,7 @@ module.exports = new Command("appdistribution:testers:add [emails...]")
   .action(async (emails: string[], options?: any) => {
     const projectName = await getProjectName(options);
     const appDistroClient = new AppDistributionClient();
-    const emailsArr = getEmails(emails, options.file);
-    utils.logBullet(`Adding ${emailsArr.length} testers to project`);
-    await appDistroClient.addTesters(projectName, emails);
+    const emailsToAdd = getEmails(emails, options.file);
+    utils.logBullet(`Adding ${emailsToAdd.length} testers to project`);
+    await appDistroClient.addTesters(projectName, emailsToAdd);
   });

--- a/src/commands/appdistribution-testers-add.ts
+++ b/src/commands/appdistribution-testers-add.ts
@@ -1,0 +1,19 @@
+import { Command } from "../command";
+import * as utils from "../utils";
+import { requireAuth } from "../requireAuth";
+import { FirebaseError } from "../error";
+import { AppDistributionClient } from "../appdistribution/client";
+import { getEmails, getProjectName } from "../appdistribution/options-parser-util";
+import { needProjectNumber } from "../projectUtils";
+
+module.exports = new Command("appdistribution:testers:add [emails...]")
+  .description("add testers to project")
+  .option("--file <file>", "a path to a file containing a list of tester emails to be added")
+  .before(requireAuth)
+  .action(async (emails: string[], options?: any) => {
+    const projectName = await getProjectName(options);
+    const appDistroClient = new AppDistributionClient();
+    const emailsArr = getEmails(emails, options.file);
+    utils.logBullet(`Adding ${emailsArr.length} testers to project`);
+    await appDistroClient.addTesters(projectName, emails);
+  });

--- a/src/commands/appdistribution-testers-remove.ts
+++ b/src/commands/appdistribution-testers-remove.ts
@@ -1,0 +1,31 @@
+import { Command } from "../command";
+import * as utils from "../utils";
+import { requireAuth } from "../requireAuth";
+import { FirebaseError } from "../error";
+import { AppDistributionClient } from "../appdistribution/client";
+import { getEmails, getProjectName } from "../appdistribution/options-parser-util";
+import { logger } from "../logger";
+
+module.exports = new Command("appdistribution:testers:remove [emails...]")
+  .description("remove testers from a project")
+  .option("--file <file>", "a path to a file containing a list of tester emails to be removed")
+  .before(requireAuth)
+  .action(async (emails: string[], options?: any) => {
+    const projectName = await getProjectName(options);
+    const appDistroClient = new AppDistributionClient();
+    const emailsArr = getEmails(emails, options.file);
+    let deleteResponse;
+    try {
+      utils.logBullet(`Deleting ${emailsArr.length} testers from project`);
+      deleteResponse = await appDistroClient.removeTesters(projectName, emailsArr);
+    } catch (err) {
+      throw new FirebaseError(`Failed to remove testers ${err}`);
+    }
+
+    if (!deleteResponse.emails) {
+      utils.logSuccess(`Testers did not exist`);
+      return;
+    }
+    logger.debug(`Testers: ${deleteResponse.emails}, have been successfully deleted`);
+    utils.logSuccess(`${deleteResponse.emails.length} testers have successfully been deleted`);
+  });

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -15,6 +15,9 @@ module.exports = function (client) {
 
   client.appdistribution = {};
   client.appdistribution.distribute = loadCommand("appdistribution-distribute");
+  client.appdistribution.testers = {};
+  client.appdistribution.testers.add = loadCommand("appdistribution-testers-add");
+  client.appdistribution.testers.delete = loadCommand("appdistribution-testers-remove");
   client.apps = {};
   client.apps.create = loadCommand("apps-create");
   client.apps.list = loadCommand("apps-list");

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -10,7 +10,6 @@ import { FirebaseError } from "../../error";
 import * as api from "../../api";
 import * as nock from "nock";
 import { Distribution } from "../../appdistribution/distribution";
-import { describe } from "mocha";
 
 tmp.setGracefulCleanup();
 

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -1,15 +1,11 @@
 import { expect } from "chai";
 import { join } from "path";
+import * as fs from "fs-extra";
 import * as rimraf from "rimraf";
 import * as sinon from "sinon";
 import * as tmp from "tmp";
 
-import {
-  AppDistributionClient,
-  AppView,
-  UploadStatus,
-  UploadStatusResponse,
-} from "../../appdistribution/client";
+import { AppDistributionClient } from "../../appdistribution/client";
 import { FirebaseError } from "../../error";
 import * as api from "../../api";
 import * as nock from "nock";
@@ -19,11 +15,12 @@ tmp.setGracefulCleanup();
 
 describe("distribution", () => {
   const tempdir = tmp.dirSync();
-  const appId = "1:12345789:ios:abc123def456";
-  const mockDistribution = new Distribution(join(tempdir.name, "app.ipa"));
+  const projectNumber = "123456789";
+  const appId = "1:123456789:ios:abc123def456";
+  const binaryFile = join(tempdir.name, "app.ipa");
+  fs.ensureFileSync(binaryFile);
+  const mockDistribution = new Distribution(binaryFile);
   const appDistributionClient = new AppDistributionClient(appId);
-  const appViewBasic = "BASIC";
-  const appViewFull = "FULL";
 
   let sandbox: sinon.SinonSandbox;
 
@@ -40,194 +37,67 @@ describe("distribution", () => {
     rimraf.sync(tempdir.name);
   });
 
-  describe("getApp", () => {
-    it("should throw error when app does not exist", async () => {
-      nock(api.appDistributionOrigin)
-        .get(`/v1alpha/apps/${appId}`)
-        .query({ appView: appViewBasic })
-        .reply(404, {});
-      await expect(appDistributionClient.getApp()).to.be.rejected;
-      expect(nock.isDone()).to.be.true;
-    });
-
-    it("should resolve when request succeeds", async () => {
-      nock(api.appDistributionOrigin)
-        .get(`/v1alpha/apps/${appId}`)
-        .query({ appView: appViewBasic })
-        .reply(200, {});
-      await expect(appDistributionClient.getApp()).to.be.fulfilled;
-      expect(nock.isDone()).to.be.true;
-    });
-
-    it("requests basic appView", async () => {
-      nock(api.appDistributionOrigin)
-        .get(`/v1alpha/apps/${appId}`)
-        .query({ appView: appViewBasic })
-        .reply(200, {});
-      await expect(appDistributionClient.getApp(AppView.BASIC)).to.be.fulfilled;
-      expect(nock.isDone()).to.be.true;
-    });
-
-    it("requests full appView", async () => {
-      nock(api.appDistributionOrigin)
-        .get(`/v1alpha/apps/${appId}`)
-        .query({ appView: appViewFull })
-        .reply(200, {});
-      await expect(appDistributionClient.getApp(AppView.FULL)).to.be.fulfilled;
-      expect(nock.isDone()).to.be.true;
-    });
-
-    it("should throw an error when the request fails", async () => {
-      nock(api.appDistributionOrigin)
-        .get(`/v1alpha/apps/${appId}`)
-        .query({ appView: appViewBasic })
-        .reply(404, {});
-      await expect(appDistributionClient.getApp()).to.be.rejected;
-      expect(nock.isDone()).to.be.true;
-    });
-  });
-
-  describe("uploadDistribution", () => {
+  describe("uploadRelease", () => {
     it("should throw error if upload fails", async () => {
-      nock(api.appDistributionOrigin).post(`/app-binary-uploads?app_id=${appId}`).reply(400, {});
-      await expect(appDistributionClient.uploadDistribution(mockDistribution)).to.be.rejected;
+      nock(api.appDistributionOrigin)
+        .post(`/upload/v1/projects/${projectNumber}/apps/${appId}/releases:upload`)
+        .reply(400, {});
+      await expect(appDistributionClient.uploadRelease(mockDistribution)).to.be.rejected;
       expect(nock.isDone()).to.be.true;
     });
 
     it("should return token if upload succeeds", async () => {
-      const fakeToken = "fake-token";
+      const fakeOperation = "fake-operation-name";
       nock(api.appDistributionOrigin)
-        .post(`/app-binary-uploads?app_id=${appId}`)
-        .reply(200, { token: fakeToken });
-      await expect(appDistributionClient.uploadDistribution(mockDistribution)).to.be.eventually.eq(
-        fakeToken
+        .post(`/upload/v1/projects/${projectNumber}/apps/${appId}/releases:upload`)
+        .reply(200, { name: fakeOperation });
+      await expect(appDistributionClient.uploadRelease(mockDistribution)).to.be.eventually.eq(
+        fakeOperation
       );
       expect(nock.isDone()).to.be.true;
     });
   });
 
-  describe("pollReleaseIdByHash", () => {
-    describe("when getUploadStatus returns IN_PROGRESS", () => {
-      it("should throw error when retry count >= AppDistributionClient.MAX_POLLING_RETRIES", () => {
-        sandbox.stub(appDistributionClient, "getUploadStatus").resolves({
-          status: UploadStatus.IN_PROGRESS,
-          message: "",
-          errorCode: "",
-          release: { id: "" },
-        });
-        return expect(
-          appDistributionClient.pollUploadStatus(
-            "mock-hash",
-            AppDistributionClient.MAX_POLLING_RETRIES
-          )
-        ).to.be.rejectedWith(
-          FirebaseError,
-          "it took longer than expected to process your binary, please try again"
-        );
-      });
-    });
-
-    it("should return release id when request succeeds", () => {
-      const releaseId = "fake-release-id";
-      sandbox.stub(appDistributionClient, "getUploadStatus").resolves({
-        status: UploadStatus.SUCCESS,
-        message: "",
-        errorCode: "",
-        release: {
-          id: releaseId,
-        },
-      });
-      return expect(
-        appDistributionClient.pollUploadStatus(
-          "mock-hash",
-          AppDistributionClient.MAX_POLLING_RETRIES
-        )
-      ).to.eventually.eq(releaseId);
-    });
-  });
-
-  describe("getUploadStatus", () => {
-    it("should throw an error when request fails", async () => {
-      const fakeHash = "fake-hash";
-      nock(api.appDistributionOrigin)
-        .get(`/v1alpha/apps/${appId}/upload_status/${fakeHash}`)
-        .reply(400, {});
-
-      await expect(appDistributionClient.getUploadStatus(fakeHash)).to.be.rejectedWith(
-        FirebaseError,
-        "HTTP Error: 400"
-      );
-      expect(nock.isDone()).to.be.true;
-    });
-
-    describe("when request succeeds", () => {
-      it("should return the upload status", async () => {
-        const releaseId = "fake-release-id";
-        const fakeHash = "fake-hash";
-        const response: UploadStatusResponse = {
-          status: UploadStatus.SUCCESS,
-          errorCode: "0",
-          message: "",
-          release: {
-            id: releaseId,
-          },
-        };
-        nock(api.appDistributionOrigin)
-          .get(`/v1alpha/apps/${appId}/upload_status/${fakeHash}`)
-          .reply(200, response);
-
-        await expect(appDistributionClient.getUploadStatus(fakeHash)).to.eventually.deep.eq(
-          response
-        );
-        expect(nock.isDone()).to.be.true;
-      });
-    });
-  });
-
-  describe("addReleaseNotes", () => {
+  describe("updateReleaseNotes", () => {
+    const releaseName = `projects/${projectNumber}/apps/${appId}/releases/fake-release-id`;
     it("should return immediately when no release notes are specified", async () => {
       const apiSpy = sandbox.spy(api, "request");
-      await expect(appDistributionClient.addReleaseNotes("fake-release-id", "")).to.eventually.be
+      await expect(appDistributionClient.updateReleaseNotes(releaseName, "")).to.eventually.be
         .fulfilled;
       expect(apiSpy).to.not.be.called;
     });
 
     it("should throw error when request fails", async () => {
-      const releaseId = "fake-release-id";
       nock(api.appDistributionOrigin)
-        .post(`/v1alpha/apps/${appId}/releases/${releaseId}/notes`)
+        .patch(`/v1/${releaseName}?updateMask=release_notes.text`)
         .reply(400, {});
       await expect(
-        appDistributionClient.addReleaseNotes(releaseId, "release notes")
-      ).to.be.rejectedWith(FirebaseError, "failed to add release notes");
+        appDistributionClient.updateReleaseNotes(releaseName, "release notes")
+      ).to.be.rejectedWith(FirebaseError, "failed to update release notes");
       expect(nock.isDone()).to.be.true;
     });
 
     it("should resolve when request succeeds", async () => {
-      const releaseId = "fake-release-id";
       nock(api.appDistributionOrigin)
-        .post(`/v1alpha/apps/${appId}/releases/${releaseId}/notes`)
+        .patch(`/v1/${releaseName}?updateMask=release_notes.text`)
         .reply(200, {});
-      await expect(appDistributionClient.addReleaseNotes(releaseId, "release notes")).to.eventually
-        .be.fulfilled;
+      await expect(appDistributionClient.updateReleaseNotes(releaseName, "release notes")).to
+        .eventually.be.fulfilled;
       expect(nock.isDone()).to.be.true;
     });
   });
 
-  describe("enableAccess", () => {
+  describe("distribute", () => {
+    const releaseName = `projects/${projectNumber}/apps/${appId}/releases/fake-release-id`;
     it("should return immediately when testers and groups are empty", async () => {
       const apiSpy = sandbox.spy(api, "request");
-      await expect(appDistributionClient.enableAccess("fake-release-id")).to.eventually.be
-        .fulfilled;
+      await expect(appDistributionClient.distribute(releaseName)).to.eventually.be.fulfilled;
       expect(apiSpy).to.not.be.called;
     });
 
     it("should resolve when request succeeds", async () => {
-      const releaseId = "fake-release-id";
-      nock(api.appDistributionOrigin)
-        .post(`/v1alpha/apps/${appId}/releases/${releaseId}/enable_access`)
-        .reply(200, {});
-      await expect(appDistributionClient.enableAccess(releaseId, ["tester1"], ["group1"])).to.be
+      nock(api.appDistributionOrigin).post(`/v1/${releaseName}:distribute`).reply(200, {});
+      await expect(appDistributionClient.distribute(releaseName, ["tester1"], ["group1"])).to.be
         .fulfilled;
       expect(nock.isDone()).to.be.true;
     });
@@ -241,44 +111,47 @@ describe("distribution", () => {
       });
 
       it("should throw invalid testers error when status code is FAILED_PRECONDITION ", async () => {
-        const releaseId = "fake-release-id";
         nock(api.appDistributionOrigin)
-          .post(`/v1alpha/apps/${appId}/releases/${releaseId}/enable_access`, {
-            emails: testers,
-            groupIds: groups,
+          .post(`/v1/${releaseName}:distribute`, {
+            testerEmails: testers,
+            groupAliases: groups,
           })
           .reply(412, { error: { status: "FAILED_PRECONDITION" } });
         await expect(
-          appDistributionClient.enableAccess(releaseId, testers, groups)
-        ).to.be.rejectedWith(FirebaseError, "failed to add testers/groups: invalid testers");
+          appDistributionClient.distribute(releaseName, testers, groups)
+        ).to.be.rejectedWith(
+          FirebaseError,
+          "failed to distribute to testers/groups: invalid testers"
+        );
         expect(nock.isDone()).to.be.true;
       });
 
       it("should throw invalid groups error when status code is INVALID_ARGUMENT", async () => {
-        const releaseId = "fake-release-id";
         nock(api.appDistributionOrigin)
-          .post(`/v1alpha/apps/${appId}/releases/${releaseId}/enable_access`, {
-            emails: testers,
-            groupIds: groups,
+          .post(`/v1/${releaseName}:distribute`, {
+            testerEmails: testers,
+            groupAliases: groups,
           })
           .reply(412, { error: { status: "INVALID_ARGUMENT" } });
         await expect(
-          appDistributionClient.enableAccess(releaseId, testers, groups)
-        ).to.be.rejectedWith(FirebaseError, "failed to add testers/groups: invalid groups");
+          appDistributionClient.distribute(releaseName, testers, groups)
+        ).to.be.rejectedWith(
+          FirebaseError,
+          "failed to distribute to testers/groups: invalid groups"
+        );
         expect(nock.isDone()).to.be.true;
       });
 
       it("should throw default error", async () => {
-        const releaseId = "fake-release-id";
         nock(api.appDistributionOrigin)
-          .post(`/v1alpha/apps/${appId}/releases/${releaseId}/enable_access`, {
-            emails: testers,
-            groupIds: groups,
+          .post(`/v1/${releaseName}:distribute`, {
+            testerEmails: testers,
+            groupAliases: groups,
           })
           .reply(400, {});
         await expect(
-          appDistributionClient.enableAccess(releaseId, ["tester1"], ["group1"])
-        ).to.be.rejectedWith(FirebaseError, "failed to add testers/groups");
+          appDistributionClient.distribute(releaseName, ["tester1"], ["group1"])
+        ).to.be.rejectedWith(FirebaseError, "failed to distribute to testers/groups");
         expect(nock.isDone()).to.be.true;
       });
     });


### PR DESCRIPTION
### Description

- Adds `appdistribution:testers:add` and `appdistribution:testers:remove` commands.
- Uses public v1 AppDistribution API.

### Scenarios Tested

- Uploading APKs, AABs, and IPAs, adding release notes, distribute to groups and/or individual testers
- adding and removing testers
