### PR TITLE
Ignore empty values when writing to .env files

### DIFF
--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -174,6 +174,7 @@ async function writeEnvFiles(
 ): Promise<void> {
   for (const spec of specs) {
     const content = Object.entries(spec.params)
+      .filter((r) => r[1].baseValue !== "") // Don't write empty values
       .sort((a, b) => {
         return a[0].localeCompare(b[0]);
       })

--- a/src/test/extensions/manifest.spec.ts
+++ b/src/test/extensions/manifest.spec.ts
@@ -249,6 +249,41 @@ describe("manifest", () => {
         false
       );
     });
+
+    it("should not write empty values", async () => {
+      // Chooses to overwrite instead of merge.
+      sandbox.stub(prompt, "promptOnce").resolves(true);
+
+      await manifest.writeToManifest(
+        [
+          {
+            instanceId: "instance-1",
+            ref: {
+              publisherId: "firebase",
+              extensionId: "bigquery-export",
+              version: "1.0.0",
+            },
+            params: { a: { baseValue: "pikachu" }, b: { baseValue: "" } },
+          },
+        ],
+        generateBaseConfig(),
+        { nonInteractive: false, force: false },
+        true /** allowOverwrite */
+      );
+      expect(writeProjectFileStub).calledWithExactly("firebase.json", {
+        extensions: {
+          // Original list deleted here.
+          "instance-1": "firebase/bigquery-export@1.0.0",
+        },
+      });
+
+      expect(askWriteProjectFileStub).to.have.been.calledOnce;
+      expect(askWriteProjectFileStub).calledWithExactly(
+        "extensions/instance-1.env",
+        `a=pikachu`,
+        false
+      );
+    });
   });
 
   describe(`${manifest.writeLocalSecrets.name}`, () => {


### PR DESCRIPTION
### Description
While testing out some extensions, I noticed that we were writing empty values to the .env file. This lead to some awkward behavior, since it wasn't clear whether we should treat this as "" or undefined at deploy/emulation time. To clarify this, I'm changing this behavior to filter out empty optional params when we are writing to the manifest.

Note that there is no way to pass in "" to a required param, so this will only apply to optional params.

### Scenarios Tested
`ext:install firebase/storage-resize-images  --local` and verified that empty param values were not written to the .env file:
<img width="459" alt="Screen Shot 2022-04-05 at 4 09 55 PM" src="https://user-images.githubusercontent.com/4635763/161865587-8b2e7e5d-9f9b-4ae7-970b-bdd8a1d699af.png">

