### PR TITLE
Start inferring wantBackend details from existingBackend

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -288,6 +288,22 @@ export function empty(): Backend {
 }
 
 /**
+ * A helper utility to create a backend from a list of endpoints.
+ * Useful in unit tests.
+ */
+export function of(...endpoints: Endpoint[]): Backend {
+  const bkend = { ...empty() };
+  for (const endpoint of endpoints) {
+    bkend.endpoints[endpoint.region] = bkend.endpoints[endpoint.region] || {};
+    if (bkend.endpoints[endpoint.region][endpoint.id]) {
+      throw new Error("Trying to create a backend with the same endpiont twice");
+    }
+    bkend.endpoints[endpoint.region][endpoint.id] = endpoint;
+  }
+  return bkend;
+}
+
+/**
  * A helper utility to test whether a backend is empty.
  * Consumers should use this before assuming a backend is empty (e.g. nooping
  * deploy processes) because it's possible that fields have been added.

--- a/src/test/deploy/functions/prepare.spec.ts
+++ b/src/test/deploy/functions/prepare.spec.ts
@@ -30,7 +30,7 @@ describe("prepare", () => {
         },
       };
 
-      prepare.inferDetailsFromExisting(backend.of(newE), backend.of(oldE), /* usedDotEnv= */ false);
+      prepare.inferDetailsFromExisting(backend.of(newE), backend.of(oldE), /* usedDotenv= */ false);
 
       expect(newE.environmentVariables).to.deep.equals({
         old: "value",

--- a/src/test/deploy/functions/prepare.spec.ts
+++ b/src/test/deploy/functions/prepare.spec.ts
@@ -1,0 +1,72 @@
+import { expect } from "chai";
+import * as backend from "../../../deploy/functions/backend";
+import * as prepare from "../../../deploy/functions/prepare";
+
+describe("prepare", () => {
+  describe("inferDetailsFromExisting", () => {
+    const ENDPOINT: backend.Endpoint = {
+      platform: "gcfv2",
+      id: "id",
+      region: "region",
+      project: "project",
+      entryPoint: "entry",
+      runtime: "nodejs16",
+      httpsTrigger: {},
+    };
+
+    it("merges env vars if .env is not used", () => {
+      const oldE = {
+        ...ENDPOINT,
+        environmentVariables: {
+          foo: "old value",
+          old: "value",
+        },
+      };
+      const newE = {
+        ...ENDPOINT,
+        environmentVariables: {
+          foo: "new value",
+          new: "value",
+        },
+      };
+
+      prepare.inferDetailsFromExisting(backend.of(newE), backend.of(oldE), /* usedDotEnv= */ false);
+
+      expect(newE.environmentVariables).to.deep.equals({
+        old: "value",
+        new: "value",
+        foo: "new value",
+      });
+    });
+
+    it("overwrites env vars if .env is used", () => {
+      const oldE = {
+        ...ENDPOINT,
+        environmentVariables: {
+          foo: "old value",
+          old: "value",
+        },
+      };
+      const newE = {
+        ...ENDPOINT,
+        environmentVariables: {
+          foo: "new value",
+          new: "value",
+        },
+      };
+
+      prepare.inferDetailsFromExisting(backend.of(newE), backend.of(oldE), /* usedDotEnv= */ true);
+
+      expect(newE.environmentVariables).to.deep.equals({
+        new: "value",
+        foo: "new value",
+      });
+    });
+
+    it("can noop when there is no prior endpoint", () => {
+      const e = { ...ENDPOINT };
+      prepare.inferDetailsFromExisting(backend.of(e), backend.of(), /* usedDotEnv= */ false);
+      expect(e).to.deep.equal(ENDPOINT);
+    });
+  });
+});

--- a/src/test/deploy/functions/prompts.spec.ts
+++ b/src/test/deploy/functions/prompts.spec.ts
@@ -45,17 +45,6 @@ const SAMPLE_OPTIONS: Options = {
   rc: new RC(),
 };
 
-function backendOf(...endpoints: backend.Endpoint[]): backend.Backend {
-  const bkend: backend.Backend = {
-    ...backend.empty(),
-  };
-  for (const endpoint of endpoints) {
-    bkend.endpoints[endpoint.region] = bkend.endpoints[endpoint.region] || {};
-    bkend.endpoints[endpoint.region][endpoint.id] = endpoint;
-  }
-  return bkend;
-}
-
 describe("promptForFailurePolicies", () => {
   let promptStub: sinon.SinonStub;
 
@@ -78,7 +67,11 @@ describe("promptForFailurePolicies", () => {
     promptStub.resolves(true);
 
     await expect(
-      functionPrompts.promptForFailurePolicies(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForFailurePolicies(
+        SAMPLE_OPTIONS,
+        backend.of(endpoint),
+        backend.empty()
+      )
     ).not.to.be.rejected;
     expect(promptStub).to.have.been.calledOnce;
   });
@@ -95,8 +88,8 @@ describe("promptForFailurePolicies", () => {
     await expect(
       functionPrompts.promptForFailurePolicies(
         SAMPLE_OPTIONS,
-        backendOf(endpoint),
-        backendOf(endpoint)
+        backend.of(endpoint),
+        backend.of(endpoint)
       )
     ).eventually.be.fulfilled;
     expect(promptStub).to.not.have.been.called;
@@ -113,7 +106,11 @@ describe("promptForFailurePolicies", () => {
     promptStub.resolves(false);
 
     await expect(
-      functionPrompts.promptForFailurePolicies(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForFailurePolicies(
+        SAMPLE_OPTIONS,
+        backend.of(endpoint),
+        backend.empty()
+      )
     ).to.eventually.be.rejectedWith(FirebaseError, /Deployment canceled/);
     expect(promptStub).to.have.been.calledOnce;
   });
@@ -137,8 +134,8 @@ describe("promptForFailurePolicies", () => {
     await expect(
       functionPrompts.promptForFailurePolicies(
         SAMPLE_OPTIONS,
-        backendOf(newEndpoint),
-        backendOf(endpoint)
+        backend.of(newEndpoint),
+        backend.of(endpoint)
       )
     ).eventually.be.fulfilled;
     expect(promptStub).to.have.been.calledOnce;
@@ -155,7 +152,11 @@ describe("promptForFailurePolicies", () => {
     promptStub.resolves(false);
 
     await expect(
-      functionPrompts.promptForFailurePolicies(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForFailurePolicies(
+        SAMPLE_OPTIONS,
+        backend.of(endpoint),
+        backend.empty()
+      )
     ).to.eventually.be.rejectedWith(FirebaseError, /Deployment canceled/);
     expect(promptStub).to.have.been.calledOnce;
   });
@@ -170,7 +171,11 @@ describe("promptForFailurePolicies", () => {
     promptStub.resolves();
 
     await expect(
-      functionPrompts.promptForFailurePolicies(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForFailurePolicies(
+        SAMPLE_OPTIONS,
+        backend.of(endpoint),
+        backend.empty()
+      )
     ).to.eventually.be.fulfilled;
     expect(promptStub).not.to.have.been.called;
   });
@@ -186,7 +191,7 @@ describe("promptForFailurePolicies", () => {
     const options = { ...SAMPLE_OPTIONS, nonInteractive: true };
 
     await expect(
-      functionPrompts.promptForFailurePolicies(options, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForFailurePolicies(options, backend.of(endpoint), backend.empty())
     ).to.be.rejectedWith(FirebaseError, /--force option/);
     expect(promptStub).not.to.have.been.called;
   });
@@ -202,7 +207,7 @@ describe("promptForFailurePolicies", () => {
     const options = { ...SAMPLE_OPTIONS, nonInteractive: true, force: true };
 
     await expect(
-      functionPrompts.promptForFailurePolicies(options, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForFailurePolicies(options, backend.of(endpoint), backend.empty())
     ).to.eventually.be.fulfilled;
     expect(promptStub).not.to.have.been.called;
   });
@@ -230,20 +235,20 @@ describe("promptForMinInstances", () => {
     promptStub.resolves(true);
 
     await expect(
-      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backend.of(endpoint), backend.empty())
     ).not.to.be.rejected;
     expect(promptStub).to.have.been.calledOnce;
   });
 
   it("should not prompt if no fucntion has minInstance", async () => {
-    const bkend = backendOf(SAMPLE_ENDPOINT);
+    const bkend = backend.of(SAMPLE_ENDPOINT);
     await expect(functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, bkend, bkend)).to.eventually
       .be.fulfilled;
     expect(promptStub).to.not.have.been.called;
   });
 
   it("should not prompt if all functions with minInstances already had the same number of minInstances", async () => {
-    const bkend = backendOf({
+    const bkend = backend.of({
       ...SAMPLE_ENDPOINT,
       minInstances: 1,
     });
@@ -266,15 +271,15 @@ describe("promptForMinInstances", () => {
     await expect(
       functionPrompts.promptForMinInstances(
         SAMPLE_OPTIONS,
-        backendOf(newEndpoint),
-        backendOf(endpoint)
+        backend.of(newEndpoint),
+        backend.of(endpoint)
       )
     ).eventually.be.fulfilled;
     expect(promptStub).to.not.have.been.called;
   });
 
   it("should throw if user declines the prompt", async () => {
-    const bkend = backendOf({
+    const bkend = backend.of({
       ...SAMPLE_ENDPOINT,
       minInstances: 1,
     });
@@ -295,8 +300,8 @@ describe("promptForMinInstances", () => {
     await expect(
       functionPrompts.promptForMinInstances(
         SAMPLE_OPTIONS,
-        backendOf(newEndpoint),
-        backendOf(SAMPLE_ENDPOINT)
+        backend.of(newEndpoint),
+        backend.of(SAMPLE_ENDPOINT)
       )
     ).eventually.be.fulfilled;
     expect(promptStub).to.have.been.calledOnce;
@@ -316,8 +321,8 @@ describe("promptForMinInstances", () => {
     await expect(
       functionPrompts.promptForMinInstances(
         SAMPLE_OPTIONS,
-        backendOf(newEndpoint),
-        backendOf(endpoint)
+        backend.of(newEndpoint),
+        backend.of(endpoint)
       )
     ).eventually.be.fulfilled;
     expect(promptStub).to.have.been.calledOnce;
@@ -339,8 +344,8 @@ describe("promptForMinInstances", () => {
     await expect(
       functionPrompts.promptForMinInstances(
         SAMPLE_OPTIONS,
-        backendOf(newEndpoint),
-        backendOf(endpoint)
+        backend.of(newEndpoint),
+        backend.of(endpoint)
       )
     ).eventually.be.fulfilled;
     expect(promptStub).to.have.been.calledOnce;
@@ -354,7 +359,7 @@ describe("promptForMinInstances", () => {
     promptStub.resolves(false);
 
     await expect(
-      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backend.of(endpoint), backend.empty())
     ).to.eventually.be.rejectedWith(FirebaseError, /Deployment canceled/);
     expect(promptStub).to.have.been.calledOnce;
   });
@@ -365,7 +370,7 @@ describe("promptForMinInstances", () => {
     await expect(
       functionPrompts.promptForMinInstances(
         SAMPLE_OPTIONS,
-        backendOf(SAMPLE_ENDPOINT),
+        backend.of(SAMPLE_ENDPOINT),
         backend.empty()
       )
     ).to.eventually.be.fulfilled;
@@ -380,7 +385,7 @@ describe("promptForMinInstances", () => {
     const options = { ...SAMPLE_OPTIONS, nonInteractive: true };
 
     await expect(
-      functionPrompts.promptForMinInstances(options, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForMinInstances(options, backend.of(endpoint), backend.empty())
     ).to.be.rejectedWith(FirebaseError, /--force option/);
     expect(promptStub).not.to.have.been.called;
   });
@@ -393,7 +398,7 @@ describe("promptForMinInstances", () => {
     const options = { ...SAMPLE_OPTIONS, nonInteractive: true, force: true };
 
     await expect(
-      functionPrompts.promptForMinInstances(options, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForMinInstances(options, backend.of(endpoint), backend.empty())
     ).to.eventually.be.fulfilled;
     expect(promptStub).not.to.have.been.called;
   });
@@ -407,7 +412,7 @@ describe("promptForMinInstances", () => {
     promptStub.resolves(true);
 
     await expect(
-      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backend.of(endpoint), backend.empty())
     ).to.eventually.be.fulfilled;
     expect(promptStub).to.have.been.called;
     expect(logStub.firstCall.args[1]).to.match(/Cannot calculate the minimum monthly bill/);
@@ -422,7 +427,7 @@ describe("promptForMinInstances", () => {
     promptStub.resolves(true);
 
     await expect(
-      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backendOf(endpoint), backend.empty())
+      functionPrompts.promptForMinInstances(SAMPLE_OPTIONS, backend.of(endpoint), backend.empty())
     ).to.eventually.be.fulfilled;
     expect(promptStub).to.have.been.called;
     expect(logStub.firstCall.args[1]).to.match(new RegExp("https://cloud.google.com/run/cud"));


### PR DESCRIPTION
Creating a new point in our deploy process where we can modify the desired backend to fill in details from the backend we already have. For example, we can preserve existing environment variables when previews.dotenv is off or we can remember a trigger region from the previous deploy.

This simplifies our existing codebase to no longer need to pass overwriteExistingEnvs to the release planner. I also noticed that this is the third time I've wanted to code `backendOf` in a unit test, so I created `backend.of`