### PR TITLE
Add checks for product provisioning and billing to `deploy --only extensions`

### DIFF
--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -83,7 +83,7 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
         );
       } else if (!enabled) {
         await displayNode10CreateBillingNotice(spec, false);
-        await enableBilling(projectId, spec.displayName || spec.name);
+        await enableBilling(projectId);
       } else {
         await displayNode10CreateBillingNotice(spec, !nonInteractive);
       }

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -226,7 +226,7 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
         }
         if (!enabled) {
           if (!options.nonInteractive) {
-            await enableBilling(projectId, instanceId);
+            await enableBilling(projectId);
           } else {
             throw new FirebaseError(
               "The extension requires your project to be upgraded to the Blaze plan. " +

--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -44,9 +44,11 @@ export async function want(
       const instanceId = e[0];
       const ref = refs.parse(e[1]);
       ref.version = await resolveVersion(ref);
+
       const params = readParams(projectDir, instanceId);
       const autoPopulatedParams = await getFirebaseProjectParams(projectId);
       const subbedParams = substituteParams(params, autoPopulatedParams);
+
       instanceSpecs.push({
         instanceId,
         ref,

--- a/src/deploy/extensions/validate.ts
+++ b/src/deploy/extensions/validate.ts
@@ -1,0 +1,15 @@
+import { checkBillingEnabled } from "../../gcp/cloudbilling";
+import { enableBilling } from "../../extensions/checkProjectBilling";
+import { FirebaseError } from "../../error";
+
+export async function checkBilling(projectId: string, nonInteractive: boolean) {
+  const enabled = await checkBillingEnabled(projectId);
+  if (!enabled && nonInteractive) {
+    throw new FirebaseError(
+      `Extensions require the Blaze plan, but project ${projectId} is not on the Blaze plan. ` +
+        `Please visit https://console.cloud.google.com/billing/linkedaccount?project=${projectId} to upgrade your project.`
+    );
+  } else if (!enabled) {
+    await enableBilling(projectId);
+  }
+}

--- a/src/extensions/checkProjectBilling.ts
+++ b/src/extensions/checkProjectBilling.ts
@@ -50,7 +50,6 @@ async function openBillingAccount(projectId: string, url: string, open: boolean)
  */
 async function chooseBillingAccount(
   projectId: string,
-  extensionName: string,
   accounts: cloudbilling.BillingAccount[]
 ): Promise<void> {
   const choices = accounts.map((m) => m.displayName);
@@ -59,9 +58,7 @@ async function chooseBillingAccount(
   const answer = await prompt.promptOnce({
     name: "billing",
     type: "list",
-    message: `The extension ${clc.underline(
-      extensionName
-    )} requires your project to be upgraded to the Blaze plan. You have access to the following billing accounts.
+    message: `Extensions require your project to be upgraded to the Blaze plan. You have access to the following billing accounts.
 Please select the one that you would like to associate with this project:`,
     choices: choices,
   });
@@ -82,14 +79,12 @@ Please select the one that you would like to associate with this project:`,
  * Directs user to set up billing account over the web and stalls until
  * user responds.
  */
-async function setUpBillingAccount(projectId: string, extensionName: string) {
+async function setUpBillingAccount(projectId: string) {
   const billingURL = `https://console.cloud.google.com/billing/linkedaccount?project=${projectId}`;
 
   logger.info();
   logger.info(
-    `The extension ${clc.bold(
-      extensionName
-    )} requires your project to be upgraded to the Blaze plan. Please visit the following link to add a billing account:`
+    `Extension require your project to be upgraded to the Blaze plan. Please visit the following link to add a billing account:`
   );
   logger.info();
   logger.info(clc.bold.underline(billingURL));
@@ -108,15 +103,13 @@ async function setUpBillingAccount(projectId: string, extensionName: string) {
 /**
  * Sets up billing for the given project.
  * @param {string} projectId
- * @param {string} extensionName
- * @return {Promise<void | undefined>}
  */
-export async function enableBilling(projectId: string, extensionName: string): Promise<void> {
+export async function enableBilling(projectId: string): Promise<void> {
   const billingAccounts = await cloudbilling.listBillingAccounts();
   if (billingAccounts) {
     const accounts = billingAccounts.filter((account) => account.open);
     return accounts.length > 0
-      ? chooseBillingAccount(projectId, extensionName, accounts)
-      : setUpBillingAccount(projectId, extensionName);
+      ? chooseBillingAccount(projectId, accounts)
+      : setUpBillingAccount(projectId);
   }
 }

--- a/src/extensions/provisioningHelper.ts
+++ b/src/extensions/provisioningHelper.ts
@@ -2,7 +2,10 @@ import * as marked from "marked";
 
 import * as extensionsApi from "./extensionsApi";
 import * as api from "../api";
+import * as refs from "./refs";
+import { flattenArray } from "../functional";
 import { FirebaseError } from "../error";
+import { InstanceSpec } from "../deploy/extensions/planner";
 
 /** Product for which provisioning can be (or is) deferred */
 export enum DeferredProduct {
@@ -20,6 +23,30 @@ export async function checkProductsProvisioned(
   spec: extensionsApi.ExtensionSpec
 ): Promise<void> {
   const usedProducts = getUsedProducts(spec);
+  await checkProducts(projectId, usedProducts);
+}
+
+/**
+ * Checks whether products used for any extension version in a deploy requires provisioning.
+ *
+ * @param extensionVersionRefs
+ */
+export async function bulkCheckProductsProvisioned(
+  projectId: string,
+  instanceSpecs: InstanceSpec[]
+): Promise<void> {
+  const usedProducts = await Promise.all(
+    instanceSpecs.map(async (i) => {
+      const extensionVersion = await extensionsApi.getExtensionVersion(
+        refs.toExtensionVersionRef(i.ref!)
+      );
+      return getUsedProducts(extensionVersion.spec);
+    })
+  );
+  await checkProducts(projectId, [...flattenArray(usedProducts)]);
+}
+
+async function checkProducts(projectId: string, usedProducts: DeferredProduct[]) {
   const needProvisioning = [] as DeferredProduct[];
   let isStorageProvisionedPromise;
   let isAuthProvisionedPromise;
@@ -41,7 +68,7 @@ export async function checkProductsProvisioned(
     let errorMessage =
       "Some services used by this extension have not been set up on your " +
       "Firebase project. To ensure this extension works as intended, you must enable these " +
-      "services by following the provided links, then retry installing the extension\n\n";
+      "services by following the provided links, then retry this command\n\n";
     if (needProvisioning.includes(DeferredProduct.STORAGE)) {
       errorMessage +=
         " - Firebase Storage: store and retrieve user-generated files like images, audio, and " +

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -44,7 +44,6 @@ export async function displayWarningPrompts(
   extensionVersion: ExtensionVersion
 ): Promise<void> {
   const trustedPublishers = await getTrustedPublishers();
-  console.log(trustedPublishers);
   if (!trustedPublishers.includes(publisherId)) {
     displayEAPWarning({
       publisherId,

--- a/src/test/extensions/checkProjectBilling.spec.ts
+++ b/src/test/extensions/checkProjectBilling.spec.ts
@@ -36,13 +36,12 @@ describe("checkProjectBilling", () => {
 
   it("should resolve if billing enabled", async () => {
     const projectId = "already enabled";
-    const extensionName = "test extension";
 
     checkBillingEnabledStub.resolves(true);
 
     const enabled = await cloudbilling.checkBillingEnabled(projectId);
     if (!enabled) {
-      await checkProjectBilling.enableBilling(projectId, extensionName);
+      await checkProjectBilling.enableBilling(projectId);
     }
 
     expect(listBillingAccountsStub.notCalled);
@@ -52,7 +51,6 @@ describe("checkProjectBilling", () => {
 
   it("should list accounts if no billing account set, but accounts available.", async () => {
     const projectId = "not set, but have list";
-    const extensionName = "test extension 2";
     const accounts = [
       {
         name: "test-cloud-billing-account-name",
@@ -68,7 +66,7 @@ describe("checkProjectBilling", () => {
 
     const enabled = await cloudbilling.checkBillingEnabled(projectId);
     if (!enabled) {
-      await checkProjectBilling.enableBilling(projectId, extensionName);
+      await checkProjectBilling.enableBilling(projectId);
     }
 
     expect(listBillingAccountsStub.calledOnce);
@@ -78,7 +76,6 @@ describe("checkProjectBilling", () => {
 
   it("should not list accounts if no billing accounts set or available.", async () => {
     const projectId = "not set, not available";
-    const extensionName = "test extension 3";
 
     checkBillingEnabledStub.onCall(0).resolves(false);
     checkBillingEnabledStub.onCall(1).resolves(true);
@@ -87,7 +84,7 @@ describe("checkProjectBilling", () => {
 
     const enabled = await cloudbilling.checkBillingEnabled(projectId);
     if (!enabled) {
-      await checkProjectBilling.enableBilling(projectId, extensionName);
+      await checkProjectBilling.enableBilling(projectId);
     }
 
     expect(listBillingAccountsStub.calledOnce);


### PR DESCRIPTION
### Description
Add checks for product provisioning and billing before we make any API calls.

### Scenarios Tested
Attempting to deploy an extension that uses storage, without storage provisioned:
<img width="1440" alt="Screen Shot 2021-10-14 at 5 42 06 PM" src="https://user-images.githubusercontent.com/4635763/137526398-12db96e5-f24b-42ef-b9d4-e9b1aba3acfd.png">
Trying that same deploy again after enabling storage:
<img width="720" alt="Screen Shot 2021-10-14 at 5 43 31 PM" src="https://user-images.githubusercontent.com/4635763/137526466-027e4151-40f1-4d76-b349-3c2aa23528fd.png">

Attempting to deploy, in interactive mode, without billing enabled:
<img width="837" alt="Screen Shot 2021-10-15 at 10 04 42 AM" src="https://user-images.githubusercontent.com/4635763/137526503-1b71dd19-3bd3-4726-a851-4c3569a78ab0.png">

Attempting to deploy in noninteractive mode, without billing enabled:
<img width="729" alt="Screen Shot 2021-10-15 at 10 05 15 AM" src="https://user-images.githubusercontent.com/4635763/137526620-53279678-952a-4756-9e56-d326dae508c3.png">

Successfully deploying after enabling billing:
<img width="918" alt="Screen Shot 2021-10-15 at 10 11 35 AM" src="https://user-images.githubusercontent.com/4635763/137526769-098e6399-bbbd-4594-9e59-1f12bb2dd25b.png">

