### PR TITLE
Add --local flag to ext:uninstall command.

### DIFF
--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -66,7 +66,7 @@ export default new Command("ext:install [extensionName]")
   .before(diagnoseAndFixProject)
   .action(async (extensionName: string, options: Options) => {
     const projectId = needProjectId(options);
-    const paramsEnvPath = (options.params ?? {}) as string;
+    const paramsEnvPath = (options.params ?? "") as string;
     let learnMore = false;
     if (!extensionName) {
       if (options.interactive) {

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -33,7 +33,7 @@ export default new Command("ext:uninstall <extensionInstanceId>")
   .withForce()
   .option(
     "--local",
-    "remove from firebase.json rather than directly uninstall at a Firebase project"
+    "remove from firebase.json rather than directly uninstall from a Firebase project"
   )
   .before(requirePermissions, ["firebaseextensions.instances.delete"])
   .before(ensureExtensionsApiEnabled)

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -21,6 +21,8 @@ import { promptOnce } from "../prompt";
 import { requirePermissions } from "../requirePermissions";
 import * as utils from "../utils";
 import { logger } from "../logger";
+import * as manifest from "../extensions/manifest";
+import { Options } from "../options";
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -29,14 +31,21 @@ marked.setOptions({
 export default new Command("ext:uninstall <extensionInstanceId>")
   .description("uninstall an extension that is installed in your Firebase project by instance ID")
   .withForce()
+  .option("--local", "remove from firebase.json rather than directly uninstall at a Firebase project")
   .before(requirePermissions, ["firebaseextensions.instances.delete"])
   .before(ensureExtensionsApiEnabled)
   .before(checkMinRequiredVersion, "extMinVersion")
   .before(diagnoseAndFixProject)
-  .action(async (instanceId: string, options: any) => {
+  .action(async (instanceId: string, options: Options) => {  
+    if (options.local) {
+      const config = manifest.loadConfig(options);
+      manifest.removeFromManifest(instanceId, config);
+      return;
+    }
+    
+    // TODO(b/220900194): Remove everything below and make --local the default behavior.
     const projectId = needProjectId(options);
     let instance;
-
     try {
       instance = await extensionsApi.getInstance(projectId, instanceId);
     } catch (err: any) {

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -31,18 +31,21 @@ marked.setOptions({
 export default new Command("ext:uninstall <extensionInstanceId>")
   .description("uninstall an extension that is installed in your Firebase project by instance ID")
   .withForce()
-  .option("--local", "remove from firebase.json rather than directly uninstall at a Firebase project")
+  .option(
+    "--local",
+    "remove from firebase.json rather than directly uninstall at a Firebase project"
+  )
   .before(requirePermissions, ["firebaseextensions.instances.delete"])
   .before(ensureExtensionsApiEnabled)
   .before(checkMinRequiredVersion, "extMinVersion")
   .before(diagnoseAndFixProject)
-  .action(async (instanceId: string, options: Options) => {  
+  .action(async (instanceId: string, options: Options) => {
     if (options.local) {
       const config = manifest.loadConfig(options);
       manifest.removeFromManifest(instanceId, config);
       return;
     }
-    
+
     // TODO(b/220900194): Remove everything below and make --local the default behavior.
     const projectId = needProjectId(options);
     let instance;

--- a/src/config.ts
+++ b/src/config.ts
@@ -203,6 +203,10 @@ export class Config {
     fs.writeFileSync(this.path(p), content, "utf8");
   }
 
+  deleteProjectFile(p: string) {
+    fs.removeSync(this.path(p));
+  }
+
   askWriteProjectFile(p: string, content: any, force?: boolean) {
     const writeTo = this.path(p);
     let next;

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -59,14 +59,9 @@ export async function writeToManifest(
 /**
  * Remove an instance from extensions manifest.
  */
- export function removeFromManifest(
-  instanceId: string,
-  config: Config,
-) {
+export function removeFromManifest(instanceId: string, config: Config) {
   if (!instanceExists(instanceId, config)) {
-    throw new FirebaseError(
-      `Extension instance ${instanceId} not found in firebase.json.`
-    );
+    throw new FirebaseError(`Extension instance ${instanceId} not found in firebase.json.`);
   }
 
   const extensions = config.get("extensions", {});

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -56,11 +56,34 @@ export async function writeToManifest(
   await writeEnvFiles(specs, config, options.force);
 }
 
+/**
+ * Remove an instance from extensions manifest.
+ */
+ export function removeFromManifest(
+  instanceId: string,
+  config: Config,
+) {
+  if (!instanceExists(instanceId, config)) {
+    throw new FirebaseError(
+      `Extension instance ${instanceId} not found in firebase.json.`
+    );
+  }
+
+  const extensions = config.get("extensions", {});
+  extensions[instanceId] = undefined;
+  config.set("extensions", extensions);
+  config.writeProjectFile("firebase.json", config.src);
+  logger.info(`Removed extension instance ${instanceId} from firebase.json`);
+
+  config.deleteProjectFile(`extensions/${instanceId}.env`);
+  logger.info(`Removed extension instance environment config extensions/${instanceId}.env`);
+}
+
 export function loadConfig(options: any): Config {
   const existingConfig = Config.load(options, true);
   if (!existingConfig) {
     throw new FirebaseError(
-      "Not currently in a Firebase directory. Please run `firebase init` to create a Firebase directory."
+      "Not currently in a Firebase directory. Run `firebase init` to create a Firebase directory."
     );
   }
   return existingConfig;

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -72,6 +72,9 @@ export function removeFromManifest(instanceId: string, config: Config) {
 
   config.deleteProjectFile(`extensions/${instanceId}.env`);
   logger.info(`Removed extension instance environment config extensions/${instanceId}.env`);
+  config.deleteProjectFile(`extensions/${instanceId}.env.local`);
+  logger.info(`Removed extension instance environment config extensions/${instanceId}.env.local`);
+  // TODO(lihes): Remove all project specific env files.
 }
 
 export function loadConfig(options: any): Config {

--- a/src/test/extensions/manifest.spec.ts
+++ b/src/test/extensions/manifest.spec.ts
@@ -76,7 +76,7 @@ describe("manifest", () => {
       sandbox.restore();
     });
 
-    it("should remove form firebase.json and remove .env file", () => {
+    it("should remove from firebase.json and remove .env file", () => {
       const result = manifest.removeFromManifest("delete-user-data", generateBaseConfig());
 
       expect(writeProjectFileStub).calledWithExactly("firebase.json", {

--- a/src/test/extensions/manifest.spec.ts
+++ b/src/test/extensions/manifest.spec.ts
@@ -10,44 +10,43 @@ import * as prompt from "../../prompt";
 import { FirebaseError } from "../../error";
 
 /**
- * Returns a base config in firebase.json style.
+ * Returns a base Config with some extensions data.
  *
- * This cannot be a constant because Config edits in-place and mutates
+ * The inner content cannot be a constant because Config edits in-place and mutates
  * the state between tests.
  */
-function baseConfigFactory() {
-  return {
-    extensions: {
-      "delete-user-data": "firebase/delete-user-data@0.1.12",
-      "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
+function generateBaseConfig(): Config {
+  return new Config(
+    {
+      extensions: {
+        "delete-user-data": "firebase/delete-user-data@0.1.12",
+        "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
+      },
     },
-  };
+    {}
+  );
 }
 
 describe("manifest", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
 
   describe(`${manifest.instanceExists.name}`, () => {
-    const config = new Config(baseConfigFactory(), {});
-
     it("should return true for an existing instance", () => {
-      const result = manifest.instanceExists("delete-user-data", config);
+      const result = manifest.instanceExists("delete-user-data", generateBaseConfig());
 
       expect(result).to.be.true;
     });
 
     it("should return false for a non-existing instance", () => {
-      const result = manifest.instanceExists("does-not-exist", config);
+      const result = manifest.instanceExists("does-not-exist", generateBaseConfig());
 
       expect(result).to.be.false;
     });
   });
 
   describe(`${manifest.getInstanceRef.name}`, () => {
-    const config = new Config(baseConfigFactory(), {});
-
     it("should return the correct ref for an existing instance", () => {
-      const result = manifest.getInstanceRef("delete-user-data", config);
+      const result = manifest.getInstanceRef("delete-user-data", generateBaseConfig());
 
       expect(refs.toExtensionVersionRef(result)).to.equal(
         refs.toExtensionVersionRef({
@@ -59,13 +58,13 @@ describe("manifest", () => {
     });
 
     it("should throw when looking for a non-existing instance", () => {
-      expect(() => manifest.getInstanceRef("does-not-exist", config)).to.throw(FirebaseError);
+      expect(() => manifest.getInstanceRef("does-not-exist", generateBaseConfig())).to.throw(
+        FirebaseError
+      );
     });
   });
 
   describe(`${manifest.removeFromManifest.name}`, () => {
-    const config = new Config(baseConfigFactory(), {});
-
     let deleteProjectFileStub: sinon.SinonStub;
     let writeProjectFileStub: sinon.SinonStub;
     beforeEach(() => {
@@ -78,7 +77,7 @@ describe("manifest", () => {
     });
 
     it("should remove form firebase.json and remove .env file", () => {
-      const result = manifest.removeFromManifest("delete-user-data", config);
+      const result = manifest.removeFromManifest("delete-user-data", generateBaseConfig());
 
       expect(writeProjectFileStub).calledWithExactly("firebase.json", {
         extensions: {
@@ -92,8 +91,6 @@ describe("manifest", () => {
   });
 
   describe(`${manifest.writeToManifest.name}`, () => {
-    const config = new Config(baseConfigFactory(), {});
-
     let askWriteProjectFileStub: sinon.SinonStub;
     let writeProjectFileStub: sinon.SinonStub;
     beforeEach(() => {
@@ -127,7 +124,7 @@ describe("manifest", () => {
             params: { a: "eevee", b: "squirtle" },
           },
         ],
-        config,
+        generateBaseConfig(),
         { nonInteractive: false, force: false }
       );
       expect(writeProjectFileStub).calledWithExactly("firebase.json", {
@@ -177,7 +174,7 @@ describe("manifest", () => {
             params: { a: "eevee", b: "squirtle" },
           },
         ],
-        config,
+        generateBaseConfig(),
         { nonInteractive: false, force: false },
         true /** allowOverwrite */
       );

--- a/src/test/extensions/manifest.spec.ts
+++ b/src/test/extensions/manifest.spec.ts
@@ -9,18 +9,26 @@ import { Config } from "../../config";
 import * as prompt from "../../prompt";
 import { FirebaseError } from "../../error";
 
-const BASE_CONFIG_CONTENT = {
-  extensions: {
-    "delete-user-data": "firebase/delete-user-data@0.1.12",
-    "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
-  },
-};
+/**
+ * Returns a base config in firebase.json style.
+ *
+ * This cannot be a constant because Config edits in-place and mutates
+ * the state between tests.
+ */
+function baseConfigFactory() {
+  return {
+    extensions: {
+      "delete-user-data": "firebase/delete-user-data@0.1.12",
+      "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
+    },
+  };
+}
 
 describe("manifest", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
 
   describe(`${manifest.instanceExists.name}`, () => {
-    const config = new Config(BASE_CONFIG_CONTENT, {});
+    const config = new Config(baseConfigFactory(), {});
 
     it("should return true for an existing instance", () => {
       const result = manifest.instanceExists("delete-user-data", config);
@@ -36,7 +44,7 @@ describe("manifest", () => {
   });
 
   describe(`${manifest.getInstanceRef.name}`, () => {
-    const config = new Config(BASE_CONFIG_CONTENT, {});
+    const config = new Config(baseConfigFactory(), {});
 
     it("should return the correct ref for an existing instance", () => {
       const result = manifest.getInstanceRef("delete-user-data", config);
@@ -56,7 +64,7 @@ describe("manifest", () => {
   });
 
   describe(`${manifest.removeFromManifest.name}`, () => {
-    const config = new Config(BASE_CONFIG_CONTENT, {});
+    const config = new Config(baseConfigFactory(), {});
 
     let deleteProjectFileStub: sinon.SinonStub;
     let writeProjectFileStub: sinon.SinonStub;
@@ -84,7 +92,7 @@ describe("manifest", () => {
   });
 
   describe(`${manifest.writeToManifest.name}`, () => {
-    const config = new Config(BASE_CONFIG_CONTENT, {});
+    const config = new Config(baseConfigFactory(), {});
 
     let askWriteProjectFileStub: sinon.SinonStub;
     let writeProjectFileStub: sinon.SinonStub;

--- a/src/test/extensions/manifest.spec.ts
+++ b/src/test/extensions/manifest.spec.ts
@@ -9,36 +9,37 @@ import { Config } from "../../config";
 import * as prompt from "../../prompt";
 import { FirebaseError } from "../../error";
 
-const BASE_CONFIG = new Config(
-  {
-    extensions: {
-      "delete-user-data": "firebase/delete-user-data@0.1.12",
-      "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
-    },
+const BASE_CONFIG_CONTENT = {
+  extensions: {
+    "delete-user-data": "firebase/delete-user-data@0.1.12",
+    "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
   },
-  {}
-);
+};
 
 describe("manifest", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
 
   describe(`${manifest.instanceExists.name}`, () => {
+    const config = new Config(BASE_CONFIG_CONTENT, {});
+
     it("should return true for an existing instance", () => {
-      const result = manifest.instanceExists("delete-user-data", BASE_CONFIG);
+      const result = manifest.instanceExists("delete-user-data", config);
 
       expect(result).to.be.true;
     });
 
     it("should return false for a non-existing instance", () => {
-      const result = manifest.instanceExists("does-not-exist", BASE_CONFIG);
+      const result = manifest.instanceExists("does-not-exist", config);
 
       expect(result).to.be.false;
     });
   });
 
   describe(`${manifest.getInstanceRef.name}`, () => {
+    const config = new Config(BASE_CONFIG_CONTENT, {});
+
     it("should return the correct ref for an existing instance", () => {
-      const result = manifest.getInstanceRef("delete-user-data", BASE_CONFIG);
+      const result = manifest.getInstanceRef("delete-user-data", config);
 
       expect(refs.toExtensionVersionRef(result)).to.equal(
         refs.toExtensionVersionRef({
@@ -50,11 +51,13 @@ describe("manifest", () => {
     });
 
     it("should throw when looking for a non-existing instance", () => {
-      expect(() => manifest.getInstanceRef("does-not-exist", BASE_CONFIG)).to.throw(FirebaseError);
+      expect(() => manifest.getInstanceRef("does-not-exist", config)).to.throw(FirebaseError);
     });
   });
 
   describe(`${manifest.removeFromManifest.name}`, () => {
+    const config = new Config(BASE_CONFIG_CONTENT, {});
+
     let deleteProjectFileStub: sinon.SinonStub;
     let writeProjectFileStub: sinon.SinonStub;
     beforeEach(() => {
@@ -67,7 +70,7 @@ describe("manifest", () => {
     });
 
     it("should remove form firebase.json and remove .env file", () => {
-      const result = manifest.removeFromManifest("delete-user-data", BASE_CONFIG);
+      const result = manifest.removeFromManifest("delete-user-data", config);
 
       expect(writeProjectFileStub).calledWithExactly("firebase.json", {
         extensions: {
@@ -81,6 +84,8 @@ describe("manifest", () => {
   });
 
   describe(`${manifest.writeToManifest.name}`, () => {
+    const config = new Config(BASE_CONFIG_CONTENT, {});
+
     let askWriteProjectFileStub: sinon.SinonStub;
     let writeProjectFileStub: sinon.SinonStub;
     beforeEach(() => {
@@ -114,7 +119,7 @@ describe("manifest", () => {
             params: { a: "eevee", b: "squirtle" },
           },
         ],
-        BASE_CONFIG,
+        config,
         { nonInteractive: false, force: false }
       );
       expect(writeProjectFileStub).calledWithExactly("firebase.json", {
@@ -164,7 +169,7 @@ describe("manifest", () => {
             params: { a: "eevee", b: "squirtle" },
           },
         ],
-        BASE_CONFIG,
+        config,
         { nonInteractive: false, force: false },
         true /** allowOverwrite */
       );

--- a/src/test/extensions/manifest.spec.ts
+++ b/src/test/extensions/manifest.spec.ts
@@ -34,6 +34,32 @@ describe("manifest", () => {
     });
   });
 
+  describe(`${manifest.removeFromManifest.name}`, () => {
+    let deleteProjectFileStub: sinon.SinonStub;
+    let writeProjectFileStub: sinon.SinonStub;
+    beforeEach(() => {
+      deleteProjectFileStub = sandbox.stub(Config.prototype, "deleteProjectFile");
+      writeProjectFileStub = sandbox.stub(Config.prototype, "writeProjectFile");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it("should remove form firebase.json and remove .env file", () => {
+      const result = manifest.removeFromManifest("delete-user-data", BASE_CONFIG);
+
+      expect(writeProjectFileStub).calledWithExactly("firebase.json", {
+        extensions: {
+          "delete-user-data": undefined,
+          "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
+        },
+      });
+
+      expect(deleteProjectFileStub).calledWithExactly("extensions/delete-user-data.env");
+    });
+  });
+
   describe(`${manifest.writeToManifest}`, () => {
     let askWriteProjectFileStub: sinon.SinonStub;
     let writeProjectFileStub: sinon.SinonStub;


### PR DESCRIPTION
### Description

Add `--local` flag to `ext:uninstall` command.

### Scenarios Tested

```
lihes-macbookpro2:ext-emu lihes$ 
lihes-macbookpro2:ext-emu lihes$ firebase ext:uninstall delete-user-data --local
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK
Removed extension instance delete-user-data from firebase.json
Removed extension instance environment config extensions/delete-user-data.env
lihes-macbookpro2:ext-emu lihes$ 
```

```
lihes-macbookpro2:ext-emu lihes$ 
lihes-macbookpro2:ext-emu lihes$ firebase ext:uninstall delete-user-data --local
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK

Error: Extension instance delete-user-data not found in firebase.json.
lihes-macbookpro2:ext-emu lihes$ 
lihes-macbookpro2:ext-emu lihes$ 
lihes-macbookpro2:ext-emu lihes$ 
```

New firebase.json
```
{
  "functions": {
    "predeploy": [
      "npm --prefix \"$RESOURCE_DIR\" run lint",
      "npm --prefix \"$RESOURCE_DIR\" run build"
    ],
    "source": "functions"
  },
  "emulators": {
    "functions": {
      "port": 5001
    },
    "firestore": {
      "port": 8080
    },
    "ui": {
      "enabled": true
    }
  },
  "extensions": {
    "delete-user-data-7tqe": "firebase/delete-user-data@0.1.12",
    "delete-user-data-t6tm": "firebase/delete-user-data@0.1.12",
    "delete-user-data-or4a": "firebase/delete-user-data@0.1.12",
    "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12"
  }
}
```