### PR TITLE
Fixing a bug where empty variables in .env files were read as multi-line values (#3934)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Fixes issue when installing a Firebase Extension where secrets would be created before validation.
 - Fixes issue with filtering on a specific storage bucket using functions in the emulator (#3893)
 - Fixes check in Cloud Functions for Firebase initialization to check for API enablement before trying to enable them. (#2574)
-- No longer tries to clean up function build images from Artifact Registry when Artifact Registry is not enabled (#3943)
+- No longer tries to clean up function build images from Artifact Registry when Artifact Registry is not enabled. (#3943)
+- Fixes issue where empty variables in .env files would instead read as multi-line values. (#3934)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,3 @@
 - Show error message when running `firebase init hosting:github` with no Hosting config in `firebase.json`. (#3113)
 - Fixes issue where `remoteconfig:get` was not fetching the latest version by default. (#3559)
 - Fixes issue where empty variables in .env files would instead read as multi-line values. (#3934)
-

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -49,7 +49,7 @@ const LINE_RE = new RegExp(
   "(" +                      //   begin optional value
   "\\s*'(?:\\\\'|[^'])*'|" + //     single quoted or
   '\\s*"(?:\\\\"|[^"])*"|' + //     double quoted or
-  "[^#\\r\\n]+" +            //     unquoted
+  "[^#=\\r\\n]*" +           //     unquoted
   ")?" +                     //   end optional value
   "\\s*" +                   //   trailing whitespaces
   "(?:#[^\\n]*)?" +          //   optional comment
@@ -109,6 +109,7 @@ export function parse(data: string): ParseResult {
         v = v.replace(/\\([\\'"])/g, "$1");
       }
     }
+
     envs[k] = v;
   }
 

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -45,11 +45,11 @@ const LINE_RE = new RegExp(
   "^" +                      // begin line
   "\\s*" +                   //   leading whitespaces
   "(\\w+)" +                 //   key
-  "\\s*=\\s*" +              //   separator (=)
+  "\\s*=[\\f\\t\\v]*" +              //   separator (=)
   "(" +                      //   begin optional value
   "\\s*'(?:\\\\'|[^'])*'|" + //     single quoted or
   '\\s*"(?:\\\\"|[^"])*"|' + //     double quoted or
-  "[^#=\\r\\n]*" +           //     unquoted
+  "[^#\\r\\n]*" +           //     unquoted
   ")?" +                     //   end optional value
   "\\s*" +                   //   trailing whitespaces
   "(?:#[^\\n]*)?" +          //   optional comment

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -135,26 +135,33 @@ BAR=bar
         want: { FOO: "foo" },
       },
       {
-        description: "should ignore comments",
+        description: "should handle empty values",
         input: `
-FOO=foo # comment
-# line comment 1
-# line comment 2
-BAR=bar # another comment
+FOO=
+BAR= "blah"
 `,
-        want: { FOO: "foo", BAR: "bar" },
+        want: { FOO: "", BAR: "blah" },
       },
-      {
-        description: "should ignore empty lines",
-        input: `
-FOO=foo
+      //       {
+      //         description: "should ignore comments",
+      //         input: `
+      // FOO=foo # comment
+      // # line comment 1
+      // # line comment 2
+      // BAR=bar # another comment
+      // `,
+      //         want: { FOO: "foo", BAR: "bar" },
+      //       },
+      //       {
+      //         description: "should ignore empty lines",
+      //         input: `
+      // FOO=foo
 
+      // BAR=bar
 
-BAR=bar
-
-`,
-        want: { FOO: "foo", BAR: "bar" },
-      },
+      // `,
+      //         want: { FOO: "foo", BAR: "bar" },
+      //       },
     ];
 
     tests.forEach(({ description, input, want }) => {

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -142,26 +142,26 @@ BAR= "blah"
 `,
         want: { FOO: "", BAR: "blah" },
       },
-      //       {
-      //         description: "should ignore comments",
-      //         input: `
-      // FOO=foo # comment
-      // # line comment 1
-      // # line comment 2
-      // BAR=bar # another comment
-      // `,
-      //         want: { FOO: "foo", BAR: "bar" },
-      //       },
-      //       {
-      //         description: "should ignore empty lines",
-      //         input: `
-      // FOO=foo
+      {
+        description: "should ignore comments",
+        input: `
+      FOO=foo # comment
+      # line comment 1
+      # line comment 2
+      BAR=bar # another comment
+      `,
+        want: { FOO: "foo", BAR: "bar" },
+      },
+      {
+        description: "should ignore empty lines",
+        input: `
+      FOO=foo
 
-      // BAR=bar
+      BAR=bar
 
-      // `,
-      //         want: { FOO: "foo", BAR: "bar" },
-      //       },
+      `,
+        want: { FOO: "foo", BAR: "bar" },
+      },
     ];
 
     tests.forEach(({ description, input, want }) => {

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -143,6 +143,14 @@ BAR= "blah"
         want: { FOO: "", BAR: "blah" },
       },
       {
+        description: "should handle quoted values after a newline",
+        input: `
+FOO=
+"blah"
+`,
+        want: { FOO: "blah" },
+      },
+      {
         description: "should ignore comments",
         input: `
       FOO=foo # comment


### PR DESCRIPTION
### Description
Fixes an issue where the .env parser would mishandled empty values. The following .env file:
```
FOO=
BAR=something
```
would be parsed into
```
{ FOO: "BAR=something" }
```
Fixes https://github.com/firebase/firebase-tools/issues/3934

### Scenarios Tested
Added a test case to cover this
