### PR TITLE
Diverge tenant config defaults

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -32,6 +32,7 @@ import {
   UsageMode,
   AgentProjectState,
   TenantProjectState,
+  MfaConfig,
 } from "./state";
 import { MfaEnrollments, Schemas } from "./types";
 
@@ -2692,6 +2693,14 @@ function createTenant(
     throw new InternalError("INTERNAL_ERROR: Can only create tenant in agent project", "INTERNAL");
   }
 
+  const mfaConfig = reqBody.mfaConfig ?? {};
+  if (!("state" in mfaConfig)) {
+    mfaConfig.state = "DISABLED";
+  }
+  if (!("enabledProviders" in mfaConfig)) {
+    mfaConfig.enabledProviders = [];
+  }
+
   // Default to production settings if unset
   const tenant = {
     displayName: reqBody.displayName,
@@ -2699,7 +2708,7 @@ function createTenant(
     enableEmailLinkSignin: reqBody.enableEmailLinkSignin ?? false,
     enableAnonymousUser: reqBody.enableAnonymousUser ?? false,
     disableAuth: reqBody.disableAuth ?? false,
-    mfaConfig: reqBody.mfaConfig ?? { state: "DISABLED" },
+    mfaConfig: mfaConfig as MfaConfig,
     tenantId: "", // Placeholder until one is generated
   };
 

--- a/src/test/emulators/auth/helpers.ts
+++ b/src/test/emulators/auth/helpers.ts
@@ -5,7 +5,7 @@ import { expect, AssertionError } from "chai";
 import { IdpJwtPayload } from "../../../emulator/auth/operations";
 import { OobRecord, PhoneVerificationRecord, Tenant, UserInfo } from "../../../emulator/auth/state";
 import { TestAgent, PROJECT_ID } from "./setup";
-import { MfaEnrollments } from "../../../emulator/auth/types";
+import { MfaEnrollments, Schemas } from "../../../emulator/auth/types";
 
 export { PROJECT_ID };
 export const TEST_PHONE_NUMBER = "+15555550100";
@@ -407,7 +407,7 @@ export function deleteAccount(testAgent: TestAgent, reqBody: {}): Promise<string
 export function registerTenant(
   testAgent: TestAgent,
   projectId: string,
-  tenant?: Partial<Tenant>
+  tenant?: Schemas["GoogleCloudIdentitytoolkitAdminV2Tenant"]
 ): Promise<Tenant> {
   return testAgent
     .post(`/identitytoolkit.googleapis.com/v2/projects/${projectId}/tenants`)

--- a/src/test/emulators/auth/tenant.spec.ts
+++ b/src/test/emulators/auth/tenant.spec.ts
@@ -53,6 +53,7 @@ describeAuthEmulator("tenant management", ({ authApi }) => {
           expect(res.body.enableEmailLinkSignin).to.be.false;
           expect(res.body.mfaConfig).to.eql({
             state: "DISABLED",
+            enabledProviders: [],
           });
         });
     });
@@ -367,7 +368,10 @@ describeAuthEmulator("tenant management", ({ authApi }) => {
           expect(res.body.disableAuth).to.be.false;
           expect(res.body.enableAnonymousUser).to.be.false;
           expect(res.body.enableEmailLinkSignin).to.be.false;
-          expect(res.body.mfaConfig).to.eql({});
+          expect(res.body.mfaConfig).to.eql({
+            enabledProviders: [],
+            state: "DISABLED",
+          });
         });
     });
   });


### PR DESCRIPTION
### Description

Diverge in tenant config defaults. Tenant configs default to enabled for implicitly created tenants and default to disabled for explicitly created tenants.

Corresponding internal bug: b/192387245

### Scenarios Tested

`npm test` passes

### Sample Commands

N/A