### PR TITLE
Fill in SAMLResponse nameId for pre-populated users

### DIFF
--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -201,7 +201,7 @@ export function registerHandlers(
           <span class="mdc-list-item__text"><span class="mdc-list-item__primary-text">${
             info.displayName || "(No display name)"
           }</span>
-          <span class="mdc-list-item__secondary-text fallback-secondary-text">${
+          <span class="mdc-list-item__secondary-text fallback-secondary-text" id="reuse-email">${
             info.email || ""
           }</span>
       </li>`

--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -176,7 +176,7 @@ function finishWithUser(urlEncodedIdToken) {
 
   // Save reasonable defaults for SAML providers
   if (isSamlProvider) {
-    var email = document.getElementById('email-input').value;
+    var email = document.getElementById('email-input').value || document.getElementById('reuse-email').innerText;
     url += '&SAMLResponse=' + encodeURIComponent(JSON.stringify({
       assertion: {
         subject: {

--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -158,16 +158,17 @@ var reuseAccountEls = document.querySelectorAll('.js-reuse-account');
 if (reuseAccountEls.length) {
   [].forEach.call(reuseAccountEls, function (el) {
     var urlEncodedIdToken = el.dataset.idToken;
+    const decoded = JSON.parse(decodeURIComponent(urlEncodedIdToken));
     el.addEventListener('click', function (e) {
       e.preventDefault();
-      finishWithUser(urlEncodedIdToken);
+      finishWithUser(urlEncodedIdToken, decoded.email);
     });
   });
 } else {
   document.querySelector('.js-accounts-help-text').textContent = "No " + formattedProviderId + " accounts exist in the Auth Emulator.";
 }
 
-function finishWithUser(urlEncodedIdToken) {
+function finishWithUser(urlEncodedIdToken, email) {
   // Use widget URL, but replace all query parameters (no apiKey etc.).
   var url = window.location.href.split('?')[0];
   // Avoid URLSearchParams for browser compatibility.
@@ -176,7 +177,6 @@ function finishWithUser(urlEncodedIdToken) {
 
   // Save reasonable defaults for SAML providers
   if (isSamlProvider) {
-    var email = document.getElementById('email-input').value || document.getElementById('reuse-email').innerText;
     url += '&SAMLResponse=' + encodeURIComponent(JSON.stringify({
       assertion: {
         subject: {
@@ -234,7 +234,7 @@ document.getElementById('main-form').addEventListener('submit', function(e) {
     if (screenName) claims.screenName = screenName;
     if (photoUrl) claims.photoUrl = photoUrl;
 
-    finishWithUser(createFakeClaims(claims));
+    finishWithUser(createFakeClaims(claims), email);
   }
 });
 

--- a/src/emulator/auth/widget_ui.ts
+++ b/src/emulator/auth/widget_ui.ts
@@ -234,7 +234,7 @@ document.getElementById('main-form').addEventListener('submit', function(e) {
     if (screenName) claims.screenName = screenName;
     if (photoUrl) claims.photoUrl = photoUrl;
 
-    finishWithUser(createFakeClaims(claims), email);
+    finishWithUser(createFakeClaims(claims), claims.email);
   }
 });
 


### PR DESCRIPTION
### Description

A bit of cleanup from https://github.com/firebase/firebase-tools/pull/3927. Widget should fill in the SAMLResponse correctly even for users that were signed in previously.

Corresponding internal bug: b/192387796

### Scenarios Tested

Manually tested against the JSSDK Auth Demo page. See instructions [here](https://github.com/firebase/firebase-js-sdk/tree/master/packages/auth/demo#running-against-auth-emulator)

### Sample Commands

N/A
