### PR TITLE
Add --local flag to ext:update

### DIFF
--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -79,13 +79,13 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
         refs.toExtensionVersionRef(oldRef)
       );
       updateSource = inferUpdateSource(updateSource, refs.toExtensionRef(oldRef));
-      
+
       // TODO(b/213335255): Allow local sources after manifest supports that.
       const newSourceOrigin = getSourceOrigin(updateSource);
       if (
         ![SourceOrigin.PUBLISHED_EXTENSION, SourceOrigin.PUBLISHED_EXTENSION_VERSION].includes(
           newSourceOrigin
-          )
+        )
       ) {
         throw new FirebaseError(`Only updating to a published extension version is allowed`);
       }
@@ -101,7 +101,7 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
         );
         return;
       }
-      
+
       utils.logLabeledBullet(
         logPrefix,
         `Updating ${clc.bold(instanceId)} from version ${clc.bold(
@@ -109,11 +109,13 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
         )} to version ${clc.bold(newExtensionVersion.ref)}.`
       );
 
-      if (!await confirm({
-        nonInteractive: options.nonInteractive,
-        force: options.force,
-        default: false,
-      })) {
+      if (
+        !(await confirm({
+          nonInteractive: options.nonInteractive,
+          force: options.force,
+          default: false,
+        }))
+      ) {
         utils.logLabeledBullet(logPrefix, "Update aborted.");
         return;
       }

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -7,6 +7,7 @@ import { logger } from "../logger";
 import { promptOnce } from "../prompt";
 import { readEnvFile } from "./paramHelper";
 import { FirebaseError } from "../error";
+import * as utils from "../utils";
 
 const ENV_DIRECTORY = "extensions";
 
@@ -108,8 +109,8 @@ function writeExtensionsToFirebaseJson(specs: InstanceSpec[], config: Config): v
     extensions[s.instanceId] = refs.toExtensionVersionRef(s.ref!);
   }
   config.set("extensions", extensions);
-  logger.info("Adding Extensions to " + clc.bold("firebase.json") + "...");
   config.writeProjectFile("firebase.json", config.src);
+  utils.logSuccess("Wrote extensions to " + clc.bold("firebase.json") + "...");
 }
 
 async function writeEnvFiles(

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -146,7 +146,7 @@ export async function getParamsForUpdate(args: {
  * @param newSpec A extensionSpec to compare to
  * @param currentParams A set of current params and their values
  */
- export async function promptForNewParams(args: {
+export async function promptForNewParams(args: {
   spec: extensionsApi.ExtensionSpec;
   newSpec: extensionsApi.ExtensionSpec;
   currentParams: { [option: string]: string };
@@ -159,23 +159,17 @@ export async function getParamsForUpdate(args: {
   };
 
   // Some params are in the spec but not in currentParams, remove so we can prompt for them.
-  const oldParams = args.spec.params.filter((p) => Object.keys(args.currentParams).includes(p.param));
-  
-  let paramsDiffDeletions = _.differenceWith(
-    oldParams,
-    args.newSpec.params,
-    comparer
+  const oldParams = args.spec.params.filter((p) =>
+    Object.keys(args.currentParams).includes(p.param)
   );
+
+  let paramsDiffDeletions = _.differenceWith(oldParams, args.newSpec.params, comparer);
   paramsDiffDeletions = substituteParams<extensionsApi.Param[]>(
     paramsDiffDeletions,
     firebaseProjectParams
   );
 
-  let paramsDiffAdditions = _.differenceWith(
-    args.newSpec.params,
-    oldParams,
-    comparer
-  );
+  let paramsDiffAdditions = _.differenceWith(args.newSpec.params, oldParams, comparer);
   paramsDiffAdditions = substituteParams<extensionsApi.Param[]>(
     paramsDiffAdditions,
     firebaseProjectParams

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -146,7 +146,7 @@ export async function getParamsForUpdate(args: {
  * @param newSpec A extensionSpec to compare to
  * @param currentParams A set of current params and their values
  */
-export async function promptForNewParams(args: {
+ export async function promptForNewParams(args: {
   spec: extensionsApi.ExtensionSpec;
   newSpec: extensionsApi.ExtensionSpec;
   currentParams: { [option: string]: string };
@@ -157,9 +157,13 @@ export async function promptForNewParams(args: {
   const comparer = (param1: extensionsApi.Param, param2: extensionsApi.Param) => {
     return param1.type === param2.type && param1.param === param2.param;
   };
+
+  // Some params are in the spec but not in currentParams, remove so we can prompt for them.
+  const oldParams = args.spec.params.filter((p) => Object.keys(args.currentParams).includes(p.param));
+  
   let paramsDiffDeletions = _.differenceWith(
-    args.spec.params,
-    _.get(args.newSpec, "params", []),
+    oldParams,
+    args.newSpec.params,
     comparer
   );
   paramsDiffDeletions = substituteParams<extensionsApi.Param[]>(
@@ -169,7 +173,7 @@ export async function promptForNewParams(args: {
 
   let paramsDiffAdditions = _.differenceWith(
     args.newSpec.params,
-    _.get(args.spec, "params", []),
+    oldParams,
     comparer
   );
   paramsDiffAdditions = substituteParams<extensionsApi.Param[]>(

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -267,7 +267,7 @@ describe("paramHelper", () => {
               version: "0.1.0",
               roles: [],
               resources: [],
-              params: TEST_PARAMS,
+              params: [...TEST_PARAMS],
               sourceUrl: "",
             },
           },
@@ -389,6 +389,30 @@ describe("paramHelper", () => {
           type: "input",
         },
       ]);
+    });
+
+    it("should prompt for params that are not currently populated", async () => {
+      promptStub.resolves("user input");
+      const newSpec = _.cloneDeep(SPEC);
+      newSpec.params = TEST_PARAMS_2;
+
+      const newParams = await paramHelper.promptForNewParams({
+        spec: SPEC,
+        newSpec,
+        currentParams: {
+          A_PARAMETER: "value",
+          // ANOTHER_PARAMETER is not populated
+        },
+        projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
+      });
+
+      const expected = {
+        ANOTHER_PARAMETER: "user input",
+        NEW_PARAMETER: "user input",
+        THIRD_PARAMETER: "user input",
+      };
+      expect(newParams).to.eql(expected);
     });
 
     it("should not prompt the user for params that did not change type or param", async () => {


### PR DESCRIPTION
### Description

Add --local flag to ext:update

### Scenarios Tested
Update to from `0.1.1` to `0.1.12`, new params added
```
lihes-macbookpro2:ext-emu lihes$ firebase ext:update delete-user-data-7tqe --local
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK
i  extensions: Updating delete-user-data-7tqe from version firebase/delete-user-data@0.1.1 to version firebase/delete-user-data@0.1.12.
? Do you wish to continue? Yes
To update this instance, configure the following new parameters:

Cloud Firestore delete mode: (Only applicable if you use the Cloud Firestore paths parameter.) How do you want to delete Cloud Firestore documents? To also delete documents in subcollections, set this parameter to recursive.
? Which option do you want enabled for this parameter? Select an option with the arrow keys
, and use Enter to confirm your choice. You may only select one option. Recursive

Realtime Database instance (Optional): From which Realtime Database instance do you want to delete user data?
? Enter a value for Realtime Database instance: 
✔  Wrote extensions to firebase.json...
✔  Wrote extensions/delete-user-data-7tqe.env
```


Update to from `0.1.1` to `0.1.12`, manually cleared content of its env file. Should prompt for existing params
```
lihes-macbookpro2:ext-emu lihes$ firebase ext:update delete-user-data-7tqe --local
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK
i  extensions: Updating delete-user-data-7tqe from version firebase/delete-user-data@0.1.1 to version firebase/delete-user-data@0.1.12.
? Do you wish to continue? Yes
To update this instance, configure the following new parameters:

Cloud Functions location: Where do you want to deploy the functions created for this extension?  You usually want a location close to your database or Storage bucket. For help selecting a location, refer to the location selection  guide (https://firebase.google.com/docs/functions/locations).
? Which option do you want enabled for this parameter? Select an option with the arrow keys
, and use Enter to confirm your choice. You may only select one option. Iowa (us-central1)

Cloud Firestore paths (Optional): Which paths in your Cloud Firestore instance contain user data? Leave empty if you don't use Cloud Firestore.
Enter the full paths, separated by commas. You can represent the User ID of the deleted user with {UID}.
For example, if you have the collections users and admins, and each collection has documents with User ID as document IDs, then you can enter users/{UID},admins/{UID}.
? Enter a value for Cloud Firestore paths: 

Cloud Firestore delete mode: (Only applicable if you use the Cloud Firestore paths parameter.) How do you want to delete Cloud Firestore documents? To also delete documents in subcollections, set this parameter to recursive.
? Which option do you want enabled for this parameter? Select an option with the arrow keys
, and use Enter to confirm your choice. You may only select one option. Recursive

Realtime Database instance (Optional): From which Realtime Database instance do you want to delete user data?
? Enter a value for Realtime Database instance: 

Realtime Database paths (Optional): Which paths in your Realtime Database instance contain user data? Leave empty if you don't use Realtime Database.
Enter the full paths, separated by commas. You can represent the User ID of the deleted user with {UID}.
For example: users/{UID},admins/{UID}.
? Enter a value for Realtime Database paths: 

Cloud Storage paths (Optional): Where in Google Cloud Storage do you store user data? Leave empty if you don't use Cloud Storage.
Enter the full paths to files or directories in your Storage buckets, separated by commas. Use {UID} to represent the User ID of the deleted user, and use {DEFAULT} to represent your default Storage bucket.
Here's a series of examples. To delete all the files in your default bucket with the file naming scheme {UID}-pic.png, enter {DEFAULT}/{UID}-pic.png. To also delete all the files in another bucket called my-app-logs with the file naming scheme {UID}-logs.txt, enter {DEFAULT}/{UID}-pic.png,my-app-logs/{UID}-logs.txt. To also delete a User ID-labeled directory and all its files (like media/{UID}), enter {DEFAULT}/{UID}-pic.png,my-app-logs/{UID}-logs.txt,{DEFAULT}/media/{UID}.
? Enter a value for Cloud Storage paths: 
✔  Wrote extensions to firebase.json...
✔  Wrote extensions/delete-user-data-7tqe.env
lihes-macbookpro2:ext-emu lihes$ 
```

Update to same version
```
lihes-macbookpro2:ext-emu lihes$ firebase ext:update delete-user-data-7tqe 0.1.10 --local
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK
i  extensions: delete-user-data-7tqe is already up to date. Its version is firebase/delete-user-data@0.1.10.
```

Regular update, prompt to confirm
```
lihes-macbookpro2:ext-emu lihes$ firebase ext:update delete-user-data-7tqe 0.1.11 --local
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK
i  extensions: Updating delete-user-data-7tqe to version firebase/delete-user-data@0.1.11.
? Do you wish to continue? Yes
✔  Wrote extensions to firebase.json...
✔  Wrote extensions/delete-user-data-7tqe.env
```

Force update, does not prompt
```
lihes-macbookpro2:ext-emu lihes$ firebase ext:update delete-user-data-7tqe 0.1.12 --local --force
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK
i  extensions: Updating delete-user-data-7tqe to version firebase/delete-user-data@0.1.12.
✔  Wrote extensions to firebase.json...
✔  Wrote extensions/delete-user-data-7tqe.env
```

Force update to same version
```
lihes-macbookpro2:ext-emu lihes$ firebase ext:update delete-user-data-7tqe 0.1.12 --local --force
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: Checking project IAM policy...
✔  extensions: Project IAM policy OK
i  extensions: delete-user-data-7tqe is already up to date. Its version is firebase/delete-user-data@0.1.12.
```