### PR TITLE
Backport Database Emulator v4.7.3 to Firebase CLI v9.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Upgrades Database Emulator to v4.7.3, removing log4j dependency.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -27,14 +27,14 @@ const CACHE_DIR =
 
 export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDetails } = {
   database: {
-    downloadPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.7.2.jar"),
-    version: "4.7.2",
+    downloadPath: path.join(CACHE_DIR, "firebase-database-emulator-v4.7.3.jar"),
+    version: "4.7.3",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.7.2.jar",
-      expectedSize: 28910604,
-      expectedChecksum: "264e5df0c0661c064ef7dc9ce8179aba",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.7.3.jar",
+      expectedSize: 28862098,
+      expectedChecksum: "8f696f24ee89c937a789498a0c0e4899",
       namePrefix: "firebase-database-emulator",
     },
   },


### PR DESCRIPTION
This backports #3955 to CLI v9.x.

* Release Database Emulator v4.7.3.

* Update CHANGELOG.md.