### PR TITLE
Fix Storage Emulator rules resource evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Updates reserved environment variables for CF3 to include 'EVENTARC_CLOUD_EVENT_SOURCE' (#4196).
 - Fixes arg order for `firebase emulators:start --only storage` (#4195).
+- Fixes Storage Emulator rules resource evaluation (#4214).

--- a/scripts/storage-emulator-integration/storage.rules
+++ b/scripts/storage-emulator-integration/storage.rules
@@ -3,7 +3,7 @@ service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
       allow read, create, update: if request.auth != null;
-      allow delete: if request.auth != null && resource.name != null;
+      allow delete: if request.auth != null && resource.contentType != 'text/plain';
     }
 
     match /public/{allPaths=**} {

--- a/scripts/storage-emulator-integration/storage.rules
+++ b/scripts/storage-emulator-integration/storage.rules
@@ -2,7 +2,8 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      allow read, write: if request.auth != null;
+      allow read, create, update: if request.auth != null;
+      allow delete: if request.auth != null && resource.name != null;
     }
 
     match /public/{allPaths=**} {

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -1187,30 +1187,46 @@ describe("Storage emulator", () => {
         });
       });
 
-      it("#delete()", async () => {
-        const downloadUrl = await page.evaluate((filename) => {
-          return firebase.storage().ref(filename).getDownloadURL();
-        }, filename);
+      describe("deleteFile", () => {
+        it("should delete file", async () => {
+          await page.evaluate((filename) => {
+            return firebase.storage().ref(filename).delete();
+          }, filename);
 
-        expect(downloadUrl).to.be.not.null;
+          const error = await page.evaluate((filename) => {
+            return new Promise((resolve) => {
+              firebase
+                .storage()
+                .ref(filename)
+                .getDownloadURL()
+                .catch((err) => {
+                  resolve(err.message);
+                });
+            });
+          }, filename);
 
-        await page.evaluate((filename) => {
-          return firebase.storage().ref(filename).delete();
-        }, filename);
+          expect(error).to.contain("does not exist.");
+        });
 
-        const error = await page.evaluate((filename) => {
-          return new Promise((resolve) => {
-            firebase
-              .storage()
-              .ref(filename)
-              .getDownloadURL()
-              .catch((err) => {
-                resolve(err.message);
-              });
-          });
-        }, filename);
+        it("should not delete file when security rule on resource object disallows it", async () => {
+          await page.evaluate((filename) => {
+            firebase.storage().ref(filename).updateMetadata({ contentType: "text/plain" });
+          }, filename);
 
-        expect(error).to.contain("does not exist.");
+          const error = await page.evaluate((filename) => {
+            return new Promise((resolve) => {
+              firebase
+                .storage()
+                .ref(filename)
+                .delete()
+                .catch((err) => {
+                  resolve(err.message);
+                });
+            });
+          }, filename);
+
+          expect(error).to.contain("does not have permission to access");
+        });
       });
     });
 

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -591,6 +591,13 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
   firebaseStorageAPI.delete("/b/:bucketId/o/:objectId", async (req, res) => {
     const decodedObjectId = decodeURIComponent(req.params.objectId);
     const operationPath = ["b", req.params.bucketId, "o", decodedObjectId].join("/");
+    const md = storageLayer.getMetadata(req.params.bucketId, decodedObjectId);
+
+    const rulesFiles: { before?: RulesResourceMetadata } = {};
+
+    if (md) {
+      rulesFiles.before = md.asRulesResource();
+    }
 
     if (
       !(await isPermitted({
@@ -598,9 +605,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
         method: RulesetOperationMethod.DELETE,
         path: operationPath,
         authorization: req.header("authorization"),
-        file: {
-          // TODO load before metadata
-        },
+        file: rulesFiles,
       }))
     ) {
       return res.status(403).json({
@@ -610,8 +615,6 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
         },
       });
     }
-
-    const md = storageLayer.getMetadata(req.params.bucketId, decodedObjectId);
 
     if (!md) {
       res.sendStatus(404);


### PR DESCRIPTION
### Description
#### Issue
Fixes #3760.

The `resource` object was not being evaluated correctly in security rules for the Storage Emulator. An `EvaluationException` is thrown and the user receives a null value error. Moreover, the corresponding rule is not enforced.

#### Cause
The file metadata corresponding to the `resource` object was not being passed to the evaluator binary.

### Scenarios Tested
Added additional security rule evaluating `resource` and verified that existing integration tests now pass with the fix.