### PR TITLE
replace single usage of enable with ensure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes issue with filtering on a specific storage bucket using functions in the emulator (#3893)
+- Fixes check in Cloud Functions for Firebase initialization to check for API enablement before trying to enable them. (#2574)

--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -43,7 +43,7 @@ export async function check(
  * @param projectId The project in which to enable the API.
  * @param apiName The name of the API e.g. `someapi.googleapis.com`.
  */
-export async function enable(projectId: string, apiName: string): Promise<void> {
+async function enable(projectId: string, apiName: string): Promise<void> {
   try {
     await apiClient.post(`/projects/${projectId}/services/${apiName}:enable`);
   } catch (err) {

--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -40,6 +40,9 @@ export async function check(
 /**
  * Attempt to enable an API on the specified project (just once).
  *
+ * If enabling an API for a customer, prefer `ensure` which will check for the
+ * API first, which is a seperate permission than enabling.
+ *
  * @param projectId The project in which to enable the API.
  * @param apiName The name of the API e.g. `someapi.googleapis.com`.
  */

--- a/src/init/features/functions/index.ts
+++ b/src/init/features/functions/index.ts
@@ -5,7 +5,7 @@ import { promptOnce } from "../../../prompt";
 import { requirePermissions } from "../../../requirePermissions";
 import { previews } from "../../../previews";
 import { Options } from "../../../options";
-import * as ensureApiEnabled from "../../../ensureApiEnabled";
+import { ensure } from "../../../ensureApiEnabled";
 
 module.exports = async function (setup: any, config: any, options: Options) {
   logger.info();
@@ -22,8 +22,8 @@ module.exports = async function (setup: any, config: any, options: Options) {
   if (projectId) {
     await requirePermissions({ ...options, project: projectId });
     await Promise.all([
-      ensureApiEnabled.enable(projectId, "cloudfunctions.googleapis.com"),
-      ensureApiEnabled.enable(projectId, "runtimeconfig.googleapis.com"),
+      ensure(projectId, "cloudfunctions.googleapis.com", "unused", true),
+      ensure(projectId, "runtimeconfig.googleapis.com", "unused", true),
     ]);
   }
   const choices = [

--- a/src/test/ensureApiEnabled.spec.ts
+++ b/src/test/ensureApiEnabled.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as nock from "nock";
 
-import { check, enable, ensure, POLL_SETTINGS } from "../ensureApiEnabled";
+import { check, ensure, POLL_SETTINGS } from "../ensureApiEnabled";
 
 const FAKE_PROJECT_ID = "my_project";
 const FAKE_API = "myapi.googleapis.com";
@@ -40,26 +40,6 @@ describe("ensureApiEnabled", () => {
         .reply(200, { state: "DISABLED" });
 
       await expect(check(FAKE_PROJECT_ID, FAKE_API, "", true)).to.eventually.be.false;
-    });
-  });
-
-  describe("enable", () => {
-    before(() => {
-      nock.disableNetConnect();
-    });
-
-    after(() => {
-      nock.enableNetConnect();
-    });
-
-    it("should call the API to enable the API", async () => {
-      nock("https://serviceusage.googleapis.com")
-        .post(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}:enable`)
-        .reply(200);
-
-      await enable(FAKE_PROJECT_ID, FAKE_API);
-
-      expect(nock.isDone()).to.be.true;
     });
   });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Permissions for checking if an API is enabled and actually enabling the API are separate. Some users may have the former, not the latter. So, let's stick to using only `ensure` so that those users can succeed.

I went ahead and un-exported `enable` to make it harder to use it outside its file (and added a comment in code).

Fixes #2574.

### Scenarios Tested

`init`'d functions. also did it turning off the API to make sure it was re-enabled.