### PR TITLE
Use trigger.entryPoint instead of trigger.name

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -911,11 +911,10 @@ export class FunctionsEmulator implements EmulatorInstance {
     envs.PORT = "80";
 
     if (trigger) {
-      const service = trigger.name;
-      const target = service.replace(/-/g, ".");
+      const target = trigger.entryPoint.replace(/-/g, ".");
       envs.FUNCTION_TARGET = target;
       envs.FUNCTION_SIGNATURE_TYPE = getSignatureType(trigger);
-      envs.K_SERVICE = service;
+      envs.K_SERVICE = trigger.name;
     }
     return envs;
   }


### PR DESCRIPTION
### Description
Fixes a subtle change in behavior that slipped in via #4149 . Previous, we looked for the functions code at EmulatedTriggerDefinition.entryPoint. After those changes, we started looking for the functions code at EmulatedTriggerDefinition.name. This is extra subtle, because we set these values to the same thing for CF3 functions - however, GCF allows them to be different  & the are always different for Extensions.
