### PR TITLE
Dynamically invoke correct trigger when running functions emulator with --inspect-functions flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fixes Storage Emulator rules resource evaluation (#4214).
 - Fixes bug where securityLevel is overwritten on https function re-deploys (#4208).
 - Fixes bug where functions emulator ignored functions.runtime option in firebase.json (#4207).
+- Fixes bug where functions emulator triggered wrong functions when when started w/ --inspect-functions flag (#4232).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@
 - Fixes Storage Emulator rules resource evaluation (#4214).
 - Fixes bug where securityLevel is overwritten on https function re-deploys (#4208).
 - Fixes bug where functions emulator ignored functions.runtime option in firebase.json (#4207).
-- Fixes bug where functions emulator triggered wrong functions when when started w/ --inspect-functions flag (#4232).
+- Fixes bug where functions emulator triggered wrong functions when started with --inspect-functions flag (#4232).

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -122,7 +122,7 @@ functionsEmulator.setTriggersForTesting(
 );
 
 // TODO(samstern): This is an ugly way to just override the InvokeRuntimeOpts on each call
-const startFunctionRuntime = functionsEmulator.invokeTrigger.bind(functionsEmulator);
+const invokeTrigger = functionsEmulator.invokeTrigger.bind(functionsEmulator);
 function useFunctions(triggers: () => {}): void {
   const serializedTriggers = triggers.toString();
 
@@ -133,7 +133,7 @@ function useFunctions(triggers: () => {}): void {
     proto?: any,
     runtimeOpts?: InvokeRuntimeOpts
   ): Promise<RuntimeWorker> => {
-    return startFunctionRuntime(testBackend, trigger, proto, {
+    return invokeTrigger(testBackend, trigger, proto, {
       nodeBinary: process.execPath,
       serializedTriggers,
     });

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -122,12 +122,12 @@ functionsEmulator.setTriggersForTesting(
 );
 
 // TODO(samstern): This is an ugly way to just override the InvokeRuntimeOpts on each call
-const startFunctionRuntime = functionsEmulator.startFunctionRuntime.bind(functionsEmulator);
+const startFunctionRuntime = functionsEmulator.invokeTrigger.bind(functionsEmulator);
 function useFunctions(triggers: () => {}): void {
   const serializedTriggers = triggers.toString();
 
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  functionsEmulator.startFunctionRuntime = (
+  functionsEmulator.invokeTrigger = (
     backend: EmulatableBackend,
     trigger: EmulatedTriggerDefinition,
     proto?: any,

--- a/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
+++ b/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
@@ -48,7 +48,7 @@ async function countLogEntries(worker: RuntimeWorker): Promise<{ [key: string]: 
   return counts;
 }
 
-async function startRuntimeWithFunctions(
+async function invokeFunction(
   frb: FunctionsRuntimeBundle,
   triggers: () => {},
   signatureType: SignatureType,
@@ -129,7 +129,7 @@ describe("FunctionsEmulator-Runtime", () => {
   describe("Stubs, Mocks, and Helpers (aka Magic, Glee, and Awesomeness)", () => {
     describe("_InitializeNetworkFiltering(...)", () => {
       it("should log outgoing unknown HTTP requests via 'http'", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp();
@@ -152,7 +152,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_LONG);
 
       it("should log outgoing unknown HTTP requests via 'https'", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp();
@@ -175,7 +175,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_LONG);
 
       it("should log outgoing Google API requests", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp();
@@ -210,7 +210,7 @@ describe("FunctionsEmulator-Runtime", () => {
       });
 
       it("should provide stubbed default app from initializeApp", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp();
@@ -228,7 +228,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide a stubbed app with custom options", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp({
@@ -258,7 +258,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide non-stubbed non-default app from initializeApp", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp(); // We still need to initialize default for snapshots
@@ -276,7 +276,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should route all sub-fields accordingly", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onCreate,
           () => {
             require("firebase-admin").initializeApp();
@@ -308,7 +308,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should expose Firestore prod when the emulator is not running", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             const admin = require("firebase-admin");
@@ -340,7 +340,7 @@ describe("FunctionsEmulator-Runtime", () => {
           port: 9090,
         });
 
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             const admin = require("firebase-admin");
@@ -367,7 +367,7 @@ describe("FunctionsEmulator-Runtime", () => {
       it("should expose RTDB prod when the emulator is not running", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
 
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             const admin = require("firebase-admin");
@@ -397,7 +397,7 @@ describe("FunctionsEmulator-Runtime", () => {
           port: 9090,
         });
 
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             const admin = require("firebase-admin");
@@ -427,7 +427,7 @@ describe("FunctionsEmulator-Runtime", () => {
           port: 9090,
         });
 
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             const admin = require("firebase-admin");
@@ -449,7 +449,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should return a real databaseURL when RTDB emulator is not running", async () => {
         const frb = _.cloneDeep(FunctionRuntimeBundles.onRequest);
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             const admin = require("firebase-admin");
@@ -484,7 +484,7 @@ describe("FunctionsEmulator-Runtime", () => {
     });
 
     it("should tell the user if they've accessed a non-existent function field", async () => {
-      const worker = await startRuntimeWithFunctions(
+      const worker = await invokeFunction(
         FunctionRuntimeBundles.onCreate,
         () => {
           require("firebase-admin").initializeApp();
@@ -513,7 +513,7 @@ describe("FunctionsEmulator-Runtime", () => {
     describe("HTTPS", () => {
       it("should handle a GET request", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -533,7 +533,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with form data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -564,7 +564,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with JSON data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -595,7 +595,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with text data", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -626,7 +626,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request with any other type", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -658,7 +658,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle a POST request and store rawBody", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -689,7 +689,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should forward request to Express app", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -717,7 +717,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should handle `x-forwarded-host`", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -741,7 +741,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("should report GMT time zone", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             return {
@@ -761,7 +761,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
     describe("Cloud Firestore", () => {
       it("should provide Change for firestore.onWrite()", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onWrite,
           () => {
             require("firebase-admin").initializeApp();
@@ -795,7 +795,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide Change for firestore.onUpdate()", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onUpdate,
           () => {
             require("firebase-admin").initializeApp();
@@ -828,7 +828,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide DocumentSnapshot for firestore.onDelete()", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onDelete,
           () => {
             require("firebase-admin").initializeApp();
@@ -860,7 +860,7 @@ describe("FunctionsEmulator-Runtime", () => {
       }).timeout(TIMEOUT_MED);
 
       it("should provide DocumentSnapshot for firestore.onCreate()", async () => {
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           FunctionRuntimeBundles.onWrite,
           () => {
             require("firebase-admin").initializeApp();
@@ -895,7 +895,7 @@ describe("FunctionsEmulator-Runtime", () => {
     describe("Error handling", () => {
       it("Should handle regular functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -921,7 +921,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("Should handle async functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();
@@ -950,7 +950,7 @@ describe("FunctionsEmulator-Runtime", () => {
 
       it("Should handle async/runWith functions for Express handlers", async () => {
         const frb = FunctionRuntimeBundles.onRequest;
-        const worker = await startRuntimeWithFunctions(
+        const worker = await invokeFunction(
           frb,
           () => {
             require("firebase-admin").initializeApp();

--- a/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
+++ b/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
@@ -67,7 +67,7 @@ async function startRuntimeWithFunctions(
     entryPoint: "function_id",
     platform: "gcfv1" as const,
   };
-  return functionsEmulator.startFunctionRuntime(
+  return functionsEmulator.invokeTrigger(
     testBackend,
     {
       ...dummyTriggerDef,

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -68,6 +68,16 @@ export interface FunctionsRuntimeBundle {
   // and none of these extra properties.
   socketPath?: string;
   disabled_features?: FunctionsRuntimeFeatures;
+  // TODO(danielylee): To make debugging in Functions Emulator w/ --inspect-functions flag a good experience, we run
+  // All functions in a single runtime process. This is drastically different to production environment where each
+  // function runs in isolated, independent containers. Until we have better design for supporting --inspect-functions
+  // flag, we begrudgingly include the target function name in the runtime bundle so the "debug" runtime can invoke
+  // correct function accordingly.
+  // See https://github.com/firebase/firebase-tools/issues/4189.
+  debug?: {
+    functionTarget: string;
+    functionSignature: string;
+  };
 }
 
 export interface FunctionsRuntimeFeatures {

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -69,10 +69,10 @@ export interface FunctionsRuntimeBundle {
   socketPath?: string;
   disabled_features?: FunctionsRuntimeFeatures;
   // TODO(danielylee): To make debugging in Functions Emulator w/ --inspect-functions flag a good experience, we run
-  // All functions in a single runtime process. This is drastically different to production environment where each
+  // all functions in a single runtime process. This is drastically different to production environment where each
   // function runs in isolated, independent containers. Until we have better design for supporting --inspect-functions
-  // flag, we begrudgingly include the target function name in the runtime bundle so the "debug" runtime can invoke
-  // correct function accordingly.
+  // flag, we begrudgingly include the target trigger info in the runtime bundle so the "debug" runtime process can
+  // choose which trigger to run at runtime.
   // See https://github.com/firebase/firebase-tools/issues/4189.
   debug?: {
     functionTarget: string;

--- a/src/emulator/functionsEmulatorShell.ts
+++ b/src/emulator/functionsEmulatorShell.ts
@@ -64,7 +64,7 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
       data,
     };
 
-    this.emu.startFunctionRuntime(this.backend, trigger, proto);
+    this.emu.invokeTrigger(this.backend, trigger, proto);
   }
 
   private getTrigger(name: string): EmulatedTriggerDefinition {


### PR DESCRIPTION
In https://github.com/firebase/firebase-tools/pull/4149, we made large refactor of the Functions Runtime. Namely:

1) We no longer relied on Functions Runtime to parse triggers. Instead, we use [`RuntimeDelegate`](https://github.com/firebase/firebase-tools/blob/2a56d9520241ab9897a59aac22c9fd016251a7cd/src/deploy/functions/runtimes/index.ts#L114), the same procedure used to parse trigger in `firebase deploy` command.

2) Each process running the Functions Runtime was bound to a specific trigger.

Unfortunately, this change broke support for `--inspect-function` where users can attach Node Debugger to step through their function when triggered.

The debugging experience supported w/ `--inspect-function` relies on the fact that a single process executes all function triggers. This is drastically different to how functions run in Production environment, but it is a very useful feature that makes it easy to step through all functions in a single debug session.

I wasn't aware of the debugging capabilities when making the refactor. Unfortunately, the debug feature cuts across a strong assumption I've made for the future of Functions Emulator. This is a rather hasty rollback - I'm going to have to think more deeply about how we want the evolve this feature.

Fixes https://github.com/firebase/firebase-tools/issues/4189, https://github.com/firebase/firebase-tools/issues/4166