### PR TITLE
Remove httpsTrigger from field mask to stop overwrite of securityLevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,3 @@
 - Fixes an issue in the storage emulator where a file upload would trigger functions with a metadata update handler (#4213).
 - Fixes Storage Emulator rules resource evaluation (#4214).
 - Fixes bug where securityLevel is overwritten on https function re-deploys (#4208).
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes bug where updating gen 2 pubsub functions always failed (#4198).
 - Updates reserved environment variables for CF3 to include 'EVENTARC_CLOUD_EVENT_SOURCE' (#4196).
 - Fixes arg order for `firebase emulators:start --only storage` (#4195).
+- Fixes bug where securityLevel is overwritten on https function re-deploys (#4208).

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -257,8 +257,10 @@ export type Endpoint = TargetIds &
     // on GCFv2 always
     uri?: string;
     sourceUploadUrl?: string;
-    // GCFv1 can be http or https and
-    // GCFv2 is always https
+    // TODO(colerogers): yank this field and set securityLevel to SECURE_ALWAYS
+    // in functionFromEndpoint during a breaking change release.
+    // This is a temporary fix to address https://github.com/firebase/firebase-tools/issues/4171
+    // GCFv1 can be http or https and GCFv2 is always https
     securityLevel?: SecurityLevel;
   };
 

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -204,8 +204,6 @@ export interface ServiceConfiguration {
 
 export type FunctionsPlatform = "gcfv1" | "gcfv2";
 
-export type SecurityLevel = "SECURE_ALWAYS" | "SECURE_OPTIONAL";
-
 export type Triggered =
   | HttpsTriggered
   | CallableTriggered
@@ -261,7 +259,7 @@ export type Endpoint = TargetIds &
     // in functionFromEndpoint during a breaking change release.
     // This is a temporary fix to address https://github.com/firebase/firebase-tools/issues/4171
     // GCFv1 can be http or https and GCFv2 is always https
-    securityLevel?: SecurityLevel;
+    securityLevel?: gcf.SecurityLevel;
   };
 
 export interface RequiredAPI {

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -204,6 +204,8 @@ export interface ServiceConfiguration {
 
 export type FunctionsPlatform = "gcfv1" | "gcfv2";
 
+export type SecurityLevel = "SECURE_ALWAYS" | "SECURE_OPTIONAL";
+
 export type Triggered =
   | HttpsTriggered
   | CallableTriggered
@@ -255,6 +257,9 @@ export type Endpoint = TargetIds &
     // on GCFv2 always
     uri?: string;
     sourceUploadUrl?: string;
+    // GCFv1 can be http or https and
+    // GCFv2 is always https
+    securityLevel?: SecurityLevel;
   };
 
 export interface RequiredAPI {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -205,6 +205,10 @@ export function inferDetailsFromExisting(
       wantE.availableMemoryMb = haveE.availableMemoryMb;
     }
 
+    if (haveE.securityLevel) {
+      wantE.securityLevel = haveE.securityLevel;
+    }
+
     maybeCopyTriggerRegion(wantE, haveE);
   }
 }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -205,7 +205,7 @@ export function inferDetailsFromExisting(
       wantE.availableMemoryMb = haveE.availableMemoryMb;
     }
 
-    wantE.securityLevel = (haveE.securityLevel) ? haveE.securityLevel : "SECURE_ALWAYS";
+    wantE.securityLevel = haveE.securityLevel ? haveE.securityLevel : "SECURE_ALWAYS";
 
     maybeCopyTriggerRegion(wantE, haveE);
   }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -205,9 +205,7 @@ export function inferDetailsFromExisting(
       wantE.availableMemoryMb = haveE.availableMemoryMb;
     }
 
-    if (haveE.securityLevel) {
-      wantE.securityLevel = haveE.securityLevel;
-    }
+    wantE.securityLevel = (haveE.securityLevel) ? haveE.securityLevel : "SECURE_ALWAYS";
 
     maybeCopyTriggerRegion(wantE, haveE);
   }

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -358,11 +358,9 @@ export async function updateFunction(
   const endpoint = `/${cloudFunction.name}`;
   // Keys in labels and environmentVariables are user defined, so we don't recurse
   // for field masks.
-  const fieldMasks = proto.fieldMasks(
-    cloudFunction,
-    /* doNotRecurseIn...=*/ "labels",
-    "environmentVariables"
-  );
+  const fieldMasks = proto
+    .fieldMasks(cloudFunction, /* doNotRecurseIn...=*/ "labels", "environmentVariables")
+    .filter((fm) => fm !== "httpsTrigger"); // TODO(colerogers): remove and set securityLevel in functionFromEndpoint during a breaking change
 
   // Failure policy is always an explicit policy and is only signified by the presence or absence of
   // a protobuf.Empty value, so we have to manually add it in the missing case.

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -356,11 +356,16 @@ export async function updateFunction(
   cloudFunction: Omit<CloudFunction, OutputOnlyFields>
 ): Promise<Operation> {
   const endpoint = `/${cloudFunction.name}`;
+  // TODO(colerogers): remove cloudFunctionWithoutHttpsTrigger and set securityLevel in functionFromEndpoint during a breaking change release
+  const cloudFunctionWithoutHttpsTrigger = { ...cloudFunction };
+  delete cloudFunctionWithoutHttpsTrigger.httpsTrigger;
   // Keys in labels and environmentVariables are user defined, so we don't recurse
   // for field masks.
-  const fieldMasks = proto
-    .fieldMasks(cloudFunction, /* doNotRecurseIn...=*/ "labels", "environmentVariables")
-    .filter((fm) => fm !== "httpsTrigger"); // TODO(colerogers): remove and set securityLevel in functionFromEndpoint during a breaking change
+  const fieldMasks = proto.fieldMasks(
+    cloudFunctionWithoutHttpsTrigger,
+    /* doNotRecurseIn...=*/ "labels",
+    "environmentVariables"
+  );
 
   // Failure policy is always an explicit policy and is only signified by the presence or absence of
   // a protobuf.Empty value, so we have to manually add it in the missing case.


### PR DESCRIPTION
Fixes #4171 by removing `httpsTrigger` from the field mask array on updates.

This is a patch bug fix that does not break currently deployed https functions. @inlined suggested changing `proto.fieldMasks` to ignore empty objects, but empty objects are needed for protobuf.Empty. When we introduce a breaking change, then we should either set the `securityLevel` in Fabricator's `updateV1Function` or directly in `functionFromEndpoint`.