### PR TITLE
Update versions of dependencies functions init templates to latest

### DIFF
--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -14,11 +14,11 @@
   },
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^9.8.0",
-    "firebase-functions": "^3.14.1"
+    "firebase-admin": "^10.0.2",
+    "firebase-functions": "^3.18.0"
   },
   "devDependencies": {
-    "eslint": "^7.6.0",
+    "eslint": "^8.9.0",
     "eslint-config-google": "^0.14.0",
     "firebase-functions-test": "^0.2.0"
   },

--- a/templates/init/functions/javascript/package.nolint.json
+++ b/templates/init/functions/javascript/package.nolint.json
@@ -13,8 +13,8 @@
   },
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^9.8.0",
-    "firebase-functions": "^3.14.1"
+    "firebase-admin": "^10.0.2",
+    "firebase-functions": "^3.18.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -14,17 +14,17 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^9.8.0",
-    "firebase-functions": "^3.14.1"
+    "firebase-admin": "^10.0.2",
+    "firebase-functions": "^3.18.0"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^3.9.1",
-    "@typescript-eslint/parser": "^3.8.0",
-    "eslint": "^7.6.0",
+    "@typescript-eslint/eslint-plugin": "^5.12.0",
+    "@typescript-eslint/parser": "^5.12.0",
+    "eslint": "^8.9.0",
     "eslint-config-google": "^0.14.0",
-    "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-import": "^2.25.4",
     "firebase-functions-test": "^0.2.0",
-    "typescript": "^3.8.0"
+    "typescript": "^4.5.4"
   },
   "private": true
 }

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -13,11 +13,11 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^9.8.0",
-    "firebase-functions": "^3.14.1"
+    "firebase-admin": "^10.0.2",
+    "firebase-functions": "^3.18.0"
   },
   "devDependencies": {
-    "typescript": "^3.8.0",
+    "typescript": "^4.5.4",
     "firebase-functions-test": "^0.2.0"
   },
   "private": true


### PR DESCRIPTION
Following dependencies have had major version bump:

* typescript
* firebase-admin
* eslint

I manually confirmed that firebase-admin v10 poses no issue for functions SDK (as expcted).

Fixes https://github.com/firebase/firebase-tools/issues/4155