### PR TITLE
Moved Storage rules integration tests under scripts/

### DIFF
--- a/scripts/storage-emulator-integration/rules/manager.test.ts
+++ b/scripts/storage-emulator-integration/rules/manager.test.ts
@@ -2,15 +2,14 @@ import { expect } from "chai";
 import { tmpdir } from "os";
 import { v4 as uuidv4 } from "uuid";
 
-import { FirebaseError } from "../../../../error";
-import { StorageRulesFiles, TIMEOUT_MED } from "../../fixtures";
-import { StorageRulesManager } from "../../../../emulator/storage/rules/manager";
-import { StorageRulesRuntime } from "../../../../emulator/storage/rules/runtime";
-import { Persistence } from "../../../../emulator/storage/persistence";
-import { RulesetOperationMethod } from "../../../../emulator/storage/rules/types";
+import { FirebaseError } from "../../../src/error";
+import { StorageRulesFiles, TIMEOUT_MED } from "../../../src/test/emulators/fixtures";
+import { StorageRulesManager } from "../../../src/emulator/storage/rules/manager";
+import { StorageRulesRuntime } from "../../../src/emulator/storage/rules/runtime";
+import { Persistence } from "../../../src/emulator/storage/persistence";
+import { RulesetOperationMethod } from "../../../src/emulator/storage/rules/types";
 
-// TODO(hsinpei: Make this an integration test
-describe.skip("Storage Rules Manager", function () {
+describe("Storage Rules Manager", function () {
   const rulesRuntime = new StorageRulesRuntime();
   const rulesManager = new StorageRulesManager(rulesRuntime);
 

--- a/scripts/storage-emulator-integration/rules/runtime.test.ts
+++ b/scripts/storage-emulator-integration/rules/runtime.test.ts
@@ -1,19 +1,16 @@
 import {
   RulesetVerificationOpts,
   StorageRulesRuntime,
-} from "../../../../emulator/storage/rules/runtime";
+} from "../../../src/emulator/storage/rules/runtime";
 import { expect } from "chai";
-import { StorageRulesFiles } from "../../fixtures";
+import { StorageRulesFiles } from "../../emulator-tests/fixtures";
 import * as jwt from "jsonwebtoken";
-import { EmulatorLogger } from "../../../../emulator/emulatorLogger";
-import { ExpressionValue } from "../../../../emulator/storage/rules/expressionValue";
-import { RulesetOperationMethod } from "../../../../emulator/storage/rules/types";
-import {
-  downloadIfNecessary,
-  getDownloadDetails,
-} from "../../../../emulator/downloadableEmulators";
-import { Emulators } from "../../../../emulator/types";
-import { RulesResourceMetadata } from "../../../../emulator/storage/metadata";
+import { EmulatorLogger } from "../../../src/emulator/emulatorLogger";
+import { ExpressionValue } from "../../../src/emulator/storage/rules/expressionValue";
+import { RulesetOperationMethod } from "../../../src/emulator/storage/rules/types";
+import { downloadIfNecessary } from "../../../src/emulator/downloadableEmulators";
+import { Emulators } from "../../../src/emulator/types";
+import { RulesResourceMetadata } from "../../../src/emulator/storage/metadata";
 
 const TOKENS = {
   signedInUser: jwt.sign(
@@ -46,7 +43,7 @@ function createFakeResourceMetadata(params: {
   };
 }
 
-describe.skip("Storage Rules Runtime", function () {
+describe("Storage Rules Runtime", function () {
   let runtime: StorageRulesRuntime;
 
   // eslint-disable-next-line @typescript-eslint/no-invalid-this

--- a/scripts/storage-emulator-integration/run.sh
+++ b/scripts/storage-emulator-integration/run.sh
@@ -7,6 +7,8 @@ set -e # Immediately exit on failure
 # Prepare the storage emulator rules runtime
 firebase setup:emulators:storage
 
+mocha scripts/storage-emulator-integration/rules/*.test.ts
+
 mocha \
   --require ts-node/register \
   --require source-map-support/register \


### PR DESCRIPTION
### Description
Follow up to #4297 (and #3233). Previously, we disabled the Storage rules unit tests because they were failing on deploy. This is because our deploy pipeline doesn't support `java`, which is needed to run the rules JAR. However, unit tests should not be downloading and spinning up a JAR in the first place. We therefore move them to `scripts/`, where integration tests live.

### Sample Commands
`npm run test:storage-emulator-integration` will run these tests before `storage-emulator-integration/tests.ts`.