### PR TITLE
better json-parsing-error logging

### DIFF
--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -410,6 +410,8 @@ export class Client {
               try {
                 body = JSON.parse(text) as ResT;
               } catch (err: unknown) {
+                // JSON-parse errors are useless. Log the response for better debugging.
+                this.logResponse(res, text, options);
                 throw new FirebaseError(`Unable to parse JSON: ${err}`);
               }
             }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When debugging issues that don't return valid JSON, it's very irritating when the only error is "Unable to parse JSON".

This gives us a little better insight into those scenarios:

```
[2022-02-07T19:09:22.323Z] >>> [apiv2][query] GET https://firebase.googleapis.com/v1beta1/projectzs/site [none]
[2022-02-07T19:09:22.425Z] <<< [apiv2][status] GET https://firebase.googleapis.com/v1beta1/projectzs/site 404
[2022-02-07T19:09:22.425Z] <<< [apiv2][body] GET https://firebase.googleapis.com/v1beta1/projectzs/site "<h1>Not Found</h1>\n<h2>Error 404</h2>\n"
[2022-02-07T19:09:22.426Z] Unable to parse JSON: SyntaxError: Unexpected token < in JSON at position 0
[2022-02-07T19:09:22.427Z] FirebaseError: Unable to parse JSON: SyntaxError: Unexpected token < in JSON at position 0
    at RetryOperation._fn (/Users/bkend/Repositories/firebase-tools/lib/apiv2.js:258:39)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```
