### PR TITLE
Switching extensions emulator to use the same function IDs as prod

### DIFF
--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -117,6 +117,7 @@ export class ExtensionsEmulator {
     const env = Object.assign(this.autoPopulatedParams(instance), instance.params);
     const { extensionTriggers, nodeMajorVersion } = await getExtensionFunctionInfo(
       extensionDir,
+      instance.instanceId,
       env
     );
     const extensionVersion = await planner.getExtensionVersion(instance);

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -46,6 +46,7 @@ export async function buildOptions(options: any): Promise<any> {
 // TODO: Better name? Also, should this be in extensionsEmulator instead?
 export async function getExtensionFunctionInfo(
   extensionDir: string,
+  instanceId: string,
   params: Record<string, string>
 ): Promise<{
   nodeMajorVersion: number;
@@ -53,9 +54,12 @@ export async function getExtensionFunctionInfo(
 }> {
   const spec = await specHelper.readExtensionYaml(extensionDir);
   const functionResources = specHelper.getFunctionResourcesWithParamSubstitution(spec, params);
-  const extensionTriggers: ParsedTriggerDefinition[] = functionResources.map((r) =>
-    triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
-  );
+  const extensionTriggers: ParsedTriggerDefinition[] = functionResources
+    .map((r) => triggerHelper.functionResourceToEmulatedTriggerDefintion(r))
+    .map((trigger) => {
+      trigger.name = `ext-${instanceId}-${trigger.name}`;
+      return trigger;
+    });
   const nodeMajorVersion = specHelper.getNodeVersion(functionResources);
   return {
     extensionTriggers,

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -70,7 +70,7 @@ describe("Extensions Emulator", () => {
                 resource: "projects/_/buckets/${param:IMG_BUCKET}",
                 service: "storage.googleapis.com",
               },
-              name: "generateResizedImage",
+              name: "ext-ext-test-generateResizedImage",
               platform: "gcfv1",
               regions: ["us-west1"],
             },


### PR DESCRIPTION
### Description
Just like prod, the Extensions emulator should namespace function names with `ext-${instanceId}-`, so that multiple extensions with the same function name can run without interfering with each other.

### Scenarios Tested
<img width="1396" alt="Screen Shot 2022-02-08 at 3 05 46 PM" src="https://user-images.githubusercontent.com/4635763/153091326-214a339f-a69f-4c70-88a1-50ccbcd8d225.png">

