### PR TITLE
Add void in front of unawaited promises to remove lint errors

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -469,7 +469,7 @@ async function loginRemotely(userHint?: string): Promise<UserCredentials> {
       codeVerifier
     );
 
-    track("login", "google_remote");
+    void track("login", "google_remote");
 
     return {
       user: jwt.decode(tokens.id_token!) as User,
@@ -493,7 +493,7 @@ async function loginWithLocalhostGoogle(port: number, userHint?: string): Promis
     getTokensFromAuthorizationCode
   );
 
-  track("login", "google_localhost");
+  void track("login", "google_localhost");
   // getTokensFromAuthoirzationCode doesn't handle the --token case, so we know we'll
   // always have an id_token.
   return {
@@ -514,7 +514,7 @@ async function loginWithLocalhostGitHub(port: number): Promise<string> {
     successTemplate,
     getGithubTokensFromAuthorizationCode
   );
-  track("login", "google_localhost");
+  void track("login", "google_localhost");
   return tokens;
 }
 

--- a/src/command.ts
+++ b/src/command.ts
@@ -195,7 +195,7 @@ export class Command {
             );
           }
           const duration = new Date().getTime() - start;
-          track(this.name, "success", duration).then(() => process.exit());
+          void track(this.name, "success", duration).then(() => process.exit());
         })
         .catch(async (err) => {
           if (getInheritedOption(options, "json")) {

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -95,7 +95,7 @@ export async function checkHttpIam(
   }
 
   if (!passed) {
-    track("Error (User)", "deploy:functions:http_create_missing_iam");
+    void track("Error (User)", "deploy:functions:http_create_missing_iam");
     throw new FirebaseError(
       `Missing required permission on project ${bold(
         context.projectId

--- a/src/deploy/functions/ensure.ts
+++ b/src/deploy/functions/ensure.ts
@@ -30,7 +30,7 @@ export async function defaultServiceAccount(e: backend.Endpoint): Promise<string
 }
 
 function nodeBillingError(projectId: string): FirebaseError {
-  track("functions_runtime_notices", "nodejs10_billing_error");
+  void track("functions_runtime_notices", "nodejs10_billing_error");
   return new FirebaseError(
     `Cloud Functions deployment requires the pay-as-you-go (Blaze) billing plan. To upgrade your project, visit the following URL:
       
@@ -44,7 +44,7 @@ ${FAQ_URL}`,
 }
 
 function nodePermissionError(projectId: string): FirebaseError {
-  track("functions_runtime_notices", "nodejs10_permission_error");
+  void track("functions_runtime_notices", "nodejs10_permission_error");
   return new FirebaseError(`Cloud Functions deployment requires the Cloud Build API to be enabled. The current credentials do not have permission to enable APIs for project ${clc.bold(
     projectId
   )}.

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -93,7 +93,7 @@ export async function prepare(
     : usedDotenv
     ? "dotenv"
     : "none";
-  await track("functions_codebase_deploy_env_method", tag);
+  void track("functions_codebase_deploy_env_method", tag);
 
   logger.debug(`Analyzing ${runtimeDelegate.name} backend spec`);
   const wantBackend = await runtimeDelegate.discoverSpec(runtimeConfig, firebaseEnvs);

--- a/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
+++ b/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
@@ -79,7 +79,7 @@ export function getRuntimeChoice(sourceDir: string, runtimeFromConfig?: string):
       : UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG) + DEPRECATED_NODE_VERSION_INFO;
 
   if (!runtime || !ENGINE_RUNTIMES_NAMES.includes(runtime)) {
-    track("functions_runtime_notices", "package_missing_runtime");
+    void track("functions_runtime_notices", "package_missing_runtime");
     throw new FirebaseError(errorMessage, { exit: 1 });
   }
 
@@ -87,7 +87,7 @@ export function getRuntimeChoice(sourceDir: string, runtimeFromConfig?: string):
   // it's in ENGINE_RUNTIME_NAMES and not in DEPRECATED_RUNTIMES. This is still a
   // good defense in depth and also lets us upcast the response to Runtime safely.
   if (runtimes.isDeprecatedRuntime(runtime) || !runtimes.isValidRuntime(runtime)) {
-    track("functions_runtime_notices", `${runtime}_deploy_prohibited`);
+    void track("functions_runtime_notices", `${runtime}_deploy_prohibited`);
     throw new FirebaseError(errorMessage, { exit: 1 });
   }
 

--- a/src/deploy/functions/runtimes/node/versioning.ts
+++ b/src/deploy/functions/runtimes/node/versioning.ts
@@ -85,7 +85,7 @@ export function getLatestSDKVersion(): string | undefined {
 export function checkFunctionsSDKVersion(currentVersion: string): void {
   try {
     if (semver.lt(currentVersion, MIN_SDK_VERSION)) {
-      track("functions_runtime_notices", "functions_sdk_too_old");
+      void track("functions_runtime_notices", "functions_sdk_too_old");
       utils.logWarning(FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
     }
 

--- a/src/deploy/hosting/deploy.ts
+++ b/src/deploy/hosting/deploy.ts
@@ -83,7 +83,7 @@ export async function deploy(
     try {
       await uploader.start();
     } catch (err: any) {
-      track("Hosting Deploy", "failure");
+      void track("Hosting Deploy", "failure");
       throw err;
     } finally {
       clearInterval(progressInterval);
@@ -97,7 +97,7 @@ export async function deploy(
     const dt = Date.now() - t0;
     logger.debug("[hosting] deploy completed after " + dt + "ms");
 
-    track("Hosting Deploy", "success", dt);
+    void track("Hosting Deploy", "success", dt);
     return runDeploys(deploys, debugging);
   }
 

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -139,7 +139,7 @@ export async function startEmulator(instance: EmulatorInstance): Promise<void> {
   const name = instance.getName();
 
   // Log the command for analytics
-  track("Emulator Run", name);
+  void track("Emulator Run", name);
 
   await EmulatorRegistry.start(instance);
 }
@@ -396,7 +396,7 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
     // since we originally mistakenly reported emulators:start events
     // for each emulator, by reporting the "hub" we ensure that our
     // historical data can still be viewed.
-    track("emulators:start", "hub");
+    void track("emulators:start", "hub");
     await startEmulator(hub);
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1263,7 +1263,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       });
 
       // For analytics, track the invoked service
-      track(EVENT_INVOKE, getFunctionService(trigger));
+      void track(EVENT_INVOKE, getFunctionService(trigger));
 
       worker.waitForDone().then(() => {
         resolve({ status: "acknowledged" });
@@ -1377,7 +1377,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     // Wait for the worker to set up its internal HTTP server
     await worker.waitForSocketReady();
 
-    track(EVENT_INVOKE, "https");
+    void track(EVENT_INVOKE, "https");
 
     this.logger.log("DEBUG", `[functions] Runtime ready! Sending request!`);
 

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -93,7 +93,7 @@ export async function getParams(args: {
       !!args.reconfiguring
     );
   }
-  track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
+  void track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
   return params;
 }
 
@@ -134,7 +134,7 @@ export async function getParamsForUpdate(args: {
       instanceId: args.instanceId,
     });
   }
-  track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
+  void track("Extension Params", _.isEmpty(params) ? "Not Present" : "Present", _.size(params));
   return params;
 }
 
@@ -207,9 +207,9 @@ export function getParamsFromFile(args: {
   let envParams;
   try {
     envParams = readEnvFile(args.paramsEnvPath);
-    track("Extension Env File", "Present");
+    void track("Extension Env File", "Present");
   } catch (err: any) {
-    track("Extension Env File", "Invalid");
+    void track("Extension Env File", "Invalid");
     throw new FirebaseError(`Error reading env file: ${err.message}\n`, { original: err });
   }
   const params = populateDefaultParams(envParams, args.paramSpecs);


### PR DESCRIPTION
In an async context, it is normally expected that all promises are awaited, and that is the basis of the lint. However, there are times where one or more promises are intentionally not awaited. 

This in case, while 'track' returns a promise, the consumers of the commands that use track are unlikely to want to wait for that promise to complete. They only care about the command they are running.