### PR TITLE
Fix bug in ext:install - only firebase extensions can be installed

### DIFF
--- a/src/extensions/utils.ts
+++ b/src/extensions/utils.ts
@@ -33,12 +33,14 @@ export function convertExtensionOptionToLabeledList(options: ParamOption[]): Lis
 export function convertOfficialExtensionsToList(officialExts: {
   [key: string]: RegistryEntry;
 }): ListItem[] {
-  return _.map(officialExts, (entry: RegistryEntry, key: string) => {
+  const l = _.map(officialExts, (entry: RegistryEntry, key: string) => {
     return {
       checked: false,
       value: `${entry.publisher}/${key}`,
     };
   });
+  l.sort((a, b) => a.value.localeCompare(b.value));
+  return l;
 }
 
 /**

--- a/src/extensions/utils.ts
+++ b/src/extensions/utils.ts
@@ -36,7 +36,7 @@ export function convertOfficialExtensionsToList(officialExts: {
   return _.map(officialExts, (entry: RegistryEntry, key: string) => {
     return {
       checked: false,
-      value: key,
+      value: `${entry.publisher}/${key}`,
     };
   });
 }


### PR DESCRIPTION
### Description

Currently `firebase ext:install -i` only lists extensionName in the interactive flow, so any non-firebase published extensions will then be treated as firebase extensions, which then breaks the install flow.

Before:
![Screen Shot 2022-02-01 at 12 11 37 PM](https://user-images.githubusercontent.com/6955348/152016586-c9c9b5cb-4776-4fed-964d-f8c762284f03.png)
![Screen Shot 2022-02-01 at 11 51 08 AM](https://user-images.githubusercontent.com/6955348/152013300-7387d68c-abe3-48d6-9b1f-083221724533.png)

After:
![Screen Shot 2022-02-01 at 12 02 25 PM](https://user-images.githubusercontent.com/6955348/152015202-786a7e04-a551-4cbd-bfcd-bdc3007bcdcf.png)
![Screen Shot 2022-02-01 at 12 02 36 PM](https://user-images.githubusercontent.com/6955348/152015205-8348972f-c0c2-47f2-aedf-9b9236e38096.png)

`infoInstallByReference` handles both ref and extensionName, so this doesn't impact the installation code path after line 306
