### PR TITLE
Fix duplicate import for Storage Emulator

### DIFF
--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -584,15 +584,11 @@ export class StorageLayer {
       }
 
       const decodedBlobPath = decodeURIComponent(blobPath);
-      const decodedMetadataPath = decodeURIComponent(metadataRelPath);
-
       const blobDiskPath = this._persistence.getDiskPath(decodedBlobPath);
-      const metadataDiskPath = this._persistence.getDiskPath(decodedMetadataPath);
 
       const file = new StoredFile(metadata, blobDiskPath);
       this._files.set(decodedBlobPath, file);
 
-      fse.copyFileSync(f, metadataDiskPath);
       fse.copyFileSync(blobAbsPath, blobDiskPath);
     }
   }


### PR DESCRIPTION
### Description
Follow up to #4358. With this PR we should be able to close out #4326 and #4322.

#### Issue
Previously, I made a mistake in writing the new import logic, causing a duplicate metadata file to be written to the `blobs` directory. You can see this when you export the data again:
<img width="431" alt="duplicate-import" src="https://user-images.githubusercontent.com/37965489/161142484-37ec4ec4-35a9-4da0-b2fd-cf9a4dd55a1e.png">
Note the presence of the `test_upload.jpg.json` file; we expect to see only the `test_upload.jpg` file.

#### Cause
I thought that we needed to copy over the metadata as a file on disk when importing the emulator data. This is false; we only need to copy over its contents into the `StoredFile`. Only on export do we turn the metadata into a JSON file, which goes into the `metadata`, not `blobs`, directory.

### Scenarios Tested
Added an integration test checking that the imported emulator data contains only the expected file blobs. As before, we do this by checking the exported data.