### PR TITLE
Set env var FUNCTION_SIGNATURE_TYPE=cloudevent when deploying gen2 functions

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -31,9 +31,6 @@ function hasDotenv(opts: functionsEnv.UserEnvsOpts): boolean {
   return functionsEnv.hasUserEnvs(opts);
 }
 
-/**
- *
- */
 export async function prepare(
   context: args.Context,
   options: Options,

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -31,6 +31,9 @@ function hasDotenv(opts: functionsEnv.UserEnvsOpts): boolean {
   return functionsEnv.hasUserEnvs(opts);
 }
 
+/**
+ *
+ */
 export async function prepare(
   context: args.Context,
   options: Options,
@@ -138,6 +141,13 @@ export async function prepare(
   // Setup environment variables on each function.
   for (const endpoint of backend.allEndpoints(wantBackend)) {
     endpoint.environmentVariables = wantBackend.environmentVariables;
+    if (endpoint.platform === "gcfv2") {
+      // By default, Functions Framework in GCFv2 opts to downcast incoming cloudevent messages to legacy formats.
+      // Since Firebase Functions SDK expects messages in cloudevent format, we set FUNCTION_SIGNATURE_TYPE to tell
+      // Functions Framework to pass cloudevent messages to function handler.
+      // See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/README.md#configure-the-functions-framework
+      endpoint.environmentVariables["FUNCTION_SIGNATURE_TYPE"] = "cloudevent";
+    }
   }
 
   // Enable required APIs. This may come implicitly from triggers (e.g. scheduled triggers

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -139,11 +139,13 @@ export async function prepare(
   for (const endpoint of backend.allEndpoints(wantBackend)) {
     endpoint.environmentVariables = wantBackend.environmentVariables;
     if (endpoint.platform === "gcfv2") {
-      // By default, Functions Framework in GCFv2 opts to downcast incoming cloudevent messages to legacy formats.
-      // Since Firebase Functions SDK expects messages in cloudevent format, we set FUNCTION_SIGNATURE_TYPE to tell
-      // Functions Framework to pass cloudevent messages to function handler.
-      // See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/README.md#configure-the-functions-framework
-      endpoint.environmentVariables["FUNCTION_SIGNATURE_TYPE"] = "cloudevent";
+      if (backend.isEventTriggered(endpoint)) {
+        // By default, Functions Framework in GCFv2 opts to downcast incoming cloudevent messages to legacy formats.
+        // Since Firebase Functions SDK expects messages in cloudevent format, we set FUNCTION_SIGNATURE_TYPE to tell
+        // Functions Framework to pass cloudevent messages to function handler.
+        // See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/README.md#configure-the-functions-framework
+        endpoint.environmentVariables["FUNCTION_SIGNATURE_TYPE"] = "cloudevent";
+      }
     }
   }
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -142,7 +142,7 @@ export async function prepare(
       if (backend.isEventTriggered(endpoint)) {
         // By default, Functions Framework in GCFv2 opts to downcast incoming cloudevent messages to legacy formats.
         // Since Firebase Functions SDK expects messages in cloudevent format, we set FUNCTION_SIGNATURE_TYPE to tell
-        // Functions Framework to pass cloudevent messages to function handler.
+        // Functions Framework to disable downcast before passing the cloudevent message to function handler.
         // See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/README.md#configure-the-functions-framework
         endpoint.environmentVariables["FUNCTION_SIGNATURE_TYPE"] = "cloudevent";
       }


### PR DESCRIPTION
By setting FUNCTION_SIGNATURE_TYPE=cloudevent, we prevent deployed gen2 functions from downcasting cloudevent messages.