### PR TITLE
Fix bug where environment variables for v2 functions weren't being updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes bug where updating gen 2 pubsub functions always failed (#4198).
 - Updates reserved environment variables for CF3 to include 'EVENTARC_CLOUD_EVENT_SOURCE' (#4196).
 - Fixes arg order for `firebase emulators:start --only storage` (#4195).
+- Fixes bug where environment variable for gen 2 functions weren't updated on deploy (#4209).

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -285,7 +285,7 @@ export async function getFunction(
  */
 export async function listFunctions(projectId: string, region: string): Promise<CloudFunction[]> {
   const res = await listFunctionsInternal(projectId, region);
-  if (res.unreachable!.includes(region)) {
+  if (res.unreachable.includes(region)) {
     throw new FirebaseError(`Cloud Functions region ${region} is unavailable`);
   }
   return res.functions;
@@ -333,9 +333,16 @@ async function listFunctionsInternal(
 export async function updateFunction(
   cloudFunction: Omit<CloudFunction, OutputOnlyFields>
 ): Promise<Operation> {
+  // Keys in labels and environmentVariables are user defined, so we don't recurse
+  // for field masks.
+  const fieldMasks = proto.fieldMasks(
+    cloudFunction,
+    /* doNotRecurseIn...=*/ "labels",
+    "serviceConfig.environmentVariables"
+  );
   try {
     const queryParams = {
-      updateMask: proto.fieldMasks(cloudFunction).join(","),
+      updateMask: fieldMasks.join(","),
     };
     const res = await client.patch<typeof cloudFunction, Operation>(
       cloudFunction.name,
@@ -472,7 +479,7 @@ export function endpointFromFunction(gcfFunction: CloudFunction): backend.Endpoi
   } else if (gcfFunction.eventTrigger) {
     trigger = {
       eventTrigger: {
-        eventType: gcfFunction.eventTrigger!.eventType,
+        eventType: gcfFunction.eventTrigger.eventType,
         eventFilters: {},
         retry: false,
       },


### PR DESCRIPTION
When calculating update mask for v2, we weren't properly accounting for the fact that the object holding environment variables should not be recursed.

Fixes https://github.com/firebase/firebase-tools/issues/4192