### PR TITLE
Adding support for project specific .env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- `firebase deploy --only extensions` now supports project specifc .env files. When deploying to multiple projects, param values that are different between projects can be put in `extensions/${extensionInstanceId}.env.${projectIdOrAlias}` and common param values can be put in `extensions/${extensionInstanceId}.env`.

--- a/src/deploy/extensions/params.ts
+++ b/src/deploy/extensions/params.ts
@@ -1,0 +1,54 @@
+import * as path from "path";
+import { logger } from "../../logger";
+
+import { readEnvFile } from "../../extensions/paramHelper";
+import { FirebaseError } from "../../error";
+
+const ENV_DIRECTORY = "extensions";
+
+/**
+ * readParams gets the params for an extension instance from the `extensions` folder,
+ * checking for project specific env files, then falling back to generic env files.
+ * This checks the following locations & if a param is defined in multiple places, it prefers
+ * whichever is higher on this list:
+ *  - extensions/{instanceId}.env.{projectID}
+ *  - extensions/{instanceId}.env.{projectNumber}
+ *  - extensions/{instanceId}.env.{projectAlias}
+ *  - extensions/{instanceId}.env
+ */
+export function readParams(args: {
+  projectDir: string;
+  projectId: string;
+  projectNumber: string;
+  aliases: string[];
+  instanceId: string;
+}): Record<string, string> {
+  const filesToCheck = [
+    `${args.instanceId}.env`,
+    ...args.aliases.map((alias) => `${args.instanceId}.env.${alias}`),
+    `${args.instanceId}.env.${args.projectNumber}`,
+    `${args.instanceId}.env.${args.projectId}`,
+  ];
+  let noFilesFound = true;
+  const combinedParams = {};
+  for (const fileToCheck of filesToCheck) {
+    try {
+      const params = readParamsFile(args.projectDir, fileToCheck);
+      logger.debug(`Successfully read params from ${fileToCheck}`);
+      noFilesFound = false;
+      Object.assign(combinedParams, params);
+    } catch (err) {
+      logger.debug(`${err}`);
+    }
+  }
+  if (noFilesFound) {
+    throw new FirebaseError(`No params file found for ${args.instanceId}`);
+  }
+  return combinedParams;
+}
+
+function readParamsFile(projectDir: string, fileName: string): Record<string, string> {
+  const paramPath = path.join(projectDir, ENV_DIRECTORY, fileName);
+  const params = readEnvFile(paramPath);
+  return params as Record<string, string>;
+}

--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -5,7 +5,7 @@ import { FirebaseError } from "../../error";
 import * as extensionsApi from "../../extensions/extensionsApi";
 import { getFirebaseProjectParams, substituteParams } from "../../extensions/extensionsHelper";
 import * as refs from "../../extensions/refs";
-import { readEnvFile } from "../../extensions/paramHelper";
+import { readParams } from "./params";
 import { logger } from "../../logger";
 
 export interface InstanceSpec {
@@ -46,8 +46,6 @@ export async function getExtension(i: InstanceSpec): Promise<extensionsApi.Exten
   return i.extension;
 }
 
-const ENV_DIRECTORY = "extensions";
-
 /**
  * have checks a project for what extension instances are currently installed,
  * and returns them as a list of instanceSpecs.
@@ -76,21 +74,29 @@ export async function have(projectId: string): Promise<InstanceSpec[]> {
  * @param projectDir The directory containing firebase.json and extensions/
  * @param extensions The extensions section of firebase.jsonm
  */
-export async function want(
-  projectId: string,
-  projectDir: string,
-  extensions: Record<string, string>
-): Promise<InstanceSpec[]> {
+export async function want(args: {
+  projectId: string;
+  projectNumber: string;
+  aliases: string[];
+  projectDir: string;
+  extensions: Record<string, string>;
+}): Promise<InstanceSpec[]> {
   const instanceSpecs: InstanceSpec[] = [];
   const errors: FirebaseError[] = [];
-  for (const e of Object.entries(extensions)) {
+  for (const e of Object.entries(args.extensions)) {
     try {
       const instanceId = e[0];
       const ref = refs.parse(e[1]);
       ref.version = await resolveVersion(ref);
 
-      const params = readParams(projectDir, instanceId);
-      const autoPopulatedParams = await getFirebaseProjectParams(projectId);
+      const params = readParams({
+        projectDir: args.projectDir,
+        instanceId,
+        projectId: args.projectId,
+        projectNumber: args.projectNumber,
+        aliases: args.aliases,
+      });
+      const autoPopulatedParams = await getFirebaseProjectParams(args.projectId);
       const subbedParams = substituteParams(params, autoPopulatedParams);
 
       instanceSpecs.push({
@@ -133,10 +139,4 @@ export async function resolveVersion(ref: refs.Ref): Promise<string> {
     );
   }
   return maxSatisfying;
-}
-
-function readParams(projectDir: string, instanceId: string): Record<string, string> {
-  const paramPath = path.join(projectDir, ENV_DIRECTORY, `${instanceId}.env`);
-  const params = readEnvFile(paramPath);
-  return params as Record<string, string>;
 }

--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -3,7 +3,7 @@ import * as deploymentSummary from "./deploymentSummary";
 import * as prompt from "../../prompt";
 import * as refs from "../../extensions/refs";
 import { Options } from "../../options";
-import { needProjectId } from "../../projectUtils";
+import { getAliases, needProjectId, needProjectNumber } from "../../projectUtils";
 import { logger } from "../../logger";
 import { Context, Payload } from "./args";
 import { FirebaseError } from "../../error";
@@ -15,16 +15,20 @@ import { displayWarningsForDeploy } from "../../extensions/warnings";
 
 export async function prepare(context: Context, options: Options, payload: Payload) {
   const projectId = needProjectId(options);
+  const projectNumber = await needProjectNumber(options);
+  const aliases = getAliases(options, projectId);
 
   await ensureExtensionsApiEnabled(options);
   await requirePermissions(options, ["firebaseextensions.instances.list"]);
 
   context.have = await planner.have(projectId);
-  context.want = await planner.want(
+  context.want = await planner.want({
     projectId,
-    options.config.projectDir,
-    options.config.get("extensions")
-  );
+    projectNumber,
+    aliases,
+    projectDir: options.config.projectDir,
+    extensions: options.config.get("extensions"),
+  });
 
   // Check if any extension instance that we want is using secrets,
   // and ensure the API is enabled if so.

--- a/src/projectUtils.ts
+++ b/src/projectUtils.ts
@@ -90,3 +90,17 @@ export async function needProjectNumber(options: any): Promise<string> {
   options.projectNumber = metadata.projectNumber;
   return options.projectNumber;
 }
+
+/**
+ * Looks up all aliases for projectId.
+ * @param options CLI options.
+ * @param projectId A project id to get the aliases for
+ */
+export function getAliases(options: any, projectId: string): string[] {
+  if (options.rc.hasProjects) {
+    return Object.entries(options.rc.projects)
+      .filter((entry) => entry[1] === projectId)
+      .map((entry) => entry[0]);
+  }
+  return [];
+}

--- a/src/test/deploy/extensions/params.spec.ts
+++ b/src/test/deploy/extensions/params.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import * as params from "../../../deploy/extensions/params";
+import * as paramHelper from "../../../extensions/paramHelper";
+
+describe("readParams", () => {
+  let readEnvFileStub: sinon.SinonStub;
+  const testProjectDir = "test";
+  const testProjectId = "my-project";
+  const testProjectNumber = "123456";
+  const testInstanceId = "extensionId";
+
+  beforeEach(() => {
+    readEnvFileStub = sinon.stub(paramHelper, "readEnvFile").returns({});
+  });
+
+  afterEach(() => {
+    readEnvFileStub.restore();
+  });
+
+  it("should read from generic .env file", () => {
+    readEnvFileStub
+      .withArgs("test/extensions/extensionId.env")
+      .returns({ param: "otherValue", param2: "value2" });
+
+    expect(
+      params.readParams({
+        projectDir: testProjectDir,
+        instanceId: testInstanceId,
+        projectId: testProjectId,
+        projectNumber: testProjectNumber,
+        aliases: [],
+      })
+    ).to.deep.equal({ param: "otherValue", param2: "value2" });
+  });
+
+  it("should read from project id .env file", () => {
+    readEnvFileStub
+      .withArgs("test/extensions/extensionId.env.my-project")
+      .returns({ param: "otherValue", param2: "value2" });
+
+    expect(
+      params.readParams({
+        projectDir: testProjectDir,
+        instanceId: testInstanceId,
+        projectId: testProjectId,
+        projectNumber: testProjectNumber,
+        aliases: [],
+      })
+    ).to.deep.equal({ param: "otherValue", param2: "value2" });
+  });
+
+  it("should read from project number .env file", () => {
+    readEnvFileStub
+      .withArgs("test/extensions/extensionId.env.123456")
+      .returns({ param: "otherValue", param2: "value2" });
+
+    expect(
+      params.readParams({
+        projectDir: testProjectDir,
+        instanceId: testInstanceId,
+        projectId: testProjectId,
+        projectNumber: testProjectNumber,
+        aliases: [],
+      })
+    ).to.deep.equal({ param: "otherValue", param2: "value2" });
+  });
+
+  it("should read from an alias .env file", () => {
+    readEnvFileStub
+      .withArgs("test/extensions/extensionId.env.prod")
+      .returns({ param: "otherValue", param2: "value2" });
+
+    expect(
+      params.readParams({
+        projectDir: testProjectDir,
+        instanceId: testInstanceId,
+        projectId: testProjectId,
+        projectNumber: testProjectNumber,
+        aliases: ["prod"],
+      })
+    ).to.deep.equal({ param: "otherValue", param2: "value2" });
+  });
+
+  it("should prefer values from project specific env files", () => {
+    readEnvFileStub
+      .withArgs("test/extensions/extensionId.env.my-project")
+      .returns({ param: "value" });
+    readEnvFileStub
+      .withArgs("test/extensions/extensionId.env")
+      .returns({ param: "otherValue", param2: "value2" });
+
+    expect(
+      params.readParams({
+        projectDir: testProjectDir,
+        instanceId: testInstanceId,
+        projectId: testProjectId,
+        projectNumber: testProjectNumber,
+        aliases: [],
+      })
+    ).to.deep.equal({ param: "value", param2: "value2" });
+  });
+});

--- a/src/test/projectUtils.spec.ts
+++ b/src/test/projectUtils.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 
-import { needProjectNumber, needProjectId, getProjectId } from "../projectUtils";
+import { needProjectNumber, needProjectId, getAliases, getProjectId } from "../projectUtils";
 import * as projects from "../management/projects";
 import { RC } from "../rc";
 
@@ -67,5 +67,34 @@ describe("needProjectNumber", () => {
       Error,
       "oh no"
     );
+  });
+});
+
+describe("getAliases", () => {
+  it("should return the aliases for a projectId", () => {
+    const testProjectId = "my-project";
+    const testOptions = {
+      rc: {
+        hasProjects: true,
+        projects: {
+          prod: testProjectId,
+          prod2: testProjectId,
+          staging: "other-project",
+        },
+      },
+    };
+
+    expect(getAliases(testOptions, testProjectId).sort()).to.deep.equal(["prod", "prod2"]);
+  });
+
+  it("should return an empty array if there are no aliases in rc", () => {
+    const testProjectId = "my-project";
+    const testOptions = {
+      rc: {
+        hasProjects: false,
+      },
+    };
+
+    expect(getAliases(testOptions, testProjectId)).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
### Description
Adds support for project specific .env files to `firebase deploy --only extensions`. This lets you set up different configurations for different environments/projects from one firebase directory. It checks the following locations for .env files:
- `extensions/instanceId.env.projectId`
- `extensions/instanceId.env.projectNumber`
- `extensions/instanceId.env.projectAlias`
- `extensions/instanceId.env`

Happened to need this for my hackweek project, so I figured I should do it now and put up a PR - no need to rush on reviewing this during hackweek.

### Scenarios Tested
Tested a few different scenarios and verified that the instances were configured as expected in the console
- `extensions/instanceId.env.projectId` with all params
- `extensions/instanceId.env.projectNumber` with all params
-  Create a prod alias with `firebase use --add` ann `extensions/instanceId.env.prod` with all param
- `extensions/instanceId.env` with all params
- `extensions/instanceId.env.projectId` with some params and `extensions/instanceId.env` with the rest
- `extensions/instanceId.env.projectId` with all params and `extensions/instanceId.env` with the all params
-  No matching .env files exist
