### PR TITLE
fix version check in remoteconfig:get

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Fixes issue when installing a Firebase Extension where secrets would be created before validation.
-- Fixes issue with filtering on a specific storage bucket using functions in the emulator (#3893)
+- Fixes issue with filtering on a specific storage bucket using functions in the emulator. (#3893)
 - Fixes check in Cloud Functions for Firebase initialization to check for API enablement before trying to enable them. (#2574)
 - No longer tries to clean up function build images from Artifact Registry when Artifact Registry is not enabled (#3943)
+- Fixes issue where `remoteconfig:get` was not fetching the latest version by default. (#3559)

--- a/src/commands/remoteconfig-get.ts
+++ b/src/commands/remoteconfig-get.ts
@@ -12,17 +12,18 @@ import * as utils from "../utils";
 import Table = require("cli-table");
 import * as fs from "fs";
 import util = require("util");
+import { FirebaseError } from "../error";
 
 const tableHead = ["Entry Name", "Value"];
 
 // Creates a maximum limit of 50 names for each entry
 const MAX_DISPLAY_ITEMS = 20;
 
-function checkValidNumber(versionNumber: string): string {
-  if (typeof Number(versionNumber) == "number") {
+function checkValidOptionalNumber(versionNumber?: string): string | undefined {
+  if (!versionNumber || typeof Number(versionNumber) == "number") {
     return versionNumber;
   }
-  return "null";
+  throw new FirebaseError(`Could not interpret "${versionNumber}" as a valid number.`);
 }
 
 module.exports = new Command("remoteconfig:get")
@@ -35,10 +36,10 @@ module.exports = new Command("remoteconfig:get")
   .before(requireAuth)
   .before(requirePermissions, ["cloudconfig.configs.get"])
   .action(async (options: Options) => {
-    utils.assertIsString(options.versionNumber);
+    utils.assertIsStringOrUndefined(options.versionNumber);
     const template: RemoteConfigTemplate = await rcGet.getTemplate(
       needProjectId(options),
-      checkValidNumber(options.versionNumber)
+      checkValidOptionalNumber(options.versionNumber)
     );
     const table = new Table({ head: tableHead, style: { head: ["green"] } });
     if (template.conditions) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

The version argument to the function is optional, but the code wasn't allowing it. Now it does.

### Scenarios Tested

`remoteconfig:get`

Fixes #3559