### PR TITLE
Release Firestore Emulator v1.14.1.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-- Release Cloud Firestore emulator v1.14.0:
-  - Adds support of x-goog-request-params http header for routing.
-  - Changes `read-past-max-staleness` error code to align with production
-    implementation.
-  - Updates readtime-in-the-future error message.
-  - Supports importing exports from Windows on UNIX systems. (#2421)
+-   Release Cloud Firestore emulator v1.14.1:
+    -   Adds support of x-goog-request-params http header for routing.
+    -   Changes `read-past-max-staleness` error code to align with production
+        implementation.
+    -   Updates readtime-in-the-future error message.
+    -   Supports importing exports from Windows on UNIX systems. (#2421)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-*   Release Cloud Firestore emulator v1.14.0
-    *   Chore: add support of x-goog-request-params http header for routing.
-    *   Fix: change read-past-max-staleness error code to align with production
-        implementation.
-    *   Fix: update readtime-in-the-future error message.
-    *   Fix: support importing exports from Windows on UNIX systems. (#2421)
+- Release Cloud Firestore emulator v1.14.0
+  - Chore: add support of x-goog-request-params http header for routing.
+  - Fix: change read-past-max-staleness error code to align with production
+    implementation.
+  - Fix: update readtime-in-the-future error message.
+  - Fix: support importing exports from Windows on UNIX systems. (#2421)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+*   Release Cloud Firestore emulator v1.14.0
+    *   Chore: prepare for aggregate support.
+    *   Chore: add support of x-goog-request-params http header for routing.
+    *   Fix: change read-past-max-staleness error code to align with production
+        implementation.
+    *   Fix: update readtime-in-the-future error message.
+    *   Fix: support importing exports from Windows on UNIX systems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 *   Release Cloud Firestore emulator v1.14.0
-    *   Chore: prepare for aggregate support.
     *   Chore: add support of x-goog-request-params http header for routing.
     *   Fix: change read-past-max-staleness error code to align with production
         implementation.
     *   Fix: update readtime-in-the-future error message.
-    *   Fix: support importing exports from Windows on UNIX systems.
+    *   Fix: support importing exports from Windows on UNIX systems. (#2421)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-- Release Cloud Firestore emulator v1.14.0
-  - Chore: add support of x-goog-request-params http header for routing.
-  - Fix: change read-past-max-staleness error code to align with production
+- Release Cloud Firestore emulator v1.14.0:
+  - Adds support of x-goog-request-params http header for routing.
+  - Changes `read-past-max-staleness` error code to align with production
     implementation.
-  - Fix: update readtime-in-the-future error message.
-  - Fix: support importing exports from Windows on UNIX systems. (#2421)
+  - Updates readtime-in-the-future error message.
+  - Supports importing exports from Windows on UNIX systems. (#2421)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -39,14 +39,14 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.14.0.jar"),
-    version: "1.14.0",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.14.1.jar"),
+    version: "1.14.1",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.14.0.jar",
-      expectedSize: 60393111,
-      expectedChecksum: "1471acb8c9ef0d56b5f110c6fc42ff14",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.14.1.jar",
+      expectedSize: 60416634,
+      expectedChecksum: "33cffe8065d4250816f257eb19245932",
       namePrefix: "cloud-firestore-emulator",
     },
   },

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -39,14 +39,14 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
     },
   },
   firestore: {
-    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.13.1.jar"),
-    version: "1.13.1",
+    downloadPath: path.join(CACHE_DIR, "cloud-firestore-emulator-v1.14.0.jar"),
+    version: "1.14.0",
     opts: {
       cacheDir: CACHE_DIR,
       remoteUrl:
-        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.13.1.jar",
-      expectedSize: 60486708,
-      expectedChecksum: "e0590880408eacb790874643147c0081",
+        "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.14.0.jar",
+      expectedSize: 60393111,
+      expectedChecksum: "1471acb8c9ef0d56b5f110c6fc42ff14",
       namePrefix: "cloud-firestore-emulator",
     },
   },


### PR DESCRIPTION
### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

This PR updates Firestore Emulator to v1.14.1.

### Scenarios Tested

Started emulators and it downloads and verifies the checksum correctly.

```
node ../firebase-tools/lib/bin/firebase.js emulators:start
i  emulators: Starting emulators: auth, functions, firestore, database
⚠  functions: The following emulators are not running, calls to these services from the Functions emulator will affect production: hos
ting, pubsub, storage
✔  functions: Using node@12 from host.
i  firestore: downloading cloud-firestore-emulator-v1.14.1.jar...
Progress: ============================================================================================================> (100% of 61MB)
i  firestore: Removing outdated emulator files: cloud-firestore-emulator-v1.13.1.jar
i  firestore: Firestore Emulator logging to firestore-debug.log
⚠  database: Did not find a Realtime Database rules file specified in a firebase.json config file. The emulator will default to allowi
ng all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_
rules_configuration.
i  database: Database Emulator logging to database-debug.log
i  ui: downloading ui-v1.6.5.zip...
Progress: =============================================================================================================> (100% of 4MB)
i  ui: Removing outdated emulator files: ui-v1.6.4
i  ui: Removing outdated emulator files: ui-v1.6.4.zip
i  ui: Emulator UI logging to ui-debug.log
```

Fixes #2421