### PR TITLE
A few fixes and cleanup for `secrets`

### DIFF
--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -87,9 +87,6 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
       } else {
         await displayNode10CreateBillingNotice(spec, !nonInteractive);
       }
-      if (usesSecrets) {
-        await secretsUtils.ensureSecretManagerApiEnabled(options);
-      }
     }
     const apis = spec.apis || [];
     if (usesSecrets) {
@@ -99,13 +96,16 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
       });
     }
     if (apis.length) {
-      await askUserForConsent.displayApis(spec.displayName || spec.name, projectId, apis);
+      askUserForConsent.displayApis(spec.displayName || spec.name, projectId, apis);
       const consented = await confirm({ nonInteractive, force, default: true });
       if (!consented) {
         throw new FirebaseError(
           "Without explicit consent for the APIs listed, we cannot deploy this extension."
         );
       }
+    }
+    if (usesSecrets) {
+      await secretsUtils.ensureSecretManagerApiEnabled(options);
     }
 
     const roles = spec.roles ? spec.roles.map((role: extensionsApi.Role) => role.role) : [];

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -9,6 +9,7 @@ import { Command } from "../command";
 import { FirebaseError } from "../error";
 import { needProjectId } from "../projectUtils";
 import * as extensionsApi from "../extensions/extensionsApi";
+import * as secretsUtils from "../extensions/secretsUtils";
 import {
   ensureExtensionsApiEnabled,
   logPrefix,
@@ -70,6 +71,7 @@ export default new Command("ext:uninstall <extensionInstanceId>")
       const serviceAccountMessage = `Uninstalling deletes the service account used by this extension instance:\n${clc.bold(
         instance.serviceAccountEmail
       )}\n\n`;
+      const activeSecrets = secretsUtils.getActiveSecrets(instance);
       const resourcesMessage = _.get(instance, "config.source.spec.resources", []).length
         ? "Uninstalling deletes all extension resources created for this extension instance:\n" +
           instance.config.source.spec.resources
@@ -78,6 +80,10 @@ export default new Command("ext:uninstall <extensionInstanceId>")
                 `- ${resourceTypeToNiceName[resource.type] || resource.type}: ${resource.name} \n`
               )
             )
+            .join("") +
+          activeSecrets
+            .map(secretsUtils.prettySecretName)
+            .map((s) => clc.bold(`- Secret: ${s}\n`))
             .join("") +
           "\n"
         : "";

--- a/src/extensions/askUserForConsent.ts
+++ b/src/extensions/askUserForConsent.ts
@@ -71,7 +71,7 @@ export async function displayRoles(
  * @param projectId ID of user's project
  * @param apis APIs that require user approval
  */
- export async function displayApis(
+export async function displayApis(
   extensionName: string,
   projectId: string,
   apis: extensionsApi.Api[]

--- a/src/extensions/askUserForConsent.ts
+++ b/src/extensions/askUserForConsent.ts
@@ -71,24 +71,18 @@ export async function displayRoles(
  * @param projectId ID of user's project
  * @param apis APIs that require user approval
  */
-export async function displayApis(
-  extensionName: string,
-  projectId: string,
-  apis: extensionsApi.Api[]
-): Promise<void> {
+export function displayApis(extensionName: string, projectId: string, apis: extensionsApi.Api[]) {
   if (!apis.length) {
     return;
   }
   const question = `${clc.bold(
     extensionName
   )} will enable the following APIs for project ${clc.bold(projectId)}`;
-  const results: string[] = await Promise.all(
-    apis.map((api: extensionsApi.Api) => {
-      return `- ${api.apiName}: ${api.reason}`;
-    })
-  );
+  const results: string[] = apis.map((api: extensionsApi.Api) => {
+    return `- ${api.apiName}: ${api.reason}`;
+  });
   results.unshift(question);
-  const message = _.join(results, "\n");
+  const message = results.join("\n");
   utils.logLabeledBullet(logPrefix, message);
 }
 

--- a/src/extensions/askUserForConsent.ts
+++ b/src/extensions/askUserForConsent.ts
@@ -5,6 +5,7 @@ import TerminalRenderer = require("marked-terminal");
 
 import { FirebaseError } from "../error";
 import { logPrefix } from "../extensions/extensionsHelper";
+import * as extensionsApi from "./extensionsApi";
 import * as iam from "../gcp/iam";
 import { promptOnce, Question } from "../prompt";
 import * as utils from "../utils";
@@ -61,6 +62,33 @@ export async function displayRoles(
   }
 
   const message = await formatDescription(extensionName, projectId, roles);
+  utils.logLabeledBullet(logPrefix, message);
+}
+
+/**
+ * Displays APIs that will be enabled for the project and corresponding descriptions.
+ * @param extensionName name of extension to install/update
+ * @param projectId ID of user's project
+ * @param apis APIs that require user approval
+ */
+ export async function displayApis(
+  extensionName: string,
+  projectId: string,
+  apis: extensionsApi.Api[]
+): Promise<void> {
+  if (!apis.length) {
+    return;
+  }
+  const question = `${clc.bold(
+    extensionName
+  )} will enable the following APIs for project ${clc.bold(projectId)}`;
+  const results: string[] = await Promise.all(
+    apis.map((api: extensionsApi.Api) => {
+      return `- ${api.apiName}: ${api.reason}`;
+    })
+  );
+  results.unshift(question);
+  const message = _.join(results, "\n");
   utils.logLabeledBullet(logPrefix, message);
 }
 

--- a/src/extensions/askUserForParam.ts
+++ b/src/extensions/askUserForParam.ts
@@ -186,7 +186,7 @@ async function promptCreateSecret(
     name: paramSpec.param,
     type: "password",
     default: paramSpec.default,
-    message: `This secret will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${secretName}.\nEnter a value for ${paramSpec.label.trim()}:`,
+    message: `This secret will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${secretName} and managed by Firebase Extensions (Firebase Extensions Service Agent will be granted Secret Admin role on this secret).\nEnter a value for ${paramSpec.label.trim()}:`,
   });
   const secret = await secretManagerApi.createSecret(
     projectId,

--- a/src/extensions/askUserForParam.ts
+++ b/src/extensions/askUserForParam.ts
@@ -163,7 +163,11 @@ async function promptReconfigureSecret(
         message: `This secret will be stored in Cloud Secret Manager as ${secretName}.\nEnter new value for ${paramSpec.label.trim()}:`,
       });
       if (!secret) {
-        secret = await secretManagerApi.createSecret(projectId, secretName);
+        secret = await secretManagerApi.createSecret(
+          projectId,
+          secretName,
+          getSecretLabels(instanceId)
+        );
       }
       return addNewSecretVersion(projectId, instanceId, secret, paramSpec, secretValue);
     case SecretUpdateAction.LEAVE:
@@ -184,8 +188,16 @@ async function promptCreateSecret(
     default: paramSpec.default,
     message: `This secret will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${secretName}.\nEnter a value for ${paramSpec.label.trim()}:`,
   });
-  const secret = await secretManagerApi.createSecret(projectId, secretName);
+  const secret = await secretManagerApi.createSecret(
+    projectId,
+    secretName,
+    getSecretLabels(instanceId)
+  );
   return addNewSecretVersion(projectId, instanceId, secret, paramSpec, secretValue);
+}
+
+function getSecretLabels(instanceId: string): Record<string, string> {
+  return { "firebase-extensions-managed": instanceId };
 }
 
 async function generateSecretName(

--- a/src/extensions/askUserForParam.ts
+++ b/src/extensions/askUserForParam.ts
@@ -159,7 +159,7 @@ async function promptReconfigureSecret(
 
       const secretValue = await promptOnce({
         name: paramSpec.param,
-        type: "input",
+        type: "password",
         message: `This secret will be stored in Cloud Secret Manager as ${secretName}.\nEnter new value for ${paramSpec.label.trim()}:`,
       });
       if (!secret) {
@@ -184,7 +184,7 @@ async function promptCreateSecret(
   const secretName = await generateSecretName(projectId, instanceId, paramSpec.param);
   const secretValue = await promptOnce({
     name: paramSpec.param,
-    type: "input",
+    type: "password",
     default: paramSpec.default,
     message: `This secret will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${secretName}.\nEnter a value for ${paramSpec.label.trim()}:`,
   });

--- a/src/extensions/secretsUtils.ts
+++ b/src/extensions/secretsUtils.ts
@@ -1,10 +1,10 @@
-import * as api from "../api";
 import { getProjectNumber } from "../getProjectNumber";
 import * as utils from "../utils";
 import { ensure } from "../ensureApiEnabled";
 import { needProjectId } from "../projectUtils";
 import * as extensionsApi from "./extensionsApi";
 import * as secretManagerApi from "../gcp/secretManager";
+import { logger } from "../logger";
 
 export async function ensureSecretManagerApiEnabled(options: any): Promise<void> {
   const projectId = needProjectId(options);
@@ -38,6 +38,7 @@ export function prettySecretName(secretResourceName: string): string {
   const nameTokens = secretResourceName.split("/");
   if (nameTokens.length != 4 && nameTokens.length != 6) {
     // not a familiar format, return as is
+    logger.debug(`unable to parse secret secretResourceName: ${secretResourceName}`);
     return secretResourceName;
   }
   return nameTokens.slice(0, 4).join("/");

--- a/src/extensions/secretsUtils.ts
+++ b/src/extensions/secretsUtils.ts
@@ -27,3 +27,18 @@ export async function grantFirexServiceAgentSecretAdminRole(
 
   return secretManagerApi.grantServiceAgentRole(secret, saEmail, "roles/secretmanager.admin");
 }
+
+export function getActiveSecrets(instance: extensionsApi.ExtensionInstance): string[] {
+  return instance.config.source.spec.params
+    .map((p) => p.type == extensionsApi.ParamType.SECRET && instance.config.params[p.param])
+    .filter((pv) => !!pv);
+}
+
+export function prettySecretName(secretResourceName: string): string {
+  const nameTokens = secretResourceName.split("/");
+  if (nameTokens.length != 4 && nameTokens.length != 6) {
+    // not a familiar format, return as is
+    return secretResourceName;
+  }
+  return nameTokens.slice(0, 4).join("/");
+}

--- a/src/gcp/secretManager.ts
+++ b/src/gcp/secretManager.ts
@@ -48,7 +48,11 @@ export function parseSecretResourceName(resourceName: string): Secret {
   };
 }
 
-export async function createSecret(projectId: string, name: string): Promise<Secret> {
+export async function createSecret(
+  projectId: string,
+  name: string,
+  labels: Record<string, string>
+): Promise<Secret> {
   const createRes = await api.request(
     "POST",
     `/v1beta1/projects/${projectId}/secrets?secretId=${name}`,
@@ -59,6 +63,7 @@ export async function createSecret(projectId: string, name: string): Promise<Sec
         replication: {
           automatic: {},
         },
+        labels,
       },
     }
   );


### PR DESCRIPTION
* Added API consent during install
* Use prompt type `password` for secrets
* Apply `firebase-extensions-managed` label to the secrets created for extensions
* List secrets to be deleted when extension is uninstalled
