### PR TITLE
Update all other endpoints that are impacted by multi-tenancy

### DIFF
--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -426,11 +426,44 @@ function addEmulatorOperations(openapi3: any): void {
           type: "string",
         },
       },
+    ],
+    servers: [{ url: "" }],
+    get: {
+      description: "List all pending confirmation codes for the project.",
+      operationId: "emulator.projects.oobCodes.list",
+      responses: {
+        "200": {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes",
+              },
+            },
+          },
+        },
+      },
+      security: [],
+      tags: ["emulator"],
+    },
+  };
+  openapi3.paths["/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/oobCodes"] = {
+    parameters: [
+      {
+        name: "targetProjectId",
+        in: "path",
+        description: "The ID of the Google Cloud project that the confirmation codes belongs to.",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
       {
         name: "tenantId",
-        in: "query",
+        in: "path",
         description:
           "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+        required: true,
         schema: { type: "string" },
       },
     ],
@@ -483,11 +516,44 @@ function addEmulatorOperations(openapi3: any): void {
           type: "string",
         },
       },
+    ],
+    servers: [{ url: "" }],
+    get: {
+      description: "List all pending phone verification codes for the project.",
+      operationId: "emulator.projects.verificationCodes.list",
+      responses: {
+        "200": {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes",
+              },
+            },
+          },
+        },
+      },
+      security: [],
+      tags: ["emulator"],
+    },
+  };
+  openapi3.paths["/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/verificationCodes"] = {
+    parameters: [
+      {
+        name: "targetProjectId",
+        in: "path",
+        description: "The ID of the Google Cloud project that the verification codes belongs to.",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
       {
         name: "tenantId",
-        in: "query",
+        in: "path",
         description:
           "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+        required: true,
         schema: { type: "string" },
       },
     ],

--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -305,6 +305,7 @@ function pushServersDownToEachPath(openapi3: any): void {
   });
 }
 
+// TODO(lisajian): add tenantId as query param for all emulator config endpoints
 function addEmulatorOperations(openapi3: any): void {
   openapi3.tags.push({ name: "emulator" });
   openapi3.paths["/emulator/v1/projects/{targetProjectId}/accounts"] = {
@@ -425,6 +426,13 @@ function addEmulatorOperations(openapi3: any): void {
           type: "string",
         },
       },
+      {
+        name: "tenantId",
+        in: "query",
+        description:
+          "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+        schema: { type: "string" },
+      },
     ],
     servers: [{ url: "" }],
     get: {
@@ -474,6 +482,13 @@ function addEmulatorOperations(openapi3: any): void {
         schema: {
           type: "string",
         },
+      },
+      {
+        name: "tenantId",
+        in: "query",
+        description:
+          "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+        schema: { type: "string" },
       },
     ],
     servers: [{ url: "" }],

--- a/src/emulator/auth/apiSpec.js
+++ b/src/emulator/auth/apiSpec.js
@@ -3706,6 +3706,13 @@ export default {
           required: true,
           schema: { type: "string" },
         },
+        {
+          name: "tenantId",
+          in: "query",
+          description:
+            "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+          schema: { type: "string" },
+        },
       ],
       servers: [{ url: "" }],
       get: {
@@ -3732,6 +3739,13 @@ export default {
           in: "path",
           description: "The ID of the Google Cloud project that the verification codes belongs to.",
           required: true,
+          schema: { type: "string" },
+        },
+        {
+          name: "tenantId",
+          in: "query",
+          description:
+            "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
           schema: { type: "string" },
         },
       ],

--- a/src/emulator/auth/apiSpec.js
+++ b/src/emulator/auth/apiSpec.js
@@ -3706,11 +3706,40 @@ export default {
           required: true,
           schema: { type: "string" },
         },
+      ],
+      servers: [{ url: "" }],
+      get: {
+        description: "List all pending confirmation codes for the project.",
+        operationId: "emulator.projects.oobCodes.list",
+        responses: {
+          200: {
+            description: "Successful response",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes" },
+              },
+            },
+          },
+        },
+        security: [],
+        tags: ["emulator"],
+      },
+    },
+    "/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/oobCodes": {
+      parameters: [
+        {
+          name: "targetProjectId",
+          in: "path",
+          description: "The ID of the Google Cloud project that the confirmation codes belongs to.",
+          required: true,
+          schema: { type: "string" },
+        },
         {
           name: "tenantId",
-          in: "query",
+          in: "path",
           description:
             "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+          required: true,
           schema: { type: "string" },
         },
       ],
@@ -3741,11 +3770,40 @@ export default {
           required: true,
           schema: { type: "string" },
         },
+      ],
+      servers: [{ url: "" }],
+      get: {
+        description: "List all pending phone verification codes for the project.",
+        operationId: "emulator.projects.verificationCodes.list",
+        responses: {
+          200: {
+            description: "Successful response",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes" },
+              },
+            },
+          },
+        },
+        security: [],
+        tags: ["emulator"],
+      },
+    },
+    "/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/verificationCodes": {
+      parameters: [
+        {
+          name: "targetProjectId",
+          in: "path",
+          description: "The ID of the Google Cloud project that the verification codes belongs to.",
+          required: true,
+          schema: { type: "string" },
+        },
         {
           name: "tenantId",
-          in: "query",
+          in: "path",
           description:
             "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+          required: true,
           schema: { type: "string" },
         },
       ],
@@ -6592,7 +6650,7 @@ export default {
           },
           bindings: {
             description:
-              "Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member.",
+            "Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member.",
             items: { $ref: "#/components/schemas/GoogleIamV1Binding" },
             type: "array",
           },

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -12,10 +12,13 @@ import { PROVIDERS_LIST_PLACEHOLDER, WIDGET_UI } from "./widget_ui";
  */
 export function registerHandlers(
   app: express.Express,
-  getProjectStateByApiKey: (apiKey: string) => ProjectState
+  getProjectStateByApiKey: (apiKey: string, tenantId?: string) => ProjectState
 ): void {
   app.get(`/emulator/action`, (req, res) => {
-    const { mode, oobCode, continueUrl, apiKey } = req.query as Record<string, string | undefined>;
+    const { mode, oobCode, continueUrl, apiKey, tenantId } = req.query as Record<
+      string,
+      string | undefined
+    >;
 
     if (!apiKey) {
       return res.status(400).json({
@@ -33,7 +36,7 @@ export function registerHandlers(
         },
       });
     }
-    const state = getProjectStateByApiKey(apiKey);
+    const state = getProjectStateByApiKey(apiKey, tenantId);
 
     switch (mode) {
       case "recoverEmail": {
@@ -169,6 +172,7 @@ export function registerHandlers(
     res.set("Content-Type", "text/html; charset=utf-8");
     const apiKey = req.query.apiKey as string | undefined;
     const providerId = req.query.providerId as string | undefined;
+    const tenantId = req.query.tenantId as string | undefined;
     if (!apiKey || !providerId) {
       return res.status(400).json({
         authEmulator: {
@@ -176,7 +180,7 @@ export function registerHandlers(
         },
       });
     }
-    const state = getProjectStateByApiKey(apiKey);
+    const state = getProjectStateByApiKey(apiKey, tenantId);
     const providerInfos = state.listProviderInfosByProviderId(providerId);
 
     const options = providerInfos

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1,5 +1,5 @@
 import { URLSearchParams } from "url";
-import { decode as decodeJwt, sign as signJwt, JwtHeader, decode } from "jsonwebtoken";
+import { decode as decodeJwt, sign as signJwt, JwtHeader } from "jsonwebtoken";
 import * as express from "express";
 import { ExegesisContext } from "exegesis-express";
 import {
@@ -1054,10 +1054,6 @@ export function setAccountInfoImpl(
 
       const newEmail = canonicalizeEmailAddress(reqBody.email);
       if (newEmail !== user.email) {
-        assert(
-          state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY",
-          "EMAIL_CHANGE_NEEDS_VERIFICATION"
-        );
         assert(!state.getUserByEmail(newEmail), "EMAIL_EXISTS");
         updates.email = newEmail;
         // TODO: Set verified if email is verified by IDP linked to account.

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1,5 +1,5 @@
 import { URLSearchParams } from "url";
-import { decode as decodeJwt, sign as signJwt, JwtHeader } from "jsonwebtoken";
+import { decode as decodeJwt, sign as signJwt, JwtHeader, decode } from "jsonwebtoken";
 import * as express from "express";
 import { ExegesisContext } from "exegesis-express";
 import {
@@ -89,8 +89,19 @@ export const authOperations: AuthOps = {
         get: getTenant,
         list: listTenants,
         patch: updateTenant,
+        createSessionCookie,
+        accounts: {
+          _: signUp,
+          batchCreate,
+          batchDelete,
+          batchGet,
+          delete: deleteAccount,
+          lookup,
+          query: queryAccounts,
+          sendOobCode,
+          update: setAccountInfo,
+        },
       },
-      // TODO(lisajian): Adjust all other endpoints that use tenantId
     },
   },
   securetoken: {
@@ -135,6 +146,7 @@ function signUp(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignUpRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1SignUpResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   let provider: string | undefined;
   const updates: Omit<Partial<UserInfo>, "localId" | "providerUserInfo"> = {
@@ -172,9 +184,11 @@ function signUp(
       assert(reqBody.email, "MISSING_EMAIL");
       assert(reqBody.password, "MISSING_PASSWORD");
       provider = PROVIDER_PASSWORD;
+      assert(state.allowPasswordSignup, "OPERATION_NOT_ALLOWED");
     } else {
       // Most attributes are ignored when creating anon user without privilege.
       provider = PROVIDER_ANONYMOUS;
+      assert(state.enableAnonymousUser, "ADMIN_ONLY_OPERATION");
     }
   }
 
@@ -198,6 +212,9 @@ function signUp(
     updates.mfaInfo = getMfaEnrollmentsFromRequest(state, reqBody.mfaInfo, {
       generateEnrollmentIds: true,
     });
+  }
+  if (reqBody.tenantId) {
+    updates.tenantId = reqBody.tenantId;
   }
   let user: UserInfo | undefined;
   if (reqBody.idToken) {
@@ -229,6 +246,7 @@ function lookup(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1GetAccountInfoRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1GetAccountInfoResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   const seenLocalIds = new Set<string>();
   const users: UserInfo[] = [];
   function tryAddUser(maybeUser: UserInfo | undefined): void {
@@ -276,6 +294,7 @@ function batchCreate(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1UploadAccountRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1UploadAccountResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   assert(reqBody.users?.length, "MISSING_USER_ACCOUNT");
 
@@ -325,6 +344,13 @@ function batchCreate(
         photoUrl: userInfo.photoUrl,
         lastLoginAt: userInfo.lastLoginAt,
       };
+      if (userInfo.tenantId) {
+        assert(
+          state instanceof TenantProjectState && state.tenantId === userInfo.tenantId,
+          "Tenant id in userInfo does not match the tenant id in request."
+        );
+        fields.tenantId = state.tenantId;
+      }
 
       // password
       if (userInfo.passwordHash) {
@@ -493,6 +519,7 @@ function batchGet(
   reqBody: unknown,
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1DownloadAccountResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   const maxResults = Math.min(Math.floor(ctx.params.query.maxResults) || 20, 1000);
 
   const users = state.queryUsers(
@@ -520,6 +547,7 @@ function createAuthUri(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1CreateAuthUriRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1CreateAuthUriResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   const sessionId = reqBody.sessionId || randomId(27);
   if (reqBody.providerId) {
@@ -626,6 +654,7 @@ function deleteAccount(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1DeleteAccountRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1DeleteAccountResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   let user: UserInfo;
   if (ctx.security?.Oauth2) {
     assert(reqBody.localId, "MISSING_LOCAL_ID");
@@ -647,6 +676,8 @@ function deleteAccount(
 function getProjects(
   state: ProjectState
 ): Schemas["GoogleCloudIdentitytoolkitV1GetProjectConfigResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state instanceof AgentProjectState, "UNSUPPORTED_TENANT_OPERATION");
   return {
     projectId: state.projectNumber,
     authorizedDomains: [
@@ -658,7 +689,10 @@ function getProjects(
   };
 }
 
-function getRecaptchaParams(): Schemas["GoogleCloudIdentitytoolkitV1GetRecaptchaParamResponse"] {
+function getRecaptchaParams(
+  state: ProjectState
+): Schemas["GoogleCloudIdentitytoolkitV1GetRecaptchaParamResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   return {
     kind: "identitytoolkit#GetRecaptchaParamResponse",
 
@@ -677,6 +711,7 @@ function queryAccounts(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1QueryUserInfoRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1QueryUserInfoResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   if (reqBody.expression?.length) {
     throw new NotImplementedError("expression is not implemented.");
   }
@@ -735,7 +770,9 @@ export function resetPassword(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1ResetPasswordRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1ResetPasswordResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
+  assert(state.allowPasswordSignup, "PASSWORD_LOGIN_DISABLED");
   assert(reqBody.oobCode, "MISSING_OOB_CODE");
   const oob = state.validateOobCode(reqBody.oobCode);
   assert(oob, "INVALID_OOB_CODE");
@@ -781,6 +818,7 @@ function sendOobCode(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1GetOobCodeRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1GetOobCodeResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   assert(
     reqBody.requestType && reqBody.requestType !== "OOB_REQ_TYPE_UNSPECIFIED",
@@ -801,6 +839,7 @@ function sendOobCode(
 
   switch (reqBody.requestType) {
     case "EMAIL_SIGNIN":
+      assert(state.enableEmailLinkSignin, "OPERATION_NOT_ALLOWED");
       mode = "signIn";
       assert(reqBody.email, "MISSING_EMAIL");
       email = canonicalizeEmailAddress(reqBody.email);
@@ -868,6 +907,8 @@ function sendVerificationCode(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SendVerificationCodeRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SendVerificationCodeResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state instanceof AgentProjectState, "UNSUPPORTED_TENANT_OPERATION");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   // reqBody.iosReceipt, iosSecret, and recaptchaToken are intentionally ignored.
 
@@ -903,6 +944,7 @@ function setAccountInfo(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SetAccountInfoRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1SetAccountInfoResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   const url = authEmulatorUrl(ctx.req as express.Request);
   return setAccountInfoImpl(state, reqBody, {
@@ -1012,6 +1054,10 @@ export function setAccountInfoImpl(
 
       const newEmail = canonicalizeEmailAddress(reqBody.email);
       if (newEmail !== user.email) {
+        assert(
+          state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY",
+          "EMAIL_CHANGE_NEEDS_VERIFICATION"
+        );
         assert(!state.getUserByEmail(newEmail), "EMAIL_EXISTS");
         updates.email = newEmail;
         // TODO: Set verified if email is verified by IDP linked to account.
@@ -1176,6 +1222,10 @@ function createOobRecord(
       url.searchParams.set("continueUrl", params.continueUrl);
     }
 
+    if (state instanceof TenantProjectState) {
+      url.searchParams.set("tenantId", state.tenantId);
+    }
+
     return url.toString();
   });
 
@@ -1213,10 +1263,17 @@ function signInWithCustomToken(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithCustomTokenRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithCustomTokenResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(reqBody.token, "MISSING_CUSTOM_TOKEN");
 
   // eslint-disable-next-line camelcase
-  let payload: { aud?: unknown; uid?: unknown; user_id?: unknown; claims?: unknown };
+  let payload: {
+    aud?: unknown;
+    uid?: unknown;
+    user_id?: unknown;
+    claims?: unknown;
+    tenantId?: unknown;
+  };
   if (reqBody.token.startsWith("{")) {
     // In the emulator only, we allow plain JSON strings as custom tokens, to
     // simplify testing. This won't work in production.
@@ -1233,6 +1290,9 @@ function signInWithCustomToken(
       header: JwtHeader;
       payload: typeof payload;
     } | null;
+    if (state instanceof TenantProjectState) {
+      assert(decoded?.payload.tenantId === state.tenantId, "TENANT_ID_MISMATCH");
+    }
     assert(decoded, "INVALID_CUSTOM_TOKEN : Invalid assertion format");
     if (decoded.header.alg !== "none") {
       // We may have received a real token, signed using a service account private
@@ -1270,6 +1330,7 @@ function signInWithCustomToken(
   const updates = {
     customAuth: true,
     lastLoginAt: Date.now().toString(),
+    tenantId: state instanceof TenantProjectState ? state.tenantId : undefined,
   };
 
   if (user) {
@@ -1293,6 +1354,8 @@ function signInWithEmailLink(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithEmailLinkRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithEmailLinkResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state.enableEmailLinkSignin, "OPERATION_NOT_ALLOWED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   const userFromIdToken = reqBody.idToken ? parseIdToken(state, reqBody.idToken).user : undefined;
   assert(reqBody.email, "MISSING_EMAIL");
@@ -1307,11 +1370,15 @@ function signInWithEmailLink(
 
   state.deleteOobCode(reqBody.oobCode);
 
-  const updates = {
+  const updates: Omit<Partial<UserInfo>, "localId" | "providerUserInfo"> = {
     email,
     emailVerified: true,
     emailLinkSignin: true,
   };
+
+  if (state instanceof TenantProjectState) {
+    updates.tenantId = state.tenantId;
+  }
 
   let user = state.getUserByEmail(email);
   const isNewUser = !user && !userFromIdToken;
@@ -1334,7 +1401,10 @@ function signInWithEmailLink(
     isNewUser,
   };
 
-  if (user.mfaInfo?.length) {
+  if (
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+    user.mfaInfo?.length
+  ) {
     return { ...response, ...mfaPending(state, user, PROVIDER_PASSWORD) };
   } else {
     user = state.updateUserByLocalId(user.localId, { lastLoginAt: Date.now().toString() });
@@ -1348,6 +1418,7 @@ function signInWithIdp(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithIdpRequest"]
 ): SignInWithIdpResponse {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
 
   if (reqBody.returnRefreshToken) {
@@ -1453,6 +1524,7 @@ function signInWithIdp(
       ...accountUpdates.fields,
       lastLoginAt: Date.now().toString(),
       providerUserInfo: [providerUserInfo],
+      tenantId: state instanceof TenantProjectState ? state.tenantId : undefined,
     });
     response.localId = user.localId;
   } else {
@@ -1474,7 +1546,14 @@ function signInWithIdp(
     response.emailVerified = user.emailVerified;
   }
 
-  if (user.mfaInfo?.length) {
+  if (state instanceof TenantProjectState) {
+    response.tenantId = state.tenantId;
+  }
+
+  if (
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+    user.mfaInfo?.length
+  ) {
     return { ...response, ...mfaPending(state, user, providerId) };
   } else {
     user = state.updateUserByLocalId(user.localId, { lastLoginAt: Date.now().toString() });
@@ -1486,6 +1565,8 @@ function signInWithPassword(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithPasswordRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithPasswordResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state.allowPasswordSignup, "PASSWORD_LOGIN_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   assert(reqBody.email, "MISSING_EMAIL");
   assert(reqBody.password, "MISSING_PASSWORD");
@@ -1512,7 +1593,10 @@ function signInWithPassword(
     email,
   };
 
-  if (user.mfaInfo?.length) {
+  if (
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+    user.mfaInfo?.length
+  ) {
     return { ...response, ...mfaPending(state, user, PROVIDER_PASSWORD) };
   } else {
     user = state.updateUserByLocalId(user.localId, { lastLoginAt: Date.now().toString() });
@@ -1524,6 +1608,8 @@ function signInWithPhoneNumber(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithPhoneNumberRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithPhoneNumberResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state instanceof AgentProjectState, "UNSUPPORTED_TENANT_OPERATION");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   let phoneNumber: string;
   if (reqBody.temporaryProof) {
@@ -1680,6 +1766,12 @@ function mfaEnrollmentStart(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2StartMfaEnrollmentRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2StartMfaEnrollmentResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   assert(reqBody.idToken, "MISSING_ID_TOKEN");
 
   const { user, signInProvider } = parseIdToken(state, reqBody.idToken);
@@ -1727,6 +1819,12 @@ function mfaEnrollmentFinalize(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaEnrollmentRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaEnrollmentResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   assert(reqBody.idToken, "MISSING_ID_TOKEN");
   let { user, signInProvider } = parseIdToken(state, reqBody.idToken);
   assert(
@@ -1783,6 +1881,7 @@ function mfaEnrollmentWithdraw(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2WithdrawMfaRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2WithdrawMfaResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(reqBody.idToken, "MISSING_ID_TOKEN");
 
   let { user, signInProvider } = parseIdToken(state, reqBody.idToken);
@@ -1804,6 +1903,12 @@ function mfaSignInStart(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2StartMfaSignInRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2StartMfaSignInResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   assert(
     reqBody.mfaPendingCredential,
     "MISSING_MFA_PENDING_CREDENTIAL : Request does not have MFA pending credential."
@@ -1844,6 +1949,12 @@ function mfaSignInFinalize(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaSignInRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaSignInResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   // Inconsistent with mfaSignInStart (where MISSING_MFA_PENDING_CREDENTIAL is
   // returned), but matches production behavior.
   assert(reqBody.mfaPendingCredential, "MISSING_CREDENTIAL : Please set MFA Pending Credential.");
@@ -1930,6 +2041,8 @@ function issueTokens(
 
   const usageMode = state.usageMode === UsageMode.PASSTHROUGH ? "passthrough" : undefined;
 
+  const tenantId = state instanceof TenantProjectState ? state.tenantId : undefined;
+
   const expiresInSeconds = 60 * 60;
   const idToken = generateJwt(user, {
     projectId: state.projectId,
@@ -1938,6 +2051,7 @@ function issueTokens(
     extraClaims,
     secondFactor,
     usageMode,
+    tenantId,
   });
   const refreshToken =
     state.usageMode === UsageMode.DEFAULT
@@ -1978,6 +2092,13 @@ function parseIdToken(
       "Received a signed JWT. Auth Emulator does not validate JWTs and IS NOT SECURE"
     );
   }
+  if (decoded.payload.firebase.tenant) {
+    assert(
+      state instanceof TenantProjectState,
+      "((Parsed token that belongs to tenant in a non-tenant project.))"
+    );
+    assert(decoded.payload.firebase.tenant === state.tenantId, "TENANT_ID_MISMATCH");
+  }
   const user = state.getUserByLocalId(decoded.payload.user_id);
   assert(user, "USER_NOT_FOUND");
   // To make interactive debugging easier, idTokens in the emulator never expire
@@ -1998,6 +2119,7 @@ function generateJwt(
     extraClaims = {},
     secondFactor,
     usageMode,
+    tenantId,
   }: {
     projectId: string;
     signInProvider: string;
@@ -2005,6 +2127,7 @@ function generateJwt(
     extraClaims?: Record<string, unknown>;
     secondFactor?: SecondFactorRecord;
     usageMode?: string;
+    tenantId?: string;
   }
 ): string {
   const identities: Record<string, string[]> = {};
@@ -2050,6 +2173,7 @@ function generateJwt(
       second_factor_identifier: secondFactor?.identifier,
       sign_in_second_factor: secondFactor?.provider,
       usage_mode: usageMode,
+      tenant: tenantId,
     },
   };
   /* eslint-enable camelcase */
@@ -2466,6 +2590,7 @@ interface MfaPendingCredential {
   localId: string;
   signInProvider: string;
   projectId: string;
+  tenantId?: string;
   // MfaPendingCredential in emulator never expire to make interactive debugging
   // a bit easier. Therefore, there's no need to record createdAt timestamps.
 }
@@ -2482,8 +2607,11 @@ function mfaPending(
     _AuthEmulatorMfaPendingCredential: "DO NOT MODIFY",
     localId: user.localId,
     signInProvider,
-    projectId: state.projectId, // TODO: Handle tenants.
+    projectId: state.projectId,
   };
+  if (state instanceof TenantProjectState) {
+    pendingCredentialPayload.tenantId = state.tenantId;
+  }
 
   // Encode pendingCredentialPayload using base64. We don't encrypt or sign the
   // data in the Auth Emulator but just trust developers not to modify it.
@@ -2544,6 +2672,12 @@ function parsePendingCredential(
     pendingCredentialPayload.projectId === state.projectId,
     "INVALID_PROJECT_ID : Project ID does not match MFA pending credential."
   );
+  if (state instanceof TenantProjectState) {
+    assert(
+      pendingCredentialPayload.tenantId === state.tenantId,
+      "INVALID_PROJECT_ID : Project ID does not match MFA pending credential."
+    );
+  }
 
   const { localId, signInProvider } = pendingCredentialPayload;
   const user = state.getUserByLocalId(localId);
@@ -2653,6 +2787,7 @@ export interface FirebaseJwtPayload {
     sign_in_second_factor?: string;
     second_factor_identifier?: string;
     usage_mode?: string;
+    tenant?: string;
   };
   // ...and other fields that we don't care for now.
 }

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -2816,7 +2816,7 @@ export interface components {
        */
       auditConfigs?: components["schemas"]["GoogleIamV1AuditConfig"][];
       /**
-       * Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member.
+       * Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member. The `bindings` in a `Policy` can refer to up to 1,500 members; up to 250 of these members can be Google groups. Each occurrence of a member counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other member, then you can add another 1,450 members to the `bindings` in the `Policy`.
        */
       bindings?: components["schemas"]["GoogleIamV1Binding"][];
       /**

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -1852,6 +1852,15 @@ export interface components {
       suggestedTimeout?: string;
     };
     /**
+     * Configuration options related to authenticating an anonymous user.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Anonymous: {
+      /**
+       * Whether anonymous user auth is enabled for the project or not.
+       */
+      enabled?: boolean;
+    };
+    /**
      * Additional config for SignInWithApple.
      */
     GoogleCloudIdentitytoolkitAdminV2AppleSignInConfig: {
@@ -1860,6 +1869,32 @@ export interface components {
        */
       bundleIds?: string[];
       codeFlowConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2CodeFlowConfig"];
+    };
+    /**
+     * Configuration related to Blocking Functions.
+     */
+    GoogleCloudIdentitytoolkitAdminV2BlockingFunctionsConfig: {
+      forwardInboundCredentials?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2ForwardInboundCredentials"];
+      /**
+       * Map of Trigger to event type. Key should be one of the supported event types: "beforeCreate", "beforeSignIn"
+       */
+      triggers?: {
+        [key: string]: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Trigger"];
+      };
+    };
+    /**
+     * Options related to how clients making requests on behalf of a project should be configured.
+     */
+    GoogleCloudIdentitytoolkitAdminV2ClientConfig: {
+      /**
+       * Output only. API key that can be used when making requests for this project.
+       */
+      apiKey?: string;
+      /**
+       * Output only. Firebase subdomain.
+       */
+      firebaseSubdomain?: string;
+      permissions?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Permissions"];
     };
     /**
      * Additional config for Apple for code flow.
@@ -1877,6 +1912,31 @@ export interface components {
        * Apple Developer Team ID.
        */
       teamId?: string;
+    };
+    /**
+     * Represents an Identity Toolkit project.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Config: {
+      /**
+       * List of domains authorized for OAuth redirects
+       */
+      authorizedDomains?: string[];
+      blockingFunctions?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2BlockingFunctionsConfig"];
+      client?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2ClientConfig"];
+      mfa?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig"];
+      monitoring?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MonitoringConfig"];
+      multiTenant?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MultiTenantConfig"];
+      /**
+       * Output only. The name of the Config resource. Example: "projects/my-awesome-project/config"
+       */
+      name?: string;
+      notification?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2NotificationConfig"];
+      quota?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2QuotaConfig"];
+      signIn?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SignInConfig"];
+      /**
+       * Output only. The subtype of this config.
+       */
+      subtype?: "SUBTYPE_UNSPECIFIED" | "IDENTITY_PLATFORM" | "FIREBASE_AUTH";
     };
     /**
      * Standard Identity Toolkit-trusted IDPs.
@@ -1912,6 +1972,99 @@ export interface components {
        * The name of the DefaultSupportedIdpConfig resource, for example: "projects/my-awesome-project/defaultSupportedIdpConfigs/google.com"
        */
       name?: string;
+    };
+    /**
+     * Information of custom domain DNS verification. By default, default_domain will be used. A custom domain can be configured using VerifyCustomDomain.
+     */
+    GoogleCloudIdentitytoolkitAdminV2DnsInfo: {
+      /**
+       * Output only. The applied verified custom domain.
+       */
+      customDomain?: string;
+      /**
+       * Output only. The current verification state of the custom domain. The custom domain will only be used once the domain verification is successful.
+       */
+      customDomainState?:
+        | "VERIFICATION_STATE_UNSPECIFIED"
+        | "NOT_STARTED"
+        | "IN_PROGRESS"
+        | "FAILED"
+        | "SUCCEEDED";
+      /**
+       * Output only. The timestamp of initial request for the current domain verification.
+       */
+      domainVerificationRequestTime?: string;
+      /**
+       * Output only. The custom domain that's to be verified.
+       */
+      pendingCustomDomain?: string;
+      /**
+       * Whether to use custom domain.
+       */
+      useCustomDomain?: boolean;
+    };
+    /**
+     * Configuration options related to authenticating a user by their email address.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Email: {
+      /**
+       * Whether email auth is enabled for the project or not.
+       */
+      enabled?: boolean;
+      /**
+       * Whether a password is required for email auth or not. If true, both an email and password must be provided to sign in. If false, a user may sign in via either email/password or email link.
+       */
+      passwordRequired?: boolean;
+    };
+    /**
+     * Email template. The subject and body fields can contain the following placeholders which will be replaced with the appropriate values: %LINK% - The link to use to redeem the send OOB code. %EMAIL% - The email where the email is being sent. %NEW_EMAIL% - The new email being set for the account (when applicable). %APP_NAME% - The GCP project's display name. %DISPLAY_NAME% - The user's display name.
+     */
+    GoogleCloudIdentitytoolkitAdminV2EmailTemplate: {
+      /**
+       * Email body
+       */
+      body?: string;
+      /**
+       * Email body format
+       */
+      bodyFormat?: "BODY_FORMAT_UNSPECIFIED" | "PLAIN_TEXT" | "HTML";
+      /**
+       * Output only. Whether the body or subject of the email is customized.
+       */
+      customized?: boolean;
+      /**
+       * Reply-to address
+       */
+      replyTo?: string;
+      /**
+       * Sender display name
+       */
+      senderDisplayName?: string;
+      /**
+       * Local part of From address
+       */
+      senderLocalPart?: string;
+      /**
+       * Subject of the email
+       */
+      subject?: string;
+    };
+    /**
+     * Indicates which credentials to pass to the registered Blocking Functions.
+     */
+    GoogleCloudIdentitytoolkitAdminV2ForwardInboundCredentials: {
+      /**
+       * Whether to pass the user's OAuth identity provider's access token.
+       */
+      accessToken?: boolean;
+      /**
+       * Whether to pass the user's OIDC identity provider's ID token.
+       */
+      idToken?: boolean;
+      /**
+       * Whether to pass the user's OAuth identity provider's refresh token.
+       */
+      refreshToken?: boolean;
     };
     /**
      * History information of the hash algorithm and key. Different accounts' passwords may be generated by different version.
@@ -2076,6 +2229,12 @@ export interface components {
       tenants?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Tenant"][];
     };
     /**
+     * Configuration related to monitoring project activity.
+     */
+    GoogleCloudIdentitytoolkitAdminV2MonitoringConfig: {
+      requestLogging?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2RequestLogging"];
+    };
+    /**
      * Options related to MultiFactor Authentication for the project.
      */
     GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig: {
@@ -2087,6 +2246,30 @@ export interface components {
        * Whether MultiFactor Authentication has been enabled for this project.
        */
       state?: "STATE_UNSPECIFIED" | "DISABLED" | "ENABLED" | "MANDATORY";
+    };
+    /**
+     * Configuration related to multi-tenant functionality.
+     */
+    GoogleCloudIdentitytoolkitAdminV2MultiTenantConfig: {
+      /**
+       * Whether this project can have tenants or not.
+       */
+      allowTenants?: boolean;
+      /**
+       * The default cloud parent org or folder that the tenant project should be created under. The parent resource name should be in the format of "/", such as "folders/123" or "organizations/456". If the value is not set, the tenant will be created under the same organization or folder as the agent project.
+       */
+      defaultTenantLocation?: string;
+    };
+    /**
+     * Configuration related to sending notifications to users.
+     */
+    GoogleCloudIdentitytoolkitAdminV2NotificationConfig: {
+      /**
+       * Default locale used for email and SMS in IETF BCP 47 format.
+       */
+      defaultLocale?: string;
+      sendEmail?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SendEmail"];
+      sendSms?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SendSms"];
     };
     /**
      * Configuration options for authenticating with an OAuth IDP.
@@ -2136,6 +2319,128 @@ export interface components {
       token?: boolean;
     };
     /**
+     * Configuration related to restricting a user's ability to affect their account.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Permissions: {
+      /**
+       * When true, end users cannot delete their account on the associated project through any of our API methods
+       */
+      disabledUserDeletion?: boolean;
+      /**
+       * When true, end users cannot sign up for a new account on the associated project through any of our API methods
+       */
+      disabledUserSignup?: boolean;
+    };
+    /**
+     * Configuration options related to authenticated a user by their phone number.
+     */
+    GoogleCloudIdentitytoolkitAdminV2PhoneNumber: {
+      /**
+       * Whether phone number auth is enabled for the project or not.
+       */
+      enabled?: boolean;
+      /**
+       * A map of that can be used for phone auth testing.
+       */
+      testPhoneNumbers?: { [key: string]: string };
+    };
+    /**
+     * Configuration related to quotas.
+     */
+    GoogleCloudIdentitytoolkitAdminV2QuotaConfig: {
+      signUpQuotaConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2TemporaryQuota"];
+    };
+    /**
+     * Configuration for logging requests made to this project to Stackdriver Logging
+     */
+    GoogleCloudIdentitytoolkitAdminV2RequestLogging: {
+      /**
+       * Whether logging is enabled for this project or not.
+       */
+      enabled?: boolean;
+    };
+    /**
+     * Options for email sending.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SendEmail: {
+      /**
+       * action url in email template.
+       */
+      callbackUri?: string;
+      changeEmailTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      dnsInfo?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2DnsInfo"];
+      legacyResetPasswordTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      /**
+       * The method used for sending an email.
+       */
+      method?: "METHOD_UNSPECIFIED" | "DEFAULT" | "CUSTOM_SMTP";
+      resetPasswordTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      revertSecondFactorAdditionTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      smtp?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Smtp"];
+      verifyEmailTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+    };
+    /**
+     * Options for SMS sending.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SendSms: {
+      smsTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SmsTemplate"];
+      /**
+       * Whether to use the accept_language header for SMS.
+       */
+      useDeviceLocale?: boolean;
+    };
+    /**
+     * Configuration related to local sign in methods.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SignInConfig: {
+      /**
+       * Whether to allow more than one account to have the same email.
+       */
+      allowDuplicateEmails?: boolean;
+      anonymous?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Anonymous"];
+      email?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Email"];
+      hashConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2HashConfig"];
+      phoneNumber?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2PhoneNumber"];
+    };
+    /**
+     * The template to use when sending an SMS.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SmsTemplate: {
+      /**
+       * Output only. The SMS's content. Can contain the following placeholders which will be replaced with the appropriate values: %APP_NAME% - For Android or iOS apps, the app's display name. For web apps, the domain hosting the application. %LOGIN_CODE% - The OOB code being sent in the SMS.
+       */
+      content?: string;
+    };
+    /**
+     * Configuration for SMTP relay
+     */
+    GoogleCloudIdentitytoolkitAdminV2Smtp: {
+      /**
+       * SMTP relay host
+       */
+      host?: string;
+      /**
+       * SMTP relay password
+       */
+      password?: string;
+      /**
+       * SMTP relay port
+       */
+      port?: number;
+      /**
+       * SMTP security mode.
+       */
+      securityMode?: "SECURITY_MODE_UNSPECIFIED" | "SSL" | "START_TLS";
+      /**
+       * Sender email for the SMTP relay
+       */
+      senderEmail?: string;
+      /**
+       * SMTP relay username
+       */
+      username?: string;
+    };
+    /**
      * The SP's certificate data for IDP to verify the SAMLRequest generated by the SP.
      */
     GoogleCloudIdentitytoolkitAdminV2SpCertificate: {
@@ -2164,6 +2469,23 @@ export interface components {
        * Unique identifier for all SAML entities.
        */
       spEntityId?: string;
+    };
+    /**
+     * Temporary quota increase / decrease
+     */
+    GoogleCloudIdentitytoolkitAdminV2TemporaryQuota: {
+      /**
+       * Corresponds to the 'refill_token_count' field in QuotaServer config
+       */
+      quota?: string;
+      /**
+       * How long this quota will be active for
+       */
+      quotaDuration?: string;
+      /**
+       * When this quota will take affect
+       */
+      startTime?: string;
     };
     /**
      * A Tenant contains configuration for the tenant in a multi-tenant project.
@@ -2200,6 +2522,19 @@ export interface components {
        * A map of pairs that can be used for MFA. The phone number should be in E.164 format (https://www.itu.int/rec/T-REC-E.164/) and a maximum of 10 pairs can be added (error will be thrown once exceeded).
        */
       testPhoneNumbers?: { [key: string]: string };
+    };
+    /**
+     * Synchronous Cloud Function with HTTP Trigger
+     */
+    GoogleCloudIdentitytoolkitAdminV2Trigger: {
+      /**
+       * HTTP URI trigger for the Cloud Function.
+       */
+      functionUri?: string;
+      /**
+       * When the trigger was changed.
+       */
+      updateTime?: string;
     };
     /**
      * The information required to auto-retrieve an SMS.

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -470,9 +470,7 @@ function toExegesisController(
       if (ctx.params.path.tenantId && ctx.requestBody?.tenantId) {
         assert(ctx.params.path.tenantId === ctx.requestBody.tenantId, "TENANT_ID_MISMATCH");
       }
-      // Rely on query param tenantId for emulator endpoints
-      const targetTenantId: string =
-        ctx.params.path.tenantId || ctx.requestBody?.tenantId || ctx.params.query.tenantId;
+      const targetTenantId: string = ctx.params.path.tenantId || ctx.requestBody?.tenantId;
       return operation(getProjectStateById(targetProjectId, targetTenantId), ctx.requestBody, ctx);
     };
   }

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -138,7 +138,9 @@ export async function createApp(
   });
 
   registerLegacyRoutes(app);
-  registerHandlers(app, (apiKey) => getProjectStateById(getProjectIdByApiKey(apiKey)));
+  registerHandlers(app, (apiKey, tenantId) =>
+    getProjectStateById(getProjectIdByApiKey(apiKey), tenantId)
+  );
 
   const apiKeyAuthenticator: PromiseAuthenticator = (ctx, info) => {
     if (info.in !== "query") {
@@ -468,7 +470,9 @@ function toExegesisController(
       if (ctx.params.path.tenantId && ctx.requestBody?.tenantId) {
         assert(ctx.params.path.tenantId === ctx.requestBody.tenantId, "TENANT_ID_MISMATCH");
       }
-      const targetTenantId: string = ctx.params.path.tenantId || ctx.requestBody?.tenantId;
+      // Rely on query param tenantId for emulator endpoints
+      const targetTenantId: string =
+        ctx.params.path.tenantId || ctx.requestBody?.tenantId || ctx.params.query.tenantId;
       return operation(getProjectStateById(targetProjectId, targetTenantId), ctx.requestBody, ctx);
     };
   }

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -714,6 +714,9 @@ export class TenantProjectState extends ProjectState {
     return this._tenantConfig;
   }
 
+  // TODO(lisajian): Handle divergence in tenant config settings between what is
+  // needed for admin SDK (default disabled, parallels production) vs emulator
+  // tests (default enabled, for convenience)
   get allowPasswordSignup() {
     return this._tenantConfig.allowPasswordSignup ?? true;
   }

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -715,7 +715,7 @@ export class TenantProjectState extends ProjectState {
   }
 
   get allowPasswordSignup() {
-    return this._tenantConfig.allowPasswordSignup ?? false;
+    return this._tenantConfig.allowPasswordSignup ?? true;
   }
 
   get disableAuth() {
@@ -723,15 +723,20 @@ export class TenantProjectState extends ProjectState {
   }
 
   get mfaConfig() {
-    return this._tenantConfig.mfaConfig ?? {};
+    return (
+      this._tenantConfig.mfaConfig ?? {
+        state: "ENABLED" as const,
+        enabledProviders: ["PHONE_SMS" as const],
+      }
+    );
   }
 
   get enableAnonymousUser() {
-    return this._tenantConfig.enableAnonymousUser ?? false;
+    return this._tenantConfig.enableAnonymousUser ?? true;
   }
 
   get enableEmailLinkSignin() {
-    return this._tenantConfig.enableEmailLinkSignin ?? false;
+    return this._tenantConfig.enableEmailLinkSignin ?? true;
   }
 
   delete(): void {

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -7,7 +7,7 @@ import {
 } from "./utils";
 import { MakeRequired } from "./utils";
 import { AuthCloudFunction } from "./cloudFunctions";
-import { assert, NotImplementedError } from "./errors";
+import { assert } from "./errors";
 import { MfaEnrollments, Schemas } from "./types";
 
 export const PROVIDER_PASSWORD = "password";
@@ -44,6 +44,16 @@ export abstract class ProjectState {
   abstract get authCloudFunction(): AuthCloudFunction;
 
   abstract get usageMode(): UsageMode;
+
+  abstract get allowPasswordSignup(): boolean;
+
+  abstract get disableAuth(): boolean;
+
+  abstract get mfaConfig(): Schemas["GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig"];
+
+  abstract get enableAnonymousUser(): boolean;
+
+  abstract get enableEmailLinkSignin(): boolean;
 
   createUser(props: Omit<UserInfo, "localId" | "createdAt" | "lastRefreshAt">): UserInfo {
     for (let i = 0; i < 10; i++) {
@@ -388,7 +398,13 @@ export abstract class ProjectState {
   ): string {
     const localId = userInfo.localId;
     const refreshToken = randomBase64UrlStr(204);
-    this.refreshTokens.set(refreshToken, { localId, provider, extraClaims, secondFactor });
+    this.refreshTokens.set(refreshToken, {
+      localId,
+      provider,
+      extraClaims,
+      secondFactor,
+      tenantId: userInfo.tenantId,
+    });
     let refreshTokens = this.refreshTokensForLocalId.get(localId);
     if (!refreshTokens) {
       refreshTokens = new Set();
@@ -597,6 +613,26 @@ export class AgentProjectState extends ProjectState {
     this._usageMode = usageMode;
   }
 
+  get allowPasswordSignup() {
+    return true;
+  }
+
+  get disableAuth() {
+    return false;
+  }
+
+  get mfaConfig() {
+    return { state: "ENABLED" as const, enabledProviders: ["PHONE_SMS" as const] };
+  }
+
+  get enableAnonymousUser() {
+    return true;
+  }
+
+  get enableEmailLinkSignin() {
+    return true;
+  }
+
   getTenantProject(tenantId: string): TenantProjectState {
     if (!this.tenantProjectForTenantId.has(tenantId)) {
       this.createTenantWithTenantId(tenantId, { tenantId });
@@ -676,6 +712,26 @@ export class TenantProjectState extends ProjectState {
 
   get tenantConfig() {
     return this._tenantConfig;
+  }
+
+  get allowPasswordSignup() {
+    return this._tenantConfig.allowPasswordSignup ?? false;
+  }
+
+  get disableAuth() {
+    return this._tenantConfig.disableAuth ?? false;
+  }
+
+  get mfaConfig() {
+    return this._tenantConfig.mfaConfig ?? {};
+  }
+
+  get enableAnonymousUser() {
+    return this._tenantConfig.enableAnonymousUser ?? false;
+  }
+
+  get enableEmailLinkSignin() {
+    return this._tenantConfig.enableEmailLinkSignin ?? false;
   }
 
   delete(): void {
@@ -759,6 +815,7 @@ interface RefreshTokenRecord {
   provider: string;
   extraClaims: Record<string, unknown>;
   secondFactor?: SecondFactorRecord;
+  tenantId?: string;
 }
 
 export interface SecondFactorRecord {

--- a/src/test/emulators/auth/batch.spec.ts
+++ b/src/test/emulators/auth/batch.spec.ts
@@ -18,6 +18,7 @@ import {
   TEST_PHONE_NUMBER,
   updateAccountByLocalId,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 import { UserInfo } from "../../../emulator/auth/state";
 
@@ -162,6 +163,20 @@ describeAuthEmulator("accounts:batchGet", ({ authApi }) => {
         // Empty page with no page token returned.
         expect(res.body.users || []).to.have.length(0);
         expect(res.body).not.to.have.property("nextPageToken");
+      });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .get(
+        `/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/tenants/${tenant.tenantId}/accounts:batchGet`
+      )
+      .set("Authorization", "Bearer owner")
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
       });
   });
 });
@@ -627,6 +642,62 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if user tenantId does not match state tenantId", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({
+        tenantId: tenant.tenantId,
+        users: [{ localId: "test1", tenantId: "not-matching-tenant-id" }],
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.error).eql([
+          {
+            index: 0,
+            message: "Tenant id in userInfo does not match the tenant id in request.",
+          },
+        ]);
+      });
+  });
+
+  it("should create users with tenantId if present", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+    const user = {
+      localId: "foo",
+      email: "me@example.com",
+      rawPassword: "notasecret",
+      tenantId: tenant.tenantId,
+    };
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({ tenantId: tenant.tenantId, users: [user] })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.error || []).to.have.length(0);
+      });
+
+    const userInfo = await getAccountInfoByLocalId(authApi(), user.localId, tenant.tenantId);
+    expect(userInfo.tenantId).to.eql(tenant.tenantId);
   });
 });
 

--- a/src/test/emulators/auth/createAuthUri.spec.ts
+++ b/src/test/emulators/auth/createAuthUri.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from "chai";
 import { PROVIDER_PASSWORD, SIGNIN_METHOD_EMAIL_LINK } from "../../../emulator/auth/state";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   registerUser,
   signInWithFakeClaims,
   signInWithEmailLink,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:createAuthUri", ({ authApi }) => {
@@ -195,6 +196,23 @@ describeAuthEmulator("accounts:createAuthUri", ({ authApi }) => {
         expect(res.body.error)
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:createAuthUri")
+      .send({
+        tenantId: tenant.tenantId,
+        continueUri: "http://example.com/",
+        identifier: "notregistered@example.com",
+      })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("PROJECT_DISABLED");
       });
   });
 });

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -2,13 +2,14 @@ import { expect } from "chai";
 import { decode as decodeJwt, sign as signJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload, CUSTOM_TOKEN_AUDIENCE } from "../../../emulator/auth/operations";
 import { PROVIDER_CUSTOM } from "../../../emulator/auth/state";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   getAccountInfoByIdToken,
   updateAccountByLocalId,
   signInWithEmailLink,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
@@ -270,5 +271,72 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equal("USER_DISABLED");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
+      .query({ key: "fake-api-key" })
+      .send({
+        tenantId: tenant.tenantId,
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if custom token tenantId does not match", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+    const uid = "someuid";
+    const claims = { abc: "def", ultimate: { answer: 42 } };
+    const token = signJwt({ uid, claims, tenantId: "not-matching-tenant-id" }, "", {
+      algorithm: "none",
+      expiresIn: 3600,
+
+      subject: "fake-service-account@example.com",
+      issuer: "fake-service-account@example.com",
+      audience: CUSTOM_TOKEN_AUDIENCE,
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
+      .query({ key: "fake-api-key" })
+      .send({ token, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.include("TENANT_ID_MISMATCH");
+      });
+  });
+
+  it("should create a new account from custom token with tenantId", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+    const uid = "someuid";
+    const claims = { abc: "def", ultimate: { answer: 42 } };
+    const token = signJwt({ uid, claims, tenantId: tenant.tenantId }, "", {
+      algorithm: "none",
+      expiresIn: 3600,
+
+      subject: "fake-service-account@example.com",
+      issuer: "fake-service-account@example.com",
+      audience: CUSTOM_TOKEN_AUDIENCE,
+    });
+
+    const idToken = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
+      .query({ key: "fake-api-key" })
+      .send({ token, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.isNewUser).to.equal(true);
+        expect(res.body).to.have.property("refreshToken").that.is.a("string");
+
+        return res.body.idToken as string;
+      });
+
+    const info = await getAccountInfoByIdToken(authApi(), idToken, tenant.tenantId);
+    expect(info.tenantId).to.equal(tenant.tenantId);
   });
 });

--- a/src/test/emulators/auth/deleteAccount.spec.ts
+++ b/src/test/emulators/auth/deleteAccount.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   registerUser,
@@ -8,6 +8,7 @@ import {
   expectUserNotExistsForIdToken,
   updateProjectConfig,
   deleteAccount,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:delete", ({ authApi }) => {
@@ -136,6 +137,19 @@ describeAuthEmulator("accounts:delete", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equals("USER_NOT_FOUND");
+      });
+  });
+
+  it("should delete the user of the idToken", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:delete")
+      .send({ tenantId: tenant.tenantId })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
       });
   });
 });

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   registerUser,
@@ -12,8 +12,9 @@ import {
   createEmailSignInOob,
   TEST_PHONE_NUMBER,
   TEST_MFA_INFO,
-  deleteAccount,
   updateProjectConfig,
+  registerTenant,
+  getAccountInfoByLocalId,
 } from "./helpers";
 
 describeAuthEmulator("email link sign-in", ({ authApi }) => {
@@ -235,6 +236,87 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
       .query({ key: "fake-api-key" })
       .send({ email, oobCode, idToken })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body).not.to.have.property("idToken");
+        expect(res.body).not.to.have.property("refreshToken");
+        expect(res.body.mfaPendingCredential).to.be.a("string");
+        expect(res.body.mfaInfo).to.be.an("array").with.lengthOf(1);
+      });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.include("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if email link sign in is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      enableEmailLinkSignin: false,
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.include("OPERATION_NOT_ALLOWED");
+      });
+  });
+
+  it("should create account on sign-in with tenantId", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      enableEmailLinkSignin: true,
+    });
+    const email = "alice@example.com";
+    const { oobCode } = await createEmailSignInOob(authApi(), email, tenant.tenantId);
+
+    const localId = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ oobCode, email, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(200, res);
+        return res.body.localId;
+      });
+
+    const user = await getAccountInfoByLocalId(authApi(), localId, tenant.tenantId);
+    expect(user.tenantId).to.eql(tenant.tenantId);
+  });
+
+  it("should return pending credential if user has MFA and enabled on tenant projects", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      enableEmailLinkSignin: true,
+      allowPasswordSignup: true,
+      mfaConfig: {
+        state: "ENABLED",
+      },
+    });
+    const user = {
+      email: "alice@example.com",
+      password: "notasecret",
+      mfaInfo: [TEST_MFA_INFO],
+      tenantId: tenant.tenantId,
+    };
+    const { idToken, email } = await registerUser(authApi(), user);
+    const { oobCode } = await createEmailSignInOob(authApi(), email, tenant.tenantId);
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ email, oobCode, idToken, tenantId: tenant.tenantId })
       .then((res) => {
         expectStatusCode(200, res);
         expect(res.body).not.to.have.property("idToken");

--- a/src/test/emulators/auth/helpers.ts
+++ b/src/test/emulators/auth/helpers.ts
@@ -286,26 +286,26 @@ export function getAccountInfoByLocalId(
 }
 
 export function inspectOobs(testAgent: TestAgent, tenantId?: string): Promise<OobRecord[]> {
-  return testAgent
-    .get(`/emulator/v1/projects/${PROJECT_ID}/oobCodes`)
-    .query({ tenantId })
-    .then((res) => {
-      expectStatusCode(200, res);
-      return res.body.oobCodes;
-    });
+  const path = tenantId
+    ? `/emulator/v1/projects/${PROJECT_ID}/tenants/${tenantId}/oobCodes`
+    : `/emulator/v1/projects/${PROJECT_ID}/oobCodes`;
+  return testAgent.get(path).then((res) => {
+    expectStatusCode(200, res);
+    return res.body.oobCodes;
+  });
 }
 
 export function inspectVerificationCodes(
   testAgent: TestAgent,
   tenantId?: string
 ): Promise<PhoneVerificationRecord[]> {
-  return testAgent
-    .get(`/emulator/v1/projects/${PROJECT_ID}/verificationCodes`)
-    .query({ tenantId })
-    .then((res) => {
-      expectStatusCode(200, res);
-      return res.body.verificationCodes;
-    });
+  const path = tenantId
+    ? `/emulator/v1/projects/${PROJECT_ID}/tenants/${tenantId}/verificationCodes`
+    : `/emulator/v1/projects/${PROJECT_ID}/verificationCodes`;
+  return testAgent.get(path).then((res) => {
+    expectStatusCode(200, res);
+    return res.body.verificationCodes;
+  });
 }
 
 export function createEmailSignInOob(

--- a/src/test/emulators/auth/rest.spec.ts
+++ b/src/test/emulators/auth/rest.spec.ts
@@ -167,17 +167,16 @@ describeAuthEmulator("authentication", ({ authApi }) => {
       });
   });
 
-  // TODO(lisajian): uncomment when tenant endpoints are added
-  // it.only("should deny requests where tenant IDs do not match", async () => {
-  //   await authApi()
-  //     .post(
-  //       "/identitytoolkit.googleapis.com/v1/projects/project-id/tenants/tenant-id/accounts:delete"
-  //     )
-  //     .set("Authorization", "Bearer owner")
-  //     .send({ localId: "local-id", tenantId: "mismatching-tenant-id" })
-  //     .then((res) => {
-  //       expectStatusCode(400, res);
-  //       expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
-  //     });
-  // });
+  it("should deny requests where tenant IDs do not match", async () => {
+    await authApi()
+      .post(
+        "/identitytoolkit.googleapis.com/v1/projects/project-id/tenants/tenant-id/accounts:delete"
+      )
+      .set("Authorization", "Bearer owner")
+      .send({ localId: "local-id", tenantId: "mismatching-tenant-id" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
+      });
+  });
 });

--- a/src/test/emulators/auth/setAccountInfo.spec.ts
+++ b/src/test/emulators/auth/setAccountInfo.spec.ts
@@ -1172,28 +1172,6 @@ describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
       });
   });
 
-  it("should error on setting email when MFA is disabled", async () => {
-    const tenant = await registerTenant(authApi(), PROJECT_ID, {
-      disableAuth: false,
-      mfaConfig: { state: "DISABLED" as const },
-      allowPasswordSignup: true,
-    });
-
-    const user = { email: "bob@example.com", password: "notasecret", tenantId: tenant.tenantId };
-    const { idToken } = await registerUser(authApi(), user);
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
-      .send({ idToken, email: "alice@example.com", tenantId: tenant.tenantId })
-      .query({ key: "fake-api-key" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("EMAIL_CHANGE_NEEDS_VERIFICATION");
-      });
-  });
-
   it("should set tenantId in oobLink", async () => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, {
       disableAuth: false,

--- a/src/test/emulators/auth/setAccountInfo.spec.ts
+++ b/src/test/emulators/auth/setAccountInfo.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
 import { ProviderUserInfo, PROVIDER_PASSWORD, PROVIDER_PHONE } from "../../../emulator/auth/state";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   getAccountInfoByIdToken,
@@ -22,6 +22,7 @@ import {
   TEST_INVALID_PHONE_NUMBER,
   deleteAccount,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
@@ -1156,5 +1157,71 @@ describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error on setting email when MFA is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      mfaConfig: { state: "DISABLED" as const },
+      allowPasswordSignup: true,
+    });
+
+    const user = { email: "bob@example.com", password: "notasecret", tenantId: tenant.tenantId };
+    const { idToken } = await registerUser(authApi(), user);
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .send({ idToken, email: "alice@example.com", tenantId: tenant.tenantId })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error)
+          .to.have.property("message")
+          .equals("EMAIL_CHANGE_NEEDS_VERIFICATION");
+      });
+  });
+
+  it("should set tenantId in oobLink", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      mfaConfig: { state: "ENABLED" as const },
+      allowPasswordSignup: true,
+    });
+    const oldEmail = "alice@example.com";
+    const password = "notasecret";
+    const newEmail = "bob@example.com";
+    const { idToken } = await registerUser(authApi(), {
+      email: oldEmail,
+      password,
+      tenantId: tenant.tenantId,
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, email: newEmail, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(200, res);
+      });
+
+    // An oob is sent to the oldEmail
+    const oobs = await inspectOobs(authApi(), tenant.tenantId);
+    expect(oobs).to.have.length(1);
+    expect(oobs[0].email).to.equal(oldEmail);
+    expect(oobs[0].requestType).to.equal("RECOVER_EMAIL");
+    expect(oobs[0].oobLink).to.include(tenant.tenantId);
   });
 });

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   getAccountInfoByIdToken,
@@ -17,6 +17,7 @@ import {
   TEST_PHONE_NUMBER_2,
   TEST_INVALID_PHONE_NUMBER,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:signUp", ({ authApi }) => {
@@ -530,5 +531,61 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if password sign up is not allowed", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { allowPasswordSignup: false });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId, email: "me@example.com", password: "notasecret" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("OPERATION_NOT_ALLOWED");
+      });
+  });
+
+  it("should error if anonymous user is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { enableAnonymousUser: false });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId, returnSecureToken: true })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("ADMIN_ONLY_OPERATION");
+      });
+  });
+
+  it("should create new account with tenant info", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { allowPasswordSignup: true });
+    const user = { tenantId: tenant.tenantId, email: "alice@example.com", password: "notasecret" };
+
+    const localId = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send(user)
+      .then((res) => {
+        expectStatusCode(200, res);
+        return res.body.localId;
+      });
+    const info = await getAccountInfoByLocalId(authApi(), localId, tenant.tenantId);
+
+    expect(info.tenantId).to.eql(tenant.tenantId);
   });
 });


### PR DESCRIPTION
### Description

Any endpoints that use `tenantId` explicitly in the request path or in the request body are updated to account for `Tenant` settings and any other tenant specific logic in this PR. Some things to highlight

- Providers are disabled by default on tenant projects based on observable behavior on Cloud dashboard. Agent projects have settings default enabled to be consistent with existing behavior until project `Config` management is introduced
- Supported tenant operations are listed at go/firebase-tools-3795-tenantOps; all other endpoints throw errors when called with a `TenantProjectState`. Some endpoints are not explicitly listed but are supported on tenant projects including:
  - `getRecaptchaParams`
  - `createSessionCookie`
  - `grantToken`
- Some, but not all, emulator endpoints were modified to take `tenantId` as a query param to correctly retrieve `TenantProjectState`. Not all emulator endpoints were updated but should be - a `TODO` was added in `gen-auth-api-spec.ts` that will be addressed in a subsequent PR (this one was getting bloated)

**Callouts:**
- `apiSpec.js` was not regenerated with the command `npm run generate:auth-api` so far. Regenerating `apiSpec.js` appears to break several tests and will be investigated separately (b/201833004)
- Noticed that no tests currently exist for `getProjects` and `getRecaptchaParams` - not sure if this was intentionally left out, clarification on this front would be appreciated!

Corresponding internal bug: b/192387245

### Scenarios Tested

`npm test` passes

**See above for callouts**

### Sample Commands

N/A
