### PR TITLE
Fix download token duplication on multiple setMetadata calls

### DIFF
--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -1107,7 +1107,7 @@ describe("Storage emulator", () => {
 
           // Check that the tokens are saved in Cloud metadata
           const [storedMetadata] = await cloudFile.getMetadata();
-          expect(storedMetadata.metadata.firebaseStorageDownloadTokens).to.deep.equal(
+          expect(storedMetadata.metadata.firebaseStorageDownloadTokens).to.equal(
             incomingMetadata.metadata.firebaseStorageDownloadTokens
           );
         });

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -1075,6 +1075,43 @@ describe("Storage emulator", () => {
           expect(metadata.contentLanguage).to.equal("en");
         });
 
+        it("should not duplicate data when called repeatedly", async () => {
+          const destination = "public/small_file";
+          await testBucket.upload(smallFilePath, {
+            destination,
+            metadata: {},
+          });
+
+          const cloudFile = testBucket.file(destination);
+          const incomingMetadata = {
+            metadata: {
+              firebaseStorageDownloadTokens: "myFirstToken,mySecondToken",
+            },
+          };
+
+          // Check that metadata isn't duplicated when setting multiple times in a row
+          await cloudFile.setMetadata(incomingMetadata);
+          await cloudFile.setMetadata(incomingMetadata);
+          await cloudFile.setMetadata(incomingMetadata);
+
+          // Check that the tokens are saved in Firebase metadata
+          await supertest(STORAGE_EMULATOR_HOST)
+            .get(`/v0/b/${testBucket.name}/o/${encodeURIComponent(destination)}`)
+            .expect(200)
+            .then((res) => {
+              const firebaseMd = res.body;
+              expect(firebaseMd.downloadTokens).to.equal(
+                incomingMetadata.metadata.firebaseStorageDownloadTokens
+              );
+            });
+
+          // Check that the tokens are saved in Cloud metadata
+          const [storedMetadata] = await cloudFile.getMetadata();
+          expect(storedMetadata.metadata.firebaseStorageDownloadTokens).to.deep.equal(
+            incomingMetadata.metadata.firebaseStorageDownloadTokens
+          );
+        });
+
         it("should allow fields under .metadata", async () => {
           await testBucket.upload(smallFilePath);
           const [metadata] = await testBucket

--- a/src/emulator/storage/metadata.ts
+++ b/src/emulator/storage/metadata.ts
@@ -142,10 +142,10 @@ export class StoredFileMetadata {
     }
 
     if (this.customMetadata.firebaseStorageDownloadTokens) {
-      this.downloadTokens = [
+      this.downloadTokens = [...new Set([
         ...this.downloadTokens,
         ...this.customMetadata.firebaseStorageDownloadTokens.split(","),
-      ];
+      ])];
       delete this.customMetadata.firebaseStorageDownloadTokens;
     }
   }

--- a/src/emulator/storage/metadata.ts
+++ b/src/emulator/storage/metadata.ts
@@ -142,10 +142,12 @@ export class StoredFileMetadata {
     }
 
     if (this.customMetadata.firebaseStorageDownloadTokens) {
-      this.downloadTokens = [...new Set([
-        ...this.downloadTokens,
-        ...this.customMetadata.firebaseStorageDownloadTokens.split(","),
-      ])];
+      this.downloadTokens = [
+        ...new Set([
+          ...this.downloadTokens,
+          ...this.customMetadata.firebaseStorageDownloadTokens.split(","),
+        ]),
+      ];
       delete this.customMetadata.firebaseStorageDownloadTokens;
     }
   }


### PR DESCRIPTION
### Description

This fixes a bug (#4341) where download tokens are duplicated when `setMetadata` is called multiple times in a row. This happened because we always concatenated the user-provided and existing token arrays and never enforced uniqueness.