### PR TITLE
Emulate extensions from firebase.json

### DIFF
--- a/src/commands/ext-dev-emulators-start.ts
+++ b/src/commands/ext-dev-emulators-start.ts
@@ -24,7 +24,6 @@ module.exports = new Command("ext:dev:emulators:start")
     } catch (e: any) {
       await controller.cleanShutdown();
       if (!(e instanceof FirebaseError)) {
-        console.log(e);
         throw new FirebaseError("Error in ext:dev:emulator:start", e);
       }
       throw e;

--- a/src/commands/ext-dev-emulators-start.ts
+++ b/src/commands/ext-dev-emulators-start.ts
@@ -24,6 +24,7 @@ module.exports = new Command("ext:dev:emulators:start")
     } catch (e: any) {
       await controller.cleanShutdown();
       if (!(e instanceof FirebaseError)) {
+        console.log(e);
         throw new FirebaseError("Error in ext:dev:emulator:start", e);
       }
       throw e;

--- a/src/deploy/extensions/params.ts
+++ b/src/deploy/extensions/params.ts
@@ -22,6 +22,7 @@ export function readParams(args: {
   projectNumber: string;
   aliases: string[];
   instanceId: string;
+  checkLocal?: boolean;
 }): Record<string, string> {
   const filesToCheck = [
     `${args.instanceId}.env`,
@@ -29,6 +30,9 @@ export function readParams(args: {
     `${args.instanceId}.env.${args.projectNumber}`,
     `${args.instanceId}.env.${args.projectId}`,
   ];
+  if (args.checkLocal) {
+    filesToCheck.push(`${args.instanceId}.env.local`);
+  }
   let noFilesFound = true;
   const combinedParams = {};
   for (const fileToCheck of filesToCheck) {

--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -80,6 +80,7 @@ export async function want(args: {
   aliases: string[];
   projectDir: string;
   extensions: Record<string, string>;
+  checkLocal?: boolean;
 }): Promise<InstanceSpec[]> {
   const instanceSpecs: InstanceSpec[] = [];
   const errors: FirebaseError[] = [];
@@ -95,6 +96,7 @@ export async function want(args: {
         projectId: args.projectId,
         projectNumber: args.projectNumber,
         aliases: args.aliases,
+        checkLocal: args.checkLocal,
       });
       const autoPopulatedParams = await getFirebaseProjectParams(args.projectId);
       const subbedParams = substituteParams(params, autoPopulatedParams);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -447,15 +447,15 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
     }
 
     const account = getProjectDefaultAccount(options.projectRoot);
-    const extensionEmulator = new ExtensionsEmulator({options});
-    const extensionsBackends = await extensionEmulator.getEmulatableBackends();
+    const extensionEmulator = new ExtensionsEmulator({ options });
+    const extensionsBackends = await extensionEmulator.getExtensionBackends();
     const emulatableBackends: EmulatableBackend[] = [
       {
         functionsDir,
         env: {
           ...options.extensionEnv,
         },
-        // TODO: predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands. 
+        // TODO: predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
         // Ideally, we should handle that case via ExtensionEmulator.
         predefinedTriggers: options.extensionTriggers as ParsedTriggerDefinition[] | undefined,
         nodeMajorVersion: parseRuntimeVersion(

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -332,6 +332,7 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
     );
   }
   const hubLogger = EmulatorLogger.forEmulator(Emulators.HUB);
+  // TODO (b/217189992): Support '--only extensions` & add extensions to this logging.
   hubLogger.logLabeled("BULLET", "emulators", `Starting emulators: ${targets.join(", ")}`);
 
   const projectId: string = getProjectId(options) || ""; // TODO: Next breaking change, consider making this fall back to demo project.

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -455,7 +455,7 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
         env: {
           ...options.extensionEnv,
         },
-        // TODO: predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
+        // TODO(b/213335255): predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
         // Ideally, we should handle that case via ExtensionEmulator.
         predefinedTriggers: options.extensionTriggers as ParsedTriggerDefinition[] | undefined,
         nodeMajorVersion: parseRuntimeVersion(
@@ -464,7 +464,7 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
       },
       ...extensionsBackends,
     ];
-    // TODO: Figure out how to watch for changes to extensions .env files & reload triggers when they change.
+    // TODO(b/213241033): Figure out how to watch for changes to extensions .env files & reload triggers when they change.
     const functionsEmulator = new FunctionsEmulator({
       projectId,
       emulatableBackends,

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -43,10 +43,14 @@ export async function downloadEmulator(name: DownloadableEmulators): Promise<voi
   removeOldFiles(name, emulator);
 }
 
-export async function downloadExtensionVersion(extensionVersionRef: string, sourceDownloadUri: string, targetDir: string): Promise<void> {
+export async function downloadExtensionVersion(
+  extensionVersionRef: string,
+  sourceDownloadUri: string,
+  targetDir: string
+): Promise<void> {
   try {
     fs.mkdirSync(targetDir);
-  } catch(err) {
+  } catch (err) {
     console.log(`${extensionVersionRef} already downloaded...`);
   }
   EmulatorLogger.forExtension(extensionVersionRef).logLabeled(
@@ -64,7 +68,7 @@ export async function downloadExtensionVersion(extensionVersionRef: string, sour
   );
   // TODO: We should not need to do this wait
   // However, when I remove this, unzipDir doesn't contain everything yet.
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  await new Promise((resolve) => setTimeout(resolve, 1000));
 }
 
 function unzip(zipPath: string, unzipDir: string): Promise<void> {

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -51,7 +51,11 @@ export async function downloadExtensionVersion(
   try {
     fs.mkdirSync(targetDir);
   } catch (err) {
-    console.log(`${extensionVersionRef} already downloaded...`);
+    EmulatorLogger.forExtension(extensionVersionRef).logLabeled(
+      "BULLET",
+      "extensions",
+      `${extensionVersionRef} already downloaded...`
+    );
   }
   EmulatorLogger.forExtension(extensionVersionRef).logLabeled(
     "BULLET",

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -43,6 +43,30 @@ export async function downloadEmulator(name: DownloadableEmulators): Promise<voi
   removeOldFiles(name, emulator);
 }
 
+export async function downloadExtensionVersion(extensionVersionRef: string, sourceDownloadUri: string, targetDir: string): Promise<void> {
+  try {
+    fs.mkdirSync(targetDir);
+  } catch(err) {
+    console.log(`${extensionVersionRef} already downloaded...`);
+  }
+  EmulatorLogger.forExtension(extensionVersionRef).logLabeled(
+    "BULLET",
+    "extensions",
+    `downloading ${sourceDownloadUri}...`
+  );
+  const sourceCodeZip = await downloadUtils.downloadToTmp(sourceDownloadUri);
+  await unzip(sourceCodeZip, targetDir);
+
+  EmulatorLogger.forExtension(extensionVersionRef).logLabeled(
+    "BULLET",
+    "extensions",
+    `Downloaded to ${targetDir}...`
+  );
+  // TODO: We should not need to do this wait
+  // However, when I remove this, unzipDir doesn't contain everything yet.
+  await new Promise(resolve => setTimeout(resolve, 1000));
+}
+
 function unzip(zipPath: string, unzipDir: string): Promise<void> {
   return new Promise((resolve, reject) => {
     fs.createReadStream(zipPath)

--- a/src/emulator/emulatorLogger.ts
+++ b/src/emulator/emulatorLogger.ts
@@ -61,6 +61,20 @@ export class EmulatorLogger {
     });
   }
 
+  static forExtension(ref?: string, instanceId?: string) {
+    return new EmulatorLogger({
+      metadata: {
+        emulator: {
+          name: "extensions",
+        },
+        extension: {
+          ref,
+          instanceId,
+        },
+      },
+    });
+  }
+
   /**
    * Within this file, utils.logFoo() or logger.Foo() should not be called directly,
    * so that we can respect the "quiet" flag.

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -1,0 +1,107 @@
+import * as fs from "fs-extra";
+import * as os from "os";
+import * as path from "path";
+import { spawnSync } from "child_process";
+
+import * as planner from "../deploy/extensions/planner";
+import { Options } from "../options";
+import { getAliases, needProjectId, needProjectNumber } from "../projectUtils";
+import { FirebaseError } from "../error";
+import { toExtensionVersionRef } from "../extensions/refs";
+import { downloadExtensionVersion } from "./download";
+import { EmulatableBackend } from "./functionsEmulator";
+import { getExtensionFunctionInfo } from "../extensions/emulator/optionsHelper";
+
+const CACHE_DIR =
+  process.env.FIREBASE_EXTENSIONS_CACHE_PATH || path.join(os.homedir(), ".cache", "firebase", "extensions");
+
+export interface ExtensionEmulatorArgs {
+  options: Options,
+}
+// TODO: Consider a different name, since this does not implement the EmulatorInstance interface
+export class ExtensionsEmulator {
+
+  private want: planner.InstanceSpec[] = [];
+  private options: Options;
+
+  constructor(args: ExtensionEmulatorArgs) {
+    this.options = args.options;
+  }
+
+  // readManifest checks the `extensions` section of `firebase.json` for the extension instances to emulate,
+  // and the `{projectRoot}/extensions` directory for param values.
+  private async readManifest(): Promise<void> {
+    // TODO: Ideally, this should not error out if called with a fake projectId.
+    const projectId = needProjectId(this.options);
+    const projectNumber = await needProjectNumber(this.options);
+    const aliases = getAliases(this.options, projectId);
+
+    this.want = await planner.want({
+      projectId,
+      projectNumber,
+      aliases,
+      projectDir: this.options.config.projectDir,
+      extensions: this.options.config.get("extensions"),
+      checkLocal: true,
+    })
+  } 
+
+  // ensureSourceCode checks the cache for the source code for a given extension version,
+  // downloads and builds it if it is not found, then returns the path to that source code.
+  private async ensureSourceCode(instance: planner.InstanceSpec): Promise<string> {
+    // TODO: Handle local extensions.
+    if (!instance.ref) {
+      throw new FirebaseError(`No ref found for ${instance.instanceId}. Emulating local extensions is not yet supported.`)
+    }
+    const sourceCodePath = path.join(CACHE_DIR, toExtensionVersionRef(instance.ref));
+
+    // Check if something is at the cache location already. If so, assume its the extension source code!
+    // TODO: Add some better sanity checking that it is the extension source code & was successfully downloaded.
+    if (!fs.existsSync(sourceCodePath)) {
+      const extensionVersion = await planner.getExtensionVersion(instance);
+      await downloadExtensionVersion(toExtensionVersionRef(instance.ref), extensionVersion.sourceDownloadUri, sourceCodePath);
+      this.installAndBuildSourceCode(sourceCodePath);
+    }
+    return sourceCodePath;
+  }
+
+  private installAndBuildSourceCode(sourceCodePath: string): void {
+    const npmInstall = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "install"], 
+      {encoding: "utf8"});
+    if (npmInstall.error) {
+      throw npmInstall.error
+    }
+  
+    const npmRunBuild = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "run", "build"], 
+      {encoding: "utf8"});
+    if (npmRunBuild.error) {
+      // TODO: Make sure this does not error out if "build" is not defined, but does error if it fails otherwise.
+      throw npmRunBuild.error
+    }
+  
+    const npmRunGCPBuild = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "run", "gcp-build"], 
+      {encoding: "utf8"});
+    if (npmRunGCPBuild.error) {
+      // TODO: Make sure this does not error out if "gcp-build" is not defined, but does error if it fails otherwise.
+      throw npmRunGCPBuild.error
+    }
+  }
+
+  public async getEmulatableBackends() {
+    await this.readManifest();
+    return Promise.all(this.want.map(this.toEmulatableBackend))
+  }
+
+  private async toEmulatableBackend(instance: planner.InstanceSpec): Promise<EmulatableBackend> {
+    const functionsDir = await this.ensureSourceCode(instance);
+    const { extensionTriggers, nodeMajorVersion } = await getExtensionFunctionInfo(functionsDir, instance.params);
+    return {
+      functionsDir,
+      env: instance.params,
+      predefinedTriggers: extensionTriggers, 
+      nodeMajorVersion: nodeMajorVersion,
+      extensionInstanceId: instance.instanceId,
+    }
+  }
+
+}

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -4,50 +4,41 @@ import * as path from "path";
 import { spawnSync } from "child_process";
 
 import * as planner from "../deploy/extensions/planner";
-import { Options } from "../options";
-import { getAliases, needProjectId, needProjectNumber } from "../projectUtils";
 import { FirebaseError } from "../error";
 import { toExtensionVersionRef } from "../extensions/refs";
 import { downloadExtensionVersion } from "./download";
 import { EmulatableBackend } from "./functionsEmulator";
 import { getExtensionFunctionInfo } from "../extensions/emulator/optionsHelper";
-import { getProjectId } from "../projectUtils";
-
-const CACHE_DIR =
-  process.env.FIREBASE_EXTENSIONS_CACHE_PATH ||
-  path.join(os.homedir(), ".cache", "firebase", "extensions");
 
 export interface ExtensionEmulatorArgs {
-  options: Options;
+  projectId: string;
+  projectNumber: string;
+  aliases?: string[];
+  extensions: Record<string, string>;
+  projectDir: string;
 }
 // TODO: Consider a different name, since this does not implement the EmulatorInstance interface
-// Note: At the moment, this doesn't reallt seem like it needs to be a class. However, I think the
+// Note: At the moment, this doesn't really seem like it needs to be a class. However, I think the
 // statefulness that enables will be useful once we want to watch .env files for config changes.
 export class ExtensionsEmulator {
   private want: planner.InstanceSpec[] = [];
-  private options: Options;
+  private args: ExtensionEmulatorArgs;
 
   constructor(args: ExtensionEmulatorArgs) {
-    this.options = args.options;
+    this.args = args;
   }
 
   // readManifest checks the `extensions` section of `firebase.json` for the extension instances to emulate,
   // and the `{projectRoot}/extensions` directory for param values.
   private async readManifest(): Promise<void> {
-    if (this.options.config.has("extensions")) {
-      // TODO: Ideally, this should not error out if called with a fake projectId.
-      const projectId = needProjectId(this.options);
-      const projectNumber = await needProjectNumber(this.options);
-      const aliases = getAliases(this.options, projectId);
-      this.want = await planner.want({
-        projectId,
-        projectNumber,
-        aliases,
-        projectDir: this.options.config.projectDir,
-        extensions: this.options.config.get("extensions"),
-        checkLocal: true,
-      });
-    }
+    this.want = await planner.want({
+      projectId: this.args.projectId,
+      projectNumber: this.args.projectNumber,
+      aliases: this.args.aliases ?? [],
+      projectDir: this.args.projectDir,
+      extensions: this.args.extensions,
+      checkLocal: true,
+    });
   }
 
   // ensureSourceCode checks the cache for the source code for a given extension version,
@@ -60,7 +51,11 @@ export class ExtensionsEmulator {
       );
     }
     // TODO: If ref contains 'latest', we need to resolve that to a real version.
-    const sourceCodePath = path.join(CACHE_DIR, toExtensionVersionRef(instance.ref));
+
+    const cacheDir =
+      process.env.FIREBASE_EXTENSIONS_CACHE_PATH ||
+      path.join(os.homedir(), ".cache", "firebase", "extensions");
+    const sourceCodePath = path.join(cacheDir, toExtensionVersionRef(instance.ref));
 
     // Check if something is at the cache location already. If so, assume its the extension source code!
     // TODO(b/216376066): Add some better sanity checking that it is the extension source code & was successfully downloaded.
@@ -111,7 +106,11 @@ export class ExtensionsEmulator {
     );
   }
 
-  private async toEmulatableBackend(instance: planner.InstanceSpec): Promise<EmulatableBackend> {
+  /**
+   * toEmulatableBackend turns a InstanceSpec into an EmulatableBackend which can be run by the Functions emulator.
+   * It is exported for testing.
+   */
+  public async toEmulatableBackend(instance: planner.InstanceSpec): Promise<EmulatableBackend> {
     const extensionDir = await this.ensureSourceCode(instance);
     // TODO: This should find package.json, then use that as functionsDir.
     const functionsDir = path.join(extensionDir, "functions");
@@ -130,7 +129,7 @@ export class ExtensionsEmulator {
   }
 
   private autoPopulatedParams(instance: planner.InstanceSpec): Record<string, string> {
-    const projectId = getProjectId(this.options);
+    const projectId = this.args.projectId;
     return {
       PROJECT_ID: projectId ?? "", // TODO: Should this fallback to a default?
       EXT_INSTANCE_ID: instance.instanceId,

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -34,11 +34,11 @@ export class ExtensionsEmulator {
   // readManifest checks the `extensions` section of `firebase.json` for the extension instances to emulate,
   // and the `{projectRoot}/extensions` directory for param values.
   private async readManifest(): Promise<void> {
-    // TODO: Ideally, this should not error out if called with a fake projectId.
-    const projectId = needProjectId(this.options);
-    const projectNumber = await needProjectNumber(this.options);
-    const aliases = getAliases(this.options, projectId);
     if (this.options.config.has("extensions")) {
+      // TODO: Ideally, this should not error out if called with a fake projectId.
+      const projectId = needProjectId(this.options);
+      const projectNumber = await needProjectNumber(this.options);
+      const aliases = getAliases(this.options, projectId);
       this.want = await planner.want({
         projectId,
         projectNumber,

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -76,7 +76,7 @@ export class ExtensionsEmulator {
   }
 
   private installAndBuildSourceCode(sourceCodePath: string): void {
-    //TODO: Add logging during this so it is clear what is happening.
+    // TODO: Add logging during this so it is clear what is happening.
     const npmInstall = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "install"], {
       encoding: "utf8",
     });

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -13,14 +13,16 @@ import { EmulatableBackend } from "./functionsEmulator";
 import { getExtensionFunctionInfo } from "../extensions/emulator/optionsHelper";
 
 const CACHE_DIR =
-  process.env.FIREBASE_EXTENSIONS_CACHE_PATH || path.join(os.homedir(), ".cache", "firebase", "extensions");
+  process.env.FIREBASE_EXTENSIONS_CACHE_PATH ||
+  path.join(os.homedir(), ".cache", "firebase", "extensions");
 
 export interface ExtensionEmulatorArgs {
-  options: Options,
+  options: Options;
 }
 // TODO: Consider a different name, since this does not implement the EmulatorInstance interface
+// Note: At the moment, this doesn't reallt seem like it needs to be a class. However, I think the
+// statefulness that enables will be useful once we want to watch .env files for config changes.
 export class ExtensionsEmulator {
-
   private want: planner.InstanceSpec[] = [];
   private options: Options;
 
@@ -43,15 +45,17 @@ export class ExtensionsEmulator {
       projectDir: this.options.config.projectDir,
       extensions: this.options.config.get("extensions"),
       checkLocal: true,
-    })
-  } 
+    });
+  }
 
   // ensureSourceCode checks the cache for the source code for a given extension version,
   // downloads and builds it if it is not found, then returns the path to that source code.
   private async ensureSourceCode(instance: planner.InstanceSpec): Promise<string> {
     // TODO: Handle local extensions.
     if (!instance.ref) {
-      throw new FirebaseError(`No ref found for ${instance.instanceId}. Emulating local extensions is not yet supported.`)
+      throw new FirebaseError(
+        `No ref found for ${instance.instanceId}. Emulating local extensions is not yet supported.`
+      );
     }
     const sourceCodePath = path.join(CACHE_DIR, toExtensionVersionRef(instance.ref));
 
@@ -59,49 +63,72 @@ export class ExtensionsEmulator {
     // TODO: Add some better sanity checking that it is the extension source code & was successfully downloaded.
     if (!fs.existsSync(sourceCodePath)) {
       const extensionVersion = await planner.getExtensionVersion(instance);
-      await downloadExtensionVersion(toExtensionVersionRef(instance.ref), extensionVersion.sourceDownloadUri, sourceCodePath);
+      await downloadExtensionVersion(
+        toExtensionVersionRef(instance.ref),
+        extensionVersion.sourceDownloadUri,
+        sourceCodePath
+      );
       this.installAndBuildSourceCode(sourceCodePath);
     }
     return sourceCodePath;
   }
 
   private installAndBuildSourceCode(sourceCodePath: string): void {
-    const npmInstall = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "install"], 
-      {encoding: "utf8"});
+    const npmInstall = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "install"], {
+      encoding: "utf8",
+    });
     if (npmInstall.error) {
-      throw npmInstall.error
+      throw npmInstall.error;
     }
-  
-    const npmRunBuild = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "run", "build"], 
-      {encoding: "utf8"});
+
+    const npmRunBuild = spawnSync(
+      "npm",
+      ["--prefix", `/${sourceCodePath}/functions/`, "run", "build"],
+      { encoding: "utf8" }
+    );
     if (npmRunBuild.error) {
       // TODO: Make sure this does not error out if "build" is not defined, but does error if it fails otherwise.
-      throw npmRunBuild.error
+      throw npmRunBuild.error;
     }
-  
-    const npmRunGCPBuild = spawnSync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "run", "gcp-build"], 
-      {encoding: "utf8"});
+
+    const npmRunGCPBuild = spawnSync(
+      "npm",
+      ["--prefix", `/${sourceCodePath}/functions/`, "run", "gcp-build"],
+      { encoding: "utf8" }
+    );
     if (npmRunGCPBuild.error) {
       // TODO: Make sure this does not error out if "gcp-build" is not defined, but does error if it fails otherwise.
-      throw npmRunGCPBuild.error
+      throw npmRunGCPBuild.error;
     }
   }
 
-  public async getEmulatableBackends() {
+  /**
+   *  getEmulatableBackends reads firebase.json & .env files for a list of extension instances to emulate,
+   *  downloads & builds the necessary source code (if it hasn't previously been cached),
+   *  then builds returns a list of emulatableBackends
+   *  @returns A list of emulatableBackends, one for each extension instance to be emulated
+   */
+  public async getExtensionBackends(): Promise<EmulatableBackend[]> {
     await this.readManifest();
-    return Promise.all(this.want.map(this.toEmulatableBackend))
+    return Promise.all(
+      this.want.map((i: planner.InstanceSpec) => {
+        return this.toEmulatableBackend(i);
+      })
+    );
   }
 
   private async toEmulatableBackend(instance: planner.InstanceSpec): Promise<EmulatableBackend> {
     const functionsDir = await this.ensureSourceCode(instance);
-    const { extensionTriggers, nodeMajorVersion } = await getExtensionFunctionInfo(functionsDir, instance.params);
+    const { extensionTriggers, nodeMajorVersion } = await getExtensionFunctionInfo(
+      functionsDir,
+      instance.params
+    );
     return {
       functionsDir,
       env: instance.params,
-      predefinedTriggers: extensionTriggers, 
+      predefinedTriggers: extensionTriggers,
       nodeMajorVersion: nodeMajorVersion,
       extensionInstanceId: instance.instanceId,
-    }
+    };
   }
-
 }

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -38,15 +38,16 @@ export class ExtensionsEmulator {
     const projectId = needProjectId(this.options);
     const projectNumber = await needProjectNumber(this.options);
     const aliases = getAliases(this.options, projectId);
-
-    this.want = await planner.want({
-      projectId,
-      projectNumber,
-      aliases,
-      projectDir: this.options.config.projectDir,
-      extensions: this.options.config.get("extensions"),
-      checkLocal: true,
-    });
+    if (this.options.config.has("extensions")) {
+      this.want = await planner.want({
+        projectId,
+        projectNumber,
+        aliases,
+        projectDir: this.options.config.projectDir,
+        extensions: this.options.config.get("extensions"),
+        checkLocal: true,
+      });
+    }
   }
 
   // ensureSourceCode checks the cache for the source code for a given extension version,

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -52,17 +52,17 @@ export class ExtensionsEmulator {
   // ensureSourceCode checks the cache for the source code for a given extension version,
   // downloads and builds it if it is not found, then returns the path to that source code.
   private async ensureSourceCode(instance: planner.InstanceSpec): Promise<string> {
-    // TODO: Handle local extensions.
+    // TODO(b/213335255): Handle local extensions.
     if (!instance.ref) {
       throw new FirebaseError(
         `No ref found for ${instance.instanceId}. Emulating local extensions is not yet supported.`
       );
     }
-    // TODO: If ref contains 'latest', we need to reolve that to a real version.
+    // TODO: If ref contains 'latest', we need to resolve that to a real version.
     const sourceCodePath = path.join(CACHE_DIR, toExtensionVersionRef(instance.ref));
 
     // Check if something is at the cache location already. If so, assume its the extension source code!
-    // TODO: Add some better sanity checking that it is the extension source code & was successfully downloaded.
+    // TODO(b/216376066): Add some better sanity checking that it is the extension source code & was successfully downloaded.
     if (!fs.existsSync(sourceCodePath)) {
       const extensionVersion = await planner.getExtensionVersion(instance);
       await downloadExtensionVersion(

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -81,6 +81,7 @@ export interface EmulatableBackend {
   predefinedTriggers?: ParsedTriggerDefinition[];
   nodeMajorVersion?: number;
   nodeBinary?: string;
+  extensionInstanceId?: string;
 }
 
 export interface FunctionsEmulatorArgs {

--- a/src/emulator/functionsEmulatorUtils.ts
+++ b/src/emulator/functionsEmulatorUtils.ts
@@ -80,7 +80,7 @@ export function parseRuntimeVersion(runtime?: string): number | undefined {
   }
 
   const runtimeRe = /(nodejs)?([0-9]+)/;
-  const match = runtime.match(runtimeRe);
+  const match = runtimeRe.exec(runtime);
   if (match) {
     return Number.parseInt(match[2]);
   }

--- a/src/emulator/loggingEmulator.ts
+++ b/src/emulator/loggingEmulator.ts
@@ -24,6 +24,10 @@ export interface LogData {
     function?: {
       name: string;
     };
+    extension?: {
+      ref?: string;
+      instanceId?: string;
+    };
   };
 }
 

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -43,6 +43,25 @@ export async function buildOptions(options: any): Promise<any> {
   return options;
 }
 
+export async function getExtensionFunctionInfo(extensionDir: string, params: Record<string, string>): Promise<{
+  nodeMajorVersion: number,
+  extensionTriggers: ParsedTriggerDefinition[]}
+> {
+  const spec = await specHelper.readExtensionYaml(extensionDir);
+  const functionResources = specHelper.getFunctionResourcesWithParamSubstitution(
+    spec,
+    params
+  ) as Resource[];
+  const extensionTriggers: ParsedTriggerDefinition[] = functionResources.map((r) =>
+  triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
+);
+  const nodeMajorVersion = specHelper.getNodeVersion(functionResources);
+  return {
+    extensionTriggers,
+    nodeMajorVersion,
+  }
+}
+
 // Exported for testing
 export function getParams(options: any, extensionSpec: ExtensionSpec) {
   const projectId = needProjectId(options);

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -46,7 +46,8 @@ export async function buildOptions(options: any): Promise<any> {
 // TODO: Better name? Also, should this be in extensionsEmulator instead?
 export async function getExtensionFunctionInfo(
   extensionDir: string,
-  params: Record<string, string>
+  params: Record<string, string>,
+  
 ): Promise<{
   nodeMajorVersion: number;
   extensionTriggers: ParsedTriggerDefinition[];

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -52,10 +52,7 @@ export async function getExtensionFunctionInfo(
   extensionTriggers: ParsedTriggerDefinition[];
 }> {
   const spec = await specHelper.readExtensionYaml(extensionDir);
-  const functionResources = specHelper.getFunctionResourcesWithParamSubstitution(
-    spec,
-    params
-  ) as Resource[];
+  const functionResources = specHelper.getFunctionResourcesWithParamSubstitution(spec, params);
   const extensionTriggers: ParsedTriggerDefinition[] = functionResources.map((r) =>
     triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
   );

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -43,23 +43,27 @@ export async function buildOptions(options: any): Promise<any> {
   return options;
 }
 
-export async function getExtensionFunctionInfo(extensionDir: string, params: Record<string, string>): Promise<{
-  nodeMajorVersion: number,
-  extensionTriggers: ParsedTriggerDefinition[]}
-> {
+// TODO: Better name? Also, should this be in extensionsEmulator instead?
+export async function getExtensionFunctionInfo(
+  extensionDir: string,
+  params: Record<string, string>
+): Promise<{
+  nodeMajorVersion: number;
+  extensionTriggers: ParsedTriggerDefinition[];
+}> {
   const spec = await specHelper.readExtensionYaml(extensionDir);
   const functionResources = specHelper.getFunctionResourcesWithParamSubstitution(
     spec,
     params
   ) as Resource[];
   const extensionTriggers: ParsedTriggerDefinition[] = functionResources.map((r) =>
-  triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
-);
+    triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
+  );
   const nodeMajorVersion = specHelper.getNodeVersion(functionResources);
   return {
     extensionTriggers,
     nodeMajorVersion,
-  }
+  };
 }
 
 // Exported for testing

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -46,8 +46,7 @@ export async function buildOptions(options: any): Promise<any> {
 // TODO: Better name? Also, should this be in extensionsEmulator instead?
 export async function getExtensionFunctionInfo(
   extensionDir: string,
-  params: Record<string, string>,
-  
+  params: Record<string, string>
 ): Promise<{
   nodeMajorVersion: number;
   extensionTriggers: ParsedTriggerDefinition[];

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -6,8 +6,6 @@ import * as fs from "fs-extra";
 import { ExtensionSpec, Resource } from "../extensionsApi";
 import { FirebaseError } from "../../error";
 import { substituteParams } from "../extensionsHelper";
-import { EmulatorLogger } from "../../emulator/emulatorLogger";
-import { Emulators } from "../../emulator/types";
 
 const SPEC_FILE = "extension.yaml";
 const validFunctionTypes = [
@@ -84,38 +82,19 @@ export function getFunctionProperties(resources: Resource[]) {
   return resources.map((r) => r.properties);
 }
 
-/**
- * Choses a node version to use based on the 'nodeVersion' field in resources.
- * Currently, the emulator will use 1 node version for all functions, even though
- * an extension can specify different node versions for each function when deployed.
- * For now, we choose the newest version that a user lists in their function resources,
- * and fall back to node 8 if none is listed.
- */
-export function getNodeVersion(resources: Resource[]): string {
-  const functionNamesWithoutRuntime: string[] = [];
+export function getNodeVersion(resources: Resource[]): number {
+  const invalidRuntimes: string[] = [];
   const versions = resources.map((r: Resource) => {
-    if (_.includes(r.type, "function")) {
-      if (r.properties?.runtime) {
-        return r.properties?.runtime;
+    if (r.properties?.runtime) {
+      const runtimeName = r.properties?.runtime as string
+      if (!runtimeName.match(/nodejs\d+/)) {
+        invalidRuntimes.push(runtimeName);
       } else {
-        functionNamesWithoutRuntime.push(r.name);
+        return runtimeName.slice(6) as unknown as number; // TODO: Cast to int, cant remember how to right now.
       }
     }
-    return "nodejs8";
-  });
-
-  if (functionNamesWithoutRuntime.length) {
-    EmulatorLogger.forEmulator(Emulators.FUNCTIONS).logLabeled(
-      "WARN",
-      "extensions",
-      `No 'runtime' property found for the following functions, defaulting to nodejs8: ${functionNamesWithoutRuntime.join(
-        ", "
-      )}`
-    );
-  }
-  const invalidRuntimes = _.filter(versions, (v) => {
-    return !_.includes(v, "nodejs");
-  });
+    return 14;
+  })
 
   if (invalidRuntimes.length) {
     throw new FirebaseError(
@@ -124,16 +103,5 @@ export function getNodeVersion(resources: Resource[]): string {
       )}. \n Only Node runtimes are supported.`
     );
   }
-  if (_.includes(versions, "nodejs10")) {
-    return "10";
-  }
-  if (_.includes(versions, "nodejs6")) {
-    EmulatorLogger.forEmulator(Emulators.FUNCTIONS).logLabeled(
-      "WARN",
-      "extensions",
-      "Node 6 is deprecated. We recommend upgrading to a newer version."
-    );
-    return "6";
-  }
-  return "8";
+  return Math.max(...versions)
 }

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -6,6 +6,7 @@ import * as fs from "fs-extra";
 import { ExtensionSpec, Resource } from "../extensionsApi";
 import { FirebaseError } from "../../error";
 import { substituteParams } from "../extensionsHelper";
+import { parseRuntimeVersion } from "../../emulator/functionsEmulatorUtils";
 
 const SPEC_FILE = "extension.yaml";
 const validFunctionTypes = [
@@ -86,15 +87,16 @@ export function getNodeVersion(resources: Resource[]): number {
   const invalidRuntimes: string[] = [];
   const versions = resources.map((r: Resource) => {
     if (r.properties?.runtime) {
-      const runtimeName = r.properties?.runtime as string
-      if (!runtimeName.match(/nodejs\d+/)) {
+      const runtimeName = r.properties?.runtime as string;
+      const runtime = parseRuntimeVersion(runtimeName);
+      if (!runtime) {
         invalidRuntimes.push(runtimeName);
       } else {
-        return runtimeName.slice(6) as unknown as number; // TODO: Cast to int, cant remember how to right now.
+        return runtime;
       }
     }
     return 14;
-  })
+  });
 
   if (invalidRuntimes.length) {
     throw new FirebaseError(
@@ -103,5 +105,5 @@ export function getNodeVersion(resources: Resource[]): number {
       )}. \n Only Node runtimes are supported.`
     );
   }
-  return Math.max(...versions)
+  return Math.max(...versions);
 }

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -72,7 +72,7 @@ export function readFileFromDirectory(
 export function getFunctionResourcesWithParamSubstitution(
   extensionSpec: ExtensionSpec,
   params: { [key: string]: string }
-): object[] {
+): Resource[] {
   const rawResources = extensionSpec.resources.filter((resource) =>
     validFunctionTypes.includes(resource.type)
   );

--- a/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/extension.yaml
+++ b/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/extension.yaml
@@ -1,0 +1,226 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: storage-resize-images
+version: 0.1.18
+specVersion: v1beta
+
+displayName: Resize Images
+description: Resizes images uploaded to Cloud Storage to a specified size, and optionally keeps or deletes the original image.
+
+license: Apache-2.0
+
+sourceUrl: https://github.com/firebase/extensions/tree/master/storage-resize-images
+releaseNotesUrl: https://github.com/firebase/extensions/blob/master/storage-resize-images/CHANGELOG.md
+
+author:
+  authorName: Firebase
+  url: https://firebase.google.com
+
+contributors:
+  - authorName: Tina Liang
+    url: https://github.com/tinaliang
+  - authorName: Chris Bianca
+    email: chris@csfrequency.com
+    url: https://github.com/chrisbianca
+  - authorName: Invertase
+    email: oss@invertase.io
+    url: https://github.com/invertase
+
+billingRequired: true
+
+apis:
+  - apiName: storage-component.googleapis.com
+    reason: Needed to use Cloud Storage
+
+roles:
+  - role: storage.admin
+    reason: Allows the extension to store resized images in Cloud Storage
+
+resources:
+  - name: generateResizedImage
+    type: firebaseextensions.v1beta.function
+    description: >-
+      Listens for new images uploaded to your specified Cloud Storage bucket, resizes the images,
+      then stores the resized images in the same bucket. Optionally keeps or deletes the original images.
+    properties:
+      location: ${param:LOCATION}
+      runtime: nodejs10
+      eventTrigger:
+        eventType: google.storage.object.finalize
+        resource: projects/_/buckets/${param:IMG_BUCKET}
+
+params:
+  - param: LOCATION
+    label: Cloud Functions location
+    description: >-
+      Where do you want to deploy the functions created for this extension?
+      You usually want a location close to your Storage bucket. For help selecting a
+      location, refer to the [location selection
+      guide](https://firebase.google.com/docs/functions/locations).
+    type: select
+    options:
+      - label: Iowa (us-central1)
+        value: us-central1
+      - label: South Carolina (us-east1)
+        value: us-east1
+      - label: Northern Virginia (us-east4)
+        value: us-east4
+      - label: Los Angeles (us-west2)
+        value: us-west2
+      - label: Salt Lake City (us-west3)
+        value: us-west3
+      - label: Las Vegas (us-west4)
+        value: us-west4
+      - label: Belgium (europe-west1)
+        value: europe-west1
+      - label: London (europe-west2)
+        value: europe-west2
+      - label: Frankfurt (europe-west3)
+        value: europe-west3
+      - label: Zurich (europe-west6)
+        value: europe-west6
+      - label: Hong Kong (asia-east2)
+        value: asia-east2
+      - label: Tokyo (asia-northeast1)
+        value: asia-northeast1
+      - label: Osaka (asia-northeast2)
+        value: asia-northeast2
+      - label: Seoul (asia-northeast3)
+        value: asia-northeast3
+      - label: Mumbai (asia-south1)
+        value: asia-south1
+      - label: Jakarta (asia-southeast2)
+        value: asia-southeast2
+      - label: Montreal (northamerica-northeast1)
+        value: northamerica-northeast1
+      - label: Sao Paulo (southamerica-east1)
+        value: southamerica-east1
+      - label: Sydney (australia-southeast1)
+        value: australia-southeast1
+    default: us-central1
+    required: true
+    immutable: true
+
+  - param: IMG_BUCKET
+    label: Cloud Storage bucket for images
+    description: >
+      To which Cloud Storage bucket will you upload images that you want to resize?
+      Resized images will be stored in this bucket. Depending on your extension configuration,
+      original images are either kept or deleted.
+    type: string
+    example: my-project-12345.appspot.com
+    validationRegex: ^([0-9a-z_.-]*)$
+    validationErrorMessage: Invalid storage bucket
+    default: ${STORAGE_BUCKET}
+    required: true
+
+  - param: IMG_SIZES
+    label: Sizes of resized images
+    description: >
+      What sizes of images would you like (in pixels)? Enter the sizes as a
+      comma-separated list of WIDTHxHEIGHT values. Learn more about
+      [how this parameter works](https://firebase.google.com/products/extensions/storage-resize-images).
+    type: string
+    example: "200x200"
+    validationRegex: ^\d+x(\d+,\d+x)*\d+$
+    validationErrorMessage: Invalid sizes, must be a comma-separated list of WIDTHxHEIGHT values.
+    default: "200x200"
+    required: true
+
+  - param: DELETE_ORIGINAL_FILE
+    label: Deletion of original file
+    description: >-
+      Do you want to automatically delete the original file from the Cloud Storage
+      bucket? Note that these deletions cannot be undone.
+    type: select
+    options:
+      - label: Yes
+        value: true
+      - label: No
+        value: false
+      - label: Delete on successful resize
+        value: on_success
+    default: false
+    required: true
+
+  - param: RESIZED_IMAGES_PATH
+    label: Cloud Storage path for resized images
+    description: >
+      A relative path in which to store resized images. For example,
+      if you specify a path here of `thumbs` and you upload an image to
+      `/images/original.jpg`, then the resized image is stored at
+      `/images/thumbs/original_200x200.jpg`. If you prefer to store resized
+      images at the root of your bucket, leave this field empty.
+    example: thumbnails
+    required: false
+
+  - param: INCLUDE_PATH_LIST
+    label: Paths that contain images you want to resize
+    description: >
+      Restrict storage-resize-images to only resize images in specific locations in your Storage bucket by 
+      supplying a comma-separated list of absolute paths. For example, to only resize the images 
+      stored in `/users/pictures` directory, specify the path `/users/pictures`. 
+      If you prefer to resize every image uploaded to the storage bucket, 
+      leave this field empty.
+    type: string
+    example: "/users/avatars,/design/pictures"
+    validationRegex: ^(\/[^\s\/\,]+)+(\,(\/[^\s\/\,]+)+)*$
+    validationErrorMessage: Invalid paths, must be a comma-separated list of absolute path values.
+    required: false
+
+  - param: EXCLUDE_PATH_LIST
+    label: List of absolute paths not included for resized images
+    description: >
+      A comma-separated list of absolute paths to not take into account for 
+      images to be resized. For example, to not resize the images 
+      stored in `/users/pictures/avatars` directory, specify the path 
+      `/users/pictures/avatars`. If you prefer to resize every image uploaded 
+      to the storage bucket, leave this field empty.
+    type: string
+    example: "/users/avatars/thumbs,/design/pictures/thumbs"
+    validationRegex: ^(\/[^\s\/\,]+)+(\,(\/[^\s\/\,]+)+)*$
+    validationErrorMessage: Invalid paths, must be a comma-separated list of absolute path values.
+    required: false
+
+  - param: CACHE_CONTROL_HEADER
+    label: Cache-Control header for resized images
+    description: >
+      This extension automatically copies any `Cache-Control` metadata from the original image
+      to the resized images. For the resized images, do you want to overwrite this copied
+      `Cache-Control` metadata or add `Cache-Control` metadata? Learn more about
+      [`Cache-Control` headers](https://developer.mozilla.org/docs/Web/HTTP/Headers/Cache-Control).
+      If you prefer not to overwrite or add `Cache-Control` metadata, leave this field empty.
+    example: max-age=86400
+    required: false
+
+  - param: IMAGE_TYPE
+    label: Convert image to preferred type
+    description: >
+      The image type you'd like your source image to convert to. The default for this option will 
+      be to keep the original file type.
+    type: select
+    options:
+      - label: jpg
+        value: jpg
+      - label: png
+        value: png
+      - label: webp
+        value: webp
+      - label: tiff
+        value: tiff
+      - label: Do not convert
+        value: false
+    default: false
+    required: false

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -1,9 +1,81 @@
 import { expect } from "chai";
 
 import { ExtensionsEmulator } from "../../emulator/extensionsEmulator";
+import { EmulatableBackend } from "../../emulator/functionsEmulator";
+import * as planner from "../../deploy/extensions/planner";
 
 describe("Extensions Emulator", () => {
-  describe("getEmulatableBackends", () => {
-    // TODO: Write some tests for this (or maybe just write functional tests?)
+  describe("toEmulatableBackends", () => {
+    let previousCachePath: string | undefined;
+    beforeEach(() => {
+      previousCachePath = process.env.FIREBASE_EXTENSIONS_CACHE_PATH;
+      process.env.FIREBASE_EXTENSIONS_CACHE_PATH = "./extensions";
+    });
+    afterEach(() => {
+      process.env.FIREBASE_EXTENSIONS_CACHE_PATH = previousCachePath;
+    });
+    const testCases: {
+      desc: string;
+      input: planner.InstanceSpec;
+      expected: EmulatableBackend;
+    }[] = [
+      {
+        desc: "should transform a instance spec to a backend",
+        input: {
+          instanceId: "ext-test",
+          ref: {
+            publisherId: "firebase",
+            extensionId: "storage-resize-images",
+            version: "0.1.18",
+          },
+          params: {
+            LOCATION: "us-west1",
+          },
+        },
+        expected: {
+          env: {
+            LOCATION: "us-west1",
+            DATABASE_INSTANCE: "test-project",
+            DATABASE_URL: "https://test-project.firebaseio.com",
+            EXT_INSTANCE_ID: "ext-test",
+            PROJECT_ID: "test-project",
+            STORAGE_BUCKET: "test-project.appspot.com",
+          },
+          extensionInstanceId: "ext-test",
+          functionsDir:
+            "src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions",
+          nodeMajorVersion: 10,
+          predefinedTriggers: [
+            {
+              entryPoint: "generateResizedImage",
+              eventTrigger: {
+                eventType: "google.storage.object.finalize",
+                resource: "projects/_/buckets/${param:IMG_BUCKET}",
+                service: "storage.googleapis.com",
+              },
+              name: "generateResizedImage",
+              platform: "gcfv1",
+              regions: ["us-west1"],
+            },
+          ],
+        },
+      },
+    ];
+    for (const testCase of testCases) {
+      it(testCase.desc, async () => {
+        process.env.FIREBASE_EXTENSIONS_CACHE_PATH = "./src/test/emulators/extensions";
+        const e = new ExtensionsEmulator({
+          projectId: "test-project",
+          projectNumber: "1234567",
+          projectDir: ".",
+          extensions: {},
+          aliases: [],
+        });
+
+        const result = await e.toEmulatableBackend(testCase.input);
+
+        expect(result).to.deep.equal(testCase.expected);
+      });
+    }
   });
 });

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -1,0 +1,9 @@
+import { expect } from "chai";
+
+import { ExtensionsEmulator } from "../../emulator/extensionsEmulator";
+
+describe("Extensions Emulator", () => {
+  describe("getEmulatableBackends", () => {
+    // TODO: Write some tests for this (or maybe just write functional tests?)
+  })
+})

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -9,7 +9,7 @@ describe("Extensions Emulator", () => {
     let previousCachePath: string | undefined;
     beforeEach(() => {
       previousCachePath = process.env.FIREBASE_EXTENSIONS_CACHE_PATH;
-      process.env.FIREBASE_EXTENSIONS_CACHE_PATH = "./extensions";
+      process.env.FIREBASE_EXTENSIONS_CACHE_PATH = "./src/test/emulators/extensions";
     });
     afterEach(() => {
       process.env.FIREBASE_EXTENSIONS_CACHE_PATH = previousCachePath;
@@ -63,7 +63,6 @@ describe("Extensions Emulator", () => {
     ];
     for (const testCase of testCases) {
       it(testCase.desc, async () => {
-        process.env.FIREBASE_EXTENSIONS_CACHE_PATH = "./src/test/emulators/extensions";
         const e = new ExtensionsEmulator({
           projectId: "test-project",
           projectNumber: "1234567",

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -5,5 +5,5 @@ import { ExtensionsEmulator } from "../../emulator/extensionsEmulator";
 describe("Extensions Emulator", () => {
   describe("getEmulatableBackends", () => {
     // TODO: Write some tests for this (or maybe just write functional tests?)
-  })
-})
+  });
+});


### PR DESCRIPTION
### Description
Adds support to download, build, and emulate Extensions declared in firebase.json

### Scenarios Tested
I tested out firebase/storage-resize-images, firebase/firestore-translate-text, and a few test extensions published under joehanley, and verified that their functions run & triggered as expected.

### Sample Commands
Add an extensions section to firebase.json
```
  "extensions": {
    "translate": "firebase/firestore-translate-text",
  }
```
Add a config file to the ./extensions/ directory:
```
## extensions/translate.env
LOCATION=us-west1
LANGUAGES=en,es,de,fr
COLLECTION_PATH=translations
INPUT_FIELD_NAME=input
OUTPUT_FIELD_NAME=translated
```
Then, run an emulator command:
```
firebase emualtors:start -P my-project
```