### PR TITLE
speed up fetchWebSetup tests

### DIFF
--- a/src/test/fetchWebSetup.spec.ts
+++ b/src/test/fetchWebSetup.spec.ts
@@ -8,6 +8,14 @@ import { firebaseApiOrigin } from "../api";
 import { FirebaseError } from "../error";
 
 describe("fetchWebSetup module", () => {
+  before(() => {
+    nock.disableNetConnect();
+  });
+
+  after(() => {
+    nock.enableNetConnect();
+  });
+
   afterEach(() => {
     expect(nock.isDone()).to.be.true;
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

disabling http connect with nock makes these tests much faster. I'm not 100% sure why, but the resolution time for the nock without this is 10x more, so... /shrug