### PR TITLE
Update v2 function deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,2 @@
-- Fixes bug where updating gen 2 pubsub functions always failed (#4198).
 - Updates reserved environment variables for CF3 to include 'EVENTARC_CLOUD_EVENT_SOURCE' (#4196).
 - Fixes arg order for `firebase emulators:start --only storage` (#4195).

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -138,15 +138,6 @@ export async function prepare(
   // Setup environment variables on each function.
   for (const endpoint of backend.allEndpoints(wantBackend)) {
     endpoint.environmentVariables = wantBackend.environmentVariables;
-    if (endpoint.platform === "gcfv2") {
-      if (backend.isEventTriggered(endpoint)) {
-        // By default, Functions Framework in GCFv2 opts to downcast incoming cloudevent messages to legacy formats.
-        // Since Firebase Functions SDK expects messages in cloudevent format, we set FUNCTION_SIGNATURE_TYPE to tell
-        // Functions Framework to disable downcast before passing the cloudevent message to function handler.
-        // See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/README.md#configure-the-functions-framework
-        endpoint.environmentVariables["FUNCTION_SIGNATURE_TYPE"] = "cloudevent";
-      }
-    }
   }
 
   // Enable required APIs. This may come implicitly from triggers (e.g. scheduled triggers

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -446,6 +446,14 @@ export function functionFromEndpoint(endpoint: backend.Endpoint, source: Storage
     if (endpoint.eventTrigger.retry) {
       logger.warn("Cannot set a retry policy on Cloud Function", endpoint.id);
     }
+    // By default, Functions Framework in GCFv2 opts to downcast incoming cloudevent messages to legacy formats.
+    // Since Firebase Functions SDK expects messages in cloudevent format, we set FUNCTION_SIGNATURE_TYPE to tell
+    // Functions Framework to disable downcast before passing the cloudevent message to function handler.
+    // See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/master/README.md#configure-the-functions-
+    gcfFunction.serviceConfig.environmentVariables = {
+      ...gcfFunction.serviceConfig.environmentVariables,
+      FUNCTION_SIGNATURE_TYPE: "cloudevent",
+    };
   } else if (backend.isScheduleTriggered(endpoint)) {
     // trigger type defaults to HTTPS.
     gcfFunction.labels = { ...gcfFunction.labels, "deployment-scheduled": "true" };

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -117,6 +117,10 @@ describe("cloudfunctionsv2", () => {
             },
           ],
         },
+        serviceConfig: {
+          ...CLOUD_FUNCTION_V2.serviceConfig,
+          environmentVariables: { FUNCTION_SIGNATURE_TYPE: "cloudevent" },
+        },
       };
       expect(
         cloudfunctionsv2.functionFromEndpoint(eventEndpoint, CLOUD_FUNCTION_V2_SOURCE)
@@ -215,6 +219,7 @@ describe("cloudfunctionsv2", () => {
           minInstanceCount: 1,
           timeoutSeconds: 15,
           availableMemory: "128M",
+          environmentVariables: { FUNCTION_SIGNATURE_TYPE: "cloudevent" },
         },
       };
 


### PR DESCRIPTION
This PR is combination of the following:

* Rollback of https://github.com/firebase/firebase-tools/pull/4198: This PR made wrong diagnosis and doesn't fix anything.
* Fix foward of https://github.com/firebase/firebase-tools/pull/4197: Environment variables are set on more appropriate module.
* Partial rollback of https://github.com/firebase/firebase-tools/pull/4124: We need to iron out some details with event trigger parsing before enabling for v2 preview.