### PR TITLE
pin cli-table to specific version 0.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3098,27 +3098,11 @@
       "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ=="
     },
     "cli-table": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.8.tgz",
-      "integrity": "sha512-5IO15fJRzgM+hHZjvQlqD6UPRuVGWR4Ny5ZzaM5VJxJEQqSIEVyVh9dMAUN6CBAVfMc4/6CFEzbhnRftLRCyug==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
+      "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
       "requires": {
-        "colors": "1.0.3",
-        "strip-ansi": "^6.0.1"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
+        "colors": "1.0.3"
       }
     },
     "cli-width": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "chokidar": "^3.0.2",
     "cjson": "^0.3.1",
     "cli-color": "^1.2.0",
-    "cli-table": "^0.3.8",
+    "cli-table": "0.3.11",
     "commander": "^4.0.1",
     "configstore": "^5.0.1",
     "cors": "^2.8.5",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

[cli-table](https://github.com/chalk/strip-ansi) has broken twice in as many weeks, both on `0.3.8` and `0.3.10`. `0.3.11` seems to be completely working, and I'm disallowing any automatic updates to it any more. This will be the version we use.

Basically, any table that only contained a number in a cell (not a string) would fail (since it does not have the `split` method.

### Scenarios Tested

`firebase database:profile` was failing with an issue rendering the table. Updated cli-table and now it's not.