### PR TITLE
Fix bug where empty vpc connector setting was removed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Preserve empty vpc connector setting on function deploy. (#3973)

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -212,9 +212,9 @@ export function addResourcesToBackend(
       runtime: runtime,
       ...triggered,
     };
-    if (annotation.vpcConnector) {
+    if (annotation.vpcConnector != null) {
       let maybeId = annotation.vpcConnector;
-      if (!maybeId.includes("/")) {
+      if (maybeId && !maybeId.includes("/")) {
         maybeId = `projects/${projectId}/locations/${region}/connectors/${maybeId}`;
       }
       endpoint.vpcConnector = maybeId;

--- a/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -289,4 +289,23 @@ describe("addResourcesToBackend", () => {
 
     expect(result).to.deep.equal(expected);
   });
+
+  it("should preserve empty vpc connector setting", () => {
+    const trigger: parseTriggers.TriggerAnnotation = {
+      ...BASIC_TRIGGER,
+      httpsTrigger: {},
+      vpcConnector: "",
+    };
+
+    const result = backend.empty();
+    parseTriggers.addResourcesToBackend("project", "nodejs16", trigger, result);
+
+    const expected: backend.Backend = backend.of({
+      ...BASIC_ENDPOINT,
+      httpsTrigger: {},
+      vpcConnector: "",
+    });
+
+    expect(result).to.deep.equal(expected);
+  });
 });


### PR DESCRIPTION
Today, empty vpc connector setting is removed in the function update request, e.g.:

```js
exports.vpc = functions.runWith({ vpcConnector: '' }).https.onRequest((request, response) => {
  functions.logger.info("Hello logs!", {structuredData: true});
  response.send("Hello from Firebase!");
});
```

This is unfortunate since the existing behavior makes it impossible to clear vpc connector setting (see https://github.com/firebase/firebase-tools/issues/3968 for discussion). The change here preserves the empty string as a vpc connector setting which in turn allows someone to clear the vpc connector setting on deploy.