### PR TITLE
Fix uploadObject function to use the correct url.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Improves experience for `firebase login --no-localhost`.
+- Fixes bug where local extension installation failed to upload source to GCS bucket.

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -182,9 +182,8 @@ export async function uploadObject(
   if (path.extname(source.file) !== ".zip") {
     throw new FirebaseError(`Expected a file name ending in .zip, got ${source.file}`);
   }
-  const storageAPIClient = new Client({ urlPrefix: storageOrigin, apiVersion: "v1" });
-  const location = `/${bucketName}/${path.basename(source.file)}`;
   const localAPIClient = new Client({ urlPrefix: storageOrigin });
+  const location = `/${bucketName}/${path.basename(source.file)}`;
   const res = await localAPIClient.request({
     method: "PUT",
     path: location,

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -184,7 +184,8 @@ export async function uploadObject(
   }
   const storageAPIClient = new Client({ urlPrefix: storageOrigin, apiVersion: "v1" });
   const location = `/${bucketName}/${path.basename(source.file)}`;
-  const res = await storageAPIClient.request({
+  const localAPIClient = new Client({ urlPrefix: storageOrigin });
+  const res = await localAPIClient.request({
     method: "PUT",
     path: location,
     headers: {


### PR DESCRIPTION
This fixes failing installation of local firebase extensions.

Bug sneaked in at https://github.com/firebase/firebase-tools/pull/4031.