### PR TITLE
Merge master; backport recent changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,0 @@
-- `ext:dev:publish` and `ext:update` now support --force and --non-interactive flags.
-- Fixes issue where account specified by `login:use` was not being correctly loaded (#3759).
-- Fixes minor layout issues in Auth Emulator IDP sign-in page (#3774).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-tools",
-  "version": "9.18.0",
+  "version": "9.20.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-tools",
-  "version": "9.18.0",
+  "version": "9.20.0",
   "description": "Command-Line Interface for Firebase",
   "main": "./lib/index.js",
   "bin": {

--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -305,6 +305,7 @@ function pushServersDownToEachPath(openapi3: any): void {
   });
 }
 
+// TODO(lisajian): add tenantId as query param for all emulator config endpoints
 function addEmulatorOperations(openapi3: any): void {
   openapi3.tags.push({ name: "emulator" });
   openapi3.paths["/emulator/v1/projects/{targetProjectId}/accounts"] = {
@@ -446,6 +447,46 @@ function addEmulatorOperations(openapi3: any): void {
       tags: ["emulator"],
     },
   };
+  openapi3.paths["/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/oobCodes"] = {
+    parameters: [
+      {
+        name: "targetProjectId",
+        in: "path",
+        description: "The ID of the Google Cloud project that the confirmation codes belongs to.",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+      {
+        name: "tenantId",
+        in: "path",
+        description:
+          "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+        required: true,
+        schema: { type: "string" },
+      },
+    ],
+    servers: [{ url: "" }],
+    get: {
+      description: "List all pending confirmation codes for the project.",
+      operationId: "emulator.projects.oobCodes.list",
+      responses: {
+        "200": {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes",
+              },
+            },
+          },
+        },
+      },
+      security: [],
+      tags: ["emulator"],
+    },
+  };
   openapi3.components.schemas.EmulatorV1ProjectsOobCodes = {
     type: "object",
     description: "Details of all pending confirmation codes.",
@@ -474,6 +515,46 @@ function addEmulatorOperations(openapi3: any): void {
         schema: {
           type: "string",
         },
+      },
+    ],
+    servers: [{ url: "" }],
+    get: {
+      description: "List all pending phone verification codes for the project.",
+      operationId: "emulator.projects.verificationCodes.list",
+      responses: {
+        "200": {
+          description: "Successful response",
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes",
+              },
+            },
+          },
+        },
+      },
+      security: [],
+      tags: ["emulator"],
+    },
+  };
+  openapi3.paths["/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/verificationCodes"] = {
+    parameters: [
+      {
+        name: "targetProjectId",
+        in: "path",
+        description: "The ID of the Google Cloud project that the verification codes belongs to.",
+        required: true,
+        schema: {
+          type: "string",
+        },
+      },
+      {
+        name: "tenantId",
+        in: "path",
+        description:
+          "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+        required: true,
+        schema: { type: "string" },
       },
     ],
     servers: [{ url: "" }],

--- a/src/api.js
+++ b/src/api.js
@@ -204,6 +204,10 @@ var api = {
   ),
   githubOrigin: utils.envOverride("GITHUB_URL", "https://github.com"),
   githubApiOrigin: utils.envOverride("GITHUB_API_URL", "https://api.github.com"),
+  secretManagerOrigin: utils.envOverride(
+    "CLOUD_SECRET_MANAGER_URL",
+    "https://secretmanager.googleapis.com"
+  ),
   githubClientId: utils.envOverride("GITHUB_CLIENT_ID", "89cf50f02ac6aaed3484"),
   githubClientSecret: utils.envOverride(
     "GITHUB_CLIENT_SECRET",

--- a/src/commands/crashlytics-symbols-upload.ts
+++ b/src/commands/crashlytics-symbols-upload.ts
@@ -1,0 +1,201 @@
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import * as spawn from "cross-spawn";
+import * as uuid from "uuid";
+
+import { Command } from "../command";
+import * as downloadUtils from "../downloadUtils";
+import { FirebaseError } from "../error";
+import { logger } from "../logger";
+import * as rimraf from "rimraf";
+import * as utils from "../utils";
+
+enum SymbolGenerator {
+  breakpad = "breakpad",
+  csym = "csym",
+}
+
+interface Options {
+  app: string | null;
+  generator: SymbolGenerator | null;
+  dryRun: boolean | null;
+  debug: boolean | null;
+  // Temporary override to use a local JAR until we get the fat jar in our
+  // bucket
+  localJar: string | null;
+}
+
+interface JarOptions {
+  jarFile: string;
+  app: string;
+  generator: SymbolGenerator;
+  cachePath: string;
+  symbolFile: string;
+  generate: boolean;
+}
+
+const SYMBOL_CACHE_ROOT_DIR = process.env.FIREBASE_CRASHLYTICS_CACHE_PATH || os.tmpdir();
+const JAR_CACHE_DIR =
+  process.env.FIREBASE_CRASHLYTICS_BUILDTOOLS_PATH ||
+  path.join(os.homedir(), ".cache", "firebase", "crashlytics", "buildtools");
+const JAR_VERSION = "2.8.0";
+const JAR_URL = `https://storage.googleapis.com/firebase-preview-drop/android/crashlytics-eap/crashlytics-buildtools/firebase-crashlytics-buildtools-${JAR_VERSION}-alpha-all.jar`;
+
+export default new Command("crashlytics:symbols:upload <symbolFiles...>")
+  .description("Upload symbols for native code, to symbolicate stack traces.")
+  .option("--app <appID>", "the app id of your Firebase app")
+  .option("--generator [breakpad|csym]", "the symbol generator being used, defaults to breakpad.")
+  .option("--dry-run", "generate symbols without uploading them")
+  .option("--debug", "print debug output and logging from the underlying uploader tool")
+  .action(async (symbolFiles: string[], options: Options) => {
+    const app = getGoogleAppID(options) || "";
+    const generator = getSymbolGenerator(options);
+    const dryRun = !!options.dryRun;
+    const debug = !!options.debug;
+
+    // If you set LOCAL_JAR to a path it will override the downloaded
+    // buildtools.jar
+    let jarFile = await downloadBuiltoolsJar();
+    if (process.env.LOCAL_JAR) {
+      jarFile = process.env.LOCAL_JAR;
+    }
+
+    const jarOptions: JarOptions = {
+      jarFile,
+      app,
+      generator,
+      cachePath: path.join(
+        SYMBOL_CACHE_ROOT_DIR,
+        `crashlytics-${uuid.v4()}`,
+        "nativeSymbols",
+        app,
+        generator
+      ),
+      symbolFile: "",
+      generate: true,
+    };
+
+    for (const symbolFile of symbolFiles) {
+      utils.logBullet(`Generating symbols for ${symbolFile}`);
+      const generateArgs = buildArgs({ ...jarOptions, symbolFile });
+      const output = runJar(generateArgs, debug);
+      if (output.length > 0) {
+        utils.logBullet(output);
+      } else {
+        utils.logBullet(`Generated symbols for ${symbolFile}`);
+        utils.logBullet(`Output Path: ${jarOptions.cachePath}`);
+      }
+    }
+
+    if (dryRun) {
+      utils.logBullet("Skipping upload because --dry-run was passed");
+      return;
+    }
+
+    utils.logBullet(`Uploading all generated symbols`);
+    const uploadArgs = buildArgs({ ...jarOptions, generate: false });
+    const output = runJar(uploadArgs, debug);
+    if (output.length > 0) {
+      utils.logBullet(output);
+    } else {
+      utils.logBullet("Successfully uploaded all symbols");
+    }
+  });
+
+function getGoogleAppID(options: Options): string | null {
+  if (!options.app) {
+    throw new FirebaseError("set the --app option to a valid Firebase app id and try again");
+  }
+  return options.app;
+}
+
+function getSymbolGenerator(options: Options): SymbolGenerator {
+  // Default to using BreakPad symbols
+  if (!options.generator) {
+    return SymbolGenerator.breakpad;
+  }
+  if (!Object.values(SymbolGenerator).includes(options.generator)) {
+    throw new FirebaseError('--symbol-generator should be set to either "breakpad" or "csym"');
+  }
+  return options.generator;
+}
+
+async function downloadBuiltoolsJar(): Promise<string> {
+  const jarPath = path.join(JAR_CACHE_DIR, `crashlytics-buildtools-${JAR_VERSION}.jar`);
+  if (fs.existsSync(jarPath)) {
+    logger.debug(`Buildtools Jar already downloaded at ${jarPath}`);
+    return jarPath;
+  }
+  // If the Jar cache directory exists, but the jar for the current version
+  // doesn't, then we're running the CLI with a new Jar version and we can
+  // delete the old version.
+  if (fs.existsSync(JAR_CACHE_DIR)) {
+    logger.debug(
+      `Deleting Jar cache at ${JAR_CACHE_DIR} because the CLI was run with a newer Jar version`
+    );
+    rimraf.sync(JAR_CACHE_DIR);
+  }
+  utils.logBullet("Downloading buildtools.jar to " + jarPath);
+  utils.logBullet(
+    "For open source licenses used by this command, look in the META-INF directory in the buildtools.jar file"
+  );
+  const tmpfile = await downloadUtils.downloadToTmp(JAR_URL);
+  fs.mkdirSync(JAR_CACHE_DIR, { recursive: true });
+  fs.copySync(tmpfile, jarPath);
+  return jarPath;
+}
+
+function buildArgs(options: JarOptions): string[] {
+  const baseArgs = [
+    "-jar",
+    options.jarFile,
+    `-symbolGenerator=${options.generator}`,
+    `-symbolFileCacheDir=${options.cachePath}`,
+    "-verbose",
+  ];
+
+  if (options.generate) {
+    return baseArgs.concat(["-generateNativeSymbols", `-unstrippedLibrary=${options.symbolFile}`]);
+  }
+
+  return baseArgs.concat([
+    "-uploadNativeSymbols",
+    `-googleAppId=${options.app}`,
+    // `-androidApplicationId=`,
+  ]);
+}
+
+function runJar(args: string[], debug: boolean): string {
+  // Inherit is better for debug output because it'll print as it goes. If we
+  // pipe here and print after it'll wait until the command has finished to
+  // print all the output.
+  const outputs = spawn.sync("java", args, {
+    stdio: debug ? "inherit" : "pipe",
+  });
+
+  if (outputs.status || 0 > 0) {
+    if (!debug) {
+      utils.logWarning(outputs.stdout?.toString() || "An unknown error occurred");
+    }
+    throw new FirebaseError("Failed to upload symbols");
+  }
+
+  // This is a bit gross, but since we don't have a great way to communicate
+  // between the buildtools.jar and the CLI, we just pull the logs out of the
+  // jar output.
+  if (!debug) {
+    let logRegex = /(Generated symbol file.*$)/m;
+    let matched = (outputs.stdout?.toString() || "").match(logRegex);
+    if (matched) {
+      return matched[1];
+    }
+    logRegex = /(Crashlytics symbol file uploaded successfully.*$)/m;
+    matched = (outputs.stdout?.toString() || "").match(logRegex);
+    if (matched) {
+      return matched[1];
+    }
+    return "";
+  }
+  return "";
+}

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -64,6 +64,8 @@ export default new Command("ext:configure <extensionInstanceId>")
         paramSpecs: paramSpecWithNewDefaults,
         nonInteractive: options.nonInteractive,
         paramsEnvPath: options.params,
+        instanceId,
+        reconfiguring: true,
       });
       if (immutableParams.length) {
         const plural = immutableParams.length > 1;

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -14,6 +14,7 @@ import { Command } from "../command";
 import { FirebaseError } from "../error";
 import { needProjectId } from "../projectUtils";
 import * as extensionsApi from "../extensions/extensionsApi";
+import * as secretsUtils from "../extensions/secretsUtils";
 import * as provisioningHelper from "../extensions/provisioningHelper";
 import * as refs from "../extensions/refs";
 import { displayWarningPrompts } from "../extensions/warnings";
@@ -70,7 +71,8 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
   try {
     await provisioningHelper.checkProductsProvisioned(projectId, spec);
 
-    if (spec.billingRequired) {
+    const usesSecrets = secretsUtils.usesSecrets(spec);
+    if (spec.billingRequired || usesSecrets) {
       const enabled = await checkBillingEnabled(projectId);
       if (!enabled && nonInteractive) {
         throw new FirebaseError(
@@ -86,6 +88,26 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
         await displayNode10CreateBillingNotice(spec, !nonInteractive);
       }
     }
+    const apis = spec.apis || [];
+    if (usesSecrets) {
+      apis.push({
+        apiName: "secretmanager.googleapis.com",
+        reason: `To access and manage secrets which are used by this extension. By using this product you agree to the terms and conditions of the following license: https://console.cloud.google.com/tos?id=cloud&project=${projectId}`,
+      });
+    }
+    if (apis.length) {
+      askUserForConsent.displayApis(spec.displayName || spec.name, projectId, apis);
+      const consented = await confirm({ nonInteractive, force, default: true });
+      if (!consented) {
+        throw new FirebaseError(
+          "Without explicit consent for the APIs listed, we cannot deploy this extension."
+        );
+      }
+    }
+    if (usesSecrets) {
+      await secretsUtils.ensureSecretManagerApiEnabled(options);
+    }
+
     const roles = spec.roles ? spec.roles.map((role: extensionsApi.Role) => role.role) : [];
     if (roles.length) {
       await askUserForConsent.displayRoles(spec.displayName || spec.name, projectId, roles);
@@ -125,6 +147,7 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
           paramSpecs: spec.params,
           nonInteractive,
           paramsEnvPath,
+          instanceId,
         });
         spinner.text = "Installing your extension instance. This usually takes 3 to 5 minutes...";
         spinner.start();
@@ -148,6 +171,7 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
           paramSpecs: spec.params,
           nonInteractive,
           paramsEnvPath,
+          instanceId,
         });
         spinner.text = "Updating your extension instance. This usually takes 3 to 5 minutes...";
         spinner.start();
@@ -233,7 +257,7 @@ async function infoInstallByReference(
   }
   const extVersion = await extensionsApi.getExtensionVersion(extensionName);
   displayExtInfo(extensionName, ref.publisherId, extVersion.spec, true);
-  displayWarningPrompts(ref.publisherId, extension.registryLaunchStage, extVersion);
+  await displayWarningPrompts(ref.publisherId, extension.registryLaunchStage, extVersion);
   return extVersion;
 }
 

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -9,6 +9,7 @@ import { Command } from "../command";
 import { FirebaseError } from "../error";
 import { needProjectId } from "../projectUtils";
 import * as extensionsApi from "../extensions/extensionsApi";
+import * as secretsUtils from "../extensions/secretsUtils";
 import {
   ensureExtensionsApiEnabled,
   logPrefix,
@@ -70,6 +71,7 @@ export default new Command("ext:uninstall <extensionInstanceId>")
       const serviceAccountMessage = `Uninstalling deletes the service account used by this extension instance:\n${clc.bold(
         instance.serviceAccountEmail
       )}\n\n`;
+      const managedSecrets = await secretsUtils.getManagedSecrets(instance);
       const resourcesMessage = _.get(instance, "config.source.spec.resources", []).length
         ? "Uninstalling deletes all extension resources created for this extension instance:\n" +
           instance.config.source.spec.resources
@@ -78,6 +80,10 @@ export default new Command("ext:uninstall <extensionInstanceId>")
                 `- ${resourceTypeToNiceName[resource.type] || resource.type}: ${resource.name} \n`
               )
             )
+            .join("") +
+          managedSecrets
+            .map(secretsUtils.prettySecretName)
+            .map((s) => clc.bold(`- Secret: ${s}\n`))
             .join("") +
           "\n"
         : "";

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -11,6 +11,7 @@ import { displayNode10UpdateBillingNotice } from "../extensions/billingMigration
 import { enableBilling } from "../extensions/checkProjectBilling";
 import { checkBillingEnabled } from "../gcp/cloudbilling";
 import * as extensionsApi from "../extensions/extensionsApi";
+import * as secretsUtils from "../extensions/secretsUtils";
 import * as provisioningHelper from "../extensions/provisioningHelper";
 import {
   ensureExtensionsApiEnabled,
@@ -210,7 +211,8 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
 
       await provisioningHelper.checkProductsProvisioned(projectId, newSpec);
 
-      if (newSpec.billingRequired) {
+      const usesSecrets = secretsUtils.usesSecrets(newSpec);
+      if (newSpec.billingRequired || usesSecrets) {
         const enabled = await checkBillingEnabled(projectId);
         displayNode10UpdateBillingNotice(existingSpec, newSpec);
         if (
@@ -235,7 +237,12 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
             );
           }
         }
+        if (usesSecrets) {
+          await secretsUtils.ensureSecretManagerApiEnabled(options);
+        }
       }
+      // make a copy of existingParams -- they get overridden by paramHelper.getParamsForUpdate
+      const oldParamValues = { ...existingParams };
       const newParams = await paramHelper.getParamsForUpdate({
         spec: existingSpec,
         newSpec,
@@ -243,6 +250,7 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
         projectId,
         paramsEnvPath: options.params,
         nonInteractive: options.nonInteractive,
+        instanceId,
       });
       spinner.start();
       const updateOptions: UpdateOptions = {
@@ -254,7 +262,7 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
       } else {
         updateOptions.source = newSource;
       }
-      if (!_.isEqual(newParams, existingParams)) {
+      if (!_.isEqual(newParams, oldParamValues)) {
         updateOptions.params = newParams;
       }
       await update(updateOptions);

--- a/src/commands/functions-config-export.ts
+++ b/src/commands/functions-config-export.ts
@@ -1,0 +1,153 @@
+import * as path from "path";
+
+import * as clc from "cli-color";
+
+import requireInteractive from "../requireInteractive";
+import { Command } from "../command";
+import { FirebaseError } from "../error";
+import { testIamPermissions } from "../gcp/iam";
+import { logger } from "../logger";
+import { resolveProjectPath } from "../projectPath";
+import { promptOnce } from "../prompt";
+import { requirePermissions } from "../requirePermissions";
+import { logBullet, logWarning } from "../utils";
+import { zip } from "../functional";
+import * as configExport from "../functions/runtimeConfigExport";
+import * as requireConfig from "../requireConfig";
+
+import type { Options } from "../options";
+
+const REQUIRED_PERMISSIONS = [
+  "runtimeconfig.configs.list",
+  "runtimeconfig.configs.get",
+  "runtimeconfig.variables.list",
+  "runtimeconfig.variables.get",
+];
+
+const RESERVED_PROJECT_ALIAS = ["local"];
+const MAX_ATTEMPTS = 3;
+
+function checkReservedAliases(pInfos: configExport.ProjectConfigInfo[]): void {
+  for (const pInfo of pInfos) {
+    if (pInfo.alias && RESERVED_PROJECT_ALIAS.includes(pInfo.alias)) {
+      logWarning(
+        `Project alias (${clc.bold(pInfo.alias)}) is reserved for internal use. ` +
+          `Saving exported config in .env.${pInfo.projectId} instead.`
+      );
+      delete pInfo.alias;
+    }
+  }
+}
+
+/* For projects where we failed to fetch the runtime config, find out what permissions are missing in the project. */
+async function checkRequiredPermission(pInfos: configExport.ProjectConfigInfo[]): Promise<void> {
+  pInfos = pInfos.filter((pInfo) => !pInfo.config);
+  const testPermissions = pInfos.map((pInfo) =>
+    testIamPermissions(pInfo.projectId, REQUIRED_PERMISSIONS)
+  );
+  const results = await Promise.all(testPermissions);
+  for (const [pInfo, result] of zip(pInfos, results)) {
+    if (result.passed) {
+      // We should've been able to fetch the config but couldn't. Ask the user to try export command again.
+      throw new FirebaseError(
+        `Unexpectedly failed to fetch runtime config for project ${pInfo.projectId}`
+      );
+    }
+    logWarning(
+      "You are missing the following permissions to read functions config on project " +
+        `${clc.bold(pInfo.projectId)}:\n\t${result.missing.join("\n\t")}`
+    );
+
+    const confirm = await promptOnce({
+      type: "confirm",
+      name: "skip",
+      default: true,
+      message: `Continue without importing configs from project ${pInfo.projectId}?`,
+    });
+
+    if (!confirm) {
+      throw new FirebaseError("Command aborted!");
+    }
+  }
+}
+
+async function promptForPrefix(errMsg: string): Promise<string> {
+  logWarning("The following configs keys could not be exported as environment variables:\n");
+  logWarning(errMsg);
+  return await promptOnce(
+    {
+      type: "input",
+      name: "prefix",
+      default: "CONFIG_",
+      message: "Enter a PREFIX to rename invalid environment variable keys:",
+    },
+    {}
+  );
+}
+
+function fromEntries<V>(itr: Iterable<[string, V]>): Record<string, V> {
+  const obj: Record<string, V> = {};
+  for (const [k, v] of itr) {
+    obj[k] = v;
+  }
+  return obj;
+}
+
+export default new Command("functions:config:export")
+  .description("Export environment config as environment variables in dotenv format")
+  .before(requirePermissions, [
+    "runtimeconfig.configs.list",
+    "runtimeconfig.configs.get",
+    "runtimeconfig.variables.list",
+    "runtimeconfig.variables.get",
+  ])
+  .before(requireConfig)
+  .before(requireInteractive)
+  .action(async (options: Options) => {
+    let pInfos = configExport.getProjectInfos(options);
+    checkReservedAliases(pInfos);
+
+    logBullet(
+      "Importing functions configs from projects [" +
+        pInfos.map(({ projectId }) => `${clc.bold(projectId)}`).join(", ") +
+        "]"
+    );
+
+    await configExport.hydrateConfigs(pInfos);
+    await checkRequiredPermission(pInfos);
+    pInfos = pInfos.filter((pInfo) => pInfo.config);
+
+    logger.debug(`Loaded function configs: ${JSON.stringify(pInfos)}`);
+    logBullet(`Importing configs from projects: [${pInfos.map((p) => p.projectId).join(", ")}]`);
+
+    let attempts = 0;
+    let prefix = "";
+    while (true) {
+      if (attempts >= MAX_ATTEMPTS) {
+        throw new FirebaseError("Exceeded max attempts to fix invalid config keys.");
+      }
+
+      const errMsg = configExport.hydrateEnvs(pInfos, prefix);
+      if (errMsg.length == 0) {
+        break;
+      }
+      prefix = await promptForPrefix(errMsg);
+      attempts += 1;
+    }
+
+    const header = `# Exported firebase functions:config:export command on ${new Date().toLocaleDateString()}`;
+    const dotEnvs = pInfos.map((pInfo) => configExport.toDotenvFormat(pInfo.envs!, header));
+    const filenames = pInfos.map(configExport.generateDotenvFilename);
+    const filesToWrite = fromEntries(zip(filenames, dotEnvs));
+    filesToWrite[
+      ".env.local"
+    ] = `${header}\n# .env.local file contains environment variables for the Functions Emulator.\n`;
+    filesToWrite[
+      ".env"
+    ] = `${header}# .env file contains environment variables that applies to all projects.\n`;
+
+    const functionsDir = options.config.get("functions.source", ".");
+    for (const [filename, content] of Object.entries(filesToWrite)) {
+      await options.config.askWriteProjectFile(path.join(functionsDir, filename), content);
+    }
+  });

--- a/src/commands/functions-delete.ts
+++ b/src/commands/functions-delete.ts
@@ -10,6 +10,7 @@ import * as utils from "../utils";
 import * as args from "../deploy/functions/args";
 import * as backend from "../deploy/functions/backend";
 import { Options } from "../options";
+import { FirebaseError } from "../error";
 
 export default new Command("functions:delete [filters...]")
   .description("delete one or more Cloud Functions by name or group name.")
@@ -33,58 +34,65 @@ export default new Command("functions:delete [filters...]")
     const filterChunks = filters.map((filter: string) => {
       return filter.split(".");
     });
-    const [config, existingBackend] = await Promise.all([
-      functionsConfig.getFirebaseConfig(options),
-      backend.existingBackend(context),
-    ]);
-    await backend.checkAvailability(context, /* want=*/ backend.empty());
-    const appEngineLocation = functionsConfig.getAppEngineLocation(config);
 
-    const functionsToDelete = existingBackend.cloudFunctions.filter((fn) => {
-      const regionMatches = options.region ? fn.region === options.region : true;
-      const nameMatches = helper.functionMatchesAnyGroup(fn, filterChunks);
-      return regionMatches && nameMatches;
-    });
-    if (functionsToDelete.length === 0) {
-      return utils.reject(
-        `The specified filters do not match any existing functions in project ${clc.bold(
-          context.projectId
-        )}.`,
-        { exit: 1 }
+    try {
+      const [config, existingBackend] = await Promise.all([
+        functionsConfig.getFirebaseConfig(options),
+        backend.existingBackend(context),
+      ]);
+      await backend.checkAvailability(context, /* want=*/ backend.empty());
+      const appEngineLocation = functionsConfig.getAppEngineLocation(config);
+
+      const functionsToDelete = existingBackend.cloudFunctions.filter((fn) => {
+        const regionMatches = options.region ? fn.region === options.region : true;
+        const nameMatches = helper.functionMatchesAnyGroup(fn, filterChunks);
+        return regionMatches && nameMatches;
+      });
+      if (functionsToDelete.length === 0) {
+        throw new Error(
+          `The specified filters do not match any existing functions in project ${clc.bold(
+            context.projectId
+          )}.`
+        );
+      }
+
+      const schedulesToDelete = existingBackend.schedules.filter((schedule) => {
+        functionsToDelete.some(backend.sameFunctionName(schedule.targetService));
+      });
+      const topicsToDelete = existingBackend.topics.filter((topic) => {
+        functionsToDelete.some(backend.sameFunctionName(topic.targetService));
+      });
+
+      const deleteList = functionsToDelete
+        .map((func) => {
+          return "\t" + helper.getFunctionLabel(func);
+        })
+        .join("\n");
+      const confirmDeletion = await promptOnce(
+        {
+          type: "confirm",
+          name: "force",
+          default: false,
+          message:
+            "You are about to delete the following Cloud Functions:\n" +
+            deleteList +
+            "\n  Are you sure?",
+        },
+        options
       );
+      if (!confirmDeletion) {
+        throw new Error("Command aborted.");
+      }
+      return await deleteFunctions(
+        functionsToDelete,
+        schedulesToDelete,
+        topicsToDelete,
+        appEngineLocation
+      );
+    } catch (err) {
+      throw new FirebaseError("Failed to delete functions", {
+        original: err,
+        exit: 1,
+      });
     }
-
-    const schedulesToDelete = existingBackend.schedules.filter((schedule) => {
-      functionsToDelete.some(backend.sameFunctionName(schedule.targetService));
-    });
-    const topicsToDelete = existingBackend.topics.filter((topic) => {
-      functionsToDelete.some(backend.sameFunctionName(topic.targetService));
-    });
-
-    const deleteList = functionsToDelete
-      .map((func) => {
-        return "\t" + helper.getFunctionLabel(func);
-      })
-      .join("\n");
-    const confirmDeletion = await promptOnce(
-      {
-        type: "confirm",
-        name: "force",
-        default: false,
-        message:
-          "You are about to delete the following Cloud Functions:\n" +
-          deleteList +
-          "\n  Are you sure?",
-      },
-      options
-    );
-    if (!confirmDeletion) {
-      return utils.reject("Command aborted.", { exit: 1 });
-    }
-    return await deleteFunctions(
-      functionsToDelete,
-      schedulesToDelete,
-      topicsToDelete,
-      appEngineLocation
-    );
   });

--- a/src/commands/functions-list.ts
+++ b/src/commands/functions-list.ts
@@ -46,7 +46,7 @@ export default new Command("functions:list")
       logger.info(table.toString());
       return endpointsList;
     } catch (err) {
-      throw new FirebaseError(`Failed to list functions ${err.message}`, {
+      throw new FirebaseError("Failed to list functions", {
         exit: 1,
         original: err,
       });

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -30,6 +30,11 @@ module.exports = function (client) {
   client.auth = {};
   client.auth.export = loadCommand("auth-export");
   client.auth.upload = loadCommand("auth-import");
+  if (previews.crashlyticsSymbolsUpload) {
+    client.crashlytics = {};
+    client.crashlytics.symbols = {};
+    client.crashlytics.symbols.upload = loadCommand("crashlytics-symbols-upload");
+  }
   client.database = {};
   client.database.get = loadCommand("database-get");
   client.database.instances = {};
@@ -88,6 +93,9 @@ module.exports = function (client) {
   client.functions = {};
   client.functions.config = {};
   client.functions.config.clone = loadCommand("functions-config-clone");
+  if (previews.dotenv) {
+    client.functions.config.export = loadCommand("functions-config-export");
+  }
   client.functions.config.get = loadCommand("functions-config-get");
   client.functions.config.set = loadCommand("functions-config-set");
   client.functions.config.unset = loadCommand("functions-config-unset");

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -461,7 +461,15 @@ async function loadExistingBackend(ctx: Context & PrivateContextFields): Promise
     return;
   }
 
-  const gcfV2Results = await gcfV2.listAllFunctions(ctx.projectId);
+  let gcfV2Results;
+  try {
+    gcfV2Results = await gcfV2.listAllFunctions(ctx.projectId);
+  } catch (err) {
+    if (err.status === 404 && err.message?.toLowerCase().includes("method not found")) {
+      return; // customer has preview enabled without allowlist set
+    }
+    throw err;
+  }
   for (const apiFunction of gcfV2Results.functions) {
     const endpoint = gcfV2.endpointFromFunction(apiFunction);
     ctx.existingBackend.endpoints[endpoint.region] =

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -12,6 +12,13 @@ import * as runtimes from "../../runtimes";
 
 const TRIGGER_PARSER = path.resolve(__dirname, "./triggerParser.js");
 
+export const GCS_EVENTS: Set<string> = new Set<string>([
+  "google.cloud.storage.object.v1.finalized",
+  "google.cloud.storage.object.v1.archived",
+  "google.cloud.storage.object.v1.deleted",
+  "google.cloud.storage.object.v1.metadataUpdated",
+]);
+
 export interface ScheduleRetryConfig {
   retryCount?: number;
   maxRetryDuration?: string;
@@ -172,6 +179,15 @@ export function addResourcesToBackend(
         triggered = { scheduleTrigger: annotation.schedule };
       } else {
         triggered = { eventTrigger: trigger };
+      }
+
+      if (GCS_EVENTS.has(annotation.eventTrigger?.eventType || "")) {
+        trigger.eventFilters = {
+          bucket: annotation.eventTrigger!.resource,
+        };
+        (triggered as backend.EventTriggered).eventTrigger.eventFilters = {
+          bucket: annotation.eventTrigger!.resource,
+        };
       }
     }
     const cloudFunctionName: backend.TargetIds = {

--- a/src/deploy/functions/triggerRegionHelper.ts
+++ b/src/deploy/functions/triggerRegionHelper.ts
@@ -1,0 +1,51 @@
+import * as backend from "./backend";
+import * as storage from "../../gcp/storage";
+import { FirebaseError } from "../../error";
+import { logger } from "../../logger";
+
+const noop = (): Promise<void> => Promise.resolve();
+
+const LOOKUP_BY_EVENT_TYPE: Record<string, (ep: backend.EventTriggered) => Promise<void>> = {
+  "google.cloud.pubsub.topic.v1.messagePublished": noop,
+  "google.cloud.storage.object.v1.finalized": lookupBucketRegion,
+  "google.cloud.storage.object.v1.archived": lookupBucketRegion,
+  "google.cloud.storage.object.v1.deleted": lookupBucketRegion,
+  "google.cloud.storage.object.v1.metadataUpdated": lookupBucketRegion,
+};
+
+/**
+ * Sets the trigger region to what we currently have deployed
+ * @param want the list of function specs we want to deploy
+ * @param have the list of function specs we have deployed
+ */
+export async function lookupMissingTriggerRegions(want: backend.Backend): Promise<void> {
+  const regionLookups: Array<Promise<void>> = [];
+  for (const ep of backend.allEndpoints(want)) {
+    if (ep.platform === "gcfv1" || !backend.isEventTriggered(ep) || ep.eventTrigger.region) {
+      continue;
+    }
+    const lookup = LOOKUP_BY_EVENT_TYPE[ep.eventTrigger.eventType];
+    if (!lookup) {
+      logger.debug(
+        "Don't know how to look up trigger region for event type",
+        ep.eventTrigger.eventType,
+        ". Deploy will fail unless this event type is global"
+      );
+      continue;
+    }
+    regionLookups.push(lookup(ep));
+  }
+  await Promise.all(regionLookups);
+}
+
+/** Sets a GCS event trigger's region to the region of its bucket. */
+async function lookupBucketRegion(endpoint: backend.EventTriggered): Promise<void> {
+  try {
+    const bucket: { location: string } = await storage.getBucket(
+      endpoint.eventTrigger.eventFilters.bucket!
+    );
+    endpoint.eventTrigger.region = bucket.location.toLowerCase();
+  } catch (err) {
+    throw new FirebaseError("Can't find the storage bucket region", { original: err });
+  }
+}

--- a/src/downloadUtils.ts
+++ b/src/downloadUtils.ts
@@ -1,0 +1,45 @@
+import { URL } from "url";
+import * as fs from "fs-extra";
+import * as ProgressBar from "progress";
+import * as tmp from "tmp";
+
+import { Client } from "./apiv2";
+import { FirebaseError } from "./error";
+
+/**
+ * Downloads the resource at `remoteUrl` to a temporary file.
+ * Resolves to the temporary file's name, rejects if there's any error.
+ * @param remoteUrl URL to download.
+ */
+export async function downloadToTmp(remoteUrl: string): Promise<string> {
+  const u = new URL(remoteUrl);
+  const c = new Client({ urlPrefix: u.origin, auth: false });
+  const tmpfile = tmp.fileSync();
+  const writeStream = fs.createWriteStream(tmpfile.name);
+
+  const res = await c.request<void, NodeJS.ReadableStream>({
+    method: "GET",
+    path: u.pathname,
+    queryParams: u.searchParams,
+    responseType: "stream",
+    resolveOnHTTPError: true,
+  });
+  if (res.status !== 200) {
+    throw new FirebaseError(`download failed, status ${res.status}`, { exit: 1 });
+  }
+
+  const total = parseInt(res.response.headers.get("content-length") || "0", 10);
+  const totalMb = Math.ceil(total / 1000000);
+  const bar = new ProgressBar(`Progress: :bar (:percent of ${totalMb}MB)`, { total, head: ">" });
+
+  res.body.on("data", (chunk) => {
+    bar.tick(chunk.length);
+  });
+
+  await new Promise((resolve) => {
+    writeStream.on("finish", resolve);
+    res.body.pipe(writeStream);
+  });
+
+  return tmpfile.name;
+}

--- a/src/emulator/auth/apiSpec.js
+++ b/src/emulator/auth/apiSpec.js
@@ -2148,6 +2148,75 @@ export default {
         { $ref: "#/components/parameters/upload_protocol" },
       ],
     },
+    "/v2/projects/{targetProjectId}/config": {
+      get: {
+        description: "Retrieve an Identity Toolkit project configuration.",
+        operationId: "identitytoolkit.projects.getConfig",
+        responses: {
+          200: {
+            description: "Successful response",
+            content: {
+              "*/*": {
+                schema: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Config" },
+              },
+            },
+          },
+        },
+        parameters: [
+          { name: "targetProjectId", in: "path", required: true, schema: { type: "string" } },
+        ],
+        security: [{ Oauth2: ["https://www.googleapis.com/auth/cloud-platform"] }, { apiKey: [] }],
+        tags: ["projects"],
+      },
+      patch: {
+        description: "Update an Identity Toolkit project configuration.",
+        operationId: "identitytoolkit.projects.updateConfig",
+        responses: {
+          200: {
+            description: "Successful response",
+            content: {
+              "*/*": {
+                schema: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Config" },
+              },
+            },
+          },
+        },
+        parameters: [
+          { name: "targetProjectId", in: "path", required: true, schema: { type: "string" } },
+          {
+            name: "updateMask",
+            in: "query",
+            description:
+              "The update mask applies to the resource. Fields set in the config but not included in this update mask will be ignored. For the `FieldMask` definition, see https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask",
+            schema: { type: "string" },
+          },
+        ],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Config" },
+            },
+          },
+        },
+        security: [
+          { Oauth2: ["https://www.googleapis.com/auth/cloud-platform"] },
+          { Oauth2: ["https://www.googleapis.com/auth/firebase"] },
+          { apiKey: [] },
+        ],
+        tags: ["projects"],
+      },
+      parameters: [
+        { $ref: "#/components/parameters/access_token" },
+        { $ref: "#/components/parameters/alt" },
+        { $ref: "#/components/parameters/callback" },
+        { $ref: "#/components/parameters/fields" },
+        { $ref: "#/components/parameters/oauth_token" },
+        { $ref: "#/components/parameters/prettyPrint" },
+        { $ref: "#/components/parameters/quotaUser" },
+        { $ref: "#/components/parameters/uploadType" },
+        { $ref: "#/components/parameters/upload_protocol" },
+      ],
+    },
     "/v2/projects/{targetProjectId}/defaultSupportedIdpConfigs": {
       post: {
         description:
@@ -3725,12 +3794,84 @@ export default {
         tags: ["emulator"],
       },
     },
+    "/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/oobCodes": {
+      parameters: [
+        {
+          name: "targetProjectId",
+          in: "path",
+          description: "The ID of the Google Cloud project that the confirmation codes belongs to.",
+          required: true,
+          schema: { type: "string" },
+        },
+        {
+          name: "tenantId",
+          in: "path",
+          description:
+            "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+      servers: [{ url: "" }],
+      get: {
+        description: "List all pending confirmation codes for the project.",
+        operationId: "emulator.projects.oobCodes.list",
+        responses: {
+          200: {
+            description: "Successful response",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes" },
+              },
+            },
+          },
+        },
+        security: [],
+        tags: ["emulator"],
+      },
+    },
     "/emulator/v1/projects/{targetProjectId}/verificationCodes": {
       parameters: [
         {
           name: "targetProjectId",
           in: "path",
           description: "The ID of the Google Cloud project that the verification codes belongs to.",
+          required: true,
+          schema: { type: "string" },
+        },
+      ],
+      servers: [{ url: "" }],
+      get: {
+        description: "List all pending phone verification codes for the project.",
+        operationId: "emulator.projects.verificationCodes.list",
+        responses: {
+          200: {
+            description: "Successful response",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/EmulatorV1ProjectsOobCodes" },
+              },
+            },
+          },
+        },
+        security: [],
+        tags: ["emulator"],
+      },
+    },
+    "/emulator/v1/projects/{targetProjectId}/tenants/{tenantId}/verificationCodes": {
+      parameters: [
+        {
+          name: "targetProjectId",
+          in: "path",
+          description: "The ID of the Google Cloud project that the verification codes belongs to.",
+          required: true,
+          schema: { type: "string" },
+        },
+        {
+          name: "tenantId",
+          in: "path",
+          description:
+            "The ID of the Identity Platform tenant the accounts belongs to. If not specified, accounts on the Identity Platform project are returned.",
           required: true,
           schema: { type: "string" },
         },
@@ -5869,6 +6010,16 @@ export default {
         },
         type: "object",
       },
+      GoogleCloudIdentitytoolkitAdminV2Anonymous: {
+        description: "Configuration options related to authenticating an anonymous user.",
+        properties: {
+          enabled: {
+            description: "Whether anonymous user auth is enabled for the project or not.",
+            type: "boolean",
+          },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitAdminV2AppleSignInConfig: {
         description: "Additional config for SignInWithApple.",
         properties: {
@@ -5883,6 +6034,44 @@ export default {
         },
         type: "object",
       },
+      GoogleCloudIdentitytoolkitAdminV2BlockingFunctionsConfig: {
+        description: "Configuration related to Blocking Functions.",
+        properties: {
+          forwardInboundCredentials: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2ForwardInboundCredentials",
+          },
+          triggers: {
+            additionalProperties: {
+              $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Trigger",
+            },
+            description:
+              'Map of Trigger to event type. Key should be one of the supported event types: "beforeCreate", "beforeSignIn"',
+            type: "object",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2ClientConfig: {
+        description:
+          "Options related to how clients making requests on behalf of a project should be configured.",
+        properties: {
+          apiKey: {
+            description:
+              "Output only. API key that can be used when making requests for this project.",
+            readOnly: true,
+            type: "string",
+          },
+          firebaseSubdomain: {
+            description: "Output only. Firebase subdomain.",
+            readOnly: true,
+            type: "string",
+          },
+          permissions: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Permissions",
+          },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitAdminV2CodeFlowConfig: {
         description: "Additional config for Apple for code flow.",
         properties: {
@@ -5892,6 +6081,47 @@ export default {
             type: "string",
           },
           teamId: { description: "Apple Developer Team ID.", type: "string" },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2Config: {
+        description: "Represents an Identity Toolkit project.",
+        properties: {
+          authorizedDomains: {
+            description: "List of domains authorized for OAuth redirects",
+            items: { type: "string" },
+            type: "array",
+          },
+          blockingFunctions: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2BlockingFunctionsConfig",
+          },
+          client: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2ClientConfig" },
+          mfa: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig",
+          },
+          monitoring: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2MonitoringConfig",
+          },
+          multiTenant: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2MultiTenantConfig",
+          },
+          name: {
+            description:
+              'Output only. The name of the Config resource. Example: "projects/my-awesome-project/config"',
+            readOnly: true,
+            type: "string",
+          },
+          notification: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2NotificationConfig",
+          },
+          quota: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2QuotaConfig" },
+          signIn: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2SignInConfig" },
+          subtype: {
+            description: "Output only. The subtype of this config.",
+            enum: ["SUBTYPE_UNSPECIFIED", "IDENTITY_PLATFORM", "FIREBASE_AUTH"],
+            readOnly: true,
+            type: "string",
+          },
         },
         type: "object",
       },
@@ -5920,6 +6150,100 @@ export default {
             description:
               'The name of the DefaultSupportedIdpConfig resource, for example: "projects/my-awesome-project/defaultSupportedIdpConfigs/google.com"',
             type: "string",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2DnsInfo: {
+        description:
+          "Information of custom domain DNS verification. By default, default_domain will be used. A custom domain can be configured using VerifyCustomDomain.",
+        properties: {
+          customDomain: {
+            description: "Output only. The applied verified custom domain.",
+            readOnly: true,
+            type: "string",
+          },
+          customDomainState: {
+            description:
+              "Output only. The current verification state of the custom domain. The custom domain will only be used once the domain verification is successful.",
+            enum: [
+              "VERIFICATION_STATE_UNSPECIFIED",
+              "NOT_STARTED",
+              "IN_PROGRESS",
+              "FAILED",
+              "SUCCEEDED",
+            ],
+            readOnly: true,
+            type: "string",
+          },
+          domainVerificationRequestTime: {
+            description:
+              "Output only. The timestamp of initial request for the current domain verification.",
+            format: "google-datetime",
+            readOnly: true,
+            type: "string",
+          },
+          pendingCustomDomain: {
+            description: "Output only. The custom domain that's to be verified.",
+            readOnly: true,
+            type: "string",
+          },
+          useCustomDomain: { description: "Whether to use custom domain.", type: "boolean" },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2Email: {
+        description:
+          "Configuration options related to authenticating a user by their email address.",
+        properties: {
+          enabled: {
+            description: "Whether email auth is enabled for the project or not.",
+            type: "boolean",
+          },
+          passwordRequired: {
+            description:
+              "Whether a password is required for email auth or not. If true, both an email and password must be provided to sign in. If false, a user may sign in via either email/password or email link.",
+            type: "boolean",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2EmailTemplate: {
+        description:
+          "Email template. The subject and body fields can contain the following placeholders which will be replaced with the appropriate values: %LINK% - The link to use to redeem the send OOB code. %EMAIL% - The email where the email is being sent. %NEW_EMAIL% - The new email being set for the account (when applicable). %APP_NAME% - The GCP project's display name. %DISPLAY_NAME% - The user's display name.",
+        properties: {
+          body: { description: "Email body", type: "string" },
+          bodyFormat: {
+            description: "Email body format",
+            enum: ["BODY_FORMAT_UNSPECIFIED", "PLAIN_TEXT", "HTML"],
+            type: "string",
+          },
+          customized: {
+            description: "Output only. Whether the body or subject of the email is customized.",
+            readOnly: true,
+            type: "boolean",
+          },
+          replyTo: { description: "Reply-to address", type: "string" },
+          senderDisplayName: { description: "Sender display name", type: "string" },
+          senderLocalPart: { description: "Local part of From address", type: "string" },
+          subject: { description: "Subject of the email", type: "string" },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2ForwardInboundCredentials: {
+        description: "Indicates which credentials to pass to the registered Blocking Functions.",
+        properties: {
+          accessToken: {
+            description: "Whether to pass the user's OAuth identity provider's access token.",
+            type: "boolean",
+          },
+          idToken: {
+            description: "Whether to pass the user's OIDC identity provider's ID token.",
+            type: "boolean",
+          },
+          refreshToken: {
+            description: "Whether to pass the user's OAuth identity provider's refresh token.",
+            type: "boolean",
           },
         },
         type: "object",
@@ -6121,6 +6445,15 @@ export default {
         },
         type: "object",
       },
+      GoogleCloudIdentitytoolkitAdminV2MonitoringConfig: {
+        description: "Configuration related to monitoring project activity.",
+        properties: {
+          requestLogging: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2RequestLogging",
+          },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig: {
         description: "Options related to MultiFactor Authentication for the project.",
         properties: {
@@ -6134,6 +6467,33 @@ export default {
             enum: ["STATE_UNSPECIFIED", "DISABLED", "ENABLED", "MANDATORY"],
             type: "string",
           },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2MultiTenantConfig: {
+        description: "Configuration related to multi-tenant functionality.",
+        properties: {
+          allowTenants: {
+            description: "Whether this project can have tenants or not.",
+            type: "boolean",
+          },
+          defaultTenantLocation: {
+            description:
+              'The default cloud parent org or folder that the tenant project should be created under. The parent resource name should be in the format of "/", such as "folders/123" or "organizations/456". If the value is not set, the tenant will be created under the same organization or folder as the agent project.',
+            type: "string",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2NotificationConfig: {
+        description: "Configuration related to sending notifications to users.",
+        properties: {
+          defaultLocale: {
+            description: "Default locale used for email and SMS in IETF BCP 47 format.",
+            type: "string",
+          },
+          sendEmail: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2SendEmail" },
+          sendSms: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2SendSms" },
         },
         type: "object",
       },
@@ -6185,6 +6545,144 @@ export default {
         },
         type: "object",
       },
+      GoogleCloudIdentitytoolkitAdminV2Permissions: {
+        description:
+          "Configuration related to restricting a user's ability to affect their account.",
+        properties: {
+          disabledUserDeletion: {
+            description:
+              "When true, end users cannot delete their account on the associated project through any of our API methods",
+            type: "boolean",
+          },
+          disabledUserSignup: {
+            description:
+              "When true, end users cannot sign up for a new account on the associated project through any of our API methods",
+            type: "boolean",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2PhoneNumber: {
+        description: "Configuration options related to authenticated a user by their phone number.",
+        properties: {
+          enabled: {
+            description: "Whether phone number auth is enabled for the project or not.",
+            type: "boolean",
+          },
+          testPhoneNumbers: {
+            additionalProperties: { type: "string" },
+            description: "A map of that can be used for phone auth testing.",
+            type: "object",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2QuotaConfig: {
+        description: "Configuration related to quotas.",
+        properties: {
+          signUpQuotaConfig: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2TemporaryQuota",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2RequestLogging: {
+        description:
+          "Configuration for logging requests made to this project to Stackdriver Logging",
+        properties: {
+          enabled: {
+            description: "Whether logging is enabled for this project or not.",
+            type: "boolean",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2SendEmail: {
+        description: "Options for email sending.",
+        properties: {
+          callbackUri: { description: "action url in email template.", type: "string" },
+          changeEmailTemplate: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2EmailTemplate",
+          },
+          dnsInfo: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2DnsInfo" },
+          legacyResetPasswordTemplate: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2EmailTemplate",
+          },
+          method: {
+            description: "The method used for sending an email.",
+            enum: ["METHOD_UNSPECIFIED", "DEFAULT", "CUSTOM_SMTP"],
+            type: "string",
+          },
+          resetPasswordTemplate: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2EmailTemplate",
+          },
+          revertSecondFactorAdditionTemplate: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2EmailTemplate",
+          },
+          smtp: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Smtp" },
+          verifyEmailTemplate: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2EmailTemplate",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2SendSms: {
+        description: "Options for SMS sending.",
+        properties: {
+          smsTemplate: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2SmsTemplate",
+          },
+          useDeviceLocale: {
+            description: "Whether to use the accept_language header for SMS.",
+            type: "boolean",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2SignInConfig: {
+        description: "Configuration related to local sign in methods.",
+        properties: {
+          allowDuplicateEmails: {
+            description: "Whether to allow more than one account to have the same email.",
+            type: "boolean",
+          },
+          anonymous: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Anonymous" },
+          email: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2Email" },
+          hashConfig: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2HashConfig" },
+          phoneNumber: {
+            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2PhoneNumber",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2SmsTemplate: {
+        description: "The template to use when sending an SMS.",
+        properties: {
+          content: {
+            description:
+              "Output only. The SMS's content. Can contain the following placeholders which will be replaced with the appropriate values: %APP_NAME% - For Android or iOS apps, the app's display name. For web apps, the domain hosting the application. %LOGIN_CODE% - The OOB code being sent in the SMS.",
+            readOnly: true,
+            type: "string",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2Smtp: {
+        description: "Configuration for SMTP relay",
+        properties: {
+          host: { description: "SMTP relay host", type: "string" },
+          password: { description: "SMTP relay password", type: "string" },
+          port: { description: "SMTP relay port", format: "int32", type: "integer" },
+          securityMode: {
+            description: "SMTP security mode.",
+            enum: ["SECURITY_MODE_UNSPECIFIED", "SSL", "START_TLS"],
+            type: "string",
+          },
+          senderEmail: { description: "Sender email for the SMTP relay", type: "string" },
+          username: { description: "SMTP relay username", type: "string" },
+        },
+        type: "object",
+      },
       GoogleCloudIdentitytoolkitAdminV2SpCertificate: {
         description:
           "The SP's certificate data for IDP to verify the SAMLRequest generated by the SP.",
@@ -6214,6 +6712,27 @@ export default {
             type: "array",
           },
           spEntityId: { description: "Unique identifier for all SAML entities.", type: "string" },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2TemporaryQuota: {
+        description: "Temporary quota increase / decrease",
+        properties: {
+          quota: {
+            description: "Corresponds to the 'refill_token_count' field in QuotaServer config",
+            format: "int64",
+            type: "string",
+          },
+          quotaDuration: {
+            description: "How long this quota will be active for",
+            format: "google-duration",
+            type: "string",
+          },
+          startTime: {
+            description: "When this quota will take affect",
+            format: "google-datetime",
+            type: "string",
+          },
         },
         type: "object",
       },
@@ -6256,6 +6775,18 @@ export default {
             description:
               "A map of pairs that can be used for MFA. The phone number should be in E.164 format (https://www.itu.int/rec/T-REC-E.164/) and a maximum of 10 pairs can be added (error will be thrown once exceeded).",
             type: "object",
+          },
+        },
+        type: "object",
+      },
+      GoogleCloudIdentitytoolkitAdminV2Trigger: {
+        description: "Synchronous Cloud Function with HTTP Trigger",
+        properties: {
+          functionUri: { description: "HTTP URI trigger for the Cloud Function.", type: "string" },
+          updateTime: {
+            description: "When the trigger was changed.",
+            format: "google-datetime",
+            type: "string",
           },
         },
         type: "object",
@@ -6578,7 +7109,7 @@ export default {
           },
           bindings: {
             description:
-              "Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member.",
+              "Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member. The `bindings` in a `Policy` can refer to up to 1,500 members; up to 250 of these members can be Google groups. Each occurrence of a member counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other member, then you can add another 1,450 members to the `bindings` in the `Policy`.",
             items: { $ref: "#/components/schemas/GoogleIamV1Binding" },
             type: "array",
           },

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -12,10 +12,13 @@ import { PROVIDERS_LIST_PLACEHOLDER, WIDGET_UI } from "./widget_ui";
  */
 export function registerHandlers(
   app: express.Express,
-  getProjectStateByApiKey: (apiKey: string) => ProjectState
+  getProjectStateByApiKey: (apiKey: string, tenantId?: string) => ProjectState
 ): void {
   app.get(`/emulator/action`, (req, res) => {
-    const { mode, oobCode, continueUrl, apiKey } = req.query as Record<string, string | undefined>;
+    const { mode, oobCode, continueUrl, apiKey, tenantId } = req.query as Record<
+      string,
+      string | undefined
+    >;
 
     if (!apiKey) {
       return res.status(400).json({
@@ -33,7 +36,7 @@ export function registerHandlers(
         },
       });
     }
-    const state = getProjectStateByApiKey(apiKey);
+    const state = getProjectStateByApiKey(apiKey, tenantId);
 
     switch (mode) {
       case "recoverEmail": {
@@ -169,6 +172,7 @@ export function registerHandlers(
     res.set("Content-Type", "text/html; charset=utf-8");
     const apiKey = req.query.apiKey as string | undefined;
     const providerId = req.query.providerId as string | undefined;
+    const tenantId = req.query.tenantId as string | undefined;
     if (!apiKey || !providerId) {
       return res.status(400).json({
         authEmulator: {
@@ -176,7 +180,7 @@ export function registerHandlers(
         },
       });
     }
-    const state = getProjectStateByApiKey(apiKey);
+    const state = getProjectStateByApiKey(apiKey, tenantId);
     const providerInfos = state.listProviderInfosByProviderId(providerId);
 
     const options = providerInfos

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -31,6 +31,7 @@ import {
   SecondFactorRecord,
   UsageMode,
   AgentProjectState,
+  TenantProjectState,
 } from "./state";
 import { MfaEnrollments, Schemas } from "./types";
 
@@ -82,6 +83,25 @@ export const authOperations: AuthOps = {
         batchDelete,
         batchGet,
       },
+      tenants: {
+        create: createTenant,
+        delete: deleteTenant,
+        get: getTenant,
+        list: listTenants,
+        patch: updateTenant,
+        createSessionCookie,
+        accounts: {
+          _: signUp,
+          batchCreate,
+          batchDelete,
+          batchGet,
+          delete: deleteAccount,
+          lookup,
+          query: queryAccounts,
+          sendOobCode,
+          update: setAccountInfo,
+        },
+      },
     },
   },
   securetoken: {
@@ -126,6 +146,7 @@ function signUp(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignUpRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1SignUpResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   let provider: string | undefined;
   const updates: Omit<Partial<UserInfo>, "localId" | "providerUserInfo"> = {
@@ -163,9 +184,11 @@ function signUp(
       assert(reqBody.email, "MISSING_EMAIL");
       assert(reqBody.password, "MISSING_PASSWORD");
       provider = PROVIDER_PASSWORD;
+      assert(state.allowPasswordSignup, "OPERATION_NOT_ALLOWED");
     } else {
       // Most attributes are ignored when creating anon user without privilege.
       provider = PROVIDER_ANONYMOUS;
+      assert(state.enableAnonymousUser, "ADMIN_ONLY_OPERATION");
     }
   }
 
@@ -189,6 +212,9 @@ function signUp(
     updates.mfaInfo = getMfaEnrollmentsFromRequest(state, reqBody.mfaInfo, {
       generateEnrollmentIds: true,
     });
+  }
+  if (reqBody.tenantId) {
+    updates.tenantId = reqBody.tenantId;
   }
   let user: UserInfo | undefined;
   if (reqBody.idToken) {
@@ -220,6 +246,7 @@ function lookup(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1GetAccountInfoRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1GetAccountInfoResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   const seenLocalIds = new Set<string>();
   const users: UserInfo[] = [];
   function tryAddUser(maybeUser: UserInfo | undefined): void {
@@ -267,6 +294,7 @@ function batchCreate(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1UploadAccountRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1UploadAccountResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   assert(reqBody.users?.length, "MISSING_USER_ACCOUNT");
 
@@ -316,6 +344,13 @@ function batchCreate(
         photoUrl: userInfo.photoUrl,
         lastLoginAt: userInfo.lastLoginAt,
       };
+      if (userInfo.tenantId) {
+        assert(
+          state instanceof TenantProjectState && state.tenantId === userInfo.tenantId,
+          "Tenant id in userInfo does not match the tenant id in request."
+        );
+        fields.tenantId = state.tenantId;
+      }
 
       // password
       if (userInfo.passwordHash) {
@@ -484,6 +519,7 @@ function batchGet(
   reqBody: unknown,
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1DownloadAccountResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   const maxResults = Math.min(Math.floor(ctx.params.query.maxResults) || 20, 1000);
 
   const users = state.queryUsers(
@@ -511,6 +547,7 @@ function createAuthUri(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1CreateAuthUriRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1CreateAuthUriResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   const sessionId = reqBody.sessionId || randomId(27);
   if (reqBody.providerId) {
@@ -617,6 +654,7 @@ function deleteAccount(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1DeleteAccountRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1DeleteAccountResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   let user: UserInfo;
   if (ctx.security?.Oauth2) {
     assert(reqBody.localId, "MISSING_LOCAL_ID");
@@ -638,6 +676,8 @@ function deleteAccount(
 function getProjects(
   state: ProjectState
 ): Schemas["GoogleCloudIdentitytoolkitV1GetProjectConfigResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state instanceof AgentProjectState, "UNSUPPORTED_TENANT_OPERATION");
   return {
     projectId: state.projectNumber,
     authorizedDomains: [
@@ -649,7 +689,10 @@ function getProjects(
   };
 }
 
-function getRecaptchaParams(): Schemas["GoogleCloudIdentitytoolkitV1GetRecaptchaParamResponse"] {
+function getRecaptchaParams(
+  state: ProjectState
+): Schemas["GoogleCloudIdentitytoolkitV1GetRecaptchaParamResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   return {
     kind: "identitytoolkit#GetRecaptchaParamResponse",
 
@@ -668,6 +711,7 @@ function queryAccounts(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1QueryUserInfoRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1QueryUserInfoResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   if (reqBody.expression?.length) {
     throw new NotImplementedError("expression is not implemented.");
   }
@@ -726,7 +770,9 @@ export function resetPassword(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1ResetPasswordRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1ResetPasswordResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
+  assert(state.allowPasswordSignup, "PASSWORD_LOGIN_DISABLED");
   assert(reqBody.oobCode, "MISSING_OOB_CODE");
   const oob = state.validateOobCode(reqBody.oobCode);
   assert(oob, "INVALID_OOB_CODE");
@@ -772,6 +818,7 @@ function sendOobCode(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1GetOobCodeRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1GetOobCodeResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   assert(
     reqBody.requestType && reqBody.requestType !== "OOB_REQ_TYPE_UNSPECIFIED",
@@ -792,6 +839,7 @@ function sendOobCode(
 
   switch (reqBody.requestType) {
     case "EMAIL_SIGNIN":
+      assert(state.enableEmailLinkSignin, "OPERATION_NOT_ALLOWED");
       mode = "signIn";
       assert(reqBody.email, "MISSING_EMAIL");
       email = canonicalizeEmailAddress(reqBody.email);
@@ -859,6 +907,8 @@ function sendVerificationCode(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SendVerificationCodeRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SendVerificationCodeResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state instanceof AgentProjectState, "UNSUPPORTED_TENANT_OPERATION");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   // reqBody.iosReceipt, iosSecret, and recaptchaToken are intentionally ignored.
 
@@ -894,6 +944,7 @@ function setAccountInfo(
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SetAccountInfoRequest"],
   ctx: ExegesisContext
 ): Schemas["GoogleCloudIdentitytoolkitV1SetAccountInfoResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   const url = authEmulatorUrl(ctx.req as express.Request);
   return setAccountInfoImpl(state, reqBody, {
@@ -1167,6 +1218,10 @@ function createOobRecord(
       url.searchParams.set("continueUrl", params.continueUrl);
     }
 
+    if (state instanceof TenantProjectState) {
+      url.searchParams.set("tenantId", state.tenantId);
+    }
+
     return url.toString();
   });
 
@@ -1204,10 +1259,17 @@ function signInWithCustomToken(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithCustomTokenRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithCustomTokenResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(reqBody.token, "MISSING_CUSTOM_TOKEN");
 
   // eslint-disable-next-line camelcase
-  let payload: { aud?: unknown; uid?: unknown; user_id?: unknown; claims?: unknown };
+  let payload: {
+    aud?: unknown;
+    uid?: unknown;
+    user_id?: unknown;
+    claims?: unknown;
+    tenantId?: unknown;
+  };
   if (reqBody.token.startsWith("{")) {
     // In the emulator only, we allow plain JSON strings as custom tokens, to
     // simplify testing. This won't work in production.
@@ -1224,6 +1286,9 @@ function signInWithCustomToken(
       header: JwtHeader;
       payload: typeof payload;
     } | null;
+    if (state instanceof TenantProjectState) {
+      assert(decoded?.payload.tenantId === state.tenantId, "TENANT_ID_MISMATCH");
+    }
     assert(decoded, "INVALID_CUSTOM_TOKEN : Invalid assertion format");
     if (decoded.header.alg !== "none") {
       // We may have received a real token, signed using a service account private
@@ -1261,6 +1326,7 @@ function signInWithCustomToken(
   const updates = {
     customAuth: true,
     lastLoginAt: Date.now().toString(),
+    tenantId: state instanceof TenantProjectState ? state.tenantId : undefined,
   };
 
   if (user) {
@@ -1284,6 +1350,8 @@ function signInWithEmailLink(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithEmailLinkRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithEmailLinkResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state.enableEmailLinkSignin, "OPERATION_NOT_ALLOWED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   const userFromIdToken = reqBody.idToken ? parseIdToken(state, reqBody.idToken).user : undefined;
   assert(reqBody.email, "MISSING_EMAIL");
@@ -1298,11 +1366,15 @@ function signInWithEmailLink(
 
   state.deleteOobCode(reqBody.oobCode);
 
-  const updates = {
+  const updates: Omit<Partial<UserInfo>, "localId" | "providerUserInfo"> = {
     email,
     emailVerified: true,
     emailLinkSignin: true,
   };
+
+  if (state instanceof TenantProjectState) {
+    updates.tenantId = state.tenantId;
+  }
 
   let user = state.getUserByEmail(email);
   const isNewUser = !user && !userFromIdToken;
@@ -1325,7 +1397,10 @@ function signInWithEmailLink(
     isNewUser,
   };
 
-  if (user.mfaInfo?.length) {
+  if (
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+    user.mfaInfo?.length
+  ) {
     return { ...response, ...mfaPending(state, user, PROVIDER_PASSWORD) };
   } else {
     user = state.updateUserByLocalId(user.localId, { lastLoginAt: Date.now().toString() });
@@ -1339,6 +1414,7 @@ function signInWithIdp(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithIdpRequest"]
 ): SignInWithIdpResponse {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
 
   if (reqBody.returnRefreshToken) {
@@ -1444,6 +1520,7 @@ function signInWithIdp(
       ...accountUpdates.fields,
       lastLoginAt: Date.now().toString(),
       providerUserInfo: [providerUserInfo],
+      tenantId: state instanceof TenantProjectState ? state.tenantId : undefined,
     });
     response.localId = user.localId;
   } else {
@@ -1465,7 +1542,14 @@ function signInWithIdp(
     response.emailVerified = user.emailVerified;
   }
 
-  if (user.mfaInfo?.length) {
+  if (state instanceof TenantProjectState) {
+    response.tenantId = state.tenantId;
+  }
+
+  if (
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+    user.mfaInfo?.length
+  ) {
     return { ...response, ...mfaPending(state, user, providerId) };
   } else {
     user = state.updateUserByLocalId(user.localId, { lastLoginAt: Date.now().toString() });
@@ -1477,6 +1561,8 @@ function signInWithPassword(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithPasswordRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithPasswordResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state.allowPasswordSignup, "PASSWORD_LOGIN_DISABLED");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   assert(reqBody.email, "MISSING_EMAIL");
   assert(reqBody.password, "MISSING_PASSWORD");
@@ -1503,7 +1589,10 @@ function signInWithPassword(
     email,
   };
 
-  if (user.mfaInfo?.length) {
+  if (
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+    user.mfaInfo?.length
+  ) {
     return { ...response, ...mfaPending(state, user, PROVIDER_PASSWORD) };
   } else {
     user = state.updateUserByLocalId(user.localId, { lastLoginAt: Date.now().toString() });
@@ -1515,6 +1604,8 @@ function signInWithPhoneNumber(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV1SignInWithPhoneNumberRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV1SignInWithPhoneNumberResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(state instanceof AgentProjectState, "UNSUPPORTED_TENANT_OPERATION");
   assert(state.usageMode !== UsageMode.PASSTHROUGH, "UNSUPPORTED_PASSTHROUGH_OPERATION");
   let phoneNumber: string;
   if (reqBody.temporaryProof) {
@@ -1671,6 +1762,12 @@ function mfaEnrollmentStart(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2StartMfaEnrollmentRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2StartMfaEnrollmentResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   assert(reqBody.idToken, "MISSING_ID_TOKEN");
 
   const { user, signInProvider } = parseIdToken(state, reqBody.idToken);
@@ -1718,6 +1815,12 @@ function mfaEnrollmentFinalize(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaEnrollmentRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaEnrollmentResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   assert(reqBody.idToken, "MISSING_ID_TOKEN");
   let { user, signInProvider } = parseIdToken(state, reqBody.idToken);
   assert(
@@ -1774,6 +1877,7 @@ function mfaEnrollmentWithdraw(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2WithdrawMfaRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2WithdrawMfaResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(reqBody.idToken, "MISSING_ID_TOKEN");
 
   let { user, signInProvider } = parseIdToken(state, reqBody.idToken);
@@ -1795,6 +1899,12 @@ function mfaSignInStart(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2StartMfaSignInRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2StartMfaSignInResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   assert(
     reqBody.mfaPendingCredential,
     "MISSING_MFA_PENDING_CREDENTIAL : Request does not have MFA pending credential."
@@ -1835,6 +1945,12 @@ function mfaSignInFinalize(
   state: ProjectState,
   reqBody: Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaSignInRequest"]
 ): Schemas["GoogleCloudIdentitytoolkitV2FinalizeMfaSignInResponse"] {
+  assert(!state.disableAuth, "PROJECT_DISABLED");
+  assert(
+    (state.mfaConfig.state === "ENABLED" || state.mfaConfig.state === "MANDATORY") &&
+      state.mfaConfig.enabledProviders?.includes("PHONE_SMS"),
+    "OPERATION_NOT_ALLOWED : SMS based MFA not enabled."
+  );
   // Inconsistent with mfaSignInStart (where MISSING_MFA_PENDING_CREDENTIAL is
   // returned), but matches production behavior.
   assert(reqBody.mfaPendingCredential, "MISSING_CREDENTIAL : Please set MFA Pending Credential.");
@@ -1921,6 +2037,8 @@ function issueTokens(
 
   const usageMode = state.usageMode === UsageMode.PASSTHROUGH ? "passthrough" : undefined;
 
+  const tenantId = state instanceof TenantProjectState ? state.tenantId : undefined;
+
   const expiresInSeconds = 60 * 60;
   const idToken = generateJwt(user, {
     projectId: state.projectId,
@@ -1929,6 +2047,7 @@ function issueTokens(
     extraClaims,
     secondFactor,
     usageMode,
+    tenantId,
   });
   const refreshToken =
     state.usageMode === UsageMode.DEFAULT
@@ -1969,6 +2088,13 @@ function parseIdToken(
       "Received a signed JWT. Auth Emulator does not validate JWTs and IS NOT SECURE"
     );
   }
+  if (decoded.payload.firebase.tenant) {
+    assert(
+      state instanceof TenantProjectState,
+      "((Parsed token that belongs to tenant in a non-tenant project.))"
+    );
+    assert(decoded.payload.firebase.tenant === state.tenantId, "TENANT_ID_MISMATCH");
+  }
   const user = state.getUserByLocalId(decoded.payload.user_id);
   assert(user, "USER_NOT_FOUND");
   // To make interactive debugging easier, idTokens in the emulator never expire
@@ -1989,6 +2115,7 @@ function generateJwt(
     extraClaims = {},
     secondFactor,
     usageMode,
+    tenantId,
   }: {
     projectId: string;
     signInProvider: string;
@@ -1996,6 +2123,7 @@ function generateJwt(
     extraClaims?: Record<string, unknown>;
     secondFactor?: SecondFactorRecord;
     usageMode?: string;
+    tenantId?: string;
   }
 ): string {
   const identities: Record<string, string[]> = {};
@@ -2041,6 +2169,7 @@ function generateJwt(
       second_factor_identifier: secondFactor?.identifier,
       sign_in_second_factor: secondFactor?.provider,
       usage_mode: usageMode,
+      tenant: tenantId,
     },
   };
   /* eslint-enable camelcase */
@@ -2457,6 +2586,7 @@ interface MfaPendingCredential {
   localId: string;
   signInProvider: string;
   projectId: string;
+  tenantId?: string;
   // MfaPendingCredential in emulator never expire to make interactive debugging
   // a bit easier. Therefore, there's no need to record createdAt timestamps.
 }
@@ -2473,8 +2603,11 @@ function mfaPending(
     _AuthEmulatorMfaPendingCredential: "DO NOT MODIFY",
     localId: user.localId,
     signInProvider,
-    projectId: state.projectId, // TODO: Handle tenants.
+    projectId: state.projectId,
   };
+  if (state instanceof TenantProjectState) {
+    pendingCredentialPayload.tenantId = state.tenantId;
+  }
 
   // Encode pendingCredentialPayload using base64. We don't encrypt or sign the
   // data in the Auth Emulator but just trust developers not to modify it.
@@ -2535,12 +2668,90 @@ function parsePendingCredential(
     pendingCredentialPayload.projectId === state.projectId,
     "INVALID_PROJECT_ID : Project ID does not match MFA pending credential."
   );
+  if (state instanceof TenantProjectState) {
+    assert(
+      pendingCredentialPayload.tenantId === state.tenantId,
+      "INVALID_PROJECT_ID : Project ID does not match MFA pending credential."
+    );
+  }
 
   const { localId, signInProvider } = pendingCredentialPayload;
   const user = state.getUserByLocalId(localId);
   assert(user, "((User in pendingCredentialPayload does not exist.))");
 
   return { user, signInProvider };
+}
+
+function createTenant(
+  state: ProjectState,
+  reqBody: Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"]
+): Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] {
+  if (!(state instanceof AgentProjectState)) {
+    throw new InternalError("INTERNAL_ERROR: Can only create tenant in agent project", "INTERNAL");
+  }
+
+  const tenant = {
+    displayName: reqBody.displayName,
+    allowPasswordSignup: reqBody.allowPasswordSignup,
+    enableEmailLinkSignin: reqBody.enableEmailLinkSignin,
+    enableAnonymousUser: reqBody.enableAnonymousUser,
+    disableAuth: reqBody.disableAuth,
+    mfaConfig: reqBody.mfaConfig,
+    tenantId: "", // Placeholder until one is generated
+  };
+
+  return state.createTenant(tenant);
+}
+
+function listTenants(
+  state: ProjectState,
+  reqBody: unknown,
+  ctx: ExegesisContext
+): Schemas["GoogleCloudIdentitytoolkitAdminV2ListTenantsResponse"] {
+  assert(state instanceof AgentProjectState, "((Can only list tenants in agent project.))");
+  const pageSize = Math.min(Math.floor(ctx.params.query.pageSize) || 20, 1000);
+  const tenants = state.listTenants(ctx.params.query.pageToken);
+
+  // As a non-standard behavior, passing in negative pageSize will
+  // return all users starting from the pageToken.
+  let nextPageToken: string | undefined = undefined;
+  if (pageSize > 0 && tenants.length >= pageSize) {
+    tenants.length = pageSize;
+    nextPageToken = tenants[tenants.length - 1].tenantId;
+  }
+
+  return {
+    nextPageToken,
+    tenants,
+  };
+}
+
+function deleteTenant(
+  state: ProjectState,
+  reqBody: unknown,
+  ctx: ExegesisContext
+): Schemas["GoogleProtobufEmpty"] {
+  assert(state instanceof TenantProjectState, "((Can only delete tenant on tenant projects.))");
+  state.delete();
+  return {};
+}
+
+function getTenant(
+  state: ProjectState,
+  reqBody: unknown,
+  ctx: ExegesisContext
+): Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] {
+  assert(state instanceof TenantProjectState, "((Can only get tenant on tenant projects.))");
+  return state.tenantConfig;
+}
+
+function updateTenant(
+  state: ProjectState,
+  reqBody: Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"],
+  ctx: ExegesisContext
+): Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"] {
+  assert(state instanceof TenantProjectState, "((Can only update tenant on tenant projects.))");
+  return state.updateTenant(reqBody, ctx.params.query.updateMask);
 }
 
 /* eslint-disable camelcase */
@@ -2572,6 +2783,7 @@ export interface FirebaseJwtPayload {
     sign_in_second_factor?: string;
     second_factor_identifier?: string;
     usage_mode?: string;
+    tenant?: string;
   };
   // ...and other fields that we don't care for now.
 }

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -1852,6 +1852,15 @@ export interface components {
       suggestedTimeout?: string;
     };
     /**
+     * Configuration options related to authenticating an anonymous user.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Anonymous: {
+      /**
+       * Whether anonymous user auth is enabled for the project or not.
+       */
+      enabled?: boolean;
+    };
+    /**
      * Additional config for SignInWithApple.
      */
     GoogleCloudIdentitytoolkitAdminV2AppleSignInConfig: {
@@ -1860,6 +1869,32 @@ export interface components {
        */
       bundleIds?: string[];
       codeFlowConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2CodeFlowConfig"];
+    };
+    /**
+     * Configuration related to Blocking Functions.
+     */
+    GoogleCloudIdentitytoolkitAdminV2BlockingFunctionsConfig: {
+      forwardInboundCredentials?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2ForwardInboundCredentials"];
+      /**
+       * Map of Trigger to event type. Key should be one of the supported event types: "beforeCreate", "beforeSignIn"
+       */
+      triggers?: {
+        [key: string]: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Trigger"];
+      };
+    };
+    /**
+     * Options related to how clients making requests on behalf of a project should be configured.
+     */
+    GoogleCloudIdentitytoolkitAdminV2ClientConfig: {
+      /**
+       * Output only. API key that can be used when making requests for this project.
+       */
+      apiKey?: string;
+      /**
+       * Output only. Firebase subdomain.
+       */
+      firebaseSubdomain?: string;
+      permissions?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Permissions"];
     };
     /**
      * Additional config for Apple for code flow.
@@ -1877,6 +1912,31 @@ export interface components {
        * Apple Developer Team ID.
        */
       teamId?: string;
+    };
+    /**
+     * Represents an Identity Toolkit project.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Config: {
+      /**
+       * List of domains authorized for OAuth redirects
+       */
+      authorizedDomains?: string[];
+      blockingFunctions?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2BlockingFunctionsConfig"];
+      client?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2ClientConfig"];
+      mfa?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig"];
+      monitoring?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MonitoringConfig"];
+      multiTenant?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2MultiTenantConfig"];
+      /**
+       * Output only. The name of the Config resource. Example: "projects/my-awesome-project/config"
+       */
+      name?: string;
+      notification?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2NotificationConfig"];
+      quota?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2QuotaConfig"];
+      signIn?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SignInConfig"];
+      /**
+       * Output only. The subtype of this config.
+       */
+      subtype?: "SUBTYPE_UNSPECIFIED" | "IDENTITY_PLATFORM" | "FIREBASE_AUTH";
     };
     /**
      * Standard Identity Toolkit-trusted IDPs.
@@ -1912,6 +1972,99 @@ export interface components {
        * The name of the DefaultSupportedIdpConfig resource, for example: "projects/my-awesome-project/defaultSupportedIdpConfigs/google.com"
        */
       name?: string;
+    };
+    /**
+     * Information of custom domain DNS verification. By default, default_domain will be used. A custom domain can be configured using VerifyCustomDomain.
+     */
+    GoogleCloudIdentitytoolkitAdminV2DnsInfo: {
+      /**
+       * Output only. The applied verified custom domain.
+       */
+      customDomain?: string;
+      /**
+       * Output only. The current verification state of the custom domain. The custom domain will only be used once the domain verification is successful.
+       */
+      customDomainState?:
+        | "VERIFICATION_STATE_UNSPECIFIED"
+        | "NOT_STARTED"
+        | "IN_PROGRESS"
+        | "FAILED"
+        | "SUCCEEDED";
+      /**
+       * Output only. The timestamp of initial request for the current domain verification.
+       */
+      domainVerificationRequestTime?: string;
+      /**
+       * Output only. The custom domain that's to be verified.
+       */
+      pendingCustomDomain?: string;
+      /**
+       * Whether to use custom domain.
+       */
+      useCustomDomain?: boolean;
+    };
+    /**
+     * Configuration options related to authenticating a user by their email address.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Email: {
+      /**
+       * Whether email auth is enabled for the project or not.
+       */
+      enabled?: boolean;
+      /**
+       * Whether a password is required for email auth or not. If true, both an email and password must be provided to sign in. If false, a user may sign in via either email/password or email link.
+       */
+      passwordRequired?: boolean;
+    };
+    /**
+     * Email template. The subject and body fields can contain the following placeholders which will be replaced with the appropriate values: %LINK% - The link to use to redeem the send OOB code. %EMAIL% - The email where the email is being sent. %NEW_EMAIL% - The new email being set for the account (when applicable). %APP_NAME% - The GCP project's display name. %DISPLAY_NAME% - The user's display name.
+     */
+    GoogleCloudIdentitytoolkitAdminV2EmailTemplate: {
+      /**
+       * Email body
+       */
+      body?: string;
+      /**
+       * Email body format
+       */
+      bodyFormat?: "BODY_FORMAT_UNSPECIFIED" | "PLAIN_TEXT" | "HTML";
+      /**
+       * Output only. Whether the body or subject of the email is customized.
+       */
+      customized?: boolean;
+      /**
+       * Reply-to address
+       */
+      replyTo?: string;
+      /**
+       * Sender display name
+       */
+      senderDisplayName?: string;
+      /**
+       * Local part of From address
+       */
+      senderLocalPart?: string;
+      /**
+       * Subject of the email
+       */
+      subject?: string;
+    };
+    /**
+     * Indicates which credentials to pass to the registered Blocking Functions.
+     */
+    GoogleCloudIdentitytoolkitAdminV2ForwardInboundCredentials: {
+      /**
+       * Whether to pass the user's OAuth identity provider's access token.
+       */
+      accessToken?: boolean;
+      /**
+       * Whether to pass the user's OIDC identity provider's ID token.
+       */
+      idToken?: boolean;
+      /**
+       * Whether to pass the user's OAuth identity provider's refresh token.
+       */
+      refreshToken?: boolean;
     };
     /**
      * History information of the hash algorithm and key. Different accounts' passwords may be generated by different version.
@@ -2076,6 +2229,12 @@ export interface components {
       tenants?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Tenant"][];
     };
     /**
+     * Configuration related to monitoring project activity.
+     */
+    GoogleCloudIdentitytoolkitAdminV2MonitoringConfig: {
+      requestLogging?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2RequestLogging"];
+    };
+    /**
      * Options related to MultiFactor Authentication for the project.
      */
     GoogleCloudIdentitytoolkitAdminV2MultiFactorAuthConfig: {
@@ -2087,6 +2246,30 @@ export interface components {
        * Whether MultiFactor Authentication has been enabled for this project.
        */
       state?: "STATE_UNSPECIFIED" | "DISABLED" | "ENABLED" | "MANDATORY";
+    };
+    /**
+     * Configuration related to multi-tenant functionality.
+     */
+    GoogleCloudIdentitytoolkitAdminV2MultiTenantConfig: {
+      /**
+       * Whether this project can have tenants or not.
+       */
+      allowTenants?: boolean;
+      /**
+       * The default cloud parent org or folder that the tenant project should be created under. The parent resource name should be in the format of "/", such as "folders/123" or "organizations/456". If the value is not set, the tenant will be created under the same organization or folder as the agent project.
+       */
+      defaultTenantLocation?: string;
+    };
+    /**
+     * Configuration related to sending notifications to users.
+     */
+    GoogleCloudIdentitytoolkitAdminV2NotificationConfig: {
+      /**
+       * Default locale used for email and SMS in IETF BCP 47 format.
+       */
+      defaultLocale?: string;
+      sendEmail?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SendEmail"];
+      sendSms?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SendSms"];
     };
     /**
      * Configuration options for authenticating with an OAuth IDP.
@@ -2136,6 +2319,128 @@ export interface components {
       token?: boolean;
     };
     /**
+     * Configuration related to restricting a user's ability to affect their account.
+     */
+    GoogleCloudIdentitytoolkitAdminV2Permissions: {
+      /**
+       * When true, end users cannot delete their account on the associated project through any of our API methods
+       */
+      disabledUserDeletion?: boolean;
+      /**
+       * When true, end users cannot sign up for a new account on the associated project through any of our API methods
+       */
+      disabledUserSignup?: boolean;
+    };
+    /**
+     * Configuration options related to authenticated a user by their phone number.
+     */
+    GoogleCloudIdentitytoolkitAdminV2PhoneNumber: {
+      /**
+       * Whether phone number auth is enabled for the project or not.
+       */
+      enabled?: boolean;
+      /**
+       * A map of that can be used for phone auth testing.
+       */
+      testPhoneNumbers?: { [key: string]: string };
+    };
+    /**
+     * Configuration related to quotas.
+     */
+    GoogleCloudIdentitytoolkitAdminV2QuotaConfig: {
+      signUpQuotaConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2TemporaryQuota"];
+    };
+    /**
+     * Configuration for logging requests made to this project to Stackdriver Logging
+     */
+    GoogleCloudIdentitytoolkitAdminV2RequestLogging: {
+      /**
+       * Whether logging is enabled for this project or not.
+       */
+      enabled?: boolean;
+    };
+    /**
+     * Options for email sending.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SendEmail: {
+      /**
+       * action url in email template.
+       */
+      callbackUri?: string;
+      changeEmailTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      dnsInfo?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2DnsInfo"];
+      legacyResetPasswordTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      /**
+       * The method used for sending an email.
+       */
+      method?: "METHOD_UNSPECIFIED" | "DEFAULT" | "CUSTOM_SMTP";
+      resetPasswordTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      revertSecondFactorAdditionTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+      smtp?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Smtp"];
+      verifyEmailTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2EmailTemplate"];
+    };
+    /**
+     * Options for SMS sending.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SendSms: {
+      smsTemplate?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SmsTemplate"];
+      /**
+       * Whether to use the accept_language header for SMS.
+       */
+      useDeviceLocale?: boolean;
+    };
+    /**
+     * Configuration related to local sign in methods.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SignInConfig: {
+      /**
+       * Whether to allow more than one account to have the same email.
+       */
+      allowDuplicateEmails?: boolean;
+      anonymous?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Anonymous"];
+      email?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2Email"];
+      hashConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2HashConfig"];
+      phoneNumber?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2PhoneNumber"];
+    };
+    /**
+     * The template to use when sending an SMS.
+     */
+    GoogleCloudIdentitytoolkitAdminV2SmsTemplate: {
+      /**
+       * Output only. The SMS's content. Can contain the following placeholders which will be replaced with the appropriate values: %APP_NAME% - For Android or iOS apps, the app's display name. For web apps, the domain hosting the application. %LOGIN_CODE% - The OOB code being sent in the SMS.
+       */
+      content?: string;
+    };
+    /**
+     * Configuration for SMTP relay
+     */
+    GoogleCloudIdentitytoolkitAdminV2Smtp: {
+      /**
+       * SMTP relay host
+       */
+      host?: string;
+      /**
+       * SMTP relay password
+       */
+      password?: string;
+      /**
+       * SMTP relay port
+       */
+      port?: number;
+      /**
+       * SMTP security mode.
+       */
+      securityMode?: "SECURITY_MODE_UNSPECIFIED" | "SSL" | "START_TLS";
+      /**
+       * Sender email for the SMTP relay
+       */
+      senderEmail?: string;
+      /**
+       * SMTP relay username
+       */
+      username?: string;
+    };
+    /**
      * The SP's certificate data for IDP to verify the SAMLRequest generated by the SP.
      */
     GoogleCloudIdentitytoolkitAdminV2SpCertificate: {
@@ -2164,6 +2469,23 @@ export interface components {
        * Unique identifier for all SAML entities.
        */
       spEntityId?: string;
+    };
+    /**
+     * Temporary quota increase / decrease
+     */
+    GoogleCloudIdentitytoolkitAdminV2TemporaryQuota: {
+      /**
+       * Corresponds to the 'refill_token_count' field in QuotaServer config
+       */
+      quota?: string;
+      /**
+       * How long this quota will be active for
+       */
+      quotaDuration?: string;
+      /**
+       * When this quota will take affect
+       */
+      startTime?: string;
     };
     /**
      * A Tenant contains configuration for the tenant in a multi-tenant project.
@@ -2200,6 +2522,19 @@ export interface components {
        * A map of pairs that can be used for MFA. The phone number should be in E.164 format (https://www.itu.int/rec/T-REC-E.164/) and a maximum of 10 pairs can be added (error will be thrown once exceeded).
        */
       testPhoneNumbers?: { [key: string]: string };
+    };
+    /**
+     * Synchronous Cloud Function with HTTP Trigger
+     */
+    GoogleCloudIdentitytoolkitAdminV2Trigger: {
+      /**
+       * HTTP URI trigger for the Cloud Function.
+       */
+      functionUri?: string;
+      /**
+       * When the trigger was changed.
+       */
+      updateTime?: string;
     };
     /**
      * The information required to auto-retrieve an SMS.
@@ -2481,7 +2816,7 @@ export interface components {
        */
       auditConfigs?: components["schemas"]["GoogleIamV1AuditConfig"][];
       /**
-       * Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member.
+       * Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member. The `bindings` in a `Policy` can refer to up to 1,500 members; up to 250 of these members can be Google groups. Each occurrence of a member counts towards these limits. For example, if the `bindings` grant 50 different roles to `user:alice@example.com`, and not to any other member, then you can add another 1,450 members to the `bindings` in the `Policy`.
        */
       bindings?: components["schemas"]["GoogleIamV1Binding"][];
       /**

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -6,8 +6,8 @@ import * as _ from "lodash";
 import { OpenAPIObject, PathsObject, ServerObject, OperationObject } from "openapi3-ts";
 import { EmulatorLogger } from "../emulatorLogger";
 import { Emulators } from "../types";
-import { authOperations, AuthOps, AuthOperation } from "./operations";
-import { AgentProjectState, ProjectState, TenantProjectState } from "./state";
+import { authOperations, AuthOps, AuthOperation, FirebaseJwtPayload } from "./operations";
+import { AgentProjectState, ProjectState } from "./state";
 import apiSpecUntyped from "./apiSpec";
 import {
   PromiseController,
@@ -33,6 +33,7 @@ import { camelCase } from "lodash";
 import { registerHandlers } from "./handlers";
 import bodyParser = require("body-parser");
 import { URLSearchParams } from "url";
+import { decode, JwtHeader } from "jsonwebtoken";
 const apiSpec = apiSpecUntyped as OpenAPIObject;
 
 const API_SPEC_PATH = "/emulator/openapi.json";
@@ -103,11 +104,6 @@ function specWithEmulatorServer(protocol: string, host: string | undefined): Ope
   }
 }
 
-export interface AgentProject {
-  state: AgentProjectState;
-  tenantProjects: Map<string, TenantProjectState>;
-}
-
 /**
  * Create an Express app that serves Auth Emulator APIs.
  *
@@ -120,7 +116,7 @@ export interface AgentProject {
  */
 export async function createApp(
   defaultProjectId: string,
-  projectStateForId = new Map<string, AgentProject>()
+  projectStateForId = new Map<string, AgentProjectState>()
 ): Promise<express.Express> {
   const app = express();
   app.set("json spaces", 2);
@@ -143,7 +139,9 @@ export async function createApp(
   });
 
   registerLegacyRoutes(app);
-  registerHandlers(app, (apiKey) => getProjectStateById(getProjectIdByApiKey(apiKey)));
+  registerHandlers(app, (apiKey, tenantId) =>
+    getProjectStateById(getProjectIdByApiKey(apiKey), tenantId)
+  );
 
   const apiKeyAuthenticator: PromiseAuthenticator = (ctx, info) => {
     if (info.in !== "query") {
@@ -253,6 +251,10 @@ export async function createApp(
         // TODO
         return true;
       },
+      "google-duration"() {
+        // TODO
+        return true;
+      },
       uint64() {
         // TODO
         return true;
@@ -333,22 +335,16 @@ export async function createApp(
   }
 
   function getProjectStateById(projectId: string, tenantId?: string): ProjectState {
-    let agentProject = projectStateForId.get(projectId);
-    if (!agentProject) {
-      const state = new AgentProjectState(projectId);
-      agentProject = { state, tenantProjects: new Map<string, TenantProjectState>() };
-      projectStateForId.set(projectId, agentProject);
+    let agentState = projectStateForId.get(projectId);
+    if (!agentState) {
+      agentState = new AgentProjectState(projectId);
+      projectStateForId.set(projectId, agentState);
     }
     if (!tenantId) {
-      return agentProject.state;
+      return agentState;
     }
 
-    let tenantState = agentProject.tenantProjects.get(tenantId);
-    if (!tenantState) {
-      tenantState = new TenantProjectState(projectId, tenantId, agentProject.state);
-      agentProject.tenantProjects.set(tenantId, tenantState);
-    }
-    return tenantState;
+    return agentState.getTenantProject(tenantId);
   }
 }
 
@@ -422,7 +418,7 @@ function registerLegacyRoutes(app: express.Express): void {
 
 function toExegesisController(
   ops: AuthOps,
-  getProjectStateById: (projectId: string, tenantId: string) => ProjectState
+  getProjectStateById: (projectId: string, tenantId?: string) => ProjectState
 ): Record<string, PromiseController> {
   const result: Record<string, PromiseController> = {};
   processNested(ops, "");
@@ -476,10 +472,26 @@ function toExegesisController(
         // See: https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/signUp
         targetProjectId = ctx.user;
       }
+
+      let targetTenantId: string | undefined = undefined;
       if (ctx.params.path.tenantId && ctx.requestBody?.tenantId) {
         assert(ctx.params.path.tenantId === ctx.requestBody.tenantId, "TENANT_ID_MISMATCH");
       }
-      const targetTenantId: string = ctx.params.path.tenantId || ctx.requestBody?.tenantId;
+      targetTenantId = ctx.params.path.tenantId || ctx.requestBody?.tenantId;
+
+      // Perform initial token parsing to get correct project state
+      if (ctx.requestBody?.idToken) {
+        const idToken = ctx.requestBody?.idToken;
+        const decoded = decode(idToken, { complete: true }) as {
+          header: JwtHeader;
+          payload: FirebaseJwtPayload;
+        } | null;
+        if (decoded?.payload.firebase.tenant && targetTenantId) {
+          assert(decoded?.payload.firebase.tenant === targetTenantId, "TENANT_ID_MISMATCH");
+        }
+        targetTenantId = targetTenantId || decoded?.payload.firebase.tenant;
+      }
+
       return operation(getProjectStateById(targetProjectId, targetTenantId), ctx.requestBody, ctx);
     };
   }

--- a/src/extensions/askUserForConsent.ts
+++ b/src/extensions/askUserForConsent.ts
@@ -5,6 +5,7 @@ import TerminalRenderer = require("marked-terminal");
 
 import { FirebaseError } from "../error";
 import { logPrefix } from "../extensions/extensionsHelper";
+import * as extensionsApi from "./extensionsApi";
 import * as iam from "../gcp/iam";
 import { promptOnce, Question } from "../prompt";
 import * as utils from "../utils";
@@ -61,6 +62,27 @@ export async function displayRoles(
   }
 
   const message = await formatDescription(extensionName, projectId, roles);
+  utils.logLabeledBullet(logPrefix, message);
+}
+
+/**
+ * Displays APIs that will be enabled for the project and corresponding descriptions.
+ * @param extensionName name of extension to install/update
+ * @param projectId ID of user's project
+ * @param apis APIs that require user approval
+ */
+export function displayApis(extensionName: string, projectId: string, apis: extensionsApi.Api[]) {
+  if (!apis.length) {
+    return;
+  }
+  const question = `${clc.bold(
+    extensionName
+  )} will enable the following APIs for project ${clc.bold(projectId)}`;
+  const results: string[] = apis.map((api: extensionsApi.Api) => {
+    return `- ${api.apiName}: ${api.reason}`;
+  });
+  results.unshift(question);
+  const message = results.join("\n");
   utils.logLabeledBullet(logPrefix, message);
 }
 

--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -155,6 +155,7 @@ export enum ParamType {
   STRING = "STRING",
   SELECT = "SELECT",
   MULTISELECT = "MULTISELECT",
+  SECRET = "SECRET",
 }
 
 export interface ParamOption {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -47,6 +47,7 @@ export enum SpecParamType {
   MULTISELECT = "multiSelect",
   STRING = "string",
   SELECTRESOURCE = "selectResource",
+  SECRET = "secret",
 }
 
 export enum SourceOrigin {

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -61,6 +61,8 @@ export async function getParams(args: {
   paramSpecs: extensionsApi.Param[];
   nonInteractive?: boolean;
   paramsEnvPath?: string;
+  instanceId: string;
+  reconfiguring?: boolean;
 }): Promise<{ [key: string]: string }> {
   let params: any;
   if (args.nonInteractive && !args.paramsEnvPath) {
@@ -84,7 +86,13 @@ export async function getParams(args: {
     });
   } else {
     const firebaseProjectParams = await getFirebaseProjectParams(args.projectId);
-    params = await askUserForParam.ask(args.paramSpecs, firebaseProjectParams);
+    params = await askUserForParam.ask(
+      args.projectId,
+      args.instanceId,
+      args.paramSpecs,
+      firebaseProjectParams,
+      !!args.reconfiguring
+    );
   }
   track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
   return params;
@@ -97,6 +105,7 @@ export async function getParamsForUpdate(args: {
   projectId: string;
   paramsEnvPath?: string;
   nonInteractive?: boolean;
+  instanceId: string;
 }) {
   let params: any;
   if (args.nonInteractive && !args.paramsEnvPath) {
@@ -124,6 +133,7 @@ export async function getParamsForUpdate(args: {
       newSpec: args.newSpec,
       currentParams: args.currentParams,
       projectId: args.projectId,
+      instanceId: args.instanceId,
     });
   }
   track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
@@ -143,6 +153,7 @@ export async function promptForNewParams(args: {
   newSpec: extensionsApi.ExtensionSpec;
   currentParams: { [option: string]: string };
   projectId: string;
+  instanceId: string;
 }): Promise<any> {
   const firebaseProjectParams = await getFirebaseProjectParams(args.projectId);
   const comparer = (param1: extensionsApi.Param, param2: extensionsApi.Param) => {
@@ -178,7 +189,12 @@ export async function promptForNewParams(args: {
   if (paramsDiffAdditions.length) {
     logger.info("To update this instance, configure the following new parameters:");
     for (const param of paramsDiffAdditions) {
-      const chosenValue = await askUserForParam.askForParam(param);
+      const chosenValue = await askUserForParam.askForParam(
+        args.projectId,
+        args.instanceId,
+        param,
+        false
+      );
       args.currentParams[param.param] = chosenValue;
     }
   }

--- a/src/extensions/secretsUtils.ts
+++ b/src/extensions/secretsUtils.ts
@@ -1,0 +1,70 @@
+import { getProjectNumber } from "../getProjectNumber";
+import * as utils from "../utils";
+import { ensure } from "../ensureApiEnabled";
+import { needProjectId } from "../projectUtils";
+import * as extensionsApi from "./extensionsApi";
+import * as secretManagerApi from "../gcp/secretManager";
+import { logger } from "../logger";
+
+const SECRET_LABEL = "firebase-extensions-managed";
+
+export async function ensureSecretManagerApiEnabled(options: any): Promise<void> {
+  const projectId = needProjectId(options);
+  return await ensure(projectId, "secretmanager.googleapis.com", "extensions", options.markdown);
+}
+
+export function usesSecrets(spec: extensionsApi.ExtensionSpec): boolean {
+  return spec.params && !!spec.params.find((p) => p.type == extensionsApi.ParamType.SECRET);
+}
+
+export async function grantFirexServiceAgentSecretAdminRole(
+  secret: secretManagerApi.Secret
+): Promise<void> {
+  const projectNumber = await getProjectNumber({ projectId: secret.projectId });
+  const firexSaProjectId = utils.envOverride(
+    "FIREBASE_EXTENSIONS_SA_PROJECT_ID",
+    "gcp-sa-firebasemods"
+  );
+  const saEmail = `service-${projectNumber}@${firexSaProjectId}.iam.gserviceaccount.com`;
+
+  return secretManagerApi.grantServiceAgentRole(secret, saEmail, "roles/secretmanager.admin");
+}
+
+export async function getManagedSecrets(
+  instance: extensionsApi.ExtensionInstance
+): Promise<string[]> {
+  return (
+    await Promise.all(
+      getActiveSecrets(instance).map(async (secretResourceName) => {
+        const secret = secretManagerApi.parseSecretResourceName(secretResourceName);
+        const labels = await secretManagerApi.getSecretLabels(secret.projectId, secret.name);
+        if (labels && labels[SECRET_LABEL]) {
+          return secretResourceName;
+        }
+        return Promise.resolve("");
+      })
+    )
+  ).filter((secretId) => !!secretId);
+}
+
+function getActiveSecrets(instance: extensionsApi.ExtensionInstance): string[] {
+  return instance.config.source.spec.params
+    .map((p) => p.type == extensionsApi.ParamType.SECRET && instance.config.params[p.param])
+    .filter((pv) => !!pv);
+}
+
+export function getSecretLabels(instanceId: string): Record<string, string> {
+  const labels: Record<string, string> = {};
+  labels[SECRET_LABEL] = instanceId;
+  return labels;
+}
+
+export function prettySecretName(secretResourceName: string): string {
+  const nameTokens = secretResourceName.split("/");
+  if (nameTokens.length != 4 && nameTokens.length != 6) {
+    // not a familiar format, return as is
+    logger.debug(`unable to parse secret secretResourceName: ${secretResourceName}`);
+    return secretResourceName;
+  }
+  return nameTokens.slice(0, 4).join("/");
+}

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -88,3 +88,18 @@ export function assertExhaustive(val: never): never {
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   throw new Error(`Never has a value (${val}). This should be impossible`);
 }
+
+/**
+ * Utility to partition an array into two based on callbackFn's truthiness for each element.
+ * Returns a Array containing two Array<T>. The first array contains all elements that returned true,
+ * the second contains all elements that returned false.
+ */
+export function partition<T>(arr: T[], callbackFn: (elem: T) => boolean): T[][] {
+  return arr.reduce<T[][]>(
+    (acc, elem) => {
+      acc[callbackFn(elem) ? 0 : 1].push(elem);
+      return acc;
+    },
+    [[], []]
+  );
+}

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -125,7 +125,11 @@ export function parse(data: string): ParseResult {
   return { envs, errors };
 }
 
-class KeyValidationError extends Error {}
+export class KeyValidationError extends Error {
+  constructor(public key: string, public message: string) {
+    super(`Failed to validate key ${key}: ${message}`);
+  }
+}
 
 /**
  * Validates string for use as an env var key.
@@ -135,16 +139,18 @@ class KeyValidationError extends Error {}
  */
 export function validateKey(key: string): void {
   if (RESERVED_KEYS.includes(key)) {
-    throw new KeyValidationError(`Key ${key} is reserved for internal use.`);
+    throw new KeyValidationError(key, `Key ${key} is reserved for internal use.`);
   }
   if (!/^[A-Z_][A-Z0-9_]*$/.test(key)) {
     throw new KeyValidationError(
+      key,
       `Key ${key} must start with an uppercase ASCII letter or underscore` +
         ", and then consist of uppercase ASCII letters, digits, and underscores."
     );
   }
   if (key.startsWith("X_GOOGLE_") || key.startsWith("FIREBASE_")) {
     throw new KeyValidationError(
+      key,
       `Key ${key} starts with a reserved prefix (X_GOOGLE_ or FIREBASE_)`
     );
   }

--- a/src/functions/runtimeConfigExport.ts
+++ b/src/functions/runtimeConfigExport.ts
@@ -1,0 +1,199 @@
+import * as fs from "fs";
+import * as path from "path";
+
+import * as clc from "cli-color";
+
+import * as env from "./env";
+import * as functionsConfig from "../functionsConfig";
+import { FirebaseError } from "../error";
+import { logger } from "../logger";
+import { getProjectId } from "../projectUtils";
+import { loadRC } from "../rc";
+import { logWarning } from "../utils";
+import { flatten } from "../functional";
+
+export interface ProjectConfigInfo {
+  projectId: string;
+  alias?: string;
+  config?: Record<string, unknown>;
+  envs?: EnvMap[];
+}
+
+export interface EnvMap {
+  origKey: string;
+  newKey: string;
+  value: string;
+  err?: string;
+}
+
+export interface ConfigToEnvResult {
+  success: EnvMap[];
+  errors: Required<EnvMap>[];
+}
+
+/**
+ * Find all projects (and its alias) associated with the current directory.
+ */
+export function getProjectInfos(options: {
+  project?: string;
+  projectId?: string;
+  cwd?: string;
+}): ProjectConfigInfo[] {
+  const result: Record<string, string> = {};
+
+  const rc = loadRC(options);
+  if (rc.projects) {
+    for (const [alias, projectId] of Object.entries(rc.projects)) {
+      if (Object.keys(result).includes(projectId)) {
+        logWarning(
+          `Multiple aliases found for ${clc.bold(projectId)}. ` +
+            `Preferring alias (${clc.bold(result[projectId])}) over (${clc.bold(alias)}).`
+        );
+        continue;
+      }
+      result[projectId] = alias;
+    }
+  }
+
+  // We export runtime config of a --project set via CLI flag, allowing export command to run on projects that's
+  // never been added to the .firebaserc file.
+  const projectId = getProjectId(options);
+  if (projectId && !Object.keys(result).includes(projectId)) {
+    result[projectId] = projectId;
+  }
+
+  return Object.entries(result).map(([k, v]) => {
+    const result: ProjectConfigInfo = { projectId: k };
+    if (k !== v) {
+      result.alias = v;
+    }
+    return result;
+  });
+}
+
+/**
+ * Fetch and fill in runtime config for each project.
+ */
+export async function hydrateConfigs(pInfos: ProjectConfigInfo[]): Promise<void> {
+  const hydrate = pInfos.map((info) => {
+    return functionsConfig
+      .materializeAll(info.projectId)
+      .then((config) => {
+        info.config = config;
+        return;
+      })
+      .catch((err) => {
+        logger.debug(
+          `Failed to fetch runtime config for project ${info.projectId}: ${err.message}`
+        );
+      });
+  });
+  await Promise.all(hydrate);
+}
+
+/**
+ * Converts functions config key from runtime config to env var key.
+ * If the original config key fails to convert, try again with provided prefix.
+ *
+ * Throws KeyValidationError if the converted key is invalid.
+ */
+export function convertKey(configKey: string, prefix: string): string {
+  /* prettier-ignore */
+  const baseKey = configKey
+      .toUpperCase()       // 1. Uppercase all characters (e.g. SOME-SERVICE.KEY)
+      .replace(/\./g, "_") // 2. Dots to underscores (e.g. SOME-SERVICE_KEY)
+      .replace(/-/g, "_"); // 3. Dashses to underscores (e.g. SOME_SERVICE_KEY)
+
+  let envKey = baseKey;
+  try {
+    env.validateKey(envKey);
+  } catch (err) {
+    if (err instanceof env.KeyValidationError) {
+      envKey = prefix + envKey;
+      env.validateKey(envKey);
+    }
+  }
+  return envKey;
+}
+
+/**
+ * Convert runtime config into a map of env vars.
+ */
+export function configToEnv(configs: Record<string, unknown>, prefix: string): ConfigToEnvResult {
+  const success = [];
+  const errors = [];
+
+  for (const [configKey, value] of flatten(configs)) {
+    try {
+      const envKey = convertKey(configKey, prefix);
+      success.push({ origKey: configKey, newKey: envKey, value: value as string });
+    } catch (err) {
+      if (err instanceof env.KeyValidationError) {
+        errors.push({
+          origKey: configKey,
+          newKey: err.key,
+          err: err.message,
+          value: value as string,
+        });
+      } else {
+        throw new FirebaseError("Unexpected error while converting config", {
+          exit: 2,
+          original: err,
+        });
+      }
+    }
+  }
+  return { success, errors };
+}
+
+/**
+ * Fill in environment variables for each project by converting project's runtime config.
+ *
+ * @return {ConfigToEnvResult} Collection of successful and errored conversion.
+ */
+export function hydrateEnvs(pInfos: ProjectConfigInfo[], prefix: string): string {
+  let errMsg = "";
+  for (const pInfo of pInfos) {
+    const { success, errors } = configToEnv(pInfo.config!, prefix);
+    if (errors.length > 0) {
+      const msg =
+        `${pInfo.projectId} ` +
+        `${pInfo.alias ? "(" + pInfo.alias + ")" : ""}:\n` +
+        errors.map((err) => `\t${err.origKey} => ${clc.bold(err.newKey)} (${err.err})`).join("\n") +
+        "\n";
+      errMsg += msg;
+    } else {
+      pInfo.envs = success;
+    }
+  }
+  return errMsg;
+}
+
+function escape(s: string): string {
+  // Escape newlines and tabs
+  const result = s
+    .replace("\n", "\\n")
+    .replace("\r", "\\r")
+    .replace("\t", "\\t")
+    .replace("\v", "\\v");
+  return result.replace(/(['"])/g, "\\$1");
+}
+
+/**
+ * Convert env var mapping to  dotenv compatible string.
+ */
+export function toDotenvFormat(envs: EnvMap[], header = ""): string {
+  const lines = envs.map(({ newKey, value }) => `${newKey}="${escape(value)}"`);
+  const maxLineLen = Math.max(...lines.map((l) => l.length));
+  return (
+    `${header}\n` +
+    lines.map((line, idx) => `${line.padEnd(maxLineLen)} # from ${envs[idx].origKey}`).join("\n")
+  );
+}
+
+/**
+ * Generate dotenv filename for given project.
+ */
+export function generateDotenvFilename(pInfo: ProjectConfigInfo): string {
+  return `.env.${pInfo.alias ?? pInfo.projectId}`;
+}

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -432,9 +432,11 @@ async function list(projectId: string, region: string): Promise<ListFunctionsRes
       unreachable: res.body.unreachable || [],
     };
   } catch (err) {
-    logger.debug("[functions] failed to list functions for " + projectId);
+    logger.debug(`[functions] failed to list functions for ${projectId}`);
     logger.debug(`[functions] ${err?.message}`);
-    return Promise.reject(err?.message);
+    throw new FirebaseError(`Failed to list functions for ${projectId}`, {
+      original: err,
+    });
   }
 }
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -387,6 +387,9 @@ export function functionFromSpec(cloudFunction: backend.FunctionSpec, source: St
     gcfFunction.eventTrigger = {
       eventType: cloudFunction.trigger.eventType,
     };
+    if (cloudFunction.trigger.region) {
+      gcfFunction.eventTrigger.triggerRegion = cloudFunction.trigger.region;
+    }
     if (gcfFunction.eventTrigger.eventType === PUBSUB_PUBLISH_EVENT) {
       gcfFunction.eventTrigger.pubsubTopic = cloudFunction.trigger.eventFilters.resource;
     } else {
@@ -414,6 +417,9 @@ export function specFromFunction(gcfFunction: CloudFunction): backend.FunctionSp
       eventFilters: {},
       retry: false,
     };
+    if (gcfFunction.eventTrigger!.triggerRegion) {
+      trigger.region = gcfFunction.eventTrigger.triggerRegion;
+    }
     if (gcfFunction.eventTrigger.pubsubTopic) {
       trigger.eventFilters.resource = gcfFunction.eventTrigger.pubsubTopic;
     } else {

--- a/src/gcp/secretManager.ts
+++ b/src/gcp/secretManager.ts
@@ -1,0 +1,154 @@
+import * as api from "../api";
+
+export interface Secret {
+  // Secret name/label (this is not resource name)
+  name: string;
+  // This is either projectID or number
+  projectId: string;
+}
+
+export interface SecretVersion {
+  secret: Secret;
+  versionId: string;
+}
+
+export async function listSecrets(projectId: string): Promise<Secret[]> {
+  const listRes = await api.request("GET", `/v1beta1/projects/${projectId}/secrets`, {
+    auth: true,
+    origin: api.secretManagerOrigin,
+  });
+  return listRes.body.secrets.map((s: any) => parseSecretResourceName(s.name));
+}
+
+export async function getSecret(projectId: string, name: string): Promise<Secret> {
+  const getRes = await api.request("GET", `/v1beta1/projects/${projectId}/secrets/${name}`, {
+    auth: true,
+    origin: api.secretManagerOrigin,
+  });
+  return parseSecretResourceName(getRes.body.name);
+}
+
+export async function getSecretLabels(
+  projectId: string,
+  name: string
+): Promise<Record<string, string>> {
+  const getRes = await api.request("GET", `/v1beta1/projects/${projectId}/secrets/${name}`, {
+    auth: true,
+    origin: api.secretManagerOrigin,
+  });
+  return getRes.body.labels;
+}
+
+export async function secretExists(projectId: string, name: string): Promise<boolean> {
+  try {
+    await getSecret(projectId, name);
+    return true;
+  } catch (err) {
+    if (err.status === 404) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export function parseSecretResourceName(resourceName: string): Secret {
+  const nameTokens = resourceName.split("/");
+  return {
+    projectId: nameTokens[1],
+    name: nameTokens[3],
+  };
+}
+
+export async function createSecret(
+  projectId: string,
+  name: string,
+  labels: Record<string, string>
+): Promise<Secret> {
+  const createRes = await api.request(
+    "POST",
+    `/v1beta1/projects/${projectId}/secrets?secretId=${name}`,
+    {
+      auth: true,
+      origin: api.secretManagerOrigin,
+      data: {
+        replication: {
+          automatic: {},
+        },
+        labels,
+      },
+    }
+  );
+  return parseSecretResourceName(createRes.body.name);
+}
+
+export async function addVersion(secret: Secret, payloadData: string): Promise<SecretVersion> {
+  const res = await api.request(
+    "POST",
+    `/v1beta1/projects/${secret.projectId}/secrets/${secret.name}:addVersion`,
+    {
+      auth: true,
+      origin: api.secretManagerOrigin,
+      data: {
+        payload: {
+          data: Buffer.from(payloadData).toString("base64"),
+        },
+      },
+    }
+  );
+  const nameTokens = res.body.name.split("/");
+  return {
+    secret: {
+      projectId: nameTokens[1],
+      name: nameTokens[3],
+    },
+    versionId: nameTokens[5],
+  };
+}
+
+export async function grantServiceAgentRole(
+  secret: Secret,
+  serviceAccountEmail: string,
+  role: string
+): Promise<void> {
+  const getPolicyRes = await api.request(
+    "GET",
+    `/v1beta1/projects/${secret.projectId}/secrets/${secret.name}:getIamPolicy`,
+    {
+      auth: true,
+      origin: api.secretManagerOrigin,
+    }
+  );
+
+  const bindings = getPolicyRes.body.bindings || [];
+  if (
+    bindings.find(
+      (b: any) =>
+        b.role == role &&
+        b.members.find((m: string) => m == `serviceAccount:${serviceAccountEmail}`)
+    )
+  ) {
+    // binding already exists, short-circuit.
+    return;
+  }
+  bindings.push({
+    role: role,
+    members: [`serviceAccount:${serviceAccountEmail}`],
+  });
+
+  await api.request(
+    "POST",
+    `/v1beta1/projects/${secret.projectId}/secrets/${secret.name}:setIamPolicy`,
+    {
+      auth: true,
+      origin: api.secretManagerOrigin,
+      data: {
+        policy: {
+          bindings,
+        },
+        updateMask: {
+          paths: "bindings",
+        },
+      },
+    }
+  );
+}

--- a/src/gcp/storage.js
+++ b/src/gcp/storage.js
@@ -91,9 +91,31 @@ function _deleteObject(location) {
   });
 }
 
+/**
+ * Gets a storage bucket from GCP.
+ * Ref: https://cloud.google.com/storage/docs/json_api/v1/buckets/get
+ * @param {string} bucketName name of the storage bucket
+ * @returns a bucket resource object
+ */
+async function _getBucket(bucketName) {
+  try {
+    const result = await api.request("GET", `/storage/v1/b/${bucketName}`, {
+      auth: true,
+      origin: api.storageOrigin,
+    });
+    return result.body;
+  } catch (err) {
+    logger.debug(err);
+    throw new FirebaseError("Failed to obtain the storage bucket", {
+      original: err,
+    });
+  }
+}
+
 module.exports = {
   getDefaultBucket: _getDefaultBucket,
   deleteObject: _deleteObject,
   upload: _uploadSource,
   uploadObject: _uploadObject,
+  getBucket: _getBucket,
 };

--- a/src/previews.ts
+++ b/src/previews.ts
@@ -10,6 +10,7 @@ interface PreviewFlags {
   golang: boolean;
   deletegcfartifacts: boolean;
   dotenv: boolean;
+  crashlyticsSymbolsUpload: boolean;
 }
 
 export const previews: PreviewFlags = {
@@ -22,6 +23,7 @@ export const previews: PreviewFlags = {
   golang: false,
   deletegcfartifacts: false,
   dotenv: false,
+  crashlyticsSymbolsUpload: false,
 
   ...configstore.get("previews"),
 };

--- a/src/requireInteractive.ts
+++ b/src/requireInteractive.ts
@@ -1,0 +1,14 @@
+import type { Options } from "./options";
+
+import { FirebaseError } from "./error";
+
+export default function requireInteractive(options: Options) {
+  if (options.nonInteractive) {
+    return Promise.reject(
+      new FirebaseError("This command cannot run in non-interactive mode", {
+        exit: 1,
+      })
+    );
+  }
+  return Promise.resolve();
+}

--- a/src/test/deploy/functions/backend.spec.ts
+++ b/src/test/deploy/functions/backend.spec.ts
@@ -279,6 +279,13 @@ describe("Backend", () => {
     }
 
     describe("existingBackend", () => {
+      it("should throw error when functions list fails", async () => {
+        const context = newContext();
+        listAllFunctions.rejects(new FirebaseError("Failed to list functions"));
+
+        await expect(backend.existingBackend(context)).to.be.rejected;
+      });
+
       it("should cache", async () => {
         const context = newContext();
         listAllFunctions.onFirstCall().resolves({
@@ -316,6 +323,44 @@ describe("Backend", () => {
           ...backend.empty(),
           cloudFunctions: [FUNCTION_SPEC],
           endpoints: { region: { id: { ...ENDPOINT, httpsTrigger: {} } } },
+        });
+      });
+
+      it("should throw an error if v2 list api throws an error", async () => {
+        previews.functionsv2 = true;
+        listAllFunctions.onFirstCall().resolves({
+          functions: [],
+          unreachable: [],
+        });
+        listAllFunctionsV2.throws(
+          new FirebaseError("HTTP Error: 500, Internal Error", { status: 500 })
+        );
+
+        await expect(backend.existingBackend(newContext())).to.be.rejectedWith(
+          "HTTP Error: 500, Internal Error"
+        );
+      });
+
+      it("should read v1 functions only when user is not allowlisted for v2", async () => {
+        previews.functionsv2 = true;
+        listAllFunctions.onFirstCall().resolves({
+          functions: [
+            {
+              ...HAVE_CLOUD_FUNCTION,
+              httpsTrigger: {},
+            },
+          ],
+          unreachable: [],
+        });
+        listAllFunctionsV2.throws(
+          new FirebaseError("HTTP Error: 404, Method not found", { status: 404 })
+        );
+
+        const have = await backend.existingBackend(newContext());
+
+        expect(have).to.deep.equal({
+          ...backend.of({ ...ENDPOINT, httpsTrigger: {} }),
+          cloudFunctions: [FUNCTION_SPEC],
         });
       });
 
@@ -419,6 +464,13 @@ describe("Backend", () => {
     });
 
     describe("checkAvailability", () => {
+      it("should throw error when functions list fails", async () => {
+        const context = newContext();
+        listAllFunctions.rejects(new FirebaseError("Failed to list functions"));
+
+        await expect(backend.checkAvailability(context, backend.empty())).to.be.rejected;
+      });
+
       it("should do nothing when regions are all avalable", async () => {
         listAllFunctions.onFirstCall().resolves({
           functions: [],

--- a/src/test/deploy/functions/triggerRegionHelper.spec.ts
+++ b/src/test/deploy/functions/triggerRegionHelper.spec.ts
@@ -1,0 +1,108 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import * as backend from "../../../deploy/functions/backend";
+import * as storage from "../../../gcp/storage";
+import * as triggerRegionHelper from "../../../deploy/functions/triggerRegionHelper";
+
+const SPEC = {
+  region: "us-west1",
+  project: "my-project",
+  runtime: "nodejs14",
+};
+
+describe("TriggerRegionHelper", () => {
+  describe("setTriggerRegion", () => {
+    let storageStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      storageStub = sinon.stub(storage, "getBucket").throws("Do not call");
+    });
+
+    afterEach(() => {
+      sinon.verifyAndRestore();
+    });
+
+    it("should throw an error if we can't find the bucket region", async () => {
+      const ep: backend.Endpoint = {
+        id: "fn",
+        entryPoint: "fnn",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.storage.object.v1.finalized",
+          eventFilters: {
+            bucket: "my-bucket",
+          },
+          retry: false,
+        },
+        ...SPEC,
+      };
+
+      await expect(
+        triggerRegionHelper.lookupMissingTriggerRegions(backend.of(ep))
+      ).to.be.rejectedWith("Can't find the storage bucket region");
+    });
+
+    it("should skip v1 and callable functions", async () => {
+      const v1EventFn: backend.Endpoint = {
+        id: "v1eventfn",
+        entryPoint: "v1Fn",
+        platform: "gcfv1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: {
+            resource: "projects/_/buckets/myBucket",
+          },
+          retry: false,
+        },
+        ...SPEC,
+      };
+      const v2CallableFn: backend.Endpoint = {
+        id: "v2callablefn",
+        entryPoint: "v2callablefn",
+        platform: "gcfv2",
+        httpsTrigger: {},
+        ...SPEC,
+      };
+
+      await triggerRegionHelper.lookupMissingTriggerRegions(backend.of(v1EventFn, v2CallableFn));
+
+      expect(v1EventFn.eventTrigger).to.deep.eq({
+        eventType: "google.storage.object.create",
+        eventFilters: {
+          resource: "projects/_/buckets/myBucket",
+        },
+        retry: false,
+      });
+      expect(v2CallableFn.httpsTrigger).to.deep.eq({});
+    });
+
+    it("should set trigger region from API", async () => {
+      storageStub.resolves({ location: "US" });
+      const wantFn: backend.Endpoint = {
+        id: "wantFn",
+        entryPoint: "wantFn",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.storage.object.v1.finalized",
+          eventFilters: {
+            bucket: "my-bucket",
+          },
+          retry: false,
+        },
+        ...SPEC,
+      };
+
+      await triggerRegionHelper.lookupMissingTriggerRegions(backend.of(wantFn));
+
+      expect(wantFn.eventTrigger).to.deep.eq({
+        eventType: "google.cloud.storage.object.v1.finalized",
+        eventFilters: {
+          bucket: "my-bucket",
+        },
+        retry: false,
+        region: "us",
+      });
+    });
+  });
+});

--- a/src/test/emulators/auth/batch.spec.ts
+++ b/src/test/emulators/auth/batch.spec.ts
@@ -18,6 +18,7 @@ import {
   TEST_PHONE_NUMBER,
   updateAccountByLocalId,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 import { UserInfo } from "../../../emulator/auth/state";
 
@@ -162,6 +163,20 @@ describeAuthEmulator("accounts:batchGet", ({ authApi }) => {
         // Empty page with no page token returned.
         expect(res.body.users || []).to.have.length(0);
         expect(res.body).not.to.have.property("nextPageToken");
+      });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .get(
+        `/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/tenants/${tenant.tenantId}/accounts:batchGet`
+      )
+      .set("Authorization", "Bearer owner")
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
       });
   });
 });
@@ -627,6 +642,62 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if user tenantId does not match state tenantId", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({
+        tenantId: tenant.tenantId,
+        users: [{ localId: "test1", tenantId: "not-matching-tenant-id" }],
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.error).eql([
+          {
+            index: 0,
+            message: "Tenant id in userInfo does not match the tenant id in request.",
+          },
+        ]);
+      });
+  });
+
+  it("should create users with tenantId if present", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+    const user = {
+      localId: "foo",
+      email: "me@example.com",
+      rawPassword: "notasecret",
+      tenantId: tenant.tenantId,
+    };
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({ tenantId: tenant.tenantId, users: [user] })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.error || []).to.have.length(0);
+      });
+
+    const userInfo = await getAccountInfoByLocalId(authApi(), user.localId, tenant.tenantId);
+    expect(userInfo.tenantId).to.eql(tenant.tenantId);
   });
 });
 

--- a/src/test/emulators/auth/createAuthUri.spec.ts
+++ b/src/test/emulators/auth/createAuthUri.spec.ts
@@ -1,12 +1,13 @@
 import { expect } from "chai";
 import { PROVIDER_PASSWORD, SIGNIN_METHOD_EMAIL_LINK } from "../../../emulator/auth/state";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   registerUser,
   signInWithFakeClaims,
   signInWithEmailLink,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:createAuthUri", ({ authApi }) => {
@@ -195,6 +196,23 @@ describeAuthEmulator("accounts:createAuthUri", ({ authApi }) => {
         expect(res.body.error)
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
+      });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:createAuthUri")
+      .send({
+        tenantId: tenant.tenantId,
+        continueUri: "http://example.com/",
+        identifier: "notregistered@example.com",
+      })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("PROJECT_DISABLED");
       });
   });
 });

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -2,13 +2,14 @@ import { expect } from "chai";
 import { decode as decodeJwt, sign as signJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload, CUSTOM_TOKEN_AUDIENCE } from "../../../emulator/auth/operations";
 import { PROVIDER_CUSTOM } from "../../../emulator/auth/state";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   getAccountInfoByIdToken,
   updateAccountByLocalId,
   signInWithEmailLink,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
@@ -270,5 +271,72 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equal("USER_DISABLED");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
+      .query({ key: "fake-api-key" })
+      .send({
+        tenantId: tenant.tenantId,
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if custom token tenantId does not match", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+    const uid = "someuid";
+    const claims = { abc: "def", ultimate: { answer: 42 } };
+    const token = signJwt({ uid, claims, tenantId: "not-matching-tenant-id" }, "", {
+      algorithm: "none",
+      expiresIn: 3600,
+
+      subject: "fake-service-account@example.com",
+      issuer: "fake-service-account@example.com",
+      audience: CUSTOM_TOKEN_AUDIENCE,
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
+      .query({ key: "fake-api-key" })
+      .send({ token, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.include("TENANT_ID_MISMATCH");
+      });
+  });
+
+  it("should create a new account from custom token with tenantId", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
+    const uid = "someuid";
+    const claims = { abc: "def", ultimate: { answer: 42 } };
+    const token = signJwt({ uid, claims, tenantId: tenant.tenantId }, "", {
+      algorithm: "none",
+      expiresIn: 3600,
+
+      subject: "fake-service-account@example.com",
+      issuer: "fake-service-account@example.com",
+      audience: CUSTOM_TOKEN_AUDIENCE,
+    });
+
+    const idToken = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
+      .query({ key: "fake-api-key" })
+      .send({ token, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.isNewUser).to.equal(true);
+        expect(res.body).to.have.property("refreshToken").that.is.a("string");
+
+        return res.body.idToken as string;
+      });
+
+    const info = await getAccountInfoByIdToken(authApi(), idToken, tenant.tenantId);
+    expect(info.tenantId).to.equal(tenant.tenantId);
   });
 });

--- a/src/test/emulators/auth/deleteAccount.spec.ts
+++ b/src/test/emulators/auth/deleteAccount.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   registerUser,
@@ -8,6 +8,7 @@ import {
   expectUserNotExistsForIdToken,
   updateProjectConfig,
   deleteAccount,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:delete", ({ authApi }) => {
@@ -136,6 +137,19 @@ describeAuthEmulator("accounts:delete", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equals("USER_NOT_FOUND");
+      });
+  });
+
+  it("should delete the user of the idToken", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:delete")
+      .send({ tenantId: tenant.tenantId })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
       });
   });
 });

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   registerUser,
@@ -12,8 +12,9 @@ import {
   createEmailSignInOob,
   TEST_PHONE_NUMBER,
   TEST_MFA_INFO,
-  deleteAccount,
   updateProjectConfig,
+  registerTenant,
+  getAccountInfoByLocalId,
 } from "./helpers";
 
 describeAuthEmulator("email link sign-in", ({ authApi }) => {
@@ -235,6 +236,87 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
       .query({ key: "fake-api-key" })
       .send({ email, oobCode, idToken })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body).not.to.have.property("idToken");
+        expect(res.body).not.to.have.property("refreshToken");
+        expect(res.body.mfaPendingCredential).to.be.a("string");
+        expect(res.body.mfaInfo).to.be.an("array").with.lengthOf(1);
+      });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.include("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if email link sign in is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      enableEmailLinkSignin: false,
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.include("OPERATION_NOT_ALLOWED");
+      });
+  });
+
+  it("should create account on sign-in with tenantId", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      enableEmailLinkSignin: true,
+    });
+    const email = "alice@example.com";
+    const { oobCode } = await createEmailSignInOob(authApi(), email, tenant.tenantId);
+
+    const localId = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ oobCode, email, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(200, res);
+        return res.body.localId;
+      });
+
+    const user = await getAccountInfoByLocalId(authApi(), localId, tenant.tenantId);
+    expect(user.tenantId).to.eql(tenant.tenantId);
+  });
+
+  it("should return pending credential if user has MFA and enabled on tenant projects", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      enableEmailLinkSignin: true,
+      allowPasswordSignup: true,
+      mfaConfig: {
+        state: "ENABLED",
+      },
+    });
+    const user = {
+      email: "alice@example.com",
+      password: "notasecret",
+      mfaInfo: [TEST_MFA_INFO],
+      tenantId: tenant.tenantId,
+    };
+    const { idToken, email } = await registerUser(authApi(), user);
+    const { oobCode } = await createEmailSignInOob(authApi(), email, tenant.tenantId);
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
+      .query({ key: "fake-api-key" })
+      .send({ email, oobCode, idToken, tenantId: tenant.tenantId })
       .then((res) => {
         expectStatusCode(200, res);
         expect(res.body).not.to.have.property("idToken");

--- a/src/test/emulators/auth/helpers.ts
+++ b/src/test/emulators/auth/helpers.ts
@@ -3,7 +3,7 @@ import { inspect } from "util";
 import * as supertest from "supertest";
 import { expect, AssertionError } from "chai";
 import { IdpJwtPayload } from "../../../emulator/auth/operations";
-import { OobRecord, PhoneVerificationRecord, UserInfo } from "../../../emulator/auth/state";
+import { OobRecord, PhoneVerificationRecord, Tenant, UserInfo } from "../../../emulator/auth/state";
 import { TestAgent, PROJECT_ID } from "./setup";
 import { MfaEnrollments } from "../../../emulator/auth/types";
 
@@ -93,6 +93,7 @@ export function registerUser(
     password: string;
     displayName?: string;
     mfaInfo?: MfaEnrollments;
+    tenantId?: string;
   }
 ): Promise<{ idToken: string; localId: string; refreshToken: string; email: string }> {
   return testAgent
@@ -200,7 +201,8 @@ export async function signInWithPhoneNumber(
 export function signInWithFakeClaims(
   testAgent: TestAgent,
   providerId: string,
-  claims: Partial<IdpJwtPayload> & { sub: string }
+  claims: Partial<IdpJwtPayload> & { sub: string },
+  tenantId?: string
 ): Promise<{ idToken: string; localId: string; refreshToken: string; email?: string }> {
   const fakeIdToken = JSON.stringify(fakeClaims(claims));
   return testAgent
@@ -213,6 +215,7 @@ export function signInWithFakeClaims(
       requestUri: "http://localhost",
       returnIdpCredential: true,
       returnSecureToken: true,
+      tenantId,
     })
     .then((res) => {
       expectStatusCode(200, res);
@@ -250,10 +253,14 @@ export async function expectIdTokenExpired(testAgent: TestAgent, idToken: string
     });
 }
 
-export function getAccountInfoByIdToken(testAgent: TestAgent, idToken: string): Promise<UserInfo> {
+export function getAccountInfoByIdToken(
+  testAgent: TestAgent,
+  idToken: string,
+  tenantId?: string
+): Promise<UserInfo> {
   return testAgent
     .post("/identitytoolkit.googleapis.com/v1/accounts:lookup")
-    .send({ idToken })
+    .send({ idToken, tenantId })
     .query({ key: "fake-api-key" })
     .then((res) => {
       expectStatusCode(200, res);
@@ -262,10 +269,14 @@ export function getAccountInfoByIdToken(testAgent: TestAgent, idToken: string): 
     });
 }
 
-export function getAccountInfoByLocalId(testAgent: TestAgent, localId: string): Promise<UserInfo> {
+export function getAccountInfoByLocalId(
+  testAgent: TestAgent,
+  localId: string,
+  tenantId?: string
+): Promise<UserInfo> {
   return testAgent
     .post("/identitytoolkit.googleapis.com/v1/accounts:lookup")
-    .send({ localId: [localId] })
+    .send({ localId: [localId], tenantId })
     .set("Authorization", "Bearer owner")
     .then((res) => {
       expectStatusCode(200, res);
@@ -274,15 +285,24 @@ export function getAccountInfoByLocalId(testAgent: TestAgent, localId: string): 
     });
 }
 
-export function inspectOobs(testAgent: TestAgent): Promise<OobRecord[]> {
-  return testAgent.get(`/emulator/v1/projects/${PROJECT_ID}/oobCodes`).then((res) => {
+export function inspectOobs(testAgent: TestAgent, tenantId?: string): Promise<OobRecord[]> {
+  const path = tenantId
+    ? `/emulator/v1/projects/${PROJECT_ID}/tenants/${tenantId}/oobCodes`
+    : `/emulator/v1/projects/${PROJECT_ID}/oobCodes`;
+  return testAgent.get(path).then((res) => {
     expectStatusCode(200, res);
     return res.body.oobCodes;
   });
 }
 
-export function inspectVerificationCodes(testAgent: TestAgent): Promise<PhoneVerificationRecord[]> {
-  return testAgent.get(`/emulator/v1/projects/${PROJECT_ID}/verificationCodes`).then((res) => {
+export function inspectVerificationCodes(
+  testAgent: TestAgent,
+  tenantId?: string
+): Promise<PhoneVerificationRecord[]> {
+  const path = tenantId
+    ? `/emulator/v1/projects/${PROJECT_ID}/tenants/${tenantId}/verificationCodes`
+    : `/emulator/v1/projects/${PROJECT_ID}/verificationCodes`;
+  return testAgent.get(path).then((res) => {
     expectStatusCode(200, res);
     return res.body.verificationCodes;
   });
@@ -290,11 +310,12 @@ export function inspectVerificationCodes(testAgent: TestAgent): Promise<PhoneVer
 
 export function createEmailSignInOob(
   testAgent: TestAgent,
-  email: string
+  email: string,
+  tenantId?: string
 ): Promise<{ oobCode: string; oobLink: string }> {
   return testAgent
     .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
-    .send({ email, requestType: "EMAIL_SIGNIN", returnOobLink: true })
+    .send({ email, requestType: "EMAIL_SIGNIN", returnOobLink: true, tenantId })
     .set("Authorization", "Bearer owner")
     .then((res) => {
       expectStatusCode(200, res);
@@ -343,24 +364,25 @@ export function updateAccountByLocalId(
 export async function enrollPhoneMfa(
   testAgent: TestAgent,
   idToken: string,
-  phoneNumber: string
+  phoneNumber: string,
+  tenantId?: string
 ): Promise<{ idToken: string; refreshToken: string }> {
   const sessionInfo = await testAgent
     .post("/identitytoolkit.googleapis.com/v2/accounts/mfaEnrollment:start")
     .query({ key: "fake-api-key" })
-    .send({ idToken, phoneEnrollmentInfo: { phoneNumber } })
+    .send({ idToken, phoneEnrollmentInfo: { phoneNumber }, tenantId })
     .then((res) => {
       expectStatusCode(200, res);
       expect(res.body.phoneSessionInfo.sessionInfo).to.be.a("string");
       return res.body.phoneSessionInfo.sessionInfo as string;
     });
 
-  const code = (await inspectVerificationCodes(testAgent))[0].code;
+  const code = (await inspectVerificationCodes(testAgent, tenantId))[0].code;
 
   return testAgent
     .post("/identitytoolkit.googleapis.com/v2/accounts/mfaEnrollment:finalize")
     .query({ key: "fake-api-key" })
-    .send({ idToken, phoneVerificationInfo: { code, sessionInfo } })
+    .send({ idToken, phoneVerificationInfo: { code, sessionInfo }, tenantId })
     .then((res) => {
       expectStatusCode(200, res);
       expect(res.body.idToken).to.be.a("string");
@@ -378,5 +400,21 @@ export function deleteAccount(testAgent: TestAgent, reqBody: {}): Promise<string
       expectStatusCode(200, res);
       expect(res.body).not.to.have.property("error");
       return res.body.kind;
+    });
+}
+
+export function registerTenant(
+  testAgent: TestAgent,
+  projectId: string,
+  tenant?: Partial<Tenant>
+): Promise<Tenant> {
+  return testAgent
+    .post(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+    .query({ key: "fake-api-key" })
+    .set("Authorization", "Bearer owner")
+    .send(tenant)
+    .then((res) => {
+      expectStatusCode(200, res);
+      return res.body;
     });
 }

--- a/src/test/emulators/auth/rest.spec.ts
+++ b/src/test/emulators/auth/rest.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
-import { expectStatusCode } from "./helpers";
-import { describeAuthEmulator } from "./setup";
+import { expectStatusCode, registerTenant, registerUser } from "./helpers";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 
 describeAuthEmulator("REST API mapping", ({ authApi }) => {
   it("should respond to status checks", async () => {
@@ -167,17 +167,60 @@ describeAuthEmulator("authentication", ({ authApi }) => {
       });
   });
 
-  // TODO(lisajian): uncomment when tenant endpoints are added
-  // it.only("should deny requests where tenant IDs do not match", async () => {
-  //   await authApi()
-  //     .post(
-  //       "/identitytoolkit.googleapis.com/v1/projects/project-id/tenants/tenant-id/accounts:delete"
-  //     )
-  //     .set("Authorization", "Bearer owner")
-  //     .send({ localId: "local-id", tenantId: "mismatching-tenant-id" })
-  //     .then((res) => {
-  //       expectStatusCode(400, res);
-  //       expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
-  //     });
-  // });
+  it("should deny requests where tenant IDs do not match in the request body and path", async () => {
+    await authApi()
+      .post(
+        "/identitytoolkit.googleapis.com/v1/projects/project-id/tenants/tenant-id/accounts:delete"
+      )
+      .set("Authorization", "Bearer owner")
+      .send({ localId: "local-id", tenantId: "mismatching-tenant-id" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
+      });
+  });
+
+  it("should deny requests where tenant IDs do not match in the token and path", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      allowPasswordSignup: true,
+    });
+    const { idToken, localId } = await registerUser(authApi(), {
+      email: "alice@example.com",
+      password: "notasecret",
+      tenantId: tenant.tenantId,
+    });
+
+    await authApi()
+      .post(
+        `/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/tenants/not-matching-tenant-id/accounts:lookup`
+      )
+      .send({ idToken })
+      .set("Authorization", "Bearer owner")
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
+      });
+  });
+
+  it("should deny requests where tenant IDs do not match in the token and request body", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      allowPasswordSignup: true,
+    });
+    const { idToken, localId } = await registerUser(authApi(), {
+      email: "alice@example.com",
+      password: "notasecret",
+      tenantId: tenant.tenantId,
+    });
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:lookup`)
+      .send({ idToken, tenantId: "not-matching-tenant-id" })
+      .set("Authorization", "Bearer owner")
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("TENANT_ID_MISMATCH");
+      });
+  });
 });

--- a/src/test/emulators/auth/setAccountInfo.spec.ts
+++ b/src/test/emulators/auth/setAccountInfo.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
 import { ProviderUserInfo, PROVIDER_PASSWORD, PROVIDER_PHONE } from "../../../emulator/auth/state";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   getAccountInfoByIdToken,
@@ -22,6 +22,7 @@ import {
   TEST_INVALID_PHONE_NUMBER,
   deleteAccount,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
@@ -1156,5 +1157,49 @@ describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("PROJECT_DISABLED");
+      });
+  });
+
+  it("should set tenantId in oobLink", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      mfaConfig: { state: "ENABLED" as const },
+      allowPasswordSignup: true,
+    });
+    const oldEmail = "alice@example.com";
+    const password = "notasecret";
+    const newEmail = "bob@example.com";
+    const { idToken } = await registerUser(authApi(), {
+      email: oldEmail,
+      password,
+      tenantId: tenant.tenantId,
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, email: newEmail, tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(200, res);
+      });
+
+    // An oob is sent to the oldEmail
+    const oobs = await inspectOobs(authApi(), tenant.tenantId);
+    expect(oobs).to.have.length(1);
+    expect(oobs[0].email).to.equal(oldEmail);
+    expect(oobs[0].requestType).to.equal("RECOVER_EMAIL");
+    expect(oobs[0].oobLink).to.include(tenant.tenantId);
   });
 });

--- a/src/test/emulators/auth/setup.ts
+++ b/src/test/emulators/auth/setup.ts
@@ -1,7 +1,8 @@
 import { Suite } from "mocha";
 import { useFakeTimers } from "sinon";
 import supertest = require("supertest");
-import { AgentProject, createApp } from "../../../emulator/auth/server";
+import { createApp } from "../../../emulator/auth/server";
+import { AgentProjectState } from "../../../emulator/auth/state";
 
 export const PROJECT_ID = "example";
 
@@ -40,7 +41,7 @@ export type AuthTestUtils = {
 
 // Keep a global auth server since start-up takes too long:
 let cachedAuthApp: Express.Application;
-const projectStateForId = new Map<string, AgentProject>();
+const projectStateForId = new Map<string, AgentProjectState>();
 
 async function createOrReuseApp(): Promise<Express.Application> {
   if (!cachedAuthApp) {

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
-import { describeAuthEmulator } from "./setup";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
   expectStatusCode,
   getAccountInfoByIdToken,
@@ -17,6 +17,7 @@ import {
   TEST_PHONE_NUMBER_2,
   TEST_INVALID_PHONE_NUMBER,
   updateProjectConfig,
+  registerTenant,
 } from "./helpers";
 
 describeAuthEmulator("accounts:signUp", ({ authApi }) => {
@@ -530,5 +531,61 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
           .to.have.property("message")
           .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
+  });
+
+  it("should error if auth is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("PROJECT_DISABLED");
+      });
+  });
+
+  it("should error if password sign up is not allowed", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { allowPasswordSignup: false });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId, email: "me@example.com", password: "notasecret" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("OPERATION_NOT_ALLOWED");
+      });
+  });
+
+  it("should error if anonymous user is disabled", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { enableAnonymousUser: false });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send({ tenantId: tenant.tenantId, returnSecureToken: true })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").includes("ADMIN_ONLY_OPERATION");
+      });
+  });
+
+  it("should create new account with tenant info", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, { allowPasswordSignup: true });
+    const user = { tenantId: tenant.tenantId, email: "alice@example.com", password: "notasecret" };
+
+    const localId = await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .query({ key: "fake-api-key" })
+      .send(user)
+      .then((res) => {
+        expectStatusCode(200, res);
+        return res.body.localId;
+      });
+    const info = await getAccountInfoByLocalId(authApi(), localId, tenant.tenantId);
+
+    expect(info.tenantId).to.eql(tenant.tenantId);
   });
 });

--- a/src/test/emulators/auth/tenant.spec.ts
+++ b/src/test/emulators/auth/tenant.spec.ts
@@ -1,0 +1,311 @@
+import { expect } from "chai";
+import { Tenant } from "../../../emulator/auth/state";
+import { expectStatusCode, registerTenant } from "./helpers";
+import { describeAuthEmulator } from "./setup";
+
+describeAuthEmulator("tenant management", ({ authApi }) => {
+  describe("createTenant", () => {
+    it("should create tenants", async () => {
+      await authApi()
+        .post("/identitytoolkit.googleapis.com/v2/projects/project-id/tenants")
+        .set("Authorization", "Bearer owner")
+        .send({
+          allowPasswordSignup: true,
+          disableAuth: false,
+          displayName: "display",
+          enableAnonymousUser: true,
+          enableEmailLinkSignin: true,
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.allowPasswordSignup).to.be.true;
+          expect(res.body.disableAuth).to.be.false;
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.enableAnonymousUser).to.be.true;
+          expect(res.body.enableEmailLinkSignin).to.be.true;
+          expect(res.body.mfaConfig).to.eql({
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          });
+
+          // Should have a non-empty tenantId and matching resource name
+          expect(res.body).to.have.property("tenantId");
+          expect(res.body.tenantId).to.not.eql("");
+          expect(res.body).to.have.property("name");
+          expect(res.body.name).to.eql(`projects/project-id/tenants/${res.body.tenantId}`);
+        });
+    });
+  });
+
+  describe("getTenants", () => {
+    it("should get tenants", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`)
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body).to.eql(tenant);
+        });
+    });
+
+    it("should create tenants if they do not exist", async () => {
+      // No projects exist initially
+      const projectId = "project-id";
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(0);
+        });
+
+      // Get should implicitly create a tenant that does not exist
+      const tenantId = "tenant-id";
+      const createdTenant: Tenant = {
+        tenantId,
+        name: `projects/${projectId}/tenants/${tenantId}`,
+      };
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenantId}`)
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body).to.eql(createdTenant);
+        });
+
+      // The newly created tenant should be returned
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(1);
+          expect(res.body.tenants[0].tenantId).to.eql(tenantId);
+        });
+    });
+  });
+
+  describe("deleteTenants", () => {
+    it("should delete tenants", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .delete(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+        });
+    });
+  });
+
+  describe("listTenants", () => {
+    it("should list tenants", async () => {
+      const projectId = "project-id";
+      const tenant1 = await registerTenant(authApi(), projectId, {});
+      const tenant2 = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(2);
+          expect(res.body.tenants.map((tenant: Tenant) => tenant.tenantId)).to.have.members([
+            tenant1.tenantId,
+            tenant2.tenantId,
+          ]);
+          expect(res.body).not.to.have.property("nextPageToken");
+        });
+    });
+
+    it("should allow specifying pageSize and pageToken", async () => {
+      const projectId = "project-id";
+      const tenant1 = await registerTenant(authApi(), projectId, {});
+      const tenant2 = await registerTenant(authApi(), projectId, {});
+      const tenantIds = [tenant1.tenantId, tenant2.tenantId].sort();
+
+      const nextPageToken = await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageSize: 1 })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(1);
+          expect(res.body.tenants[0].tenantId).to.eql(tenantIds[0]);
+          expect(res.body).to.have.property("nextPageToken").which.is.a("string");
+          return res.body.nextPageToken;
+        });
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageToken: nextPageToken })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(1);
+          expect(res.body.tenants[0].tenantId).to.eql(tenantIds[1]);
+          expect(res.body).not.to.have.property("nextPageToken");
+        });
+    });
+
+    it("should always return a page token even if page is full", async () => {
+      const projectId = "project-id";
+      const tenant1 = await registerTenant(authApi(), projectId, {});
+      const tenant2 = await registerTenant(authApi(), projectId, {});
+      const tenantIds = [tenant1.tenantId, tenant2.tenantId].sort();
+
+      const nextPageToken = await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageSize: 2 })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants).to.have.length(2);
+          expect(res.body.tenants[0].tenantId).to.eql(tenantIds[0]);
+          expect(res.body.tenants[1].tenantId).to.eql(tenantIds[1]);
+          expect(res.body).to.have.property("nextPageToken").which.is.a("string");
+          return res.body.nextPageToken;
+        });
+
+      await authApi()
+        .get(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)
+        .set("Authorization", "Bearer owner")
+        .query({ pageToken: nextPageToken })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.tenants || []).to.have.length(0);
+          expect(res.body).not.to.have.property("nextPageToken");
+        });
+    });
+  });
+
+  describe("updateTenants", () => {
+    it("updates tenant config", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+      const updateMask =
+        "allowPasswordSignup,disableAuth,displayName,enableAnonymousUser,enableEmailLinkSignin,mfaConfig";
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask })
+        .send({
+          allowPasswordSignup: true,
+          disableAuth: false,
+          displayName: "display",
+          enableAnonymousUser: true,
+          enableEmailLinkSignin: true,
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.allowPasswordSignup).to.be.true;
+          expect(res.body.disableAuth).to.be.false;
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.enableAnonymousUser).to.be.true;
+          expect(res.body.enableEmailLinkSignin).to.be.true;
+          expect(res.body.mfaConfig).to.eql({
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          });
+        });
+    });
+
+    it("does not update if the field does not exist on the update tenant", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+      const updateMask = "displayName";
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask })
+        .send({})
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body).not.to.have.property("displayName");
+        });
+    });
+
+    it("does not update if indexing a primitive field or array on the update tenant", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {
+        displayName: "display",
+        mfaConfig: {
+          enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+        },
+      });
+      const updateMask = "displayName.0,mfaConfig.enabledProviders.nonexistentField";
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask })
+        .send({
+          displayName: "unused",
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED"],
+          },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.mfaConfig.enabledProviders).to.eql(["PROVIDER_UNSPECIFIED", "PHONE_SMS"]);
+        });
+    });
+
+    it("performs a full update if the update mask is empty", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .patch(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .send({
+          allowPasswordSignup: true,
+          disableAuth: false,
+          displayName: "display",
+          enableAnonymousUser: true,
+          enableEmailLinkSignin: true,
+          mfaConfig: {
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          },
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.allowPasswordSignup).to.be.true;
+          expect(res.body.disableAuth).to.be.false;
+          expect(res.body.displayName).to.eql("display");
+          expect(res.body.enableAnonymousUser).to.be.true;
+          expect(res.body.enableEmailLinkSignin).to.be.true;
+          expect(res.body.mfaConfig).to.eql({
+            enabledProviders: ["PROVIDER_UNSPECIFIED", "PHONE_SMS"],
+            state: "ENABLED",
+          });
+        });
+    });
+  });
+});

--- a/src/test/extensions/askUserForParam.spec.ts
+++ b/src/test/extensions/askUserForParam.spec.ts
@@ -213,7 +213,7 @@ describe("askUserForParam", () => {
     });
 
     it("should keep prompting user until valid input is given", async () => {
-      await askForParam(testSpec);
+      await askForParam("project-id", "instance-id", testSpec, false);
       expect(promptStub.calledThrice).to.be.true;
     });
   });
@@ -236,7 +236,7 @@ describe("askUserForParam", () => {
     it("should call substituteParams with the right parameters", async () => {
       const spec = [testSpec];
       const firebaseProjectVars = { PROJECT_ID: "my-project" };
-      await ask(spec, firebaseProjectVars);
+      await ask("project-id", "instance-id", spec, firebaseProjectVars, false);
       expect(subVarSpy.calledWith(spec, firebaseProjectVars)).to.be.true;
     });
   });

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -12,6 +12,7 @@ import * as paramHelper from "../../extensions/paramHelper";
 import * as prompt from "../../prompt";
 
 const PROJECT_ID = "test-proj";
+const INSTANCE_ID = "ext-instance";
 const TEST_PARAMS: Param[] = [
   {
     param: "A_PARAMETER",
@@ -100,6 +101,7 @@ describe("paramHelper", () => {
         paramSpecs: TEST_PARAMS,
         nonInteractive: false,
         paramsEnvPath: "./a/path/to/a/file.env",
+        instanceId: INSTANCE_ID,
       });
 
       expect(params).to.eql({
@@ -118,6 +120,7 @@ describe("paramHelper", () => {
         paramSpecs: TEST_PARAMS,
         nonInteractive: false,
         paramsEnvPath: "./a/path/to/a/file.env",
+        instanceId: INSTANCE_ID,
       });
 
       expect(params).to.eql({
@@ -136,6 +139,7 @@ describe("paramHelper", () => {
         paramSpecs: TEST_PARAMS_3,
         nonInteractive: false,
         paramsEnvPath: "./a/path/to/a/file.env",
+        instanceId: INSTANCE_ID,
       });
 
       expect(params).to.eql({
@@ -154,6 +158,7 @@ describe("paramHelper", () => {
           paramSpecs: TEST_PARAMS,
           nonInteractive: false,
           paramsEnvPath: "./a/path/to/a/file.env",
+          instanceId: INSTANCE_ID,
         })
       ).to.be.rejectedWith(
         FirebaseError,
@@ -174,6 +179,7 @@ describe("paramHelper", () => {
         paramSpecs: TEST_PARAMS,
         nonInteractive: false,
         paramsEnvPath: "./a/path/to/a/file.env",
+        instanceId: INSTANCE_ID,
       });
 
       expect(loggerSpy).to.have.been.calledWith(
@@ -191,6 +197,7 @@ describe("paramHelper", () => {
           paramSpecs: TEST_PARAMS,
           nonInteractive: false,
           paramsEnvPath: "./a/path/to/a/file.env",
+          instanceId: INSTANCE_ID,
         })
       ).to.be.rejectedWith(FirebaseError, "Error reading env file: Error during parsing");
     });
@@ -199,6 +206,7 @@ describe("paramHelper", () => {
       const params = await paramHelper.getParams({
         projectId: PROJECT_ID,
         paramSpecs: TEST_PARAMS,
+        instanceId: INSTANCE_ID,
       });
 
       expect(params).to.eql({
@@ -334,6 +342,7 @@ describe("paramHelper", () => {
           ANOTHER_PARAMETER: "value",
         },
         projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
       });
 
       const expected = {
@@ -374,6 +383,7 @@ describe("paramHelper", () => {
           ANOTHER_PARAMETER: "value",
         },
         projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
       });
 
       const expected = {
@@ -398,6 +408,7 @@ describe("paramHelper", () => {
           ANOTHER_PARAMETER: "value",
         },
         projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
       });
 
       const expected = {
@@ -437,6 +448,7 @@ describe("paramHelper", () => {
           ANOTHER_PARAMETER: "value",
         },
         projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
       });
 
       const expected = {
@@ -461,6 +473,7 @@ describe("paramHelper", () => {
             ANOTHER_PARAMETER: "value",
           },
           projectId: PROJECT_ID,
+          instanceId: INSTANCE_ID,
         })
       ).to.be.rejectedWith(FirebaseError, "this is an error");
       // Ensure that we don't continue prompting if one fails

--- a/src/test/extensions/secretUtils.spec.ts
+++ b/src/test/extensions/secretUtils.spec.ts
@@ -1,0 +1,79 @@
+import * as nock from "nock";
+import { expect } from "chai";
+
+import * as api from "../../api";
+import * as extensionsApi from "../../extensions/extensionsApi";
+import * as secretsUtils from "../../extensions/secretsUtils";
+
+const PROJECT_ID = "test-project";
+const TEST_INSTANCE: extensionsApi.ExtensionInstance = {
+  name: "projects/invader-zim/instances/image-resizer",
+  createTime: "2019-05-19T00:20:10.416947Z",
+  updateTime: "2019-05-19T00:20:10.416947Z",
+  state: "ACTIVE",
+  serviceAccountEmail: "service@account.com",
+  config: {
+    name:
+      "projects/invader-zim/instances/image-resizer/configurations/95355951-397f-4821-a5c2-9c9788b2cc63",
+    createTime: "2019-05-19T00:20:10.416947Z",
+    source: {
+      name: "",
+      state: "ACTIVE",
+      packageUri: "url",
+      hash: "hash",
+      spec: {
+        name: "test",
+        displayName: "Old",
+        description: "descriptive",
+        version: "1.0.0",
+        license: "MIT",
+        resources: [],
+        author: { authorName: "Tester" },
+        contributors: [{ authorName: "Tester 2" }],
+        billingRequired: true,
+        sourceUrl: "test.com",
+        params: [
+          {
+            param: "SECRET1",
+            label: "secret 1",
+            type: extensionsApi.ParamType.SECRET,
+          },
+          {
+            param: "SECRET2",
+            label: "secret 2",
+            type: extensionsApi.ParamType.SECRET,
+          },
+        ],
+      },
+    },
+    params: {
+      SECRET1: "projects/test-project/secrets/secret1/versions/1",
+      SECRET2: "projects/test-project/secrets/secret2/versions/1",
+    },
+  },
+};
+
+describe("secretsUtils", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("getManagedSecrets", () => {
+    it("only returns secrets that have labels set", async () => {
+      nock(api.secretManagerOrigin)
+        .get(`/v1beta1/projects/${PROJECT_ID}/secrets/secret1`)
+        .reply(200, {
+          labels: { "firebase-extensions-managed": "true" },
+        });
+      nock(api.secretManagerOrigin)
+        .get(`/v1beta1/projects/${PROJECT_ID}/secrets/secret2`)
+        .reply(200, {}); // no labels
+
+      expect(await secretsUtils.getManagedSecrets(TEST_INSTANCE)).to.deep.equal([
+        "projects/test-project/secrets/secret1/versions/1",
+      ]);
+
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});

--- a/src/test/functional.spec.ts
+++ b/src/test/functional.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { flatten } from "lodash";
-import { define } from "mime";
 
 import * as f from "../functional";
 
@@ -121,5 +120,23 @@ describe("functional", () => {
       // compilation if uncommented
       // f.assertExhaustive(animal);
     }
+  });
+
+  describe("partition", () => {
+    it("should split an array into true and false", () => {
+      const arr = ["T1", "F1", "T2", "F2"];
+      expect(
+        f.partition<string>(arr, (s: string) => s.startsWith("T"))
+      ).to.deep.equal([
+        ["T1", "T2"],
+        ["F1", "F2"],
+      ]);
+    });
+
+    it("can handle an empty array", () => {
+      expect(
+        f.partition<string>([], (s: string) => s.startsWith("T"))
+      ).to.deep.equal([[], []]);
+    });
   });
 });

--- a/src/test/functions/runtimeConfigExport.spec.ts
+++ b/src/test/functions/runtimeConfigExport.spec.ts
@@ -1,0 +1,159 @@
+import { expect } from "chai";
+
+import * as configExport from "../../../src/functions/runtimeConfigExport";
+import * as env from "../../../src/functions/env";
+import * as sinon from "sinon";
+import * as rc from "../../rc";
+
+describe("functions-config-export", () => {
+  describe("getAllProjects", () => {
+    let loadRCStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      loadRCStub = sinon.stub(rc, "loadRC").returns({} as any); // eslint-disable-line @typescript-eslint/no-explicit-any
+    });
+
+    afterEach(() => {
+      loadRCStub.restore();
+    });
+
+    it("should include projectId from the options", () => {
+      expect(configExport.getProjectInfos({ projectId: "project-0" })).to.have.deep.members([
+        {
+          projectId: "project-0",
+        },
+      ]);
+    });
+
+    it("should include project and its alias from firebaserc", () => {
+      loadRCStub.returns({ projects: { dev: "project-0", prod: "project-1" } });
+      expect(configExport.getProjectInfos({ projectId: "project-0" })).to.have.deep.members([
+        {
+          projectId: "project-0",
+          alias: "dev",
+        },
+        {
+          projectId: "project-1",
+          alias: "prod",
+        },
+      ]);
+    });
+  });
+
+  describe("convertKey", () => {
+    it("should converts valid config key", () => {
+      expect(configExport.convertKey("service.api.url", "")).to.be.equal("SERVICE_API_URL");
+      expect(configExport.convertKey("foo-bar.car", "")).to.be.equal("FOO_BAR_CAR");
+    });
+
+    it("should throw error if conversion is invalid", () => {
+      expect(() => {
+        configExport.convertKey("1.api.url", "");
+      }).to.throw();
+      expect(() => {
+        configExport.convertKey("x.google.env", "");
+      }).to.throw();
+      expect(() => {
+        configExport.convertKey("k.service", "");
+      }).to.throw();
+    });
+
+    it("should use prefix to fix invalid config keys", () => {
+      expect(configExport.convertKey("1.api.url", "CONFIG_")).to.equal("CONFIG_1_API_URL");
+      expect(configExport.convertKey("x.google.env", "CONFIG_")).to.equal("CONFIG_X_GOOGLE_ENV");
+      expect(configExport.convertKey("k.service", "CONFIG_")).to.equal("CONFIG_K_SERVICE");
+    });
+
+    it("should throw error if prefix is invalid", () => {
+      expect(() => {
+        configExport.convertKey("1.api.url", "X_GOOGLE_");
+      }).to.throw();
+      expect(() => {
+        configExport.convertKey("x.google.env", "FIREBASE_");
+      }).to.throw();
+      expect(() => {
+        configExport.convertKey("k.service", "123_");
+      }).to.throw();
+    });
+  });
+
+  describe("configToEnv", () => {
+    it("should convert valid functions config ", () => {
+      const { success, errors } = configExport.configToEnv(
+        { foo: { bar: "foobar" }, service: { api: { url: "foobar", name: "a service" } } },
+        ""
+      );
+      expect(success).to.have.deep.members([
+        { origKey: "service.api.url", newKey: "SERVICE_API_URL", value: "foobar" },
+        { origKey: "service.api.name", newKey: "SERVICE_API_NAME", value: "a service" },
+        { origKey: "foo.bar", newKey: "FOO_BAR", value: "foobar" },
+      ]);
+      expect(errors).to.be.empty;
+    });
+
+    it("should collect errors for invalid conversions", () => {
+      const { success, errors } = configExport.configToEnv(
+        { firebase: { name: "foobar" }, service: { api: { url: "foobar", name: "a service" } } },
+        ""
+      );
+      expect(success).to.have.deep.members([
+        { origKey: "service.api.url", newKey: "SERVICE_API_URL", value: "foobar" },
+        { origKey: "service.api.name", newKey: "SERVICE_API_NAME", value: "a service" },
+      ]);
+      expect(errors).to.not.be.empty;
+    });
+
+    it("should use prefix to fix invalid keys", () => {
+      const { success, errors } = configExport.configToEnv(
+        { firebase: { name: "foobar" }, service: { api: { url: "foobar", name: "a service" } } },
+        "CONFIG_"
+      );
+      expect(success).to.have.deep.members([
+        { origKey: "service.api.url", newKey: "SERVICE_API_URL", value: "foobar" },
+        { origKey: "service.api.name", newKey: "SERVICE_API_NAME", value: "a service" },
+        { origKey: "firebase.name", newKey: "CONFIG_FIREBASE_NAME", value: "foobar" },
+      ]);
+      expect(errors).to.be.empty;
+    });
+  });
+
+  describe("toDotenvFormat", () => {
+    it("should produce valid dotenv file with keys", () => {
+      const dotenv = configExport.toDotenvFormat([
+        { origKey: "service.api.url", newKey: "SERVICE_API_URL", value: "hello" },
+        { origKey: "service.api.name", newKey: "SERVICE_API_NAME", value: "world" },
+      ]);
+      const { envs, errors } = env.parse(dotenv);
+      expect(envs).to.be.deep.equal({
+        SERVICE_API_URL: "hello",
+        SERVICE_API_NAME: "world",
+      });
+      expect(errors).to.be.empty;
+    });
+
+    it("should preserve newline characters", () => {
+      const dotenv = configExport.toDotenvFormat([
+        { origKey: "service.api.url", newKey: "SERVICE_API_URL", value: "hello\nworld" },
+      ]);
+      const { envs, errors } = env.parse(dotenv);
+      expect(envs).to.be.deep.equal({
+        SERVICE_API_URL: "hello\nworld",
+      });
+      expect(errors).to.be.empty;
+    });
+  });
+
+  describe("generateDotenvFilename", () => {
+    it("should generate dotenv filename using project alias", () => {
+      expect(
+        configExport.generateDotenvFilename({ projectId: "my-project", alias: "prod" })
+      ).to.equal(".env.prod");
+    });
+
+    it("should generate dotenv filename using project id if alias doesn't exist", () => {
+      expect(configExport.generateDotenvFilename({ projectId: "my-project" })).to.equal(
+        ".env.my-project"
+      );
+    });
+  });
+});

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -440,6 +440,7 @@ describe("cloudfunctionsv2", () => {
             resource: "projects/p/topics/t",
           },
           retry: false,
+          region: "us",
         },
         maxInstances: 42,
         minInstances: 1,
@@ -454,6 +455,7 @@ describe("cloudfunctionsv2", () => {
         eventTrigger: {
           eventType: cloudfunctionsv2.PUBSUB_PUBLISH_EVENT,
           pubsubTopic: "projects/p/topics/t",
+          triggerRegion: "us",
         },
         serviceConfig: {
           ...CLOUD_FUNCTION_V2.serviceConfig,
@@ -516,6 +518,7 @@ describe("cloudfunctionsv2", () => {
                 value: "compute.googleapis.com",
               },
             ],
+            triggerRegion: "us",
           },
         })
       ).to.deep.equal({
@@ -529,6 +532,7 @@ describe("cloudfunctionsv2", () => {
             serviceName: "compute.googleapis.com",
           },
           retry: false,
+          region: "us",
         },
       });
     });


### PR DESCRIPTION
Merges master + corrections and backports.

1. Applied @colerogers's hack where we detect "region" for GCS functions and make it "bucket" to the Endpoints version of parseTriggers.ts
2. Moved the logic where we get trigger regions from previous deploys to the new `inferDetailsFromExisting`
3. Renamed the function for looking up missing trigger names to clarify that it only affects missing names.

While I was looking at the codebase for (3) again, I rewrote it quickly.
1. We need to be making these API calls in parallel. This could have massive implications on first deploy speed.
2. This common idiom for this kind of code is a [dispatch table](https://en.wikipedia.org/wiki/Dispatch_table). This makes it very easy to add cases without creating nested spaghetti code.