### PR TITLE
Add support to select TenantProjectState when tenantId is in request body idToken

### DIFF
--- a/src/test/emulators/auth/rest.spec.ts
+++ b/src/test/emulators/auth/rest.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-import { expectStatusCode } from "./helpers";
-import { describeAuthEmulator } from "./setup";
+import { expectStatusCode, registerTenant, registerUser } from "./helpers";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 
 describeAuthEmulator("REST API mapping", ({ authApi }) => {
   it("should respond to status checks", async () => {
@@ -167,13 +167,57 @@ describeAuthEmulator("authentication", ({ authApi }) => {
       });
   });
 
-  it("should deny requests where tenant IDs do not match", async () => {
+  it("should deny requests where tenant IDs do not match in the request body and path", async () => {
     await authApi()
       .post(
         "/identitytoolkit.googleapis.com/v1/projects/project-id/tenants/tenant-id/accounts:delete"
       )
       .set("Authorization", "Bearer owner")
       .send({ localId: "local-id", tenantId: "mismatching-tenant-id" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
+      });
+  });
+
+  it("should deny requests where tenant IDs do not match in the token and path", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      allowPasswordSignup: true,
+    });
+    const { idToken, localId } = await registerUser(authApi(), {
+      email: "alice@example.com",
+      password: "notasecret",
+      tenantId: tenant.tenantId,
+    });
+
+    await authApi()
+      .post(
+        `/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/tenants/not-matching-tenant-id/accounts:lookup`
+      )
+      .send({ idToken })
+      .set("Authorization", "Bearer owner")
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
+      });
+  });
+
+  it("should deny requests where tenant IDs do not match in the token and request body", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      allowPasswordSignup: true,
+    });
+    const { idToken, localId } = await registerUser(authApi(), {
+      email: "alice@example.com",
+      password: "notasecret",
+      tenantId: tenant.tenantId,
+    });
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:lookup`)
+      .send({ idToken, tenantId: "not-matching-tenant-id" })
+      .set("Authorization", "Bearer owner")
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");


### PR DESCRIPTION
### Description

`TenantProjectState` should still be selected even if tenantId is not in the request path or body. This reflects the logic here ([go/firebase-tools-3810-tenantid](http://go/firebase-tools-3810-tenantid)) and impacts logic for endpoints such as `v1/accounts:lookup` ([go/firebase-tools-3810-lookup](http://go/firebase-tools-3810-lookup)).

Corresponding internal bug: b/192387245

### Scenarios Tested

`npm test` passes

### Sample Commands

N/A