### PR TITLE
Fix bug where migration of config-clone command to TS broke the command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-- Fixes an issue where ext:list was not printing out information about installed Extension instances.
-- Fixes issue where Functions Emulator crashed when parsing triggers if accessing functions config values.
+- Fixes an issue where ext:list was not printing out information about installed Extension instances (#4156)
+- Fixes issue where Functions Emulator crashed when parsing triggers if accessing functions config values (#4162).
 - `firebase emulators:start --export-on-exit <dir>` now rejects overwriting the current directory or parents (#4127).
+- Fixes broken functions:config:clone command (#4173).

--- a/src/commands/functions-config-clone.ts
+++ b/src/commands/functions-config-clone.ts
@@ -39,7 +39,7 @@ export default new Command("functions:config:clone")
       throw new FirebaseError("Cannot use both --only and --except at the same time.");
     }
 
-    let only: string[] = [];
+    let only: string[] | undefined;
     let except: string[] = [];
     if (options.only) {
       only = options.only.split(",");


### PR DESCRIPTION
While migrating the command to TS in https://github.com/firebase/firebase-tools/pull/4025, we introduced a small bug that effectively broke the `functions:config:clone` command that did not pass the `--only` flag.

Fixes https://github.com/firebase/firebase-tools/issues/4112