### PR TITLE
Stop setting deployment tool on v2 updates

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -172,7 +172,10 @@ export class Fabricator {
   }
 
   async updateEndpoint(update: planner.EndpointUpdate, scraper: SourceTokenScraper): Promise<void> {
-    update.endpoint.labels = { ...update.endpoint.labels, ...deploymentTool.labels() };
+    // GCF team wants us to stop setting the deployment-tool labels on updates for gen 2
+    if (update.deleteAndRecreate || update.endpoint.platform !== "gcfv2") {
+      update.endpoint.labels = { ...update.endpoint.labels, ...deploymentTool.labels() };
+    }
     if (update.deleteAndRecreate) {
       await this.deleteEndpoint(update.deleteAndRecreate);
       await this.createEndpoint(update.endpoint, scraper);


### PR DESCRIPTION
From internal discussions, v2 is going to only propagate the deployment-tool to the underlying Run service on Function create. They've asked us to stop setting the label on updates.