### PR TITLE
Adding extensions to emulatorRegistry

### DIFF
--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -3,7 +3,6 @@ import * as clc from "cli-color";
 import * as fs from "fs";
 import * as path from "path";
 
-import { Config } from "../config";
 import { logger } from "../logger";
 import * as track from "../track";
 import * as utils from "../utils";
@@ -460,6 +459,10 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
     });
     const extensionsBackends = await extensionEmulator.getExtensionBackends();
     emulatableBackends.push(...extensionsBackends);
+
+    // Log the command for analytics
+    void track("Emulator Run", Emulators.EXTENSIONS);
+    EmulatorRegistry.registerExtensionsEmulator();
   }
 
   if (emulatableBackends.length) {

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -81,9 +81,12 @@ export class EmulatorHub implements EmulatorInstance {
 
     this.hub.get(EmulatorHub.PATH_EMULATORS, (req, res) => {
       const body: GetEmulatorsResponse = {};
-      EmulatorRegistry.listRunning().forEach((name) => {
-        body[name] = EmulatorRegistry.get(name)!.getInfo();
-      });
+      for (const emulator of EmulatorRegistry.listRunning()) {
+        const info = EmulatorRegistry.getInfo(emulator);
+        if (info) {
+          body[emulator] = info;
+        }
+      }
       res.json(body);
     });
 

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -11,6 +11,8 @@ import { EmulatorLogger } from "./emulatorLogger";
  * through the start() and stop() methods which ensures correctness.
  */
 export class EmulatorRegistry {
+  private static extensionsEmulatorRegistered: boolean = false;
+
   static async start(instance: EmulatorInstance): Promise<void> {
     const description = Constants.description(instance.getName());
     if (this.isRunning(instance.getName())) {
@@ -25,6 +27,10 @@ export class EmulatorRegistry {
 
     const info = instance.getInfo();
     await portUtils.waitForPortClosed(info.port, info.host);
+  }
+
+  static registerExtensionsEmulator(): void {
+    this.extensionsEmulatorRegistered = true;
   }
 
   static async stop(name: Emulators): Promise<void> {
@@ -92,6 +98,11 @@ export class EmulatorRegistry {
   }
 
   static isRunning(emulator: Emulators): boolean {
+    if (emulator === Emulators.EXTENSIONS) {
+      return (
+        this.extensionsEmulatorRegistered && this.INSTANCES.get(Emulators.FUNCTIONS) !== undefined
+      );
+    }
     const instance = this.INSTANCES.get(emulator);
     return instance !== undefined;
   }
@@ -111,7 +122,10 @@ export class EmulatorRegistry {
   }
 
   static getInfo(emulator: Emulators): EmulatorInfo | undefined {
-    const instance = this.INSTANCES.get(emulator);
+    // For Extensions, return the info for the Functions Emulator.
+    const instance = this.INSTANCES.get(
+      emulator === Emulators.EXTENSIONS ? Emulators.FUNCTIONS : emulator
+    );
     if (!instance) {
       return undefined;
     }

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -76,6 +76,7 @@ export const ALL_EMULATORS = [
   Emulators.HUB,
   Emulators.UI,
   Emulators.LOGGING,
+  Emulators.EXTENSIONS,
   ...ALL_SERVICE_EMULATORS,
 ];
 


### PR DESCRIPTION
### Description
Adds extensions emulator to emulator registry so that it is returned from http://localhost:{hubPort}/emulators. Since the Extensions emulator is part of the functions emulator under the hood, this endpoint will return the same info for both.

### Scenarios Tested
Verified that extensions is returned from /emulators when the Extensions emulator is running, and that the emulators cleanly start up and shut down.
<img width="1106" alt="Screen Shot 2022-02-24 at 10 22 20 AM" src="https://user-images.githubusercontent.com/4635763/155622496-af914798-774d-4738-8688-76947a1c1bb6.png">

