### PR TITLE
Only apply CORS to /backends in Functions emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 - `ext:export` now uses stable ordering for params in .env files (#4256).
 - Adds alerting event provider (#4258).
 - Fixes bug where project-specific environment variables weren't loaded by the Functions Emulator (#4273).
-- Fixes bug where CORS was enabled too broadly on the Functions emualtor (#4294).
+- Fixes bug where CORS was enabled too broadly on the Functions emulator (#4294).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - `ext:export` now uses stable ordering for params in .env files (#4256).
 - Adds alerting event provider (#4258).
 - Fixes bug where project-specific environment variables weren't loaded by the Functions Emulator (#4273).
+- Fixes bug where CORS was enabled too broadly on the Functions emualtor (#4294).

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -238,7 +238,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     this.workQueue.start();
 
     const hub = express();
-    hub.use(cors({ origin: true })); // Enable cors so the Emulator UI can call out to the Functions Emulator.
 
     const dataMiddleware: express.RequestHandler = (req, res, next) => {
       const chunks: Buffer[] = [];
@@ -349,7 +348,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     // The ordering here is important. The longer routes (background)
     // need to be registered first otherwise the HTTP functions consume
     // all events.
-    hub.get(listBackendsRoute, dataMiddleware, listBackendsHandler);
+    hub.get(listBackendsRoute, cors({ origin: true }), listBackendsHandler); // This route needs CORS so the Emulator UI can call it.
     hub.post(backgroundFunctionRoute, dataMiddleware, backgroundHandler);
     hub.post(multicastFunctionRoute, dataMiddleware, multicastHandler);
     hub.all(httpsFunctionRoutes, dataMiddleware, httpsHandler);


### PR DESCRIPTION
### Description
When adding the /backends route to the Functions emulator, we enabled CORS so that the Emulator UI could call the new endpoint. However, we did so too broadly, and caused some unexpected behavior changes (like #4294 ). This instead only applies CORS to just the /backends route.

I also noticed that we were unnecessarily using 'dataMiddleware' for this route, so I removed that.
Fixes #4294 
