### PR TITLE
Remove @types/winston dependency

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -116,7 +116,6 @@
         "@types/triple-beam": "^1.3.0",
         "@types/unzipper": "^0.10.0",
         "@types/uuid": "^8.3.1",
-        "@types/winston": "^2.4.4",
         "@types/ws": "^7.2.3",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
         "@typescript-eslint/parser": "^5.9.0",
@@ -2358,16 +2357,6 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true
-    },
-    "node_modules/@types/winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
-      "deprecated": "This is a stub types definition. winston provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "winston": "*"
-      }
     },
     "node_modules/@types/ws": {
       "version": "7.2.3",
@@ -15435,15 +15424,6 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
       "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true
-    },
-    "@types/winston": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
-      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
-      "dev": true,
-      "requires": {
-        "winston": "*"
-      }
     },
     "@types/ws": {
       "version": "7.2.3",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,6 @@
     "@types/triple-beam": "^1.3.0",
     "@types/unzipper": "^0.10.0",
     "@types/uuid": "^8.3.1",
-    "@types/winston": "^2.4.4",
     "@types/ws": "^7.2.3",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

[`winston`](https://www.npmjs.com/package/winston) provides its own type definitions and [`@types/winston`](https://www.npmjs.com/package/@types/winston) is only a stub. The dependency is therefore not needed anymore.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/27002 and https://github.com/winstonjs/winston/pull/1374

This removes  the deprecation warning from the logs when installing `firebase-tools`:
```
npm WARN deprecated @types/winston@2.4.4: This is a stub types definition. winston provides its own type definitions, so you do not need this installed.
```

### Scenarios Tested

* `npm test`
* `npm run build`

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

