### PR TITLE
Add support for UpdateConfig

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1746,17 +1746,14 @@ function updateEmulatorProjectConfig(
   // New developers should not use updateEmulatorProjectConfig to update the
   // allowDuplicateEmails and usageMode settings and should instead use
   // updateConfig to do so.
-  let updateMask = "";
-  if (reqBody.signIn?.allowDuplicateEmails) {
-    updateMask += "signIn.allowDupliateEmails";
+  const updateMask = [];
+  if (reqBody.signIn?.allowDuplicateEmails != null) {
+    updateMask.push("signIn.allowDuplicateEmails");
   }
   if (reqBody.usageMode) {
-    assert(reqBody.usageMode !== "USAGE_MODE_UNSPECIFIED", "Invalid usage mode provided");
-    if (reqBody.usageMode === "PASSTHROUGH") {
-      assert(state.getUserCount() === 0, "Users are present, unable to set passthrough mode");
-    }
-    updateMask += ",usageMode";
+    updateMask.push("usageMode");
   }
+  ctx.params.query.updateMask = updateMask.join();
 
   updateConfig(state, reqBody, ctx);
   return getEmulatorProjectConfig(state);

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -33,6 +33,7 @@ import {
   AgentProjectState,
   TenantProjectState,
   MfaConfig,
+  BlockingFunctionEvents,
 } from "./state";
 import { MfaEnrollments, Schemas } from "./types";
 
@@ -2008,6 +2009,18 @@ function updateConfig(
     state instanceof AgentProjectState,
     "((Can only update top-level configurations on agent projects.))"
   );
+  for (const event in reqBody.blockingFunctions?.triggers) {
+    if (Object.prototype.hasOwnProperty.call(reqBody.blockingFunctions!.triggers, event)) {
+      assert(
+        Object.values(BlockingFunctionEvents).includes(event as BlockingFunctionEvents),
+        "INVALID_BLOCKING_FUNCTION: ((Event type is invalid.))"
+      );
+      assert(
+        parseAbsoluteUri(reqBody.blockingFunctions!.triggers[event].functionUri!),
+        "INVALID_BLOCKING_FUNCTION: ((Expected an absolute URI with valid scheme and host.))"
+      );
+    }
+  }
   return state.updateConfig(reqBody, ctx.params.query.updateMask);
 }
 

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -4,6 +4,7 @@ import {
   mirrorFieldTo,
   randomDigits,
   isValidPhoneNumber,
+  DeepPartial,
 } from "./utils";
 import { MakeRequired } from "./utils";
 import { AuthCloudFunction } from "./cloudFunctions";
@@ -581,11 +582,71 @@ export abstract class ProjectState {
   }
 }
 
+/**
+ * Updates fields based on specified update mask. Note that this is a no-op if
+ * the update mask is empty.
+ *
+ * @param updateMask a comma separated list of fully qualified names of fields
+ * @param dest the destination to apply updates to
+ * @param update the updates to apply
+ * @returns the updated destination object
+ */
+function applyMask<T>(updateMask: string, dest: T, update: DeepPartial<T>): T {
+  const paths = updateMask.split(",");
+  for (const path of paths) {
+    const fields = path.split(".");
+    // Using `any` here to recurse over destination objects
+    let updateField: any = update;
+    let existingField: any = dest;
+    let field;
+    for (let i = 0; i < fields.length - 1; i++) {
+      field = fields[i];
+
+      // Doesn't exist on update
+      if (updateField[field] == null) {
+        console.warn(`Unable to find field '${field}' in update '${updateField}`);
+        break;
+      }
+
+      // Field on existing is an array or is a primitive (i.e. cannot index
+      // any further)
+      if (Array.isArray(updateField[field]) || Object(updateField[field]) !== updateField[field]) {
+        console.warn(`Field '${field}' is singular and cannot have sub-fields`);
+        break;
+      }
+
+      // Non-standard behavior, this creates new fields regardless of if the
+      // final field is set. Typical behavior would not modify the config
+      // payload if the final field is not successfully set.
+      if (!existingField[field]) {
+        existingField[field] = {};
+      }
+
+      updateField = updateField[field];
+      existingField = existingField[field];
+    }
+    // Reassign final field if possible
+    field = fields[fields.length - 1];
+    if (updateField[field] == null) {
+      console.warn(`Unable to find field '${field}' in update '${JSON.stringify(updateField)}`);
+      continue;
+    }
+    existingField[field] = updateField[field];
+  }
+
+  return dest;
+}
+
 export class AgentProjectState extends ProjectState {
   private _oneAccountPerEmail = true;
   private _usageMode = UsageMode.DEFAULT;
   private tenantProjectForTenantId: Map<string, TenantProjectState> = new Map();
   private readonly _authCloudFunction = new AuthCloudFunction(this.projectId);
+  private _config: Config = {
+    signIn: { allowDuplicateEmails: false },
+    usageMode: UsageMode.DEFAULT,
+    blockingFunctions: {},
+  };
 
   constructor(projectId: string) {
     super(projectId);
@@ -596,19 +657,19 @@ export class AgentProjectState extends ProjectState {
   }
 
   get oneAccountPerEmail() {
-    return this._oneAccountPerEmail;
+    return !this._config.signIn.allowDuplicateEmails;
   }
 
   set oneAccountPerEmail(oneAccountPerEmail: boolean) {
-    this._oneAccountPerEmail = oneAccountPerEmail;
+    this._config.signIn.allowDuplicateEmails = !oneAccountPerEmail;
   }
 
   get usageMode() {
-    return this._usageMode;
+    return this._config.usageMode;
   }
 
   set usageMode(usageMode: UsageMode) {
-    this._usageMode = usageMode;
+    this._config.usageMode = usageMode;
   }
 
   get allowPasswordSignup() {
@@ -629,6 +690,34 @@ export class AgentProjectState extends ProjectState {
 
   get enableEmailLinkSignin() {
     return true;
+  }
+
+  get config() {
+    return this._config;
+  }
+
+  get blockingFunctionsConfig() {
+    return this._config.blockingFunctions;
+  }
+
+  set blockingFunctionsConfig(blockingFunctions: BlockingFunctionsConfig) {
+    this._config.blockingFunctions = blockingFunctions;
+  }
+
+  // TODO(lisajian): Once v2 API discovery is updated, type of update should be
+  // changed to Schemas["GoogleCloudIdentitytoolkitAdminV2Config"].
+  updateConfig(
+    update: Schemas["GoogleCloudIdentitytoolkitAdminV2Config"] & { usageMode?: UsageMode },
+    updateMask: string | undefined
+  ): Config {
+    // Empty masks indicate a full update.
+    if (!updateMask) {
+      this.oneAccountPerEmail = !update.signIn?.allowDuplicateEmails ?? true;
+      this.blockingFunctionsConfig = update.blockingFunctions ?? {};
+      this.usageMode = update.usageMode ?? UsageMode.DEFAULT;
+      return this.config;
+    }
+    return applyMask(updateMask, this.config, update);
   }
 
   getTenantProject(tenantId: string): TenantProjectState {
@@ -779,52 +868,7 @@ export class TenantProjectState extends ProjectState {
       return this.tenantConfig;
     }
 
-    const paths = updateMask.split(",");
-    for (const path of paths) {
-      const fields = path.split(".");
-      // Using `any` here to recurse over Tenant config objects
-      let updateField: any = update;
-      let existingField: any = this._tenantConfig;
-      let field;
-      for (let i = 0; i < fields.length - 1; i++) {
-        field = fields[i];
-
-        // Doesn't exist on update
-        if (updateField[field] == null) {
-          console.warn(`Unable to find field '${field}' in update '${updateField}`);
-          break;
-        }
-
-        // Field on existing is an array or is a primitive (i.e. cannot index
-        // any further)
-        if (
-          Array.isArray(updateField[field]) ||
-          Object(updateField[field]) !== updateField[field]
-        ) {
-          console.warn(`Field '${field}' is singular and cannot have sub-fields`);
-          break;
-        }
-
-        // Non-standard behavior, this creates new fields regardless of if the
-        // final field is set. Typical behavior would not modify the config
-        // payload if the final field is not successfully set.
-        if (!existingField[field]) {
-          existingField[field] = {};
-        }
-
-        updateField = updateField[field];
-        existingField = existingField[field];
-      }
-      // Reassign final field if possible
-      field = fields[fields.length - 1];
-      if (updateField[field] == null) {
-        console.warn(`Unable to find field '${field}' in update '${JSON.stringify(updateField)}`);
-        continue;
-      }
-      existingField[field] = updateField[field];
-    }
-
-    return this.tenantConfig;
+    return applyMask(updateMask, this.tenantConfig, update);
   }
 }
 
@@ -850,6 +894,24 @@ export type Tenant = Omit<
   >,
   "testPhoneNumbers" | "mfaConfig"
 > & { tenantId: string; mfaConfig: MfaConfig };
+
+export type SignInConfig = MakeRequired<
+  Schemas["GoogleCloudIdentitytoolkitAdminV2SignInConfig"],
+  "allowDuplicateEmails"
+>;
+
+export type BlockingFunctionsConfig =
+  Schemas["GoogleCloudIdentitytoolkitAdminV2BlockingFunctionsConfig"];
+
+// Serves as a substitute for Schemas["GoogleCloudIdentitytoolkitAdminV2Config"],
+// i.e. the configuration object for top-level AgentProjectStates. Emulator
+// fixes certain configurations for ease of use / testing, so as non-standard
+// behavior, Config only stores the configurable fields.
+export type Config = {
+  signIn: SignInConfig;
+  usageMode: UsageMode;
+  blockingFunctions: BlockingFunctionsConfig;
+};
 
 interface RefreshTokenRecord {
   localId: string;

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -582,61 +582,6 @@ export abstract class ProjectState {
   }
 }
 
-/**
- * Updates fields based on specified update mask. Note that this is a no-op if
- * the update mask is empty.
- *
- * @param updateMask a comma separated list of fully qualified names of fields
- * @param dest the destination to apply updates to
- * @param update the updates to apply
- * @returns the updated destination object
- */
-function applyMask<T>(updateMask: string, dest: T, update: DeepPartial<T>): T {
-  const paths = updateMask.split(",");
-  for (const path of paths) {
-    const fields = path.split(".");
-    // Using `any` here to recurse over destination objects
-    let updateField: any = update;
-    let existingField: any = dest;
-    let field;
-    for (let i = 0; i < fields.length - 1; i++) {
-      field = fields[i];
-
-      // Doesn't exist on update
-      if (updateField[field] == null) {
-        console.warn(`Unable to find field '${field}' in update '${updateField}`);
-        break;
-      }
-
-      // Field on existing is an array or is a primitive (i.e. cannot index
-      // any further)
-      if (Array.isArray(updateField[field]) || Object(updateField[field]) !== updateField[field]) {
-        console.warn(`Field '${field}' is singular and cannot have sub-fields`);
-        break;
-      }
-
-      // Non-standard behavior, this creates new fields regardless of if the
-      // final field is set. Typical behavior would not modify the config
-      // payload if the final field is not successfully set.
-      if (!existingField[field]) {
-        existingField[field] = {};
-      }
-
-      updateField = updateField[field];
-      existingField = existingField[field];
-    }
-    // Reassign final field if possible
-    field = fields[fields.length - 1];
-    if (updateField[field] == null) {
-      console.warn(`Unable to find field '${field}' in update '${JSON.stringify(updateField)}`);
-      continue;
-    }
-    existingField[field] = updateField[field];
-  }
-
-  return dest;
-}
-
 export class AgentProjectState extends ProjectState {
   private _oneAccountPerEmail = true;
   private _usageMode = UsageMode.DEFAULT;
@@ -710,6 +655,13 @@ export class AgentProjectState extends ProjectState {
     update: Schemas["GoogleCloudIdentitytoolkitAdminV2Config"] & { usageMode?: UsageMode },
     updateMask: string | undefined
   ): Config {
+    if (update.usageMode) {
+      assert(update.usageMode !== UsageMode.USAGE_MODE_UNSPECIFIED, "Invalid usage mode provided");
+      if (update.usageMode === UsageMode.PASSTHROUGH) {
+        assert(this.getUserCount() === 0, "Users are present, unable to set passthrough mode");
+      }
+    }
+
     // Empty masks indicate a full update.
     if (!updateMask) {
       this.oneAccountPerEmail = !update.signIn?.allowDuplicateEmails ?? true;
@@ -943,6 +895,14 @@ export interface PhoneVerificationRecord {
   sessionInfo: string;
 }
 
+export enum UsageMode {
+  DEFAULT = "DEFAULT",
+  PASSTHROUGH = "PASSTHROUGH",
+
+  // Should never be used
+  USAGE_MODE_UNSPECIFIED = "USAGE_MODE_UNSPECIFIED",
+}
+
 interface TemporaryProofRecord {
   phoneNumber: string;
   temporaryProof: string;
@@ -961,7 +921,57 @@ function getProviderEmailsForUser(user: UserInfo): Set<string> {
   return emails;
 }
 
-export enum UsageMode {
-  DEFAULT = "DEFAULT",
-  PASSTHROUGH = "PASSTHROUGH",
+/**
+ * Updates fields based on specified update mask. Note that this is a no-op if
+ * the update mask is empty.
+ *
+ * @param updateMask a comma separated list of fully qualified names of fields
+ * @param dest the destination to apply updates to
+ * @param update the updates to apply
+ * @returns the updated destination object
+ */
+function applyMask<T>(updateMask: string, dest: T, update: DeepPartial<T>): T {
+  const paths = updateMask.split(",");
+  for (const path of paths) {
+    const fields = path.split(".");
+    // Using `any` here to recurse over destination objects
+    let updateField: any = update;
+    let existingField: any = dest;
+    let field;
+    for (let i = 0; i < fields.length - 1; i++) {
+      field = fields[i];
+
+      // Doesn't exist on update
+      if (updateField[field] == null) {
+        console.warn(`Unable to find field '${field}' in update '${updateField}`);
+        break;
+      }
+
+      // Field on existing is an array or is a primitive (i.e. cannot index
+      // any further)
+      if (Array.isArray(updateField[field]) || Object(updateField[field]) !== updateField[field]) {
+        console.warn(`Field '${field}' is singular and cannot have sub-fields`);
+        break;
+      }
+
+      // Non-standard behavior, this creates new fields regardless of if the
+      // final field is set. Typical behavior would not modify the config
+      // payload if the final field is not successfully set.
+      if (!existingField[field]) {
+        existingField[field] = {};
+      }
+
+      updateField = updateField[field];
+      existingField = existingField[field];
+    }
+    // Reassign final field if possible
+    field = fields[fields.length - 1];
+    if (updateField[field] == null) {
+      console.warn(`Unable to find field '${field}' in update '${JSON.stringify(updateField)}`);
+      continue;
+    }
+    existingField[field] = updateField[field];
+  }
+
+  return dest;
 }

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -649,27 +649,21 @@ export class AgentProjectState extends ProjectState {
   }
 
   // TODO(lisajian): Once v2 API discovery is updated, type of update should be
-  // changed to Schemas["GoogleCloudIdentitytoolkitAdminV2Config"].
+  // changed to Schemas["GoogleCloudIdentitytoolkitAdminV2Config"] and validation
+  // of update.usageMode should be moved to operations.ts
   updateConfig(
     update: Schemas["GoogleCloudIdentitytoolkitAdminV2Config"] & { usageMode?: UsageMode },
     updateMask: string | undefined
   ): Config {
     if (update.usageMode) {
-      assert(update.usageMode !== UsageMode.USAGE_MODE_UNSPECIFIED, "Invalid usage mode provided");
+      assert(
+        update.usageMode !== UsageMode.USAGE_MODE_UNSPECIFIED,
+        "INVALID_USAGE_MODE: ((Invalid usage mode provided.))"
+      );
       if (update.usageMode === UsageMode.PASSTHROUGH) {
-        assert(this.getUserCount() === 0, "Users are present, unable to set passthrough mode");
-      }
-    }
-
-    for (const event in update.blockingFunctions?.triggers) {
-      if (Object.prototype.hasOwnProperty.call(update.blockingFunctions!.triggers, event)) {
         assert(
-          Object.values(BlockingFunctionEvents).includes(event as BlockingFunctionEvents),
-          "INVALID_BLOCKING_FUNCTION ((Event type is invalid.))"
-        );
-        assert(
-          parseAbsoluteUri(update.blockingFunctions!.triggers[event].functionUri!),
-          "INVALID_BLOCKING_FUNCTION ((Expected an absolute URI with valid scheme and host.))"
+          this.getUserCount() === 0,
+          "USERS_STILL_EXIST: ((Users are present, unable to set passthrough mode.))"
         );
       }
     }
@@ -908,14 +902,14 @@ export interface PhoneVerificationRecord {
 }
 
 export enum UsageMode {
-  DEFAULT = "DEFAULT",
-  PASSTHROUGH = "PASSTHROUGH",
-
   // Should never be used
   USAGE_MODE_UNSPECIFIED = "USAGE_MODE_UNSPECIFIED",
+
+  DEFAULT = "DEFAULT",
+  PASSTHROUGH = "PASSTHROUGH",
 }
 
-enum BlockingFunctionEvents {
+export enum BlockingFunctionEvents {
   BEFORE_CREATE = "beforeCreate",
   BEFORE_SIGN_IN = "beforeSignIn",
 }

--- a/src/emulator/auth/utils.ts
+++ b/src/emulator/auth/utils.ts
@@ -10,6 +10,13 @@ import { EmulatorLogger } from "../emulatorLogger";
 export type MakeRequired<T, K extends keyof T> = T & Required<Pick<T, K>>;
 
 /**
+ * Utility type to make all fields recursively optional.
+ */
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
+/**
  * Checks if email looks like a valid email address.
  *
  * The testing only checks if the email has two parts joined by an "@" symbol.

--- a/src/test/emulators/auth/config.spec.ts
+++ b/src/test/emulators/auth/config.spec.ts
@@ -1,0 +1,93 @@
+import { expect } from "chai";
+import { expectStatusCode } from "./helpers";
+import { describeAuthEmulator, PROJECT_ID } from "./setup";
+
+describeAuthEmulator("config management", ({ authApi }) => {
+  describe("updateConfig", () => {
+    it("updates the project level config", async () => {
+      const updateMask =
+        "signIn.allowDuplicateEmails,blockingFunctions.forwardInboundCredentials.idToken,usageMode";
+
+      await authApi()
+        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask })
+        .send({
+          signIn: { allowDuplicateEmails: true },
+          blockingFunctions: { forwardInboundCredentials: { idToken: true } },
+          usageMode: "PASSTHROUGH",
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.signIn?.allowDuplicateEmails).to.be.true;
+          expect(res.body.blockingFunctions).to.eql({
+            forwardInboundCredentials: { idToken: true },
+          });
+          expect(res.body.usageMode).to.eql("PASSTHROUGH");
+        });
+    });
+
+    it("does not update if the field does not exist on the update config", async () => {
+      await authApi()
+        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
+        .set("Authorization", "Bearer owner")
+        .query({ updateMask: "displayName" })
+        .send({})
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body).not.to.have.property("displayName");
+        });
+    });
+
+    it("performs a full update if the update mask is empty", async () => {
+      await authApi()
+        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
+        .set("Authorization", "Bearer owner")
+        .send({
+          signIn: { allowDuplicateEmails: true },
+          blockingFunctions: { forwardInboundCredentials: { idToken: true } },
+          usageMode: "PASSTHROUGH",
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.signIn?.allowDuplicateEmails).to.be.true;
+          expect(res.body.blockingFunctions).to.eql({
+            forwardInboundCredentials: { idToken: true },
+          });
+          expect(res.body.usageMode).to.eql("PASSTHROUGH");
+        });
+    });
+
+    it("performs a full update with production defaults if the update mask is empty", async () => {
+      // Update to non-default values
+      await authApi()
+        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
+        .set("Authorization", "Bearer owner")
+        .send({
+          signIn: { allowDuplicateEmails: true },
+          blockingFunctions: { forwardInboundCredentials: { idToken: true } },
+          usageMode: "PASSTHROUGH",
+        })
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.signIn?.allowDuplicateEmails).to.be.true;
+          expect(res.body.blockingFunctions).to.eql({
+            forwardInboundCredentials: { idToken: true },
+          });
+          expect(res.body.usageMode).to.eql("PASSTHROUGH");
+        });
+
+      // Check that production defaults are set
+      await authApi()
+        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
+        .set("Authorization", "Bearer owner")
+        .send({})
+        .then((res) => {
+          expectStatusCode(200, res);
+          expect(res.body.signIn?.allowDuplicateEmails).to.be.false;
+          expect(res.body.blockingFunctions).to.eql({});
+          expect(res.body.usageMode).to.eql("DEFAULT");
+        });
+    });
+  });
+});

--- a/src/test/emulators/auth/config.spec.ts
+++ b/src/test/emulators/auth/config.spec.ts
@@ -119,5 +119,43 @@ describeAuthEmulator("config management", ({ authApi }) => {
             .equals("Users are present, unable to set passthrough mode");
         });
     });
+
+    it("should error when updating an invalid blocking function event", async () => {
+      await authApi()
+        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
+        .set("Authorization", "Bearer owner")
+        .send({
+          blockingFunctions: {
+            triggers: {
+              invalidEventTrigger: {
+                functionUri: "http://localhost",
+              },
+            },
+          },
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error).to.have.property("message").contains("INVALID_BLOCKING_FUNCTION");
+        });
+    });
+
+    it("should error if functionUri is invalid", async () => {
+      await authApi()
+        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
+        .set("Authorization", "Bearer owner")
+        .send({
+          blockingFunctions: {
+            triggers: {
+              beforeCreate: {
+                functionUri: "invalidUri",
+              },
+            },
+          },
+        })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error).to.have.property("message").contains("INVALID_BLOCKING_FUNCTION");
+        });
+    });
   });
 });

--- a/src/test/emulators/auth/config.spec.ts
+++ b/src/test/emulators/auth/config.spec.ts
@@ -99,7 +99,7 @@ describeAuthEmulator("config management", ({ authApi }) => {
         })
         .then((res) => {
           expectStatusCode(400, res);
-          expect(res.body.error).to.have.property("message").equals("Invalid usage mode provided");
+          expect(res.body.error).to.have.property("message").contains("INVALID_USAGE_MODE");
         });
     });
 
@@ -114,9 +114,7 @@ describeAuthEmulator("config management", ({ authApi }) => {
         })
         .then((res) => {
           expectStatusCode(400, res);
-          expect(res.body.error)
-            .to.have.property("message")
-            .equals("Users are present, unable to set passthrough mode");
+          expect(res.body.error).to.have.property("message").contains("USERS_STILL_EXIST");
         });
     });
 

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -523,7 +523,7 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
       .send({ usageMode: "USAGE_MODE_UNSPECIFIED" })
       .then((res) => {
         expectStatusCode(400, res);
-        expect(res.body.error).to.have.property("message").equals("Invalid usage mode provided");
+        expect(res.body.error).to.have.property("message").contains("INVALID_USAGE_MODE");
       });
   });
 
@@ -547,9 +547,7 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
       .send({ usageMode: "PASSTHROUGH" })
       .then((res) => {
         expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("Users are present, unable to set passthrough mode");
+        expect(res.body.error).to.have.property("message").contains("USERS_STILL_EXIST");
       });
   });
 });


### PR DESCRIPTION
### Description

Adds support for `updateConfig`. Some noteworthy changes:
- Moved logic from `updateTenant` into a helper function for applying updateMasks
- Only stores in state a subset of `GoogleCloudIdentitytoolkitAdminV2Config` fields as `Config`, specifically only the fields that are configurable on the agent project level
- Point `updateEmulatorProjectConfig` to call `updateConfig` for updating `usageMode` and `allowDuplicateEmails`
- Update error codes for passthrough mode

Corresponding internal bug: b/192387243, b/192387797

### Scenarios Tested

`npm test` succeeds

### Sample Commands

N/A
