### PR TITLE
Pin @firebase/database-compat to previous version when running Emulator Trigger test.

### DIFF
--- a/scripts/triggers-end-to-end-tests/functions/package.json
+++ b/scripts/triggers-end-to-end-tests/functions/package.json
@@ -8,7 +8,8 @@
   "dependencies": {
     "@google-cloud/pubsub": "^1.1.5",
     "firebase-admin": "^9.3.0",
-    "firebase-functions": "^3.15.1"
+    "firebase-functions": "^3.15.1",
+    "@firebase/database-compat": "0.1.2"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"


### PR DESCRIPTION
Still trying to understand why the emulator test broke with the latest release of the @firebase/database-compat (a dependency of firebase-admin package).

For now, propose that we roll this change out to unblock test failures.