### PR TITLE
Load project-specific environment variables in the Functions Emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes bug where functions' memory configurations weren't preserved in batched function deploys (#4253).
 - `ext:export` now uses stable ordering for params in .env files (#4256).
 - Adds alerting event provider (#4258).
+- Fixes bug where project-specific environment variables weren't loaded by the Functions Emulator (#4273).

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -512,6 +512,7 @@ export async function startAll(options: EmulatorOptions, showUI: boolean = true)
       host: functionsAddr.host,
       port: functionsAddr.port,
       debugPort: inspectFunctions,
+      projectAlias: options.projectAlias,
     });
     await startEmulator(functionsEmulator);
   }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -119,6 +119,7 @@ export interface FunctionsEmulatorArgs {
   debugPort?: number;
   remoteEmulators?: { [key: string]: EmulatorInfo };
   adminSdkConfig?: AdminSdkConfig;
+  projectAlias?: string;
 }
 
 // FunctionsRuntimeInstance is the handler for a running function invocation
@@ -944,6 +945,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     const projectInfo = {
       functionsSource: backend.functionsDir,
       projectId: this.args.projectId,
+      projectAlias: this.args.projectAlias,
       isEmulator: true,
     };
 

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -161,6 +161,9 @@ export function validateKey(key: string): void {
 // Parse dotenv file, but throw errors if:
 //   1. Input has any invalid lines.
 //   2. Any env key fails validation.
+/**
+ *
+ */
 export function parseStrict(data: string): Record<string, string> {
   const { envs, errors } = parse(data);
 
@@ -198,11 +201,10 @@ function findEnvfiles(
   const files: string[] = [".env"];
   if (isEmulator) {
     files.push(FUNCTIONS_EMULATOR_DOTENV);
-  } else {
-    files.push(`.env.${projectId}`);
-    if (projectAlias && projectAlias.length) {
-      files.push(`.env.${projectAlias}`);
-    }
+  }
+  files.push(`.env.${projectId}`);
+  if (projectAlias && projectAlias.length) {
+    files.push(`.env.${projectAlias}`);
   }
 
   return files

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -196,12 +196,12 @@ function findEnvfiles(
   isEmulator?: boolean
 ): string[] {
   const files: string[] = [".env"];
-  if (isEmulator) {
-    files.push(FUNCTIONS_EMULATOR_DOTENV);
-  }
   files.push(`.env.${projectId}`);
   if (projectAlias) {
     files.push(`.env.${projectAlias}`);
+  }
+  if (isEmulator) {
+    files.push(FUNCTIONS_EMULATOR_DOTENV);
   }
 
   return files

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -161,9 +161,6 @@ export function validateKey(key: string): void {
 // Parse dotenv file, but throw errors if:
 //   1. Input has any invalid lines.
 //   2. Any env key fails validation.
-/**
- *
- */
 export function parseStrict(data: string): Record<string, string> {
   const { envs, errors } = parse(data);
 
@@ -203,7 +200,7 @@ function findEnvfiles(
     files.push(FUNCTIONS_EMULATOR_DOTENV);
   }
   files.push(`.env.${projectId}`);
-  if (projectAlias && projectAlias.length) {
+  if (projectAlias) {
     files.push(`.env.${projectAlias}`);
   }
 

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -46,6 +46,7 @@ export class FunctionsServer {
       projectId,
       projectDir: options.config.projectDir,
       emulatableBackends: [this.backend],
+      projectAlias: options.projectAlias,
       account,
       ...partialArgs,
     };

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -368,6 +368,21 @@ FOO=foo
       });
     });
 
+    it("loads envs, preferring .local for the emulator", () => {
+      createEnvFiles(tmpdir, {
+        ".env": "FOO=bad\nBAR=bar",
+        [`.env.${projectInfo.projectId}`]: "FOO=another bad",
+        ".env.local": "FOO=good",
+      });
+
+      expect(
+        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true })
+      ).to.be.deep.equal({
+        FOO: "good",
+        BAR: "bar",
+      });
+    });
+
     it("throws an error if both .env.<project> and .env.<alias> exists", () => {
       createEnvFiles(tmpdir, {
         ".env": "FOO=foo\nBAR=bar",

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -328,6 +328,20 @@ FOO=foo
       });
     });
 
+    it("loads envs, preferring ones from .env.<project> for emulators too", () => {
+      createEnvFiles(tmpdir, {
+        ".env": "FOO=bad\nBAR=bar",
+        [`.env.${projectInfo.projectId}`]: "FOO=good",
+      });
+
+      expect(
+        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true })
+      ).to.be.deep.equal({
+        FOO: "good",
+        BAR: "bar",
+      });
+    });
+
     it("loads envs, preferring ones from .env.<alias>", () => {
       createEnvFiles(tmpdir, {
         ".env": "FOO=bad\nBAR=bar",
@@ -335,6 +349,20 @@ FOO=foo
       });
 
       expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+        FOO: "good",
+        BAR: "bar",
+      });
+    });
+
+    it("loads envs, preferring ones from .env.<alias> for emulators too", () => {
+      createEnvFiles(tmpdir, {
+        ".env": "FOO=bad\nBAR=bar",
+        [`.env.${projectInfo.projectAlias}`]: "FOO=good",
+      });
+
+      expect(
+        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true })
+      ).to.be.deep.equal({
         FOO: "good",
         BAR: "bar",
       });

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -368,7 +368,20 @@ FOO=foo
       });
     });
 
-    it("loads envs, preferring .local for the emulator", () => {
+    it("loads envs ignoring .env.local", () => {
+      createEnvFiles(tmpdir, {
+        ".env": "FOO=bad\nBAR=bar",
+        [`.env.${projectInfo.projectId}`]: "FOO=good",
+        ".env.local": "FOO=bad",
+      });
+
+      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+        FOO: "good",
+        BAR: "bar",
+      });
+    });
+
+    it("loads envs, preferring .env.local for the emulator", () => {
       createEnvFiles(tmpdir, {
         ".env": "FOO=bad\nBAR=bar",
         [`.env.${projectInfo.projectId}`]: "FOO=another bad",


### PR DESCRIPTION
Today, Functions Emulator does not load project-specific environment variables. This contradicts the public documentation which states:

> When using a local Cloud Functions emulator, you can override environment variables for your project by setting up a .env.local file. Contents of .env.local take precedence over .env and the project-specific .env file.

https://firebase.google.com/docs/functions/config-env#emulator_support

The patch fixes the bug by making appropriate changes to load project-specific environment variables (either in `.env.projectId` or `.env.projectAlias`) when emulating functions.

Fixes https://github.com/firebase/firebase-tools/issues/4239