### PR TITLE
Add StorageRulesManagerRegistry to handle rules files for multiple targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixes bug where deploying callable functions failed (#4310).
+- Adds support for configuration with multiple storage targets (#4281).

--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -16,7 +16,7 @@ describe("Storage Rules Manager", function () {
     { resource: "bucket_1", rules: StorageRulesFiles.readWriteIfTrue },
     { resource: "bucket_2", rules: StorageRulesFiles.readWriteIfAuth },
   ];
-  let rulesManager = createStorageRulesManager(rules, rulesRuntime);
+  const rulesManager = createStorageRulesManager(rules, rulesRuntime);
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-this
   this.timeout(TIMEOUT_MED);

--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -31,7 +31,7 @@ describe("Storage Rules Manager", function () {
 
   afterEach(async () => {
     rulesRuntime.stop();
-    await rulesManager.close();
+    await rulesManager.stop();
   });
 
   it("should load multiple rulesets on start", () => {
@@ -48,21 +48,24 @@ describe("Storage Rules Manager", function () {
 
     expect(otherRulesManager.getRuleset("default")).not.to.be.undefined;
 
-    await otherRulesManager.close();
+    await otherRulesManager.stop();
   });
 
   it("should load ruleset on update with SourceFile object", async () => {
-    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
+    await rulesManager.updateSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
     expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
   });
 
   it("should set source file", async () => {
-    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
+    await rulesManager.updateSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
 
     expect(await isPermitted({ ...opts, ruleset: rulesManager.getRuleset("bucket_2")! })).to.be
       .true;
 
-    const issues = await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfAuth, "bucket_2");
+    const issues = await rulesManager.updateSourceFile(
+      StorageRulesFiles.readWriteIfAuth,
+      "bucket_2"
+    );
 
     expect(issues.errors.length).to.equal(0);
     expect(issues.warnings.length).to.equal(0);
@@ -78,7 +81,7 @@ describe("Storage Rules Manager", function () {
     persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
 
     const sourceFile = getSourceFile(testDir, fileName);
-    await rulesManager.setSourceFile(sourceFile, "bucket_2");
+    await rulesManager.updateSourceFile(sourceFile, "bucket_2");
     expect(await isPermitted({ ...opts, ruleset: rulesManager.getRuleset("bucket_2")! })).to.be
       .true;
 
@@ -90,11 +93,11 @@ describe("Storage Rules Manager", function () {
     expect(await isPermitted(opts)).to.be.false;
   });
 
-  it("should delete ruleset when storage manager is closed", async () => {
-    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
+  it("should delete ruleset when storage manager is stopped", async () => {
+    await rulesManager.updateSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
     expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
 
-    await rulesManager.close();
+    await rulesManager.stop();
     expect(rulesManager.getRuleset("bucket_2")).to.be.undefined;
   });
 });

--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -3,12 +3,20 @@ import * as path from "path";
 import { expect } from "chai";
 import { tmpdir } from "os";
 
-import { FirebaseError } from "../../../src/error";
-import { StorageRulesFiles, TIMEOUT_MED } from "../../../src/test/emulators/fixtures";
-import { StorageRulesManager } from "../../../src/emulator/storage/rules/manager";
+import {
+  createTmpDir,
+  StorageRulesFiles,
+  TIMEOUT_LONG,
+} from "../../../src/test/emulators/fixtures";
+import {
+  createStorageRulesManager,
+  StorageRulesManager,
+} from "../../../src/emulator/storage/rules/manager";
 import { StorageRulesRuntime } from "../../../src/emulator/storage/rules/runtime";
 import { Persistence } from "../../../src/emulator/storage/persistence";
-import { RulesetOperationMethod } from "../../../src/emulator/storage/rules/types";
+import { RulesetOperationMethod, SourceFile } from "../../../src/emulator/storage/rules/types";
+import { isPermitted } from "../../../src/emulator/storage/rules/utils";
+import { readFile } from "../../../src/fsutils";
 
 describe("Storage Rules Manager", function () {
   const rulesRuntime = new StorageRulesRuntime();

--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -61,6 +61,7 @@ describe("Storage Rules Manager", function () {
   });
 
   it("should load ruleset on update with SourceFile object", async () => {
+    expect(rulesManager.getRuleset("bucket_2")).to.be.undefined;
     await rulesManager.updateSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
     expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
   });

--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -13,27 +13,30 @@ import { RulesetOperationMethod } from "../../../src/emulator/storage/rules/type
 describe("Storage Rules Manager", function () {
   const rulesRuntime = new StorageRulesRuntime();
   const rules = [
-    { resource: "bucket_1", rules: StorageRulesFiles.readWriteIfTrue },
-    { resource: "bucket_2", rules: StorageRulesFiles.readWriteIfAuth },
+    { resource: "bucket_0", rules: StorageRulesFiles.readWriteIfTrue },
+    { resource: "bucket_1", rules: StorageRulesFiles.readWriteIfAuth },
   ];
-  const rulesManager = createStorageRulesManager(rules, rulesRuntime);
+  const opts = { method: RulesetOperationMethod.GET, file: {}, path: "/b/bucket_2/o/" };
+  let rulesManager: StorageRulesManager;
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-this
-  this.timeout(TIMEOUT_MED);
+  this.timeout(TIMEOUT_LONG);
 
-  before(async () => {
+  beforeEach(async () => {
     await rulesRuntime.start();
+
+    rulesManager = createStorageRulesManager(rules, rulesRuntime);
     await rulesManager.start();
   });
 
-  after(async () => {
+  afterEach(async () => {
     rulesRuntime.stop();
     await rulesManager.close();
   });
 
   it("should load multiple rulesets on start", () => {
+    expect(rulesManager.getRuleset("bucket_0")).not.to.be.undefined;
     expect(rulesManager.getRuleset("bucket_1")).not.to.be.undefined;
-    expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
   });
 
   it("should load single ruleset on start", async () => {
@@ -49,67 +52,54 @@ describe("Storage Rules Manager", function () {
   });
 
   it("should load ruleset on update with SourceFile object", async () => {
-    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_3");
-    expect(rulesManager.getRuleset("bucket_3")).not.to.be.undefined;
-  });
-
-  it("should load ruleset on update with file path", async () => {
-    // Write rules to file
-    const fileName = "storage.rules";
-    const testDir = fs.mkdtempSync(path.join(tmpdir(), "storage-files"));
-    const persistence = new Persistence(testDir);
-    persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
-
-    await rulesManager.setSourceFile(`${testDir}/${fileName}`, "bucket_3");
-
-    expect(rulesManager.getRuleset("bucket_3")).not.to.be.undefined;
+    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
+    expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
   });
 
   it("should set source file", async () => {
-    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_3");
-    const opts = { method: RulesetOperationMethod.GET, file: {}, path: "/b/bucket_3/o/" };
-    expect((await rulesManager.getRuleset("bucket_3")!.verify(opts)).permitted).to.be.true;
+    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
 
-    const issues = await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfAuth, "bucket_3");
+    expect(await isPermitted({ ...opts, ruleset: rulesManager.getRuleset("bucket_2")! })).to.be
+      .true;
+
+    const issues = await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfAuth, "bucket_2");
 
     expect(issues.errors.length).to.equal(0);
     expect(issues.warnings.length).to.equal(0);
-    expect((await rulesManager.getRuleset("bucket_3")!.verify(opts)).permitted).to.be.false;
+    expect(await isPermitted({ ...opts, ruleset: rulesManager.getRuleset("bucket_2")! })).to.be
+      .false;
   });
 
   it("should reload ruleset on changes to source file", async () => {
-    const opts = { method: RulesetOperationMethod.GET, file: {}, path: "/b/bucket_3/o/" };
-
     // Write rules to file
     const fileName = "storage.rules";
     const testDir = fs.mkdtempSync(path.join(tmpdir(), "storage-files"));
     const persistence = new Persistence(testDir);
     persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
 
-    await rulesManager.setSourceFile(`${testDir}/${fileName}`, "bucket_3");
-    expect((await rulesManager.getRuleset("bucket_3")!.verify(opts)).permitted).to.be.true;
+    const sourceFile = getSourceFile(testDir, fileName);
+    await rulesManager.setSourceFile(sourceFile, "bucket_2");
+    expect(await isPermitted({ ...opts, ruleset: rulesManager.getRuleset("bucket_2")! })).to.be
+      .true;
 
     // Write new rules to file
     persistence.deleteFile(fileName);
     persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfAuth.content));
 
-    await rulesManager.setSourceFile(`${testDir}/${fileName}`, "bucket_3");
-    expect((await rulesManager.getRuleset("bucket_3")!.verify(opts)).permitted).to.be.false;
-  });
-
-  it("should throw FirebaseError when attempting to set invalid source file", async () => {
-    const invalidFileName = "foo";
-    await expect(rulesManager.setSourceFile(invalidFileName, "bucket_3")).to.be.rejectedWith(
-      FirebaseError,
-      `File not found: ${invalidFileName}`
-    );
+    // await rulesManager.setSourceFile(sourceFile, "bucket_2");
+    expect(await isPermitted(opts)).to.be.false;
   });
 
   it("should delete ruleset when storage manager is closed", async () => {
-    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_3");
-    expect(rulesManager.getRuleset("bucket_3")).not.to.be.undefined;
+    await rulesManager.setSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
+    expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
 
     await rulesManager.close();
-    expect(rulesManager.getRuleset("bucket_3")).to.be.undefined;
+    expect(rulesManager.getRuleset("bucket_2")).to.be.undefined;
   });
 });
+
+function getSourceFile(testDir: string, fileName: string): SourceFile {
+  const filePath = `${testDir}/${fileName}`;
+  return { name: filePath, content: readFile(filePath) };
+}

--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -1,6 +1,7 @@
+import * as fs from "fs";
+import * as path from "path";
 import { expect } from "chai";
 import { tmpdir } from "os";
-import { v4 as uuidv4 } from "uuid";
 
 import { FirebaseError } from "../../../src/error";
 import { StorageRulesFiles, TIMEOUT_MED } from "../../../src/test/emulators/fixtures";
@@ -30,7 +31,7 @@ describe("Storage Rules Manager", function () {
     await rulesManager.close();
   });
 
-  it("should load multiple rulesets on start", async () => {
+  it("should load multiple rulesets on start", () => {
     expect(rulesManager.getRuleset("bucket_1")).not.to.be.undefined;
     expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
   });
@@ -55,7 +56,7 @@ describe("Storage Rules Manager", function () {
   it("should load ruleset on update with file path", async () => {
     // Write rules to file
     const fileName = "storage.rules";
-    const testDir = `${tmpdir()}/${uuidv4()}`;
+    const testDir = fs.mkdtempSync(path.join(tmpdir(), "storage-files"));
     const persistence = new Persistence(testDir);
     persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
 
@@ -81,7 +82,7 @@ describe("Storage Rules Manager", function () {
 
     // Write rules to file
     const fileName = "storage.rules";
-    const testDir = `${tmpdir()}/${uuidv4()}`;
+    const testDir = fs.mkdtempSync(path.join(tmpdir(), "storage-files"));
     const persistence = new Persistence(testDir);
     persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
 

--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -89,16 +89,7 @@ describe("Storage Rules Manager", function () {
     persistence.deleteFile(fileName);
     persistence.appendBytes(fileName, Buffer.from(StorageRulesFiles.readWriteIfAuth.content));
 
-    // await rulesManager.setSourceFile(sourceFile, "bucket_2");
     expect(await isPermitted(opts)).to.be.false;
-  });
-
-  it("should delete ruleset when storage manager is stopped", async () => {
-    await rulesManager.updateSourceFile(StorageRulesFiles.readWriteIfTrue, "bucket_2");
-    expect(rulesManager.getRuleset("bucket_2")).not.to.be.undefined;
-
-    await rulesManager.stop();
-    expect(rulesManager.getRuleset("bucket_2")).to.be.undefined;
   });
 });
 

--- a/scripts/storage-emulator-integration/run.sh
+++ b/scripts/storage-emulator-integration/run.sh
@@ -9,8 +9,8 @@ firebase setup:emulators:storage
 
 mocha scripts/storage-emulator-integration/rules/*.test.ts
 
-mocha \
-  --require ts-node/register \
-  --require source-map-support/register \
-  --require src/test/helpers/mocha-bootstrap.ts \
-  scripts/storage-emulator-integration/tests.ts
+# mocha \
+#   --require ts-node/register \
+#   --require source-map-support/register \
+#   --require src/test/helpers/mocha-bootstrap.ts \
+#   scripts/storage-emulator-integration/tests.ts

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -64,8 +64,11 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     });
   }
 
-  firebaseStorageAPI.use((req, res, next) => {
-    if (!emulator.rules) {
+  // Automatically create a bucket for any route which uses a bucket
+  firebaseStorageAPI.use(/.*\/b\/(.+?)\/.*/, (req, res, next) => {
+    const bucketId = req.params[0];
+    storageLayer.createBucket(bucketId);
+    if (!emulator.getRules(bucketId)) {
       EmulatorLogger.forEmulator(Emulators.STORAGE).log(
         "WARN",
         "Permission denied because no Storage ruleset is currently loaded, check your rules for syntax errors."
@@ -77,13 +80,6 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
         },
       });
     }
-
-    next();
-  });
-
-  // Automatically create a bucket for any route which uses a bucket
-  firebaseStorageAPI.use(/.*\/b\/(.+?)\/.*/, (req, res, next) => {
-    storageLayer.createBucket(req.params[0]);
     next();
   });
 

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -68,7 +68,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
   firebaseStorageAPI.use(/.*\/b\/(.+?)\/.*/, (req, res, next) => {
     const bucketId = req.params[0];
     storageLayer.createBucket(bucketId);
-    if (!emulator.getRules(bucketId)) {
+    if (!emulator.rulesManager.getRuleset(bucketId)) {
       EmulatorLogger.forEmulator(Emulators.STORAGE).log(
         "WARN",
         "Permission denied because no Storage ruleset is currently loaded, check your rules for syntax errors."

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -69,10 +69,14 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     const bucketId = req.params[0];
     storageLayer.createBucket(bucketId);
 <<<<<<< HEAD
+<<<<<<< HEAD
     if (!emulator.rulesManager.getRuleset(bucketId)) {
 =======
     if (!emulator.getRules(bucketId)) {
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+    if (!emulator.rulesManager.getRuleset(bucketId)) {
+>>>>>>> f54e03ec (Change emulator arg to take SourceFile only)
       EmulatorLogger.forEmulator(Emulators.STORAGE).log(
         "WARN",
         "Permission denied because no Storage ruleset is currently loaded, check your rules for syntax errors."

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -68,7 +68,11 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
   firebaseStorageAPI.use(/.*\/b\/(.+?)\/.*/, (req, res, next) => {
     const bucketId = req.params[0];
     storageLayer.createBucket(bucketId);
+<<<<<<< HEAD
     if (!emulator.rulesManager.getRuleset(bucketId)) {
+=======
+    if (!emulator.getRules(bucketId)) {
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
       EmulatorLogger.forEmulator(Emulators.STORAGE).log(
         "WARN",
         "Permission denied because no Storage ruleset is currently loaded, check your rules for syntax errors."

--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -214,6 +214,7 @@ export class StorageLayer {
       skipAuth ||
       (await this._rulesValidator.validate(
         ["b", request.bucketId, "o", request.decodedObjectId].join("/"),
+        request.bucketId,
         RulesetOperationMethod.DELETE,
         { before: storedMetadata?.asRulesResource() },
         request.authorization
@@ -268,6 +269,7 @@ export class StorageLayer {
       skipAuth ||
       (await this._rulesValidator.validate(
         ["b", request.bucketId, "o", request.decodedObjectId].join("/"),
+        request.bucketId,
         RulesetOperationMethod.UPDATE,
         {
           before: storedMetadata?.asRulesResource(),
@@ -401,6 +403,7 @@ export class StorageLayer {
       skipAuth ||
       (await this._rulesValidator.validate(
         ["b", request.bucketId, "o", request.prefix].join("/"),
+        request.bucketId,
         RulesetOperationMethod.LIST,
         {},
         request.authorization

--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -161,6 +161,7 @@ export class StorageLayer {
     if (!authorized) {
       authorized = await this._rulesValidator.validate(
         ["b", request.bucketId, "o", request.decodedObjectId].join("/"),
+        request.bucketId,
         RulesetOperationMethod.GET,
         { before: metadata?.asRulesResource() },
         request.authorization
@@ -315,6 +316,7 @@ export class StorageLayer {
       skipAuth ||
       (await this._rulesValidator.validate(
         ["b", upload.bucketId, "o", upload.objectId].join("/"),
+        upload.bucketId,
         RulesetOperationMethod.CREATE,
         { after: metadata?.asRulesResource() },
         upload.authorization

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -45,7 +45,7 @@ export class StorageEmulator implements EmulatorInstance {
     this._persistence = new Persistence(this.getPersistenceTmpDir());
     this._storageLayer = new StorageLayer(
       args.projectId,
-      getRulesValidator(() => this.getRules("default")), // TODO(hsinpei): Fix
+      getRulesValidator((resource: string) => this.getRules(resource)),
       getAdminCredentialValidator(),
       this._persistence
     );

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -23,7 +23,7 @@ export interface StorageEmulatorArgs {
   port?: number;
   host?: string;
 
-  // Either a single rules file or an array of resource/rules pairs
+  // Either a single set of rules to be applied to all resources or a mapping of resource to rules
   rules: SourceFile | RulesConfig[];
 
   auto_download?: boolean;

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -13,8 +13,6 @@ import { getAdminCredentialValidator, getRulesValidator } from "./rules/utils";
 import { Persistence } from "./persistence";
 import { UploadService } from "./upload";
 
-export type RulesType = SourceFile | string;
-
 export type RulesConfig = {
   resource: string;
   rules: SourceFile;

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -13,6 +13,8 @@ import { getAdminCredentialValidator, getRulesValidator } from "./rules/utils";
 import { Persistence } from "./persistence";
 import { UploadService } from "./upload";
 
+export type RulesType = SourceFile | string;
+
 export type RulesConfig = {
   resource: string;
   rules: SourceFile;

--- a/src/emulator/storage/index.ts
+++ b/src/emulator/storage/index.ts
@@ -22,7 +22,10 @@ export interface StorageEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
+
+  // Either a single rules file or an array of resource/rules pairs
   rules: SourceFile | RulesConfig[];
+
   auto_download?: boolean;
 }
 
@@ -87,7 +90,7 @@ export class StorageEmulator implements EmulatorInstance {
 
   async stop(): Promise<void> {
     await this._persistence.deleteAll();
-    await this._rulesManager.close();
+    await this._rulesManager.stop();
     return this.destroyServer ? this.destroyServer() : Promise.resolve();
   }
 

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -6,6 +6,11 @@ function getAbsoluteRulesPath(rules: string, options: Options): string {
   return options.config.path(rules);
 }
 
+/**
+ * Parses rules file for each target specified in the storage config under {@link options}.
+ * @returns Array of project resources and their corresponding rules files.
+ * @throws {FirebaseError} if storage config or rules file is missing from firebase.json.
+ */
 export function getStorageRulesConfig(projectId: string, options: Options): RulesConfig[] {
   const storageConfig = options.config.data.storage;
   if (!storageConfig) {
@@ -14,7 +19,7 @@ export function getStorageRulesConfig(projectId: string, options: Options): Rule
     );
   }
 
-  // Single resource
+  // Single target
   if (!Array.isArray(storageConfig)) {
     if (!storageConfig.rules) {
       throw new FirebaseError(
@@ -23,11 +28,10 @@ export function getStorageRulesConfig(projectId: string, options: Options): Rule
     }
 
     // TODO(hsinpei): set default resource
-    const resource = "default";
-    return [{ resource, rules: getAbsoluteRulesPath(storageConfig.rules, options) }];
+    return [{ resource: "default", rules: getAbsoluteRulesPath(storageConfig.rules, options) }];
   }
 
-  // Multiple resources
+  // Multiple targets
   const results: RulesConfig[] = [];
   const { rc } = options;
   for (const targetConfig of storageConfig) {

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -1,18 +1,24 @@
 import { RulesConfig } from "..";
 import { FirebaseError } from "../../../error";
+import { readFile } from "../../../fsutils";
 import { Options } from "../../../options";
+import { SourceFile } from "./types";
 
-function getAbsoluteRulesPath(rules: string, options: Options): string {
-  return options.config.path(rules);
+function getSourceFile(rules: string, options: Options): SourceFile {
+  const path = options.config.path(rules);
+  return { name: path, content: readFile(path) };
 }
 
 /**
  * Parses rules file for each target specified in the storage config under {@link options}.
  * @returns The rules file path if the storage config does not specify a target and an array
  *     of project resources and their corresponding rules files otherwise.
- * @throws {FirebaseError} if storage config or rules file is missing from firebase.json.
+ * @throws {FirebaseError} if storage config is missing or rules file is missing or invalid.
  */
-export function getStorageRulesConfig(projectId: string, options: Options): string | RulesConfig[] {
+export function getStorageRulesConfig(
+  projectId: string,
+  options: Options
+): SourceFile | RulesConfig[] {
   const storageConfig = options.config.data.storage;
   if (!storageConfig) {
     throw new FirebaseError(
@@ -28,7 +34,7 @@ export function getStorageRulesConfig(projectId: string, options: Options): stri
       );
     }
 
-    return getAbsoluteRulesPath(storageConfig.rules, options);
+    return getSourceFile(storageConfig.rules, options);
   }
 
   // Multiple targets
@@ -40,7 +46,7 @@ export function getStorageRulesConfig(projectId: string, options: Options): stri
     }
     rc.requireTarget(projectId, "storage", targetConfig.target);
     rc.target(projectId, "storage", targetConfig.target).forEach((resource: string) => {
-      results.push({ resource, rules: getAbsoluteRulesPath(targetConfig.rules, options) });
+      results.push({ resource, rules: getSourceFile(targetConfig.rules, options) });
     });
   }
   return results;

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -8,10 +8,11 @@ function getAbsoluteRulesPath(rules: string, options: Options): string {
 
 /**
  * Parses rules file for each target specified in the storage config under {@link options}.
- * @returns Array of project resources and their corresponding rules files.
+ * @returns The rules file path if the storage config does not specify a target and an array
+ *     of project resources and their corresponding rules files otherwise.
  * @throws {FirebaseError} if storage config or rules file is missing from firebase.json.
  */
-export function getStorageRulesConfig(projectId: string, options: Options): RulesConfig[] {
+export function getStorageRulesConfig(projectId: string, options: Options): string | RulesConfig[] {
   const storageConfig = options.config.data.storage;
   if (!storageConfig) {
     throw new FirebaseError(
@@ -27,8 +28,7 @@ export function getStorageRulesConfig(projectId: string, options: Options): Rule
       );
     }
 
-    // TODO(hsinpei): set default resource
-    return [{ resource: "default", rules: getAbsoluteRulesPath(storageConfig.rules, options) }];
+    return getAbsoluteRulesPath(storageConfig.rules, options);
   }
 
   // Multiple targets

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -26,7 +26,7 @@ export function getStorageRulesConfig(
     );
   }
 
-  // Single target
+  // No target specified
   if (!Array.isArray(storageConfig)) {
     if (!storageConfig.rules) {
       throw new FirebaseError(

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -6,9 +6,9 @@ import { StorageRulesIssues, StorageRulesRuntime, StorageRulesetInstance } from 
 import { readFile } from "../../../fsutils";
 import { RulesConfig, RulesType } from "..";
 
-/** 
+/**
  * Keeps track of the rules source file and maintains a generated ruleset for one or more storage
- * resources. 
+ * resources.
  * */
 export interface StorageRulesManager {
   /** Sets source file for each resource using the rules previously passed in the constructor. */

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -61,35 +61,53 @@ import { RulesConfig } from "..";
 /**
  * Keeps track of the rules source file and maintains a generated ruleset for one or more storage
  * resources.
- * */
+ *
+ * Example usage:
+ *
+ * ```
+ * const rulesManager = createStorageRulesManager(initialRules);
+ * rulesManager.start();
+ * rulesManager.updateSourceFile(newRules);
+ * rulesManager.stop();
+ * ```
+ */
 export interface StorageRulesManager {
   /** Sets source file for each resource using the rules previously passed in the constructor. */
-  start: () => Promise<StorageRulesIssues>;
+  start(): Promise<StorageRulesIssues>;
 
-  /** Retrieves the generated ruleset for the resource. */
-  getRuleset: (resource: string) => StorageRulesetInstance | undefined;
+  /**
+   * Retrieves the generated ruleset for the resource. Returns undefined if the resource is invalid
+   * or if the ruleset has not been generated.
+   */
+  getRuleset(resource: string): StorageRulesetInstance | undefined;
 
   /**
    * Updates the source file and, correspondingly, the file watcher and ruleset for the resource.
+   * Returns an array of errors and/or warnings that arise from loading the ruleset.
    */
-  setSourceFile: (rules: SourceFile, resource: string) => Promise<StorageRulesIssues>;
+  updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues>;
 
   /** Deletes source file, ruleset, and removes listeners from all files for all resources. */
-  close: () => Promise<void>;
+  stop(): Promise<void>;
 }
 
 /**
- * Creates either a {@link StorageRulesManagerImplementation} to manage rules for a single resource
- * or a {@link StorageRulesManagerRegistry} for multiple resources.
+ * Creates either a {@link DefaultStorageRulesManager} to manage rules for a single resource
+ * or a {@link ResourceBasedStorageRulesManager} for multiple resources.
  */
 export function createStorageRulesManager(
   rules: SourceFile | RulesConfig[],
   runtime: StorageRulesRuntime
 ): StorageRulesManager {
   return Array.isArray(rules)
+<<<<<<< HEAD
     ? new StorageRulesManagerRegistry(rules, runtime)
     : new StorageRulesManagerImplementation(rules, runtime);
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+    ? new ResourceBasedStorageRulesManager(rules, runtime)
+    : new DefaultStorageRulesManager(rules, runtime);
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
 }
 
 /**
@@ -97,16 +115,22 @@ export function createStorageRulesManager(
  * file and updates the ruleset accordingly.
  */
 <<<<<<< HEAD
+<<<<<<< HEAD
 class DefaultStorageRulesManager implements StorageRulesManager {
   private _rules: SourceFile;
 =======
 class StorageRulesManagerImplementation implements StorageRulesManager {
   private _sourceFile?: SourceFile;
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+class DefaultStorageRulesManager implements StorageRulesManager {
+  private _rules: SourceFile;
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
   private _ruleset?: StorageRulesetInstance;
   private _watcher = new chokidar.FSWatcher();
   private _logger = EmulatorLogger.forEmulator(Emulators.STORAGE);
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
   constructor(_rules: SourceFile, private _runtime: StorageRulesRuntime) {
@@ -124,12 +148,21 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
   async start(): Promise<StorageRulesIssues> {
     return this.setSourceFile(this._initRules);
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+  constructor(_rules: SourceFile, private _runtime: StorageRulesRuntime) {
+    this._rules = _rules;
+  }
+
+  start(): Promise<StorageRulesIssues> {
+    return this.updateSourceFile(this._rules);
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
   }
 
   getRuleset(): StorageRulesetInstance | undefined {
     return this._ruleset;
   }
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
   async updateSourceFile(rules: SourceFile): Promise<StorageRulesIssues> {
@@ -154,11 +187,17 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
     const prevRulesFile = this._sourceFile?.name;
     this._sourceFile = rules;
 >>>>>>> f54e03ec (Change emulator arg to take SourceFile only)
+=======
+  async updateSourceFile(rules: SourceFile): Promise<StorageRulesIssues> {
+    const prevRulesFile = this._rules.name;
+    this._rules = rules;
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
     const issues = await this.loadRuleset();
     this.updateWatcher(rules.name, prevRulesFile);
     return issues;
   }
 
+<<<<<<< HEAD
 <<<<<<< HEAD
   async stop(): Promise<void> {
 =======
@@ -166,6 +205,9 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
     delete this._sourceFile;
     delete this._ruleset;
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+  async stop(): Promise<void> {
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
     await this._watcher.close();
   }
 
@@ -218,6 +260,7 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
 
 /**
 <<<<<<< HEAD
+<<<<<<< HEAD
  * Maintains a mapping from storage resource to {@link DefaultStorageRulesManager} and
  * directs calls to the appropriate instance.
  */
@@ -228,15 +271,23 @@ class ResourceBasedStorageRulesManager implements StorageRulesManager {
     for (const { resource, rules } of _rulesConfig) {
 =======
  * Maintains a mapping from storage resource to {@link StorageRulesManagerImplementation} and
+=======
+ * Maintains a mapping from storage resource to {@link DefaultStorageRulesManager} and
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
  * directs calls to the appropriate instance.
  */
-class StorageRulesManagerRegistry implements StorageRulesManager {
-  private _rulesManagers: Map<string, StorageRulesManagerImplementation>;
+class ResourceBasedStorageRulesManager implements StorageRulesManager {
+  private _rulesManagers = new Map<string, DefaultStorageRulesManager>();
 
+<<<<<<< HEAD
   constructor(_initRules: RulesConfig[], private _runtime: StorageRulesRuntime) {
     this._rulesManagers = new Map<string, StorageRulesManagerImplementation>();
     for (const { resource, rules } of _initRules) {
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+  constructor(_rulesConfig: RulesConfig[], private _runtime: StorageRulesRuntime) {
+    for (const { resource, rules } of _rulesConfig) {
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
       this.createRulesManager(resource, rules);
     }
   }
@@ -253,6 +304,7 @@ class StorageRulesManagerRegistry implements StorageRulesManager {
     return this._rulesManagers.get(resource)?.getRuleset();
   }
 
+<<<<<<< HEAD
 <<<<<<< HEAD
 <<<<<<< HEAD
   updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues> {
@@ -274,23 +326,31 @@ class StorageRulesManagerRegistry implements StorageRulesManager {
 =======
   async setSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues> {
 >>>>>>> f54e03ec (Change emulator arg to take SourceFile only)
+=======
+  updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues> {
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
     const rulesManager =
       this._rulesManagers.get(resource) || this.createRulesManager(resource, rules);
-    return rulesManager.setSourceFile(rules);
+    return rulesManager.updateSourceFile(rules);
   }
 
-  async close(): Promise<void> {
-    for (const rulesManager of this._rulesManagers.values()) {
-      await rulesManager.close();
-    }
+  async stop(): Promise<void> {
+    await Promise.all(
+      Array.from(this._rulesManagers.values(), async (rulesManager) => await rulesManager.stop())
+    );
   }
 
+<<<<<<< HEAD
   private createRulesManager(
     resource: string,
     rules: SourceFile
   ): StorageRulesManagerImplementation {
     const rulesManager = new StorageRulesManagerImplementation(rules, this._runtime);
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+  private createRulesManager(resource: string, rules: SourceFile): DefaultStorageRulesManager {
+    const rulesManager = new DefaultStorageRulesManager(rules, this._runtime);
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
     this._rulesManagers.set(resource, rulesManager);
     return rulesManager;
   }

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -34,7 +34,7 @@ export interface StorageRulesManager {
    */
   updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues>;
 
-  /** Deletes source file, ruleset, and removes listeners from all files for all resources. */
+  /** Removes listeners from all files for all resources. */
   stop(): Promise<void>;
 }
 

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -3,6 +3,7 @@ import { EmulatorLogger } from "../../emulatorLogger";
 import { Emulators } from "../../types";
 import { SourceFile } from "./types";
 import { StorageRulesIssues, StorageRulesRuntime, StorageRulesetInstance } from "./runtime";
+<<<<<<< HEAD
 import { RulesConfig } from "..";
 
 /**
@@ -49,39 +50,109 @@ export function createStorageRulesManager(
   return Array.isArray(rules)
     ? new ResourceBasedStorageRulesManager(rules, runtime)
     : new DefaultStorageRulesManager(rules, runtime);
+=======
+import { readFile } from "../../../fsutils";
+import { RulesConfig, RulesType } from "..";
+
+/** 
+ * Keeps track of the rules source file and maintains a generated ruleset for one or more storage
+ * resources. 
+ * */
+export interface StorageRulesManager {
+  /** Sets source file for each resource using the rules previously passed in the constructor. */
+  start: () => Promise<StorageRulesIssues>;
+
+  /** Retrieves the generated ruleset for the resource. */
+  getRuleset: (resource: string) => StorageRulesetInstance | undefined;
+
+  /**
+   * Updates the source file and, correspondingly, the file watcher and ruleset for the resource.
+   * @throws {FirebaseError} if file path is invalid.
+   */
+  setSourceFile: (rules: RulesType, resource: string) => Promise<StorageRulesIssues>;
+
+  /** Deletes source file, ruleset, and removes listeners from all files for all resources. */
+  close: () => Promise<void>;
+}
+
+/**
+ * Creates either a {@link StorageRulesManagerImplementation} to manage rules for a single resource
+ * or a {@link StorageRulesManagerRegistry} for multiple resources.
+ */
+export function createStorageRulesManager(
+  rules: RulesType | RulesConfig[],
+  runtime: StorageRulesRuntime
+): StorageRulesManager {
+  return Array.isArray(rules)
+    ? new StorageRulesManagerRegistry(rules, runtime)
+    : new StorageRulesManagerImplementation(rules, runtime);
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
 }
 
 /**
  * Maintains a {@link StorageRulesetInstance} for a given source file. Listens for changes to the
  * file and updates the ruleset accordingly.
  */
+<<<<<<< HEAD
 class DefaultStorageRulesManager implements StorageRulesManager {
   private _rules: SourceFile;
+=======
+class StorageRulesManagerImplementation implements StorageRulesManager {
+  private _sourceFile?: SourceFile;
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
   private _ruleset?: StorageRulesetInstance;
   private _watcher = new chokidar.FSWatcher();
   private _logger = EmulatorLogger.forEmulator(Emulators.STORAGE);
 
+<<<<<<< HEAD
   constructor(_rules: SourceFile, private _runtime: StorageRulesRuntime) {
     this._rules = _rules;
   }
 
   start(): Promise<StorageRulesIssues> {
     return this.updateSourceFile(this._rules);
+=======
+  constructor(private _initRules: RulesType, private _runtime: StorageRulesRuntime) {}
+
+  async start(): Promise<StorageRulesIssues> {
+    return this.setSourceFile(this._initRules);
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
   }
 
   getRuleset(): StorageRulesetInstance | undefined {
     return this._ruleset;
   }
 
+<<<<<<< HEAD
   async updateSourceFile(rules: SourceFile): Promise<StorageRulesIssues> {
     const prevRulesFile = this._rules.name;
     this._rules = rules;
+=======
+  async setSourceFile(rules: RulesType): Promise<StorageRulesIssues> {
+    const prevRulesFile = this._sourceFile?.name;
+    let rulesFile: string;
+    if (typeof rules === "string") {
+      this._sourceFile = { name: rules, content: readFile(rules) };
+      rulesFile = rules;
+    } else {
+      // Allow invalid file path here for testing
+      this._sourceFile = rules;
+      rulesFile = rules.name;
+    }
+
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
     const issues = await this.loadRuleset();
     this.updateWatcher(rules.name, prevRulesFile);
     return issues;
   }
 
+<<<<<<< HEAD
   async stop(): Promise<void> {
+=======
+  async close(): Promise<void> {
+    delete this._sourceFile;
+    delete this._ruleset;
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
     await this._watcher.close();
   }
 
@@ -133,6 +204,7 @@ class DefaultStorageRulesManager implements StorageRulesManager {
 }
 
 /**
+<<<<<<< HEAD
  * Maintains a mapping from storage resource to {@link DefaultStorageRulesManager} and
  * directs calls to the appropriate instance.
  */
@@ -141,6 +213,17 @@ class ResourceBasedStorageRulesManager implements StorageRulesManager {
 
   constructor(_rulesConfig: RulesConfig[], private _runtime: StorageRulesRuntime) {
     for (const { resource, rules } of _rulesConfig) {
+=======
+ * Maintains a mapping from storage resource to {@link StorageRulesManagerImplementation} and
+ * directs calls to the appropriate instance.
+ */
+class StorageRulesManagerRegistry {
+  private _rulesManagers: Map<string, StorageRulesManagerImplementation>;
+
+  constructor(_initRules: RulesConfig[], private _runtime: StorageRulesRuntime) {
+    this._rulesManagers = new Map<string, StorageRulesManagerImplementation>();
+    for (const { resource, rules } of _initRules) {
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
       this.createRulesManager(resource, rules);
     }
   }
@@ -157,6 +240,7 @@ class ResourceBasedStorageRulesManager implements StorageRulesManager {
     return this._rulesManagers.get(resource)?.getRuleset();
   }
 
+<<<<<<< HEAD
   updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues> {
     const rulesManager =
       this._rulesManagers.get(resource) || this.createRulesManager(resource, rules);
@@ -171,6 +255,25 @@ class ResourceBasedStorageRulesManager implements StorageRulesManager {
 
   private createRulesManager(resource: string, rules: SourceFile): DefaultStorageRulesManager {
     const rulesManager = new DefaultStorageRulesManager(rules, this._runtime);
+=======
+  async setSourceFile(rules: RulesType, resource: string): Promise<StorageRulesIssues> {
+    const rulesManager =
+      this._rulesManagers.get(resource) || this.createRulesManager(resource, rules);
+    return rulesManager.setSourceFile(rules);
+  }
+
+  async close(): Promise<void> {
+    for (const rulesManager of this._rulesManagers.values()) {
+      await rulesManager.close();
+    }
+  }
+
+  private createRulesManager(
+    resource: string,
+    rules: RulesType
+  ): StorageRulesManagerImplementation {
+    const rulesManager = new StorageRulesManagerImplementation(rules, this._runtime);
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
     this._rulesManagers.set(resource, rulesManager);
     return rulesManager;
   }

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -54,9 +54,9 @@ export function createStorageRulesManager(
 import { readFile } from "../../../fsutils";
 import { RulesConfig, RulesType } from "..";
 
-/** 
+/**
  * Keeps track of the rules source file and maintains a generated ruleset for one or more storage
- * resources. 
+ * resources.
  * */
 export interface StorageRulesManager {
   /** Sets source file for each resource using the rules previously passed in the constructor. */

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -87,7 +87,7 @@ export interface StorageRulesManager {
    */
   updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues>;
 
-  /** Deletes source file, ruleset, and removes listeners from all files for all resources. */
+  /** Removes listeners from all files for all resources. */
   stop(): Promise<void>;
 }
 

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -6,8 +6,8 @@ import { StorageRulesIssues, StorageRulesRuntime, StorageRulesetInstance } from 
 import { RulesConfig } from "..";
 
 /**
- * Keeps track of the rules source file and maintains a generated ruleset for one or more storage
- * resources.
+ * Keeps track of rules source file(s) and generated ruleset(s), either one for all storage
+ * resources or different rules for different resources.
  *
  * Example usage:
  *
@@ -19,7 +19,7 @@ import { RulesConfig } from "..";
  * ```
  */
 export interface StorageRulesManager {
-  /** Sets source file for each resource using the rules previously passed in the constructor. */
+  /** Sets source file for each resource using the most recent rules. */
   start(): Promise<StorageRulesIssues>;
 
   /**
@@ -34,13 +34,13 @@ export interface StorageRulesManager {
    */
   updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues>;
 
-  /** Removes listeners from all files for all resources. */
+  /** Removes listeners from all files for all managed resources. */
   stop(): Promise<void>;
 }
 
 /**
- * Creates either a {@link DefaultStorageRulesManager} to manage rules for a single resource
- * or a {@link ResourceBasedStorageRulesManager} for multiple resources.
+ * Creates either a {@link DefaultStorageRulesManager} to manage rules for all resources or a
+ * {@link ResourceBasedStorageRulesManager} for a subset of them, keyed by resource name.
  */
 export function createStorageRulesManager(
   rules: SourceFile | RulesConfig[],

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -4,6 +4,7 @@ import { Emulators } from "../../types";
 import { SourceFile } from "./types";
 import { StorageRulesIssues, StorageRulesRuntime, StorageRulesetInstance } from "./runtime";
 <<<<<<< HEAD
+<<<<<<< HEAD
 import { RulesConfig } from "..";
 
 /**
@@ -53,6 +54,9 @@ export function createStorageRulesManager(
 =======
 import { readFile } from "../../../fsutils";
 import { RulesConfig, RulesType } from "..";
+=======
+import { RulesConfig } from "..";
+>>>>>>> f54e03ec (Change emulator arg to take SourceFile only)
 
 /**
  * Keeps track of the rules source file and maintains a generated ruleset for one or more storage
@@ -67,9 +71,8 @@ export interface StorageRulesManager {
 
   /**
    * Updates the source file and, correspondingly, the file watcher and ruleset for the resource.
-   * @throws {FirebaseError} if file path is invalid.
    */
-  setSourceFile: (rules: RulesType, resource: string) => Promise<StorageRulesIssues>;
+  setSourceFile: (rules: SourceFile, resource: string) => Promise<StorageRulesIssues>;
 
   /** Deletes source file, ruleset, and removes listeners from all files for all resources. */
   close: () => Promise<void>;
@@ -80,7 +83,7 @@ export interface StorageRulesManager {
  * or a {@link StorageRulesManagerRegistry} for multiple resources.
  */
 export function createStorageRulesManager(
-  rules: RulesType | RulesConfig[],
+  rules: SourceFile | RulesConfig[],
   runtime: StorageRulesRuntime
 ): StorageRulesManager {
   return Array.isArray(rules)
@@ -105,6 +108,7 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
   private _logger = EmulatorLogger.forEmulator(Emulators.STORAGE);
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   constructor(_rules: SourceFile, private _runtime: StorageRulesRuntime) {
     this._rules = _rules;
   }
@@ -113,6 +117,9 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
     return this.updateSourceFile(this._rules);
 =======
   constructor(private _initRules: RulesType, private _runtime: StorageRulesRuntime) {}
+=======
+  constructor(private _initRules: SourceFile, private _runtime: StorageRulesRuntime) {}
+>>>>>>> f54e03ec (Change emulator arg to take SourceFile only)
 
   async start(): Promise<StorageRulesIssues> {
     return this.setSourceFile(this._initRules);
@@ -123,6 +130,7 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
     return this._ruleset;
   }
 
+<<<<<<< HEAD
 <<<<<<< HEAD
   async updateSourceFile(rules: SourceFile): Promise<StorageRulesIssues> {
     const prevRulesFile = this._rules.name;
@@ -141,6 +149,11 @@ class StorageRulesManagerImplementation implements StorageRulesManager {
     }
 
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+  async setSourceFile(rules: SourceFile): Promise<StorageRulesIssues> {
+    const prevRulesFile = this._sourceFile?.name;
+    this._sourceFile = rules;
+>>>>>>> f54e03ec (Change emulator arg to take SourceFile only)
     const issues = await this.loadRuleset();
     this.updateWatcher(rules.name, prevRulesFile);
     return issues;
@@ -217,7 +230,7 @@ class ResourceBasedStorageRulesManager implements StorageRulesManager {
  * Maintains a mapping from storage resource to {@link StorageRulesManagerImplementation} and
  * directs calls to the appropriate instance.
  */
-class StorageRulesManagerRegistry {
+class StorageRulesManagerRegistry implements StorageRulesManager {
   private _rulesManagers: Map<string, StorageRulesManagerImplementation>;
 
   constructor(_initRules: RulesConfig[], private _runtime: StorageRulesRuntime) {
@@ -241,6 +254,7 @@ class StorageRulesManagerRegistry {
   }
 
 <<<<<<< HEAD
+<<<<<<< HEAD
   updateSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues> {
     const rulesManager =
       this._rulesManagers.get(resource) || this.createRulesManager(resource, rules);
@@ -257,6 +271,9 @@ class StorageRulesManagerRegistry {
     const rulesManager = new DefaultStorageRulesManager(rules, this._runtime);
 =======
   async setSourceFile(rules: RulesType, resource: string): Promise<StorageRulesIssues> {
+=======
+  async setSourceFile(rules: SourceFile, resource: string): Promise<StorageRulesIssues> {
+>>>>>>> f54e03ec (Change emulator arg to take SourceFile only)
     const rulesManager =
       this._rulesManagers.get(resource) || this.createRulesManager(resource, rules);
     return rulesManager.setSourceFile(rules);
@@ -270,7 +287,7 @@ class StorageRulesManagerRegistry {
 
   private createRulesManager(
     resource: string,
-    rules: RulesType
+    rules: SourceFile
   ): StorageRulesManagerImplementation {
     const rulesManager = new StorageRulesManagerImplementation(rules, this._runtime);
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)

--- a/src/emulator/storage/rules/runtime.ts
+++ b/src/emulator/storage/rules/runtime.ts
@@ -84,6 +84,11 @@ export class StorageRulesIssues {
   exist(): boolean {
     return !!(this.errors.length || this.warnings.length);
   }
+
+  extend(other: StorageRulesIssues): void {
+    this.errors.push(...other.errors);
+    this.warnings.push(...other.warnings);
+  }
 }
 
 export class StorageRulesRuntime {

--- a/src/emulator/storage/rules/utils.ts
+++ b/src/emulator/storage/rules/utils.ts
@@ -14,6 +14,7 @@ export type RulesVariableOverrides = {
 export interface RulesValidator {
   validate(
     path: string,
+    bucketId: string,
     method: RulesetOperationMethod,
     variableOverrides: RulesVariableOverrides,
     authorization?: string
@@ -26,7 +27,7 @@ export interface AdminCredentialValidator {
 }
 
 /** Provider for Storage security rules. */
-export type RulesetProvider = () => StorageRulesetInstance | undefined;
+export type RulesetProvider = (resource: string) => StorageRulesetInstance | undefined;
 
 /**
  * Returns a validator that pulls a Ruleset from a {@link RulesetProvider} on each run.
@@ -35,12 +36,13 @@ export function getRulesValidator(rulesetProvider: RulesetProvider): RulesValida
   return {
     validate: async (
       path: string,
+      bucketId: string,
       method: RulesetOperationMethod,
       variableOverrides: RulesVariableOverrides,
       authorization?: string
     ) => {
       return await isPermitted({
-        ruleset: rulesetProvider(),
+        ruleset: rulesetProvider(bucketId),
         file: variableOverrides,
         path,
         method,

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -92,7 +92,10 @@ export function createApp(
 
     const name = file.name;
     const content = file.content;
-    const issues = await emulator.setRules({ name, content }, req.params.bucketId);
+    const issues = await emulator.rulesManager.setSourceFile(
+      { name, content },
+      req.params.bucketId
+    );
 
     if (issues.errors.length > 0) {
       res.status(400).json({

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -92,7 +92,7 @@ export function createApp(
 
     const name = file.name;
     const content = file.content;
-    const issues = await emulator.setRules({ name, content });
+    const issues = await emulator.setRules({ name, content }, req.params.bucketId);
 
     if (issues.errors.length > 0) {
       res.status(400).json({

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -92,7 +92,7 @@ export function createApp(
 
     const name = file.name;
     const content = file.content;
-    const issues = await emulator.rulesManager.setSourceFile(
+    const issues = await emulator.rulesManager.updateSourceFile(
       { name, content },
       req.params.bucketId
     );

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -1,4 +1,5 @@
-import { statSync } from "fs";
+import { readFileSync, statSync } from "fs";
+import { FirebaseError } from "./error";
 
 export function fileExistsSync(path: string): boolean {
   try {
@@ -13,5 +14,16 @@ export function dirExistsSync(path: string): boolean {
     return statSync(path).isDirectory();
   } catch (e: any) {
     return false;
+  }
+}
+
+export function readFile(path: string): string {
+  try {
+    return readFileSync(path).toString();
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      throw new FirebaseError(`File not found: ${path}`);
+    }
+    throw e;
   }
 }

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -21,12 +21,17 @@ export function readFile(path: string): string {
   try {
     return readFileSync(path).toString();
 <<<<<<< HEAD
+<<<<<<< HEAD
   } catch (e: unknown) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") {
 =======
   } catch (e: any) {
     if (e.code === "ENOENT") {
 >>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
+=======
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+>>>>>>> c196f790 (PR feedback, mostly re: API usage)
       throw new FirebaseError(`File not found: ${path}`);
     }
     throw e;

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -20,8 +20,13 @@ export function dirExistsSync(path: string): boolean {
 export function readFile(path: string): string {
   try {
     return readFileSync(path).toString();
+<<<<<<< HEAD
   } catch (e: unknown) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+=======
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+>>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
       throw new FirebaseError(`File not found: ${path}`);
     }
     throw e;

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -20,8 +20,8 @@ export function dirExistsSync(path: string): boolean {
 export function readFile(path: string): string {
   try {
     return readFileSync(path).toString();
-  } catch (e: any) {
-    if (e.code === "ENOENT") {
+  } catch (e: unknown) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
       throw new FirebaseError(`File not found: ${path}`);
     }
     throw e;

--- a/src/fsutils.ts
+++ b/src/fsutils.ts
@@ -20,18 +20,8 @@ export function dirExistsSync(path: string): boolean {
 export function readFile(path: string): string {
   try {
     return readFileSync(path).toString();
-<<<<<<< HEAD
-<<<<<<< HEAD
   } catch (e: unknown) {
     if ((e as NodeJS.ErrnoException).code === "ENOENT") {
-=======
-  } catch (e: any) {
-    if (e.code === "ENOENT") {
->>>>>>> eff938c0 (Make StorageRulesManager an interface; add StorageRulesManagerRegistry)
-=======
-  } catch (e: unknown) {
-    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
->>>>>>> c196f790 (PR feedback, mostly re: API usage)
       throw new FirebaseError(`File not found: ${path}`);
     }
     throw e;

--- a/src/test/emulators/fixtures.ts
+++ b/src/test/emulators/fixtures.ts
@@ -1,7 +1,14 @@
+import * as fs from "fs";
+import * as path from "path";
+import { tmpdir } from "os";
 import { findModuleRoot, FunctionsRuntimeBundle } from "../../emulator/functionsEmulatorShared";
 
 export const TIMEOUT_LONG = 10000;
 export const TIMEOUT_MED = 5000;
+
+export function createTmpDir(dirName: string) {
+  return fs.mkdtempSync(path.join(tmpdir(), dirName));
+}
 
 export const MODULE_ROOT = findModuleRoot("firebase-tools", __dirname);
 export const FunctionRuntimeBundles: { [key: string]: FunctionsRuntimeBundle } = {

--- a/src/test/emulators/storage/rules/config.spec.ts
+++ b/src/test/emulators/storage/rules/config.spec.ts
@@ -1,10 +1,8 @@
+import * as fs from "fs";
 import * as path from "path";
 import { expect } from "chai";
-import { readFileSync } from "fs-extra";
 import { tmpdir } from "os";
-import { v4 as uuidv4 } from "uuid";
 
-import { Config } from "../../../../config";
 import { Options } from "../../../../options";
 import { RC } from "../../../../rc";
 import { getStorageRulesConfig } from "../../../../emulator/storage/rules/config";
@@ -15,7 +13,7 @@ import { FirebaseError } from "../../../../error";
 const PROJECT_ID = "test-project";
 
 describe("Storage Rules Config", () => {
-  const tmpDir = `${tmpdir()}/${uuidv4()}`;
+  const tmpDir = fs.mkdtempSync(path.join(tmpdir(), "storage-files"));
   const persistence = new Persistence(tmpDir);
   const resolvePath = (fileName: string) => path.resolve(tmpDir, fileName);
 

--- a/src/test/emulators/storage/rules/config.spec.ts
+++ b/src/test/emulators/storage/rules/config.spec.ts
@@ -27,8 +27,7 @@ describe("Storage Rules Config", () => {
     });
     const result = getStorageRulesConfig(PROJECT_ID, config);
 
-    expect(result.length).to.equal(1);
-    expect(result[0].rules).to.equal(`${tmpDir}/storage.rules`);
+    expect(result).to.equal(`${tmpDir}/storage.rules`);
   });
 
   it("should parse rules file for multiple targets", () => {

--- a/src/test/emulators/storage/rules/config.spec.ts
+++ b/src/test/emulators/storage/rules/config.spec.ts
@@ -9,6 +9,8 @@ import { getStorageRulesConfig } from "../../../../emulator/storage/rules/config
 import { StorageRulesFiles } from "../../fixtures";
 import { Persistence } from "../../../../emulator/storage/persistence";
 import { FirebaseError } from "../../../../error";
+import { RulesConfig } from "../../../../emulator/storage";
+import { SourceFile } from "../../../../emulator/storage/rules/types";
 
 const PROJECT_ID = "test-project";
 
@@ -19,18 +21,25 @@ describe("Storage Rules Config", () => {
 
   it("should parse rules config for single target", () => {
     const rulesFile = "storage.rules";
-    persistence.appendBytes(rulesFile, Buffer.from(StorageRulesFiles.readWriteIfTrue.content));
+    const rulesContent = Buffer.from(StorageRulesFiles.readWriteIfTrue.content);
+    persistence.appendBytes(rulesFile, rulesContent);
 
     const config = getOptions({
       data: { storage: { rules: rulesFile } },
       path: resolvePath,
     });
-    const result = getStorageRulesConfig(PROJECT_ID, config);
+    const result = getStorageRulesConfig(PROJECT_ID, config) as SourceFile;
 
-    expect(result).to.equal(`${tmpDir}/storage.rules`);
+    expect(result.name).to.equal(`${tmpDir}/storage.rules`);
+    expect(result.content).to.contain("allow read, write: if true");
   });
 
   it("should parse rules file for multiple targets", () => {
+    const mainRulesContent = Buffer.from(StorageRulesFiles.readWriteIfTrue.content);
+    const otherRulesContent = Buffer.from(StorageRulesFiles.readWriteIfAuth.content);
+    persistence.appendBytes("storage_main.rules", mainRulesContent);
+    persistence.appendBytes("storage_other.rules", otherRulesContent);
+
     const config = getOptions({
       data: {
         storage: [
@@ -40,15 +49,20 @@ describe("Storage Rules Config", () => {
       },
       path: resolvePath,
     });
-    config.rc.applyTarget(PROJECT_ID, "storage", "main", ["bucket_1", "bucket_2"]);
-    config.rc.applyTarget(PROJECT_ID, "storage", "other", ["bucket_3"]);
+    config.rc.applyTarget(PROJECT_ID, "storage", "main", ["bucket_0", "bucket_1"]);
+    config.rc.applyTarget(PROJECT_ID, "storage", "other", ["bucket_2"]);
 
-    const result = getStorageRulesConfig(PROJECT_ID, config);
+    const result = getStorageRulesConfig(PROJECT_ID, config) as RulesConfig[];
 
     expect(result.length).to.equal(3);
-    expect(result[0]).to.eql({ resource: "bucket_1", rules: `${tmpDir}/storage_main.rules` });
-    expect(result[1]).to.eql({ resource: "bucket_2", rules: `${tmpDir}/storage_main.rules` });
-    expect(result[2]).to.eql({ resource: "bucket_3", rules: `${tmpDir}/storage_other.rules` });
+    for (let i = 0; i < result.length; i++) {
+      expect(result[i].resource).to.eql(`bucket_${i}`);
+    }
+    expect(result[0].rules.name).to.equal(`${tmpDir}/storage_main.rules`);
+    expect(result[0].rules.content).to.contain("allow read, write: if true");
+    expect(result[1].rules.name).to.equal(`${tmpDir}/storage_main.rules`);
+    expect(result[2].rules.name).to.equal(`${tmpDir}/storage_other.rules`);
+    expect(result[2].rules.content).to.contain("allow read, write: if request.auth!=null");
   });
 
   it("should throw FirebaseError when storage config is missing", () => {
@@ -64,6 +78,15 @@ describe("Storage Rules Config", () => {
     expect(() => getStorageRulesConfig(PROJECT_ID, config)).to.throw(
       FirebaseError,
       "Cannot start the Storage emulator without rules file specified in firebase.json: run 'firebase init' and set up your Storage configuration"
+    );
+  });
+
+  it("should throw FirebaseError when rules file is invalid", () => {
+    const invalidFileName = "foo";
+    const config = getOptions({ data: { storage: { rules: invalidFileName } }, path: resolvePath });
+    expect(() => getStorageRulesConfig(PROJECT_ID, config)).to.throw(
+      FirebaseError,
+      `File not found: ${resolvePath(invalidFileName)}`
     );
   });
 });

--- a/src/test/emulators/storage/rules/config.spec.ts
+++ b/src/test/emulators/storage/rules/config.spec.ts
@@ -1,12 +1,10 @@
-import * as fs from "fs";
 import * as path from "path";
 import { expect } from "chai";
-import { tmpdir } from "os";
 
 import { Options } from "../../../../options";
 import { RC } from "../../../../rc";
 import { getStorageRulesConfig } from "../../../../emulator/storage/rules/config";
-import { StorageRulesFiles } from "../../fixtures";
+import { createTmpDir, StorageRulesFiles } from "../../fixtures";
 import { Persistence } from "../../../../emulator/storage/persistence";
 import { FirebaseError } from "../../../../error";
 import { RulesConfig } from "../../../../emulator/storage";
@@ -15,7 +13,7 @@ import { SourceFile } from "../../../../emulator/storage/rules/types";
 const PROJECT_ID = "test-project";
 
 describe("Storage Rules Config", () => {
-  const tmpDir = fs.mkdtempSync(path.join(tmpdir(), "storage-files"));
+  const tmpDir = createTmpDir("storage-files");
   const persistence = new Persistence(tmpDir);
   const resolvePath = (fileName: string) => path.resolve(tmpDir, fileName);
 
@@ -55,12 +53,16 @@ describe("Storage Rules Config", () => {
     const result = getStorageRulesConfig(PROJECT_ID, config) as RulesConfig[];
 
     expect(result.length).to.equal(3);
-    for (let i = 0; i < result.length; i++) {
-      expect(result[i].resource).to.eql(`bucket_${i}`);
-    }
+
+    expect(result[0].resource).to.eql("bucket_0");
     expect(result[0].rules.name).to.equal(`${tmpDir}/storage_main.rules`);
     expect(result[0].rules.content).to.contain("allow read, write: if true");
+
+    expect(result[1].resource).to.eql("bucket_1");
     expect(result[1].rules.name).to.equal(`${tmpDir}/storage_main.rules`);
+    expect(result[1].rules.content).to.contain("allow read, write: if true");
+
+    expect(result[2].resource).to.eql("bucket_2");
     expect(result[2].rules.name).to.equal(`${tmpDir}/storage_other.rules`);
     expect(result[2].rules.content).to.contain("allow read, write: if request.auth!=null");
   });


### PR DESCRIPTION
### Description
Fixes #3390. Following up to #4263, this PR adds a `StorageRulesManager` that will live inside the Storage Emulator. The interface is implemented by:

- `StorageRulesManagerImplementation`, which keeps track of rules for a single resource
- `StorageRulesManagerRegistry`, which maps resource to `StorageRulesManagerImplementation`

In the server, all calls to the validator will pass along the `resource` aka bucket id in order to determine which ruleset to use.