### PR TITLE
upgrade firepit builder npm to 8; omit dev dependencies

### DIFF
--- a/scripts/firepit-builder/Dockerfile
+++ b/scripts/firepit-builder/Dockerfile
@@ -8,6 +8,9 @@ RUN apt-get update && \
 RUN curl -fsSL --output hub.tgz https://github.com/github/hub/releases/download/v2.11.2/hub-linux-amd64-2.11.2.tgz
 RUN tar --strip-components=2 -C /usr/bin -xf hub.tgz hub-linux-amd64-2.11.2/bin/hub
 
+# Upgrade npm to 8.
+RUN npm install --global npm@8
+
 # Create app directory
 WORKDIR /usr/src/app
 

--- a/scripts/firepit-builder/pipeline.js
+++ b/scripts/firepit-builder/pipeline.js
@@ -42,7 +42,7 @@ if (fs.existsSync(firebaseToolsPackage)) {
   npm("install", packedModule);
   rm(packedModule);
 } else {
-  npm("install", firebaseToolsPackage);
+  npm("install", "--omit=dev", firebaseToolsPackage);
 }
 
 const packageJson = JSON.parse(cat("node_modules/firebase-tools/package.json"));


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

The firepit binaries are large. It's because `npm i firebase-tools` is installing all the dev dev-dependencies too, which is a [known issue](https://github.com/npm/cli/issues/4323) for npm-shrinkwrap users.

Using `npm@8`, I have confirmed that `npm i --omit=dev firebase-tools` does do the right thing, and the pipeline produces a 1xxMB file instead of a 8xxMB file. Hopefully this addresses the issue and

Fixes #4144