### PR TITLE
Implementing some UX feedback for `ext:export `and `deploy --only extensions`

### DIFF
--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -84,7 +84,7 @@ export default new Command("ext:configure <extensionInstanceId>")
       }
 
       spinner.start();
-      const res = await extensionsApi.configureInstance(projectId, instanceId, params);
+      const res = await extensionsApi.configureInstance({ projectId, instanceId, params });
       spinner.stop();
       utils.logLabeledSuccess(logPrefix, `successfully configured ${clc.bold(instanceId)}.`);
       utils.logLabeledBullet(

--- a/src/deploy/extensions/args.ts
+++ b/src/deploy/extensions/args.ts
@@ -2,6 +2,7 @@ import * as planner from "./planner";
 
 export interface Payload {
   instancesToCreate?: planner.InstanceSpec[];
+  instancesToConfigure?: planner.InstanceSpec[];
   instancesToUpdate?: planner.InstanceSpec[];
   instancesToDelete?: planner.InstanceSpec[];
 }

--- a/src/deploy/extensions/deploy.ts
+++ b/src/deploy/extensions/deploy.ts
@@ -32,6 +32,15 @@ export async function deploy(
     void validationQueue.run(task);
   }
 
+  for (const configure of payload.instancesToConfigure ?? []) {
+    const task = tasks.configureExtensionInstanceTask(
+      projectId,
+      configure,
+      /* validateOnly=*/ true
+    );
+    void validationQueue.run(task);
+  }
+
   // Note: We need to wait() _BEFORE_ calling process() and close().
   const validationPromise = validationQueue.wait();
 

--- a/src/deploy/extensions/deploymentSummary.ts
+++ b/src/deploy/extensions/deploymentSummary.ts
@@ -1,10 +1,8 @@
-import * as clc from "cli-color";
-
 import * as planner from "./planner";
 import * as refs from "../../extensions/refs";
 
 export const humanReadable = (dep: planner.InstanceSpec) =>
-  `${clc.bold(dep.instanceId)} (${
+  `${dep.instanceId} (${
     dep.ref ? `${refs.toExtensionVersionRef(dep.ref)}` : `Installed from local source`
   })`;
 
@@ -13,14 +11,12 @@ const humanReadableUpdate = (from: planner.InstanceSpec, to: planner.InstanceSpe
     from.ref?.publisherId == to.ref?.publisherId &&
     from.ref?.extensionId == to.ref?.extensionId
   ) {
-    return `\t${clc.bold(from.instanceId)} (${refs.toExtensionVersionRef(from.ref!)} => ${
-      to.ref?.version
-    })`;
+    return `\t${from.instanceId} (${refs.toExtensionVersionRef(from.ref!)} => ${to.ref?.version})`;
   } else {
     const fromRef = from.ref
       ? `${refs.toExtensionVersionRef(from.ref)}`
       : `Installed from local source`;
-    return `\t${clc.bold(from.instanceId)} (${fromRef} => ${refs.toExtensionVersionRef(to.ref!)})`;
+    return `\t${from.instanceId} (${fromRef} => ${refs.toExtensionVersionRef(to.ref!)})`;
   }
 };
 
@@ -43,6 +39,14 @@ export function updatesSummary(
     })
     .join("\n");
   return toUpdate.length ? `The following extension instances will be updated:\n${summary}\n` : "";
+}
+
+export function configuresSummary(toConfigure: planner.InstanceSpec[]) {
+  return toConfigure.length
+    ? `The following extension instances will be configured:\n${toConfigure
+        .map((s) => `\t${humanReadable(s)}`)
+        .join("\n")}\n`
+    : "";
 }
 
 export function deletesSummary(toDelete: planner.InstanceSpec[]) {

--- a/src/deploy/extensions/deploymentSummary.ts
+++ b/src/deploy/extensions/deploymentSummary.ts
@@ -1,8 +1,10 @@
+import * as clc from "cli-color";
+
 import * as planner from "./planner";
 import * as refs from "../../extensions/refs";
 
 export const humanReadable = (dep: planner.InstanceSpec) =>
-  `${dep.instanceId} (${
+  `${clc.bold(dep.instanceId)} (${
     dep.ref ? `${refs.toExtensionVersionRef(dep.ref)}` : `Installed from local source`
   })`;
 
@@ -11,12 +13,12 @@ const humanReadableUpdate = (from: planner.InstanceSpec, to: planner.InstanceSpe
     from.ref?.publisherId == to.ref?.publisherId &&
     from.ref?.extensionId == to.ref?.extensionId
   ) {
-    return `\t${from.instanceId} (${refs.toExtensionVersionRef(from.ref!)} => ${to.ref?.version})`;
+    return `\t${clc.bold(from.instanceId)} (${refs.toExtensionVersionRef(from.ref!)} => ${to.ref?.version})`;
   } else {
     const fromRef = from.ref
       ? `${refs.toExtensionVersionRef(from.ref)}`
       : `Installed from local source`;
-    return `\t${from.instanceId} (${fromRef} => ${refs.toExtensionVersionRef(to.ref!)})`;
+    return `\t${clc.bold(from.instanceId)} (${fromRef} => ${refs.toExtensionVersionRef(to.ref!)})`;
   }
 };
 

--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -5,6 +5,7 @@ import { FirebaseError } from "../../error";
 import * as extensionsApi from "../../extensions/extensionsApi";
 import * as refs from "../../extensions/refs";
 import { readEnvFile } from "../../extensions/paramHelper";
+import { logger } from "../../logger";
 
 export interface InstanceSpec {
   instanceId: string;
@@ -48,12 +49,12 @@ export async function want(
         params,
       });
     } catch (err) {
-      console.log(e, err);
+      logger.debug(`Got error reading extensions entry ${e}: ${err}`);
       errors.push(err as FirebaseError);
     }
   }
   if (errors.length) {
-    const messages = errors.map((e) => e.message).join("\n");
+    const messages = errors.map((err) => `- ${err.message}`).join("\n");
     throw new FirebaseError(`Errors while reading 'extensions' in 'firebase.json'\n${messages}`);
   }
   return instanceSpecs;

--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -1,6 +1,7 @@
 import * as planner from "./planner";
 import * as deploymentSummary from "./deploymentSummary";
 import * as prompt from "../../prompt";
+import * as refs from "../../extensions/refs";
 import { Options } from "../../options";
 import { needProjectId } from "../../projectUtils";
 import { logger } from "../../logger";
@@ -23,7 +24,8 @@ export async function prepare(
   const want = await planner.want(options.config.get("extensions"), options.config.projectDir);
 
   payload.instancesToCreate = want.filter((dep) => !have.some(matchesInstanceId(dep)));
-  payload.instancesToUpdate = want.filter((dep) => have.some(matchesInstanceId(dep)));
+  payload.instancesToConfigure = want.filter((dep) => have.some(isConfigure(dep)));
+  payload.instancesToUpdate = want.filter((dep) => have.some(isUpdate(dep)));
   payload.instancesToDelete = have.filter((dep) => !want.some(matchesInstanceId(dep)));
 
   const permissionsNeeded: string[] = [];
@@ -36,6 +38,10 @@ export async function prepare(
     permissionsNeeded.push("firebaseextensions.instances.update");
     logger.info(deploymentSummary.updatesSummary(payload.instancesToUpdate, have));
   }
+  if (payload.instancesToConfigure.length) {
+    permissionsNeeded.push("firebaseextensions.instances.update");
+    logger.info(deploymentSummary.configuresSummary(payload.instancesToConfigure));
+  }
   if (payload.instancesToDelete.length) {
     logger.info(deploymentSummary.deletesSummary(payload.instancesToDelete));
     if (!options.force && options.nonInteractive) {
@@ -45,7 +51,9 @@ export async function prepare(
       !options.nonInteractive &&
       !(await prompt.promptOnce({
         type: "confirm",
-        message: "Would you like to delete these extension instances?",
+        message: `Would you like to delete ${payload.instancesToDelete
+          .map((i) => i.instanceId)
+          .join(", ")}?`,
         default: false,
       }))
     ) {
@@ -57,7 +65,14 @@ export async function prepare(
 
   await requirePermissions(options, permissionsNeeded);
 }
+const matchesInstanceId = (dep: planner.InstanceSpec) => (test: planner.InstanceSpec) => {
+  return dep.instanceId == test.instanceId;
+};
 
-const matchesInstanceId = (dep: { instanceId: string }) => (test: { instanceId: string }) => {
-  return dep.instanceId === test.instanceId;
+const isUpdate = (dep: planner.InstanceSpec) => (test: planner.InstanceSpec) => {
+  return dep.instanceId === test.instanceId && !refs.equal(dep.ref, test.ref);
+};
+
+const isConfigure = (dep: planner.InstanceSpec) => (test: planner.InstanceSpec) => {
+  return dep.instanceId === test.instanceId && refs.equal(dep.ref, test.ref);
 };

--- a/src/deploy/extensions/release.ts
+++ b/src/deploy/extensions/release.ts
@@ -30,6 +30,11 @@ export async function release(
     void deploymentQueue.run(task);
   }
 
+  for (const update of payload.instancesToConfigure ?? []) {
+    const task = tasks.configureExtensionInstanceTask(projectId, update);
+    void deploymentQueue.run(task);
+  }
+
   for (const deletion of payload.instancesToDelete ?? []) {
     const task = tasks.deleteExtensionInstanceTask(projectId, deletion);
     void deploymentQueue.run(task);

--- a/src/deploy/extensions/tasks.ts
+++ b/src/deploy/extensions/tasks.ts
@@ -4,12 +4,11 @@ import * as extensionsApi from "../../extensions/extensionsApi";
 import * as refs from "../../extensions/refs";
 import * as utils from "../../utils";
 import { ErrorHandler } from "./errors";
-import { OperationType } from "../functions/tasks";
 import { InstanceSpec } from "./planner";
 
 const isRetryable = (err: any) => err.status == 429 || err.status == 409;
 
-export type DeploymentType = "create" | "update" | "delete";
+export type DeploymentType = "create" | "update" | "configure" | "delete";
 export interface ExtensionDeploymentTask {
   run: () => Promise<void>;
   spec: InstanceSpec;
@@ -83,6 +82,28 @@ export function updateExtensionInstanceTask(
   };
 }
 
+export function configureExtensionInstanceTask(
+  projectId: string,
+  instanceSpec: InstanceSpec,
+  validateOnly: boolean = false
+): ExtensionDeploymentTask {
+  const run = async () => {
+    const res = await extensionsApi.configureInstance({
+      projectId,
+      instanceId: instanceSpec.instanceId,
+      params: instanceSpec.params,
+      validateOnly,
+    });
+    printSuccess(instanceSpec.instanceId, "configure", validateOnly);
+    return;
+  };
+  return {
+    run,
+    spec: instanceSpec,
+    type: "configure",
+  };
+}
+
 export function deleteExtensionInstanceTask(
   projectId: string,
   instanceSpec: InstanceSpec
@@ -99,7 +120,7 @@ export function deleteExtensionInstanceTask(
   };
 }
 
-function printSuccess(instanceId: string, type: OperationType, validateOnly: boolean) {
+function printSuccess(instanceId: string, type: DeploymentType, validateOnly: boolean) {
   const action = validateOnly ? `validated ${type} for` : `${type}d`;
   utils.logSuccess(clc.bold.green("extensions") + ` Successfully ${action} ${instanceId}`);
 }

--- a/src/extensions/export.ts
+++ b/src/extensions/export.ts
@@ -12,9 +12,8 @@ export function displayExportInfo(withRef: InstanceSpec[], withoutRef: InstanceS
   logger.info("The following Extension instances will be saved locally:");
   logger.info("");
 
-  for (const spec of withRef) {
-    displayParams(spec);
-  }
+  displaySpecs(withRef);
+
   if (withoutRef.length) {
     logger.info(
       `Your project also has the following instances installed from local sources. These will not be saved to firebase.json:`
@@ -25,13 +24,16 @@ export function displayExportInfo(withRef: InstanceSpec[], withoutRef: InstanceS
   }
 }
 
-function displayParams(spec: InstanceSpec): void {
-  logger.info(humanReadable(spec));
-  logger.info(`Configuration will be written to 'extensions/${spec.instanceId}.env`);
-  for (const p of Object.entries(spec.params)) {
-    logger.info(`\t${p[0]}: ${p[1]}`);
+function displaySpecs(specs: InstanceSpec[]): void {
+  for (let i = 0; i < specs.length; i++) {
+    const spec = specs[i];
+    logger.info(`${i + 1}. ${humanReadable(spec)}`);
+    logger.info(`Configuration will be written to 'extensions/${spec.instanceId}.env'`);
+    for (const p of Object.entries(spec.params)) {
+      logger.info(`\t${p[0]}=${p[1]}`);
+    }
+    logger.info("");
   }
-  logger.info("");
 }
 
 function writeExtensionsToFirebaseJson(have: InstanceSpec[], existingConfig: Config): void {

--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -320,20 +320,20 @@ export async function listInstances(projectId: string): Promise<ExtensionInstanc
  * @param params params to configure the extension instance
  * @param validateOnly if true, only validates the update and makes no changes
  */
-export async function configureInstance(
-  projectId: string,
-  instanceId: string,
-  params: { [option: string]: string },
-  validateOnly: boolean = false
-): Promise<any> {
+export async function configureInstance(args: {
+  projectId: string;
+  instanceId: string;
+  params: { [option: string]: string };
+  validateOnly?: boolean;
+}): Promise<any> {
   const res = await patchInstance({
-    projectId,
-    instanceId,
+    projectId: args.projectId,
+    instanceId: args.instanceId,
     updateMask: "config.params",
-    validateOnly,
+    validateOnly: args.validateOnly ?? false,
     data: {
       config: {
-        params,
+        params: args.params,
       },
     },
   });

--- a/src/extensions/refs.ts
+++ b/src/extensions/refs.ts
@@ -90,3 +90,16 @@ export function toExtensionVersionName(ref: Ref): string {
   }
   return `publishers/${ref.publisherId}/extensions/${ref.extensionId}/versions/${ref.version}`;
 }
+
+/**
+ * Checks if two refs refer to the same extensionVersion.
+ */
+export function equal(a?: Ref, b?: Ref): boolean {
+  return (
+    !!a &&
+    !!b &&
+    a.publisherId === b.publisherId &&
+    a.extensionId === b.extensionId &&
+    a.version === b.version
+  );
+}

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -310,7 +310,11 @@ describe("extensions", () => {
         .get(`/${VERSION}/operations/abc123`)
         .reply(200, { done: true });
 
-      await extensionsApi.configureInstance(PROJECT_ID, INSTANCE_ID, { MY_PARAM: "value" });
+      await extensionsApi.configureInstance({
+        projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
+        params: { MY_PARAM: "value" },
+      });
       expect(nock.isDone()).to.be.true;
     });
 
@@ -320,7 +324,12 @@ describe("extensions", () => {
         .query({ updateMask: "config.params", validateOnly: "true" })
         .reply(200, { name: "operations/abc123", done: true });
 
-      await extensionsApi.configureInstance(PROJECT_ID, INSTANCE_ID, { MY_PARAM: "value" }, true);
+      await extensionsApi.configureInstance({
+        projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
+        params: { MY_PARAM: "value" },
+        validateOnly: true,
+      });
       expect(nock.isDone()).to.be.true;
     });
 
@@ -331,7 +340,11 @@ describe("extensions", () => {
         .reply(500);
 
       await expect(
-        extensionsApi.configureInstance(PROJECT_ID, INSTANCE_ID, { MY_PARAM: "value" })
+        extensionsApi.configureInstance({
+          projectId: PROJECT_ID,
+          instanceId: INSTANCE_ID,
+          params: { MY_PARAM: "value" },
+        })
       ).to.be.rejectedWith(FirebaseError, "HTTP Error: 500");
       expect(nock.isDone()).to.be.true;
     });


### PR DESCRIPTION
### Description
Implementing some UX feedback from Will and Sonakshi, and cleaning up some ugly bits that made it through the last PR.

Specifically:
- During ext:export, I added numbered bullets when listing out the extensions to save locally, to help anchor users when there are a lot of extension instances.
- During deploy, I separated out configures and updates to match our messaging elsewhere.
- During deploy, I listed the instances to be delete in the prompt, to clarify exactly what will be deleted
- 
### Scenarios Tested
A deploy containing creates, configures, updates, and deletes
<img width="603" alt="Screen Shot 2021-10-08 at 4 15 57 PM" src="https://user-images.githubusercontent.com/4635763/136634600-87277940-736b-4bab-a346-1ccd357777a9.png">

ext:export:
<img width="655" alt="Screen Shot 2021-10-08 at 2 12 43 PM" src="https://user-images.githubusercontent.com/4635763/136634645-2d7312a3-a627-4d44-9bbb-fbaeb231ddae.png">
<img width="624" alt="Screen Shot 2021-10-08 at 2 12 52 PM" src="https://user-images.githubusercontent.com/4635763/136634654-f76bd168-ef9d-4119-8497-d5719b4ad9af.png">

