### PR TITLE
Add and verify OIDC/SAML flows

### DIFF
--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -33,6 +33,7 @@ var firebaseAppId = query.get('appId');
 var apn = query.get('apn');
 var ibi = query.get('ibi');
 var appIdentifier = apn || ibi;
+var isSamlProvider = !!providerId.match(/^saml\./);
 assert(
   appName || clientId || firebaseAppId || appIdentifier,
   'Missing one of appName / clientId / appId / apn / ibi query params.'
@@ -172,6 +173,19 @@ function finishWithUser(urlEncodedIdToken) {
   // Avoid URLSearchParams for browser compatibility.
   url += '?providerId=' + encodeURIComponent(providerId);
   url += '&id_token=' + urlEncodedIdToken;
+
+  // Save reasonable defaults for SAML providers
+  if (isSamlProvider) {
+    var email = document.getElementById('email-input').value;
+    url += '&SAMLResponse=' + encodeURIComponent(JSON.stringify({
+      assertion: {
+        subject: {
+          nameId: email,
+        },
+      },
+    }));
+  }
+
   saveAuthEvent({
     type: authType,
     eventId: eventId,


### PR DESCRIPTION
### Description

Includes assertions thrown for generic OIDC/SAML IdP providers that parallel GCIP behavior. Verified that existing `signInWithIdp` flows work against JSSDK Auth Demo page.

Corresponding internal bug: b/192387796

### Scenarios Tested

* `npm test` passes
* See videos included in https://github.com/firebase/firebase-js-sdk/pull/5776

### Sample Commands

N/A
