### PR TITLE
Make environment variables available to user code during function deployment

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -87,8 +87,9 @@ export async function prepare(
   track("functions_codebase_deploy_env_method", tag);
 
   logger.debug(`Analyzing ${runtimeDelegate.name} backend spec`);
-  const wantBackend = await runtimeDelegate.discoverSpec(runtimeConfig, firebaseEnvs);
-  wantBackend.environmentVariables = { ...userEnvs, ...firebaseEnvs };
+  const mergedEnvs = { ...userEnvs, ...firebaseEnvs };
+  const wantBackend = await runtimeDelegate.discoverSpec(runtimeConfig, mergedEnvs);
+  wantBackend.environmentVariables = mergedEnvs;
   payload.functions = { backend: wantBackend };
 
   // Note: Some of these are premium APIs that require billing to be enabled.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

We're using the framework NestJS which has the handy feature to validate environment variables before booting an application. This has the effect that deployments (for Cloud Functions) fail when an environment variable is missing or invalid. This is not a NestJS specific feature, this could also be useful for any application. I posted a short snippet below.

I enabled the new dotenv feature and tried to deploy our functions with environment variables. Though I encountered the following problem: When deploying Firebase Functions the source code gets loaded, but the environment variables defined in the .env aren't available in this context.

I introduced a small change that the user defined variables as well as the Firebase default environment variables will be merged before being passed on. As far as I can know this will be the same set of variables when the function gets deployed runs in the cloud.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Here's a small example which fails when trying to deploy a function which requires an environment variable to be present.

```javascript
const functions = require("firebase-functions");

if (!process.env.FOO) {
    throw new Error('Environment variable FOO not set');
}

exports.helloWorld = functions.https.onRequest((request, response) => {
    functions.logger.info("Hello logs!", {structuredData: true});
    response.send("Hello from Firebase! FOO=" + process.env.FOO);
});
```

Deploying this code without the change exits with the following error:

```
Error occurred while parsing your function triggers.

Error: Environment variable FOO not set
...
```

Deploying the function trigger using this change succeeds.

