### PR TITLE
Pin the cli-table dependency to 0.3.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "chokidar": "^3.0.2",
     "cjson": "^0.3.1",
     "cli-color": "^1.2.0",
-    "cli-table": "^0.3.1",
+    "cli-table": "0.3.6",
     "commander": "^4.0.1",
     "configstore": "^5.0.1",
     "cors": "^2.8.5",


### PR DESCRIPTION
### Description

Installing `firebase-tools` throws an error because of the latest release of `cli-tables` from this morning. Pinning it to version `0.3.6` solves this problem. There is currently 2 PRs open to resolve this problem: https://github.com/Automattic/cli-table/pulls, until that is merged, this problem will persist.

### Scenarios Tested

Install `firebase-tools`

### Sample Commands

`npm i -g firebase-tools@latest`
