### PR TITLE
Fix Storage Emulator resource evaluation integration test

### DIFF
--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -1210,7 +1210,7 @@ describe("Storage emulator", () => {
 
         it("should not delete file when security rule on resource object disallows it", async () => {
           await page.evaluate((filename) => {
-            firebase.storage().ref(filename).updateMetadata({ contentType: "text/plain" });
+            return firebase.storage().ref(filename).updateMetadata({ contentType: "text/plain" });
           }, filename);
 
           const error = await page.evaluate((filename) => {


### PR DESCRIPTION
### Description
#### Issue
Follow up to #4214. We added an integration test to check that the `resource` object is evaluated correctly in the security rules for the Storage Emulator. This test is currently failing on `master`.

#### Cause
`updateMetadata` is not being awaited, so the file metadata is not set. Thus the security rule condition allows the delete.

### Scenarios Tested
Ran Storage Emulator integration tests and verified that test now passes with fix.