### PR TITLE
revert hosting upload concurrency to 200

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
 - Upgrade Storage Rules Runtime to v1.0.2.
-- Lowers the number of concurrent uploads the CLI will attempt to Firebase Hosting.
-- Adds support for an environment variable `FIREBASE_HOSTING_UPLOAD_CONCURRENCY` to specify custom levels of Hosting upload concurrency.
+- Adds support for an environment variable `FIREBASE_HOSTING_UPLOAD_CONCURRENCY` to specify custom levels of Hosting upload concurrency (defaults to 200).
 - Fixes error handling in `auth:export` when API calls would fail.

--- a/src/deploy/hosting/deploy.ts
+++ b/src/deploy/hosting/deploy.ts
@@ -67,7 +67,7 @@ export async function deploy(
       `found ${files.length} files in ${clc.bold(deploy.config.public)}`
     );
 
-    let concurrency = 10;
+    let concurrency = 200;
     const envConcurrency = envOverride("FIREBASE_HOSTING_UPLOAD_CONCURRENCY", "");
     if (envConcurrency) {
       const c = parseInt(envConcurrency, 10);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

So here's the deal. 10 is real slow. Gains after ~150 get pretty minimal. I'm going to leave the default at 200 but still allow folks to adjust the concurrency with `FIREBASE_HOSTING_UPLOAD_CONCURRENCY`.

### Scenarios Tested

Concurrency | File Count | Upload Time | Seconds
-- | -- | -- | --
10 | 10000 | 61.41s user 12.11s system 10% cpu 11:52.00 total | 712
50 | 1000 | 52.94s user 10.13s system 49% cpu 2:07.57 total | 127
100 | 10000 | 48.56s user 9.07s system 65% cpu 1:27.61 total | 87
150 | 10000 | 44.92s user 7.98s system 105% cpu 49.914 total | 49
200 | 10000 | 42.33s user 7.42s system 115% cpu 43.071 total | 43


