### PR TITLE
Fix Auth Emulator deleteTenant not working with Node Admin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix Auth Emulator deleteTenant not working with Node Admin (#3817).

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -124,6 +124,14 @@ export async function createApp(
   // This is similar to production behavior. Safe since all APIs are cookieless.
   app.use(cors({ origin: true }));
 
+  // Workaround for clients (e.g. Node.js Admin SDK) that send request bodies
+  // with HTTP DELETE requests. Such requests are tolerated by production, but
+  // exegesis will reject them without the following hack.
+  app.delete("*", (req, _, next) => {
+    delete req.headers["content-type"];
+    next();
+  });
+
   app.get("/", (req, res) => {
     return res.json({
       authEmulator: {

--- a/src/test/emulators/auth/tenant.spec.ts
+++ b/src/test/emulators/auth/tenant.spec.ts
@@ -116,6 +116,9 @@ describeAuthEmulator("tenant management", ({ authApi }) => {
           `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
         )
         .set("Authorization", "Bearer owner")
+        // Sets content-type and sends "{}" in request payload. This is very
+        // uncommon for HTTP DELETE requests, but clients like the Node.js Admin
+        // SDK do it anyway. We want the emulator to tolerate this.
         .send({})
         .then((res) => {
           expectStatusCode(200, res);

--- a/src/test/emulators/auth/tenant.spec.ts
+++ b/src/test/emulators/auth/tenant.spec.ts
@@ -106,6 +106,21 @@ describeAuthEmulator("tenant management", ({ authApi }) => {
           expectStatusCode(200, res);
         });
     });
+
+    it("should delete tenants if request body is passed", async () => {
+      const projectId = "project-id";
+      const tenant = await registerTenant(authApi(), projectId, {});
+
+      await authApi()
+        .delete(
+          `/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants/${tenant.tenantId}`
+        )
+        .set("Authorization", "Bearer owner")
+        .send({})
+        .then((res) => {
+          expectStatusCode(200, res);
+        });
+    });
   });
 
   describe("listTenants", () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fix Auth Emulator deleteTenant not working with Node.js Admin SDK.

### Scenarios Tested

See test added. @lisajian to confirm the fix using Node.js Admin SDK integration tests as well.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
