### PR TITLE
Fix import path, remove export in Storage Emulator tests

### DIFF
--- a/scripts/storage-emulator-integration/import/tests.ts
+++ b/scripts/storage-emulator-integration/import/tests.ts
@@ -26,8 +26,6 @@ describe("Import Emulator Data", () => {
       Emulators.STORAGE,
       "--import",
       path.join(__dirname, "flattened-emulator-data"),
-      "--export-on-exit",
-      path.join(__dirname, "other-emulator-data"),
     ]);
 
     await supertest(STORAGE_EMULATOR_HOST)
@@ -42,7 +40,7 @@ describe("Import Emulator Data", () => {
       "--only",
       Emulators.STORAGE,
       "--import",
-      path.join(__dirname, "flattened-emulator-data"),
+      path.join(__dirname, "nested-emulator-data"),
     ]);
 
     await supertest(STORAGE_EMULATOR_HOST)


### PR DESCRIPTION
### Description
Follow up to #4358. Two quick fixes:
1. Integration test should not be exporting to a local directory on exit
2. Integration test for importing nested directory structure was importing from emulator data corresponding to flattened directory structure

There will be one more PR related to this issue addressing double URL encoding (see [this](https://github.com/firebase/firebase-tools/issues/4326#issuecomment-1080296523) and [this](https://github.com/firebase/firebase-tools/issues/4322#issuecomment-1079965782)). But I would like to get this in first. 