### PR TITLE
Adding preview flag

### DIFF
--- a/src/previews.ts
+++ b/src/previews.ts
@@ -5,6 +5,7 @@ interface PreviewFlags {
   rtdbrules: boolean;
   ext: boolean;
   extdev: boolean;
+  extensionsemulator: boolean;
   rtdbmanagement: boolean;
   functionsv2: boolean;
   golang: boolean;
@@ -18,6 +19,7 @@ export const previews: PreviewFlags = {
   rtdbrules: false,
   ext: false,
   extdev: false,
+  extensionsemulator: false,
   rtdbmanagement: false,
   functionsv2: false,
   golang: false,


### PR DESCRIPTION
### Description
Hiding this feature behind the `extensionsemulator` preview flag
### Scenarios Tested

Without flag enbaled:
<img width="1161" alt="Screen Shot 2022-02-17 at 12 47 19 PM" src="https://user-images.githubusercontent.com/4635763/154569481-7318cee1-ce53-4cb8-abc6-0f80a340daac.png">


With it enabled:
<img width="1185" alt="Screen Shot 2022-02-17 at 12 47 01 PM" src="https://user-images.githubusercontent.com/4635763/154569511-90be96b9-4d3a-4c2f-a879-d8c896a81b28.png">

