### PR TITLE
Adds CF3 triggers to listBackends endpoint

### DIFF
--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -644,7 +644,77 @@ describe("FunctionsEmulator-Hub", () => {
       .expect(200)
       .then((res) => {
         // TODO(b/216642962): Add tests for this endpoint that validate behavior when there are Extensions running
-        expect(res.body.backends).to.deep.equal([{ env: {}, functionTriggers: [] }]);
+        expect(res.body.backends).to.deep.equal([
+          {
+            env: {},
+            functionTriggers: [
+              {
+                entryPoint: "function_id",
+                httpsTrigger: {},
+                id: "us-central1-function_id",
+                labels: {},
+                name: "function_id",
+                platform: "gcfv1",
+                region: "us-central1",
+              },
+              {
+                entryPoint: "function_id",
+                httpsTrigger: {},
+                id: "europe-west2-function_id",
+                labels: {},
+                name: "function_id",
+                platform: "gcfv1",
+                region: "europe-west2",
+              },
+              {
+                entryPoint: "function_id",
+                httpsTrigger: {},
+                id: "europe-west3-function_id",
+                labels: {},
+                name: "function_id",
+                platform: "gcfv1",
+                region: "europe-west3",
+              },
+              {
+                entryPoint: "callable_function_id",
+                httpsTrigger: {},
+                id: "us-central1-callable_function_id",
+                labels: {
+                  "deployment-callable": "true",
+                },
+                name: "callable_function_id",
+                platform: "gcfv1",
+                region: "us-central1",
+              },
+              {
+                entryPoint: "nested.function_id",
+                httpsTrigger: {},
+                id: "us-central1-nested-function_id",
+                labels: {},
+                name: "nested-function_id",
+                platform: "gcfv1",
+                region: "us-central1",
+              },
+              {
+                entryPoint: "secrets_function_id",
+                httpsTrigger: {},
+                id: "us-central1-secrets_function_id",
+                labels: {},
+                name: "secrets_function_id",
+                platform: "gcfv1",
+                region: "us-central1",
+                secretEnvironmentVariables: [
+                  {
+                    key: "MY_SECRET",
+                    projectId: "fake-project-id",
+                    secret: "MY_SECRET",
+                    version: "1",
+                  },
+                ],
+              },
+            ],
+          },
+        ]);
       });
   }).timeout(TIMEOUT_LONG);
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -808,14 +808,15 @@ export class FunctionsEmulator implements EmulatorInstance {
   }
 
   getBackendInfo(): BackendInfo[] {
+    const cf3Triggers = Object.values(this.triggers)
+      .filter((t) => !t.backend.extensionInstanceId)
+      .map((t) => t.def);
     return this.args.emulatableBackends.map((e: EmulatableBackend) => {
       return {
         env: e.env,
         extensionInstanceId: e.extensionInstanceId,
         extensionVersion: e.extensionVersion,
-        functionTriggers: e.predefinedTriggers ?? [],
-        // TODO: Right now, functionTriggers will be an empty list for CF3 backends.
-        // We need to figure out how to expose the loaded triggers here here.
+        functionTriggers: e.predefinedTriggers || cf3Triggers,
       };
     });
   }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -816,7 +816,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         env: e.env,
         extensionInstanceId: e.extensionInstanceId,
         extensionVersion: e.extensionVersion,
-        functionTriggers: e.predefinedTriggers || cf3Triggers,
+        functionTriggers: e.predefinedTriggers ?? cf3Triggers,
       };
     });
   }


### PR DESCRIPTION
### Description
Exposes CF3 triggers through the list backends endpoint, so the Emulator UI can get a list of all running functions.

### Scenarios Tested
I spun up the emulator with some Extensions and CF3 functions, and confirmed that /backends was returning the expected results.
