### PR TITLE
Changing backendInfo to include extension & support local Extensions …

### DIFF
--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -6,6 +6,7 @@ import * as sinon from "sinon";
 import * as supertest from "supertest";
 import * as winston from "winston";
 import * as logform from "logform";
+import * as path from "path";
 
 import { EmulatedTriggerDefinition } from "../../src/emulator/functionsEmulatorShared";
 import {
@@ -644,8 +645,10 @@ describe("FunctionsEmulator-Hub", () => {
       .expect(200)
       .then((res) => {
         // TODO(b/216642962): Add tests for this endpoint that validate behavior when there are Extensions running
+        const expectedDirectory = path.resolve(`${__dirname}/../..`);
         expect(res.body.backends).to.deep.equal([
           {
+            directory: expectedDirectory,
             env: {},
             functionTriggers: [
               {

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -139,12 +139,14 @@ export class ExtensionsEmulator {
     const extensionDir = await this.ensureSourceCode(instance);
     // TODO: This should find package.json, then use that as functionsDir.
     const functionsDir = path.join(extensionDir, "functions");
+    // TODO(b/213335255): For local extensions, this should include extensionSpec instead of extensionVersion
     const env = Object.assign(this.autoPopulatedParams(instance), instance.params);
     const { extensionTriggers, nodeMajorVersion } = await getExtensionFunctionInfo(
       extensionDir,
       instance.instanceId,
       env
     );
+    const extension = await planner.getExtension(instance);
     const extensionVersion = await planner.getExtensionVersion(instance);
     return {
       functionsDir,
@@ -152,6 +154,7 @@ export class ExtensionsEmulator {
       predefinedTriggers: extensionTriggers,
       nodeMajorVersion: nodeMajorVersion,
       extensionInstanceId: instance.instanceId,
+      extension,
       extensionVersion,
     };
   }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -57,7 +57,7 @@ import {
 } from "./adminSdkConfig";
 import { EventUtils } from "./events/types";
 import { functionIdsAreValid } from "../deploy/functions/validate";
-import { ExtensionVersion } from "../extensions/extensionsApi";
+import { Extension, ExtensionSpec, ExtensionVersion } from "../extensions/extensionsApi";
 import { getRuntimeDelegate } from "../deploy/functions/runtimes";
 import * as backend from "../deploy/functions/backend";
 import * as functionsEnv from "../functions/env";
@@ -89,17 +89,22 @@ export interface EmulatableBackend {
   nodeMajorVersion?: number;
   nodeBinary?: string;
   extensionInstanceId?: string;
-  extensionVersion?: ExtensionVersion;
+  extension?: Extension; // Only present for published extensions
+  extensionVersion?: ExtensionVersion; // Only present for published extensions
+  extensionSpec?: ExtensionSpec; // Only present for local extensions
 }
 
 /**
  * BackendInfo is an API type used by the Emulator UI containing info about an Extension or CF3 module.
  */
 export interface BackendInfo {
+  directory: string;
   env: Record<string, string>;
   functionTriggers: ParsedTriggerDefinition[];
   extensionInstanceId?: string;
-  extensionVersion?: ExtensionVersion;
+  extension?: Extension; // Only present for published extensions
+  extensionVersion?: ExtensionVersion; // Only present for published extensions
+  extensionSpec?: ExtensionSpec; // Only present for local extensions
 }
 
 export interface FunctionsEmulatorArgs {
@@ -813,10 +818,13 @@ export class FunctionsEmulator implements EmulatorInstance {
       .map((t) => t.def);
     return this.args.emulatableBackends.map((e: EmulatableBackend) => {
       return {
+        directory: e.functionsDir,
         env: e.env,
-        extensionInstanceId: e.extensionInstanceId,
-        extensionVersion: e.extensionVersion,
-        functionTriggers: e.predefinedTriggers ?? cf3Triggers,
+        extensionInstanceId: e.extensionInstanceId, // Present on all extensions
+        extension: e.extension, // Only present on published extensions
+        extensionVersion: e.extensionVersion, // Only present on published extensions
+        extensionSpec: e.extensionSpec, // Only present on local extensions
+        functionTriggers: e.predefinedTriggers ?? cf3Triggers, // If we don't have predefinedTriggers, this is the CF3 backend.
       };
     });
   }

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -2,8 +2,21 @@ import { expect } from "chai";
 
 import { ExtensionsEmulator } from "../../emulator/extensionsEmulator";
 import { EmulatableBackend } from "../../emulator/functionsEmulator";
-import { ExtensionVersion } from "../../extensions/extensionsApi";
+import {
+  Extension,
+  ExtensionVersion,
+  RegistryLaunchStage,
+  Visibility,
+} from "../../extensions/extensionsApi";
 import * as planner from "../../deploy/extensions/planner";
+
+const TEST_EXTENSION: Extension = {
+  name: "publishers/firebase/extensions/storage-resize-images",
+  ref: "firebase/storage-resize-images",
+  visibility: Visibility.PUBLIC,
+  registryLaunchStage: RegistryLaunchStage.BETA,
+  createTime: "0",
+};
 
 const TEST_EXTENSION_VERSION: ExtensionVersion = {
   name: "publishers/firebase/extensions/storage-resize-images/versions/0.1.18",
@@ -47,6 +60,7 @@ describe("Extensions Emulator", () => {
           params: {
             LOCATION: "us-west1",
           },
+          extension: TEST_EXTENSION,
           extensionVersion: TEST_EXTENSION_VERSION,
         },
         expected: {
@@ -75,6 +89,7 @@ describe("Extensions Emulator", () => {
               regions: ["us-west1"],
             },
           ],
+          extension: TEST_EXTENSION,
           extensionVersion: TEST_EXTENSION_VERSION,
         },
       },


### PR DESCRIPTION
### Description
Changing backendInfo to include directory & extension & support local Extensions in the future, per go/firex-list-backends-api.

### Scenarios Tested
I verified that localhost:5001/backends was returning the new fields too: 
<img width="1106" alt="Screen Shot 2022-02-24 at 10 22 20 AM" src="https://user-images.githubusercontent.com/4635763/155588133-d8248bfd-bb99-4fee-be63-faee8be1c9aa.png">
