### PR TITLE
Temporarily skip Storage Rules Manager unit tests

### DIFF
--- a/src/test/emulators/storage/rules/manager.spec.ts
+++ b/src/test/emulators/storage/rules/manager.spec.ts
@@ -9,7 +9,8 @@ import { StorageRulesRuntime } from "../../../../emulator/storage/rules/runtime"
 import { Persistence } from "../../../../emulator/storage/persistence";
 import { RulesetOperationMethod } from "../../../../emulator/storage/rules/types";
 
-describe("Storage Rules Manager", function () {
+// TODO(hsinpei: Make this an integration test
+describe.skip("Storage Rules Manager", function () {
   const rulesRuntime = new StorageRulesRuntime();
   const rulesManager = new StorageRulesManager(rulesRuntime);
 


### PR DESCRIPTION
### Description
This PR temporarily skips the Storage Rules Manager unit tests added in #4245. Since the test setup downloads the rules JAR, we should make it an integration test instead. We'll do this in another PR; skipping for now so as to unblock the new release.