### PR TITLE
Adds Fabricator to release code

### DIFF
--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -1,0 +1,73 @@
+import { Queue } from "../../../throttler/queue";
+import { ThrottlerOptions } from "../../../throttler/throttler";
+
+/**
+ * An Executor runs lambdas (which may be async).
+ */
+export interface Executor {
+  run<T>(func: () => Promise<T>): Promise<T>;
+}
+
+interface Operation {
+  func: () => any;
+  result?: any;
+  error?: any;
+}
+
+/**
+ * A QueueExecutor implements the executor interface on top of a throttler queue.
+ * Any 429 will be retried within the ThrottlerOptions parameters, but all
+ * other errors are rethrown.
+ */
+export class QueueExecutor implements Executor {
+  private readonly queue: Queue<Operation, void>;
+  constructor(options: Omit<ThrottlerOptions<Operation, void>, "handler">) {
+    this.queue = new Queue({
+      ...options,
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      handler: QueueExecutor.handler,
+    });
+  }
+
+  static async handler(op: Operation): Promise<undefined> {
+    try {
+      op.result = await op.func();
+    } catch (err) {
+      // Throw retry functions back to the queue where they will be retried
+      // with backoffs. To do this we cast a wide net for possible error codes.
+      // These can be either TOO MANY REQUESTS (429) errors or CONFLICT (409)
+      // errors. This can be a raw error with the correct HTTP code, a raw
+      // error with the HTTP code stashed where GCP puts it, or a FirebaseError
+      // wrapping either of the previous two cases.
+      const code =
+        err.code ||
+        err.context?.response?.statusCode ||
+        err.original?.code ||
+        err.original?.context.response?.statusCode;
+      if (code === 429 || code === 409) {
+        throw err;
+      }
+      op.error = err;
+    }
+    return;
+  }
+
+  async run<T>(func: () => Promise<T>): Promise<T> {
+    const op: Operation = { func };
+    await this.queue.run(op);
+    if (op.error) {
+      throw op.error;
+    }
+    return op.result as T;
+  }
+}
+
+/**
+ * Inline executors run their functions right away.
+ * Useful for testing.
+ */
+export class InlineExecutor {
+  run<T>(func: () => Promise<T>): Promise<T> {
+    return func();
+  }
+}

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -8,7 +8,7 @@ import * as gcfv2 from "../../../gcp/cloudfunctionsv2";
 
 export interface EndpointUpdate {
   endpoint: backend.Endpoint;
-  deleteBeforeUpdate?: backend.Endpoint;
+  deleteAndRecreate?: backend.Endpoint;
 }
 
 export interface RegionalChanges {
@@ -53,7 +53,7 @@ export function calculateUpdate(want: backend.Endpoint, have: backend.Endpoint):
   };
   const needsDelete = changedV2PubSubTopic(want, have) || upgradedScheduleFromV1ToV2(want, have);
   if (needsDelete) {
-    update.deleteBeforeUpdate = have;
+    update.deleteAndRecreate = have;
   }
   return update;
 }

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -8,7 +8,7 @@ import * as gcfv2 from "../../../gcp/cloudfunctionsv2";
 
 export interface EndpointUpdate {
   endpoint: backend.Endpoint;
-  deleteAndRecreate: boolean;
+  deleteBeforeUpdate?: backend.Endpoint;
 }
 
 export interface RegionalChanges {
@@ -48,10 +48,14 @@ export function calculateRegionalChanges(
 export function calculateUpdate(want: backend.Endpoint, have: backend.Endpoint): EndpointUpdate {
   checkForIllegalUpdate(want, have);
 
-  const endpoint: backend.Endpoint = { ...want };
-  const deleteAndRecreate =
-    changedV2PubSubTopic(want, have) || upgradedScheduleFromV1ToV2(want, have);
-  return { endpoint, deleteAndRecreate };
+  const update: EndpointUpdate = {
+    endpoint: { ...want },
+  };
+  const needsDelete = changedV2PubSubTopic(want, have) || upgradedScheduleFromV1ToV2(want, have);
+  if (needsDelete) {
+    update.deleteBeforeUpdate = have;
+  }
+  return update;
 }
 
 /**

--- a/src/deploy/functions/release/reporter.ts
+++ b/src/deploy/functions/release/reporter.ts
@@ -1,0 +1,48 @@
+import * as backend from "../backend";
+
+import { FirebaseError } from "../../../error";
+
+export interface DeployResult {
+  durationMs: number;
+  error?: Error;
+}
+
+export type DeployResults = Record<string, Record<string, DeployResult>>;
+
+export type OperationType =
+  | "create"
+  | "update"
+  | "delete"
+  | "upsert schedule"
+  | "delete schedule"
+  | "create topic"
+  | "delete topic"
+  | "set invoker"
+  | "set concurrency";
+
+export class DeploymentError extends Error {
+  constructor(
+    readonly endpoint: backend.Endpoint,
+    readonly op: OperationType,
+    readonly original: unknown
+  ) {
+    super(`Failed to ${op} function ${endpoint.id} in region ${endpoint.region}`);
+  }
+}
+
+export class AbortedDeploymentError extends DeploymentError {
+  constructor(readonly endpoint: backend.Endpoint) {
+    super(endpoint, "delete", new Error("aborted"));
+  }
+}
+
+export function reportResults(results: DeployResults, opts: any): void {
+  throw new FirebaseError(
+    "Exceeded maximum retries while deploying functions. " +
+      "If you are deploying a large number of functions, " +
+      "please deploy your functions in batches by using the --only flag, " +
+      "and wait a few minutes before deploying again. " +
+      "Go to https://firebase.google.com/docs/cli/#partial_deploys to learn more.",
+    opts
+  );
+}

--- a/src/deploy/functions/release/reporter.ts
+++ b/src/deploy/functions/release/reporter.ts
@@ -35,14 +35,3 @@ export class AbortedDeploymentError extends DeploymentError {
     super(endpoint, "delete", new Error("aborted"));
   }
 }
-
-export function reportResults(results: DeployResults, opts: any): void {
-  throw new FirebaseError(
-    "Exceeded maximum retries while deploying functions. " +
-      "If you are deploying a large number of functions, " +
-      "please deploy your functions in batches by using the --only flag, " +
-      "and wait a few minutes before deploying again. " +
-      "Go to https://firebase.google.com/docs/cli/#partial_deploys to learn more.",
-    opts
-  );
-}

--- a/src/deploy/functions/release/reporter.ts
+++ b/src/deploy/functions/release/reporter.ts
@@ -1,13 +1,12 @@
 import * as backend from "../backend";
 
-import { FirebaseError } from "../../../error";
-
 export interface DeployResult {
   durationMs: number;
   error?: Error;
 }
 
-export type DeployResults = Record<string, Record<string, DeployResult>>;
+export type RegionalDeployResults = Record<string, DeployResult>;
+export type GlobalDeployResults = Record<string, RegionalDeployResults>;
 
 export type OperationType =
   | "create"

--- a/src/deploy/functions/release/sourceTokenScraper.ts
+++ b/src/deploy/functions/release/sourceTokenScraper.ts
@@ -28,10 +28,9 @@ export class SourceTokenScraper {
   get poller() {
     return (op: any) => {
       if (op.metadata?.sourceToken || op.done) {
-        const [, , , /* projects*/ /* project*/ /* regions*/ region] = op.metadata?.target?.split(
-          "/"
-        );
-        logger.debug(`Got source token ${op.metadata.sourceToken} for region ${region as string}`);
+        const [, , , /* projects*/ /* project*/ /* regions*/ region] =
+          op.metadata?.target?.split("/") || [];
+        logger.debug(`Got source token ${op.metadata?.sourceToken} for region ${region as string}`);
         this.resolve(op.metadata?.sourceToken);
       }
     };

--- a/src/deploy/functions/release/sourceTokenScraper.ts
+++ b/src/deploy/functions/release/sourceTokenScraper.ts
@@ -1,0 +1,39 @@
+import { logger } from "../../../logger";
+
+/**
+ * GCF v1 deploys support reusing a build between function deploys.
+ * This class will return a resolved promise for its first call to tokenPromise()
+ * and then will always return a promise that is resolved by the poller function.
+ */
+export class SourceTokenScraper {
+  private firstCall = true;
+  private resolve!: (token: string) => void;
+  private promise: Promise<string | undefined>;
+
+  constructor() {
+    this.promise = new Promise((resolve) => (this.resolve = resolve));
+  }
+
+  // Token Promise will return undefined for the first caller
+  // (because we presume it's this function's source token we'll scrape)
+  // and then returns the promise generated from the first function's onCall
+  tokenPromise(): Promise<string | undefined> {
+    if (this.firstCall) {
+      this.firstCall = false;
+      return Promise.resolve(undefined);
+    }
+    return this.promise;
+  }
+
+  get poller() {
+    return (op: any) => {
+      if (op.metadata?.sourceToken || op.done) {
+        const [, , , /* projects*/ /* project*/ /* regions*/ region] = op.metadata?.target?.split(
+          "/"
+        );
+        logger.debug(`Got source token ${op.metadata.sourceToken} for region ${region as string}`);
+        this.resolve(op.metadata?.sourceToken);
+      }
+    };
+  }
+}

--- a/src/deploy/functions/release/timer.ts
+++ b/src/deploy/functions/release/timer.ts
@@ -1,0 +1,13 @@
+/** Measures the time taken from construction to the call to stop() */
+export class Timer {
+  private readonly start: [number, number];
+
+  constructor() {
+    this.start = process.hrtime();
+  }
+
+  stop(): number {
+    const duration = process.hrtime(this.start);
+    return duration[0] * 1000 + Math.round(duration[1] * 1e-6);
+  }
+}

--- a/src/deploy/functions/release/timer.ts
+++ b/src/deploy/functions/release/timer.ts
@@ -1,13 +1,14 @@
 /** Measures the time taken from construction to the call to stop() */
 export class Timer {
-  private readonly start: [number, number];
+  private readonly start: bigint;
 
   constructor() {
-    this.start = process.hrtime();
+    this.start = process.hrtime.bigint();
   }
 
   stop(): number {
-    const duration = process.hrtime(this.start);
-    return duration[0] * 1000 + Math.round(duration[1] * 1e-6);
+    const stop = process.hrtime.bigint();
+    const elapsedNanos = stop - this.start;
+    return Number(elapsedNanos / BigInt(1e6));
   }
 }

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -143,7 +143,9 @@ export interface OperationMetadata {
 
 export interface Operation {
   name: string;
-  metadata: OperationMetadata;
+  // Note: this field is always present, but not used in prod and is a PITA
+  // to add in tests.
+  metadata?: OperationMetadata;
   done: boolean;
   error?: { code: number; message: string; details: unknown };
   response?: CloudFunction;

--- a/src/gcp/cloudscheduler.ts
+++ b/src/gcp/cloudscheduler.ts
@@ -5,6 +5,7 @@ import { logger } from "../logger";
 import * as api from "../api";
 import * as backend from "../deploy/functions/backend";
 import * as proto from "./proto";
+import { assertExhaustive } from "../functional";
 
 const VERSION = "v1beta1";
 const DEFAULT_TIME_ZONE = "America/Los_Angeles";
@@ -211,4 +212,37 @@ export function jobFromSpec(schedule: backend.ScheduleSpec, appEngineLocation: s
     },
   };
   return job;
+}
+
+/** Converts an Endpoint to a CloudScheduler v1 job */
+export function jobFromEndpoint(
+  endpoint: backend.Endpoint & backend.ScheduleTriggered,
+  appEngineLocation: string
+): Job {
+  const job: Partial<Job> = {};
+  if (endpoint.platform === "gcfv1") {
+    const id = backend.scheduleIdForFunction(endpoint);
+    const region = appEngineLocation;
+    job.name = `projects/${endpoint.project}/locations/${region}/jobs/${id}`;
+    job.pubsubTarget = {
+      topicName: `projects/${endpoint.project}/topics/${id}`,
+      attributes: {
+        scheduled: "true",
+      },
+    };
+  } else if (endpoint.platform === "gcfv2") {
+    // NB: We should figure out whether there's a good service account we can use
+    // to get ODIC tokens from while invoking the function. Hopefully either
+    // CloudScheduler has an account we can use or we can use the default compute
+    // account credentials (it's a project editor, so it should have permissions
+    // to invoke a function and editor deployers should have permission to actAs
+    // it)
+    throw new FirebaseError("Do not know how to create a scheduled GCFv2 function");
+  } else {
+    assertExhaustive(endpoint.platform);
+  }
+  proto.copyIfPresent(job, endpoint.scheduleTrigger, "retryConfig", "timeZone");
+
+  // TypeScript compiler isn't noticing that name is defined in all code paths.
+  return job as Job;
 }

--- a/src/test/deploy/functions/release/executor.spec.ts
+++ b/src/test/deploy/functions/release/executor.spec.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai";
+
+import * as executor from "../../../../deploy/functions/release/executor";
+
+describe("Executor", () => {
+  describe("QueueExecutor", () => {
+    const exec = new executor.QueueExecutor({
+      retries: 20,
+      maxBackoff: 1,
+      backoff: 1,
+    });
+
+    it("supports arbitrary return types", async () => {
+      await expect(exec.run(() => Promise.resolve(42))).to.eventually.equal(42);
+      await expect(exec.run(() => Promise.resolve({ hello: "world" }))).to.eventually.deep.equal({
+        hello: "world",
+      });
+    });
+
+    it("throws errors", async () => {
+      const handler = (): Promise<void> => Promise.reject(new Error("Fatal"));
+      await expect(exec.run(handler)).to.eventually.be.rejectedWith("Fatal");
+    });
+
+    it("retries temporary errors", async () => {
+      let throwCount = 0;
+      const handler = (): Promise<number> => {
+        if (throwCount < 2) {
+          throwCount++;
+          const err = new Error("Retryable");
+          (err as any).code = 429;
+          return Promise.reject(err);
+        }
+        return Promise.resolve(42);
+      };
+
+      await expect(exec.run(handler)).to.eventually.equal(42);
+    });
+
+    it("eventually gives up on retryable errors", async () => {
+      const handler = (): Promise<void> => {
+        const err = new Error("Retryable");
+        (err as any).code = 429;
+        throw err;
+      };
+      await expect(exec.run(handler)).to.eventually.be.rejectedWith("Retryable");
+    });
+  });
+});

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1,0 +1,972 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import * as fabricator from "../../../../deploy/functions/release/fabricator";
+import * as reporter from "../../../../deploy/functions/release/reporter";
+import * as executor from "../../../../deploy/functions/release/executor";
+import * as gcfNSV2 from "../../../../gcp/cloudfunctionsv2";
+import * as gcfNS from "../../../../gcp/cloudfunctions";
+import * as pollerNS from "../../../../operation-poller";
+import * as pubsubNS from "../../../../gcp/pubsub";
+import * as schedulerNS from "../../../../gcp/cloudscheduler";
+import * as runNS from "../../../../gcp/run";
+import * as backend from "../../../../deploy/functions/backend";
+import * as scraper from "../../../../deploy/functions/release/sourceTokenScraper";
+import * as planner from "../../../../deploy/functions/release/planner";
+
+describe("Fabricator", () => {
+  // Stub all GCP APIs to make sure this test is hermetic
+  let gcf: sinon.SinonStubbedInstance<typeof gcfNS>;
+  let gcfv2: sinon.SinonStubbedInstance<typeof gcfNSV2>;
+  let poller: sinon.SinonStubbedInstance<typeof pollerNS>;
+  let pubsub: sinon.SinonStubbedInstance<typeof pubsubNS>;
+  let scheduler: sinon.SinonStubbedInstance<typeof schedulerNS>;
+  let run: sinon.SinonStubbedInstance<typeof runNS>;
+
+  beforeEach(() => {
+    gcf = sinon.stub(gcfNS);
+    gcfv2 = sinon.stub(gcfNSV2);
+    poller = sinon.stub(pollerNS);
+    pubsub = sinon.stub(pubsubNS);
+    scheduler = sinon.stub(schedulerNS);
+    run = sinon.stub(runNS);
+
+    gcf.functionFromEndpoint.restore();
+    gcfv2.functionFromEndpoint.restore();
+    scheduler.jobFromEndpoint.restore();
+    gcf.createFunction.rejects(new Error("unexpected gcf.createFunction"));
+    gcf.updateFunction.rejects(new Error("unexpected gcf.updateFunction"));
+    gcf.deleteFunction.rejects(new Error("unexpected gcf.deleteFunction"));
+    gcf.getIamPolicy.rejects(new Error("unexpected gcf.getIamPolicy"));
+    gcf.setIamPolicy.rejects(new Error("unexpected gcf.setIamPolicy"));
+    gcf.setInvokerCreate.rejects(new Error("unexpected gcf.setInvokerCreate"));
+    gcf.setInvokerUpdate.rejects(new Error("unexpected gcf.setInvokerUpdate"));
+    gcfv2.createFunction.rejects(new Error("unexpected gcfv2.createFunction"));
+    gcfv2.updateFunction.rejects(new Error("unexpected gcfv2.updateFunction"));
+    gcfv2.deleteFunction.rejects(new Error("unexpected gcfv2.deleteFunction"));
+    run.getIamPolicy.rejects(new Error("unexpected run.getIamPolicy"));
+    run.setIamPolicy.rejects(new Error("unexpected run.setIamPolicy"));
+    run.setInvokerCreate.rejects(new Error("unexpected run.setInvokerCreate"));
+    run.setInvokerUpdate.rejects(new Error("unexpected run.setInvokerUpdate"));
+    run.replaceService.rejects(new Error("unexpected run.replaceService"));
+    poller.pollOperation.rejects(new Error("unexpected poller.pollOperation"));
+    pubsub.createTopic.rejects(new Error("unexpected pubsub.createTopic"));
+    pubsub.deleteTopic.rejects(new Error("unexpected pubsub.deleteTopic"));
+    scheduler.createOrReplaceJob.rejects(new Error("unexpected scheduler.createOrReplaceJob"));
+    scheduler.deleteJob.rejects(new Error("unexpected scheduler.deleteJob"));
+  });
+
+  afterEach(() => {
+    sinon.verifyAndRestore();
+  });
+
+  const storage: gcfNSV2.StorageSource = {
+    bucket: "bucket",
+    object: "object",
+    generation: 42,
+  };
+  const ctorArgs: fabricator.FabricatorArgs = {
+    executor: new executor.InlineExecutor(),
+    functionExecutor: new executor.InlineExecutor(),
+    sourceUrl: "https://example.com",
+    storage: {
+      "us-central1": storage,
+      "us-west1": storage,
+    },
+    appEngineLocation: "us-central1",
+  };
+  let fab: fabricator.Fabricator;
+  beforeEach(() => {
+    fab = new fabricator.Fabricator(ctorArgs);
+  });
+
+  afterEach(() => {
+    sinon.verifyAndRestore();
+  });
+
+  function endpoint(
+    trigger: backend.Triggered = { httpsTrigger: {} },
+    base: Partial<backend.Endpoint> = {}
+  ): backend.Endpoint {
+    return {
+      platform: "gcfv1",
+      id: "id",
+      region: "us-central1",
+      entryPoint: "entrypoint",
+      runtime: "nodejs16",
+      ...JSON.parse(JSON.stringify(base)),
+      ...trigger,
+    } as backend.Endpoint;
+  }
+
+  describe("createV1Function", () => {
+    it("throws on create function failure", async () => {
+      gcf.createFunction.rejects(new Error("Server failure"));
+
+      await expect(
+        fab.createV1Function(endpoint(), new scraper.SourceTokenScraper())
+      ).to.be.rejectedWith(reporter.DeploymentError, "create");
+
+      gcf.createFunction.resolves({ name: "op", type: "create", done: false });
+      poller.pollOperation.rejects(new Error("Fail whale"));
+      await expect(
+        fab.createV1Function(endpoint(), new scraper.SourceTokenScraper())
+      ).to.be.rejectedWith(reporter.DeploymentError, "create");
+    });
+
+    it("throws on set invoker failure", async () => {
+      gcf.createFunction.resolves({ name: "op", type: "create", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerCreate.rejects(new Error("Boom"));
+
+      await expect(
+        fab.createV1Function(endpoint(), new scraper.SourceTokenScraper())
+      ).to.be.rejectedWith(reporter.DeploymentError, "set invoker");
+    });
+
+    it("sets invoker by default", async () => {
+      gcf.createFunction.resolves({ name: "op", type: "create", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerCreate.resolves();
+      const ep = endpoint();
+
+      await fab.createV1Function(ep, new scraper.SourceTokenScraper());
+      expect(gcf.setInvokerCreate).to.have.been.calledWith(ep.project, backend.functionName(ep), [
+        "public",
+      ]);
+    });
+
+    it("sets explicit invoker", async () => {
+      gcf.createFunction.resolves({ name: "op", type: "create", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerCreate.resolves();
+      const ep = endpoint({
+        httpsTrigger: {
+          invoker: ["custom@"],
+        },
+      });
+
+      await fab.createV1Function(ep, new scraper.SourceTokenScraper());
+      expect(gcf.setInvokerCreate).to.have.been.calledWith(ep.project, backend.functionName(ep), [
+        "custom@",
+      ]);
+    });
+
+    it("doesn't set private invoker on create", async () => {
+      gcf.createFunction.resolves({ name: "op", type: "create", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerCreate.resolves();
+      const ep = endpoint({
+        httpsTrigger: {
+          invoker: ["private"],
+        },
+      });
+
+      await fab.createV1Function(ep, new scraper.SourceTokenScraper());
+      expect(gcf.setInvokerCreate).to.not.have.been.called;
+    });
+
+    it("doesn't set invoker on non-http functions", async () => {
+      gcf.createFunction.resolves({ name: "op", type: "create", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerCreate.resolves();
+      const ep = endpoint({
+        scheduleTrigger: {},
+      });
+
+      await fab.createV1Function(ep, new scraper.SourceTokenScraper());
+      expect(gcf.setInvokerCreate).to.not.have.been.called;
+    });
+  });
+
+  describe("updateV1Function", () => {
+    it("throws on update function failure", async () => {
+      gcf.updateFunction.rejects(new Error("Server failure"));
+
+      await expect(
+        fab.updateV1Function(endpoint(), new scraper.SourceTokenScraper())
+      ).to.be.rejectedWith(reporter.DeploymentError, "update");
+
+      gcf.updateFunction.resolves({ name: "op", type: "update", done: false });
+      poller.pollOperation.rejects(new Error("Fail whale"));
+      await expect(
+        fab.updateV1Function(endpoint(), new scraper.SourceTokenScraper())
+      ).to.be.rejectedWith(reporter.DeploymentError, "update");
+    });
+
+    it("throws on set invoker failure", async () => {
+      gcf.updateFunction.resolves({ name: "op", type: "update", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerUpdate.rejects(new Error("Boom"));
+
+      const ep = endpoint({
+        httpsTrigger: {
+          invoker: ["private"],
+        },
+      });
+      await expect(fab.updateV1Function(ep, new scraper.SourceTokenScraper())).to.be.rejectedWith(
+        reporter.DeploymentError,
+        "set invoker"
+      );
+    });
+
+    it("sets explicit invoker", async () => {
+      gcf.updateFunction.resolves({ name: "op", type: "create", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerUpdate.resolves();
+      const ep = endpoint({
+        httpsTrigger: {
+          invoker: ["custom@"],
+        },
+      });
+
+      await fab.updateV1Function(ep, new scraper.SourceTokenScraper());
+      expect(gcf.setInvokerUpdate).to.have.been.calledWith(ep.project, backend.functionName(ep), [
+        "custom@",
+      ]);
+    });
+
+    it("does not set invoker by default", async () => {
+      gcf.updateFunction.resolves({ name: "op", type: "update", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerUpdate.resolves();
+      const ep = endpoint();
+
+      await fab.updateV1Function(ep, new scraper.SourceTokenScraper());
+      expect(gcf.setInvokerUpdate).to.not.have.been.called;
+    });
+
+    it("doesn't set invoker on non-http functions", async () => {
+      gcf.updateFunction.resolves({ name: "op", type: "update", done: false });
+      poller.pollOperation.resolves();
+      gcf.setInvokerUpdate.resolves();
+      const ep = endpoint({
+        scheduleTrigger: {},
+      });
+
+      await fab.updateV1Function(ep, new scraper.SourceTokenScraper());
+      expect(gcf.setInvokerUpdate).to.not.have.been.called;
+    });
+  });
+
+  describe("deleteV1Function", () => {
+    it("throws on delete function failure", async () => {
+      gcf.deleteFunction.rejects(new Error("404"));
+      const ep = endpoint();
+
+      await expect(fab.deleteV1Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "delete");
+
+      gcf.deleteFunction.resolves({ name: "op", type: "delete", done: false });
+      poller.pollOperation.rejects(new Error("5xx"));
+
+      await expect(fab.deleteV1Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "delete");
+    });
+  });
+
+  describe("createV2Function", () => {
+    let setConcurrency: sinon.SinonStub;
+
+    beforeEach(() => {
+      setConcurrency = sinon.stub(fab, "setConcurrency");
+      setConcurrency.resolves();
+    });
+
+    it("creates topics if necessary", async () => {
+      pubsub.getTopic.callsFake(() => {
+        const err = new Error("404");
+        (err as any).status = 404;
+        return Promise.reject(err);
+      });
+      pubsub.createTopic.resolves();
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+
+      const ep = endpoint(
+        {
+          eventTrigger: {
+            eventType: gcfv2.PUBSUB_PUBLISH_EVENT,
+            eventFilters: {
+              resource: "topic",
+            },
+            retry: false,
+          },
+        },
+        {
+          platform: "gcfv2",
+        }
+      );
+
+      await fab.createV2Function(ep);
+      expect(pubsub.createTopic).to.have.been.called;
+    });
+
+    it("handles failures to create a topic", async () => {
+      pubsub.getTopic.rejects(new Error("🤷‍♂️"));
+
+      const ep = endpoint(
+        {
+          eventTrigger: {
+            eventType: gcfv2.PUBSUB_PUBLISH_EVENT,
+            eventFilters: {
+              resource: "topic",
+            },
+            retry: false,
+          },
+        },
+        {
+          platform: "gcfv2",
+        }
+      );
+
+      await expect(fab.createV2Function(ep)).to.be.rejectedWith(
+        reporter.DeploymentError,
+        "create topic"
+      );
+
+      pubsub.getTopic.callsFake(() => {
+        const err = new Error("404");
+        (err as any).status = 404;
+        return Promise.reject(err);
+      });
+      pubsub.createTopic.rejects(new Error("🤦‍♂️"));
+      await expect(fab.createV2Function(ep)).to.be.rejectedWith(
+        reporter.DeploymentError,
+        "create topic"
+      );
+    });
+
+    it("throws on create function failure", async () => {
+      gcfv2.createFunction.rejects(new Error("Server failure"));
+
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      await expect(fab.createV2Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "create");
+
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.rejects(new Error("Fail whale"));
+
+      await expect(fab.createV2Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "create");
+    });
+
+    it("throws on set invoker failure", async () => {
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.rejects(new Error("Boom"));
+
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      await expect(fab.createV2Function(ep)).to.be.rejectedWith(
+        reporter.DeploymentError,
+        "set invoker"
+      );
+    });
+
+    it("sets invoker and concurrency by default", async () => {
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+
+      await fab.createV2Function(ep);
+      expect(run.setInvokerCreate).to.have.been.calledWith(ep.project, "service", ["public"]);
+      expect(setConcurrency).to.have.been.calledWith(ep, "service", 80);
+    });
+
+    it("sets explicit invoker", async () => {
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+      const ep = endpoint(
+        {
+          httpsTrigger: {
+            invoker: ["custom@"],
+          },
+        },
+        { platform: "gcfv2" }
+      );
+
+      await fab.createV2Function(ep);
+      expect(run.setInvokerCreate).to.have.been.calledWith(ep.project, "service", ["custom@"]);
+    });
+
+    it("doesn't set private invoker on create", async () => {
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+      const ep = endpoint({ httpsTrigger: { invoker: ["private"] } }, { platform: "gcfv2" });
+
+      await fab.createV2Function(ep);
+      expect(gcf.setInvokerCreate).to.not.have.been.called;
+    });
+
+    it("doesn't set invoker on non-http functions", async () => {
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+      const ep = endpoint({ scheduleTrigger: {} }, { platform: "gcfv2" });
+
+      await fab.createV2Function(ep);
+      expect(run.setInvokerCreate).to.not.have.been.called;
+    });
+
+    it("sets explicit concurrency", async () => {
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2", concurrency: 1 });
+
+      await fab.createV2Function(ep);
+      expect(setConcurrency).to.have.been.calledWith(ep, "service", 1);
+    });
+  });
+
+  describe("updateV2Function", () => {
+    it("throws on update function failure", async () => {
+      gcfv2.updateFunction.rejects(new Error("Server failure"));
+
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      await expect(fab.updateV2Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "update");
+
+      gcfv2.updateFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.rejects(new Error("Fail whale"));
+      await expect(fab.updateV2Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "update");
+    });
+
+    it("throws on set invoker failure", async () => {
+      gcfv2.updateFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerUpdate.rejects(new Error("Boom"));
+
+      const ep = endpoint({ httpsTrigger: { invoker: ["private"] } }, { platform: "gcfv2" });
+      await expect(fab.updateV2Function(ep)).to.be.rejectedWith(
+        reporter.DeploymentError,
+        "set invoker"
+      );
+    });
+
+    it("sets explicit invoker", async () => {
+      gcfv2.updateFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerUpdate.resolves();
+      const ep = endpoint(
+        {
+          httpsTrigger: {
+            invoker: ["custom@"],
+          },
+        },
+        { platform: "gcfv2" }
+      );
+
+      await fab.updateV2Function(ep);
+      expect(run.setInvokerUpdate).to.have.been.calledWith(ep.project, "service", ["custom@"]);
+    });
+
+    it("does not set invoker by default", async () => {
+      gcfv2.updateFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerUpdate.resolves();
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+
+      await fab.updateV2Function(ep);
+      expect(run.setInvokerUpdate).to.not.have.been.called;
+    });
+
+    it("doesn't set invoker on non-http functions", async () => {
+      gcfv2.updateFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerUpdate.resolves();
+      const ep = endpoint({ scheduleTrigger: {} }, { platform: "gcfv2" });
+
+      await fab.updateV2Function(ep);
+      expect(run.setInvokerUpdate).to.not.have.been.called;
+    });
+  });
+
+  describe("deleteV2Function", () => {
+    it("throws on delete function failure", async () => {
+      gcfv2.deleteFunction.rejects(new Error("404"));
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+
+      await expect(fab.deleteV2Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "delete");
+
+      gcfv2.deleteFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.rejects(new Error("5xx"));
+
+      await expect(fab.deleteV2Function(ep)).to.be.rejectedWith(reporter.DeploymentError, "delete");
+    });
+  });
+
+  describe("setConcurrency", () => {
+    let service: runNS.Service;
+    beforeEach(() => {
+      service = {
+        apiVersion: "serving.knative.dev/v1",
+        kind: "service",
+        metadata: {
+          name: "service",
+          namespace: "project",
+        },
+        spec: {
+          template: {
+            metadata: {
+              name: "service",
+              namespace: "project",
+            },
+            spec: {
+              containerConcurrency: 80,
+            },
+          },
+          traffic: [],
+        },
+      };
+    });
+
+    it("sets concurrency when necessary", async () => {
+      run.getService.resolves(service);
+      run.replaceService.callsFake((name: string, svc: runNS.Service) => {
+        expect(svc.spec.template.spec.containerConcurrency).equals(1);
+        // Run throws if this field is set
+        expect(svc.spec.template.metadata.name).is.undefined;
+        return Promise.resolve(service);
+      });
+
+      await fab.setConcurrency(endpoint(), "service", 1);
+      expect(run.replaceService).to.have.been.called;
+    });
+
+    it("doesn't set concurrency when already at the correct value", async () => {
+      run.getService.resolves(service);
+
+      await fab.setConcurrency(
+        endpoint(),
+        "service",
+        service.spec.template.spec.containerConcurrency!
+      );
+      expect(run.replaceService).to.not.have.been.called;
+    });
+
+    it("wraps errors", async () => {
+      run.getService.rejects(new Error("Oh noes!"));
+
+      await expect(fab.setConcurrency(endpoint(), "service", 1)).to.eventually.be.rejectedWith(
+        reporter.DeploymentError,
+        "set concurrency"
+      );
+
+      run.getService.resolves(service);
+      run.replaceService.rejects(new Error("read only"));
+      await expect(fab.setConcurrency(endpoint(), "service", 1)).to.eventually.be.rejectedWith(
+        reporter.DeploymentError,
+        "set concurrency"
+      );
+    });
+  });
+
+  describe("upsertScheduleV1", () => {
+    const ep = endpoint({
+      scheduleTrigger: {
+        schedule: "every 5 minutes",
+      },
+    }) as backend.Endpoint & backend.ScheduleTriggered;
+
+    it("upserts schedules", async () => {
+      scheduler.createOrReplaceJob.resolves();
+      await fab.upsertScheduleV1(ep);
+      expect(scheduler.createOrReplaceJob).to.have.been.called;
+    });
+
+    it("wraps errors", async () => {
+      scheduler.createOrReplaceJob.rejects(new Error("Fail"));
+      await expect(fab.upsertScheduleV1(ep)).to.eventually.be.rejectedWith(
+        reporter.DeploymentError,
+        "upsert schedule"
+      );
+    });
+  });
+
+  describe("deleteScheduleV1", () => {
+    const ep = endpoint({
+      scheduleTrigger: {
+        schedule: "every 5 minutes",
+      },
+    }) as backend.Endpoint & backend.ScheduleTriggered;
+
+    it("deletes schedules and topics", async () => {
+      scheduler.deleteJob.resolves();
+      pubsub.deleteTopic.resolves();
+      await fab.deleteScheduleV1(ep);
+      expect(scheduler.deleteJob).to.have.been.called;
+      expect(pubsub.deleteTopic).to.have.been.called;
+    });
+
+    it("wraps errors", async () => {
+      scheduler.deleteJob.rejects(new Error("Fail"));
+      await expect(fab.deleteScheduleV1(ep)).to.eventually.be.rejectedWith(
+        reporter.DeploymentError,
+        "delete schedule"
+      );
+
+      scheduler.deleteJob.resolves();
+      pubsub.deleteTopic.rejects(new Error("Fail"));
+      await expect(fab.deleteScheduleV1(ep)).to.eventually.be.rejectedWith(
+        reporter.DeploymentError,
+        "delete topic"
+      );
+    });
+  });
+
+  describe("setTrigger", () => {
+    it("does nothing for HTTPS functions", async () => {
+      // all APIs throw by default
+      await fab.setTrigger(endpoint({ httpsTrigger: {} }));
+    });
+
+    it("does nothing for event triggers", async () => {
+      // all APIs throw by default
+      const ep = endpoint({
+        eventTrigger: {
+          eventType: gcfNSV2.PUBSUB_PUBLISH_EVENT,
+          eventFilters: {
+            resource: "topic",
+          },
+          retry: false,
+        },
+      });
+      await fab.setTrigger(ep);
+    });
+
+    it("sets schedule triggers", async () => {
+      const ep = endpoint({
+        scheduleTrigger: {
+          schedule: "every 5 minutes",
+        },
+      });
+      const upsertScheduleV1 = sinon.stub(fab, "upsertScheduleV1");
+      upsertScheduleV1.resolves();
+
+      await fab.setTrigger(ep);
+      expect(upsertScheduleV1).to.have.been.called;
+      upsertScheduleV1.restore();
+
+      ep.platform = "gcfv2";
+      const upsertScheduleV2 = sinon.stub(fab, "upsertScheduleV2");
+      upsertScheduleV2.resolves();
+
+      await fab.setTrigger(ep);
+      expect(upsertScheduleV2).to.have.been.called;
+    });
+  });
+
+  describe("deleteTrigger", () => {
+    it("does nothing for HTTPS functions", async () => {
+      // all APIs throw by default
+      await fab.deleteTrigger(endpoint({ httpsTrigger: {} }));
+    });
+
+    it("does nothing for event triggers", async () => {
+      // all APIs throw by default
+      const ep = endpoint({
+        eventTrigger: {
+          eventType: gcfNSV2.PUBSUB_PUBLISH_EVENT,
+          eventFilters: {
+            resource: "topic",
+          },
+          retry: false,
+        },
+      });
+      await fab.deleteTrigger(ep);
+    });
+
+    it("sets schedule triggers", async () => {
+      const ep = endpoint({
+        scheduleTrigger: {
+          schedule: "every 5 minutes",
+        },
+      });
+      const deleteScheduleV1 = sinon.stub(fab, "deleteScheduleV1");
+      deleteScheduleV1.resolves();
+
+      await fab.deleteTrigger(ep);
+      expect(deleteScheduleV1).to.have.been.called;
+      deleteScheduleV1.restore();
+
+      ep.platform = "gcfv2";
+      const deleteScheduleV2 = sinon.stub(fab, "deleteScheduleV2");
+      deleteScheduleV2.resolves();
+
+      await fab.deleteTrigger(ep);
+      expect(deleteScheduleV2).to.have.been.called;
+    });
+  });
+
+  describe("createEndpoint", () => {
+    it("creates v1 functions", async () => {
+      const ep = endpoint();
+      const setTrigger = sinon.stub(fab, "setTrigger");
+      setTrigger.resolves();
+      const createV1Function = sinon.stub(fab, "createV1Function");
+      createV1Function.resolves();
+
+      await fab.createEndpoint(ep, new scraper.SourceTokenScraper());
+      expect(createV1Function).is.calledOnce;
+      expect(setTrigger).is.calledOnce;
+      expect(setTrigger).is.calledAfter(createV1Function);
+    });
+
+    it("creates v2 functions", async () => {
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      const setTrigger = sinon.stub(fab, "setTrigger");
+      setTrigger.resolves();
+      const createV2Function = sinon.stub(fab, "createV2Function");
+      createV2Function.resolves();
+
+      await fab.createEndpoint(ep, new scraper.SourceTokenScraper());
+      expect(createV2Function).is.calledOnce;
+      expect(setTrigger).is.calledOnce;
+      expect(setTrigger).is.calledAfter(createV2Function);
+    });
+
+    it("aborts for failures midway", async () => {
+      const ep = endpoint();
+      const setTrigger = sinon.stub(fab, "setTrigger");
+      const createV1Function = sinon.stub(fab, "createV1Function");
+      createV1Function.rejects(new reporter.DeploymentError(ep, "set invoker", undefined));
+
+      await expect(fab.createEndpoint(ep, new scraper.SourceTokenScraper())).to.be.rejectedWith(
+        reporter.DeploymentError,
+        "set invoker"
+      );
+      expect(createV1Function).is.calledOnce;
+      expect(setTrigger).is.not.called;
+    });
+  });
+
+  describe("updateEndpoint", () => {
+    it("updates v1 functions", async () => {
+      const ep = endpoint();
+      const setTrigger = sinon.stub(fab, "setTrigger");
+      setTrigger.resolves();
+      const updateV1Function = sinon.stub(fab, "updateV1Function");
+      updateV1Function.resolves();
+
+      await fab.updateEndpoint({ endpoint: ep }, new scraper.SourceTokenScraper());
+      expect(updateV1Function).is.calledOnce;
+      expect(setTrigger).is.calledOnce;
+      expect(setTrigger).is.calledAfter(updateV1Function);
+    });
+
+    it("updates v2 functions", async () => {
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      const setTrigger = sinon.stub(fab, "setTrigger");
+      setTrigger.resolves();
+      const updateV2Function = sinon.stub(fab, "updateV2Function");
+      updateV2Function.resolves();
+
+      await fab.updateEndpoint({ endpoint: ep }, new scraper.SourceTokenScraper());
+      expect(updateV2Function).is.calledOnce;
+      expect(setTrigger).is.calledOnce;
+      expect(setTrigger).is.calledAfter(updateV2Function);
+    });
+
+    it("aborts for failures midway", async () => {
+      const ep = endpoint();
+      const setTrigger = sinon.stub(fab, "setTrigger");
+      const updateV1Function = sinon.stub(fab, "updateV1Function");
+      updateV1Function.rejects(new reporter.DeploymentError(ep, "set invoker", undefined));
+
+      await expect(
+        fab.updateEndpoint({ endpoint: ep }, new scraper.SourceTokenScraper())
+      ).to.be.rejectedWith(reporter.DeploymentError, "set invoker");
+      expect(updateV1Function).is.calledOnce;
+      expect(setTrigger).is.not.called;
+    });
+
+    it("can delete and create", async () => {
+      const target = endpoint(
+        { scheduleTrigger: { schedule: "every 5 minutes" } },
+        { platform: "gcfv2" }
+      );
+      const before = endpoint(
+        { scheduleTrigger: { schedule: "every 5 minutes" } },
+        { platform: "gcfv1" }
+      );
+      const update = {
+        endpoint: target,
+        deleteBeforeUpdate: before,
+      };
+
+      const deleteTrigger = sinon.stub(fab, "deleteTrigger");
+      deleteTrigger.resolves();
+      const setTrigger = sinon.stub(fab, "setTrigger");
+      setTrigger.resolves();
+      const deleteV1Function = sinon.stub(fab, "deleteV1Function");
+      deleteV1Function.resolves();
+      const createV2Function = sinon.stub(fab, "createV2Function");
+      createV2Function.resolves();
+
+      await fab.updateEndpoint(update, new scraper.SourceTokenScraper());
+
+      expect(deleteTrigger).to.have.been.called;
+      expect(deleteV1Function).to.have.been.calledImmediatelyAfter(deleteTrigger);
+      expect(createV2Function).to.have.been.calledImmediatelyAfter(deleteV1Function);
+      expect(setTrigger).to.have.been.calledImmediatelyAfter(createV2Function);
+    });
+  });
+
+  describe("deleteEndpoint", () => {
+    it("deletes v1 functions", async () => {
+      const ep = endpoint();
+      const deleteTrigger = sinon.stub(fab, "deleteTrigger");
+      deleteTrigger.resolves();
+      const deleteV1Function = sinon.stub(fab, "deleteV1Function");
+      deleteV1Function.resolves();
+
+      await fab.deleteEndpoint(ep);
+      expect(deleteTrigger).to.have.been.called;
+      expect(deleteV1Function).to.have.been.calledImmediatelyAfter(deleteTrigger);
+    });
+
+    it("deletes v2 functions", async () => {
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      const deleteTrigger = sinon.stub(fab, "deleteTrigger");
+      deleteTrigger.resolves();
+      const deleteV2Function = sinon.stub(fab, "deleteV2Function");
+      deleteV2Function.resolves();
+
+      await fab.deleteEndpoint(ep);
+      expect(deleteTrigger).to.have.been.called;
+      expect(deleteV2Function).to.have.been.calledImmediatelyAfter(deleteTrigger);
+    });
+
+    it("does not delete functions with triggers outstanding", async () => {
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      const deleteV2Function = sinon.stub(fab, "deleteV2Function");
+      const deleteTrigger = sinon.stub(fab, "deleteTrigger");
+      deleteTrigger.rejects(new reporter.DeploymentError(ep, "delete schedule", undefined));
+      deleteV2Function.resolves();
+
+      await expect(fab.deleteEndpoint(ep)).to.eventually.be.rejected;
+      expect(deleteV2Function).to.not.have.been.called;
+    });
+  });
+
+  describe("applyRegionalUpdates", () => {
+    it("shares source token scrapers across upserts", async () => {
+      const ep1 = endpoint({ httpsTrigger: {} }, { id: "A" });
+      const ep2 = endpoint({ httpsTrigger: {} }, { id: "B" });
+      const ep3 = endpoint({ httpsTrigger: {} }, { id: "C" });
+      const changes: planner.RegionalChanges = {
+        endpointsToCreate: [ep1, ep2],
+        endpointsToUpdate: [{ endpoint: ep3 }],
+        endpointsToDelete: [],
+      };
+
+      let sourceTokenScraper: scraper.SourceTokenScraper | undefined;
+      let callCount = 0;
+      const fakeUpsert = (
+        unused: backend.Endpoint | planner.EndpointUpdate,
+        s: scraper.SourceTokenScraper
+      ): Promise<void> => {
+        callCount++;
+        if (!sourceTokenScraper) {
+          expect(callCount).to.equal(1);
+          sourceTokenScraper = s;
+        }
+        expect(s).to.equal(sourceTokenScraper);
+        return Promise.resolve();
+      };
+
+      const createEndpoint = sinon.stub(fab, "createEndpoint");
+      createEndpoint.callsFake(fakeUpsert);
+      const updateEndpoint = sinon.stub(fab, "updateEndpoint");
+      updateEndpoint.callsFake(fakeUpsert);
+
+      await fab.applyRegionalChanges(changes);
+    });
+
+    it("handles errors and wraps them in results", async () => {
+      // when it hits a real API it will fail.
+      const ep = endpoint();
+      const changes: planner.RegionalChanges = {
+        endpointsToCreate: [ep],
+        endpointsToUpdate: [],
+        endpointsToDelete: [],
+      };
+
+      const results = await fab.applyRegionalChanges(changes);
+      expect(results[ep.region][ep.id].error).to.be.instanceOf(reporter.DeploymentError);
+      expect(results[ep.region][ep.id].error?.message).to.match(/create function/);
+    });
+  });
+
+  it("does not delete if there are upsert errors", async () => {
+    // when it hits a real API it will fail.
+    const createEP = endpoint({ httpsTrigger: {} }, { id: "A" });
+    const deleteEP = endpoint({ httpsTrigger: {} }, { id: "B" });
+    const changes: planner.RegionalChanges = {
+      endpointsToCreate: [createEP],
+      endpointsToUpdate: [],
+      endpointsToDelete: [deleteEP],
+    };
+
+    const results = await fab.applyRegionalChanges(changes);
+    expect(results[deleteEP.region][deleteEP.id].error).to.be.instanceOf(
+      reporter.AbortedDeploymentError
+    );
+    expect(results[deleteEP.region][deleteEP.id].durationMs).to.equal(0);
+  });
+
+  it("applies all kinds of changes", async () => {
+    const createEP = endpoint({ httpsTrigger: {} }, { id: "A" });
+    const updateEP = endpoint({ httpsTrigger: {} }, { id: "B" });
+    const deleteEP = endpoint({ httpsTrigger: {} }, { id: "C" });
+    const update: planner.EndpointUpdate = { endpoint: updateEP };
+    const changes: planner.RegionalChanges = {
+      endpointsToCreate: [createEP],
+      endpointsToUpdate: [update],
+      endpointsToDelete: [deleteEP],
+    };
+
+    const createEndpoint = sinon.stub(fab, "createEndpoint");
+    createEndpoint.resolves();
+    const updateEndpoint = sinon.stub(fab, "updateEndpoint");
+    updateEndpoint.resolves();
+    const deleteEndpoint = sinon.stub(fab, "deleteEndpoint");
+    deleteEndpoint.resolves();
+
+    const results = await fab.applyRegionalChanges(changes);
+    expect(createEndpoint).to.have.been.calledWithMatch(createEP);
+    expect(updateEndpoint).to.have.been.calledWithMatch(update);
+    expect(deleteEndpoint).to.have.been.calledWith(deleteEP);
+
+    // We can't actually verify that the timing isn't zero because tests
+    // have run in <1ms and failed.
+    expect(results[createEP.region][createEP.id].error).to.be.undefined;
+    expect(results[updateEP.region][updateEP.id].error).to.be.undefined;
+    expect(results[deleteEP.region][deleteEP.id].error).to.be.undefined;
+  });
+
+  describe("applyPlan", () => {
+    it("fans out to regions", async () => {
+      const ep1 = endpoint({ httpsTrigger: {} }, { region: "us-central1" });
+      const ep2 = endpoint({ httpsTrigger: {} }, { region: "us-west1" });
+      const plan: planner.DeploymentPlan = {
+        "us-central1": {
+          endpointsToCreate: [ep1],
+          endpointsToUpdate: [],
+          endpointsToDelete: [],
+        },
+        "us-west1": {
+          endpointsToCreate: [],
+          endpointsToUpdate: [],
+          endpointsToDelete: [ep2],
+        },
+      };
+
+      // Will fail when it hits actual API calls
+      const results = await fab.applyPlan(plan);
+      expect(results[ep1.region][ep1.id].error).to.be.instanceOf(reporter.DeploymentError);
+      expect(results[ep1.region][ep1.id].error?.message).to.match(/create function/);
+      expect(results[ep2.region][ep2.id].error).to.be.instanceOf(reporter.DeploymentError);
+      expect(results[ep2.region][ep2.id].error?.message).to.match(/delete function/);
+    });
+  });
+});

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -65,7 +65,7 @@ describe("planner", () => {
       }
       expect(planner.calculateUpdate(changed, original)).to.deep.equal({
         endpoint: changed,
-        deleteAndRecreate: true,
+        deleteBeforeUpdate: original,
       });
     });
 
@@ -79,7 +79,7 @@ describe("planner", () => {
       allowV2Upgrades();
       expect(planner.calculateUpdate(changed, original)).to.deep.equal({
         endpoint: changed,
-        deleteAndRecreate: true,
+        deleteBeforeUpdate: original,
       });
     });
 
@@ -95,7 +95,6 @@ describe("planner", () => {
       };
       expect(planner.calculateUpdate(v2Function, v1Function)).to.deep.equal({
         endpoint: v2Function,
-        deleteAndRecreate: false,
       });
     });
   });
@@ -117,7 +116,6 @@ describe("planner", () => {
         endpointsToUpdate: [
           {
             endpoint: updated,
-            deleteAndRecreate: false,
           },
         ],
         endpointsToDelete: [deleted],
@@ -147,7 +145,6 @@ describe("planner", () => {
           endpointsToUpdate: [
             {
               endpoint: group1Updated,
-              deleteAndRecreate: false,
             },
           ],
           endpointsToDelete: [group1Deleted],

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -65,7 +65,7 @@ describe("planner", () => {
       }
       expect(planner.calculateUpdate(changed, original)).to.deep.equal({
         endpoint: changed,
-        deleteBeforeUpdate: original,
+        deleteAndRecreate: original,
       });
     });
 
@@ -79,7 +79,7 @@ describe("planner", () => {
       allowV2Upgrades();
       expect(planner.calculateUpdate(changed, original)).to.deep.equal({
         endpoint: changed,
-        deleteBeforeUpdate: original,
+        deleteAndRecreate: original,
       });
     });
 

--- a/src/test/deploy/functions/release/sourceTokenScraper.spec.ts
+++ b/src/test/deploy/functions/release/sourceTokenScraper.spec.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+
+import { SourceTokenScraper } from "../../../../deploy/functions/release/sourceTokenScraper";
+
+describe("SourcTokenScraper", () => {
+  it("immediately provides the first result", async () => {
+    const scraper = new SourceTokenScraper();
+    await expect(scraper.tokenPromise()).to.eventually.be.undefined;
+  });
+
+  it("provides results after the firt operation completes", async () => {
+    const scraper = new SourceTokenScraper();
+    // First result comes right away;
+    await expect(scraper.tokenPromise()).to.eventually.be.undefined;
+
+    let gotResult = false;
+    const timeout = new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error("Timeout")), 10);
+    });
+    const getResult = (async () => {
+      await scraper.tokenPromise();
+      gotResult = true;
+    })();
+    await expect(Promise.race([getResult, timeout])).to.be.rejectedWith("Timeout");
+    expect(gotResult).to.be.false;
+
+    scraper.poller({ done: true });
+    await expect(getResult).to.eventually.be.undefined;
+  });
+
+  it("provides tokens from an operation", async () => {
+    const scraper = new SourceTokenScraper();
+    // First result comes right away
+    await expect(scraper.tokenPromise()).to.eventually.be.undefined;
+
+    scraper.poller({
+      metadata: {
+        sourceToken: "magic token",
+        target: "projects/p/locations/l/functions/f",
+      },
+    });
+    await expect(scraper.tokenPromise()).to.eventually.equal("magic token");
+  });
+});


### PR DESCRIPTION
Fabricator is the repalcement for the previous Tasks codebase, though it will not handle the portion of tracking or error reporting internally (those will be future utilities for better testing).

Some differences between tasks.ts and fabricator.ts:
* Queues are used for narrow transactions, which means we don't accidentally have an error bubble up and cause a retry on a bulk operation. There's a design pattern of executor.run.catch(rethrowAs)
* Function triggers (not EventArc triggers, which are deployed as part of the function, but external triggers like topics, and in the future intents or task queues) are only created after a successful function creation and functions are only deleted after a successful trigger deletion
* We do not delete functions if an upsert failed (this helps catch cases where a user renamed a function)
* This code is actually unit tested (hooray!)
* It handles v1 and v2 functions completely separately. IMO this dramatically improved readability by being less clever.

Personal apologies to @joehan that I'm not sure it was as respectful as I could have been to start from scratch. I tried on the from-scratch implementation for a while and ended up feeling like I was rewriting the original tasks.ts. Then I started editing tasks.ts and felt I was coming back to this design. I resumed working on the from-scratch implementation just because there were a few lower-level details I liked more about the fresh approach and I was already pretty far along.