### PR TITLE
Adding support for --only emulators

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -174,6 +174,11 @@
                     },
                     "type": "object"
                 },
+                "extensions": {
+                    "properties": {
+                    },
+                    "type": "object"
+                },
                 "firestore": {
                     "additionalProperties": false,
                     "properties": {

--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -75,7 +75,7 @@ module.exports = new Command("emulators:start")
           const isSupportedByUi = EMULATORS_SUPPORTED_BY_UI.includes(emulator);
           // The Extensions emulator runs as part of the Functions emulator, so display the Functions emulators info instead.
           const info = EmulatorRegistry.getInfo(
-            emulator == Emulators.EXTENSIONS ? Emulators.FUNCTIONS : emulator
+            emulator === Emulators.EXTENSIONS ? Emulators.FUNCTIONS : emulator
           );
           if (!info) {
             return [emulatorName, "Failed to initialize (see above)", "", ""];

--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -71,10 +71,12 @@ module.exports = new Command("emulators:start")
       ...controller
         .filterEmulatorTargets(options)
         .map((emulator) => {
-          const info = EmulatorRegistry.getInfo(emulator);
           const emulatorName = Constants.description(emulator).replace(/ emulator/i, "");
           const isSupportedByUi = EMULATORS_SUPPORTED_BY_UI.includes(emulator);
-
+          // The Extensions emulator runs as part of the Functions emulator, so display the Functions emulators info instead.
+          const info = EmulatorRegistry.getInfo(
+            emulator == Emulators.EXTENSIONS ? Emulators.FUNCTIONS : emulator
+          );
           if (!info) {
             return [emulatorName, "Failed to initialize (see above)", "", ""];
           }

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -8,6 +8,7 @@ const DEFAULT_PORTS: { [s in Emulators]: number } = {
   logging: 4500,
   hosting: 5000,
   functions: 5001,
+  extensions: 5001, // The Extensions Emulator runs on the same port as the Functions Emulator
   firestore: 8080,
   pubsub: 8085,
   database: 9000,
@@ -26,6 +27,7 @@ export const FIND_AVAILBLE_PORT_BY_DEFAULT: Record<Emulators, boolean> = {
   pubsub: false,
   auth: false,
   storage: false,
+  extensions: false,
 };
 
 export const EMULATOR_DESCRIPTION: Record<Emulators, string> = {
@@ -39,6 +41,7 @@ export const EMULATOR_DESCRIPTION: Record<Emulators, string> = {
   pubsub: "Pub/Sub Emulator",
   auth: "Authentication Emulator",
   storage: "Storage Emulator",
+  extensions: "Extensions Emulator",
 };
 
 const DEFAULT_HOST = "localhost";

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -46,7 +46,7 @@ import { ParsedTriggerDefinition } from "./functionsEmulatorShared";
 import { ExtensionsEmulator } from "./extensionsEmulator";
 
 async function getAndCheckAddress(emulator: Emulators, options: Options): Promise<Address> {
-  if (emulator == Emulators.EXTENSIONS) {
+  if (emulator === Emulators.EXTENSIONS) {
     // The Extensions emulator always runs on the same port as the Functions emulator.
     emulator = Emulators.FUNCTIONS;
   }

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -46,6 +46,10 @@ import { ParsedTriggerDefinition } from "./functionsEmulatorShared";
 import { ExtensionsEmulator } from "./extensionsEmulator";
 
 async function getAndCheckAddress(emulator: Emulators, options: Options): Promise<Address> {
+  if (emulator == Emulators.EXTENSIONS) {
+    // The Extensions emulator always runs on the same port as the Functions emulator.
+    emulator = Emulators.FUNCTIONS;
+  }
   let host = options.config.src.emulators?.[emulator]?.host || Constants.getDefaultHost(emulator);
   if (host === "localhost" && utils.isRunningInWSL()) {
     // HACK(https://github.com/firebase/firebase-tools-ui/issues/332): Use IPv4
@@ -179,7 +183,7 @@ export async function cleanShutdown(): Promise<void> {
  * @param options
  */
 export function filterEmulatorTargets(options: any): Emulators[] {
-  let targets = ALL_SERVICE_EMULATORS.filter((e) => {
+  let targets = [...ALL_SERVICE_EMULATORS, Emulators.EXTENSIONS].filter((e) => {
     return options.config.has(e) || options.config.has(`emulators.${e}`);
   });
 
@@ -404,11 +408,8 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
     }
   }
 
+  const emulatableBackends: EmulatableBackend[] = [];
   if (shouldStart(options, Emulators.FUNCTIONS)) {
-    const functionsLogger = EmulatorLogger.forEmulator(Emulators.FUNCTIONS);
-    const functionsAddr = await getAndCheckAddress(Emulators.FUNCTIONS, options);
-    const projectId = needProjectId(options);
-
     utils.assertDefined(options.config.src.functions);
     utils.assertDefined(
       options.config.src.functions.source,
@@ -421,6 +422,41 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
       options.config.src.functions.source
     );
 
+    emulatableBackends.push({
+      functionsDir,
+      env: {
+        ...options.extensionEnv,
+      },
+      // TODO(b/213335255): predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
+      // Ideally, we should handle that case via ExtensionEmulator.
+      predefinedTriggers: options.extensionTriggers as ParsedTriggerDefinition[] | undefined,
+      nodeMajorVersion: parseRuntimeVersion(
+        options.extensionNodeVersion || options.config.get("functions.runtime")
+      ),
+    });
+  }
+
+  if (shouldStart(options, Emulators.EXTENSIONS)) {
+    // TODO: This should not error out when called with a fake project.
+    const projectNumber = await needProjectNumber(options);
+    const aliases = getAliases(options, projectId);
+
+    const extensionEmulator = new ExtensionsEmulator({
+      projectId,
+      projectDir: options.config.projectDir,
+      projectNumber,
+      aliases,
+      extensions: options.config.get("extensions"),
+    });
+    const extensionsBackends = await extensionEmulator.getExtensionBackends();
+    emulatableBackends.push(...extensionsBackends);
+  }
+
+  if (emulatableBackends.length) {
+    const functionsLogger = EmulatorLogger.forEmulator(Emulators.FUNCTIONS);
+    const functionsAddr = await getAndCheckAddress(Emulators.FUNCTIONS, options);
+    const projectId = needProjectId(options);
+
     let inspectFunctions: number | undefined;
     if (options.inspectFunctions) {
       inspectFunctions = commandUtils.parseInspectionPort(options);
@@ -429,11 +465,11 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
       functionsLogger.logLabeled(
         "WARN",
         "functions",
-        `You are running the functions emulator in debug mode (port=${inspectFunctions}). This means that functions will execute in sequence rather than in parallel.`
+        `You are running the Functions/Extensions emulator in debug mode (port=${inspectFunctions}). This means that functions will execute in sequence rather than in parallel.`
       );
     }
 
-    // Warn the developer that the Functions emulator can call out to production.
+    // Warn the developer that the Functions/Extensions emulator can call out to production.
     const emulatorsNotRunning = ALL_SERVICE_EMULATORS.filter((e) => {
       return e !== Emulators.FUNCTIONS && !shouldStart(options, e);
     });
@@ -441,42 +477,13 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
       functionsLogger.logLabeled(
         "WARN",
         "functions",
-        `The following emulators are not running, calls to these services from the Functions emulator will affect production: ${clc.bold(
+        `The following emulators are not running, calls to these services from the Functions/Extensions emulator will affect production: ${clc.bold(
           emulatorsNotRunning.join(", ")
         )}`
       );
     }
 
     const account = getProjectDefaultAccount(options.projectRoot);
-    const emulatableBackends: EmulatableBackend[] = [
-      {
-        functionsDir,
-        env: {
-          ...options.extensionEnv,
-        },
-        // TODO(b/213335255): predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
-        // Ideally, we should handle that case via ExtensionEmulator.
-        predefinedTriggers: options.extensionTriggers as ParsedTriggerDefinition[] | undefined,
-        nodeMajorVersion: parseRuntimeVersion(
-          options.extensionNodeVersion || options.config.get("functions.runtime")
-        ),
-      },
-    ];
-    if (options.config.has("extensions")) {
-      // TODO: This should not error out when called with a fake project.
-      const projectNumber = await needProjectNumber(options);
-      const aliases = getAliases(options, projectId);
-
-      const extensionEmulator = new ExtensionsEmulator({
-        projectId,
-        projectDir: options.config.projectDir,
-        projectNumber,
-        aliases,
-        extensions: options.config.get("extensions"),
-      });
-      const extensionsBackends = await extensionEmulator.getExtensionBackends();
-      emulatableBackends.push(...extensionsBackends);
-    }
 
     // TODO(b/213241033): Figure out how to watch for changes to extensions .env files & reload triggers when they change.
     const functionsEmulator = new FunctionsEmulator({

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -311,7 +311,7 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
 }
 
 interface EmulatorOptions extends Options {
-  extensionEnv?: Record<string, string>;
+  extDevEnv?: Record<string, string>;
 }
 
 export async function startAll(options: EmulatorOptions, showUI: boolean = true): Promise<void> {
@@ -410,28 +410,29 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
 
   const emulatableBackends: EmulatableBackend[] = [];
   if (shouldStart(options, Emulators.FUNCTIONS)) {
+    // Note: ext:dev:emulators:* commands hit this path, not the Emulators.EXTENSIONS path
     utils.assertDefined(options.config.src.functions);
     utils.assertDefined(
       options.config.src.functions.source,
       "Error: 'functions.source' is not defined"
     );
 
-    utils.assertIsStringOrUndefined(options.extensionDir);
+    utils.assertIsStringOrUndefined(options.extDevDir);
     const functionsDir = path.join(
-      options.extensionDir || options.config.projectDir,
+      options.extDevDir || options.config.projectDir,
       options.config.src.functions.source
     );
 
     emulatableBackends.push({
       functionsDir,
       env: {
-        ...options.extensionEnv,
+        ...options.extDevEnv,
       },
       // TODO(b/213335255): predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
       // Ideally, we should handle that case via ExtensionEmulator.
-      predefinedTriggers: options.extensionTriggers as ParsedTriggerDefinition[] | undefined,
+      predefinedTriggers: options.extDevTriggers as ParsedTriggerDefinition[] | undefined,
       nodeMajorVersion: parseRuntimeVersion(
-        options.extensionNodeVersion || options.config.get("functions.runtime")
+        options.extDevNodeVersion || options.config.get("functions.runtime")
       ),
     });
   }

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -51,6 +51,9 @@ export class EmulatorRegistry {
       // Functions is next since it has side effects and
       // dependencies across all the others
       functions: 1,
+      // The Extensions emulator runs on the same process as the Functions emulator
+      // so this is a no-op.
+      extensions: 1.1,
 
       // Hosting is next because it can trigger functions.
       hosting: 2,

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -48,12 +48,13 @@ export class EmulatorRegistry {
       // once shutdown starts
       ui: 0,
 
+      // The Extensions emulator runs on the same process as the Functions emulator
+      // so this is a no-op. We put this before functions for future proofing, since
+      // the Extensions emulator depends on the Functions emulator.
+      extensions: 1,
       // Functions is next since it has side effects and
       // dependencies across all the others
-      functions: 1,
-      // The Extensions emulator runs on the same process as the Functions emulator
-      // so this is a no-op.
-      extensions: 1.1,
+      functions: 1.1,
 
       // Hosting is next because it can trigger functions.
       hosting: 2,

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -13,6 +13,7 @@ export enum Emulators {
   UI = "ui",
   LOGGING = "logging",
   STORAGE = "storage",
+  EXTENSIONS = "extensions",
 }
 
 export type DownloadableEmulators =
@@ -60,6 +61,7 @@ export const EMULATORS_SUPPORTED_BY_UI = [
   Emulators.FIRESTORE,
   Emulators.FUNCTIONS,
   Emulators.STORAGE,
+  Emulators.EXTENSIONS,
 ];
 
 export const EMULATORS_SUPPORTED_BY_USE_EMULATOR = [

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -15,9 +15,9 @@ import { needProjectId } from "../../projectUtils";
 import { Emulators } from "../../emulator/types";
 
 export async function buildOptions(options: any): Promise<any> {
-  const extensionDir = localHelper.findExtensionYaml(process.cwd());
-  options.extensionDir = extensionDir;
-  const spec = await specHelper.readExtensionYaml(extensionDir);
+  const extDevDir = localHelper.findExtensionYaml(process.cwd());
+  options.extDevDir = extDevDir;
+  const spec = await specHelper.readExtensionYaml(extDevDir);
   extensionsHelper.validateSpec(spec);
 
   const params = getParams(options, spec);
@@ -34,12 +34,12 @@ export async function buildOptions(options: any): Promise<any> {
     checkTestConfig(testConfig, functionResources);
   }
   options.config = buildConfig(functionResources, testConfig);
-  options.extensionEnv = params;
+  options.extDevEnv = params;
   const functionEmuTriggerDefs: ParsedTriggerDefinition[] = functionResources.map((r) =>
     triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
   );
-  options.extensionTriggers = functionEmuTriggerDefs;
-  options.extensionNodeVersion = specHelper.getNodeVersion(functionResources);
+  options.extDevTriggers = functionEmuTriggerDefs;
+  options.extDevNodeVersion = specHelper.getNodeVersion(functionResources);
   return options;
 }
 

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -159,6 +159,7 @@ export type EmulatorsConfig = {
     host?: string;
     port?: number | string;
   };
+  extensions?: {};
 };
 
 export type ExtensionsConfig = Record<string, string>;


### PR DESCRIPTION
### Description
Adds support for `--only extensions` to emulators commands.

### Scenarios Tested
I tested `firebase emulators:start`, 
<img width="1383" alt="Screen Shot 2022-02-08 at 2 58 52 PM" src="https://user-images.githubusercontent.com/4635763/153089841-c730d936-af3a-48f5-a86c-724ec771f3b0.png">

`firebase emulators:start --only extensions`,
<img width="1391" alt="Screen Shot 2022-02-08 at 2 58 28 PM" src="https://user-images.githubusercontent.com/4635763/153089802-df8a3bf9-0aab-4df3-9521-2cb4c94b71d3.png">

`firebase emulators:start --only functions`, 

<img width="1409" alt="Screen Shot 2022-02-08 at 2 57 50 PM" src="https://user-images.githubusercontent.com/4635763/153089746-405815d5-9ebe-4f7d-aa97-eb0674dc5f64.png">
and `firebase emulators:start --only functions,extensions,firestore,storage`.

<img width="1433" alt="Screen Shot 2022-02-08 at 2 55 49 PM" src="https://user-images.githubusercontent.com/4635763/153089677-df858ca2-6ff6-4790-983f-25056f5ecae8.png">

In all four cases, I also tested that the correct functions were running (and that functions hat should not be running were not).


