### PR TITLE
fix login:use and account resolution issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - `ext:dev:publish` and `ext:update` now support --force and --non-interactive flags.
+- Fixes issue where account specified by `login:use` was not being correctly loaded (#3759).

--- a/src/command.ts
+++ b/src/command.ts
@@ -260,6 +260,9 @@ export class Command {
     const account = getInheritedOption(options, "account");
     options.account = account;
 
+    // selectAccount needs the projectRoot to be set.
+    options.projectRoot = detectProjectRoot(options);
+
     const projectRoot = options.projectRoot;
     const activeAccount = selectAccount(account, projectRoot);
 
@@ -267,7 +270,6 @@ export class Command {
       setActiveAccount(options, activeAccount);
     }
 
-    options.projectRoot = detectProjectRoot(options);
     this.applyRC(options);
     if (options.project) {
       await this.resolveProjectIdentifiers(options);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #3759

The account resolving path wasn't being given the project root, causing the default account to always be returned. This clears that up!

### Scenarios Tested

Logged in with 2 users, `login:use` with one of them (that doesn't have permissions for a project) and tried to do something. Before, it succeeds because the wrong account was loaded. Now it uses the correct account.