### PR TITLE
Count the number of regions deployed to

### DIFF
--- a/src/deploy/functions/release/reporter.ts
+++ b/src/deploy/functions/release/reporter.ts
@@ -59,8 +59,10 @@ export async function logAndTrackDeployStats(summary: Summary): Promise<void> {
   let totalAborts = 0;
   const reports: Array<Promise<void>> = [];
 
+  const regions = new Set<string>();
   for (const result of summary.results) {
     const tag = triggerTag(result.endpoint);
+    regions.add(result.endpoint.region);
     totalTime += result.durationMs;
     if (!result.error) {
       totalSuccesses++;
@@ -73,6 +75,9 @@ export async function logAndTrackDeployStats(summary: Summary): Promise<void> {
       reports.push(track.track("function_deploy_failure", tag, result.durationMs));
     }
   }
+
+  const regionCountTag = regions.size < 5 ? regions.size.toString() : ">=5";
+  reports.push(track.track("functions_region_count", regionCountTag, 1));
 
   const gcfv1 = summary.results.find((r) => r.endpoint.platform === "gcfv1");
   const gcfv2 = summary.results.find((r) => r.endpoint.platform === "gcfv2");

--- a/src/test/deploy/functions/release/reporter.spec.ts
+++ b/src/test/deploy/functions/release/reporter.spec.ts
@@ -132,6 +132,7 @@ describe("reporter", () => {
 
       await reporter.logAndTrackDeployStats(summary);
 
+      expect(trackStub).to.have.been.calledWith("functions_region_count", "1", 1);
       expect(trackStub).to.have.been.calledWith("function_deploy_success", "v1.https", 2_000);
       expect(trackStub).to.have.been.calledWith("function_deploy_failure", "v1.https", 1_000);
       // Aborts aren't tracked because they would throw off timing metrics


### PR DESCRIPTION
We want to figure out how bad of a breaking change it will be to require one region per codebase. Since analytics only gives us sums and averages of metric counts, we'll be using the number of regions as a bucket and counting the sum of each bucket. To keep this from being unbounded, we'll cap at >=5.