### PR TITLE
Extensions - Require local secret to be not empty

### DIFF
--- a/src/extensions/askUserForParam.ts
+++ b/src/extensions/askUserForParam.ts
@@ -249,10 +249,7 @@ async function promptSecretLocations(paramSpec: Param): Promise<string[]> {
   });
 }
 
-async function promptLocalSecret(
-  instanceId: string,
-  paramSpec: Param
-): Promise<string> {
+async function promptLocalSecret(instanceId: string, paramSpec: Param): Promise<string> {
   let value;
   do {
     utils.logLabeledBullet(logPrefix, "Configure a local secret value for Extensions Emulator");

--- a/src/extensions/askUserForParam.ts
+++ b/src/extensions/askUserForParam.ts
@@ -252,15 +252,18 @@ async function promptSecretLocations(paramSpec: Param): Promise<string[]> {
 async function promptLocalSecret(
   instanceId: string,
   paramSpec: Param
-): Promise<string | undefined> {
-  utils.logLabeledBullet(logPrefix, "Configure a local secret value for Extensions Emulator");
-  const value = await promptOnce({
-    name: paramSpec.param,
-    type: "input",
-    message:
-      `This secret will be stored in ./extensions/${instanceId}.secret.local.\n` +
-      `Enter value for "${paramSpec.label.trim()}" to be used by Extensions Emulator:`,
-  });
+): Promise<string> {
+  let value;
+  do {
+    utils.logLabeledBullet(logPrefix, "Configure a local secret value for Extensions Emulator");
+    value = await promptOnce({
+      name: paramSpec.param,
+      type: "input",
+      message:
+        `This secret will be stored in ./extensions/${instanceId}.secret.local.\n` +
+        `Enter value for "${paramSpec.label.trim()}" to be used by Extensions Emulator:`,
+    });
+  } while (!value);
   return value;
 }
 

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -260,7 +260,7 @@ export function showDeprecationWarning() {
 export function showPreviewWarning() {
   utils.logLabeledWarning(
     logPrefix,
-    "These changes will be reflected in your Firebase Emulator after restart. " +
+    `See these changes in your Firebase Emulator by running "firebase emulators:start". ` +
       `Run ${clc.bold(
         "firebase deploy (--only extensions)"
       )} to deploy the changes to your Firebase project. `


### PR DESCRIPTION
### Description

- Add command to start emulator
- Require local secret to be not empty

![Screen Shot 2022-03-31 at 10 37 27 AM](https://user-images.githubusercontent.com/6955348/161081527-a116785d-f5e9-4e39-ae52-d2a4417ae4b2.png)

