### PR TITLE
Fix bug where callable functions can't be emulated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Adds support for configuration with multiple storage targets (#4281).
+- Fixes bug where callable functions couldn't be emulated (#4314).

--- a/scripts/integration-helpers/framework.ts
+++ b/scripts/integration-helpers/framework.ts
@@ -268,7 +268,7 @@ export class TriggerEndToEndTest {
     body: Record<string, unknown>,
     zone = FIREBASE_PROJECT_ZONE
   ): Promise<Response> {
-    const url = `http://localhost:${[this.functionsEmulatorPort, this.project, zone, name].join(
+    const url = `http://localhost:${this.functionsEmulatorPort}/${this.project, zone, name].join(
       "/"
     )}`;
     return fetch(url, {

--- a/scripts/integration-helpers/framework.ts
+++ b/scripts/integration-helpers/framework.ts
@@ -268,7 +268,7 @@ export class TriggerEndToEndTest {
     body: Record<string, unknown>,
     zone = FIREBASE_PROJECT_ZONE
   ): Promise<Response> {
-    const url = `http://localhost:${this.functionsEmulatorPort}/${this.project, zone, name].join(
+    const url = `http://localhost:${this.functionsEmulatorPort}/${[this.project, zone, name].join(
       "/"
     )}`;
     return fetch(url, {

--- a/scripts/integration-helpers/framework.ts
+++ b/scripts/integration-helpers/framework.ts
@@ -263,6 +263,21 @@ export class TriggerEndToEndTest {
     return fetch(url);
   }
 
+  invokeCallableFunction(
+    name: string,
+    body: Record<string, unknown>,
+    zone = FIREBASE_PROJECT_ZONE
+  ): Promise<Response> {
+    const url = `http://localhost:${[this.functionsEmulatorPort, this.project, zone, name].join(
+      "/"
+    )}`;
+    return fetch(url, {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
   writeToRtdb(): Promise<Response> {
     return this.invokeHttpFunction("writeToRtdb");
   }

--- a/scripts/triggers-end-to-end-tests/functions/index.js
+++ b/scripts/triggers-end-to-end-tests/functions/index.js
@@ -264,6 +264,11 @@ exports.storageMetadataReaction = functions.storage
     return true;
   });
 
+exports.onCall = functions.https.onCall((data) => {
+  console.log("data", JSON.stringify(data));
+  return data;
+});
+
 exports.storagev2archivedreaction = functionsV2.storage.onObjectArchived((cloudevent) => {
   console.log(STORAGE_FUNCTION_V2_ARCHIVED_LOG);
   console.log("Object", JSON.stringify(cloudevent.data));
@@ -359,3 +364,8 @@ exports.storagebucketv2metadatareaction = functionsV2.storage.onObjectMetadataUp
     return true;
   }
 );
+
+exports.oncallv2 = functionsV2.https.onCall((req) => {
+  console.log("data", JSON.stringify(req.data));
+  return req.data;
+});

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -428,6 +428,43 @@ describe("storage emulator function triggers", () => {
   });
 });
 
+describe("onCall function triggers", () => {
+  let test: TriggerEndToEndTest;
+
+  before(async function (this) {
+    this.timeout(TEST_SETUP_TIMEOUT);
+
+    expect(FIREBASE_PROJECT).to.exist.and.not.be.empty;
+
+    const config = readConfig();
+    test = new TriggerEndToEndTest(FIREBASE_PROJECT, __dirname, config);
+    await test.startEmulators(["--only", "functions"]);
+  });
+
+  after(async function (this) {
+    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
+    await test.stopEmulators();
+  });
+
+  it("should make a call to v1 callable function", async function (this) {
+    this.timeout(EMULATOR_TEST_TIMEOUT);
+
+    const response = await test.invokeCallableFunction("onCall", { data: "foobar" });
+    expect(response.status).to.equal(200);
+    const body = await response.json();
+    expect(body).to.deep.equal({ result: "foobar" });
+  });
+
+  it("should make a call to v2 callable function", async function (this) {
+    this.timeout(EMULATOR_TEST_TIMEOUT);
+
+    const response = await test.invokeCallableFunction("oncallv2", { data: "foobar" });
+    expect(response.status).to.equal(200);
+    const body = await response.json();
+    expect(body).to.deep.equal({ result: "foobar" });
+  });
+});
+
 describe("import/export end to end", () => {
   it("should be able to import/export firestore data", async function (this) {
     this.timeout(2 * TEST_SETUP_TIMEOUT);

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -159,6 +159,9 @@ export function emulatedFunctionsFromEndpoints(
     // process requires it in this form. Need to work in Firestore emulator for a proper fix...
     if (backend.isHttpsTriggered(endpoint)) {
       def.httpsTrigger = endpoint.httpsTrigger;
+    } else if (backend.isCallableTriggered(endpoint)) {
+      def.httpsTrigger = {};
+      def.labels = { ...def.labels, "deployment-callable": "true" };
     } else if (backend.isEventTriggered(endpoint)) {
       const eventTrigger = endpoint.eventTrigger;
       if (endpoint.platform === "gcfv1") {


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-tools/issues/4313

In https://github.com/firebase/firebase-tools/pull/4310, we started to support new type of triggers `callableTrigger` (distinct from `httpTrigger`).

Functions Emulator does not support `callableTrigger`. We fix this by converting `callbleTrigger` to `httpTrigger`. This is tech debt - at some point, we should use `endpoint` definitions throughout the emulator (cc @joehan).

Also adds integration tests for emulating callable triggers to prevent this kind of breakages in the future. 