### PR TITLE
Propose some functional helpers

### DIFF
--- a/src/functional.ts
+++ b/src/functional.ts
@@ -1,0 +1,80 @@
+
+/**
+ * Flattens an object so that the return value's keys are the path
+ * to a value in the source object. E.g. flattenObject({the: {answer: 42}})
+ * returns {"the.answser": 42}
+ * @param obj An object to be flattened
+ * @returns An array where values come from obj and keys are the path in obj to that value.
+ */
+export function flattenObject(obj: Record<string, unknown>): Record<string, unknown> {
+  function* helper(path: string[], obj: Record<string, unknown>): Generator<[string, unknown]> {
+    for (const [k, v] of Object.entries(obj)) {
+      if (typeof v !== "object" || v === null) {
+        yield [[...path, k].join("."), v];
+      } else {
+        // Object.entries loses type info, so we must cast
+        yield* helper([...path, k], v as Record<string, unknown>);
+      }
+    }
+  }
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of helper([], obj)) {
+    result[k] = v;
+  }
+  return result;
+}
+
+/**
+ * Yields each non-array element recursively in arr.
+ * Useful for for-of loops.
+ * [...flatten([[[1]], [2], 3])] = [1, 2, 3]
+ */
+// eslint-disable-next-line  @typescript-eslint/no-explicit-any
+export function* flatten<T = any>(arr: unknown[]): Generator<T> {
+  for (const val of arr) {
+    if (Array.isArray(val)) {
+      yield* flatten(val);
+    } else {
+      yield val as T;
+    }
+  }
+}
+
+/**
+ * Used with reduce to flatten in place.
+ * Due to the quirks of TypeScript, callers must pass [] as the
+ * second argument to reduce.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function reduceFlat<T = any>(accum: T[] | undefined, next: unknown): T[] {
+  return [...(accum || []), ...flatten<T>([next])];
+}
+
+/**
+ * Yields each element from left and right in tandem
+ * [...zip([1, 2, 3], ['a', 'b', 'c'])] = [[1, 'a], [2, 'b'], [3, 'c']]
+ */
+export function* zip<T, V>(left: T[], right: V[]): Generator<[T, V]> {
+  if (left.length != right.length) {
+    throw new Error("Cannot zip between two lists of differen lengths");
+  }
+  for (let i = 0; i < left.length; i++) {
+    yield [left[i], right[i]];
+  }
+}
+
+/** Just like zip but handles mismatched array lengths by yielding undefined */
+export function* zipLax<T, V>(left: T[], right: V[]): Generator<[T, V]> {
+  const max = Math.max(left.length, right.length);
+  for (let i = 0; i < max; i++) {
+    yield [left[i], right[i]];
+  }
+}
+
+/**
+ * Utility to zip in another array from map.
+ * [1, 2].map(zipIn(['a', 'b'])) = [[1, 'a'], [2, 'b']]
+ */
+export const zipIn = <T, V>(other: V[]) => (elem: T, ndx: number): [T, V] => {
+  return [elem, other[ndx]];
+}

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -1,4 +1,3 @@
-
 /**
  * Flattens an object so that the return value's keys are the path
  * to a value in the source object. E.g. flattenObject({the: {answer: 42}})

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -3,7 +3,7 @@
  * to a value in the source object. E.g. flattenObject({the: {answer: 42}})
  * returns {"the.answser": 42}
  * @param obj An object to be flattened
- * @returns An array where values come from obj and keys are the path in obj to that value.
+ * @return An array where values come from obj and keys are the path in obj to that value.
  */
 export function* flattenObject(obj: Record<string, unknown>): Generator<[string, unknown]> {
   function* helper(path: string[], obj: Record<string, unknown>): Generator<[string, unknown]> {

--- a/src/test/functional.spec.ts
+++ b/src/test/functional.spec.ts
@@ -6,11 +6,11 @@ import * as f from "../functional";
 
 describe("functional", () => {
   describe("flatten", () => {
-    it("Can iterate an empty object", () => {
+    it("can iterate an empty object", () => {
       expect([...f.flatten({})]).to.deep.equal([]);
     });
 
-    it("Can iterate an object that's already flat", () => {
+    it("can iterate an object that's already flat", () => {
       expect([...f.flatten({ a: "b" })]).to.deep.equal([["a", "b"]]);
     });
 

--- a/src/test/functional.spec.ts
+++ b/src/test/functional.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import { define } from "mime";
+
+import * as f from "../functional";
+
+describe("functional", () => {
+  describe("flattenObject", () => {
+    it("Can noop", () => {
+      expect(f.flattenObject({ a: "b" })).to.deep.equal({ a: "b" });
+    });
+
+    it("can handle nested objects", () => {
+      const init = {
+        outer: {
+          inner: {
+            value: 42,
+          },
+        },
+        other: {
+          value: null,
+        },
+      };
+
+      const expected = {
+        "outer.inner.value": 42,
+        "other.value": null,
+      };
+
+      expect(f.flattenObject(init)).to.deep.equal(expected);
+    });
+
+    it("can handle arrays", () => {
+      const init = { values: ["a", "b"] };
+      const expected = {
+        "values.0": "a",
+        "values.1": "b",
+      };
+
+      expect(f.flattenObject(init)).to.deep.equal(expected);
+    });
+  });
+
+  describe("flatten", () => {
+    it("can noop", () => {
+      const init = ["a", "b", "c"];
+      expect([...f.flatten(init)]).to.deep.equal(init);
+    });
+
+    it("can flatten", () => {
+      const init = [[[1]], [2], 3];
+      expect([...f.flatten(init)]).to.deep.equal([1, 2, 3]);
+    });
+  });
+
+  describe("reduceFlat", () => {
+    it("can noop", () => {
+      const init = ["a", "b", "c"];
+      expect(init.reduce(f.reduceFlat, [])).to.deep.equal(["a", "b", "c"]);
+    });
+
+    it("can flatten", () => {
+      const init = [[[1]], [2], 3];
+      expect(init.reduce(f.reduceFlat, [])).to.deep.equal([1, 2, 3]);
+    });
+  });
+
+  describe("zip", () => {
+    it("can handle an empty array", () => {
+      expect([...f.zip([], [])]).to.deep.equal([]);
+    });
+    it("can zip", () => {
+      expect([...f.zip([1], ["a"])]).to.deep.equal([[1, "a"]]);
+    });
+    it("throws on length mismatch", () => {
+      expect(() => f.zip([1], [])).to.throw;
+    });
+  });
+
+  describe("zipLax", () => {
+    it("can handle an empty array", () => {
+      expect([...f.zipLax([], [])]).to.deep.equal([]);
+    });
+    it("can zip", () => {
+      expect([...f.zipLax([1], ["a"])]).to.deep.equal([[1, "a"]]);
+    });
+    it("handles length mismatch", () => {
+      expect([...f.zipLax([1], [])]).to.deep.equal([[1, undefined]]);
+    });
+  });
+
+  it("zipIn", () => {
+    expect([1, 2].map(f.zipIn(["a", "b"]))).to.deep.equal([
+      [1, "a"],
+      [2, "b"],
+    ]);
+  });
+
+});


### PR DESCRIPTION
While reviewing #3690 I noticed that (A) one of the functions are generic enough to go in a library and (B) I really wish we had tools like zip/flatten/etc here. While writing my own code, I wished TypeScript could either assert or detect that code was dead due to type guards. Now we have all the above!

I leaned into using generator functions because they work just as well in `for-of` loops with less syntactic goop. LMK if you feel we should be returning arrays instead.

Feel free to tell me that these should be named differently, that we're missing something obvious, or that if God wanted us to have better list comprehensions they would have joined TC39.