### PR TITLE
Crashlytics fix cache directory on Windows

### DIFF
--- a/src/commands/crashlytics-symbols-upload.ts
+++ b/src/commands/crashlytics-symbols-upload.ts
@@ -69,7 +69,8 @@ export default new Command("crashlytics:symbols:upload <symbolFiles...>")
         SYMBOL_CACHE_ROOT_DIR,
         `crashlytics-${uuid.v4()}`,
         "nativeSymbols",
-        app,
+        // Windows does not allow ":" in their directory names
+        app.replace(":", "-"),
         generator
       ),
       symbolFile: "",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Windows is more restrictive in terms of what characters are allowed in directories: [source](https://stackoverflow.com/questions/1976007/what-characters-are-forbidden-in-windows-and-linux-directory-names). Google App IDs have ":" in them which causes errors.

### Scenarios Tested

EAP customer running on Windows.
