### PR TITLE
Container contract updates

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -48,7 +48,7 @@ export interface CallableTriggered {
   callableTrigger: CallableTrigger;
 }
 
-type EventFilterKey = "resource" | "topic" | "bucket" | "alerttype" | string;
+type EventFilterKey = "resource" | "topic" | "bucket" | "alerttype" | "appid" | string;
 
 /** API agnostic version of a Cloud Function's event trigger. */
 export interface EventTrigger {

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -48,7 +48,7 @@ export interface CallableTriggered {
   callableTrigger: CallableTrigger;
 }
 
-type EventFilterKey = "resource" | "topic" | "bucket" | string;
+type EventFilterKey = "resource" | "topic" | "bucket" | "alerttype" | string;
 
 /** API agnostic version of a Cloud Function's event trigger. */
 export interface EventTrigger {

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -48,16 +48,7 @@ export interface CallableTriggered {
   callableTrigger: CallableTrigger;
 }
 
-type EventFilterAttribute = "resource" | "topic" | "bucket" | string;
-
-// One or more event filters restrict the set of events delivered to an EventTrigger.
-interface EventFilter {
-  attribute: EventFilterAttribute;
-  value: string;
-
-  // if left unspecified, equality is used.
-  operator?: "match-path-pattern";
-}
+type EventFilterKey = "resource" | "topic" | "bucket" | string;
 
 /** API agnostic version of a Cloud Function's event trigger. */
 export interface EventTrigger {
@@ -73,14 +64,20 @@ export interface EventTrigger {
   eventType: string;
 
   /**
-   * Additional filters for narrowing down which events to receive.
+   * Additional exact-match filters for narrowing down which events to receive.
+   *
    * While not required by the GCF API, this is always provided in
    * the Cloud Console, and we are likely to always require it as well.
    * V1 functions will always (and only) have the "resource" filter.
    * V2 will have arbitrary filters and some EventArc filters will be
    * top-level keys in the GCF API (e.g. "pubsubTopic").
    */
-  eventFilters: EventFilter[];
+  eventFilters: Record<EventFilterKey, string>;
+
+  /**
+   * Additional path-pattern filters for narrowing down which events to receive.
+   */
+  eventFilterPathPatterns?: Record<string, string>;
 
   /** Should failures in a function execution cause an event to be retried. */
   retry: boolean;
@@ -98,6 +95,12 @@ export interface EventTrigger {
    * This field is ignored for v1 and defaults to the
    */
   serviceAccountEmail?: string;
+
+  /**
+   * The name of the channel where the function receive events.
+   * Must be provided to receive custom events.
+   */
+  channel?: string;
 }
 
 /** Something that has an EventTrigger */
@@ -574,14 +577,6 @@ export const missingEndpoint =
   (endpoint: Endpoint): boolean => {
     return !hasEndpoint(backend)(endpoint);
   };
-
-/** A helper utility to find event filter of given attribute */
-export function findEventFilter(
-  endpoint: Endpoint & EventTriggered,
-  attribute: EventFilterAttribute
-): EventFilter | undefined {
-  return endpoint.eventTrigger.eventFilters.find((ef) => ef.attribute === attribute);
-}
 
 /**
  * A standard method for sorting endpoints for display.

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -196,10 +196,7 @@ export function changedV2PubSubTopic(want: backend.Endpoint, have: backend.Endpo
   if (have.eventTrigger.eventType !== v2events.PUBSUB_PUBLISH_EVENT) {
     return false;
   }
-
-  return (
-    backend.findEventFilter(have, "topic")?.value !== backend.findEventFilter(want, "topic")?.value
-  );
+  return have.eventTrigger.eventFilters.topic !== want.eventTrigger.eventFilters.topcic;
 }
 
 /** Whether a user upgraded a scheduled function (which goes from Pub/Sub to HTTPS). */

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -196,7 +196,7 @@ export function changedV2PubSubTopic(want: backend.Endpoint, have: backend.Endpo
   if (have.eventTrigger.eventType !== v2events.PUBSUB_PUBLISH_EVENT) {
     return false;
   }
-  return have.eventTrigger.eventFilters.topic !== want.eventTrigger.eventFilters.topcic;
+  return have.eventTrigger.eventFilters.topic !== want.eventTrigger.eventFilters.topic;
 }
 
 /** Whether a user upgraded a scheduled function (which goes from Pub/Sub to HTTPS). */

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -121,17 +121,19 @@ function parseEndpoints(
     if (backend.isEventTriggered(ep)) {
       requireKeys(prefix + ".eventTrigger", ep.eventTrigger, "eventType", "eventFilters");
       assertKeyTypes(prefix + ".eventTrigger", ep.eventTrigger, {
-        eventFilters: "array",
+        eventFilters: "object",
+        eventFilterPathPatterns: "object",
         eventType: "string",
         retry: "boolean",
         region: "string",
         serviceAccountEmail: "string",
+        channel: "string",
       });
       triggered = { eventTrigger: ep.eventTrigger };
-      for (const eventFilter of triggered.eventTrigger.eventFilters) {
-        if (eventFilter.attribute === "topic" && !eventFilter.value.startsWith("projects/")) {
+      for (const [k, v] of Object.entries(triggered.eventTrigger.eventFilters)) {
+        if (k === "topic" && !v.startsWith("projects/")) {
           // Construct full pubsub topic name.
-          eventFilter.value = `projects/${project}/topics/${eventFilter.value}`;
+          triggered.eventTrigger.eventFilters[k] = `projects/${project}/topics/${v}`;
         }
       }
     } else if (backend.isHttpsTriggered(ep)) {

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -18,7 +18,7 @@ import * as validate from "./validate";
 import * as versioning from "./versioning";
 import * as parseTriggers from "./parseTriggers";
 
-const MIN_FUNCTIONS_SDK_VERSION = "3.19.0";
+const MIN_FUNCTIONS_SDK_VERSION = "3.20.0";
 
 export async function tryCreateDelegate(
   context: runtimes.DelegateContext

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -215,12 +215,7 @@ export function addResourcesToBackend(
       triggered = {
         eventTrigger: {
           eventType: annotation.eventTrigger!.eventType,
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: annotation.eventTrigger!.resource,
-            },
-          ],
+          eventFilters: { resource: annotation.eventTrigger!.resource },
           retry: !!annotation.failurePolicy,
         },
       };
@@ -229,12 +224,7 @@ export function addResourcesToBackend(
       // once we use container contract for the functionsv2 experiment.
       if (annotation.platform === "gcfv2") {
         if (annotation.eventTrigger!.eventType === v2events.PUBSUB_PUBLISH_EVENT) {
-          triggered.eventTrigger.eventFilters = [
-            {
-              attribute: "topic",
-              value: annotation.eventTrigger!.resource,
-            },
-          ];
+          triggered.eventTrigger.eventFilters = { topic: annotation.eventTrigger!.resource };
         }
 
         if (
@@ -242,12 +232,7 @@ export function addResourcesToBackend(
             (event) => event === (annotation.eventTrigger?.eventType || "")
           )
         ) {
-          triggered.eventTrigger.eventFilters = [
-            {
-              attribute: "bucket",
-              value: annotation.eventTrigger!.resource,
-            },
-          ];
+          triggered.eventTrigger.eventFilters = { bucket: annotation.eventTrigger!.resource };
         }
       }
     }

--- a/src/deploy/functions/services/storage.ts
+++ b/src/deploy/functions/services/storage.ts
@@ -43,14 +43,10 @@ export async function ensureStorageTriggerRegion(
   const { eventTrigger } = endpoint;
   if (!eventTrigger.region) {
     logger.debug("Looking up bucket region for the storage event trigger");
-    const bucketFilter = backend.findEventFilter(endpoint, "bucket");
-    if (!bucketFilter) {
-      throw new FirebaseError(
-        "Storage event trigger unexpectedly missing event filter with bucket attribute."
-      );
-    }
     try {
-      const bucket: { location: string } = await storage.getBucket(bucketFilter.value);
+      const bucket: { location: string } = await storage.getBucket(
+        eventTrigger.eventFilters.bucket!
+      );
       eventTrigger.region = bucket.location.toLowerCase();
       logger.debug("Setting the event trigger region to", eventTrigger.region, ".");
     } catch (err: any) {

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -168,34 +168,21 @@ export function emulatedFunctionsFromEndpoints(
     } else if (backend.isEventTriggered(endpoint)) {
       const eventTrigger = endpoint.eventTrigger;
       if (endpoint.platform === "gcfv1") {
-        const resourceFilter = backend.findEventFilter(endpoint, "resource");
-        if (!resourceFilter) {
-          logger.debug(
-            `Invalid event trigger ${JSON.stringify(
-              endpoint
-            )}, expected event filter with resource attribute. Skipping.`
-          );
-          // Silently skip invalid trigger.
-          continue;
-        }
         def.eventTrigger = {
           eventType: eventTrigger.eventType,
-          resource: resourceFilter.value,
+          resource: eventTrigger.eventFilters.resource,
         };
       } else {
-        const [eventFilter] = endpoint.eventTrigger.eventFilters;
-        if (!eventFilter) {
-          logger.debug(
-            `Invalid event trigger ${JSON.stringify(
-              endpoint
-            )}, expected at least one event filter. Skipping.`
-          );
-          // Silently skip invalid trigger.
+        // Only pubsub and storage events are supported for gcfv2.
+        const { resource, topic, bucket } = endpoint.eventTrigger.eventFilters;
+        const eventResource = resource || topic || bucket;
+        if (!eventResource) {
+          // Unsupported event type for GCFv2
           continue;
         }
         def.eventTrigger = {
           eventType: eventTrigger.eventType,
-          resource: eventFilter.value,
+          resource: eventResource,
         };
       }
     } else if (backend.isScheduleTriggered(endpoint)) {

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -435,25 +435,17 @@ export function functionFromEndpoint(endpoint: backend.Endpoint, source: Storage
       eventType: endpoint.eventTrigger.eventType,
     };
     if (gcfFunction.eventTrigger.eventType === PUBSUB_PUBLISH_EVENT) {
-      const pubsubFilter = backend.findEventFilter(endpoint, "topic");
-      if (!pubsubFilter) {
-        throw new FirebaseError(
-          "Invalid pubsub endpoint. Expected eventFilter with 'topic' attribute but found none."
-        );
-      }
-      gcfFunction.eventTrigger.pubsubTopic = pubsubFilter.value;
-
-      for (const filter of endpoint.eventTrigger.eventFilters) {
-        if (filter.attribute === "topic") {
-          continue;
-        }
-        if (!gcfFunction.eventTrigger.eventFilters) {
-          gcfFunction.eventTrigger.eventFilters = [];
-        }
-        gcfFunction.eventTrigger.eventFilters.push(filter);
+      gcfFunction.eventTrigger.pubsubTopic = endpoint.eventTrigger.eventFilters.topic;
+      gcfFunction.eventTrigger.eventFilters = [];
+      for (const [attribute, value] of Object.entries(endpoint.eventTrigger.eventFilters)) {
+        if (attribute === "topic") continue;
+        gcfFunction.eventTrigger.eventFilters.push({ attribute, value });
       }
     } else {
-      gcfFunction.eventTrigger.eventFilters = endpoint.eventTrigger.eventFilters;
+      gcfFunction.eventTrigger.eventFilters = [];
+      for (const [attribute, value] of Object.entries(endpoint.eventTrigger.eventFilters)) {
+        gcfFunction.eventTrigger.eventFilters.push({ attribute, value });
+      }
     }
     proto.renameIfPresent(
       gcfFunction.eventTrigger,
@@ -485,6 +477,9 @@ export function functionFromEndpoint(endpoint: backend.Endpoint, source: Storage
   return gcfFunction;
 }
 
+/**
+ *
+ */
 export function endpointFromFunction(gcfFunction: CloudFunction): backend.Endpoint {
   const [, project, , region, , id] = gcfFunction.name.split("/");
   let trigger: backend.Triggered;
@@ -504,18 +499,15 @@ export function endpointFromFunction(gcfFunction: CloudFunction): backend.Endpoi
     trigger = {
       eventTrigger: {
         eventType: gcfFunction.eventTrigger.eventType,
-        eventFilters: [],
+        eventFilters: {},
         retry: false,
       },
     };
     if (gcfFunction.eventTrigger.pubsubTopic) {
-      trigger.eventTrigger.eventFilters.push({
-        attribute: "topic",
-        value: gcfFunction.eventTrigger.pubsubTopic,
-      });
+      trigger.eventTrigger.eventFilters.topic = gcfFunction.eventTrigger.pubsubTopic;
     } else {
       for (const { attribute, value } of gcfFunction.eventTrigger.eventFilters || []) {
-        trigger.eventTrigger.eventFilters.push({ attribute, value });
+        trigger.eventTrigger.eventFilters[attribute] = value;
       }
     }
     proto.renameIfPresent(

--- a/src/test/deploy/functions/checkIam.spec.ts
+++ b/src/test/deploy/functions/checkIam.spec.ts
@@ -257,12 +257,7 @@ describe("checkIam", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -284,12 +279,7 @@ describe("checkIam", () => {
         platform: "gcfv1",
         eventTrigger: {
           eventType: "google.storage.object.create",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/_/buckets/myBucket",
-            },
-          ],
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -307,12 +297,7 @@ describe("checkIam", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -336,12 +321,7 @@ describe("checkIam", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -352,12 +332,7 @@ describe("checkIam", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.metadataUpdated",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -415,12 +390,7 @@ describe("checkIam", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -460,12 +430,7 @@ describe("checkIam", () => {
       platform: "gcfv2",
       eventTrigger: {
         eventType: "google.cloud.storage.object.v1.finalized",
-        eventFilters: [
-          {
-            attribute: "bucket",
-            value: "my-bucket",
-          },
-        ],
+        eventFilters: { bucket: "my-bucket" },
         retry: false,
       },
       ...SPEC,
@@ -476,12 +441,7 @@ describe("checkIam", () => {
       platform: "gcfv2",
       eventTrigger: {
         eventType: "google.firebase.firebasealerts.alerts.v1.published",
-        eventFilters: [
-          {
-            attribute: "alerttype",
-            value: "crashlytics.newFatalIssue",
-          },
-        ],
+        eventFilters: { alertype: "crashlytics.newFatalIssue" },
         retry: false,
       },
       ...SPEC,
@@ -535,12 +495,7 @@ describe("checkIam", () => {
       platform: "gcfv2",
       eventTrigger: {
         eventType: "google.firebase.firebasealerts.alerts.v1.published",
-        eventFilters: [
-          {
-            attribute: "alerttype",
-            value: "crashlytics.newFatalIssue",
-          },
-        ],
+        eventFilters: { alertype: "crashlytics.newFatalIssue" },
         retry: false,
       },
       ...SPEC,
@@ -571,12 +526,7 @@ describe("checkIam", () => {
       platform: "gcfv2",
       eventTrigger: {
         eventType: "google.firebase.firebasealerts.alerts.v1.published",
-        eventFilters: [
-          {
-            attribute: "alerttype",
-            value: "crashlytics.newFatalIssue",
-          },
-        ],
+        eventFilters: { alertype: "crashlytics.newFatalIssue" },
         retry: false,
       },
       ...SPEC,
@@ -587,12 +537,7 @@ describe("checkIam", () => {
       platform: "gcfv2",
       eventTrigger: {
         eventType: "google.cloud.storage.object.v1.finalized",
-        eventFilters: [
-          {
-            attribute: "bucket",
-            value: "my-bucket",
-          },
-        ],
+        eventFilters: { bucket: "my-bucket" },
         retry: false,
       },
       ...SPEC,

--- a/src/test/deploy/functions/prepare.spec.ts
+++ b/src/test/deploy/functions/prepare.spec.ts
@@ -79,12 +79,7 @@ describe("prepare", () => {
         ...ENDPOINT_BASE,
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "bucket",
-            },
-          ],
+          eventFilters: { bucket: "bucket" },
           retry: false,
         },
       };
@@ -101,18 +96,13 @@ describe("prepare", () => {
         ...ENDPOINT_BASE,
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalzied",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "us-bucket",
-            },
-          ],
+          eventFilters: { bucket: "us-bucket" },
           retry: false,
         },
       };
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const have: backend.Endpoint & backend.EventTriggered = JSON.parse(JSON.stringify(want));
-      have.eventTrigger.eventFilters = [{ attribute: "bucket", value: "us-central1-bucket" }];
+      have.eventTrigger.eventFilters = { bucket: "us-central1-bucket" };
       have.eventTrigger.region = "us-central1";
 
       prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* usedDotEnv= */ false);

--- a/src/test/deploy/functions/prompts.spec.ts
+++ b/src/test/deploy/functions/prompts.spec.ts
@@ -11,12 +11,7 @@ import { RC } from "../../../rc";
 
 const SAMPLE_EVENT_TRIGGER: backend.EventTrigger = {
   eventType: "google.pubsub.topic.publish",
-  eventFilters: [
-    {
-      attribute: "resource",
-      value: "projects/a/topics/b",
-    },
-  ],
+  eventFilters: { resource: "projects/a/topics/b" },
   retry: false,
 };
 

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -275,7 +275,7 @@ describe("Fabricator", () => {
       const ep1 = endpoint({
         eventTrigger: {
           eventType: "some.event",
-          eventFilters: [{ attribute: "resource", value: "some-resource" }],
+          eventFilters: { resource: "some-resource" },
           retry: false,
         },
       });
@@ -400,12 +400,7 @@ describe("Fabricator", () => {
         {
           eventTrigger: {
             eventType: v2events.PUBSUB_PUBLISH_EVENT,
-            eventFilters: [
-              {
-                attribute: "topic",
-                value: "topic",
-              },
-            ],
+            eventFilters: { topic: "topic" },
             retry: false,
           },
         },
@@ -426,12 +421,7 @@ describe("Fabricator", () => {
         {
           eventTrigger: {
             eventType: v2events.PUBSUB_PUBLISH_EVENT,
-            eventFilters: [
-              {
-                attribute: "topic",
-                value: "topic",
-              },
-            ],
+            eventFilters: { topic: "topic" },
             retry: false,
           },
         },
@@ -889,12 +879,7 @@ describe("Fabricator", () => {
       const ep = endpoint({
         eventTrigger: {
           eventType: v2events.PUBSUB_PUBLISH_EVENT,
-          eventFilters: [
-            {
-              attribute: "topic",
-              value: "topic",
-            },
-          ],
+          eventFilters: { topic: "topic" },
           retry: false,
         },
       });
@@ -945,12 +930,7 @@ describe("Fabricator", () => {
       const ep = endpoint({
         eventTrigger: {
           eventType: v2events.PUBSUB_PUBLISH_EVENT,
-          eventFilters: [
-            {
-              attribute: "topic",
-              value: "topic",
-            },
-          ],
+          eventFilters: { topic: "topic" },
           retry: false,
         },
       });

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -51,12 +51,7 @@ describe("planner", () => {
         ...func("a", "b", {
           eventTrigger: {
             eventType: v2events.PUBSUB_PUBLISH_EVENT,
-            eventFilters: [
-              {
-                attribute: "topic",
-                value: "topic",
-              },
-            ],
+            eventFilters: { topic: "topic" },
             retry: false,
           },
         }),
@@ -64,7 +59,7 @@ describe("planner", () => {
       };
       const changed = JSON.parse(JSON.stringify(original)) as backend.Endpoint;
       if (backend.isEventTriggered(changed)) {
-        changed.eventTrigger.eventFilters = [{ attribute: "topic", value: "anotherTopic" }];
+        changed.eventTrigger.eventFilters = { topic: "anotherTopic" };
       }
       expect(planner.calculateUpdate(changed, original)).to.deep.equal({
         endpoint: changed,
@@ -90,12 +85,7 @@ describe("planner", () => {
       const original: backend.Endpoint = func("a", "b", {
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           region: "us-west1",
           retry: false,
         },
@@ -104,12 +94,7 @@ describe("planner", () => {
       const changed: backend.Endpoint = func("a", "b", {
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalzied",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           region: "us",
           retry: false,
         },
@@ -319,7 +304,7 @@ describe("planner", () => {
       const want = func("a", "b", {
         eventTrigger: {
           eventType: "google.pubsub.topic.publish",
-          eventFilters: [],
+          eventFilters: {},
           retry: false,
         },
       });
@@ -333,7 +318,7 @@ describe("planner", () => {
       const have = func("a", "b", {
         eventTrigger: {
           eventType: "google.pubsub.topic.publish",
-          eventFilters: [],
+          eventFilters: {},
           retry: false,
         },
       });
@@ -351,7 +336,7 @@ describe("planner", () => {
     it("should not throw if a event triggered function keeps the same trigger", () => {
       const eventTrigger: backend.EventTrigger = {
         eventType: "google.pubsub.topic.publish",
-        eventFilters: [],
+        eventFilters: {},
         retry: false,
       };
       const want = func("a", "b", { eventTrigger });
@@ -384,12 +369,7 @@ describe("planner", () => {
   it("detects changes to v2 pubsub topics", () => {
     const eventTrigger: backend.EventTrigger = {
       eventType: v2events.PUBSUB_PUBLISH_EVENT,
-      eventFilters: [
-        {
-          attribute: "topic",
-          value: "projects/p/topic/t",
-        },
-      ],
+      eventFilters: { topic: "projects/p/topics/t" },
       retry: false,
     };
 
@@ -419,7 +399,7 @@ describe("planner", () => {
     // to modify only 'want'
     want = JSON.parse(JSON.stringify(want)) as backend.Endpoint;
     if (backend.isEventTriggered(want)) {
-      want.eventTrigger.eventFilters = [{ attribute: "topic", value: "projects/p/topics/t2" }];
+      want.eventTrigger.eventFilters = { topic: "projects/p/topics/t2" };
     }
     expect(planner.changedV2PubSubTopic(want, have)).to.be.true;
   });

--- a/src/test/deploy/functions/release/reporter.spec.ts
+++ b/src/test/deploy/functions/release/reporter.spec.ts
@@ -88,7 +88,7 @@ describe("reporter", () => {
           platform: "gcfv2",
           eventTrigger: {
             eventType: "google.pubsub.topic.publish",
-            eventFilters: [],
+            eventFilters: {},
             retry: false,
           },
         })

--- a/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -99,12 +99,7 @@ describe("backendFromV1Alpha1", () => {
     describe("Event triggers", () => {
       const validTrigger: backend.EventTrigger = {
         eventType: "google.pubsub.v1.topic.publish",
-        eventFilters: [
-          {
-            attribute: "resource",
-            value: "projects/p/topics/t",
-          },
-        ],
+        eventFilters: { resource: "projects/p/topics/t" },
         retry: true,
         region: "global",
         serviceAccountEmail: "root@",
@@ -325,12 +320,7 @@ describe("backendFromV1Alpha1", () => {
     it("copies event triggers", () => {
       const eventTrigger: backend.EventTrigger = {
         eventType: "google.pubsub.topic.v1.publish",
-        eventFilters: [
-          {
-            attribute: "resource",
-            value: "projects/project/topics/topic",
-          },
-        ],
+        eventFilters: { resource: "projects/project/topics/t" },
         region: "us-central1",
         serviceAccountEmail: "sa@",
         retry: true,
@@ -352,12 +342,7 @@ describe("backendFromV1Alpha1", () => {
     it("copies event triggers with full resource path", () => {
       const eventTrigger: backend.EventTrigger = {
         eventType: "google.pubsub.topic.v1.publish",
-        eventFilters: [
-          {
-            attribute: "topic",
-            value: "my-topic",
-          },
-        ],
+        eventFilters: { topic: "my-topic" },
         region: "us-central1",
         serviceAccountEmail: "sa@",
         retry: true,
@@ -375,12 +360,7 @@ describe("backendFromV1Alpha1", () => {
         ...DEFAULTED_ENDPOINT,
         eventTrigger: {
           ...eventTrigger,
-          eventFilters: [
-            {
-              attribute: "topic",
-              value: `projects/${PROJECT}/topics/my-topic`,
-            },
-          ],
+          eventFilters: { topic: `projects/${PROJECT}/topics/my-topic` },
         },
       });
       const parsed = v1alpha1.backendFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);

--- a/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -128,12 +128,7 @@ describe("addResourcesToBackend", () => {
 
         const eventTrigger: backend.EventTrigger = {
           eventType: "google.pubsub.topic.publish",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/project/topics/topic",
-            },
-          ],
+          eventFilters: { resource: "projects/project/topics/topic" },
           retry: !!failurePolicy,
         };
         const expected: backend.Backend = backend.of({ ...BASIC_ENDPOINT, eventTrigger });
@@ -202,12 +197,7 @@ describe("addResourcesToBackend", () => {
 
     const eventTrigger: backend.EventTrigger = {
       eventType: "google.pubsub.topic.publish",
-      eventFilters: [
-        {
-          attribute: "resource",
-          value: "projects/p/topics/t",
-        },
-      ],
+      eventFilters: { resource: "projects/p/topics/t" },
       retry: false,
     };
 

--- a/src/test/deploy/functions/services/firebaseAlerts.spec.ts
+++ b/src/test/deploy/functions/services/firebaseAlerts.spec.ts
@@ -11,7 +11,7 @@ const endpoint: Endpoint = {
   eventTrigger: {
     retry: false,
     eventType: "firebase.firebasealerts.alerts.v1.published",
-    eventFilters: [],
+    eventFilters: {},
   },
   entryPoint: "endpoint",
   platform: "gcfv2",

--- a/src/test/deploy/functions/triggerRegionHelper.spec.ts
+++ b/src/test/deploy/functions/triggerRegionHelper.spec.ts
@@ -30,12 +30,7 @@ describe("TriggerRegionHelper", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -53,12 +48,7 @@ describe("TriggerRegionHelper", () => {
         platform: "gcfv1",
         eventTrigger: {
           eventType: "google.storage.object.create",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/_/buckets/my-bucket",
-            },
-          ],
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -73,16 +63,13 @@ describe("TriggerRegionHelper", () => {
 
       await triggerRegionHelper.ensureTriggerRegions(backend.of(v1EventFn, v2CallableFn));
 
-      expect(v1EventFn.eventTrigger).to.deep.eq({
+      const want: backend.EventTrigger = {
         eventType: "google.storage.object.create",
-        eventFilters: [
-          {
-            attribute: "resource",
-            value: "projects/_/buckets/my-bucket",
-          },
-        ],
+        eventFilters: { resource: "projects/_/buckets/my-bucket" },
         retry: false,
-      });
+      };
+
+      expect(v1EventFn.eventTrigger).to.deep.eq(want);
       expect(v2CallableFn.httpsTrigger).to.deep.eq({});
     });
 
@@ -94,12 +81,7 @@ describe("TriggerRegionHelper", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
@@ -107,17 +89,13 @@ describe("TriggerRegionHelper", () => {
 
       await triggerRegionHelper.ensureTriggerRegions(backend.of(wantFn));
 
-      expect(wantFn.eventTrigger).to.deep.eq({
+      const want: backend.EventTrigger = {
         eventType: "google.cloud.storage.object.v1.finalized",
-        eventFilters: [
-          {
-            attribute: "bucket",
-            value: "my-bucket",
-          },
-        ],
+        eventFilters: { bucket: "my-bucket" },
         retry: false,
         region: "us",
-      });
+      };
+      expect(wantFn.eventTrigger).to.deep.eq(want);
     });
 
     it("should set trigger region from API then reject on invalid function region", async () => {
@@ -128,12 +106,7 @@ describe("TriggerRegionHelper", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: [
-            {
-              attribute: "bucket",
-              value: "my-bucket",
-            },
-          ],
+          eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,

--- a/src/test/gcp/cloudfunctions.spec.ts
+++ b/src/test/gcp/cloudfunctions.spec.ts
@@ -68,12 +68,7 @@ describe("cloudfunctions", () => {
         ...ENDPOINT,
         eventTrigger: {
           eventType: "google.pubsub.topic.publish",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/p/topics/t",
-            },
-          ],
+          eventFilters: { resource: "projects/p/topics/t" },
           retry: false,
         },
       };
@@ -196,6 +191,14 @@ describe("cloudfunctions", () => {
     });
 
     it("should translate event triggers", () => {
+      let want: backend.Endpoint = {
+        ...ENDPOINT,
+        eventTrigger: {
+          eventType: "google.pubsub.topic.publish",
+          eventFilters: { resource: "projects/p/topics/t" },
+          retry: true,
+        },
+      };
       expect(
         cloudfunctions.endpointFromFunction({
           ...HAVE_CLOUD_FUNCTION,
@@ -207,21 +210,16 @@ describe("cloudfunctions", () => {
             },
           },
         })
-      ).to.deep.equal({
-        ...ENDPOINT,
-        eventTrigger: {
-          eventType: "google.pubsub.topic.publish",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/p/topics/t",
-            },
-          ],
-          retry: true,
-        },
-      });
+      ).to.deep.equal(want);
 
       // And again w/o the failure policy
+      want = {
+        ...want,
+        eventTrigger: {
+          ...want.eventTrigger,
+          retry: false,
+        },
+      };
       expect(
         cloudfunctions.endpointFromFunction({
           ...HAVE_CLOUD_FUNCTION,
@@ -230,19 +228,7 @@ describe("cloudfunctions", () => {
             resource: "projects/p/topics/t",
           },
         })
-      ).to.deep.equal({
-        ...ENDPOINT,
-        eventTrigger: {
-          eventType: "google.pubsub.topic.publish",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/p/topics/t",
-            },
-          ],
-          retry: false,
-        },
-      });
+      ).to.deep.equal(want);
     });
 
     it("should transalte scheduled triggers", () => {

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -93,16 +93,10 @@ describe("cloudfunctionsv2", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: "google.cloud.audit.log.v1.written",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/p/regions/r/instances/i",
-            },
-            {
-              attribute: "serviceName",
-              value: "compute.googleapis.com",
-            },
-          ],
+          eventFilters: {
+            resource: "projects/p/regions/r/instances/i",
+            serviceName: "compute.googleapis.com",
+          },
           retry: false,
         },
       };
@@ -200,16 +194,10 @@ describe("cloudfunctionsv2", () => {
         platform: "gcfv2",
         eventTrigger: {
           eventType: v2events.PUBSUB_PUBLISH_EVENT,
-          eventFilters: [
-            {
-              attribute: "topic",
-              value: "projects/p/topics/t",
-            },
-            {
-              attribute: "serviceName",
-              value: "pubsub.googleapis.com",
-            },
-          ],
+          eventFilters: {
+            topic: "projects/p/topics/t",
+            serviceName: "pubsub.googleapis.com",
+          },
           retry: false,
         },
         maxInstances: 42,
@@ -260,6 +248,16 @@ describe("cloudfunctionsv2", () => {
     });
 
     it("should translate event triggers", () => {
+      let want: backend.Endpoint = {
+        ...ENDPOINT,
+        platform: "gcfv2",
+        uri: RUN_URI,
+        eventTrigger: {
+          eventType: v2events.PUBSUB_PUBLISH_EVENT,
+          eventFilters: { topic: "projects/p/topics/t" },
+          retry: false,
+        },
+      };
       expect(
         cloudfunctionsv2.endpointFromFunction({
           ...HAVE_CLOUD_FUNCTION_V2,
@@ -268,23 +266,20 @@ describe("cloudfunctionsv2", () => {
             pubsubTopic: "projects/p/topics/t",
           },
         })
-      ).to.deep.equal({
-        ...ENDPOINT,
-        platform: "gcfv2",
-        uri: RUN_URI,
-        eventTrigger: {
-          eventType: v2events.PUBSUB_PUBLISH_EVENT,
-          eventFilters: [
-            {
-              attribute: "topic",
-              value: "projects/p/topics/t",
-            },
-          ],
-          retry: false,
-        },
-      });
+      ).to.deep.equal(want);
 
       // And again w/ a normal event trigger
+      want = {
+        ...want,
+        eventTrigger: {
+          eventType: "google.cloud.audit.log.v1.written",
+          eventFilters: {
+            resource: "projects/p/regions/r/instances/i",
+            serviceName: "compute.googleapis.com",
+          },
+          retry: false,
+        },
+      };
       expect(
         cloudfunctionsv2.endpointFromFunction({
           ...HAVE_CLOUD_FUNCTION_V2,
@@ -302,25 +297,7 @@ describe("cloudfunctionsv2", () => {
             ],
           },
         })
-      ).to.deep.equal({
-        ...ENDPOINT,
-        platform: "gcfv2",
-        uri: RUN_URI,
-        eventTrigger: {
-          eventType: "google.cloud.audit.log.v1.written",
-          eventFilters: [
-            {
-              attribute: "resource",
-              value: "projects/p/regions/r/instances/i",
-            },
-            {
-              attribute: "serviceName",
-              value: "compute.googleapis.com",
-            },
-          ],
-          retry: false,
-        },
-      });
+      ).to.deep.equal(want);
     });
 
     it("should translate task queue functions", () => {


### PR DESCRIPTION
Partial revert of https://github.com/firebase/firebase-tools/pull/4240 where we transformed EventFilters to list of arrays. We now prefer to keep the object structure.

To support path-pattern operator on event filters, we add new eventFilterPathPattern property. While we are at it, we also adds channel property to event trigger definition.

Note that most of the affected changes are in test files :/

Relevant SDK change: https://github.com/firebase/firebase-functions/pull/1070