### PR TITLE
feat: use faster crc32c if available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/pubsub": "^2.7.0",
+        "@node-rs/crc32": "^1.3.0",
         "@types/archiver": "^5.1.0",
         "abort-controller": "^3.0.0",
         "ajv": "^6.12.6",
@@ -1731,6 +1732,228 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@node-rs/crc32": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32/-/crc32-1.3.0.tgz",
+      "integrity": "sha512-GfCCBxLAffYHplQz2kLXn8H0HU1jaE2PKaqvsAOPrObm+KN5orU6qEswyM+nCK5JKi+kE0cTHBiTh6z9Y8od3A==",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/crc32-android-arm-eabi": "1.3.0",
+        "@node-rs/crc32-android-arm64": "1.3.0",
+        "@node-rs/crc32-darwin-arm64": "1.3.0",
+        "@node-rs/crc32-darwin-x64": "1.3.0",
+        "@node-rs/crc32-freebsd-x64": "1.3.0",
+        "@node-rs/crc32-linux-arm-gnueabihf": "1.3.0",
+        "@node-rs/crc32-linux-arm64-gnu": "1.3.0",
+        "@node-rs/crc32-linux-arm64-musl": "1.3.0",
+        "@node-rs/crc32-linux-x64-gnu": "1.3.0",
+        "@node-rs/crc32-linux-x64-musl": "1.3.0",
+        "@node-rs/crc32-win32-arm64-msvc": "1.3.0",
+        "@node-rs/crc32-win32-ia32-msvc": "1.3.0",
+        "@node-rs/crc32-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm-eabi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.3.0.tgz",
+      "integrity": "sha512-ObGj8Qc8ahRu4FT0pRIo1lj7NQQr2g7WAvjXPk72aYDUR+a2z1wTRqhooyly0qZFvvTtCqIkYE8baGvl04YjAg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-P8ohCPsXz53bjeXQI3Br/cEJZm792+hEpxuo1+mLncoe4Hxjt9q7a6Q6OwbtvzKAoX1lQIdpBZ7MZIsosiydSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-xm9CvpDkNTbzKQLWCQKzS1XmrDWx5/j1F0n8MNThYwiNjxuJbbcFxbRJM/Nq+JMNCETtr6f+iyQd7h6WHhTMmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-uq7JL9sBZT9TMb2f8kIrw8KJTLs8lPqQprcEj6wrnQKhZ2TVrZQ61TYLfIrXOUqBy8aj1g6nRCHnMzliAdTuTA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-W79DjaJGGjds/H1RLvnbPJGu3z6t42j+IuxWuDxJHKvNnbF5EKbo0qOgnQqqiINKwdJEeto843684IW1HSPBOA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-9sqmAHvQorj//kWD7suSnBTEmDO9JEaBdtA0BszRrrgwHyzjMj/62fXXs83I64swlCJ01q7yVc4MuHsB5l9AlA==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-4X3Jz4B9ywpQJZf+sLafSBHs7pSW+L0d9EP76a8cNWfxQRYWvjkVZRgrdTFW0SueVKAMrW+ok2wViuHvsrKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-i8m822QmI7utAvte+ADjdjyuz1hVbQkvC2pEWU38ce4iatE6wADjmpDVfFziVypOw7c5fSCzS7ETjWPRf7SVww==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-jFVc5iGixWfgi8rycHCjC16PX0/cg6RVt/ZtDgB44luF2sTjDNUv+soXL4G5qOoKUA6jfeN8bE3vCpJDuN8fcw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-Qc8Km7nAfrzGBIvoMK/bdQYY3PL3Bq/95jSbxB9njjX7wxqxz8vCzzed4bG4G3Cq0moLO/EPVhCKg7gYtiYiKg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-l2c0KzCzp9Ju09jR0whtKEIJUrY8jL2jN+Yf0lt7itRVww6KoTJg0yu/UZtzFhbduN3TqMNmTraJZCyCMH0S5Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-QGtcMkQuQUI2OUZKreFFO3FgvwKnOWocvIMThWVKl7ZxLbFSO82z7LozhpBub7jgNezVMoNUkOyvZdgEr0BQHg==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4gXVloRBX2Nv8sM++77x3SZacMC5CuL4CzVB++g9RHKp6UlZyLvbw9+Q4UQzQm0Gbse+ugP8whdJ3ZTKfV2dug==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -15527,6 +15750,104 @@
           }
         }
       }
+    },
+    "@node-rs/crc32": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32/-/crc32-1.3.0.tgz",
+      "integrity": "sha512-GfCCBxLAffYHplQz2kLXn8H0HU1jaE2PKaqvsAOPrObm+KN5orU6qEswyM+nCK5JKi+kE0cTHBiTh6z9Y8od3A==",
+      "requires": {
+        "@node-rs/crc32-android-arm-eabi": "1.3.0",
+        "@node-rs/crc32-android-arm64": "1.3.0",
+        "@node-rs/crc32-darwin-arm64": "1.3.0",
+        "@node-rs/crc32-darwin-x64": "1.3.0",
+        "@node-rs/crc32-freebsd-x64": "1.3.0",
+        "@node-rs/crc32-linux-arm-gnueabihf": "1.3.0",
+        "@node-rs/crc32-linux-arm64-gnu": "1.3.0",
+        "@node-rs/crc32-linux-arm64-musl": "1.3.0",
+        "@node-rs/crc32-linux-x64-gnu": "1.3.0",
+        "@node-rs/crc32-linux-x64-musl": "1.3.0",
+        "@node-rs/crc32-win32-arm64-msvc": "1.3.0",
+        "@node-rs/crc32-win32-ia32-msvc": "1.3.0",
+        "@node-rs/crc32-win32-x64-msvc": "1.3.0"
+      }
+    },
+    "@node-rs/crc32-android-arm-eabi": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.3.0.tgz",
+      "integrity": "sha512-ObGj8Qc8ahRu4FT0pRIo1lj7NQQr2g7WAvjXPk72aYDUR+a2z1wTRqhooyly0qZFvvTtCqIkYE8baGvl04YjAg==",
+      "optional": true
+    },
+    "@node-rs/crc32-android-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.3.0.tgz",
+      "integrity": "sha512-P8ohCPsXz53bjeXQI3Br/cEJZm792+hEpxuo1+mLncoe4Hxjt9q7a6Q6OwbtvzKAoX1lQIdpBZ7MZIsosiydSw==",
+      "optional": true
+    },
+    "@node-rs/crc32-darwin-arm64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.3.0.tgz",
+      "integrity": "sha512-xm9CvpDkNTbzKQLWCQKzS1XmrDWx5/j1F0n8MNThYwiNjxuJbbcFxbRJM/Nq+JMNCETtr6f+iyQd7h6WHhTMmg==",
+      "optional": true
+    },
+    "@node-rs/crc32-darwin-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.3.0.tgz",
+      "integrity": "sha512-uq7JL9sBZT9TMb2f8kIrw8KJTLs8lPqQprcEj6wrnQKhZ2TVrZQ61TYLfIrXOUqBy8aj1g6nRCHnMzliAdTuTA==",
+      "optional": true
+    },
+    "@node-rs/crc32-freebsd-x64": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.3.0.tgz",
+      "integrity": "sha512-W79DjaJGGjds/H1RLvnbPJGu3z6t42j+IuxWuDxJHKvNnbF5EKbo0qOgnQqqiINKwdJEeto843684IW1HSPBOA==",
+      "optional": true
+    },
+    "@node-rs/crc32-linux-arm-gnueabihf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.3.0.tgz",
+      "integrity": "sha512-9sqmAHvQorj//kWD7suSnBTEmDO9JEaBdtA0BszRrrgwHyzjMj/62fXXs83I64swlCJ01q7yVc4MuHsB5l9AlA==",
+      "optional": true
+    },
+    "@node-rs/crc32-linux-arm64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.3.0.tgz",
+      "integrity": "sha512-4X3Jz4B9ywpQJZf+sLafSBHs7pSW+L0d9EP76a8cNWfxQRYWvjkVZRgrdTFW0SueVKAMrW+ok2wViuHvsrKnBw==",
+      "optional": true
+    },
+    "@node-rs/crc32-linux-arm64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.3.0.tgz",
+      "integrity": "sha512-i8m822QmI7utAvte+ADjdjyuz1hVbQkvC2pEWU38ce4iatE6wADjmpDVfFziVypOw7c5fSCzS7ETjWPRf7SVww==",
+      "optional": true
+    },
+    "@node-rs/crc32-linux-x64-gnu": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.3.0.tgz",
+      "integrity": "sha512-jFVc5iGixWfgi8rycHCjC16PX0/cg6RVt/ZtDgB44luF2sTjDNUv+soXL4G5qOoKUA6jfeN8bE3vCpJDuN8fcw==",
+      "optional": true
+    },
+    "@node-rs/crc32-linux-x64-musl": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.3.0.tgz",
+      "integrity": "sha512-Qc8Km7nAfrzGBIvoMK/bdQYY3PL3Bq/95jSbxB9njjX7wxqxz8vCzzed4bG4G3Cq0moLO/EPVhCKg7gYtiYiKg==",
+      "optional": true
+    },
+    "@node-rs/crc32-win32-arm64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.3.0.tgz",
+      "integrity": "sha512-l2c0KzCzp9Ju09jR0whtKEIJUrY8jL2jN+Yf0lt7itRVww6KoTJg0yu/UZtzFhbduN3TqMNmTraJZCyCMH0S5Q==",
+      "optional": true
+    },
+    "@node-rs/crc32-win32-ia32-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.3.0.tgz",
+      "integrity": "sha512-QGtcMkQuQUI2OUZKreFFO3FgvwKnOWocvIMThWVKl7ZxLbFSO82z7LozhpBub7jgNezVMoNUkOyvZdgEr0BQHg==",
+      "optional": true
+    },
+    "@node-rs/crc32-win32-x64-msvc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-x64-msvc/-/crc32-win32-x64-msvc-1.3.0.tgz",
+      "integrity": "sha512-4gXVloRBX2Nv8sM++77x3SZacMC5CuL4CzVB++g9RHKp6UlZyLvbw9+Q4UQzQm0Gbse+ugP8whdJ3ZTKfV2dug==",
+      "optional": true
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -85,8 +85,8 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "^2.7.0",
+    "@node-rs/crc32": "^1.3.0",
     "@types/archiver": "^5.1.0",
-    "JSONStream": "^1.2.1",
     "abort-controller": "^3.0.0",
     "ajv": "^6.12.6",
     "archiver": "^5.0.0",
@@ -112,6 +112,7 @@
     "google-auth-library": "^6.1.3",
     "inquirer": "~6.3.1",
     "js-yaml": "^3.13.1",
+    "JSONStream": "^1.2.1",
     "jsonwebtoken": "^8.5.1",
     "leven": "^3.1.0",
     "lodash": "^4.17.21",

--- a/src/emulator/storage/crc.ts
+++ b/src/emulator/storage/crc.ts
@@ -24,12 +24,22 @@ function makeCRCTable(poly: number) {
  */
 const CRC32C_TABLE = makeCRCTable(0x82f63b78);
 
+let nativeCrc32c: typeof import("@node-rs/crc32")["crc32c"] | null = null;
+
+try {
+  const { crc32c } = require("@node-rs/crc32");
+  nativeCrc32c = crc32c;
+} catch {
+  // no supported crc32 package, just continue
+}
+
 /**
  * Adapted from:
  *  - https://en.wikipedia.org/wiki/Cyclic_redundancy_check#Computation
  *  - https://stackoverflow.com/a/18639999/324977
  */
 export function crc32c(bytes: Buffer): number {
+  if (nativeCrc32c) return nativeCrc32c(bytes);
   let crc = 0 ^ -1;
 
   for (let i = 0; i < bytes.length; i++) {


### PR DESCRIPTION
The `@node-rs/crc32` package is faster and supports more platform, and it's without any postinstall scripts.


|                       | node12 | node14 | node16 |
| --------------------- | ------ | ------ | ------ |
| Windows x64           | ✓      | ✓      | ✓      |
| Windows x32           | ✓      | ✓      | ✓      |
| Windows arm64         | ✓      | ✓      | ✓      |
| macOS x64             | ✓      | ✓      | ✓      |
| macOS arm64 (m chips) | ✓      | ✓      | ✓      |
| Linux x64 gnu         | ✓      | ✓      | ✓      |
| Linux x64 musl        | ✓      | ✓      | ✓      |
| Linux arm gnu         | ✓      | ✓      | ✓      |
| Linux arm64 gnu       | ✓      | ✓      | ✓      |
| Linux arm64 musl      | ✓      | ✓      | ✓      |
| Android arm64         | ✓      | ✓      | ✓      |
| Android armv7         | ✓      | ✓      | ✓      |
| FreeBSD x64           | ✓      | ✓      | ✓      |

Fallback to JavaScript implementation if `@node-rs/crc32` is not available.