### PR TITLE
Fix metadata parse error response for multipart uploads in Storage Emulator

### DIFF
--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -220,6 +220,17 @@ describe("Storage emulator", () => {
           expect(fileMetadata).to.deep.include(metadata);
         });
 
+        it("should return an error message when uploading a file with invalid metadata", async () => {
+          const fileName = "test_upload.jpg";
+          const errorMessage = await supertest(STORAGE_EMULATOR_HOST)
+            .post(`/upload/storage/v1/b/${storageBucket}/o?name=${fileName}`)
+            .set({ Authorization: "Bearer owner", "X-Upload-Content-Type": "foo" })
+            .expect(400)
+            .then((res) => res.body.error.message);
+
+          expect(errorMessage).to.equal("Invalid Content-Type: foo");
+        });
+
         it("should be able to upload file named 'prefix/file.txt' when file named 'prefix' already exists", async () => {
           await testBucket.upload(smallFilePath, {
             destination: "prefix",
@@ -2081,6 +2092,17 @@ describe("Storage emulator", () => {
             .set({ Authorization: "Bearer somethingElse" })
             .expect(403);
         });
+      });
+
+      it("should return an error message when uploading a file with invalid metadata", async () => {
+        const fileName = "test_upload.jpg";
+        const errorMessage = await supertest(STORAGE_EMULATOR_HOST)
+          .post(`/v0/b/${storageBucket}/o/${fileName}?name=${fileName}`)
+          .set({ "x-goog-upload-protocol": "multipart", "content-type": "foo" })
+          .expect(400)
+          .then((res) => res.body.error.message);
+
+        expect(errorMessage).to.equal("Invalid Content-Type: foo");
       });
 
       it("should accept subsequent resumable upload commands without an auth header", async () => {

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -205,7 +205,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
           return res.status(400).json({
             error: {
               code: 400,
-              message: err.toString(),
+              message: err.message,
             },
           });
         }

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -240,12 +240,15 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
         await reqBodyToBuffer(req)
       ));
     } catch (err) {
-      return res.status(400).json({
-        error: {
-          code: 400,
-          message: err,
-        },
-      });
+      if (err instanceof Error) {
+        return res.status(400).json({
+          error: {
+            code: 400,
+            message: err.message,
+          },
+        });
+      }
+      throw err;
     }
 
     const upload = uploadService.multipartUpload({


### PR DESCRIPTION
### Description
#### Issue
Currently when invalid metadata is passed in a multipart upload for the Storage emulator, the response looks like this:
```
{"error":{"code":400,"message":{}}}
```

#### Context
I encountered this error recently while trying to make a new directory in the Emulator UI. This [UI fix](https://github.com/firebase/firebase-tools-ui/pull/727) should take care of it but we've not cut a new version yet I believe.