### PR TITLE
Adding secrets support to `firebase deploy --only extensions`

### DIFF
--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -12,6 +12,22 @@ export interface InstanceSpec {
   instanceId: string;
   ref?: refs.Ref;
   params: Record<string, string>;
+  extensionVersion?: extensionsApi.ExtensionVersion;
+}
+
+/**
+ * Caching fetcher for the corresponding ExtensionVersion for an instance spec.
+ */
+export async function getExtensionVersion(
+  i: InstanceSpec
+): Promise<extensionsApi.ExtensionVersion> {
+  if (!i.ref) {
+    throw new FirebaseError(`Can't get ExtensionVersion for ${i.instanceId} because it has no ref`);
+  }
+  if (!i.extensionVersion) {
+    i.extensionVersion = await extensionsApi.getExtensionVersion(refs.toExtensionVersionRef(i.ref));
+  }
+  return i.extensionVersion;
 }
 
 const ENV_DIRECTORY = "extensions";

--- a/src/deploy/extensions/release.ts
+++ b/src/deploy/extensions/release.ts
@@ -12,7 +12,7 @@ export async function release(
   payload: Payload
 ) {
   const projectId = needProjectId(options);
-
+  const dryRun = false;
   const errorHandler = new ErrorHandler();
   const deploymentQueue = new Queue<tasks.ExtensionDeploymentTask, void>({
     retries: 5,
@@ -21,17 +21,17 @@ export async function release(
   });
 
   for (const creation of payload.instancesToCreate ?? []) {
-    const task = tasks.createExtensionInstanceTask(projectId, creation);
+    const task = tasks.createExtensionInstanceTask(projectId, creation, dryRun);
     void deploymentQueue.run(task);
   }
 
   for (const update of payload.instancesToUpdate ?? []) {
-    const task = tasks.updateExtensionInstanceTask(projectId, update);
+    const task = tasks.updateExtensionInstanceTask(projectId, update, dryRun);
     void deploymentQueue.run(task);
   }
 
   for (const update of payload.instancesToConfigure ?? []) {
-    const task = tasks.configureExtensionInstanceTask(projectId, update);
+    const task = tasks.configureExtensionInstanceTask(projectId, update, dryRun);
     void deploymentQueue.run(task);
   }
 

--- a/src/deploy/extensions/release.ts
+++ b/src/deploy/extensions/release.ts
@@ -12,7 +12,7 @@ export async function release(
   payload: Payload
 ) {
   const projectId = needProjectId(options);
-  const dryRun = false;
+
   const errorHandler = new ErrorHandler();
   const deploymentQueue = new Queue<tasks.ExtensionDeploymentTask, void>({
     retries: 5,
@@ -21,17 +21,17 @@ export async function release(
   });
 
   for (const creation of payload.instancesToCreate ?? []) {
-    const task = tasks.createExtensionInstanceTask(projectId, creation, dryRun);
+    const task = tasks.createExtensionInstanceTask(projectId, creation);
     void deploymentQueue.run(task);
   }
 
   for (const update of payload.instancesToUpdate ?? []) {
-    const task = tasks.updateExtensionInstanceTask(projectId, update, dryRun);
+    const task = tasks.updateExtensionInstanceTask(projectId, update);
     void deploymentQueue.run(task);
   }
 
   for (const update of payload.instancesToConfigure ?? []) {
-    const task = tasks.configureExtensionInstanceTask(projectId, update, dryRun);
+    const task = tasks.configureExtensionInstanceTask(projectId, update);
     void deploymentQueue.run(task);
   }
 

--- a/src/deploy/extensions/secrets.ts
+++ b/src/deploy/extensions/secrets.ts
@@ -1,0 +1,233 @@
+import * as clc from "cli-color";
+
+import * as secretUtils from "../../extensions/secretsUtils";
+import * as secretManager from "../../gcp/secretManager";
+
+import { Payload } from "./args";
+import { getExtensionVersion, InstanceSpec } from "./planner";
+import { promptCreateSecret } from "../../extensions/askUserForParam";
+import { ExtensionSpec, Param, ParamType } from "../../extensions/extensionsApi";
+import { FirebaseError } from "../../error";
+import { logger } from "../../logger";
+import { logLabeledBullet } from "../../utils";
+
+interface SecretInfo {
+  secret?: secretManager.Secret;
+  secretVersion?: secretManager.SecretVersion;
+  labels: Record<string, string>;
+}
+
+export async function handleSecretParams(
+  payload: Payload,
+  have: InstanceSpec[],
+  nonInteractive: boolean
+) {
+  for (const i of payload.instancesToCreate ?? []) {
+    if (await checkSpecForSecrets(i)) {
+      logLabeledBullet("extensions", `Verifying secret params for ${clc.bold(i.instanceId)}`);
+      await handleSecretsCreateInstance(i, nonInteractive);
+    }
+  }
+  const updates = [...(payload.instancesToUpdate ?? []), ...(payload.instancesToConfigure ?? [])];
+  for (const i of updates) {
+    if (await checkSpecForSecrets(i)) {
+      logLabeledBullet("extensions", `Verifying secret params for ${clc.bold(i.instanceId)}`);
+      const previousSpec = have.find((h) => h.instanceId === i.instanceId)!;
+      await handleSecretsUpdateInstance(i, previousSpec, nonInteractive);
+    }
+  }
+}
+
+async function checkSpecForSecrets(i: InstanceSpec): Promise<boolean> {
+  const extensionVersion = await getExtensionVersion(i);
+  return secretUtils.usesSecrets(extensionVersion.spec);
+}
+
+const secretsInSpec = (spec: ExtensionSpec): Param[] => {
+  return spec.params.filter((p) => p.type === ParamType.SECRET);
+};
+
+async function handleSecretsCreateInstance(i: InstanceSpec, nonInteractive: boolean) {
+  const extensionVersion = await getExtensionVersion(i);
+  const secretParams = secretsInSpec(extensionVersion.spec);
+  for (const s of secretParams) {
+    await handleSecretParamForCreate(s, i, nonInteractive);
+  }
+}
+
+async function handleSecretsUpdateInstance(
+  i: InstanceSpec,
+  prevSpec: InstanceSpec,
+  nonInteractive: boolean
+) {
+  const extensionVersion = await getExtensionVersion(i);
+  const prevExtensionVersion = await getExtensionVersion(prevSpec);
+  const secretParams = secretsInSpec(extensionVersion.spec);
+  for (const s of secretParams) {
+    // If this was previously a secret param & was set, treat this as an update
+    const prevParam = prevExtensionVersion.spec.params.find((p) => p.param === s.param);
+    if (prevParam?.type === ParamType.SECRET && prevSpec.params[prevParam?.param]) {
+      await handleSecretParamForUpdate(s, i, prevSpec.params[prevParam?.param], nonInteractive);
+    } else {
+      // Otherwise, this is a new secret param
+      await handleSecretParamForCreate(s, i, nonInteractive);
+    }
+  }
+}
+
+async function handleSecretParamForCreate(
+  secretParam: Param,
+  i: InstanceSpec,
+  nonInteractive: boolean
+): Promise<void> {
+  const providedValue = i.params[secretParam.param];
+  if (!providedValue) {
+    return;
+  }
+  // First, check that param is well formed.
+  const [, projectId, , secretName, , version] = providedValue.split("/");
+  if (!projectId || !secretName || !version) {
+    throw new FirebaseError(
+      `${clc.bold(i.instanceId)}: Found '${providedValue}' for secret param ${
+        secretParam.param
+      }, but expected a secret version.`
+    );
+  }
+  // Then, go get all the info about the current state of the secret.
+  const secretInfo = await getSecretInfo(projectId, secretName, version);
+  // If the secret doesn't exist, prompt the user for a value, create it, and label it.
+  if (!secretInfo.secret) {
+    await promptForCreateSecret({
+      projectId,
+      secretName,
+      instanceId: i.instanceId,
+      secretParam,
+      nonInteractive,
+    });
+  } else if (!secretInfo.secretVersion) {
+    throw new FirebaseError(
+      `${clc.bold(i.instanceId)}: Found '${providedValue}' for secret param ${
+        secretParam.param
+      }. ` +
+        `projects/${projectId}/secrets/${secretName} exists, but version ${version} does not. ` +
+        `See more information about this secret at ${secretManager.secretManagerConsoleUri(
+          projectId
+        )}`
+    );
+  }
+  if (
+    !!secretInfo?.labels[secretUtils.SECRET_LABEL] &&
+    secretInfo.labels[secretUtils.SECRET_LABEL] !== i.instanceId
+  ) {
+    throw new FirebaseError(
+      `${clc.bold(i.instanceId)}: Found '${providedValue}' for secret param ${
+        secretParam.param
+      }. ` +
+        `projects/${projectId}/secrets/${secretName} is managed by a different extension instance (${
+          secretInfo.labels[secretUtils.SECRET_LABEL]
+        }), so reusing it here can lead to unexpected behavior. ` +
+        "Please choose a different name for this secret, and rerun this command."
+    );
+  }
+}
+
+async function handleSecretParamForUpdate(
+  secretParam: Param,
+  i: InstanceSpec,
+  prevValue: string,
+  nonInteractive: boolean
+) {
+  const providedValue = i.params[secretParam.param];
+  if (!providedValue) {
+    return;
+  }
+  const [, projectId, , secretName, , version] = providedValue.split("/");
+  if (!projectId || !secretName || !version) {
+    throw new FirebaseError(
+      `${clc.bold(i.instanceId)}: Found '${providedValue}' for secret param ${
+        secretParam.param
+      }, but expected a secret version.`
+    );
+  }
+  // Don't allow changing secrets, only changing versions
+  const [, prevProjectId, , prevSecretName] = prevValue.split("/");
+  if (prevProjectId !== projectId || prevSecretName !== secretName) {
+    throw new FirebaseError(
+      `${clc.bold(i.instanceId)}: Found '${providedValue}' for secret param ${
+        secretParam.param
+      }, ` +
+        `but this instance was previously using a different secret projects/${prevProjectId}/secrets/${prevSecretName}.\n` +
+        `Changing secrets is not supported. If you want to change the value of this secret, ` +
+        `use a new version of projects/${prevProjectId}/secrets/${prevSecretName}.` +
+        `You can create a new version at ${secretManager.secretManagerConsoleUri(projectId)}`
+    );
+  }
+  const secretInfo = await getSecretInfo(projectId, secretName, version);
+  if (!secretInfo.secret) {
+    await promptForCreateSecret({
+      projectId,
+      secretName,
+      instanceId: i.instanceId,
+      secretParam,
+      nonInteractive,
+    });
+  } else if (!secretInfo.secretVersion) {
+    throw new FirebaseError(
+      `${clc.bold(i.instanceId)}: Found '${providedValue}' for secret param ${
+        secretParam.param
+      }. ` +
+        `projects/${projectId}/secrets/${secretName} exists, but version ${version} does not. ` +
+        `See more information about this secret at ${secretManager.secretManagerConsoleUri(
+          projectId
+        )}`
+    );
+  }
+}
+
+async function getSecretInfo(projectId: string, secretName: string, version: string) {
+  const secretInfo: SecretInfo = {
+    labels: {},
+  };
+  try {
+    logger.debug(`Checking if projects/${projectId}/secrets/${secretName} exists`);
+    secretInfo.secret = await secretManager.getSecret(projectId, secretName);
+    logger.debug(
+      `Found secret, checking if projects/${projectId}/secrets/${secretName}/versions/${version} exists`
+    );
+    secretInfo.secretVersion = await secretManager.getSecretVersion(projectId, secretName, version);
+    logger.debug(`Found secretVersion, checking labels`);
+    secretInfo.labels = await secretManager.getSecretLabels(projectId, secretName);
+  } catch (err) {
+    // Throw anything other than the expected 404 errors.
+    if (err.status !== 404) {
+      throw err;
+    }
+  }
+  return secretInfo;
+}
+
+async function promptForCreateSecret(args: {
+  projectId: string;
+  secretName: string;
+  instanceId: string;
+  secretParam: Param;
+  nonInteractive: boolean;
+}): Promise<string> {
+  logger.info(
+    `${clc.bold(args.instanceId)}: Secret ${args.projectId}/${args.secretName} doesn't exist yet.`
+  );
+  if (args.nonInteractive) {
+    throw new FirebaseError(
+      `To create this secret, run this command in interactive mode, or go to ${secretManager.secretManagerConsoleUri(
+        args.projectId
+      )}`
+    );
+  }
+  const ret = await promptCreateSecret(
+    args.projectId,
+    args.instanceId,
+    args.secretParam,
+    args.secretName
+  );
+  return ret;
+}

--- a/src/deploy/extensions/secrets.ts
+++ b/src/deploy/extensions/secrets.ts
@@ -17,6 +17,14 @@ interface SecretInfo {
   labels: Record<string, string>;
 }
 
+/**
+ * handleSecretParams checks each spec for secret params, and validates that the secrets in the configuration exist.
+ * If they don't, it prompts the user to create them in interactive mode
+ * or throws an informative error in non-interactive mode
+ * @param payload The deploy payload
+ * @param have The instances currently installed on the project.
+ * @param nonInteractive whether the user can be prompted to create secrets that are missing.
+ */
 export async function handleSecretParams(
   payload: Payload,
   have: InstanceSpec[],
@@ -38,7 +46,7 @@ export async function handleSecretParams(
   }
 }
 
-async function checkSpecForSecrets(i: InstanceSpec): Promise<boolean> {
+export async function checkSpecForSecrets(i: InstanceSpec): Promise<boolean> {
   const extensionVersion = await getExtensionVersion(i);
   return secretUtils.usesSecrets(extensionVersion.spec);
 }

--- a/src/deploy/extensions/secrets.ts
+++ b/src/deploy/extensions/secrets.ts
@@ -11,12 +11,6 @@ import { FirebaseError } from "../../error";
 import { logger } from "../../logger";
 import { logLabeledBullet } from "../../utils";
 
-interface SecretInfo {
-  secret?: secretManager.Secret;
-  secretVersion?: secretManager.SecretVersion;
-  labels: Record<string, string>;
-}
-
 /**
  * handleSecretParams checks each spec for secret params, and validates that the secrets in the configuration exist.
  * If they don't, it prompts the user to create them in interactive mode
@@ -192,18 +186,17 @@ async function handleSecretParamForUpdate(
   }
 }
 
-async function getSecretInfo(projectId: string, secretName: string, version: string) {
-  const secretInfo: SecretInfo = {
+async function getSecretInfo(projectId: string, secretName: string, version: string): Promise<{
+  secret?: secretManager.Secret;
+  secretVersion?: secretManager.SecretVersion;
+  labels: Record<string, string>;
+}> {
+  const secretInfo: any = {
     labels: {},
   };
   try {
-    logger.debug(`Checking if projects/${projectId}/secrets/${secretName} exists`);
     secretInfo.secret = await secretManager.getSecret(projectId, secretName);
-    logger.debug(
-      `Found secret, checking if projects/${projectId}/secrets/${secretName}/versions/${version} exists`
-    );
     secretInfo.secretVersion = await secretManager.getSecretVersion(projectId, secretName, version);
-    logger.debug(`Found secretVersion, checking labels`);
     secretInfo.labels = await secretManager.getSecretLabels(projectId, secretName);
   } catch (err) {
     // Throw anything other than the expected 404 errors.
@@ -231,11 +224,10 @@ async function promptForCreateSecret(args: {
       )}`
     );
   }
-  const ret = await promptCreateSecret(
+  return promptCreateSecret(
     args.projectId,
     args.instanceId,
     args.secretParam,
     args.secretName
   );
-  return ret;
 }

--- a/src/extensions/askUserForParam.ts
+++ b/src/extensions/askUserForParam.ts
@@ -176,12 +176,13 @@ async function promptReconfigureSecret(
   }
 }
 
-async function promptCreateSecret(
+export async function promptCreateSecret(
   projectId: string,
   instanceId: string,
-  paramSpec: Param
+  paramSpec: Param,
+  secretName?: string
 ): Promise<string> {
-  const secretName = await generateSecretName(projectId, instanceId, paramSpec.param);
+  const name = secretName ?? (await generateSecretName(projectId, instanceId, paramSpec.param));
   const secretValue = await promptOnce({
     name: paramSpec.param,
     type: "password",
@@ -190,7 +191,7 @@ async function promptCreateSecret(
   });
   const secret = await secretManagerApi.createSecret(
     projectId,
-    secretName,
+    name,
     secretsUtils.getSecretLabels(instanceId)
   );
   return addNewSecretVersion(projectId, instanceId, secret, paramSpec, secretValue);

--- a/src/extensions/provisioningHelper.ts
+++ b/src/extensions/provisioningHelper.ts
@@ -5,7 +5,7 @@ import * as api from "../api";
 import * as refs from "./refs";
 import { flattenArray } from "../functional";
 import { FirebaseError } from "../error";
-import { InstanceSpec } from "../deploy/extensions/planner";
+import { getExtensionVersion, InstanceSpec } from "../deploy/extensions/planner";
 
 /** Product for which provisioning can be (or is) deferred */
 export enum DeferredProduct {
@@ -37,9 +37,7 @@ export async function bulkCheckProductsProvisioned(
 ): Promise<void> {
   const usedProducts = await Promise.all(
     instanceSpecs.map(async (i) => {
-      const extensionVersion = await extensionsApi.getExtensionVersion(
-        refs.toExtensionVersionRef(i.ref!)
-      );
+      const extensionVersion = await getExtensionVersion(i);
       return getUsedProducts(extensionVersion.spec);
     })
   );

--- a/src/extensions/secretsUtils.ts
+++ b/src/extensions/secretsUtils.ts
@@ -6,7 +6,7 @@ import * as extensionsApi from "./extensionsApi";
 import * as secretManagerApi from "../gcp/secretManager";
 import { logger } from "../logger";
 
-const SECRET_LABEL = "firebase-extensions-managed";
+export const SECRET_LABEL = "firebase-extensions-managed";
 
 export async function ensureSecretManagerApiEnabled(options: any): Promise<void> {
   const projectId = needProjectId(options);

--- a/src/gcp/secretManager.ts
+++ b/src/gcp/secretManager.ts
@@ -1,5 +1,7 @@
 import * as api from "../api";
 
+export const secretManagerConsoleUri = (projectId: string) =>
+  `https://console.cloud.google.com/security/secret-manager?project=${projectId}`;
 export interface Secret {
   // Secret name/label (this is not resource name)
   name: string;
@@ -28,6 +30,22 @@ export async function getSecret(projectId: string, name: string): Promise<Secret
   return parseSecretResourceName(getRes.body.name);
 }
 
+export async function getSecretVersion(
+  projectId: string,
+  name: string,
+  version: string
+): Promise<SecretVersion> {
+  const getRes = await api.request(
+    "GET",
+    `/v1beta1/projects/${projectId}/secrets/${name}/versions/${version}`,
+    {
+      auth: true,
+      origin: api.secretManagerOrigin,
+    }
+  );
+  return parseSecretVersionResourceName(getRes.body.name);
+}
+
 export async function getSecretLabels(
   projectId: string,
   name: string
@@ -36,7 +54,8 @@ export async function getSecretLabels(
     auth: true,
     origin: api.secretManagerOrigin,
   });
-  return getRes.body.labels;
+  // console.log(getRes.body);
+  return getRes.body.labels ?? {};
 }
 
 export async function secretExists(projectId: string, name: string): Promise<boolean> {
@@ -56,6 +75,17 @@ export function parseSecretResourceName(resourceName: string): Secret {
   return {
     projectId: nameTokens[1],
     name: nameTokens[3],
+  };
+}
+
+export function parseSecretVersionResourceName(resourceName: string): SecretVersion {
+  const nameTokens = resourceName.split("/");
+  return {
+    secret: {
+      projectId: nameTokens[1],
+      name: nameTokens[3],
+    },
+    versionId: nameTokens[5],
   };
 }
 

--- a/src/gcp/secretManager.ts
+++ b/src/gcp/secretManager.ts
@@ -54,7 +54,6 @@ export async function getSecretLabels(
     auth: true,
     origin: api.secretManagerOrigin,
   });
-  // console.log(getRes.body);
   return getRes.body.labels ?? {};
 }
 


### PR DESCRIPTION
### Description
Adding secrets support to `firebase deploy --only extensions`. 
Unit tests for the new methods in secrets.ts to follow - I wanted to get some eyes on this before it got too late in the day/

The logic here can be a little hard to follow - to help, I made a flow chart: go/firex-deploy-secrets-diagram

### Scenarios Tested
I tested each of the cases in go/firex-deploy-secrets-diagram using a bunch of instances of pavelj/secrets-test@0.0.11 & 0.0.10
<img width="1429" alt="Screen Shot 2021-10-21 at 10 55 09 AM" src="https://user-images.githubusercontent.com/4635763/138338500-b6a513b5-99e7-4416-a311-cc29cad642e1.png">

