### PR TITLE
Modify multi-tenancy impacted endpoints according to admin integ tests

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -213,8 +213,8 @@ function signUp(
       generateEnrollmentIds: true,
     });
   }
-  if (reqBody.tenantId) {
-    updates.tenantId = reqBody.tenantId;
+  if (state instanceof TenantProjectState) {
+    updates.tenantId = state.tenantId;
   }
   let user: UserInfo | undefined;
   if (reqBody.idToken) {
@@ -349,6 +349,8 @@ function batchCreate(
           state instanceof TenantProjectState && state.tenantId === userInfo.tenantId,
           "Tenant id in userInfo does not match the tenant id in request."
         );
+      }
+      if (state instanceof TenantProjectState) {
         fields.tenantId = state.tenantId;
       }
 
@@ -1268,7 +1270,7 @@ function signInWithCustomToken(
     uid?: unknown;
     user_id?: unknown;
     claims?: unknown;
-    tenantId?: unknown;
+    tenant_id?: unknown;
   };
   if (reqBody.token.startsWith("{")) {
     // In the emulator only, we allow plain JSON strings as custom tokens, to
@@ -1287,7 +1289,7 @@ function signInWithCustomToken(
       payload: typeof payload;
     } | null;
     if (state instanceof TenantProjectState) {
-      assert(decoded?.payload.tenantId === state.tenantId, "TENANT_ID_MISMATCH");
+      assert(decoded?.payload.tenant_id === state.tenantId, "TENANT_ID_MISMATCH");
     }
     assert(decoded, "INVALID_CUSTOM_TOKEN : Invalid assertion format");
     if (decoded.header.alg !== "none") {

--- a/src/test/emulators/auth/batch.spec.ts
+++ b/src/test/emulators/auth/batch.spec.ts
@@ -684,7 +684,6 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
       localId: "foo",
       email: "me@example.com",
       rawPassword: "notasecret",
-      tenantId: tenant.tenantId,
     };
 
     await authApi()

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -292,7 +292,7 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
     const uid = "someuid";
     const claims = { abc: "def", ultimate: { answer: 42 } };
-    const token = signJwt({ uid, claims, tenantId: "not-matching-tenant-id" }, "", {
+    const token = signJwt({ uid, claims, tenant_id: "not-matching-tenant-id" }, "", {
       algorithm: "none",
       expiresIn: 3600,
 
@@ -315,7 +315,7 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: false });
     const uid = "someuid";
     const claims = { abc: "def", ultimate: { answer: 42 } };
-    const token = signJwt({ uid, claims, tenantId: tenant.tenantId }, "", {
+    const token = signJwt({ uid, claims, tenant_id: tenant.tenantId }, "", {
       algorithm: "none",
       expiresIn: 3600,
 


### PR DESCRIPTION
### Description

Update endpoints impacted by multi-tenancy change so they pass tests existing in admin SDK

Corresponding internal bug: b/192387245

### Scenarios Tested

* `npm test` passes in auth emulator
* `node /Users/lisajian/dev/firebase-tools/lib/bin/firebase emulators:exec --project fake-project-id --only auth,database,firestore     'npx mocha \"test/integration/auth.spec.ts\" --slow 5000 --timeout 20000 --require ts-node/register --testMultiTenancy'` passes in firebase-admin-node SDK

### Sample Commands

N/A