### PR TITLE
Add StorageRulesManager class for emulator

### DIFF
--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -60,9 +60,8 @@ export class StorageEmulator implements EmulatorInstance {
     return this._logger;
   }
 
-  async reset(): Promise<void> {
+  reset(): void {
     this._storageLayer.reset();
-    await this._rulesManager.reset();
     this._persistence.reset(this.getPersistenceTmpDir());
     this._uploadService.reset();
   }
@@ -86,7 +85,7 @@ export class StorageEmulator implements EmulatorInstance {
 
   async stop(): Promise<void> {
     await this.storageLayer.deleteAll();
-    await this._rulesManager.reset();
+    await this._rulesManager.close();
     return this.destroyServer ? this.destroyServer() : Promise.resolve();
   }
 

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -112,8 +112,4 @@ export class StorageEmulator implements EmulatorInstance {
   private getPersistenceTmpDir(): string {
     return `${tmpdir()}/firebase/storage/blobs`;
   }
-
-  private async createRulesManager(rules: SourceFile | string): Promise<void> {
-    this._rulesManager = await StorageRulesManager.createInstance(rules, this._rulesRuntime);
-  }
 }

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -4,12 +4,10 @@ import { Constants } from "../constants";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../types";
 import { createApp } from "./server";
 import { StorageLayer } from "./files";
-import * as chokidar from "chokidar";
 import { EmulatorLogger } from "../emulatorLogger";
-import * as fs from "fs";
+import { StorageRulesManager } from "./rules/manager";
 import { StorageRulesetInstance, StorageRulesRuntime, StorageRulesIssues } from "./rules/runtime";
-import { Source } from "./rules/types";
-import { FirebaseError } from "../../error";
+import { SourceFile } from "./rules/types";
 import express = require("express");
 import { getRulesValidator } from "./rules/utils";
 import { Persistence } from "./persistence";
@@ -19,16 +17,14 @@ export interface StorageEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
-  rules: Source | string;
+  rules: SourceFile | string;
   auto_download?: boolean;
 }
 
 export class StorageEmulator implements EmulatorInstance {
   private destroyServer?: () => Promise<void>;
   private _app?: express.Express;
-  private _rulesWatcher?: chokidar.FSWatcher;
-  private _rules?: StorageRulesetInstance;
-  private _rulesetSource?: Source;
+  private _rulesManager?: StorageRulesManager;
 
   private _logger = EmulatorLogger.forEmulator(Emulators.STORAGE);
   private _rulesRuntime: StorageRulesRuntime;
@@ -56,7 +52,7 @@ export class StorageEmulator implements EmulatorInstance {
   }
 
   get rules(): StorageRulesetInstance | undefined {
-    return this._rules;
+    return this._rulesManager!.ruleset;
   }
 
   get logger(): EmulatorLogger {
@@ -72,103 +68,24 @@ export class StorageEmulator implements EmulatorInstance {
   async start(): Promise<void> {
     const { host, port } = this.getInfo();
     await this._rulesRuntime.start(this.args.auto_download);
+
+    this._rulesManager = await StorageRulesManager.createInstance(
+      this.args.rules,
+      this._rulesRuntime
+    );
+    await this._rulesManager.loadRuleset();
+
     this._app = await createApp(this.args.projectId, this);
-
-    if (typeof this.args.rules === "string") {
-      const rulesFile = this.args.rules;
-      this.updateRulesSource(rulesFile);
-    } else {
-      this._rulesetSource = this.args.rules;
-    }
-
-    if (!this._rulesetSource || this._rulesetSource.files.length === 0) {
-      throw new FirebaseError("Can not initialize Storage emulator without a rules source / file.");
-    } else if (this._rulesetSource.files.length > 1) {
-      throw new FirebaseError(
-        "Can not initialize Storage emulator with more than one rules source / file."
-      );
-    }
-
-    await this.loadRuleset();
-
-    const rulesPath = this._rulesetSource.files[0].name;
-    this._rulesWatcher = chokidar.watch(rulesPath, { persistent: true, ignoreInitial: true });
-    this._rulesWatcher.on("change", async () => {
-      // There have been some race conditions reported (on Windows) where reading the
-      // file too quickly after the watcher fires results in an empty file being read.
-      // Adding a small delay prevents that at very little cost.
-      await new Promise((res) => setTimeout(res, 5));
-
-      this._logger.logLabeled(
-        "BULLET",
-        "storage",
-        `Change detected, updating rules for Cloud Storage...`
-      );
-      this.updateRulesSource(rulesPath);
-      await this.loadRuleset();
-    });
-
     const server = this._app.listen(port, host);
     this.destroyServer = utils.createDestroyer(server);
   }
 
-  private updateRulesSource(rulesFile: string): void {
-    this._rulesetSource = {
-      files: [
-        {
-          name: rulesFile,
-          content: fs.readFileSync(rulesFile).toString(),
-        },
-      ],
-    };
-  }
-
-  public async loadRuleset(source?: Source): Promise<StorageRulesIssues> {
-    if (source) {
-      this._rulesetSource = source;
-    }
-
-    if (!this._rulesetSource) {
-      const msg = "Attempting to update ruleset without a source.";
-      this._logger.log("WARN", msg);
-
-      const error = JSON.stringify({ error: msg });
-      return new StorageRulesIssues([error], []);
-    }
-
-    const { ruleset, issues } = await this._rulesRuntime.loadRuleset(this._rulesetSource);
-
-    if (!ruleset) {
-      issues.all.forEach((issue) => {
-        let parsedIssue;
-        try {
-          parsedIssue = JSON.parse(issue);
-        } catch {
-          // Parse manually
-        }
-
-        if (parsedIssue) {
-          this._logger.log(
-            "WARN",
-            `${parsedIssue.description_.replace(/\.$/, "")} in ${
-              parsedIssue.sourcePosition_.fileName_
-            }:${parsedIssue.sourcePosition_.line_}`
-          );
-        } else {
-          this._logger.log("WARN", issue);
-        }
-      });
-
-      delete this._rules;
-    } else {
-      this._rules = ruleset;
-    }
-
-    return issues;
-  }
-
   async connect(): Promise<void> {
     // No-op
+  }
+
+  async setRules(rules: SourceFile | string): Promise<StorageRulesIssues> {
+    return this._rulesManager!.loadRuleset(rules);
   }
 
   async stop(): Promise<void> {

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -46,7 +46,7 @@ export class StorageRulesManager {
   /**
    * Deletes source file, ruleset, and removes listeners from all files.
    */
-  public async reset(): Promise<void> {
+  public async close(): Promise<void> {
     delete this._sourceFile;
     delete this._ruleset;
     await this._watcher.close();

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -24,7 +24,7 @@ export class StorageRulesManager {
 
   /**
    * Updates the source file and, correspondingly, the file watcher and ruleset.
-   * @throws {@link FirebaseError} if file path is invalid.
+   * @throws {FirebaseError} if file path is invalid.
    */
   public async setSourceFile(rules: SourceFile | string): Promise<StorageRulesIssues> {
     const prevRulesFile = this._sourceFile?.name;

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -1,0 +1,99 @@
+import * as chokidar from "chokidar";
+import * as fs from "fs";
+import { EmulatorLogger } from "../../emulatorLogger";
+import { Emulators } from "../../types";
+import { SourceFile } from "./types";
+import { StorageRulesIssues, StorageRulesRuntime, StorageRulesetInstance } from "./runtime";
+
+/**
+ * Loads and maintains a {@link StorageRulesetInstance} for a given source file. Listens for
+ * changes to the file and updates the ruleset accordingly.
+ */
+export class StorageRulesManager {
+  private _sourceFile!: SourceFile;
+  private _ruleset?: StorageRulesetInstance;
+  private _logger = EmulatorLogger.forEmulator(Emulators.STORAGE);
+
+  private constructor(_rules: SourceFile | string, private _runtime: StorageRulesRuntime) {
+    this.updateSourceFile(_rules);
+
+    const rulesFile = typeof _rules === "string" ? _rules : _rules.name;
+    chokidar.watch(rulesFile, { persistent: true, ignoreInitial: true }).on("change", async () => {
+      // There have been some race conditions reported (on Windows) where reading the
+      // file too quickly after the watcher fires results in an empty file being read.
+      // Adding a small delay prevents that at very little cost.
+      await new Promise((res) => setTimeout(res, 5));
+
+      this._logger.logLabeled(
+        "BULLET",
+        "storage",
+        "Change detected, updating rules for Cloud Storage..."
+      );
+      this.updateSourceFile(this._sourceFile.name);
+      await this.loadRuleset();
+    });
+  }
+
+  /**
+   * Constructs and initializes a {@link StorageRulesManager}. This must be done in a factory
+   * method in order to load the ruleset from the runtime asynchronously.
+   */
+  public static async createInstance(
+    rules: SourceFile | string,
+    runtime: StorageRulesRuntime
+  ): Promise<StorageRulesManager> {
+    const instance = new StorageRulesManager(rules, runtime);
+    await instance.loadRuleset();
+    return instance;
+  }
+
+  get ruleset(): StorageRulesetInstance | undefined {
+    return this._ruleset;
+  }
+
+  /**
+   * Manually updates the ruleset from a new source file or its file name. This overrides the
+   * current ruleset.
+   */
+  public async loadRuleset(rules?: SourceFile | string): Promise<StorageRulesIssues> {
+    if (rules) {
+      this.updateSourceFile(rules);
+    }
+
+    const { ruleset, issues } = await this._runtime.loadRuleset({ files: [this._sourceFile] });
+    if (ruleset) {
+      this._ruleset = ruleset;
+    } else {
+      issues.all.forEach((issue) => {
+        let parsedIssue;
+        try {
+          parsedIssue = JSON.parse(issue);
+        } catch {
+          // Parse manually
+        }
+
+        if (parsedIssue) {
+          this._logger.log(
+            "WARN",
+            `${parsedIssue.description_.replace(/\.$/, "")} in ${
+              parsedIssue.sourcePosition_.fileName_
+            }:${parsedIssue.sourcePosition_.line_}`
+          );
+        } else {
+          this._logger.log("WARN", issue);
+        }
+      });
+
+      delete this._ruleset;
+    }
+    return issues;
+  }
+
+  private updateSourceFile(rules: SourceFile | string): void {
+    if (typeof rules === "string") {
+      this._sourceFile = { name: rules, content: fs.readFileSync(rules).toString() };
+    } else {
+      this._sourceFile = rules;
+    }
+  }
+}

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -106,8 +106,8 @@ export function createApp(
     });
   });
 
-  app.post("/internal/reset", (req, res) => {
-    emulator.reset();
+  app.post("/internal/reset", async (req, res) => {
+    await emulator.reset();
     res.sendStatus(200);
   });
 

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -106,8 +106,8 @@ export function createApp(
     });
   });
 
-  app.post("/internal/reset", async (req, res) => {
-    await emulator.reset();
+  app.post("/internal/reset", (req, res) => {
+    emulator.reset();
     res.sendStatus(200);
   });
 

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -92,7 +92,7 @@ export function createApp(
 
     const name = file.name;
     const content = file.content;
-    const issues = await emulator.loadRuleset({ files: [{ name, content }] });
+    const issues = await emulator.setRules({ name, content });
 
     if (issues.errors.length > 0) {
       res.status(400).json({

--- a/src/test/emulators/storage/rules/manager.spec.ts
+++ b/src/test/emulators/storage/rules/manager.spec.ts
@@ -9,7 +9,7 @@ import { StorageRulesRuntime } from "../../../../emulator/storage/rules/runtime"
 import { Persistence } from "../../../../emulator/storage/persistence";
 import { RulesetOperationMethod } from "../../../../emulator/storage/rules/types";
 
-describe("Storage Rules Manager", function () {
+describe("Storage Rules Manager", () => {
   const rulesRuntime = new StorageRulesRuntime();
   const rulesManager = new StorageRulesManager(rulesRuntime);
 

--- a/src/test/emulators/storage/rules/manager.spec.ts
+++ b/src/test/emulators/storage/rules/manager.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from "chai";
+
+import { StorageRulesFiles, TIMEOUT_MED } from "../../fixtures";
+import { StorageRulesManager } from "../../../../emulator/storage/rules/manager";
+import { StorageRulesRuntime } from "../../../../emulator/storage/rules/runtime";
+
+describe("Storage Rules Manager", function () {
+  const rulesRuntime = new StorageRulesRuntime();
+  let rulesManager: StorageRulesManager;
+
+  // eslint-disable-next-line @typescript-eslint/no-invalid-this
+  this.timeout(10000);
+
+  before(async () => {
+    await rulesRuntime.start();
+    rulesManager = await StorageRulesManager.createInstance(
+      StorageRulesFiles.readWriteIfAuth,
+      rulesRuntime
+    );
+  });
+
+  after(async () => {
+    rulesRuntime.stop();
+    await rulesManager.watcher.close();
+  });
+
+  it("should load ruleset", () => {
+    expect(rulesManager.ruleset).not.to.be.undefined;
+  });
+
+  it("should update source file", async () => {
+    const issues = await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue);
+    expect(issues.errors.length).to.equal(0);
+    expect(issues.warnings.length).to.equal(0);
+  });
+});

--- a/src/test/emulators/storage/rules/manager.spec.ts
+++ b/src/test/emulators/storage/rules/manager.spec.ts
@@ -1,36 +1,89 @@
 import { expect } from "chai";
+import { tmpdir } from "os";
+import { v4 as uuidv4 } from "uuid";
 
-import { StorageRulesFiles, TIMEOUT_MED } from "../../fixtures";
+import { FirebaseError } from "../../../../error";
+import { StorageRulesFiles } from "../../fixtures";
 import { StorageRulesManager } from "../../../../emulator/storage/rules/manager";
 import { StorageRulesRuntime } from "../../../../emulator/storage/rules/runtime";
+import { Persistence } from "../../../../emulator/storage/persistence";
+import { RulesetOperationMethod } from "../../../../emulator/storage/rules/types";
 
 describe("Storage Rules Manager", function () {
   const rulesRuntime = new StorageRulesRuntime();
-  let rulesManager: StorageRulesManager;
-
-  // eslint-disable-next-line @typescript-eslint/no-invalid-this
-  this.timeout(10000);
+  const rulesManager = new StorageRulesManager(rulesRuntime);
 
   before(async () => {
     await rulesRuntime.start();
-    rulesManager = await StorageRulesManager.createInstance(
-      StorageRulesFiles.readWriteIfAuth,
-      rulesRuntime
-    );
   });
 
   after(async () => {
     rulesRuntime.stop();
-    await rulesManager.watcher.close();
+    await rulesManager.reset();
   });
 
-  it("should load ruleset", () => {
+  it("should load ruleset from SourceFile object", async () => {
+    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue);
     expect(rulesManager.ruleset).not.to.be.undefined;
   });
 
-  it("should update source file", async () => {
-    const issues = await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue);
+  it("should load ruleset from file path", async () => {
+    // Write rules to file
+    const fileName = "storage.rules";
+    const testDir = `${tmpdir()}/${uuidv4()}`;
+    const persistence = new Persistence(testDir);
+    persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
+
+    await rulesManager.setSourceFile(`${testDir}/${fileName}`);
+
+    expect(rulesManager.ruleset).not.to.be.undefined;
+  });
+
+  it("should set source file", async () => {
+    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue);
+    const opts = { method: RulesetOperationMethod.GET, file: {}, path: "/b/bucket/o/" };
+    expect((await rulesManager.ruleset!.verify(opts)).permitted).to.be.true;
+
+    const issues = await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfAuth);
+
     expect(issues.errors.length).to.equal(0);
     expect(issues.warnings.length).to.equal(0);
+    expect((await rulesManager.ruleset!.verify(opts)).permitted).to.be.false;
+  });
+
+  it("should reload ruleset on changes to source file", async () => {
+    const opts = { method: RulesetOperationMethod.GET, file: {}, path: "/b/bucket/o/" };
+
+    // Write rules to file
+    const fileName = "storage.rules";
+    const testDir = `${tmpdir()}/${uuidv4()}`;
+    const persistence = new Persistence(testDir);
+    persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
+
+    await rulesManager.setSourceFile(`${testDir}/${fileName}`);
+    expect((await rulesManager.ruleset!.verify(opts)).permitted).to.be.true;
+
+    // Write new rules to file
+    persistence.deleteFile(fileName);
+    persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfAuth.content));
+
+    await rulesManager.setSourceFile(`${testDir}/${fileName}`);
+    expect((await rulesManager.ruleset!.verify(opts)).permitted).to.be.false;
+  });
+
+  it("should throw FirebaseError when attempting to set invalid source file", async () => {
+    const invalidFileName = "foo";
+    await expect(rulesManager.setSourceFile(invalidFileName)).to.be.rejectedWith(
+      FirebaseError,
+      `File not found: ${invalidFileName}`
+    );
+  });
+
+  it("should delete ruleset when storage manager is reset", async () => {
+    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue);
+    expect(rulesManager.ruleset).not.to.be.undefined;
+
+    await rulesManager.reset();
+    expect(rulesManager.ruleset).to.be.undefined;
   });
 });

--- a/src/test/emulators/storage/rules/manager.spec.ts
+++ b/src/test/emulators/storage/rules/manager.spec.ts
@@ -3,15 +3,18 @@ import { tmpdir } from "os";
 import { v4 as uuidv4 } from "uuid";
 
 import { FirebaseError } from "../../../../error";
-import { StorageRulesFiles } from "../../fixtures";
+import { StorageRulesFiles, TIMEOUT_MED } from "../../fixtures";
 import { StorageRulesManager } from "../../../../emulator/storage/rules/manager";
 import { StorageRulesRuntime } from "../../../../emulator/storage/rules/runtime";
 import { Persistence } from "../../../../emulator/storage/persistence";
 import { RulesetOperationMethod } from "../../../../emulator/storage/rules/types";
 
-describe("Storage Rules Manager", () => {
+describe("Storage Rules Manager", function () {
   const rulesRuntime = new StorageRulesRuntime();
   const rulesManager = new StorageRulesManager(rulesRuntime);
+
+  // eslint-disable-next-line @typescript-eslint/no-invalid-this
+  this.timeout(TIMEOUT_MED);
 
   before(async () => {
     await rulesRuntime.start();

--- a/src/test/emulators/storage/rules/manager.spec.ts
+++ b/src/test/emulators/storage/rules/manager.spec.ts
@@ -22,7 +22,7 @@ describe("Storage Rules Manager", function () {
 
   after(async () => {
     rulesRuntime.stop();
-    await rulesManager.reset();
+    await rulesManager.close();
   });
 
   it("should load ruleset from SourceFile object", async () => {
@@ -82,11 +82,11 @@ describe("Storage Rules Manager", function () {
     );
   });
 
-  it("should delete ruleset when storage manager is reset", async () => {
+  it("should delete ruleset when storage manager is closed", async () => {
     await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue);
     expect(rulesManager.ruleset).not.to.be.undefined;
 
-    await rulesManager.reset();
+    await rulesManager.close();
     expect(rulesManager.ruleset).to.be.undefined;
   });
 });

--- a/src/test/emulators/storage/rules/runtime.spec.ts
+++ b/src/test/emulators/storage/rules/runtime.spec.ts
@@ -1,13 +1,19 @@
-import { RulesetVerificationOpts, StorageRulesRuntime } from "../../emulator/storage/rules/runtime";
+import {
+  RulesetVerificationOpts,
+  StorageRulesRuntime,
+} from "../../../../emulator/storage/rules/runtime";
 import { expect } from "chai";
-import { StorageRulesFiles } from "./fixtures";
+import { StorageRulesFiles } from "../../fixtures";
 import * as jwt from "jsonwebtoken";
-import { EmulatorLogger } from "../../emulator/emulatorLogger";
-import { ExpressionValue } from "../../emulator/storage/rules/expressionValue";
-import { RulesetOperationMethod } from "../../emulator/storage/rules/types";
-import { downloadIfNecessary, getDownloadDetails } from "../../emulator/downloadableEmulators";
-import { Emulators } from "../../emulator/types";
-import { RulesResourceMetadata } from "../../emulator/storage/metadata";
+import { EmulatorLogger } from "../../../../emulator/emulatorLogger";
+import { ExpressionValue } from "../../../../emulator/storage/rules/expressionValue";
+import { RulesetOperationMethod } from "../../../../emulator/storage/rules/types";
+import {
+  downloadIfNecessary,
+  getDownloadDetails,
+} from "../../../../emulator/downloadableEmulators";
+import { Emulators } from "../../../../emulator/types";
+import { RulesResourceMetadata } from "../../../../emulator/storage/metadata";
 
 const TOKENS = {
   signedInUser: jwt.sign(
@@ -40,7 +46,7 @@ function createFakeResourceMetadata(params: {
   };
 }
 
-describe.skip("Storage Rules", function () {
+describe.skip("Storage Rules Runtime", function () {
   let runtime: StorageRulesRuntime;
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-this


### PR DESCRIPTION
### Description
This PR moves all objects and logic related to rules out of the `StorageEmulator` into a separate `StorageRulesManager` class. 

We will still keep an instance of `StorageRulesRuntime` inside the emulator and pass a reference to it to the rules manager. This is because the next step is to make a `Map` of `StorageRulesManager`s so as to support multiple deploy targets in the Storage config, as per #3390.