### PR TITLE
Make emulator monkey-patching compatible with newer versions of firebase-functions SDK.

### DIFF
--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -448,14 +448,34 @@ async function initializeFirebaseFunctionsStubs(frb: FunctionsRuntimeBundle): Pr
   const onCallInnerMethodName = "_onCallWithOptions";
   const onCallMethodOriginal = httpsProvider[onCallInnerMethodName];
 
-  httpsProvider[onCallInnerMethodName] = (handler: CallableHandler, opts: DeploymentOptions) => {
-    const wrapped = wrapCallableHandler(handler);
-    const cf = onCallMethodOriginal(wrapped, opts);
-    return cf;
-  };
+  // Newer versions of the firebase-functions package's _onCallWithOptions method expects 3 arguments.
+  if (onCallMethodOriginal.length === 3) {
+    httpsProvider[onCallInnerMethodName] = (
+      opts: any,
+      handler: any,
+      deployOpts: DeploymentOptions
+    ) => {
+      const wrapped = wrapCallableHandler(handler);
+      const cf = onCallMethodOriginal(opts, wrapped, deployOpts);
+      return cf;
+    };
+  } else {
+    httpsProvider[onCallInnerMethodName] = (handler: any, opts: DeploymentOptions) => {
+      const wrapped = wrapCallableHandler(handler);
+      const cf = onCallMethodOriginal(wrapped, opts);
+      return cf;
+    };
+  }
 
-  httpsProvider.onCall = (handler: CallableHandler) => {
-    return httpsProvider[onCallInnerMethodName](handler, {});
+  httpsProvider.onCall = (optsOrHandler: any, handler: CallableHandler) => {
+    let opts;
+    if (arguments.length == 1) {
+      opts = {};
+      handler = optsOrHandler as CallableHandler;
+    } else {
+      opts = optsOrHandler;
+    }
+    return httpsProvider[onCallInnerMethodName](opts, handler, {});
   };
 }
 

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -467,6 +467,7 @@ async function initializeFirebaseFunctionsStubs(frb: FunctionsRuntimeBundle): Pr
     };
   }
 
+  // Newer versions of the firebase-functions package's onCAll method can accept upto 2 arguments.
   httpsProvider.onCall = (optsOrHandler: any, handler: CallableHandler) => {
     let opts;
     if (arguments.length == 1) {


### PR DESCRIPTION
We will soon land a (backward-compatible) change in the Firebase Functions SDK that allows `onCall` functions to accept optional configuration argument, e.g.

```js
import * as functions from "firebase-functions";

export const helloWorld = functions
    .https
    .onCall({allowInvalidAppCheckToken: true}, (data, context) => {
      return `Hello ${data.name}`;
    });
```

The existing monkey-patching will not correctly patch the new signature as is. The proposed change sniffs the number of arguments expected by the version of Firebase Functions SDK being used and monkey-patches  accordingly.