### PR TITLE
Renaming some variables to make it clear which parts are for ext:dev:emulators:*

### DIFF
--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -311,7 +311,7 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
 }
 
 interface EmulatorOptions extends Options {
-  extensionEnv?: Record<string, string>;
+  extDevEnv?: Record<string, string>;
 }
 
 export async function startAll(options: EmulatorOptions, showUI: boolean = true): Promise<void> {
@@ -410,28 +410,29 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
 
   const emulatableBackends: EmulatableBackend[] = [];
   if (shouldStart(options, Emulators.FUNCTIONS)) {
+    // Note: ext:dev:emulators:* commands hit this path, not the Emulators.EXTENSIONS path
     utils.assertDefined(options.config.src.functions);
     utils.assertDefined(
       options.config.src.functions.source,
       "Error: 'functions.source' is not defined"
     );
 
-    utils.assertIsStringOrUndefined(options.extensionDir);
+    utils.assertIsStringOrUndefined(options.extDevDir);
     const functionsDir = path.join(
-      options.extensionDir || options.config.projectDir,
+      options.extDevDir || options.config.projectDir,
       options.config.src.functions.source
     );
 
     emulatableBackends.push({
       functionsDir,
       env: {
-        ...options.extensionEnv,
+        ...options.extDevEnv,
       },
       // TODO(b/213335255): predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
       // Ideally, we should handle that case via ExtensionEmulator.
-      predefinedTriggers: options.extensionTriggers as ParsedTriggerDefinition[] | undefined,
+      predefinedTriggers: options.extDevTriggers as ParsedTriggerDefinition[] | undefined,
       nodeMajorVersion: parseRuntimeVersion(
-        options.extensionNodeVersion || options.config.get("functions.runtime")
+        options.extDevNodeVersion || options.config.get("functions.runtime")
       ),
     });
   }

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -15,9 +15,9 @@ import { needProjectId } from "../../projectUtils";
 import { Emulators } from "../../emulator/types";
 
 export async function buildOptions(options: any): Promise<any> {
-  const extensionDir = localHelper.findExtensionYaml(process.cwd());
-  options.extensionDir = extensionDir;
-  const spec = await specHelper.readExtensionYaml(extensionDir);
+  const extDevDir = localHelper.findExtensionYaml(process.cwd());
+  options.extDevDir = extDevDir;
+  const spec = await specHelper.readExtensionYaml(extDevDir);
   extensionsHelper.validateSpec(spec);
 
   const params = getParams(options, spec);
@@ -34,12 +34,12 @@ export async function buildOptions(options: any): Promise<any> {
     checkTestConfig(testConfig, functionResources);
   }
   options.config = buildConfig(functionResources, testConfig);
-  options.extensionEnv = params;
+  options.extDevEnv = params;
   const functionEmuTriggerDefs: ParsedTriggerDefinition[] = functionResources.map((r) =>
     triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
   );
-  options.extensionTriggers = functionEmuTriggerDefs;
-  options.extensionNodeVersion = specHelper.getNodeVersion(functionResources);
+  options.extDevTriggers = functionEmuTriggerDefs;
+  options.extDevNodeVersion = specHelper.getNodeVersion(functionResources);
   return options;
 }
 


### PR DESCRIPTION
### Description
Putting this in a separate PR to make it easier to review - this just renames some variables to clarify what is for the old ext:dev:emulators:* commands and what is for the new extension emulator.