### PR TITLE
Remove --require from mocha commands in integration test scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 firebase-debug.log
 firebase-debug.*.log
 npm-debug.log
+ui-debug.log
 yarn.lock
 .npmrc
 

--- a/scripts/client-integration-tests/run.sh
+++ b/scripts/client-integration-tests/run.sh
@@ -2,8 +2,4 @@
 
 source scripts/set-default-credentials.sh
 
-mocha \
-  --require ts-node/register \
-  --require source-map-support/register \
-  --require src/test/helpers/mocha-bootstrap.ts \
-  scripts/client-integration-tests/tests.ts
+mocha scripts/client-integration-tests/tests.ts

--- a/scripts/emulator-tests/run.sh
+++ b/scripts/emulator-tests/run.sh
@@ -15,7 +15,4 @@ trap cleanup EXIT
 cp package.json dev/package.json
 
 # Run the tests from the built dev directory.
-mocha \
-  --require ts-node/register \
-  --require src/test/helpers/mocha-bootstrap.ts \
-  dev/scripts/emulator-tests/*.spec.*
+mocha dev/scripts/emulator-tests/*.spec.*

--- a/scripts/extensions-deploy-tests/run.sh
+++ b/scripts/extensions-deploy-tests/run.sh
@@ -4,8 +4,4 @@ set -e # Immediately exit on failure
 # Globally link the CLI for the testing framework
 ./scripts/npm-link.sh
 
-mocha \
-  --require ts-node/register \
-  --require source-map-support/register \
-  --require src/test/helpers/mocha-bootstrap.ts \
-  scripts/extensions-deploy-tests/tests.ts
+mocha scripts/extensions-deploy-tests/tests.ts

--- a/scripts/extensions-emulator-tests/run.sh
+++ b/scripts/extensions-emulator-tests/run.sh
@@ -8,8 +8,4 @@ cd scripts/extensions-emulator-tests/greet-the-world
 npm i
 cd - # Return to root so that we don't need a relative path for mocha
 
-mocha \
-  --require ts-node/register \
-  --require source-map-support/register \
-  --require src/test/helpers/mocha-bootstrap.ts \
-  scripts/extensions-emulator-tests/tests.ts
+mocha scripts/extensions-emulator-tests/tests.ts

--- a/scripts/storage-emulator-integration/run.sh
+++ b/scripts/storage-emulator-integration/run.sh
@@ -9,8 +9,4 @@ firebase setup:emulators:storage
 
 mocha scripts/storage-emulator-integration/rules/*.test.ts
 
-mocha \
-  --require ts-node/register \
-  --require source-map-support/register \
-  --require src/test/helpers/mocha-bootstrap.ts \
-  scripts/storage-emulator-integration/tests.ts
+mocha scripts/storage-emulator-integration/tests.ts

--- a/scripts/triggers-end-to-end-tests/run.sh
+++ b/scripts/triggers-end-to-end-tests/run.sh
@@ -8,11 +8,6 @@ source scripts/set-default-credentials.sh
   npm install
 )
 
-npx mocha \
-  --require ts-node/register \
-  --require source-map-support/register \
-  --require src/test/helpers/mocha-bootstrap.ts \
-  --exit \
-  scripts/triggers-end-to-end-tests/tests.ts
+npx mocha --exit scripts/triggers-end-to-end-tests/tests.ts
 
 rm scripts/triggers-end-to-end-tests/functions/package.json


### PR DESCRIPTION
### Description
2 changes:

1. What the title of this PR says. As per this [comment](https://github.com/firebase/firebase-tools/pull/4309#discussion_r828357428), we don't need to specify `--require` in the `mocha` commands in the integration test scripts because the requirements are already specified in the `.mocharc` in the parent directory: https://github.com/firebase/firebase-tools/blob/c69b43757248078e0487eb9d9b666a30b1f8e9ed/.mocharc.yml#L1-L4

2. (Just throwing this one in because it has been bothering me) Add `ui-debug.log`, which is generated when running `npm run test:storage-emulator-integration`, to `.gitignore`