### PR TITLE
Fix arg order for Storage Emulator start command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Updates reserved environment variables for CF3 to include 'EVENTARC_CLOUD_EVENT_SOURCE' (#4196).
+- Fixes arg order for `firebase emulators:start --only storage` (#4195).

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -170,10 +170,10 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
     // separately in ./storage/runtime.ts (not via the start function below).
     binary: "java",
     args: [
-      "-jar",
       // Required for rules error/warning messages, which are in English only.
       // Attempts to fetch the messages in another language leads to crashes.
       "-Duser.language=en",
+      "-jar",
       getExecPath(Emulators.STORAGE),
       "serve",
     ],

--- a/src/emulator/storage/rules/runtime.ts
+++ b/src/emulator/storage/rules/runtime.ts
@@ -155,6 +155,7 @@ export class StorageRulesRuntime {
     this._childprocess.stderr?.on("data", (buf: Buffer) => {
       const error = buf.toString();
       if (error.includes("jarfile")) {
+        EmulatorLogger.forEmulator(Emulators.STORAGE).log("ERROR", error);
         throw new FirebaseError(
           "There was an issue starting the rules emulator, please run 'firebase setup:emulators:storage` again"
         );


### PR DESCRIPTION
### Description

#### Issue
The Storage Emulator crashes on start for me on OpenJDK 11.0.12. The only error logs are
```
$ firebase emulators:start --only storage
i  emulators: Starting emulators: storage

Error: There was an issue starting the rules emulator, please run 'firebase setup:emulators:storage` again

Error: Storage Emulator Rules runtime exited unexpectedly.
```

#### Cause
The args passed in the start command are in the wrong order: `java -jar -Duser.language=en <jarfile> serve` instead of `java -Duser.language=en -jar <jarfile> serve` as [recommended](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#synopsis). This causes `-Duser.language=en` to be mistakenly interpreted as the JAR file:
```
Error: Unable to access jarfile -Duser.language=en
```
This PR also adds the above message to the error logs.

### Scenarios Tested
Tested the above commands on the command line to confirm that the program launches successfully with the new order:
```
{"result":{},"id":-1,"status":"ok"}
```
Also verified that the Storage Emulator is launched successfully with the fix.