### PR TITLE
fix invalid character in header content

### DIFF
--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -462,10 +462,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
         res.header("x-goog-upload-chunk-granularity", "10000");
         res.header("x-goog-upload-control-url", "");
         res.header("x-goog-upload-status", "active");
-        res.header(
-          "x-goog-upload-url",
-          `http://${req.hostname}:${emulatorInfo?.port}/v0/b/${req.params.bucketId}/o?name=${req.query.name}&upload_id=${upload.uploadId}&upload_protocol=resumable`
-        );
+        res.header("x-goog-upload-url", encodeURI(`http://${req.hostname}:${emulatorInfo === null || emulatorInfo === void 0 ? void 0 : emulatorInfo.port}/v0/b/${req.params.bucketId}/o?name=${req.query.name}&upload_id=${upload.uploadId}&upload_protocol=resumable`));
         res.header("x-gupload-uploadid", upload.uploadId);
 
         res.status(200).send();


### PR DESCRIPTION
### Description

I fixed a bug that throws below error when a file that has no US-ASCII character name and emulator is stopped with `Error: An unexpected error has occurred.`.

```
[debug] [2021-12-19T15:03:45.960Z] TypeError [ERR_INVALID_CHAR]: Invalid character in header content ["x-goog-upload-url"]
    at ServerResponse.setHeader (node:_http_outgoing:579:3)
    at ServerResponse.header (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/response.js:771:10)
    at handleUpload (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/lib/emulator/storage/apis/firebase.js:347:21)
    at Layer.handle [as handle_request] (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:112:3)
    at Layer.handle [as handle_request] (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/layer.js:95:5)
    at /Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:281:22
    at param (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:354:14)
    at param (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:365:14)
    at param (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:365:14)
    at Function.process_params (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:410:3)
    at next (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:275:10)
    at /Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/lib/emulator/storage/apis/firebase.js:89:9
    at Layer.handle [as handle_request] (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/layer.js:95:5)
    at trim_prefix (/Users/me/.nodenv/versions/17.0.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/index.js:317:13)
```

The HTTP request header value doesn't accept no US-ASCII characters. [RFC7230](https://tools.ietf.org/html/rfc7230#section-3.2.6)
The nodejs checks the value characters here, so I thought that the value should be encoded with `encodeURI` to be accepted.
https://github.com/nodejs/node/blob/e9fc67815e37af5aa2d1e35b3054f94b27468542/lib/_http_common.js#L222

Example.
```
> let japaneseLetter = "鬼滅の刃"
undefined
> encodeURI(japaneseLetter)
'%E9%AC%BC%E6%BB%85%E3%81%AE%E5%88%83'
```