### PR TITLE
[experiment] Adds "immutable" to Hosting config to support persistence of fingerprinted assets.

### DIFF
--- a/src/commands/hosting-clone.ts
+++ b/src/commands/hosting-clone.ts
@@ -119,7 +119,9 @@ export default new Command("hosting:clone <source> <targetChannel>")
     const spinner = ora("Cloning site content...").start();
     try {
       if (!equalSiteIds) {
-        const targetVersion = await cloneVersion(targetSiteId, sourceVersionName, true);
+        const targetVersion = await cloneVersion(targetSiteId, sourceVersionName, {
+          finalize: true,
+        });
         if (!targetVersion) {
           throw new FirebaseError(
             `Could not clone the version ${bold(sourceVersion)} for site ${bold(targetSiteId)}.`


### PR DESCRIPTION
This PR uses existing Firebase Hosting REST APIs to add an experimental `immutable` config field to `firebase.json`. Users can specify a list of regexes in that field and all assets matching those regexes will be copied from the currently serving version of the channel being deployed to.

```json
{
  "hosting": {
    "public": "build",
    "immutable": ["/js/.*", "/css/.*"]
  }
}
```

Drawbacks to this approach:

1. There is no way to eventually expire old content - it copies *everything*. Immutable folders will grow unbounded over time.
2. Since this is done entirely through client-side tooling, there is a small chance of strange collisions happening if e.g. competing releases happen in between when a version clones its source and when it finishes deploying.