### PR TITLE
Adding extensions summary table

### DIFF
--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -7,6 +7,7 @@ import { Emulators, EMULATORS_SUPPORTED_BY_UI } from "../emulator/types";
 import * as clc from "cli-color";
 import { Constants } from "../emulator/constants";
 import { logLabeledWarning } from "../utils";
+import { ExtensionsEmulator } from "../emulator/extensionsEmulator";
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const Table = require("cli-table");
@@ -76,9 +77,7 @@ module.exports = new Command("emulators:start")
           const emulatorName = Constants.description(emulator).replace(/ emulator/i, "");
           const isSupportedByUi = EMULATORS_SUPPORTED_BY_UI.includes(emulator);
           // The Extensions emulator runs as part of the Functions emulator, so display the Functions emulators info instead.
-          const info = EmulatorRegistry.getInfo(
-            emulator === Emulators.EXTENSIONS ? Emulators.FUNCTIONS : emulator
-          );
+          const info = EmulatorRegistry.getInfo(emulator);
           if (!info) {
             return [emulatorName, "Failed to initialize (see above)", "", ""];
           }
@@ -94,7 +93,13 @@ module.exports = new Command("emulators:start")
         .map((col) => col.slice(0, head.length))
         .filter((v) => v)
     );
-
+    let extensionsTable: string = "";
+    if (EmulatorRegistry.isRunning(Emulators.EXTENSIONS)) {
+      const extensionsEmulatorInstance = EmulatorRegistry.get(
+        Emulators.EXTENSIONS
+      ) as ExtensionsEmulator;
+      extensionsTable = extensionsEmulatorInstance.extensionsInfoTable(options);
+    }
     logger.info(`\n${successMessageTable}
 
 ${emulatorsTable}
@@ -104,7 +109,7 @@ ${
     : clc.blackBright("  Emulator Hub not running.")
 }
 ${clc.blackBright("  Other reserved ports:")} ${reservedPortsString}
-
+${extensionsTable}
 Issues? Report them at ${stylizeLink(
       "https://github.com/firebase/firebase-tools/issues"
     )} and attach the *-debug.log files.

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -477,10 +477,9 @@ export async function startAll(
       extensionsBackends
     );
     emulatableBackends.push(...filteredExtensionsBackends);
-
     // Log the command for analytics
     void track("Emulator Run", Emulators.EXTENSIONS);
-    EmulatorRegistry.registerExtensionsEmulator();
+    await startEmulator(extensionEmulator);
   }
 
   if (emulatableBackends.length) {

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -13,11 +13,12 @@ import { downloadExtensionVersion } from "./download";
 import { EmulatableBackend } from "./functionsEmulator";
 import { getExtensionFunctionInfo } from "../extensions/emulator/optionsHelper";
 import { EmulatorLogger } from "./emulatorLogger";
-import { Emulators } from "./types";
+import { EmulatorInfo, EmulatorInstance, Emulators } from "./types";
 import { checkForUnemulatedTriggerTypes, getUnemulatedAPIs } from "./extensions/validation";
 import { enableApiURI } from "../ensureApiEnabled";
 import { shortenUrl } from "../shortenUrl";
 import { Constants } from "./constants";
+import { EmulatorRegistry } from "./registry";
 
 export interface ExtensionEmulatorArgs {
   projectId: string;
@@ -29,8 +30,9 @@ export interface ExtensionEmulatorArgs {
 // TODO: Consider a different name, since this does not implement the EmulatorInstance interface
 // Note: At the moment, this doesn't really seem like it needs to be a class. However, I think the
 // statefulness that enables will be useful once we want to watch .env files for config changes.
-export class ExtensionsEmulator {
+export class ExtensionsEmulator implements EmulatorInstance {
   private want: planner.InstanceSpec[] = [];
+  private backends: EmulatableBackend[] = [];
   private args: ExtensionEmulatorArgs;
   private logger = EmulatorLogger.forEmulator(Emulators.EXTENSIONS);
 
@@ -39,6 +41,39 @@ export class ExtensionsEmulator {
 
   constructor(args: ExtensionEmulatorArgs) {
     this.args = args;
+  }
+
+  public start(): Promise<void> {
+    this.logger.logLabeled("DEBUG", "Extensions", "Started Extensions emulator, this is a noop.");
+    return Promise.resolve();
+  }
+
+  public stop(): Promise<void> {
+    this.logger.logLabeled("DEBUG", "Extensions", "Stopping Extensions emulator, this is a noop.");
+    return Promise.resolve();
+  }
+
+  public connect(): Promise<void> {
+    this.logger.logLabeled(
+      "DEBUG",
+      "Extensions",
+      "Connecting Extensions emulator, this is a noop."
+    );
+    return Promise.resolve();
+  }
+
+  public getInfo(): EmulatorInfo {
+    const info = EmulatorRegistry.getInfo(Emulators.FUNCTIONS);
+    if (!info) {
+      throw new FirebaseError(
+        "Extensions Emulator is running but Functions emulator is not. This should never happen."
+      );
+    }
+    return info;
+  }
+
+  public getName(): Emulators {
+    return Emulators.EXTENSIONS;
   }
 
   // readManifest checks the `extensions` section of `firebase.json` for the extension instances to emulate,
@@ -158,11 +193,12 @@ export class ExtensionsEmulator {
   public async getExtensionBackends(): Promise<EmulatableBackend[]> {
     await this.readManifest();
     await this.checkAndWarnAPIs(this.want);
-    return Promise.all(
+    this.backends = await Promise.all(
       this.want.map((i: planner.InstanceSpec) => {
         return this.toEmulatableBackend(i);
       })
     );
+    return this.backends;
   }
 
   /**
@@ -280,5 +316,35 @@ export class ExtensionsEmulator {
       this.logger.log("WARN", msg);
     }
     return filteredBackends;
+  }
+
+  private extensionDetailsUILink(backend: EmulatableBackend): string {
+    const uiInfo = EmulatorRegistry.getInfo(Emulators.UI);
+    if (!uiInfo || !backend.extensionInstanceId) {
+      // If the Emulator UI is not running, or if this is not an Extension backend, return an empty string
+      return "";
+    }
+    const uiUrl = EmulatorRegistry.getInfoHostString(uiInfo);
+    return clc.underline(
+      clc.bold(`http://${uiUrl}/${Emulators.EXTENSIONS}/${backend.extensionInstanceId}`)
+    );
+  }
+
+  public extensionsInfoTable(options: Options): string {
+    const filtedBackends = this.filterUnemulatedTriggers(options, this.backends);
+    const uiRunning = EmulatorRegistry.isRunning(Emulators.UI);
+    const tableHead = ["Extension Instance Name", "Extension Ref"];
+    if (uiRunning) {
+      tableHead.push("View in Emulator UI");
+    }
+    const table = new Table({ head: tableHead, style: { head: ["yellow"] } });
+    for (const b of filtedBackends) {
+      if (b.extensionInstanceId) {
+        const tableEntry = [b.extensionInstanceId, b.extensionVersion?.ref || "Local Extension"];
+        if (uiRunning) tableEntry.push(this.extensionDetailsUILink(b));
+        table.push(tableEntry);
+      }
+    }
+    return table.toString();
   }
 }


### PR DESCRIPTION
### Description
Adding extensions summary table & refactoring extensions emulator into an EmulatorInstance.

This one spiraled on me a little bit. I first implemented the extensions table, then I realized I wanted it to print out at the end (and only on emulators-start). I then realized that because I didn't make this an EmulatorInstance in the first place, it was really hard to access it outside of controller.ts. I ended up adding stub methods to fulfill the EmulatorInstance type, so that I could make use of the EmulatorRegistry more fully. 


### Scenarios Tested
Running emulators:start with extensions:
<img width="1040" alt="Screen Shot 2022-04-04 at 3 43 09 PM" src="https://user-images.githubusercontent.com/4635763/161649873-dd3af999-89a1-4962-aec9-5807d301c657.png">

Without extensions:
<img width="1238" alt="Screen Shot 2022-04-04 at 4 42 11 PM" src="https://user-images.githubusercontent.com/4635763/161649930-5944f42a-bb35-4ee7-ba5d-ef632e027a62.png">

