### PR TITLE
static verification code in emulator

### DIFF
--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -31,7 +31,7 @@ export abstract class ProjectState {
   private verificationCodes: Map<string, PhoneVerificationRecord> = new Map();
   private temporaryProofs: Map<string, TemporaryProofRecord> = new Map();
 
-  constructor(public readonly projectId: string) {}
+  constructor(public readonly projectId: string) { }
 
   get projectNumber(): string {
     // TODO: Shall we generate something different for each project?
@@ -416,11 +416,11 @@ export abstract class ProjectState {
 
   validateRefreshToken(refreshToken: string):
     | {
-        user: UserInfo;
-        provider: string;
-        extraClaims: Record<string, unknown>;
-        secondFactor?: SecondFactorRecord;
-      }
+      user: UserInfo;
+      provider: string;
+      extraClaims: Record<string, unknown>;
+      secondFactor?: SecondFactorRecord;
+    }
     | undefined {
     const record = this.refreshTokens.get(refreshToken);
     if (!record) {
@@ -467,7 +467,7 @@ export abstract class ProjectState {
   createVerificationCode(phoneNumber: string): PhoneVerificationRecord {
     const sessionInfo = randomBase64UrlStr(226);
     const verification: PhoneVerificationRecord = {
-      code: randomDigits(6),
+      code: 123456,
       phoneNumber,
       sessionInfo,
     };

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -467,7 +467,7 @@ export abstract class ProjectState {
   createVerificationCode(phoneNumber: string): PhoneVerificationRecord {
     const sessionInfo = randomBase64UrlStr(226);
     const verification: PhoneVerificationRecord = {
-      code: 123456,
+      code: '123456',
       phoneNumber,
       sessionInfo,
     };


### PR DESCRIPTION
This PR makes the verification code for phone authentication in the emulator to be static. The reason to use a static code instead of a randomly generated one is that it's much easier to predict in testing. It's also easier to predict in manual testing which makes the process easier where it is not needed to have to look at the emulator stdout.

I do not see a good reason to have random digits here.