### PR TITLE
Improve functions deploy time by polling more frequently.

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -25,15 +25,15 @@ import * as utils from "../../../utils";
 const gcfV1PollerOptions = {
   apiOrigin: functionsOrigin,
   apiVersion: gcf.API_VERSION,
-  masterTimeout: 25 * 60 * 1000, // 25 minutes is the maximum build time for a function
-  maxBackoff: 10,
+  masterTimeout: 25 * 60 * 1_000, // 25 minutes is the maximum build time for a function
+  maxBackoff: 10_000,
 };
 
 const gcfV2PollerOptions = {
   apiOrigin: functionsV2Origin,
   apiVersion: gcfV2.API_VERSION,
-  masterTimeout: 25 * 60 * 1000, // 25 minutes is the maximum build time for a function
-  maxBackoff: 10,
+  masterTimeout: 25 * 60 * 1_000, // 25 minutes is the maximum build time for a function
+  maxBackoff: 10_000,
 };
 
 const DEFAULT_GCFV2_CONCURRENCY = 80;


### PR DESCRIPTION
Our pollers are built on Throttler Queues. These have a built in
backoff rate and GCF takes so long that we will invariably backoff
until we hit the maximum. When unspecified the maximum is 1m.

Looking at a single function deploy, we can say that we previously
wasted on average 30s sleeping (assume our second to last poll was
half way through the 0-60s range). With a new limit we should waste
only 5s polling, for an average savings of 25s. The savings will
be more dramatic for deploys of multiple functions.