### PR TITLE
Better error handling on silently failing source uploads

### DIFF
--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -490,7 +490,9 @@ export async function publishExtensionVersionFromLocalSource(args: {
     packageUri = storageOrigin + objectPath + "?alt=media";
   } catch (err: any) {
     uploadSpinner.fail();
-    throw err;
+    throw new FirebaseError(`Failed to archive and upload extension source, ${err}`, {
+      original: err,
+    });
   }
   const publishSpinner = ora(`Publishing ${clc.bold(ref)}`);
   let res;
@@ -538,7 +540,9 @@ export async function createSourceFromLocation(
       extensionRoot = "/";
     } catch (err: any) {
       uploadSpinner.fail();
-      throw err;
+      throw new FirebaseError(`Failed to archive and upload extension source, ${err}`, {
+        original: err,
+      });
     }
   } else {
     [packageUri, extensionRoot] = sourceUri.split("#");


### PR DESCRIPTION
Before
```
lihes-macbookpro2:delete-user-data lihes$ firebase ext:dev:publish lihes-test/delete-user-data
You are about to publish version 0.1.12 of lihes-test/delete-user-data to Firebase's registry of extensions. Release notes for this version:
fixed - updated dependencies


Once an extension version is published, it cannot be changed. If you wish to make changes after publishing, you will need to publish a new version.


? Do you wish to continue? Yes
✖  Archiving and uploading extension source code

Error: Unable to parse JSON: SyntaxError: Unexpected token < in JSON at position 0

Having trouble? Try firebase [command] --help

```

After

```
lihes-macbookpro2:rtdb-limit-child-nodes lihes$ firebase ext:dev:publish lihes-test/rtdb-limit-child-nodes
You are about to publish version 0.1.5 of lihes-test/rtdb-limit-child-nodes to Firebase's registry of extensions. Release notes for this version:
feature - add Taiwan and Singapore Cloud Function locations (#729)


Once an extension version is published, it cannot be changed. If you wish to make changes after publishing, you will need to publish a new version.


? Do you wish to continue? Yes
✖  Archiving and uploading extension source code

Error: Failed to archive and upload extension source, Error: Unable to parse JSON: SyntaxError: Unexpected token < in JSON at position 0

Having trouble? Try firebase [command] --help
lihes-macbookpro2:rtdb-limit-child-nodes lihes$ 
```