### PR TITLE
Adding support for local instanceSpecs to want

### DIFF
--- a/src/extensions/localHelper.ts
+++ b/src/extensions/localHelper.ts
@@ -6,6 +6,7 @@ import { fileExistsSync } from "../fsutils";
 import { FirebaseError } from "../error";
 import { ExtensionSpec } from "./extensionsApi";
 import { logger } from "../logger";
+import { parse, Ref } from "./refs";
 
 const EXTENSIONS_SPEC_FILE = "extension.yaml";
 const EXTENSIONS_PREINSTALL_FILE = "PREINSTALL.md";
@@ -56,6 +57,22 @@ export function readFile(pathToFile: string): string {
       throw new FirebaseError(`Could not find "${pathToFile}""`, { original: err });
     }
     throw new FirebaseError(`Failed to read file at "${pathToFile}"`, { original: err });
+  }
+}
+
+/**
+ * getRefOrLocalPath detects if refOrPath is an extension ref or a path to a local extension.
+ * @param refOrPath a string that may be an extension ref or path to a local extension
+ */
+export function getRefOrLocalPath(refOrPath: string): {
+  ref?: Ref;
+  localPath?: string;
+} {
+  try {
+    const ref = parse(refOrPath);
+    return { ref };
+  } catch (e) {
+    return { localPath: refOrPath };
   }
 }
 

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -150,7 +150,6 @@ export function instanceExists(instanceId: string, config: Config): boolean {
 }
 
 export function getInstanceRef(instanceId: string, config: Config): refs.Ref {
-  // TODO: Handle local paths here.
   if (!instanceExists(instanceId, config)) {
     throw new FirebaseError(`Could not find extension instance ${instanceId} in firebase.json`);
   }

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -150,6 +150,7 @@ export function instanceExists(instanceId: string, config: Config): boolean {
 }
 
 export function getInstanceRef(instanceId: string, config: Config): refs.Ref {
+  // TODO: Handle local paths here.
   if (!instanceExists(instanceId, config)) {
     throw new FirebaseError(`Could not find extension instance ${instanceId} in firebase.json`);
   }


### PR DESCRIPTION
### Description
Adding support for InstanceSpecs that represent local Extensions. This is a first step toward fully supporting local extensions in --local, deploy, and the emulators.
