### PR TITLE
ext:dev:usage - Remove cloud monitoring link and increase buffer period

### DIFF
--- a/src/commands/ext-dev-usage.ts
+++ b/src/commands/ext-dev-usage.ts
@@ -70,8 +70,8 @@ module.exports = new Command("ext:dev:usage <publisherId>")
 
     const projectNumber = getPublisherProjectFromName(profile.name);
 
-    const past30d = new Date();
-    past30d.setDate(past30d.getDate() - 30);
+    const past45d = new Date();
+    past45d.setDate(past45d.getDate() - 45);
 
     const query: CmQuery = {
       filter:
@@ -79,7 +79,7 @@ module.exports = new Command("ext:dev:usage <publisherId>")
         `resource.type="firebaseextensions.googleapis.com/ExtensionVersion" ` +
         `resource.labels.extension="${extensionName}"`,
       "interval.endTime": new Date().toJSON(),
-      "interval.startTime": past30d.toJSON(),
+      "interval.startTime": past45d.toJSON(),
       view: TimeSeriesView.FULL,
       "aggregation.alignmentPeriod": (60 * 60 * 24).toString() + "s",
       "aggregation.perSeriesAligner": Aligner.ALIGN_MAX,
@@ -117,18 +117,13 @@ module.exports = new Command("ext:dev:usage <publisherId>")
 
     logger.info(table.toString());
 
-    const link = await buildCloudMonitoringLink({
-      projectNumber: projectNumber,
-      extensionName,
-    });
-
     utils.logLabeledBullet(logPrefix, `How to read this table:`);
     logger.info(`* Due to privacy considerations, numbers are reported as ranges.`);
     logger.info(`* In the absence of significant changes, we will render a '-' symbol.`);
     logger.info(
       `* You will need more than 10 installs over a period of more than 28 days to render sufficient data.`
     );
-    logger.info(`For more detail, visit: ${link}`);
+    // TODO(b/216289102): Add buildCloudMonitoringLink back after UI is fixed.
   });
 
 async function buildCloudMonitoringLink(args: {


### PR DESCRIPTION
Increase metric buffer period from 2 days to 17 days, we had a bug where the precompute didn't run for a few days so there's data loss. https://screenshot.googleplex.com/fauTrD98LxEryKC (fixed separately)

In case things like this happens, we could just use slightly older data, because data is bucketed and mostly moving upward. Adding more buffer period to allow us to do that.

Also remove link to cloud monitoring UI until deep-linking is fixed.

![Screen Shot 2022-01-25 at 10 44 37 AM](https://user-images.githubusercontent.com/6955348/151009676-a411d02f-6a14-4155-8fa0-809196d862a0.png)

