### PR TITLE
Dynamically validate & set `engines.node` in `package.json` on `firebase init functions`

### DIFF
--- a/src/init/features/functions/typescript.js
+++ b/src/init/features/functions/typescript.js
@@ -6,6 +6,7 @@ var path = require("path");
 
 var npmDependencies = require("./npm-dependencies");
 var { prompt } = require("../../../prompt");
+var utils = require("../../../utils");
 
 var TEMPLATE_ROOT = path.resolve(__dirname, "../../../../templates/init/functions/typescript/");
 var PACKAGE_LINTING_TEMPLATE = fs.readFileSync(
@@ -38,13 +39,13 @@ module.exports = function (setup, config) {
           'npm --prefix "$RESOURCE_DIR" run build',
         ]);
         return config
-          .askWriteProjectFile("functions/package.json", PACKAGE_LINTING_TEMPLATE)
+          .askWriteProjectFile("functions/package.json", getPackage(setup.functions.lint))
           .then(function () {
             return config.askWriteProjectFile("functions/.eslintrc.js", ESLINT_TEMPLATE);
           });
       }
       _.set(setup, "config.functions.predeploy", 'npm --prefix "$RESOURCE_DIR" run build');
-      return config.askWriteProjectFile("functions/package.json", PACKAGE_NO_LINTING_TEMPLATE);
+      return config.askWriteProjectFile("functions/package.json", getPackage(setup.functions.lint));
     })
     .then(function () {
       return config.askWriteProjectFile("functions/tsconfig.json", TSCONFIG_TEMPLATE);
@@ -64,3 +65,11 @@ module.exports = function (setup, config) {
       return npmDependencies.askInstallDependencies(setup.functions, config);
     });
 };
+
+function getPackage(useLint) {
+  const nodeEngineVersion = utils.getNodeVersionString();
+  if (useLint) {
+    return PACKAGE_LINTING_TEMPLATE.replace(/{{NODE_VERSION}}/g, nodeEngineVersion);
+  }
+  return PACKAGE_NO_LINTING_TEMPLATE.replace(/{{NODE_VERSION}}/g, nodeEngineVersion);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -559,6 +559,20 @@ export function thirtyDaysFromNow(): Date {
 }
 
 /**
+ * Get the current version of Node.js engine from `process.version`.
+ * @return Node.js major release version
+ */
+export function getNodeVersionString(): string {
+  const nodeVersion: RegExpExecArray | null = /\d+/.exec(process.version);
+
+  if (nodeVersion === null) {
+    throw new Error("Node version is not found");
+  }
+
+  return nodeVersion.join("");
+}
+
+/**
  * See:
  * https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#assertion-functions
  */

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "14"
+    "node": "{{NODE_VERSION}}"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "14"
+    "node": "{{NODE_VERSION}}"
   },
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
Fix https://github.com/firebase/firebase-tools/issues/3407

This PR should help the `engines.node` attribute in `package.json` file  dynamically set to the current Node.js version on a dev's machine. If their Node.js version is not supported by Google Cloud Functions, an error will be logged.

For example, if the Node.js version on a dev's machine is 12. After running `firebase init functions`, the generated `package.json` file should contain thess lines:

```json
"engines": { 
  "node": "12"
}
```

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
* Automatically detect and set Node engine version for `package.json` with ESLint
* Automatically detect and set Node engine version for `package.json` without ESLint
