### PR TITLE
Read {instanceId}.secret.local for Extension secret overrides

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -64,6 +64,7 @@ import * as backend from "../deploy/functions/backend";
 import * as functionsEnv from "../functions/env";
 import { flattenArray } from "../functional";
 import { SecretEnvVar } from "../gcp/cloudfunctions";
+import { ENV_DIRECTORY } from "../extensions/manifest";
 
 const EVENT_INVOKE = "functions:invoke";
 const LOCAL_SECRETS_FILE = ".secret.local";
@@ -1077,16 +1078,23 @@ export class FunctionsEmulator implements EmulatorInstance {
     trigger?: EmulatedTriggerDefinition
   ): Promise<Record<string, string>> {
     let secretEnvs: Record<string, string> = {};
-
+    // Extension secret overrides live in {instanceID}.secret.local, CF3 secrets live in .secret.local
+    const secretsFile = backend.extensionInstanceId
+      ? `${backend.extensionInstanceId}${LOCAL_SECRETS_FILE}`
+      : LOCAL_SECRETS_FILE;
+    const secretDirectory = backend.extensionInstanceId
+      ? path.join(this.args.projectDir, ENV_DIRECTORY)
+      : backend.functionsDir;
+    const secretPath = path.join(secretDirectory, secretsFile);
     try {
-      const data = fs.readFileSync(path.join(backend.functionsDir, LOCAL_SECRETS_FILE), "utf8");
+      const data = fs.readFileSync(secretPath, "utf8");
       secretEnvs = functionsEnv.parseStrict(data);
     } catch (e: any) {
       if (e.code !== "ENOENT") {
         this.logger.logLabeled(
           "ERROR",
           "functions",
-          `Failed to read local secrets file ${LOCAL_SECRETS_FILE}: ${e.message}`
+          `Failed to read local secrets file ${secretsFile}: ${e.message}`
         );
       }
     }
@@ -1122,7 +1130,7 @@ export class FunctionsEmulator implements EmulatorInstance {
           "functions",
           "Unable to access secret environment variables from Google Cloud Secret Manager. " +
             "Make sure the credential used for the Functions Emulator have access " +
-            `or provide override values in ${LOCAL_SECRETS_FILE}:\n\t` +
+            `or provide override values in ${secretPath}:\n\t` +
             errs.join("\n\t")
         );
       }

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -7,9 +7,10 @@ import * as fs from "fs";
 
 import * as backend from "../deploy/functions/backend";
 import { Constants } from "./constants";
-import { InvokeRuntimeOpts } from "./functionsEmulator";
+import { EmulatableBackend, InvokeRuntimeOpts } from "./functionsEmulator";
 import { copyIfPresent } from "../gcp/proto";
 import { logger } from "../logger";
+import { ENV_DIRECTORY } from "../extensions/manifest";
 
 export type SignatureType = "http" | "event" | "cloudevent";
 
@@ -371,4 +372,19 @@ export function getSignatureType(def: EmulatedTriggerDefinition): SignatureType 
   // functions cannot receive events in legacy format. This conflicts with our goal of introducing a 'compat' layer
   // that allows CF3v1 functions to target GCFv2 and vice versa.
   return def.platform === "gcfv2" ? "cloudevent" : "event";
+}
+
+const LOCAL_SECRETS_FILE = ".secret.local";
+
+/**
+ * getSecretLocalPath returns the expected location for a .secret.local override file.
+ */
+export function getSecretLocalPath(backend: EmulatableBackend, projectDir: string) {
+  const secretsFile = backend.extensionInstanceId
+    ? `${backend.extensionInstanceId}${LOCAL_SECRETS_FILE}`
+    : LOCAL_SECRETS_FILE;
+  const secretDirectory = backend.extensionInstanceId
+    ? path.join(projectDir, ENV_DIRECTORY)
+    : backend.functionsDir;
+  return path.join(secretDirectory, secretsFile);
 }

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -10,7 +10,7 @@ import { FirebaseError } from "../error";
 import * as utils from "../utils";
 import { logPrefix } from "./extensionsHelper";
 
-const ENV_DIRECTORY = "extensions";
+export const ENV_DIRECTORY = "extensions";
 
 /**
  * Write a list of instanceSpecs to extensions manifest.


### PR DESCRIPTION
### Description
Adds support for overriding Extensions secret by including them in `extensions/{instanceId}.secret.local`

TODO: Add unit tests to this

### Scenarios Tested
I validated that I could provide secrets for the Stripe extension via `{instanceId}.secret.local`, on both a real and demo project. I also confirmed that I could still fall back to accessing secrets from Secret manager when using a real project.
