### PR TITLE
Fix broken ext:dev:list command

### DIFF
--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -516,7 +516,6 @@ export async function getExtensionVersion(extensionVersionRef: string): Promise<
 
 /**
  * @param publisherId the publisher for which we are listing Extensions
- * @param showUnpublished whether to include unpublished Extensions, default = false
  */
 export async function listExtensions(publisherId: string): Promise<Extension[]> {
   const extensions: Extension[] = [];
@@ -525,7 +524,6 @@ export async function listExtensions(publisherId: string): Promise<Extension[]> 
       `/publishers/${publisherId}/extensions`,
       {
         queryParams: {
-          showUnpublished: "false",
           pageSize: PAGE_SIZE_MAX,
           pageToken,
         },
@@ -544,7 +542,6 @@ export async function listExtensions(publisherId: string): Promise<Extension[]> 
 
 /**
  * @param ref user-friendly identifier for the ExtensionVersion (publisher-id/extension-id)
- * @param showUnpublished whether to include unpublished ExtensionVersions, default = false
  */
 export async function listExtensionVersions(ref: string, filter = ""): Promise<ExtensionVersion[]> {
   const { publisherId, extensionId } = refs.parse(ref);


### PR DESCRIPTION
### Description
Fix broken ext:dev:list command by cleaning up unused showUnpublished queryParams.

`showUnpublished` has long been removed, but we still use it in our query param.
https://source.corp.google.com/piper///depot/google3/google/firebase/extensions/v1beta/services.proto;l=750;bpv=1;bpt=0;rcl=423705523

This has been working up until recently, I'm guessing something changed at the one platform layer so undefined proto field is no longer accepted.


Before:
```
lihes-macbookpro2:firebase-tools lihes$ firebase ext:dev:usage pavelj-extensions1


Error:HTTP Error: 400, Invalid JSON payload received. Unknown name "showUnpublished": Cannot bind query parameter. Field 'showUnpublished' could not be found in request message.
```


After:
```
lihes-macbookpro2:firebase-tools lihes$ firebase ext:dev:list pavelj-extensions1
i  extensions: list of published extensions for publisher pavelj-extensions1:
┌──────────────────────────────┬─────────┬─────────────────────┐
│ Extension ID                 │ Version │ Published           │
├──────────────────────────────┼─────────┼─────────────────────┤
│ storage-resize-images        │ 0.1.22  │ 2021-10-20 20:59:50 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ rtdb-limit-child-nodes       │ 0.1.4   │ 2021-10-20 20:59:32 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ firestore-translate-text     │ 0.1.6   │ 2021-10-20 20:59:16 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ firestore-shorten-urls-bitly │ 0.1.6   │ 2021-10-20 20:58:54 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ firestore-send-email         │ 0.1.11  │ 2021-10-20 20:58:34 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ firestore-counter            │ 0.2.3   │ 2021-10-20 20:58:14 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ firestore-bigquery-export    │ 0.1.17  │ 2021-10-20 20:57:56 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ delete-user-data             │ 0.1.10  │ 2021-10-20 20:57:39 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ secret-test                  │ 0.0.11  │ 2021-09-13 23:09:42 │
├──────────────────────────────┼─────────┼─────────────────────┤
│ storage-extract-image-text   │ 0.0.2   │ 2021-06-11 13:36:03 │
└──────────────────────────────┴─────────┴─────────────────────┘
```
