### PR TITLE
Improved tracking on `firebase deploy`

### DIFF
--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -51,6 +51,7 @@ var deploy = function (targetNames, options, customContext = {}) {
   var deploys = [];
   var releases = [];
   var postdeploys = [];
+  var startTime = Date.now();
 
   for (var i = 0; i < targetNames.length; i++) {
     var targetName = targetNames[i];
@@ -96,9 +97,15 @@ var deploy = function (targetNames, options, customContext = {}) {
     })
     .then(function () {
       if (_.has(options, "config.notes.databaseRules")) {
-        track("Rules Deploy", options.config.notes.databaseRules);
+        return track("Rules Deploy", options.config.notes.databaseRules);
       }
-
+      return;
+    })
+    .then(function () {
+      const duration = Date.now() - startTime;
+      return track("Product Deployed", [...targetNames].sort().join(","), duration);
+    })
+    .then(function () {
       logger.info();
       utils.logSuccess(clc.underline.bold("Deploy complete!"));
       logger.info();

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -103,7 +103,7 @@ var deploy = function (targetNames, options, customContext = {}) {
     })
     .then(function () {
       const duration = Date.now() - startTime;
-      return track("Product Deployed", [...targetNames].sort().join(","), duration);
+      return track("Product Deploy", [...targetNames].sort().join(","), duration);
     })
     .then(function () {
       logger.info();


### PR DESCRIPTION
### Description
Added tracking of which products are deployed during each `firebase deploy`, and fixed a hanging promise that caused 'Rules Deploy' tracking to never happen.

This tracks each deploy as a single event , with action "Products Deployed" and label as a sorted, comma separated list of what products were deployed (ie "extensions,firestore,functions"). This lets us see what products are used together,  and it is pretty straightforward to count how many times a specific product was deployed by filtering on that product name (https://analytics.google.com/analytics/web/#/report/content-event-events/a29174744w105307605p109588205/_u.date00=20211112&_u.date01=20211112&explorer-segmentExplorer.segmentId=analytics.eventLabel&explorer-table.plotKeys=%5B%5D&explorer-table.filter=extensions&_r.drilldown=analytics.eventAction:Product%20Deployed for example).


### Scenarios Tested
I tested that `firebase deploy still works correctly, and I confirmed that the expected values show up in GA (https://analytics.google.com/analytics/web/#/report/content-event-events/a29174744w105307605p109588205/_u.date00=20211112&_u.date01=20211112&explorer-segmentExplorer.segmentId=analytics.eventLabel&explorer-table.plotKeys=%5B%5D&explorer-table.filter=extensions&_r.drilldown=analytics.eventAction:Product%20Deployed). 
