### PR TITLE
Load runtime config when loading triggers in the Functions Emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fixes an issue where ext:list was not printing out information about installed Extension instances.
-- Fixes issue where Functions Emulator crashed when parsing triggers if accessing functions config values. 
+- Fixes issue where Functions Emulator crashed when parsing triggers if accessing functions config values.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes an issue where ext:list was not printing out information about installed Extension instances.
+- Fixes issue where Functions Emulator crashed when parsing triggers if accessing functions config values. 


### PR DESCRIPTION
Fix for https://github.com/firebase/firebase-tools/issues/4158.

I've tried to find a way to add a test for this usecase, but there isn't a framework where I can easily hook in a change like this without big investments. I'm leaning towards releasing this bugfix as is, and finding a less urgent time to add regression test.