### PR TITLE
limit hosting upload concurrency to 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Lowers the number of concurrent uploads the CLI will attempt to Firebase Hosting.
+- Adds support for an environment variable `FIREBASE_HOSTING_UPLOAD_CONCURRENCY` to specify custom levels of Hosting upload concurrency.

--- a/src/deploy/hosting/deploy.ts
+++ b/src/deploy/hosting/deploy.ts
@@ -3,7 +3,7 @@ import { detectProjectRoot } from "../../detectProjectRoot";
 import { listFiles } from "../../listFiles";
 import { logger } from "../../logger";
 import * as track from "../../track";
-import { logLabeledBullet, logLabeledSuccess } from "../../utils";
+import { envOverride, logLabeledBullet, logLabeledSuccess } from "../../utils";
 import { HostingDeploy } from "./hostingDeploy";
 
 import * as clc from "cli-color";
@@ -67,12 +67,23 @@ export async function deploy(
       `found ${files.length} files in ${clc.bold(deploy.config.public)}`
     );
 
+    let concurrency = 10;
+    const envConcurrency = envOverride("FIREBASE_HOSTING_UPLOAD_CONCURRENCY", "");
+    if (envConcurrency) {
+      const c = parseInt(envConcurrency, 10);
+      if (!isNaN(c) && c > 0) {
+        concurrency = c;
+      }
+    }
+
+    logger.debug(`[hosting] uploading with ${concurrency} concurrency`);
     const uploader = new Uploader({
       version: deploy.version,
       files: files,
       public: publicDir,
       cwd: options.cwd,
       projectRoot: detectProjectRoot(options),
+      uploadConcurrency: concurrency,
     });
 
     const progressInterval = setInterval(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

We've had a number of requests (recently and over the years) that Hosting uploads sometimes stall out with issues that look like network issues. It's a reasonable theory that letting the Hosting uploader try 200 concurrent uploads _may_ be an issue, especially with bigger files.

This CL reduces that default concurrency to **10**, and introduces an environment variable `FIREBASE_HOSTING_UPLOAD_CONCURRENCY` for developers to optionally control how many concurrent uploads they may want to support (bigger machines may be able to have more concurrent uploads).

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Hosting deploy by default, verifying the 10 uploads, and deploying with `FIREBASE_HOSTING_UPLOAD_CONCURRENCY=100`, verifying 100 uploads.