### PR TITLE
Migrate manifest parsing to use Endpoints

### DIFF
--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -1,170 +1,179 @@
 import * as backend from "../../backend";
 import * as runtimes from "..";
+import { copyIfPresent } from "../../../../gcp/proto";
 import { assertKeyTypes, requireKeys } from "./parsing";
+import { FirebaseError } from "../../../../error";
 
+export type ManifestEndpoint = backend.ServiceConfiguration &
+  backend.Triggered &
+  Partial<backend.HttpsTriggered> &
+  Partial<backend.EventTriggered> &
+  Partial<backend.ScheduleTriggered> & {
+    region?: string[];
+    entryPoint: string;
+    platform?: backend.FunctionsPlatform;
+  };
+
+export interface Manifest {
+  specVersion: string;
+  requiredAPIs?: Record<string, string>;
+  endpoints: Record<string, ManifestEndpoint>;
+}
+
+/** Returns a Backend from a v1alpha1 Manifest. */
 export function backendFromV1Alpha1(
-  yaml: any,
+  yaml: unknown,
   project: string,
   region: string,
   runtime: runtimes.Runtime
 ): backend.Backend {
-  const bkend: backend.Backend = JSON.parse(JSON.stringify(yaml));
-  delete (bkend as any).specVersion;
-  tryValidate(bkend);
-  fillDefaults(bkend, project, region, runtime);
+  const manifest = JSON.parse(JSON.stringify(yaml)) as Manifest;
+  const bkend: backend.Backend = backend.empty();
+  bkend.requiredAPIs = parseRequiredAPIs(manifest);
+  requireKeys("", manifest, "endpoints");
+  assertKeyTypes("", manifest, {
+    specVersion: "string",
+    requiredAPIs: "object",
+    endpoints: "object",
+  });
+  for (const id of Object.keys(manifest.endpoints)) {
+    for (const parsed of parseEndpoints(manifest, id, project, region, runtime)) {
+      bkend.endpoints[parsed.region] = bkend.endpoints[parsed.region] || {};
+      bkend.endpoints[parsed.region][parsed.id] = parsed;
+    }
+  }
   return bkend;
 }
 
-function tryValidate(typed: backend.Backend) {
-  // Use a helper type to help guide code complete when writing this function
-  assertKeyTypes("", typed, {
-    requiredAPIs: "object",
-    endpoints: "object",
-    cloudFunctions: "array",
-    topics: "array",
-    schedules: "array",
-    environmentVariables: "object",
-  });
-  requireKeys("", typed, "cloudFunctions");
+function parseRequiredAPIs(manifest: Manifest): Record<string, string> {
+  const requiredAPIs: Record<string, string> = {};
+  // Note: this intentionally allows undefined to slip through as {}
+  if (typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new FirebaseError("Expected requiredApis to be a map of string to string");
+  }
+  for (const [api, reason] of Object.entries(manifest.requiredAPIs || {})) {
+    if (typeof reason !== "string") {
+      throw new FirebaseError(
+        `Invalid reason "${JSON.stringify(reason)} for API ${api}. Expected string`
+      );
+    }
+    requiredAPIs[api] = reason;
+  }
+  return requiredAPIs;
+}
 
-  for (let ndx = 0; ndx < typed.cloudFunctions.length; ndx++) {
-    const prefix = `cloudFunctions[${ndx}]`;
-    const func = typed.cloudFunctions[ndx];
-    requireKeys(prefix, func, "platform", "id", "entryPoint", "trigger");
-    assertKeyTypes(prefix, func, {
-      platform: "string",
-      id: "string",
-      region: "string",
-      project: "string",
-      runtime: "string",
-      entryPoint: "string",
-      availableMemoryMb: "number",
-      maxInstances: "number",
-      minInstances: "number",
-      concurrency: "number",
-      serviceAccountEmail: "string",
-      timeout: "string",
-      trigger: "object",
-      vpcConnector: "string",
-      vpcConnectorEgressSettings: "string",
-      labels: "object",
-      ingressSettings: "string",
-      environmentVariables: "omit",
-      uri: "omit",
-      sourceUploadUrl: "omit",
-    });
-    if (backend.isEventTrigger(func.trigger)) {
-      requireKeys(prefix + ".trigger", func.trigger, "eventType", "eventFilters");
-      assertKeyTypes(prefix + ".trigger", func.trigger, {
+function parseEndpoints(
+  manifest: Manifest,
+  id: string,
+  project: string,
+  defaultRegion: string,
+  runtime: runtimes.Runtime
+): backend.Endpoint[] {
+  const allParsed: backend.Endpoint[] = [];
+  const prefix = `endpoints[${id}]`;
+  const ep = manifest.endpoints[id];
+
+  assertKeyTypes(prefix, ep, {
+    region: "array",
+    platform: "string",
+    entryPoint: "string",
+    availableMemoryMb: "number",
+    maxInstances: "number",
+    minInstances: "number",
+    concurrency: "number",
+    serviceAccountEmail: "string",
+    timeout: "string",
+    vpcConnector: "string",
+    vpcConnectorEgressSettings: "string",
+    labels: "object",
+    ingressSettings: "string",
+    environmentVariables: "object",
+    httpsTrigger: "object",
+    eventTrigger: "object",
+    scheduleTrigger: "object",
+  });
+  let triggerCount = 0;
+  if (ep.httpsTrigger) {
+    triggerCount++;
+  }
+  if (ep.eventTrigger) {
+    triggerCount++;
+  }
+  if (ep.scheduleTrigger) {
+    triggerCount++;
+  }
+  if (!triggerCount) {
+    throw new FirebaseError("Expected trigger in endpoint" + id);
+  }
+  if (triggerCount > 1) {
+    throw new FirebaseError("Multiple triggers defined for endpoint" + id);
+  }
+  for (const region of ep.region || [defaultRegion]) {
+    let triggered: backend.Triggered;
+    if (backend.isEventTriggered(ep)) {
+      requireKeys(prefix + ".eventTrigger", ep.eventTrigger, "eventType", "eventFilters");
+      assertKeyTypes(prefix + ".eventTrigger", ep.eventTrigger, {
         eventFilters: "object",
         eventType: "string",
         retry: "boolean",
         region: "string",
         serviceAccountEmail: "string",
       });
-    } else {
-      assertKeyTypes(prefix + ".trigger", func.trigger, {
+      triggered = { eventTrigger: ep.eventTrigger };
+    } else if (backend.isHttpsTriggered(ep)) {
+      assertKeyTypes(prefix + ".httpsTrigger", ep.httpsTrigger, {
         invoker: "array",
       });
+      triggered = { httpsTrigger: {} };
+      copyIfPresent(triggered.httpsTrigger, ep.httpsTrigger, "invoker");
+    } else if (backend.isScheduleTriggered(ep)) {
+      assertKeyTypes(prefix + ".scheduleTrigger", ep.scheduleTrigger, {
+        schedule: "string",
+        timeZone: "string",
+        retryConfig: "object",
+      });
+      assertKeyTypes(prefix + ".scheduleTrigger.retryConfig", ep.scheduleTrigger.retryConfig, {
+        retryCount: "number",
+        maxDoublings: "number",
+        minBackoffDuration: "string",
+        maxBackoffDuration: "string",
+        maxRetryDuration: "string",
+      });
+      triggered = { scheduleTrigger: ep.scheduleTrigger };
+    } else {
+      throw new FirebaseError(
+        `Do not recognize trigger type for endpoint ${id}. Try upgrading ` +
+          "firebase-tools with npm install -g firebase-tools@latest"
+      );
     }
+
+    requireKeys(prefix, ep, "entryPoint");
+    const parsed: backend.Endpoint = {
+      platform: ep.platform || "gcfv2",
+      id,
+      region,
+      project,
+      runtime,
+      entryPoint: ep.entryPoint,
+      ...triggered,
+    };
+    copyIfPresent(
+      parsed,
+      ep,
+      "availableMemoryMb",
+      "maxInstances",
+      "minInstances",
+      "concurrency",
+      "serviceAccountEmail",
+      "timeout",
+      "vpcConnector",
+      "vpcConnectorEgressSettings",
+      "labels",
+      "ingressSettings",
+      "environmentVariables"
+    );
+    allParsed.push(parsed);
   }
 
-  for (let ndx = 0; ndx < typed.topics?.length; ndx++) {
-    let prefix = `topics[${ndx}]`;
-    const topic = typed.topics[ndx];
-    requireKeys(prefix, topic, "id", "targetService");
-    assertKeyTypes(prefix, topic, {
-      id: "string",
-      labels: "object",
-      project: "string",
-      targetService: "object",
-    });
-
-    prefix += ".targetService";
-    requireKeys(prefix, topic.targetService, "id");
-    assertKeyTypes(prefix, topic.targetService, {
-      id: "string",
-      project: "string",
-      region: "string",
-    });
-  }
-
-  for (let ndx = 0; ndx < typed.schedules?.length; ndx++) {
-    let prefix = `schedules[${ndx}]`;
-    const schedule = typed.schedules[ndx];
-    requireKeys(prefix, schedule, "id", "schedule", "transport", "targetService");
-    assertKeyTypes(prefix, schedule, {
-      id: "string",
-      project: "string",
-      retryConfig: "object",
-      schedule: "string",
-      timeZone: "string",
-      transport: "string",
-      targetService: "object",
-    });
-
-    assertKeyTypes(prefix + ".retryConfig", schedule.retryConfig, {
-      maxBackoffDuration: "string",
-      minBackoffDuration: "string",
-      maxDoublings: "number",
-      maxRetryDuration: "string",
-      retryCount: "number",
-    });
-
-    requireKeys((prefix = ".targetService"), schedule.targetService, "id");
-    assertKeyTypes(prefix + ".targetService", schedule.targetService, {
-      id: "string",
-      project: "string",
-      region: "string",
-    });
-  }
-}
-
-function fillDefaults(
-  want: backend.Backend,
-  project: string,
-  region: string,
-  runtime: runtimes.Runtime
-) {
-  want.requiredAPIs = want.requiredAPIs || {};
-  want.environmentVariables = want.environmentVariables || {};
-  want.schedules = want.schedules || [];
-  want.topics = want.topics || [];
-  want.endpoints = want.endpoints || {};
-
-  for (const cloudFunction of want.cloudFunctions) {
-    if (!cloudFunction.project) {
-      cloudFunction.project = project;
-    }
-    if (!cloudFunction.region) {
-      cloudFunction.region = region;
-    }
-    if (!cloudFunction.runtime) {
-      cloudFunction.runtime = runtime;
-    }
-  }
-
-  for (const topic of want.topics) {
-    if (!topic.project) {
-      topic.project = project;
-    }
-    if (!topic.targetService.project) {
-      topic.targetService.project = project;
-    }
-    if (!topic.targetService.region) {
-      topic.targetService.region = region;
-    }
-  }
-
-  for (const schedule of want.schedules) {
-    if (!schedule.project) {
-      schedule.project = project;
-    }
-    if (!schedule.targetService.project) {
-      schedule.targetService.project = project;
-    }
-    if (!schedule.targetService.region) {
-      schedule.targetService.region = region;
-    }
-  }
+  return allParsed;
 }

--- a/src/test/deploy/functions/runtimes/discovery/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/index.spec.ts
@@ -8,15 +8,15 @@ import { FirebaseError } from "../../../../../error";
 import * as discovery from "../../../../../deploy/functions/runtimes/discovery";
 import * as backend from "../../../../../deploy/functions/backend";
 
-const MIN_FUNCTION = {
-  platform: "gcfv1" as backend.FunctionsPlatform,
-  id: "function",
+const MIN_ENDPOINT = {
   entryPoint: "entrypoint",
-  trigger: {},
+  httpsTrigger: {},
 };
 
-const FUNCTION: backend.FunctionSpec = {
-  ...MIN_FUNCTION,
+const ENDPOINT: backend.Endpoint = {
+  ...MIN_ENDPOINT,
+  id: "id",
+  platform: "gcfv2",
   project: "project",
   region: api.functionsDefaultRegion,
   runtime: "nodejs16",
@@ -24,16 +24,12 @@ const FUNCTION: backend.FunctionSpec = {
 
 const YAML_OBJ = {
   specVersion: "v1alpha1",
-  ...backend.empty(),
-  cloudFunctions: [MIN_FUNCTION],
+  endpoints: { id: MIN_ENDPOINT },
 };
 
 const YAML_TEXT = yaml.dump(YAML_OBJ);
 
-const BACKEND: backend.Backend = {
-  ...backend.empty(),
-  cloudFunctions: [FUNCTION],
-};
+const BACKEND: backend.Backend = backend.of(ENDPOINT);
 
 describe("yamlToBackend", () => {
   it("Accepts a valid v1alpha1 spec", () => {
@@ -47,7 +43,7 @@ describe("yamlToBackend", () => {
   });
 
   it("Requires a spec version", () => {
-    const flawed: any = { ...YAML_OBJ };
+    const flawed: Record<string, unknown> = { ...YAML_OBJ };
     delete flawed.specVersion;
     expect(() =>
       discovery.yamlToBackend(flawed, "project", api.functionsDefaultRegion, "nodejs16")

--- a/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -8,16 +8,13 @@ import * as v1alpha1 from "../../../../../deploy/functions/runtimes/discovery/v1
 const PROJECT = "project";
 const REGION = "region";
 const RUNTIME: Runtime = "node14";
-const MIN_FUNC: Partial<backend.FunctionSpec> = {
-  platform: "gcfv1",
-  id: "id",
+const MIN_ENDPOINT: Omit<v1alpha1.ManifestEndpoint, "httpsTrigger"> = {
   entryPoint: "entryPoint",
-  trigger: {},
 };
 
 describe("backendFromV1Alpha1", () => {
   describe("parser errors", () => {
-    function assertParserError(obj: any) {
+    function assertParserError(obj: unknown): void {
       expect(() => v1alpha1.backendFromV1Alpha1(obj, PROJECT, REGION, RUNTIME)).to.throw(
         FirebaseError
       );
@@ -30,15 +27,13 @@ describe("backendFromV1Alpha1", () => {
 
       const invalidBackendTypes = {
         requiredAPIS: ["cloudscheduler.googleapis.com"],
-        cloudFunctions: {},
-        topics: {},
-        schedules: {},
-        environmentVariables: {},
+        endpoints: [],
       };
       for (const [key, value] of Object.entries(invalidBackendTypes)) {
         it(`throws on invalid value for top-level key ${key}`, () => {
           const obj = {
-            functions: [MIN_FUNC],
+            requiredAPIs: {},
+            endpoints: {},
             [key]: value,
           };
           assertParserError(obj);
@@ -50,30 +45,31 @@ describe("backendFromV1Alpha1", () => {
       });
     }); // top level keys
 
-    describe("CloudFunction keys", () => {
+    describe("Endpoint keys", () => {
       it("invalid keys", () => {
         assertParserError({
-          cloudFunctions: [
-            {
-              ...MIN_FUNC,
+          endpoints: {
+            id: {
+              ...MIN_ENDPOINT,
+              httpsTrigger: {},
               invalid: "key",
             },
-          ],
+          },
         });
       });
 
-      for (const key of Object.keys(MIN_FUNC)) {
-        it(`missing CloudFunction key ${key}`, () => {
-          const func = { ...MIN_FUNC } as Record<string, any>;
+      for (const key of Object.keys(MIN_ENDPOINT)) {
+        it(`missing Endpoint key ${key}`, () => {
+          const func = { ...MIN_ENDPOINT, httpsTrigger: {} } as Record<string, unknown>;
           delete func[key];
           assertParserError({ cloudFunctions: [func] });
         });
       }
 
       const invalidFunctionEntries = {
-        apiVersion: "five",
+        platform: 2,
         id: 1,
-        region: ["us-central1"],
+        region: "us-central1",
         project: 42,
         runtime: null,
         entryPoint: 5,
@@ -91,10 +87,11 @@ describe("backendFromV1Alpha1", () => {
       for (const [key, value] of Object.entries(invalidFunctionEntries)) {
         it(`invalid value for CloudFunction key ${key}`, () => {
           const func = {
-            ...MIN_FUNC,
+            ...MIN_ENDPOINT,
+            httpsTrigger: {},
             [key]: value,
           };
-          assertParserError({ cloudFunctions: [func] });
+          assertParserError({ endpoints: { func } });
         });
       }
     }); // Top level function keys
@@ -111,15 +108,12 @@ describe("backendFromV1Alpha1", () => {
       };
       for (const key of ["eventType", "eventFilters"]) {
         it(`missing event trigger key ${key}`, () => {
-          const trigger = { ...validTrigger } as any;
-          delete trigger[key];
+          const eventTrigger = { ...validTrigger } as Record<string, unknown>;
+          delete eventTrigger[key];
           assertParserError({
-            cloudFunctions: [
-              {
-                ...MIN_FUNC,
-                trigger,
-              },
-            ],
+            endpoints: {
+              func: { ...MIN_ENDPOINT, eventTrigger },
+            },
           });
         });
       }
@@ -133,111 +127,227 @@ describe("backendFromV1Alpha1", () => {
       };
       for (const [key, value] of Object.entries(invalidEntries)) {
         it(`invalid value for event trigger key ${key}`, () => {
-          const trigger = {
+          const eventTrigger = {
             ...validTrigger,
             [key]: value,
           };
           assertParserError({
-            cloudFunctions: [
-              {
-                ...MIN_FUNC,
-                trigger,
-              },
-            ],
+            endpoints: {
+              func: { ...MIN_ENDPOINT, eventTrigger },
+            },
           });
         });
       }
     }); // Event triggers
+
+    describe("httpsTriggers", () => {
+      it("invalid value for https trigger key invoker", () => {
+        assertParserError({
+          endpoints: {
+            func: {
+              ...MIN_ENDPOINT,
+              httpsTrigger: {
+                invoker: 42,
+              },
+            },
+          },
+        });
+      });
+    });
+
+    describe("scheduleTriggers", () => {
+      const validTrigger: backend.ScheduleTrigger = {
+        schedule: "every 5 minutes",
+        timeZone: "America/Los_Angeles",
+        retryConfig: {
+          retryCount: 42,
+          minBackoffDuration: "1s",
+          maxBackoffDuration: "20s",
+          maxDoublings: 20,
+          maxRetryDuration: "120s",
+        },
+      };
+
+      const invalidEntries = {
+        schedule: 46,
+        timeZone: {},
+      };
+      for (const [key, value] of Object.entries(invalidEntries)) {
+        it(`invalid value for schedule trigger key ${key}`, () => {
+          const scheduleTrigger = {
+            ...validTrigger,
+            [key]: value,
+          };
+          assertParserError({
+            endpoints: {
+              func: { ...MIN_ENDPOINT, scheduleTrigger },
+            },
+          });
+        });
+      }
+
+      const invalidRetryEntries = {
+        retryCount: "42",
+        minBackoffDuration: 1,
+        maxBackoffDuration: 20,
+        maxDoublings: "20",
+        maxRetryDuration: 120,
+      };
+      for (const [key, value] of Object.entries(invalidRetryEntries)) {
+        const retryConfig = {
+          ...validTrigger.retryConfig,
+          [key]: value,
+        };
+        const scheduleTrigger = {
+          ...validTrigger,
+          retryConfig,
+        };
+        assertParserError({
+          endpoints: {
+            func: { ...MIN_ENDPOINT, scheduleTrigger },
+          },
+        });
+      }
+    });
+
+    it("detects missing triggers", () => {
+      assertParserError({ endpoints: MIN_ENDPOINT });
+    });
   }); // Parser errors;
 
   describe("allows valid backends", () => {
-    const DEFAULTED_FUNC = {
-      ...MIN_FUNC,
-      project: PROJECT,
-      region: REGION,
-      runtime: RUNTIME,
-    } as backend.FunctionSpec;
-
-    const TARGET_SERVICE = {
+    const DEFAULTED_ENDPOINT: Omit<backend.Endpoint, "httpsTrigger"> = {
+      ...MIN_ENDPOINT,
+      platform: "gcfv2",
       id: "id",
       project: PROJECT,
       region: REGION,
+      runtime: RUNTIME,
     };
 
     it("fills default backend and function fields", () => {
-      const yaml = {
-        cloudFunctions: [
-          {
-            ...MIN_FUNC,
-            trigger: {},
+      const yaml: v1alpha1.Manifest = {
+        specVersion: "v1alpha1",
+        endpoints: {
+          id: {
+            ...MIN_ENDPOINT,
+            httpsTrigger: {},
           },
-        ],
+        },
       };
       const parsed = v1alpha1.backendFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
-      const expected: backend.Backend = {
-        ...backend.empty(),
-        cloudFunctions: [
-          {
-            ...DEFAULTED_FUNC,
-            trigger: {},
-          },
-        ],
-      };
+      const expected: backend.Backend = backend.of({ ...DEFAULTED_ENDPOINT, httpsTrigger: {} });
       expect(parsed).to.deep.equal(expected);
     });
 
-    it("fills defaults for pub/sub and schedules", () => {
-      const yaml = {
-        cloudFunctions: [
-          {
-            ...MIN_FUNC,
-            trigger: {},
-          },
-        ],
-        topics: [
-          {
-            id: "topic",
-            targetService: {
-              id: "id",
-            },
-          },
-        ],
-        schedules: [
-          {
-            id: "schedule",
-            schedule: "every 5 minutes",
-            transport: "https",
-            targetService: {
-              id: "id",
-            },
-          },
-        ],
+    it("copies schedules", () => {
+      const scheduleTrigger: backend.ScheduleTrigger = {
+        schedule: "every 5 minutes",
+        timeZone: "America/Los_Angeles",
+        retryConfig: {
+          retryCount: 20,
+          minBackoffDuration: "1s",
+          maxBackoffDuration: "20s",
+          maxRetryDuration: "120s",
+          maxDoublings: 10,
+        },
       };
-      const expected: backend.Backend = {
-        ...backend.empty(),
-        cloudFunctions: [
-          {
-            ...DEFAULTED_FUNC,
-            trigger: {},
+
+      const yaml: v1alpha1.Manifest = {
+        specVersion: "v1alpha1",
+        endpoints: {
+          id: {
+            ...MIN_ENDPOINT,
+            scheduleTrigger,
           },
-        ],
-        topics: [
-          {
-            id: "topic",
-            project: PROJECT,
-            targetService: TARGET_SERVICE,
-          },
-        ],
-        schedules: [
-          {
-            id: "schedule",
-            project: PROJECT,
-            schedule: "every 5 minutes",
-            transport: "https",
-            targetService: TARGET_SERVICE,
-          },
-        ],
+        },
       };
+      const expected = backend.of({ ...DEFAULTED_ENDPOINT, scheduleTrigger });
+      const parsed = v1alpha1.backendFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
+      expect(parsed).to.deep.equal(expected);
+    });
+
+    it("copies event triggers", () => {
+      const eventTrigger: backend.EventTrigger = {
+        eventType: "google.pubsub.topic.v1.publish",
+        eventFilters: {
+          resource: "projects/project/topics/topic",
+        },
+        region: "us-central1",
+        serviceAccountEmail: "sa@",
+        retry: true,
+      };
+      const yaml: v1alpha1.Manifest = {
+        specVersion: "v1alpha1",
+        endpoints: {
+          id: {
+            ...MIN_ENDPOINT,
+            eventTrigger,
+          },
+        },
+      };
+      const expected = backend.of({ ...DEFAULTED_ENDPOINT, eventTrigger });
+      const parsed = v1alpha1.backendFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
+      expect(parsed).to.deep.equal(expected);
+    });
+
+    it("copies optional fields", () => {
+      const fields: backend.ServiceConfiguration = {
+        concurrency: 42,
+        labels: { hello: "world" },
+        environmentVariables: { foo: "bar" },
+        availableMemoryMb: 256,
+        timeout: "60s",
+        maxInstances: 20,
+        minInstances: 1,
+        vpcConnector: "hello",
+        vpcConnectorEgressSettings: "ALL_TRAFFIC",
+        ingressSettings: "ALLOW_INTERNAL_ONLY",
+        serviceAccountEmail: "sa@",
+      };
+
+      const yaml: v1alpha1.Manifest = {
+        specVersion: "v1alpha1",
+        endpoints: {
+          id: {
+            ...MIN_ENDPOINT,
+            httpsTrigger: {},
+            ...fields,
+          },
+        },
+      };
+      const expected = backend.of({
+        ...DEFAULTED_ENDPOINT,
+        httpsTrigger: {},
+        ...fields,
+      });
+      const parsed = v1alpha1.backendFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
+      expect(parsed).to.deep.equal(expected);
+    });
+
+    it("handles multiple regions", () => {
+      const yaml: v1alpha1.Manifest = {
+        specVersion: "v1alpha1",
+        endpoints: {
+          id: {
+            ...MIN_ENDPOINT,
+            httpsTrigger: {},
+            region: ["region1", "region2"],
+          },
+        },
+      };
+      const expected = backend.of(
+        {
+          ...DEFAULTED_ENDPOINT,
+          httpsTrigger: {},
+          region: "region1",
+        },
+        {
+          ...DEFAULTED_ENDPOINT,
+          httpsTrigger: {},
+          region: "region2",
+        }
+      );
       const parsed = v1alpha1.backendFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
       expect(parsed).to.deep.equal(expected);
     });


### PR DESCRIPTION
Since there are no consumers of the container contract ATM I simply replaced the FunctionsSpec/PubsubSpec/ScheduleSpec code with Endpoints code.