### PR TITLE
Add --non-interactive and --force support to ext:update

### DIFF
--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -59,12 +59,12 @@ export default new Command("ext:configure <extensionInstanceId>")
         // TODO: Stop special casing "LOCATION" once all official extensions make it immutable
       });
 
-      const params = await paramHelper.getParams(
+      const params = await paramHelper.getParams({
         projectId,
-        paramSpecWithNewDefaults,
-        options.nonInteractive,
-        options.params
-      );
+        paramSpecs: paramSpecWithNewDefaults,
+        nonInteractive: options.nonInteractive,
+        paramsEnvPath: options.params,
+      });
       if (immutableParams.length) {
         const plural = immutableParams.length > 1;
         logger.info(`The following param${plural ? "s are" : " is"} immutable:`);

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -40,7 +40,7 @@ marked.setOptions({
 });
 
 interface InstallExtensionOptions {
-  paramFilePath?: string;
+  paramsEnvPath?: string;
   projectId: string;
   extensionName: string;
   source?: extensionsApi.ExtensionSource;
@@ -55,7 +55,7 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
     extensionName,
     source,
     extVersion,
-    paramFilePath,
+    paramsEnvPath,
     nonInteractive,
     force,
   } = options;
@@ -119,12 +119,12 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
     switch (choice) {
       case "installNew":
         instanceId = await promptForValidInstanceId(`${instanceId}-${getRandomString(4)}`);
-        params = await paramHelper.getParams(
+        params = await paramHelper.getParams({
           projectId,
-          _.get(spec, "params", []),
+          paramSpecs: spec.params,
           nonInteractive,
-          paramFilePath
-        );
+          paramsEnvPath,
+        });
         spinner.text = "Installing your extension instance. This usually takes 3 to 5 minutes...";
         spinner.start();
         await extensionsApi.createInstance({
@@ -142,12 +142,12 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
         );
         break;
       case "updateExisting":
-        params = await paramHelper.getParams(
+        params = await paramHelper.getParams({
           projectId,
-          _.get(spec, "params", []),
+          paramSpecs: spec.params,
           nonInteractive,
-          paramFilePath
-        );
+          paramsEnvPath,
+        });
         spinner.text = "Updating your extension instance. This usually takes 3 to 5 minutes...";
         spinner.start();
         await update({
@@ -254,7 +254,7 @@ export default new Command("ext:install [extensionName]")
   .before(checkMinRequiredVersion, "extMinVersion")
   .action(async (extensionName: string, options: any) => {
     const projectId = needProjectId(options);
-    const paramFilePath = options.params;
+    const paramsEnvPath = options.params;
     let learnMore = false;
     if (!extensionName) {
       if (options.interactive) {
@@ -313,7 +313,7 @@ export default new Command("ext:install [extensionName]")
     }
     try {
       return installExtension({
-        paramFilePath,
+        paramsEnvPath,
         projectId,
         extensionName,
         source,

--- a/src/extensions/billingMigrationHelper.ts
+++ b/src/extensions/billingMigrationHelper.ts
@@ -48,26 +48,13 @@ function hasRuntime(spec: extensionsApi.ExtensionSpec, runtime: string): boolean
  *
  * @param curSpec A current extensionSpec
  * @param newSpec A extensionSpec to compare to
- * @param prompt If true, prompts user for confirmation
  */
-export async function displayNode10UpdateBillingNotice(
+export function displayNode10UpdateBillingNotice(
   curSpec: extensionsApi.ExtensionSpec,
-  newSpec: extensionsApi.ExtensionSpec,
-  prompt: boolean
-): Promise<void> {
+  newSpec: extensionsApi.ExtensionSpec
+): void {
   if (hasRuntime(curSpec, "nodejs8") && hasRuntime(newSpec, "nodejs10")) {
     utils.logLabeledWarning(logPrefix, marked(billingMsgUpdate));
-
-    if (prompt) {
-      const continueUpdate = await promptOnce({
-        type: "confirm",
-        message: "Do you wish to continue?",
-        default: true,
-      });
-      if (!continueUpdate) {
-        throw new FirebaseError(`Cancelled.`, { exit: 2 });
-      }
-    }
   }
 }
 

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -20,7 +20,7 @@ export async function buildOptions(options: any): Promise<any> {
   const spec = await specHelper.readExtensionYaml(extensionDir);
   extensionsHelper.validateSpec(spec);
 
-  const params = await getParams(options, spec);
+  const params = getParams(options, spec);
 
   extensionsHelper.validateCommandLineParams(params, spec.params);
 
@@ -44,9 +44,9 @@ export async function buildOptions(options: any): Promise<any> {
 }
 
 // Exported for testing
-export async function getParams(options: any, extensionSpec: ExtensionSpec) {
+export function getParams(options: any, extensionSpec: ExtensionSpec) {
   const projectId = needProjectId(options);
-  const userParams = await paramHelper.readParamsFile(options.testParams);
+  const userParams = paramHelper.readEnvFile(options.testParams);
   const autoParams = {
     PROJECT_ID: projectId,
     EXT_INSTANCE_ID: extensionSpec.name,

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -56,14 +56,15 @@ export function getParamsWithCurrentValuesAsDefaults(
  * @param envFilePath a path to an env file containing param values
  * @throws FirebaseError if an invalid env file is passed in
  */
-export async function getParams(
-  projectId: string,
-  paramSpecs: extensionsApi.Param[],
-  noninteractive: boolean = false,
-  envFilePath?: string
-): Promise<{ [key: string]: string }> {
-  if (noninteractive && !envFilePath) {
-    const paramsMessage = paramSpecs
+export async function getParams(args: {
+  projectId: string;
+  paramSpecs: extensionsApi.Param[];
+  nonInteractive?: boolean;
+  paramsEnvPath?: string;
+}): Promise<{ [key: string]: string }> {
+  let params: any;
+  if (args.nonInteractive && !args.paramsEnvPath) {
+    const paramsMessage = args.paramSpecs
       .map((p) => {
         return `\t${p.param}${p.required ? "" : " (Optional)"}`;
       })
@@ -74,28 +75,56 @@ export async function getParams(
         " containing values for this extension's params:\n" +
         paramsMessage
     );
-  }
-  let commandLineParams;
-  if (envFilePath) {
-    try {
-      const buf = fs.readFileSync(path.resolve(envFilePath), "utf8");
-      commandLineParams = dotenv.parse(buf.toString().trim(), { debug: true });
-      track("Extension Env File", "Present");
-    } catch (err) {
-      track("Extension Env File", "Invalid");
-      throw new FirebaseError(`Error reading env file: ${err.message}\n`, { original: err });
-    }
+  } else if (args.paramsEnvPath) {
+    params = getParamsFromFile({
+      projectId: args.projectId,
+      paramSpecs: args.paramSpecs,
+      noninteractive: args.nonInteractive,
+      paramsEnvPath: args.paramsEnvPath,
+    });
   } else {
-    track("Extension Env File", "Not Present");
+    const firebaseProjectParams = await getFirebaseProjectParams(args.projectId);
+    params = await askUserForParam.ask(args.paramSpecs, firebaseProjectParams);
   }
-  const firebaseProjectParams = await getFirebaseProjectParams(projectId);
+  track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
+  return params;
+}
+
+export async function getParamsForUpdate(args: {
+  spec: extensionsApi.ExtensionSpec;
+  newSpec: extensionsApi.ExtensionSpec;
+  currentParams: { [option: string]: string };
+  projectId: string;
+  paramsEnvPath?: string;
+  nonInteractive?: boolean;
+}) {
   let params: any;
-  if (commandLineParams) {
-    params = populateDefaultParams(commandLineParams, paramSpecs);
-    validateCommandLineParams(params, paramSpecs);
-    logger.info(`Using param values from ${envFilePath}`);
+  if (args.nonInteractive && !args.paramsEnvPath) {
+    const paramsMessage = args.newSpec.params
+      .map((p) => {
+        return `\t${p.param}${p.required ? "" : " (Optional)"}`;
+      })
+      .join("\n");
+    throw new FirebaseError(
+      "In non-interactive mode but no `--params` flag found. " +
+        "To update this extension in non-interactive mode, set `--params` to a path to an .env file" +
+        " containing values for this extension's params:\n" +
+        paramsMessage
+    );
+  } else if (args.paramsEnvPath) {
+    params = getParamsFromFile({
+      projectId: args.projectId,
+      paramSpecs: args.newSpec.params,
+      noninteractive: args.nonInteractive,
+      paramsEnvPath: args.paramsEnvPath,
+    });
   } else {
-    params = await askUserForParam.ask(paramSpecs, firebaseProjectParams);
+    params = await promptForNewParams({
+      spec: args.spec,
+      newSpec: args.newSpec,
+      currentParams: args.currentParams,
+      projectId: args.projectId,
+    });
   }
   track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
   return params;
@@ -109,23 +138,31 @@ export async function getParams(
  * @param newSpec A extensionSpec to compare to
  * @param currentParams A set of current params and their values
  */
-export async function promptForNewParams(
-  spec: extensionsApi.ExtensionSpec,
-  newSpec: extensionsApi.ExtensionSpec,
-  currentParams: { [option: string]: string },
-  projectId: string
-): Promise<any> {
-  const firebaseProjectParams = await getFirebaseProjectParams(projectId);
+export async function promptForNewParams(args: {
+  spec: extensionsApi.ExtensionSpec;
+  newSpec: extensionsApi.ExtensionSpec;
+  currentParams: { [option: string]: string };
+  projectId: string;
+}): Promise<any> {
+  const firebaseProjectParams = await getFirebaseProjectParams(args.projectId);
   const comparer = (param1: extensionsApi.Param, param2: extensionsApi.Param) => {
     return param1.type === param2.type && param1.param === param2.param;
   };
-  let paramsDiffDeletions = _.differenceWith(spec.params, _.get(newSpec, "params", []), comparer);
+  let paramsDiffDeletions = _.differenceWith(
+    args.spec.params,
+    _.get(args.newSpec, "params", []),
+    comparer
+  );
   paramsDiffDeletions = substituteParams<extensionsApi.Param[]>(
     paramsDiffDeletions,
     firebaseProjectParams
   );
 
-  let paramsDiffAdditions = _.differenceWith(newSpec.params, _.get(spec, "params", []), comparer);
+  let paramsDiffAdditions = _.differenceWith(
+    args.newSpec.params,
+    _.get(args.spec, "params", []),
+    comparer
+  );
   paramsDiffAdditions = substituteParams<extensionsApi.Param[]>(
     paramsDiffAdditions,
     firebaseProjectParams
@@ -134,27 +171,41 @@ export async function promptForNewParams(
   if (paramsDiffDeletions.length) {
     logger.info("The following params will no longer be used:");
     paramsDiffDeletions.forEach((param) => {
-      logger.info(clc.red(`- ${param.param}: ${currentParams[param.param.toUpperCase()]}`));
-      delete currentParams[param.param.toUpperCase()];
+      logger.info(clc.red(`- ${param.param}: ${args.currentParams[param.param.toUpperCase()]}`));
+      delete args.currentParams[param.param.toUpperCase()];
     });
   }
   if (paramsDiffAdditions.length) {
     logger.info("To update this instance, configure the following new parameters:");
     for (const param of paramsDiffAdditions) {
       const chosenValue = await askUserForParam.askForParam(param);
-      currentParams[param.param] = chosenValue;
+      args.currentParams[param.param] = chosenValue;
     }
   }
-  return currentParams;
+  return args.currentParams;
 }
 
-export function readParamsFile(envFilePath: string): any {
+export function getParamsFromFile(args: {
+  projectId: string;
+  paramSpecs: extensionsApi.Param[];
+  paramsEnvPath: string;
+  noninteractive?: boolean;
+}): Record<string, string> {
+  let envParams;
   try {
-    const buf = fs.readFileSync(path.resolve(envFilePath), "utf8");
-    return dotenv.parse(buf.toString().trim(), { debug: true });
+    envParams = readEnvFile(args.paramsEnvPath);
+    track("Extension Env File", "Present");
   } catch (err) {
-    throw new FirebaseError(`Error reading --test-params file: ${err.message}\n`, {
-      original: err,
-    });
+    track("Extension Env File", "Invalid");
+    throw new FirebaseError(`Error reading env file: ${err.message}\n`, { original: err });
   }
+  const params = populateDefaultParams(envParams, args.paramSpecs);
+  validateCommandLineParams(params, args.paramSpecs);
+  logger.info(`Using param values from ${args.paramsEnvPath}`);
+  return params;
+}
+
+export function readEnvFile(envPath: string) {
+  const buf = fs.readFileSync(path.resolve(envPath), "utf8");
+  return dotenv.parse(buf.toString().trim(), { debug: true });
 }

--- a/src/test/extensions/billingMigrationHelper.spec.ts
+++ b/src/test/extensions/billingMigrationHelper.spec.ts
@@ -82,58 +82,6 @@ describe("billingMigrationHelper", () => {
     promptStub.restore();
   });
 
-  describe("displayUpdateBillingNotice", () => {
-    it("should notify the user if the runtime is being upgraded to nodejs10", () => {
-      promptStub.resolves(true);
-      const curSpec = _.cloneDeep(NODE8_SPEC);
-      const newSpec = _.cloneDeep(NODE10_SPEC);
-
-      expect(nodejsMigrationHelper.displayNode10UpdateBillingNotice(curSpec, newSpec, true)).not.to
-        .be.rejected;
-      expect(promptStub.callCount).to.equal(1);
-    });
-
-    it("should notify the user if the runtime is being upgraded to nodejs10 implicitly", () => {
-      promptStub.resolves(true);
-      const curSpec = _.cloneDeep(NO_RUNTIME_SPEC);
-      const newSpec = _.cloneDeep(NODE10_SPEC);
-
-      expect(nodejsMigrationHelper.displayNode10UpdateBillingNotice(curSpec, newSpec, true)).not.to
-        .be.rejected;
-      expect(promptStub.callCount).to.equal(1);
-    });
-
-    it("should display nothing if the runtime isn't being upgraded to nodejs10", () => {
-      promptStub.resolves(true);
-      const curSpec = _.cloneDeep(NODE8_SPEC);
-      const newSpec = _.cloneDeep(NODE8_SPEC);
-
-      expect(nodejsMigrationHelper.displayNode10UpdateBillingNotice(curSpec, newSpec, true)).not.to
-        .be.rejected;
-      expect(promptStub.callCount).to.equal(0);
-    });
-
-    it("should display nothing if the runtime is already on nodejs10", () => {
-      promptStub.resolves(true);
-      const curSpec = _.cloneDeep(NODE10_SPEC);
-      const newSpec = _.cloneDeep(NODE10_SPEC);
-
-      expect(nodejsMigrationHelper.displayNode10UpdateBillingNotice(curSpec, newSpec, true)).not.to
-        .be.rejected;
-      expect(promptStub.callCount).to.equal(0);
-    });
-
-    it("should error if the user doesn't give consent", () => {
-      promptStub.resolves(false);
-      const curSpec = _.cloneDeep(NODE8_SPEC);
-      const newSpec = _.cloneDeep(NODE10_SPEC);
-
-      expect(
-        nodejsMigrationHelper.displayNode10UpdateBillingNotice(curSpec, newSpec, true)
-      ).to.be.rejectedWith(FirebaseError, "Cancelled");
-    });
-  });
-
   describe("displayCreateBillingNotice", () => {
     it("should notify the user if the runtime requires nodejs10", () => {
       promptStub.resolves(true);

--- a/src/test/extensions/displayExtensionInfo.spec.ts
+++ b/src/test/extensions/displayExtensionInfo.spec.ts
@@ -107,11 +107,16 @@ describe("displayExtensionInfo", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.license = "To Kill";
 
-      expect(displayExtensionInfo.displayUpdateChangesRequiringConfirmation(SPEC, newSpec)).not.to
-        .be.rejected;
+      expect(
+        displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+          spec: SPEC,
+          newSpec,
+          nonInteractive: false,
+          force: false,
+        })
+      ).not.to.be.rejected;
 
       expect(promptStub.callCount).to.equal(1);
-      expect(promptStub.firstCall.args[0].message).to.contain("To Kill");
     });
 
     it("should prompt for changes to apis and continue if user gives consent", () => {
@@ -122,12 +127,16 @@ describe("displayExtensionInfo", () => {
         { apiName: "api3", reason: "" },
       ];
 
-      expect(displayExtensionInfo.displayUpdateChangesRequiringConfirmation(SPEC, newSpec)).not.to
-        .be.rejected;
+      expect(
+        displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+          spec: SPEC,
+          newSpec,
+          nonInteractive: false,
+          force: false,
+        })
+      ).not.to.be.rejected;
 
       expect(promptStub.callCount).to.equal(1);
-      expect(promptStub.firstCall.args[0].message).to.contain("- api1");
-      expect(promptStub.firstCall.args[0].message).to.contain("+ api3");
     });
 
     it("should prompt for changes to roles and continue if user gives consent", () => {
@@ -138,12 +147,16 @@ describe("displayExtensionInfo", () => {
         { role: "role3", reason: "" },
       ];
 
-      expect(displayExtensionInfo.displayUpdateChangesRequiringConfirmation(SPEC, newSpec)).not.to
-        .be.rejected;
+      expect(
+        displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+          spec: SPEC,
+          newSpec,
+          nonInteractive: false,
+          force: false,
+        })
+      ).not.to.be.rejected;
 
       expect(promptStub.callCount).to.equal(1);
-      expect(promptStub.firstCall.args[0].message).to.contain("- role1");
-      expect(promptStub.firstCall.args[0].message).to.contain("+ role3");
     });
 
     it("should prompt for changes to resources and continue if user gives consent", () => {
@@ -154,14 +167,16 @@ describe("displayExtensionInfo", () => {
         { name: "resource2", type: "other", description: "" },
       ];
 
-      expect(displayExtensionInfo.displayUpdateChangesRequiringConfirmation(SPEC, newSpec)).not.to
-        .be.rejected;
+      expect(
+        displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+          spec: SPEC,
+          newSpec,
+          nonInteractive: false,
+          force: false,
+        })
+      ).not.to.be.rejected;
 
       expect(promptStub.callCount).to.equal(1);
-      expect(promptStub.firstCall.args[0].message).to.contain("- resource1");
-      expect(promptStub.firstCall.args[0].message).to.contain("desc");
-      expect(promptStub.firstCall.args[0].message).to.contain("+ resource3");
-      expect(promptStub.firstCall.args[0].message).to.contain("new desc");
     });
 
     it("should prompt for changes to resources and continue if user gives consent", () => {
@@ -169,13 +184,16 @@ describe("displayExtensionInfo", () => {
       const oldSpec = _.cloneDeep(SPEC);
       oldSpec.billingRequired = false;
 
-      expect(displayExtensionInfo.displayUpdateChangesRequiringConfirmation(oldSpec, SPEC)).not.to
-        .be.rejected;
+      expect(
+        displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+          spec: oldSpec,
+          newSpec: SPEC,
+          nonInteractive: false,
+          force: false,
+        })
+      ).not.to.be.rejected;
 
       expect(promptStub.callCount).to.equal(1);
-      expect(promptStub.firstCall.args[0].message).to.contain(
-        "Billing is now required for the new version of this extension. Would you like to continue?"
-      );
     });
 
     it("should exit if the user consents to one change but rejects another", () => {
@@ -189,10 +207,15 @@ describe("displayExtensionInfo", () => {
       ];
 
       expect(
-        displayExtensionInfo.displayUpdateChangesRequiringConfirmation(SPEC, newSpec)
+        displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+          spec: SPEC,
+          newSpec,
+          nonInteractive: false,
+          force: false,
+        })
       ).to.be.rejectedWith(
         FirebaseError,
-        "Without explicit consent for the change to license, we cannot update this extension instance."
+        "Unable to update this extension instance without explicit consent for the change to 'License'"
       );
 
       expect(promptStub.callCount).to.equal(1);
@@ -204,10 +227,15 @@ describe("displayExtensionInfo", () => {
       newSpec.license = "new";
 
       expect(
-        displayExtensionInfo.displayUpdateChangesRequiringConfirmation(SPEC, newSpec)
+        displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+          spec: SPEC,
+          newSpec,
+          nonInteractive: false,
+          force: false,
+        })
       ).to.be.rejectedWith(
         FirebaseError,
-        "Without explicit consent for the change to license, we cannot update this extension instance."
+        "Unable to update this extension instance without explicit consent for the change to 'License'."
       );
     });
 
@@ -216,7 +244,12 @@ describe("displayExtensionInfo", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.version = "1.1.0";
 
-      await displayExtensionInfo.displayUpdateChangesRequiringConfirmation(SPEC, newSpec);
+      await displayExtensionInfo.displayUpdateChangesRequiringConfirmation({
+        spec: SPEC,
+        newSpec,
+        nonInteractive: false,
+        force: false,
+      });
 
       expect(promptStub).not.to.have.been.called;
     });

--- a/src/test/extensions/emulator/optionsHelper.spec.ts
+++ b/src/test/extensions/emulator/optionsHelper.spec.ts
@@ -29,7 +29,7 @@ describe("optionsHelper", () => {
         sourceUrl: "https://my.stuff.com",
         params: [],
       };
-      readParamsFileStub = sinon.stub(paramHelper, "readParamsFile");
+      readParamsFileStub = sinon.stub(paramHelper, "readEnvFile");
     });
 
     afterEach(() => {
@@ -52,7 +52,7 @@ describe("optionsHelper", () => {
         USER_PARAM2: "val2",
       });
 
-      expect(optionsHelper.getParams(testOptions, testSpec)).to.eventually.deep.eq({
+      expect(optionsHelper.getParams(testOptions, testSpec)).to.deep.eq({
         ...{
           USER_PARAM1: "val1",
           USER_PARAM2: "val2",
@@ -82,7 +82,7 @@ describe("optionsHelper", () => {
         USER_PARAM3: "${USER_PARAM2}",
       });
 
-      expect(optionsHelper.getParams(testOptions, testSpec)).to.eventually.deep.eq({
+      expect(optionsHelper.getParams(testOptions, testSpec)).to.deep.eq({
         ...{
           USER_PARAM1: "test-hello",
           USER_PARAM2: "val2",
@@ -107,7 +107,7 @@ describe("optionsHelper", () => {
       ];
       readParamsFileStub.resolves({});
 
-      expect(optionsHelper.getParams(testOptions, testSpec)).to.eventually.deep.eq({
+      expect(optionsHelper.getParams(testOptions, testSpec)).to.deep.eq({
         ...{
           USER_PARAM1: "hi",
           USER_PARAM2: "hello",

--- a/src/test/extensions/emulator/optionsHelper.spec.ts
+++ b/src/test/extensions/emulator/optionsHelper.spec.ts
@@ -19,7 +19,7 @@ describe("optionsHelper", () => {
       STORAGE_BUCKET: "test.appspot.com",
     };
     let testSpec: ExtensionSpec;
-    let readParamsFileStub: sinon.SinonStub;
+    let readEnvFileStub: sinon.SinonStub;
 
     beforeEach(() => {
       testSpec = {
@@ -29,11 +29,11 @@ describe("optionsHelper", () => {
         sourceUrl: "https://my.stuff.com",
         params: [],
       };
-      readParamsFileStub = sinon.stub(paramHelper, "readEnvFile");
+      readEnvFileStub = sinon.stub(paramHelper, "readEnvFile");
     });
 
     afterEach(() => {
-      readParamsFileStub.restore();
+      readEnvFileStub.restore();
     });
 
     it("should return user and autopopulated params", () => {
@@ -47,7 +47,7 @@ describe("optionsHelper", () => {
           param: "USER_PARAM2",
         },
       ];
-      readParamsFileStub.resolves({
+      readEnvFileStub.returns({
         USER_PARAM1: "val1",
         USER_PARAM2: "val2",
       });
@@ -76,7 +76,7 @@ describe("optionsHelper", () => {
           param: "USER_PARAM3",
         },
       ];
-      readParamsFileStub.resolves({
+      readEnvFileStub.returns({
         USER_PARAM1: "${PROJECT_ID}-hello",
         USER_PARAM2: "val2",
         USER_PARAM3: "${USER_PARAM2}",
@@ -105,7 +105,7 @@ describe("optionsHelper", () => {
           default: "hello",
         },
       ];
-      readParamsFileStub.resolves({});
+      readEnvFileStub.returns({});
 
       expect(optionsHelper.getParams(testOptions, testSpec)).to.deep.eq({
         ...{

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -95,12 +95,12 @@ describe("paramHelper", () => {
         ANOTHER_PARAMETER: "value",
       });
 
-      const params = await paramHelper.getParams(
-        PROJECT_ID,
-        TEST_PARAMS,
-        false,
-        "./a/path/to/a/file.env"
-      );
+      const params = await paramHelper.getParams({
+        projectId: PROJECT_ID,
+        paramSpecs: TEST_PARAMS,
+        nonInteractive: false,
+        paramsEnvPath: "./a/path/to/a/file.env",
+      });
 
       expect(params).to.eql({
         A_PARAMETER: "aValue",
@@ -113,12 +113,12 @@ describe("paramHelper", () => {
         A_PARAMETER: "aValue",
       });
 
-      const params = await paramHelper.getParams(
-        PROJECT_ID,
-        TEST_PARAMS,
-        false,
-        "./a/path/to/a/file.env"
-      );
+      const params = await paramHelper.getParams({
+        projectId: PROJECT_ID,
+        paramSpecs: TEST_PARAMS,
+        nonInteractive: false,
+        paramsEnvPath: "./a/path/to/a/file.env",
+      });
 
       expect(params).to.eql({
         A_PARAMETER: "aValue",
@@ -131,12 +131,12 @@ describe("paramHelper", () => {
         ANOTHER_PARAMETER: "aValue",
       });
 
-      const params = await paramHelper.getParams(
-        PROJECT_ID,
-        TEST_PARAMS_3,
-        false,
-        "./a/path/to/a/file.env"
-      );
+      const params = await paramHelper.getParams({
+        projectId: PROJECT_ID,
+        paramSpecs: TEST_PARAMS_3,
+        nonInteractive: false,
+        paramsEnvPath: "./a/path/to/a/file.env",
+      });
 
       expect(params).to.eql({
         ANOTHER_PARAMETER: "aValue",
@@ -149,7 +149,12 @@ describe("paramHelper", () => {
       });
 
       await expect(
-        paramHelper.getParams(PROJECT_ID, TEST_PARAMS, false, "./a/path/to/a/file.env")
+        paramHelper.getParams({
+          projectId: PROJECT_ID,
+          paramSpecs: TEST_PARAMS,
+          nonInteractive: false,
+          paramsEnvPath: "./a/path/to/a/file.env",
+        })
       ).to.be.rejectedWith(
         FirebaseError,
         "A_PARAMETER has not been set in the given params file and there is no default available. " +
@@ -164,7 +169,12 @@ describe("paramHelper", () => {
         A_THIRD_PARAMETER: "aValue",
         A_FOURTH_PARAMETER: "default",
       });
-      await paramHelper.getParams(PROJECT_ID, TEST_PARAMS, false, "./a/path/to/a/file.env");
+      await paramHelper.getParams({
+        projectId: PROJECT_ID,
+        paramSpecs: TEST_PARAMS,
+        nonInteractive: false,
+        paramsEnvPath: "./a/path/to/a/file.env",
+      });
 
       expect(loggerSpy).to.have.been.calledWith(
         "Warning: The following params were specified in your env file but" +
@@ -176,12 +186,20 @@ describe("paramHelper", () => {
       dotenvStub.throws({ message: "Error during parsing" });
 
       await expect(
-        paramHelper.getParams(PROJECT_ID, TEST_PARAMS, false, "./a/path/to/a/file.env")
+        paramHelper.getParams({
+          projectId: PROJECT_ID,
+          paramSpecs: TEST_PARAMS,
+          nonInteractive: false,
+          paramsEnvPath: "./a/path/to/a/file.env",
+        })
       ).to.be.rejectedWith(FirebaseError, "Error reading env file: Error during parsing");
     });
 
     it("should prompt the user for params if no env file is provided", async () => {
-      const params = await paramHelper.getParams(PROJECT_ID, TEST_PARAMS);
+      const params = await paramHelper.getParams({
+        projectId: PROJECT_ID,
+        paramSpecs: TEST_PARAMS,
+      });
 
       expect(params).to.eql({
         A_PARAMETER: "user input",
@@ -308,15 +326,15 @@ describe("paramHelper", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.params = TEST_PARAMS_2;
 
-      const newParams = await paramHelper.promptForNewParams(
-        SPEC,
+      const newParams = await paramHelper.promptForNewParams({
+        spec: SPEC,
         newSpec,
-        {
+        currentParams: {
           A_PARAMETER: "value",
           ANOTHER_PARAMETER: "value",
         },
-        PROJECT_ID
-      );
+        projectId: PROJECT_ID,
+      });
 
       const expected = {
         ANOTHER_PARAMETER: "value",
@@ -348,15 +366,15 @@ describe("paramHelper", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.params = TEST_PARAMS_3;
 
-      const newParams = await paramHelper.promptForNewParams(
-        SPEC,
+      const newParams = await paramHelper.promptForNewParams({
+        spec: SPEC,
         newSpec,
-        {
+        currentParams: {
           A_PARAMETER: "value",
           ANOTHER_PARAMETER: "value",
         },
-        PROJECT_ID
-      );
+        projectId: PROJECT_ID,
+      });
 
       const expected = {
         ANOTHER_PARAMETER: "value",
@@ -372,15 +390,15 @@ describe("paramHelper", () => {
       const newSpec = _.cloneDeep(SPEC);
       newSpec.params = TEST_PARAMS_2;
 
-      const newParams = await paramHelper.promptForNewParams(
-        SPEC,
+      const newParams = await paramHelper.promptForNewParams({
+        spec: SPEC,
         newSpec,
-        {
+        currentParams: {
           A_PARAMETER: "value",
           ANOTHER_PARAMETER: "value",
         },
-        PROJECT_ID
-      );
+        projectId: PROJECT_ID,
+      });
 
       const expected = {
         ANOTHER_PARAMETER: "value",
@@ -411,15 +429,15 @@ describe("paramHelper", () => {
       promptStub.resolves("Fail");
       const newSpec = _.cloneDeep(SPEC);
 
-      const newParams = await paramHelper.promptForNewParams(
-        SPEC,
+      const newParams = await paramHelper.promptForNewParams({
+        spec: SPEC,
         newSpec,
-        {
+        currentParams: {
           A_PARAMETER: "value",
           ANOTHER_PARAMETER: "value",
         },
-        PROJECT_ID
-      );
+        projectId: PROJECT_ID,
+      });
 
       const expected = {
         ANOTHER_PARAMETER: "value",
@@ -435,15 +453,15 @@ describe("paramHelper", () => {
       newSpec.params = TEST_PARAMS_2;
 
       await expect(
-        paramHelper.promptForNewParams(
-          SPEC,
+        paramHelper.promptForNewParams({
+          spec: SPEC,
           newSpec,
-          {
+          currentParams: {
             A_PARAMETER: "value",
             ANOTHER_PARAMETER: "value",
           },
-          PROJECT_ID
-        )
+          projectId: PROJECT_ID,
+        })
       ).to.be.rejectedWith(FirebaseError, "this is an error");
       // Ensure that we don't continue prompting if one fails
       expect(promptStub).to.have.been.calledOnce;

--- a/src/test/extensions/updateHelper.spec.ts
+++ b/src/test/extensions/updateHelper.spec.ts
@@ -156,12 +156,10 @@ const LOCAL_INSTANCE = {
 
 describe("updateHelper", () => {
   describe("updateFromLocalSource", () => {
-    let promptStub: sinon.SinonStub;
     let createSourceStub: sinon.SinonStub;
     let getInstanceStub: sinon.SinonStub;
 
     beforeEach(() => {
-      promptStub = sinon.stub(prompt, "promptOnce");
       createSourceStub = sinon.stub(extensionsHelper, "createSourceFromLocation");
       getInstanceStub = sinon.stub(extensionsApi, "getInstance").resolves(INSTANCE);
 
@@ -170,7 +168,6 @@ describe("updateHelper", () => {
     });
 
     afterEach(() => {
-      promptStub.restore();
       createSourceStub.restore();
       getInstanceStub.restore();
 
@@ -178,42 +175,29 @@ describe("updateHelper", () => {
     });
 
     it("should return the correct source name for a valid local source", async () => {
-      promptStub.resolves(true);
       createSourceStub.resolves(SOURCE);
       const name = await updateHelper.updateFromLocalSource(
         "test-project",
         "test-instance",
         ".",
-        SPEC,
-        SPEC.name
+        SPEC
       );
       expect(name).to.equal(SOURCE.name);
     });
 
     it("should throw an error for an invalid source", async () => {
-      promptStub.resolves(true);
       createSourceStub.throwsException("Invalid source");
       await expect(
-        updateHelper.updateFromLocalSource("test-project", "test-instance", ".", SPEC, SPEC.name)
+        updateHelper.updateFromLocalSource("test-project", "test-instance", ".", SPEC)
       ).to.be.rejectedWith(FirebaseError, "Unable to update from the source");
-    });
-
-    it("should not update if the update warning is not confirmed", async () => {
-      promptStub.resolves(false);
-      createSourceStub.resolves(SOURCE);
-      await expect(
-        updateHelper.updateFromLocalSource("test-project", "test-instance", ".", SPEC, SPEC.name)
-      ).to.be.rejectedWith(FirebaseError, "Update cancelled.");
     });
   });
 
   describe("updateFromUrlSource", () => {
-    let promptStub: sinon.SinonStub;
     let createSourceStub: sinon.SinonStub;
     let getInstanceStub: sinon.SinonStub;
 
     beforeEach(() => {
-      promptStub = sinon.stub(prompt, "promptOnce");
       createSourceStub = sinon.stub(extensionsHelper, "createSourceFromLocation");
       getInstanceStub = sinon.stub(extensionsApi, "getInstance").resolves(INSTANCE);
 
@@ -222,7 +206,6 @@ describe("updateHelper", () => {
     });
 
     afterEach(() => {
-      promptStub.restore();
       createSourceStub.restore();
       getInstanceStub.restore();
 
@@ -230,49 +213,30 @@ describe("updateHelper", () => {
     });
 
     it("should return the correct source name for a valid url source", async () => {
-      promptStub.resolves(true);
       createSourceStub.resolves(SOURCE);
       const name = await updateHelper.updateFromUrlSource(
         "test-project",
         "test-instance",
         "https://valid-source.tar.gz",
-        SPEC,
-        SPEC.name
+        SPEC
       );
       expect(name).to.equal(SOURCE.name);
     });
 
     it("should throw an error for an invalid source", async () => {
-      promptStub.resolves(true);
       createSourceStub.throws("Invalid source");
       await expect(
         updateHelper.updateFromUrlSource(
           "test-project",
           "test-instance",
           "https://valid-source.tar.gz",
-          SPEC,
-          SPEC.name
+          SPEC
         )
       ).to.be.rejectedWith(FirebaseError, "Unable to update from the source");
-    });
-
-    it("should not update if the update warning is not confirmed", async () => {
-      promptStub.resolves(false);
-      createSourceStub.resolves(SOURCE);
-      await expect(
-        updateHelper.updateFromUrlSource(
-          "test-project",
-          "test-instance",
-          "https://valid-source.tar.gz",
-          SPEC,
-          SPEC.name
-        )
-      ).to.be.rejectedWith(FirebaseError, "Update cancelled.");
     });
   });
 
   describe("updateToVersionFromPublisherSource", () => {
-    let promptStub: sinon.SinonStub;
     let getExtensionStub: sinon.SinonStub;
     let createSourceStub: sinon.SinonStub;
     let listExtensionVersionStub: sinon.SinonStub;
@@ -281,7 +245,6 @@ describe("updateHelper", () => {
     let getInstanceStub: sinon.SinonStub;
 
     beforeEach(() => {
-      promptStub = sinon.stub(prompt, "promptOnce");
       getExtensionStub = sinon.stub(extensionsApi, "getExtension");
       createSourceStub = sinon.stub(extensionsApi, "getExtensionVersion");
       listExtensionVersionStub = sinon.stub(extensionsApi, "listExtensionVersions");
@@ -293,7 +256,6 @@ describe("updateHelper", () => {
     });
 
     afterEach(() => {
-      promptStub.restore();
       getExtensionStub.restore();
       createSourceStub.restore();
       listExtensionVersionStub.restore();
@@ -303,7 +265,6 @@ describe("updateHelper", () => {
     });
 
     it("should return the correct source name for a valid published extension version source", async () => {
-      promptStub.resolves(true);
       getExtensionStub.resolves(EXTENSION);
       createSourceStub.resolves(EXTENSION_VERSION);
       listExtensionVersionStub.resolves([]);
@@ -311,14 +272,12 @@ describe("updateHelper", () => {
         "test-project",
         "test-instance",
         "test-publisher/test@0.2.0",
-        SPEC,
-        SPEC.name
+        SPEC
       );
       expect(name).to.equal(EXTENSION_VERSION.name);
     });
 
     it("should throw an error for an invalid source", async () => {
-      promptStub.resolves(true);
       getExtensionStub.throws(Error("NOT FOUND"));
       createSourceStub.throws(Error("NOT FOUND"));
       listExtensionVersionStub.resolves([]);
@@ -327,31 +286,13 @@ describe("updateHelper", () => {
           "test-project",
           "test-instance",
           "test-publisher/test@1.2.3",
-          SPEC,
-          SPEC.name
+          SPEC
         )
       ).to.be.rejectedWith("NOT FOUND");
-    });
-
-    it("should not update if the update warning is not confirmed", async () => {
-      promptStub.resolves(false);
-      getExtensionStub.resolves(EXTENSION);
-      createSourceStub.resolves(EXTENSION_VERSION);
-      listExtensionVersionStub.resolves([]);
-      await expect(
-        updateHelper.updateToVersionFromPublisherSource(
-          "test-project",
-          "test-instance",
-          "test-publisher/test@0.2.0",
-          SPEC,
-          SPEC.name
-        )
-      ).to.be.rejectedWith(FirebaseError, "Update cancelled.");
     });
   });
 
   describe("updateFromPublisherSource", () => {
-    let promptStub: sinon.SinonStub;
     let getExtensionStub: sinon.SinonStub;
     let createSourceStub: sinon.SinonStub;
     let listExtensionVersionStub: sinon.SinonStub;
@@ -360,7 +301,6 @@ describe("updateHelper", () => {
     let getInstanceStub: sinon.SinonStub;
 
     beforeEach(() => {
-      promptStub = sinon.stub(prompt, "promptOnce");
       getExtensionStub = sinon.stub(extensionsApi, "getExtension");
       createSourceStub = sinon.stub(extensionsApi, "getExtensionVersion");
       listExtensionVersionStub = sinon.stub(extensionsApi, "listExtensionVersions");
@@ -372,7 +312,6 @@ describe("updateHelper", () => {
     });
 
     afterEach(() => {
-      promptStub.restore();
       getExtensionStub.restore();
       createSourceStub.restore();
       listExtensionVersionStub.restore();
@@ -382,7 +321,6 @@ describe("updateHelper", () => {
     });
 
     it("should return the correct source name for the latest published extension source", async () => {
-      promptStub.resolves(true);
       getExtensionStub.resolves(EXTENSION);
       createSourceStub.resolves(EXTENSION_VERSION);
       listExtensionVersionStub.resolves([]);
@@ -390,14 +328,12 @@ describe("updateHelper", () => {
         "test-project",
         "test-instance",
         "test-publisher/test",
-        SPEC,
-        SPEC.name
+        SPEC
       );
       expect(name).to.equal(EXTENSION_VERSION.name);
     });
 
     it("should throw an error for an invalid source", async () => {
-      promptStub.resolves(true);
       getExtensionStub.throws(Error("NOT FOUND"));
       createSourceStub.throws(Error("NOT FOUND"));
       listExtensionVersionStub.resolves([]);
@@ -406,26 +342,9 @@ describe("updateHelper", () => {
           "test-project",
           "test-instance",
           "test-publisher/test",
-          SPEC,
-          SPEC.name
+          SPEC
         )
       ).to.be.rejectedWith("NOT FOUND");
-    });
-
-    it("should not update if the update warning is not confirmed", async () => {
-      promptStub.resolves(false);
-      getExtensionStub.resolves(EXTENSION);
-      createSourceStub.resolves(EXTENSION_VERSION);
-      listExtensionVersionStub.resolves([]);
-      await expect(
-        updateHelper.updateToVersionFromPublisherSource(
-          "test-project",
-          "test-instance",
-          "test-publisher/test",
-          SPEC,
-          SPEC.name
-        )
-      ).to.be.rejectedWith(FirebaseError, "Update cancelled.");
     });
   });
 });


### PR DESCRIPTION
### Description
ext:update can now be run with (and respects) the --force and --non-interactive flags.

I also took this opportunity to kill a bit more repetitive code around prompting users.

### Scenarios Tested
Bunch of cases to cover here:
--force, --non-interactive, --params
![Screen Shot 2021-09-10 at 2 22 52 PM](https://user-images.githubusercontent.com/4635763/132926260-4dff0565-f079-4a7f-a794-86af2618a0d9.png)
--non-interactive, --params
![Screen Shot 2021-09-10 at 2 26 15 PM](https://user-images.githubusercontent.com/4635763/132926329-c8bc17c7-4064-4bda-8741-e854100ec776.png)
--non-interactive, --force
![Screen Shot 2021-09-10 at 2 26 44 PM](https://user-images.githubusercontent.com/4635763/132926344-0d315db9-453e-4315-b686-69e96e23cef9.png)
--force, --params
![Screen Shot 2021-09-10 at 2 27 35 PM](https://user-images.githubusercontent.com/4635763/132926370-0a457b5f-a365-4c21-abfd-d6ccb443601e.png)
--force
![Screen Shot 2021-09-10 at 2 29 20 PM](https://user-images.githubusercontent.com/4635763/132926399-c5306479-88e5-471d-8b85-8d3af0241a6f.png)
--params
![Screen Shot 2021-09-10 at 4 08 04 PM](https://user-images.githubusercontent.com/4635763/132926502-adf56f93-3611-49e5-ac5c-19b5203b13ee.png)

No flags
![Screen Shot 2021-09-10 at 2 29 45 PM](https://user-images.githubusercontent.com/4635763/132926411-1826ed0f-3c4f-4c04-8813-d51ae1686cb4.png)

