### PR TITLE
ext:export now uses stable ordering for params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes bug where functions' memory configurations weren't preserved in batched function deploys (#4253).
+- `ext:export` now uses stable ordering for params in .env files (#4256).

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -121,6 +121,9 @@ async function writeEnvFiles(
 ): Promise<void> {
   for (const spec of specs) {
     const content = Object.entries(spec.params)
+      .sort((a, b) => {
+        return a[0].localeCompare(b[0]);
+      })
       .map((r) => `${r[0]}=${r[1]}`)
       .join("\n");
     await config.askWriteProjectFile(`extensions/${spec.instanceId}.env`, content, force);

--- a/src/test/extensions/manifest.spec.ts
+++ b/src/test/extensions/manifest.spec.ts
@@ -149,6 +149,53 @@ describe("manifest", () => {
       );
     });
 
+    it("should write to env files in stable, alphabetical by key order", async () => {
+      await manifest.writeToManifest(
+        [
+          {
+            instanceId: "instance-1",
+            ref: {
+              publisherId: "firebase",
+              extensionId: "bigquery-export",
+              version: "1.0.0",
+            },
+            params: { b: "bulbasaur", a: "absol" },
+          },
+          {
+            instanceId: "instance-2",
+            ref: {
+              publisherId: "firebase",
+              extensionId: "bigquery-export",
+              version: "2.0.0",
+            },
+            params: { e: "eevee", s: "squirtle" },
+          },
+        ],
+        generateBaseConfig(),
+        { nonInteractive: false, force: false }
+      );
+      expect(writeProjectFileStub).calledWithExactly("firebase.json", {
+        extensions: {
+          "delete-user-data": "firebase/delete-user-data@0.1.12",
+          "delete-user-data-gm2h": "firebase/delete-user-data@0.1.12",
+          "instance-1": "firebase/bigquery-export@1.0.0",
+          "instance-2": "firebase/bigquery-export@2.0.0",
+        },
+      });
+
+      expect(askWriteProjectFileStub).to.have.been.calledTwice;
+      expect(askWriteProjectFileStub).calledWithExactly(
+        "extensions/instance-1.env",
+        `a=absol\nb=bulbasaur`,
+        false
+      );
+      expect(askWriteProjectFileStub).calledWithExactly(
+        "extensions/instance-2.env",
+        `e=eevee\ns=squirtle`,
+        false
+      );
+    });
+
     it("should overwrite when user chooses to", async () => {
       // Chooses to overwrite instead of merge.
       sandbox.stub(prompt, "promptOnce").resolves(true);


### PR DESCRIPTION
### Description
`ext:export` now always outputs .env files in alphabetical by key order, so that .env files are stable between runs. Fixes #4256
