### PR TITLE
Remove deleteAll method from StorageLayer

### DIFF
--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -278,10 +278,6 @@ export class StorageLayer {
     }
   }
 
-  public async deleteAll(): Promise<void> {
-    return this._persistence.deleteAll();
-  }
-
   /**
    * Last step in uploading a file. Validates the request and persists the staging
    * object to its permanent location on disk.

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -91,7 +91,7 @@ export class StorageEmulator implements EmulatorInstance {
   }
 
   async stop(): Promise<void> {
-    await this.storageLayer.deleteAll();
+    await this._persistence.deleteAll();
     await this._rulesManager.close();
     return this.destroyServer ? this.destroyServer() : Promise.resolve();
   }


### PR DESCRIPTION
### Description

This was passing through to `Persistence.deleteAll` when the emulator is being stopped. There's no reason to include `StorageLayer` in this flow.