### PR TITLE
Adding cors & START_LOGGING_EMULATOR to support emulator UI

### DIFF
--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -46,6 +46,12 @@ import { ParsedTriggerDefinition } from "./functionsEmulatorShared";
 import { ExtensionsEmulator } from "./extensionsEmulator";
 import { previews } from "../previews";
 
+const START_LOGGING_EMULATOR = utils.envOverride(
+  "START_LOGGING_EMULATOR",
+  "false",
+  (val) => val == "true"
+);
+
 async function getAndCheckAddress(emulator: Emulators, options: Options): Promise<Address> {
   if (emulator === Emulators.EXTENSIONS) {
     // The Extensions emulator always runs on the same port as the Functions emulator.
@@ -724,7 +730,7 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
     );
   }
 
-  if (showUI && shouldStart(options, Emulators.UI)) {
+  if (showUI && (shouldStart(options, Emulators.UI) || START_LOGGING_EMULATOR)) {
     const loggingAddr = await getAndCheckAddress(Emulators.LOGGING, options);
     const loggingEmulator = new LoggingEmulator({
       host: loggingAddr.host,
@@ -732,7 +738,9 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
     });
 
     await startEmulator(loggingEmulator);
+  }
 
+  if (showUI && shouldStart(options, Emulators.UI)) {
     const uiAddr = await getAndCheckAddress(Emulators.UI, options);
     const ui = new EmulatorUI({
       projectId: projectId,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -5,6 +5,7 @@ import * as express from "express";
 import * as clc from "cli-color";
 import * as http from "http";
 import * as jwt from "jsonwebtoken";
+import * as cors from "cors";
 import { URL } from "url";
 
 import { Account } from "../auth";
@@ -231,6 +232,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     this.workQueue.start();
 
     const hub = express();
+    hub.use(cors({ origin: true })); // Enable cors so the Emulator UI can call out to the Functions Emulator.
 
     const dataMiddleware: express.RequestHandler = (req, res, next) => {
       const chunks: Buffer[] = [];


### PR DESCRIPTION
### Description
Some new features to support Emulator UI development:
- Enables cors for the functions emulator, so that the Emulator UI can cal the /backends endpoint from browser
- Adds a new environment variable START_LOGGING_EMULATOR, to support developing against a local copy of the emulator UI. To use this, run `export START_LOGGING_EMULATOR=true` before running emulator commands.