### PR TITLE
Fix an issue where ext:list was not displaying any info about instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes an issue where ext:list was not printing out information about installed Extension instances.

--- a/src/extensions/listExtensions.ts
+++ b/src/extensions/listExtensions.ts
@@ -57,5 +57,6 @@ export async function listExtensions(projectId: string): Promise<any> {
   });
 
   utils.logLabeledBullet(logPrefix, `list of extensions installed in ${clc.bold(projectId)}:`);
+  logger.info(table.toString());
   return formatted;
 }


### PR DESCRIPTION
### Description
Fix an issue where ext:list was not displaying any info about instances

### Scenarios Tested
<img width="916" alt="Screen Shot 2022-02-11 at 2 16 43 PM" src="https://user-images.githubusercontent.com/4635763/153678950-85f1d2c7-ea02-4601-b5b1-047f2a302f1b.png">
<img width="903" alt="Screen Shot 2022-02-11 at 2 16 36 PM" src="https://user-images.githubusercontent.com/4635763/153678968-b2457829-34e6-483f-80f1-6c0f9a5e51c9.png">

