### PR TITLE
Add EXT_ as a reserved environment variable prefix

### DIFF
--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -8,7 +8,7 @@ import { logBullet } from "../utils";
 
 const FUNCTIONS_EMULATOR_DOTENV = ".env.local";
 
-const RESERVED_PREFIX = ["X_GOOGLE_", "FIREBASE_", "EXT_"];
+const RESERVED_PREFIXES = ["X_GOOGLE_", "FIREBASE_", "EXT_"];
 const RESERVED_KEYS = [
   // Cloud Functions for Firebase
   "FIREBASE_CONFIG",
@@ -149,10 +149,10 @@ export function validateKey(key: string): void {
         ", and then consist of uppercase ASCII letters, digits, and underscores."
     );
   }
-  if (RESERVED_PREFIX.some((prefix) => key.startsWith(prefix))) {
+  if (RESERVED_PREFIXES.some((prefix) => key.startsWith(prefix))) {
     throw new KeyValidationError(
       key,
-      `Key ${key} starts with a reserved prefix (${RESERVED_PREFIX.join(" ")})`
+      `Key ${key} starts with a reserved prefix (${RESERVED_PREFIXES.join(" ")})`
     );
   }
 }

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -4,11 +4,11 @@ import * as path from "path";
 
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
-import { previews } from "../previews";
 import { logBullet } from "../utils";
 
 const FUNCTIONS_EMULATOR_DOTENV = ".env.local";
 
+const RESERVED_PREFIX = ["X_GOOGLE_", "FIREBASE_", "EXT_"];
 const RESERVED_KEYS = [
   // Cloud Functions for Firebase
   "FIREBASE_CONFIG",
@@ -149,10 +149,10 @@ export function validateKey(key: string): void {
         ", and then consist of uppercase ASCII letters, digits, and underscores."
     );
   }
-  if (key.startsWith("X_GOOGLE_") || key.startsWith("FIREBASE_")) {
+  if (RESERVED_PREFIX.some((prefix) => key.startsWith(prefix))) {
     throw new KeyValidationError(
       key,
-      `Key ${key} starts with a reserved prefix (X_GOOGLE_ or FIREBASE_)`
+      `Key ${key} starts with a reserved prefix (${RESERVED_PREFIX.join(" ")})`
     );
   }
 }

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -238,6 +238,10 @@ FOO=foo
       expect(() => {
         env.validateKey("FIREBASE_FOOBAR");
       }).to.throw("starts with a reserved prefix");
+
+      expect(() => {
+        env.validateKey("EXT_INSTANCE_ID");
+      }).to.throw("starts with a reserved prefix");
     });
   });
 


### PR DESCRIPTION
Firebase Extensions use environment variables with `EXT_` for many of their "first class" environment variable keys. We will add it to the reserved prefix list before releasing the dotenv support for all users.