### PR TITLE
Invoker user account

### DIFF
--- a/src/gcp/proto.ts
+++ b/src/gcp/proto.ts
@@ -139,7 +139,13 @@ export function getInvokerMembers(invoker: string[], projectId: string): string[
   if (invoker[0] === "public") {
     return ["allUsers"];
   }
-  return invoker.map((inv) => formatServiceAccount(inv, projectId));
+  return invoker.map((inv) => {
+    if (inv.startsWith('user:')) {
+      return inv
+    } else {
+      return formatServiceAccount(inv, projectId)
+    }
+  });
 }
 
 /**

--- a/src/gcp/proto.ts
+++ b/src/gcp/proto.ts
@@ -140,10 +140,10 @@ export function getInvokerMembers(invoker: string[], projectId: string): string[
     return ["allUsers"];
   }
   return invoker.map((inv) => {
-    if (inv.startsWith('user:')) {
-      return inv
+    if (inv.startsWith("user:")) {
+      return inv;
     } else {
-      return formatServiceAccount(inv, projectId)
+      return formatServiceAccount(inv, projectId);
     }
   });
 }

--- a/src/test/gcp/proto.spec.ts
+++ b/src/test/gcp/proto.spec.ts
@@ -175,6 +175,12 @@ describe("proto", () => {
         "serviceAccount:service-account2@project.iam.gserviceaccount.com",
       ]);
     });
+    
+    it("should return user accounts unformatted", () => {
+      const invokerMembers = proto.getInvokerMembers(["user:alice@example.com"], "project");
+
+      expect(invokerMembers).to.deep.eq(["user:alice@example.com"]);
+    });
   });
 
   describe("formatServiceAccount", () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
When setting user accounts on the invoker config, they get pre-fixed with `serviceAccount:`. This causes an error from the api. We can check for the `user:` prefix and not format as a service account.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
The account given is a user account. E2E tested from a local firebase project as well.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
