### PR TITLE
Add tenant management endpoints support

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -2556,7 +2556,9 @@ function createTenant(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"]
 ): Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] {
-  assert(state instanceof AgentProjectState, "((Can only create tenant in agent project.))");
+  if (!(state instanceof AgentProjectState)) {
+    throw new InternalError("INTERNAL_ERROR: Can only create tenant in agent project", "INTERNAL");
+  }
 
   const tenant = {
     displayName: reqBody.displayName,
@@ -2599,9 +2601,6 @@ function deleteTenant(
   reqBody: unknown,
   ctx: ExegesisContext
 ): Schemas["GoogleProtobufEmpty"] {
-  // Ideally, this would be called on the top level AgentProjectState, but
-  // because flat paths are used to generate apiSpec.js to avoid conflicting
-  // endpoints, deleteTenant will be called with a TenantProjectState
   assert(state instanceof TenantProjectState, "((Can only delete tenant on tenant projects.))");
   state.delete();
   return {};
@@ -2612,9 +2611,6 @@ function getTenant(
   reqBody: unknown,
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] {
-  // Ideally, this would be called on the top level AgentProjectState, but
-  // because flat paths are used to generate apiSpec.js to avoid conflicting
-  // endpoints, getTenant will be called with a TenantProjectState
   assert(state instanceof TenantProjectState, "((Can only get tenant on tenant projects.))");
   return state.tenantConfig;
 }

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -31,7 +31,6 @@ import {
   SecondFactorRecord,
   UsageMode,
   AgentProjectState,
-  Tenant,
   TenantProjectState,
 } from "./state";
 import { MfaEnrollments, Schemas } from "./types";
@@ -119,9 +118,6 @@ export const authOperations: AuthOps = {
 /* Handlers */
 
 const PASSWORD_MIN_LENGTH = 6;
-const PHONE_NUMBER_MAX_LENGTH = 250;
-const MIN_LENGTH_FOR_NSN = 2;
-const MAX_LENGTH_FOR_NSN = 17;
 
 // https://cloud.google.com/identity-platform/docs/use-rest-api#section-verify-custom-token
 export const CUSTOM_TOKEN_AUDIENCE =

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -2562,52 +2562,17 @@ function createTenant(
 ): Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] {
   assert(state instanceof AgentProjectState, "((Can only create tenant in agent project.))");
 
-  const formattedPhoneNumbers: Record<string, string> = {};
-  if (reqBody.testPhoneNumbers) {
-    Object.entries(reqBody.testPhoneNumbers).forEach(([phoneNumber, value]) => {
-      formattedPhoneNumbers[formatPhoneNumber(phoneNumber)] = value;
-    });
-  }
-
   const tenant = {
     displayName: reqBody.displayName,
     allowPasswordSignup: reqBody.allowPasswordSignup,
     enableEmailLinkSignin: reqBody.enableEmailLinkSignin,
     enableAnonymousUser: reqBody.enableAnonymousUser,
     disableAuth: reqBody.disableAuth,
-    testPhoneNumbers: formattedPhoneNumbers,
     mfaConfig: reqBody.mfaConfig,
     tenantId: "", // Placeholder until one is generated
   };
 
   return state.createTenant(tenant);
-}
-
-function formatPhoneNumber(phoneNumber: string) {
-  assert(
-    phoneNumber.length <= PHONE_NUMBER_MAX_LENGTH,
-    "TOO_LONG ((The string supplied was too long to parse.))"
-  );
-
-  // Only check that the phone number is reasonably formatted, but does not
-  // fully verify that phone number is valid. The regex corresponds to the
-  // following:
-  //
-  // [digits]{MIN_LENGTH_FOR_NSN}|
-  //    plus_sign*(([punctuation]|[star])*[digits]){3,}([punctuation]|[star]|[digits])*
-  //
-  // TODO: support unicode, alpha characters and extensions?
-  const validPhoneNumberPattern = /^\d{2}$|^\+*(?:[ -x\.\[\]\(\)~\*]*\d){3,}[ -x\.\[\]\(\)~\*\d]*$/g;
-  assert(validPhoneNumberPattern.test(phoneNumber), "INVALID_PHONE_NUMBER");
-
-  let normalizedNumber = phoneNumber.replace(/\D/g, "");
-  assert(
-    normalizedNumber.length <= MAX_LENGTH_FOR_NSN,
-    "TOO_LONG ((The string supplied is too long to be a phone number.))"
-  );
-  normalizedNumber = "+" + normalizedNumber;
-
-  return normalizedNumber;
 }
 
 function listTenants(
@@ -2664,16 +2629,7 @@ function updateTenant(
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] {
   assert(state instanceof TenantProjectState, "((Can only update tenant on tenant projects.))");
-  const update: Partial<Tenant> = { ...reqBody };
-  const formattedPhoneNumbers: Record<string, string> = {};
-  if (reqBody.testPhoneNumbers) {
-    Object.entries(reqBody.testPhoneNumbers).forEach(([phoneNumber, value]) => {
-      formattedPhoneNumbers[formatPhoneNumber(phoneNumber)] = value;
-    });
-    update.testPhoneNumbers = formattedPhoneNumbers;
-  }
-
-  return state.updateTenant(update, ctx.params.query.updateMask);
+  return state.updateTenant(reqBody, ctx.params.query.updateMask);
 }
 
 /* eslint-disable camelcase */

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -568,9 +568,9 @@ export abstract class ProjectState {
 }
 
 export class AgentProjectState extends ProjectState {
-  private tenantForTenantId: Map<string, Tenant> = new Map();
   private _oneAccountPerEmail = true;
   private _usageMode = UsageMode.DEFAULT;
+  private tenantProjectForTenantId: Map<string, TenantProjectState> = new Map();
   private readonly _authCloudFunction = new AuthCloudFunction(this.projectId);
 
   constructor(projectId: string) {
@@ -597,29 +597,49 @@ export class AgentProjectState extends ProjectState {
     this._usageMode = usageMode;
   }
 
-  // TODO(lisajian): Fill in when v2.projects.tenants.get is added
-  getTenant(): void {
-    throw new NotImplementedError("getTenant is not implemented yet.");
+  getTenantProject(tenantId: string): TenantProjectState {
+    assert(this.tenantProjectForTenantId.has(tenantId), "TENANT_NOT_FOUND");
+    return this.tenantProjectForTenantId.get(tenantId)!;
   }
 
-  // TODO(lisajian): Fill in when v2.projects.tenants.list is added
-  listTenants(): void {
-    throw new NotImplementedError("listTenants is not implemented yet.");
+  listTenants(startToken?: string): Tenant[] {
+    const tenantProjects = [];
+    for (const tenantProject of this.tenantProjectForTenantId.values()) {
+      if (!startToken || tenantProject.tenantId > startToken) {
+        tenantProjects.push(tenantProject);
+      }
+    }
+    // Sort in ascending order by tenantId
+    tenantProjects.sort((a, b) => {
+      if (a.tenantId < b.tenantId) {
+        return -1;
+      } else if (a.tenantId > b.tenantId) {
+        return 1;
+      }
+      return 0;
+    });
+    return tenantProjects.map((tenantProject) => tenantProject.tenantConfig);
   }
 
-  // TODO(lisajian): Fill in when v2.projects.tenants.create is added
-  createTenant(): void {
-    throw new NotImplementedError("createTenant is not implemented yet.");
+  createTenant(tenant: Tenant): Tenant {
+    for (let i = 0; i < 10; i++) {
+      const tenantId = randomId(28);
+      if (!this.tenantProjectForTenantId.has(tenantId)) {
+        tenant.name = `projects/${this.projectId}/tenants/${tenantId}`;
+        tenant.tenantId = tenantId;
+        this.tenantProjectForTenantId.set(
+          tenantId,
+          new TenantProjectState(this.projectId, tenantId, tenant, this)
+        );
+        return tenant;
+      }
+    }
+    throw new Error("Could not generate a random unique tenantId after 10 tries");
   }
 
-  // TODO(lisajian): Fill in when v2.projects.tenants.patch is added
-  updateTenant(): void {
-    throw new NotImplementedError("updateTenant is not implemented yet.");
-  }
-
-  // TODO(lisajian): Fill in when v2.projects.tenants.delete is added
-  deleteTenant(): void {
-    throw new NotImplementedError("deleteTenant is not implemented yet.");
+  deleteTenant(tenantId: string): void {
+    assert(this.tenantProjectForTenantId.has(tenantId), "TENANT_NOT_FOUND");
+    this.tenantProjectForTenantId.delete(tenantId);
   }
 }
 
@@ -627,6 +647,7 @@ export class TenantProjectState extends ProjectState {
   constructor(
     projectId: string,
     readonly tenantId: string,
+    private _tenantConfig: Tenant,
     private readonly parentProject: AgentProjectState
   ) {
     super(projectId);
@@ -643,6 +664,69 @@ export class TenantProjectState extends ProjectState {
   get usageMode() {
     return this.parentProject.usageMode;
   }
+
+  get tenantConfig() {
+    return this._tenantConfig;
+  }
+
+  delete(): void {
+    this.parentProject.deleteTenant(this.tenantId);
+  }
+
+  updateTenant(update: Partial<Tenant>, updateMask: string | undefined): Tenant {
+    // Empty masks indicate a full update
+    if (!updateMask) {
+      this._tenantConfig = { ...update, tenantId: this.tenantId, name: this.tenantConfig.name };
+      return this.tenantConfig;
+    }
+
+    const paths = updateMask.split(",");
+    for (const path of paths) {
+      const fields = path.split(".");
+      // Using `any` here to recurse over Tenant config objects
+      let updateField: any = update;
+      let existingField: any = this._tenantConfig;
+      let field;
+      for (let i = 0; i < fields.length - 1; i++) {
+        field = fields[i];
+
+        // Doesn't exist on update
+        if (updateField[field] == null) {
+          console.warn(`Unable to find field '${field}' in update '${updateField}`);
+          break;
+        }
+
+        // Field on existing is an array or is a primitive (i.e. cannot index
+        // any further)
+        if (
+          Array.isArray(updateField[field]) ||
+          Object(updateField[field]) !== updateField[field]
+        ) {
+          console.warn(`Field '${field}' is singular and cannot have sub-fields`);
+          break;
+        }
+
+        // Non-standard behavior, this creates new fields regardless of if the
+        // final field is set. Typical behavior would not modify the config
+        // payload if the final field is not successfully set.
+        if (!existingField[field]) {
+          existingField[field] = {};
+        }
+
+        updateField = updateField[field];
+        existingField = existingField[field];
+      }
+      // Reassign final field if possible
+      field = fields[fields.length - 1];
+      if (updateField[field] == null) {
+        console.warn(`Unable to find field '${field}' in update '${JSON.stringify(updateField)}`);
+        continue;
+      }
+      existingField[field] = updateField[field];
+    }
+
+    return this.tenantConfig;
+  }
 }
 
 export type ProviderUserInfo = MakeRequired<
@@ -656,7 +740,7 @@ export type UserInfo = Omit<
   localId: string;
   providerUserInfo?: ProviderUserInfo[];
 };
-export type Tenant = Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"];
+export type Tenant = Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] & { tenantId: string };
 
 interface RefreshTokenRecord {
   localId: string;

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -740,7 +740,10 @@ export type UserInfo = Omit<
   localId: string;
   providerUserInfo?: ProviderUserInfo[];
 };
-export type Tenant = Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] & { tenantId: string };
+export type Tenant = Omit<
+  Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"],
+  "testPhoneNumbers"
+> & { tenantId: string };
 
 interface RefreshTokenRecord {
   localId: string;

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -648,7 +648,6 @@ export class AgentProjectState extends ProjectState {
   }
 
   deleteTenant(tenantId: string): void {
-    assert(this.tenantProjectForTenantId.has(tenantId), "TENANT_NOT_FOUND");
     this.tenantProjectForTenantId.delete(tenantId);
   }
 }

--- a/src/test/emulators/auth/helpers.ts
+++ b/src/test/emulators/auth/helpers.ts
@@ -3,7 +3,7 @@ import { inspect } from "util";
 import * as supertest from "supertest";
 import { expect, AssertionError } from "chai";
 import { IdpJwtPayload } from "../../../emulator/auth/operations";
-import { OobRecord, PhoneVerificationRecord, UserInfo } from "../../../emulator/auth/state";
+import { OobRecord, PhoneVerificationRecord, Tenant, UserInfo } from "../../../emulator/auth/state";
 import { TestAgent, PROJECT_ID } from "./setup";
 import { MfaEnrollments } from "../../../emulator/auth/types";
 
@@ -378,5 +378,21 @@ export function deleteAccount(testAgent: TestAgent, reqBody: {}): Promise<string
       expectStatusCode(200, res);
       expect(res.body).not.to.have.property("error");
       return res.body.kind;
+    });
+}
+
+export function registerTenant(
+  testAgent: TestAgent,
+  projectId: string,
+  tenant?: Partial<Tenant>
+): Promise<Tenant> {
+  return testAgent
+    .post(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+    .query({ key: "fake-api-key" })
+    .set("Authorization", "Bearer owner")
+    .send(tenant)
+    .then((res) => {
+      expectStatusCode(200, res);
+      return res.body;
     });
 }

--- a/src/test/emulators/auth/setup.ts
+++ b/src/test/emulators/auth/setup.ts
@@ -1,7 +1,8 @@
 import { Suite } from "mocha";
 import { useFakeTimers } from "sinon";
 import supertest = require("supertest");
-import { AgentProject, createApp } from "../../../emulator/auth/server";
+import { createApp } from "../../../emulator/auth/server";
+import { AgentProjectState } from "../../../emulator/auth/state";
 
 export const PROJECT_ID = "example";
 
@@ -40,7 +41,7 @@ export type AuthTestUtils = {
 
 // Keep a global auth server since start-up takes too long:
 let cachedAuthApp: Express.Application;
-const projectStateForId = new Map<string, AgentProject>();
+const projectStateForId = new Map<string, AgentProjectState>();
 
 async function createOrReuseApp(): Promise<Express.Application> {
   if (!cachedAuthApp) {

--- a/src/test/emulators/auth/tenant.spec.ts
+++ b/src/test/emulators/auth/tenant.spec.ts
@@ -1,0 +1,373 @@
+import { expect } from "chai";
+import { Tenant } from "../../../emulator/auth/state";
+import { expectStatusCode, registerTenant } from "./helpers";
+import { describeAuthEmulator } from "./setup";
+
+describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
+  describe("createTenant", () => {
+    it("should create tenants", async () => {
+      await authApi()
+        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
+        .set("Authorization", "Bearer owner")
+        .send({
+          allowPasswordSignup: true,
+          disableAuth: false,
+          displayName: "display",
+          enableAnonymousUser: true,
+          enableEmailLinkSignin: true,
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          },
+          testPhoneNumbers: { "1234567890": "fake-code", "1(555)555-5555": "another-fake-code" },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.allowPasswordSignup).to.be.true;
+          expect(res.body.disableAuth).to.be.false;
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.enableAnonymousUser).to.be.true;
+          expect(res.body.enableEmailLinkSignin).to.be.true;
+          expect(res.body.mfaConfig).to.eql({
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          });
+          expect(res.body.testPhoneNumbers).to.eql({
+            "+1234567890": "fake-code",
+            "+15555555555": "another-fake-code",
+          });
+
+          // Should have a non-empty tenantId and matching resource name
+          expect(res.body).to.have.property("tenantId");
+          expect(res.body.tenantId).to.not.eql("");
+          expect(res.body).to.have.property("name");
+          expect(res.body.name).to.eql(`projects/project-id/tenants/${res.body.tenantId}`);
+        });
+    });
+
+    it("should error for too long phone number strings", async () => {
+      const stringOfLength251 =
+        "26309807635151999007190279164688762548403557194653647493992467370002025938089183725458712376845251478037398883690369019457887385561469910485467169892025615975626596228774429150543679701729000472697539159978901659121833328943611034838868161513522457664";
+      const testPhoneNumbers: { [key: string]: string } = {};
+      testPhoneNumbers[stringOfLength251] = "fake-code";
+
+      await authApi()
+        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
+        .set("Authorization", "Bearer owner")
+        .send({
+          testPhoneNumbers,
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.include("TOO_LONG");
+        });
+    });
+
+    it("should error for invalid phone numbers", async () => {
+      await authApi()
+        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
+        .set("Authorization", "Bearer owner")
+        .send({
+          testPhoneNumbers: { "+++++++[][][][][]": "fake-code" },
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.include("INVALID_PHONE_NUMBER");
+        });
+    });
+
+    it("should error for too short phone numbers", async () => {
+      await authApi()
+        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
+        .set("Authorization", "Bearer owner")
+        .send({
+          testPhoneNumbers: { "1": "fake-code" },
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.include("INVALID_PHONE_NUMBER");
+        });
+    });
+
+    it("should error for too long phone numbers", async () => {
+      const stringOfLength18 = "801865849451122371";
+      const testPhoneNumbers: { [key: string]: string } = {};
+      testPhoneNumbers[stringOfLength18] = "fake-code";
+
+      await authApi()
+        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
+        .set("Authorization", "Bearer owner")
+        .send({
+          testPhoneNumbers,
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.include("TOO_LONG");
+        });
+    });
+  });
+
+  describe("getTenants", () => {
+    it("should get tenants", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`)
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body).to.eql(tenant);
+        });
+    });
+
+    it("should error for tenants that do not exist", async () => {
+      await authApi()
+        .get("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants/not-found-tenant-id")
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.include("TENANT_NOT_FOUND");
+        });
+    });
+  });
+
+  describe("deleteTenants", () => {
+    it("should delete tenants", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .delete(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+        });
+    });
+
+    it("should error for tenants that do not exist", async () => {
+      await authApi()
+        .delete(
+          "/identitytoolkit.googleapis.com/v2/projects/project-id/tenants/not-found-tenant-id"
+        )
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.include("TENANT_NOT_FOUND");
+        });
+    });
+  });
+
+  describe("listTenants", () => {
+    it("should list tenants", async () => {
+      const projectId = "project-id";
+      const tenant1 = await registerTenant(authApi(), projectId, {});
+      const tenant2 = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(2);
+          expect(res.body.tenants.map((tenant: Tenant) => tenant.tenantId)).to.have.members([
+            tenant1.tenantId,
+            tenant2.tenantId,
+          ]);
+          expect(res.body).not.to.have.property("nextPageToken");
+        });
+    });
+
+    it("should allow specifying pageSize and pageToken", async () => {
+      const projectId = "project-id";
+      const tenant1 = await registerTenant(authApi(), projectId, {});
+      const tenant2 = await registerTenant(authApi(), projectId, {});
+      const tenantIds = [tenant1.tenantId, tenant2.tenantId].sort();
+
+      const nextPageToken = await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageSize: 1 })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(1);
+          expect(res.body.tenants[0].tenantId).to.eql(tenantIds[0]);
+          expect(res.body).to.have.property("nextPageToken").which.is.a("string");
+          return res.body.nextPageToken;
+        });
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageToken: nextPageToken })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(1);
+          expect(res.body.tenants[0].tenantId).to.eql(tenantIds[1]);
+          expect(res.body).not.to.have.property("nextPageToken");
+        });
+    });
+
+    it("should always return a page token even if page is full", async () => {
+      const projectId = "project-id";
+      const tenant1 = await registerTenant(authApi(), projectId, {});
+      const tenant2 = await registerTenant(authApi(), projectId, {});
+      const tenantIds = [tenant1.tenantId, tenant2.tenantId].sort();
+
+      const nextPageToken = await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageSize: 2 })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(2);
+          expect(res.body.tenants[0].tenantId).to.eql(tenantIds[0]);
+          expect(res.body.tenants[1].tenantId).to.eql(tenantIds[1]);
+          expect(res.body).to.have.property("nextPageToken").which.is.a("string");
+          return res.body.nextPageToken;
+        });
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageToken: nextPageToken })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants || []).to.have.length(0);
+          expect(res.body).not.to.have.property("nextPageToken");
+        });
+    });
+  });
+
+  describe("updateTenants", () => {
+    it("updates tenant config", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+      const updateMask =
+        "allowPasswordSignup,disableAuth,displayName,enableAnonymousUser,enableEmailLinkSignin,mfaConfig,testPhoneNumbers";
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask })
+        .send({
+          allowPasswordSignup: true,
+          disableAuth: false,
+          displayName: "display",
+          enableAnonymousUser: true,
+          enableEmailLinkSignin: true,
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          },
+          testPhoneNumbers: { "1234567890": "fake-code", "1(555)555-5555": "another-fake-code" },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.allowPasswordSignup).to.be.true;
+          expect(res.body.disableAuth).to.be.false;
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.enableAnonymousUser).to.be.true;
+          expect(res.body.enableEmailLinkSignin).to.be.true;
+          expect(res.body.mfaConfig).to.eql({
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          });
+          expect(res.body.testPhoneNumbers).to.eql({
+            "+1234567890": "fake-code",
+            "+15555555555": "another-fake-code",
+          });
+        });
+    });
+
+    it("does not update if the field does not exist on the update tenant", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+      const updateMask = "displayName";
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask })
+        .send({})
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body).not.to.have.property("displayName");
+        });
+    });
+
+    it("does not update if indexing a primitive field or array on the update tenant", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {
+        displayName: "display",
+        mfaConfig: {
+          enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+        },
+      });
+      const updateMask = "displayName.0,mfaConfig.enabledProviders.nonexistentField";
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask })
+        .send({
+          displayName: "unused",
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED"],
+          },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.mfaConfig.enabledProviders).to.eql(["PROVIDER_UNSPECIFIED", "PHONE_SMS"]);
+        });
+    });
+
+    it("performs a full update if the update mask is empty", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .send({
+          allowPasswordSignup: true,
+          disableAuth: false,
+          displayName: "display",
+          enableAnonymousUser: true,
+          enableEmailLinkSignin: true,
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          },
+          testPhoneNumbers: { "1234567890": "fake-code", "1(555)555-5555": "another-fake-code" },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.allowPasswordSignup).to.be.true;
+          expect(res.body.disableAuth).to.be.false;
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.enableAnonymousUser).to.be.true;
+          expect(res.body.enableEmailLinkSignin).to.be.true;
+          expect(res.body.mfaConfig).to.eql({
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          });
+          expect(res.body.testPhoneNumbers).to.eql({
+            "+1234567890": "fake-code",
+            "+15555555555": "another-fake-code",
+          });
+        });
+    });
+  });
+});

--- a/src/test/emulators/auth/tenant.spec.ts
+++ b/src/test/emulators/auth/tenant.spec.ts
@@ -3,7 +3,7 @@ import { Tenant } from "../../../emulator/auth/state";
 import { expectStatusCode, registerTenant } from "./helpers";
 import { describeAuthEmulator } from "./setup";
 
-describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
+describeAuthEmulator("tenant management", ({ authApi }) => {
   describe("createTenant", () => {
     it("should create tenants", async () => {
       await authApi()
@@ -19,7 +19,6 @@ describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
             enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
             state: "ENABLED",
           },
-          testPhoneNumbers: { "1234567890": "fake-code", "1(555)555-5555": "another-fake-code" },
         })
         .then((res) => {
           expectStatusCode(200, res);
@@ -32,77 +31,12 @@ describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
             enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
             state: "ENABLED",
           });
-          expect(res.body.testPhoneNumbers).to.eql({
-            "+1234567890": "fake-code",
-            "+15555555555": "another-fake-code",
-          });
 
           // Should have a non-empty tenantId and matching resource name
           expect(res.body).to.have.property("tenantId");
           expect(res.body.tenantId).to.not.eql("");
           expect(res.body).to.have.property("name");
           expect(res.body.name).to.eql(`projects/project-id/tenants/${res.body.tenantId}`);
-        });
-    });
-
-    it("should error for too long phone number strings", async () => {
-      const stringOfLength251 =
-        "26309807635151999007190279164688762548403557194653647493992467370002025938089183725458712376845251478037398883690369019457887385561469910485467169892025615975626596228774429150543679701729000472697539159978901659121833328943611034838868161513522457664";
-      const testPhoneNumbers: { [key: string]: string } = {};
-      testPhoneNumbers[stringOfLength251] = "fake-code";
-
-      await authApi()
-        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
-        .set("Authorization", "Bearer owner")
-        .send({
-          testPhoneNumbers,
-        })
-        .then((res) => {
-          expectStatusCode(400, res);
-          expect(res.body.error.message).to.include("TOO_LONG");
-        });
-    });
-
-    it("should error for invalid phone numbers", async () => {
-      await authApi()
-        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
-        .set("Authorization", "Bearer owner")
-        .send({
-          testPhoneNumbers: { "+++++++[][][][][]": "fake-code" },
-        })
-        .then((res) => {
-          expectStatusCode(400, res);
-          expect(res.body.error.message).to.include("INVALID_PHONE_NUMBER");
-        });
-    });
-
-    it("should error for too short phone numbers", async () => {
-      await authApi()
-        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
-        .set("Authorization", "Bearer owner")
-        .send({
-          testPhoneNumbers: { "1": "fake-code" },
-        })
-        .then((res) => {
-          expectStatusCode(400, res);
-          expect(res.body.error.message).to.include("INVALID_PHONE_NUMBER");
-        });
-    });
-
-    it("should error for too long phone numbers", async () => {
-      const stringOfLength18 = "801865849451122371";
-      const testPhoneNumbers: { [key: string]: string } = {};
-      testPhoneNumbers[stringOfLength18] = "fake-code";
-
-      await authApi()
-        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
-        .set("Authorization", "Bearer owner")
-        .send({
-          testPhoneNumbers,
-        })
-        .then((res) => {
-          expectStatusCode(400, res);
-          expect(res.body.error.message).to.include("TOO_LONG");
         });
     });
   });
@@ -246,7 +180,7 @@ describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
       const projectId = "project-id";
       const tenant = await registerTenant(authApi(), projectId, {});
       const updateMask =
-        "allowPasswordSignup,disableAuth,displayName,enableAnonymousUser,enableEmailLinkSignin,mfaConfig,testPhoneNumbers";
+        "allowPasswordSignup,disableAuth,displayName,enableAnonymousUser,enableEmailLinkSignin,mfaConfig";
 
       await authApi()
         .patch(
@@ -264,7 +198,6 @@ describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
             enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
             state: "ENABLED",
           },
-          testPhoneNumbers: { "1234567890": "fake-code", "1(555)555-5555": "another-fake-code" },
         })
         .then((res) => {
           expectStatusCode(200, res);
@@ -276,10 +209,6 @@ describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
           expect(res.body.mfaConfig).to.eql({
             enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
             state: "ENABLED",
-          });
-          expect(res.body.testPhoneNumbers).to.eql({
-            "+1234567890": "fake-code",
-            "+15555555555": "another-fake-code",
           });
         });
     });
@@ -350,7 +279,6 @@ describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
             enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
             state: "ENABLED",
           },
-          testPhoneNumbers: { "1234567890": "fake-code", "1(555)555-5555": "another-fake-code" },
         })
         .then((res) => {
           expectStatusCode(200, res);
@@ -362,10 +290,6 @@ describeAuthEmulator("tenant management", ({ authApi, getClock }) => {
           expect(res.body.mfaConfig).to.eql({
             enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
             state: "ENABLED",
-          });
-          expect(res.body.testPhoneNumbers).to.eql({
-            "+1234567890": "fake-code",
-            "+15555555555": "another-fake-code",
           });
         });
     });

--- a/src/test/emulators/auth/tenant.spec.ts
+++ b/src/test/emulators/auth/tenant.spec.ts
@@ -106,18 +106,6 @@ describeAuthEmulator("tenant management", ({ authApi }) => {
           expectStatusCode(200, res);
         });
     });
-
-    it("should error for tenants that do not exist", async () => {
-      await authApi()
-        .delete(
-          "/identitytoolkit.googleapis.com/v2/projects/project-id/tenants/not-found-tenant-id"
-        )
-        .set("Authorization", "Bearer owner")
-        .then((res) => {
-          expectStatusCode(400, res);
-          expect(res.body.error.message).to.include("TENANT_NOT_FOUND");
-        });
-    });
   });
 
   describe("listTenants", () => {


### PR DESCRIPTION
### Description

Add support for `create`, `delete`, `get`, `list`, and `patch` project tenants. This change also includes a bit of refactoring/restructuring to support these endpoints given the use of flatPaths instead of paths (#3761), including:

* Removed `AgentProject` interface from `server.ts` and move `tenantId` |-> `TenantProjectState` map to `AgentProjectState`
* Moved `Tenant` reference to `TenantProjectState`

Associated internal bug: b/192387245

### Scenarios Tested

`npm test` passes

### Sample Commands

N/A
