### PR TITLE
Fix exporting users with newline in display name and custom attributes

### DIFF
--- a/src/accountExporter.js
+++ b/src/accountExporter.js
@@ -34,9 +34,9 @@ var PROVIDER_ID_INDEX_MAP = {
   "github.com": 19,
 };
 
-var _escapeComma = function (str) {
-  if (str.indexOf(",") !== -1) {
-    // Encapsulate the string with quotes if it contains a comma.
+var _escapeCSV = function(str) {
+  if (str.indexOf(",") !== -1 || str.indexOf("\n") !== -1 || str.indexOf("\r") !== -1) {
+    // Encapsulate the string with quotes if it contains a comma or a newline.
     return `"${str}"`;
   }
   return str;
@@ -49,7 +49,7 @@ var _convertToNormalBase64 = function (data) {
 var _addProviderUserInfo = function (providerInfo, arr, startPos) {
   arr[startPos] = providerInfo.rawId;
   arr[startPos + 1] = providerInfo.email || "";
-  arr[startPos + 2] = _escapeComma(providerInfo.displayName || "");
+  arr[startPos + 2] = _escapeCSV(providerInfo.displayName || "");
   arr[startPos + 3] = providerInfo.photoUrl || "";
 };
 
@@ -60,7 +60,7 @@ var _transUserToArray = function (user) {
   arr[2] = user.emailVerified || false;
   arr[3] = _convertToNormalBase64(user.passwordHash || "");
   arr[4] = _convertToNormalBase64(user.salt || "");
-  arr[5] = _escapeComma(user.displayName || "");
+  arr[5] = _escapeCSV(user.displayName || "");
   arr[6] = user.photoUrl || "";
   for (var i = 0; i < (!user.providerUserInfo ? 0 : user.providerUserInfo.length); i++) {
     var providerInfo = user.providerUserInfo[i];
@@ -72,7 +72,7 @@ var _transUserToArray = function (user) {
   arr[24] = user.lastLoginAt;
   arr[25] = user.phoneNumber;
   arr[26] = user.disabled;
-  arr[27] = user.customAttributes;
+  arr[27] = _escapeCSV(user.customAttributes || "");
   return arr;
 };
 


### PR DESCRIPTION
### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
This PR fixes #3881 which is caused by newlines in the display name.
While fixing this PR I also noticed that the custom attributes are not escaped, which leads to similar issues.

Now the display name and custom attribute CSV values are escaped when a `"` or a newline is detected.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
Created a user as described in #3881 with a newline, that is exported and then imported using `auth:export` and `auth:import`.

```bash
firebase auth:export ./accounts.csv --format CSV --project $OLD_PROJECT
```

```bash
firebase auth:import ./accounts.csv    --project=$PROJECT_ID      \  
    --hash-algo=SCRYPT                                                                       \
    --hash-key=$AUTH_HASH_KEY                                                     \
    --salt-separator=$AUTH_HASH_SALT_SEPARATOR                    \
    --rounds=$AUTH_HASH_ROUNDS                                                \
    --mem-cost=$AUTH_HASH_MEM_COSTS
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
