### PR TITLE
Helping prevention of accidental directory exclusion when using the --export-on-exit option

### DIFF
--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -45,6 +45,8 @@ export const EXPORT_ON_EXIT_USAGE_ERROR =
   `"${FLAG_EXPORT_ON_EXIT_NAME}" must be used with "${FLAG_IMPORT}"` +
   ` or provide a dir directly to "${FLAG_EXPORT_ON_EXIT}"`;
 
+export const EXPORT_ON_EXIT_CWD_DANGER = `"${FLAG_EXPORT_ON_EXIT_NAME}" must point to a folder outside the CWD path`;
+
 export const FLAG_UI = "--ui";
 export const DESC_UI = "run the Emulator UI";
 
@@ -202,6 +204,10 @@ export function setExportOnExitOptions(options: any) {
       // options.exportOnExit might be an empty string when used as:
       // firebase emulators:start --debug --import '' --export-on-exit ''
       throw new FirebaseError(EXPORT_ON_EXIT_USAGE_ERROR);
+    }
+
+    if (path.resolve(".").includes(path.resolve(options.exportOnExit))) {
+      throw new FirebaseError(EXPORT_ON_EXIT_CWD_DANGER);
     }
   }
   return;

--- a/src/test/emulators/commandUtils.spec.ts
+++ b/src/test/emulators/commandUtils.spec.ts
@@ -34,6 +34,16 @@ describe("commandUtils", () => {
     });
   });
 
+  it("Should disallow the user to set the current folder via the --import flag", () => {
+    expect(() => testSetExportOnExitOptions({ import: ".", exportOnExit: true })).to.throw(
+      EXPORT_ON_EXIT_CWD_DANGER
+    );
+    const cwdSubDir = join(".", "some-dir");
+    expect(
+      testSetExportOnExitOptions({ import: cwdSubDir, exportOnExit: true }).exportOnExit
+    ).to.equal(cwdSubDir);
+  });
+
   it("should validate --export-on-exit options", () => {
     expect(testSetExportOnExitOptions({ import: "./data" }).exportOnExit).to.be.undefined;
     expect(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
Adding condition to prevent the user from setting the **--export-on-exit** option to the CWD, inflicting in directory exclusion after stopping the emulators

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested
The firebase emulators:start command should fail now if the **--export-on-exit** is set to the **CWD** or **parent directories**

Commands tested:

- Current dir (SHOULD FAIL): `firebase emulators:start --export-on-exit ./`
- Current dir parent (SHOULD FAIL): `firebase emulators:start --export-on-exit ../`
- Implicit --export-on-exit via setting the --import flag  (SHOULD FAIL): `firebase emulators:start --export-on-exit ./dump-db`

- A sub directory (SHOULD PASS): `firebase emulators:start --export-on-exit ./dump-db`
- Implicit --export-on-exit sub directory (SHOULD PASS): `firebase emulators:start --import ./dump-db --export-on-exit`

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

Should not allow:
```cmd
firebase emulators:start --export-on-exit ./
```

One that should allow:
```cmd
firebase emulators:start --export-on-exit ./dump-db
```

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
