### PR TITLE
Add method to parse multiple targets for Storage Emulator rules

### DIFF
--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -38,6 +38,7 @@ import { promptOnce } from "../prompt";
 import { FLAG_EXPORT_ON_EXIT_NAME } from "./commandUtils";
 import { fileExistsSync } from "../fsutils";
 import { StorageEmulator } from "./storage";
+import { getStorageRulesConfig } from "./storage/rules/config";
 import { getDefaultDatabaseInstance } from "../getDefaultDatabaseInstance";
 import { getProjectDefaultAccount } from "../auth";
 import { Options } from "../options";
@@ -692,19 +693,12 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
 
   if (shouldStart(options, Emulators.STORAGE)) {
     const storageAddr = await getAndCheckAddress(Emulators.STORAGE, options);
-    const storageConfig = options.config.data.storage;
-
-    if (!storageConfig?.rules) {
-      throw new FirebaseError(
-        "Cannot start the Storage emulator without rules file specified in firebase.json: run 'firebase init' and set up your Storage configuration"
-      );
-    }
 
     const storageEmulator = new StorageEmulator({
       host: storageAddr.host,
       port: storageAddr.port,
       projectId: projectId,
-      rules: options.config.path(storageConfig.rules),
+      rules: getStorageRulesConfig(projectId, options),
     });
     await startEmulator(storageEmulator);
 

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -13,11 +13,16 @@ import { getRulesValidator } from "./rules/utils";
 import { Persistence } from "./persistence";
 import { UploadService } from "./upload";
 
+export type RulesConfig = {
+  resource: string;
+  rules: string;
+};
+
 export interface StorageEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
-  rules: SourceFile | string;
+  rules: RulesConfig[];
   auto_download?: boolean;
 }
 
@@ -69,7 +74,9 @@ export class StorageEmulator implements EmulatorInstance {
   async start(): Promise<void> {
     const { host, port } = this.getInfo();
     await this._rulesRuntime.start(this.args.auto_download);
-    await this._rulesManager.setSourceFile(this.args.rules);
+
+    // TODO(hsinpei): set source file for multiple resources
+    await this._rulesManager.setSourceFile(this.args.rules[0].rules);
     this._app = await createApp(this.args.projectId, this);
     const server = this._app.listen(port, host);
     this.destroyServer = utils.createDestroyer(server);

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -1,0 +1,43 @@
+import { RulesConfig } from "..";
+import { FirebaseError } from "../../../error";
+import { Options } from "../../../options";
+
+function getAbsoluteRulesPath(rules: string, options: Options): string {
+  return options.config.path(rules);
+}
+
+export function getStorageRulesConfig(projectId: string, options: Options): RulesConfig[] {
+  const storageConfig = options.config.data.storage;
+  if (!storageConfig) {
+    throw new FirebaseError(
+      "Cannot start the Storage emulator without rules file specified in firebase.json: run 'firebase init' and set up your Storage configuration"
+    );
+  }
+
+  // Single resource
+  if (!Array.isArray(storageConfig)) {
+    if (!storageConfig.rules) {
+      throw new FirebaseError(
+        "Cannot start the Storage emulator without rules file specified in firebase.json: run 'firebase init' and set up your Storage configuration"
+      );
+    }
+
+    // TODO(hsinpei): set default resource
+    const resource = "default";
+    return [{ resource, rules: getAbsoluteRulesPath(storageConfig.rules, options) }];
+  }
+
+  // Multiple resources
+  const results: RulesConfig[] = [];
+  const { rc } = options;
+  for (const targetConfig of storageConfig) {
+    if (!targetConfig.target) {
+      throw new FirebaseError("Must supply 'target' in Storage configuration");
+    }
+    rc.requireTarget(projectId, "storage", targetConfig.target);
+    rc.target(projectId, "storage", targetConfig.target).forEach((resource: string) => {
+      results.push({ resource, rules: getAbsoluteRulesPath(targetConfig.rules, options) });
+    });
+  }
+  return results;
+}

--- a/src/test/emulators/storage/rules/config.spec.ts
+++ b/src/test/emulators/storage/rules/config.spec.ts
@@ -1,0 +1,91 @@
+import * as path from "path";
+import { expect } from "chai";
+import { readFileSync } from "fs-extra";
+import { tmpdir } from "os";
+import { v4 as uuidv4 } from "uuid";
+
+import { Config } from "../../../../config";
+import { Options } from "../../../../options";
+import { RC } from "../../../../rc";
+import { getStorageRulesConfig } from "../../../../emulator/storage/rules/config";
+import { StorageRulesFiles } from "../../fixtures";
+import { Persistence } from "../../../../emulator/storage/persistence";
+import { FirebaseError } from "../../../../error";
+
+const PROJECT_ID = "test-project";
+
+describe("Storage Rules Config", () => {
+  const tmpDir = `${tmpdir()}/${uuidv4()}`;
+  const persistence = new Persistence(tmpDir);
+  const resolvePath = (fileName: string) => path.resolve(tmpDir, fileName);
+
+  it("should parse rules config for single target", () => {
+    const rulesFile = "storage.rules";
+    persistence.appendBytes(rulesFile, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
+
+    const config = getOptions({
+      data: { storage: { rules: rulesFile } },
+      path: resolvePath,
+    });
+    const result = getStorageRulesConfig(PROJECT_ID, config);
+
+    expect(result.length).to.equal(1);
+    expect(result[0].rules).to.equal(`${tmpDir}/storage.rules`);
+  });
+
+  it("should parse rules file for multiple targets", () => {
+    const config = getOptions({
+      data: {
+        storage: [
+          { target: "main", rules: "storage_main.rules" },
+          { target: "other", rules: "storage_other.rules" },
+        ],
+      },
+      path: resolvePath,
+    });
+    config.rc.applyTarget(PROJECT_ID, "storage", "main", ["bucket_1", "bucket_2"]);
+    config.rc.applyTarget(PROJECT_ID, "storage", "other", ["bucket_3"]);
+
+    const result = getStorageRulesConfig(PROJECT_ID, config);
+
+    expect(result.length).to.equal(3);
+    expect(result[0]).to.eql({ resource: "bucket_1", rules: `${tmpDir}/storage_main.rules` });
+    expect(result[1]).to.eql({ resource: "bucket_2", rules: `${tmpDir}/storage_main.rules` });
+    expect(result[2]).to.eql({ resource: "bucket_3", rules: `${tmpDir}/storage_other.rules` });
+  });
+
+  it("should throw FirebaseError when storage config is missing", () => {
+    const config = getOptions({ data: {}, path: resolvePath });
+    expect(() => getStorageRulesConfig(PROJECT_ID, config)).to.throw(
+      FirebaseError,
+      "Cannot start the Storage emulator without rules file specified in firebase.json: run 'firebase init' and set up your Storage configuration"
+    );
+  });
+
+  it("should throw FirebaseError when rules file is missing", () => {
+    const config = getOptions({ data: { storage: {} }, path: resolvePath });
+    expect(() => getStorageRulesConfig(PROJECT_ID, config)).to.throw(
+      FirebaseError,
+      "Cannot start the Storage emulator without rules file specified in firebase.json: run 'firebase init' and set up your Storage configuration"
+    );
+  });
+});
+
+function getOptions(config: any): Options {
+  return {
+    cwd: "/",
+    configPath: "/",
+    /* eslint-disable-next-line */
+    config,
+    only: "",
+    except: "",
+    nonInteractive: false,
+    json: false,
+    interactive: false,
+    debug: false,
+    force: false,
+    filteredTargets: [],
+    rc: new RC(),
+    project: PROJECT_ID,
+  };
+}

--- a/src/test/emulators/storage/rules/storage.rules
+++ b/src/test/emulators/storage/rules/storage.rules
@@ -1,0 +1,7 @@
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /{allPaths=**} {
+      allow read, write: if request.auth != null;
+    }
+  }
+}


### PR DESCRIPTION
### Description
Part of fix for #3390.

This PR adds `getStorageRulesConfig` to parse multiple rules files and targets from the Storage config. 

After this, it remains to map resource to `StorageRulesManagers` (#4245) in the Storage Emulator and pass resource in each request.