### PR TITLE
Improve trigger region inference & add instance size inference

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -187,6 +187,13 @@ export function inferDetailsFromExisting(
       };
     }
 
+    // If the instance size is set out of bounds or was previously set and is now
+    // unset we still need to remember it so that the min instance price estimator
+    // is accurate.
+    if (!wantE.availableMemoryMb && haveE.availableMemoryMb) {
+      wantE.availableMemoryMb = haveE.availableMemoryMb;
+    }
+
     maybeCopyTriggerRegion(wantE, haveE);
   }
 }
@@ -199,11 +206,12 @@ function maybeCopyTriggerRegion(wantE: backend.Endpoint, haveE: backend.Endpoint
     return;
   }
 
-  // Don't copy the region if anything about the trigger changed. It's possible
-  // they changed the resource.
-  const oldTrigger: Record<string, unknown> = { ...haveE.eventTrigger };
-  delete oldTrigger.region;
-  if (JSON.stringify(oldTrigger) !== JSON.stringify(wantE.eventTrigger)) {
+  // Don't copy the region if anything about the trigger resource changed. It's possible
+  // they changed the region
+  if (
+    JSON.stringify(haveE.eventTrigger.eventFilters) !==
+    JSON.stringify(wantE.eventTrigger.eventFilters)
+  ) {
     return;
   }
   wantE.eventTrigger.region = haveE.eventTrigger.region;

--- a/src/test/deploy/functions/prepare.spec.ts
+++ b/src/test/deploy/functions/prepare.spec.ts
@@ -92,5 +92,38 @@ describe("prepare", () => {
       prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* usedDotEnv= */ false);
       expect(want.eventTrigger.region).to.equal("us");
     });
+
+    it("doesn't fill in regions if triggers changed", () => {
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        eventTrigger: {
+          eventType: "google.cloud.storage.object.v1.finalzied",
+          eventFilters: {
+            bucket: "us-bucket",
+          },
+          retry: false,
+        },
+      };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const have: backend.Endpoint & backend.EventTriggered = JSON.parse(JSON.stringify(want));
+      have.eventTrigger.eventFilters["bucket"] = "us-central1-bucket";
+      have.eventTrigger.region = "us-central1";
+
+      prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* usedDotEnv= */ false);
+      expect(want.eventTrigger.region).to.be.undefined;
+    });
+
+    it("fills in instance size", () => {
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+      };
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const have: backend.Endpoint = JSON.parse(JSON.stringify(want));
+      have.availableMemoryMb = 512;
+
+      prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* usedDotEnv= */ false);
+      expect(want.availableMemoryMb).to.equal(512);
+    });
   });
 });


### PR DESCRIPTION
Meant to fix bug 201075661, but also realized that our code for deciding whether to copy trigger region is too conservative. We don't need to re-calculate the region, for example, if retry is changed.