### PR TITLE
Pass environment variable of .env files during deployment

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -104,6 +104,7 @@ export async function prepare(
   };
   const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
   const usedDotenv = hasDotenv(userEnvOpt);
+  const environmentVariables = { ...userEnvs, ...firebaseEnvs };
   const tag = hasUserConfig(runtimeConfig)
     ? usedDotenv
       ? "mixed"
@@ -114,8 +115,8 @@ export async function prepare(
   await track("functions_codebase_deploy_env_method", tag);
 
   logger.debug(`Analyzing ${runtimeDelegate.name} backend spec`);
-  const wantBackend = await runtimeDelegate.discoverSpec(runtimeConfig, firebaseEnvs);
-  wantBackend.environmentVariables = { ...userEnvs, ...firebaseEnvs };
+  const wantBackend = await runtimeDelegate.discoverSpec(runtimeConfig, environmentVariables);
+  wantBackend.environmentVariables = environmentVariables;
   payload.functions = { backend: wantBackend };
 
   // Note: Some of these are premium APIs that require billing to be enabled.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Make it possible to configure the function region or other function configuration using an environment variable defined in a `.env` file.

During the deployment, the Firebase CLI loads the source code to get all the configurations needed to deploy the function.
To make sure that all configuration is present, the CLI previously added some environment variables that contain the function config accessible via `functions.config()`.

So it was possible to do something like this:

```
exports.helloWorld = functions.region(functions.config().function.region).https.onRequest((request, response) => {
  functions.logger.info("Hello logs!", {structuredData: true});
  response.send("Hello from Firebase!");
});
```

With the new environment variable based approach this does not work anymore:

This function fails during deployment, as the `REGION` environment variable is not present.
```
if (!process.env.REGION) throw new Error('REGION not set');

exports.helloWorld = functions.region(process.env.REGION).https.onRequest((request, response) => {
  functions.logger.info("Hello logs!", {structuredData: true});
  response.send("Hello from Firebase!");
});
```

---
This PR passes the environment variable defined in the `.env` file on the parser that detects which functions are present and how they should be deployed.

This issue also occurs if an environment variable somewhere else is accessed when loading the index.js file.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Deployment of this function works with the `dotenv` preview enabled:
```
if (!process.env.REGION) throw new Error('REGION not set');
exports.helloWorld = functions.region(process.env.REGION).https.onRequest((request, response) => {
  functions.logger.info("Hello logs!", {structuredData: true});
  response.send("Hello from Firebase!");
});
```
And the following `.env` file:
```
REGION=europe-west1
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
`firebase deploy --only functions`
