### PR TITLE
DOC: Suggest a `java -version` command that actually works for Java 1.8

### DIFF
--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -337,7 +337,7 @@ async function _runBinary(
         logger.logLabeled(
           "WARN",
           emulator.name,
-          "Unsupported java version, make sure java --version reports 1.8 or higher."
+          "Unsupported java version, make sure java -version reports 1.8 or higher."
         );
       }
     });


### PR DESCRIPTION
### Description

`java --version` only works for  recent Java builds.  `java -version` should work everywhere.

See https://stackoverflow.com/questions/11551888/java-version-doesnt-work-in-the-command-line

### Scenarios Tested

```
$ docker run --rm -it node:14
$ npm install -g firebase-tools@9.22.0
$ firebase emulators:start
[...]
⚠  firestore: Unsupported java version, make sure java --version reports 1.8 or higher.
⚠  firestore: Fatal error occurred:
   Firestore Emulator has exited with code: 1,
   stopping all running emulators
$ java --version
Unrecognized option: --version
Error: Could not create the Java Virtual Machine.
Error: A fatal exception has occurred. Program will exit.
$ java -version
openjdk version "1.8.0_302"
OpenJDK Runtime Environment (build 1.8.0_302-8u302-b08-1~deb9u1-b08)
OpenJDK 64-Bit Server VM (build 25.302-b08, mixed mode)
```

### Sample Commands

N/A