### PR TITLE
Minor refactoring of function deploy

### DIFF
--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -5,12 +5,24 @@ import * as deployHelper from "./functionsDeployHelper";
 
 // These types should probably be in a root deploy.ts, but we can only boil the ocean one bit at a time.
 
+interface CodebasePayload {
+  wantBackend: backend.Backend;
+  haveBackend: backend.Backend;
+}
+
 // Payload holds the output of what we want to build + what we already have.
 export interface Payload {
-  functions?: {
-    wantBackend: backend.Backend;
-    haveBackend: backend.Backend;
-  };
+  codebase?: CodebasePayload;
+}
+
+export interface Source {
+  // Filled in the "prepare" phase.
+  functionsSourceV1?: string;
+  functionsSourceV2?: string;
+
+  // Filled in the "deploy" phase.
+  sourceUrl?: string;
+  storage?: Record<string, gcfV2.StorageSource>;
 }
 
 // Context holds cached values of what we've looked up in handling this request.
@@ -22,15 +34,11 @@ export interface Context {
 
   // Filled in the "prepare" phase.
   config?: projectConfig.ValidatedSingle;
-  functionsSourceV1?: string;
-  functionsSourceV2?: string;
-  runtimeConfigEnabled?: boolean;
   artifactRegistryEnabled?: boolean;
   firebaseConfig?: FirebaseConfig;
 
-  // Filled in the "deploy" phase.
-  sourceUrl?: string;
-  storage?: Record<string, gcfV2.StorageSource>;
+  // Filled in the "prepare" and "deploy" phase.
+  source?: Source;
 }
 
 export interface FirebaseConfig {

--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -12,7 +12,7 @@ interface CodebasePayload {
 
 // Payload holds the output of what we want to build + what we already have.
 export interface Payload {
-  function?: CodebasePayload;
+  functions?: CodebasePayload;
 }
 
 export interface Source {

--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -12,7 +12,7 @@ interface CodebasePayload {
 
 // Payload holds the output of what we want to build + what we already have.
 export interface Payload {
-  functions?: CodebasePayload;
+  function?: CodebasePayload;
 }
 
 export interface Source {

--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -12,7 +12,7 @@ interface CodebasePayload {
 
 // Payload holds the output of what we want to build + what we already have.
 export interface Payload {
-  codebase?: CodebasePayload;
+  functions?: CodebasePayload;
 }
 
 export interface Source {

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -66,7 +66,7 @@ export async function checkHttpIam(
   payload: args.Payload
 ): Promise<void> {
   const filters = context.filters || getEndpointFilters(options);
-  const wantBackend = payload.function!.wantBackend;
+  const wantBackend = payload.functions!.wantBackend;
 
   const httpEndpoints = backend
     .allEndpoints(wantBackend)

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -66,7 +66,7 @@ export async function checkHttpIam(
   payload: args.Payload
 ): Promise<void> {
   const filters = context.filters || getEndpointFilters(options);
-  const wantBackend = payload.codebase!.wantBackend;
+  const wantBackend = payload.functions!.wantBackend;
 
   const httpEndpoints = backend
     .allEndpoints(wantBackend)

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -66,7 +66,7 @@ export async function checkHttpIam(
   payload: args.Payload
 ): Promise<void> {
   const filters = context.filters || getEndpointFilters(options);
-  const wantBackend = payload.functions!.wantBackend;
+  const wantBackend = payload.codebase!.wantBackend;
 
   const httpEndpoints = backend
     .allEndpoints(wantBackend)

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -66,7 +66,7 @@ export async function checkHttpIam(
   payload: args.Payload
 ): Promise<void> {
   const filters = context.filters || getEndpointFilters(options);
-  const wantBackend = payload.functions!.wantBackend;
+  const wantBackend = payload.function!.wantBackend;
 
   const httpEndpoints = backend
     .allEndpoints(wantBackend)

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -10,7 +10,7 @@ import * as validate from "./validate";
 import * as ensure from "./ensure";
 import { Options } from "../../options";
 import { endpointMatchesAnyFilter, getEndpointFilters } from "./functionsDeployHelper";
-import { logLabeledBullet, logLabeledError } from "../../utils";
+import { logLabeledBullet } from "../../utils";
 import { getFunctionsConfig, prepareFunctionsUpload } from "./prepareFunctionsUpload";
 import { promptForFailurePolicies, promptForMinInstances } from "./prompts";
 import { needProjectId, needProjectNumber } from "../../projectUtils";
@@ -50,11 +50,25 @@ export async function prepare(
     throw new FirebaseError("No function matches given --only filters. Aborting deployment.");
   }
 
+  // ===Phase 0. Check that minimum APIs required for function deploys are enabled.
+  const checkAPIsEnabled = await Promise.all([
+    ensureApiEnabled.ensure(projectId, "cloudfunctions.googleapis.com", "functions"),
+    ensureApiEnabled.check(
+      projectId,
+      "runtimeconfig.googleapis.com",
+      "runtimeconfig",
+      /* silent=*/ true
+    ),
+    ensure.cloudBuildEnabled(projectId),
+    ensure.maybeEnableAR(projectId),
+  ]);
+  context.artifactRegistryEnabled = checkAPIsEnabled[3];
+
+  // ===Phase 1. Load codebase from source.
   logLabeledBullet(
     "functions",
     `preparing codebase ${clc.bold(context.config.codebase)} for deployment`
   );
-
   const sourceDirName = context.config.source;
   if (!sourceDirName) {
     throw new FirebaseError(
@@ -62,7 +76,6 @@ export async function prepare(
     );
   }
   const sourceDir = options.config.path(sourceDirName);
-
   const delegateContext: runtimes.DelegateContext = {
     projectId,
     sourceDir,
@@ -75,25 +88,14 @@ export async function prepare(
   logger.debug(`Building ${runtimeDelegate.name} source`);
   await runtimeDelegate.build();
 
-  // Check that all necessary APIs are enabled.
-  const checkAPIsEnabled = await Promise.all([
-    ensureApiEnabled.ensure(projectId, "cloudfunctions.googleapis.com", "functions"),
-    ensureApiEnabled.check(
-      projectId,
-      "runtimeconfig.googleapis.com",
-      "runtimeconfig",
-      /* silent=*/ true
-    ),
-    ensure.cloudBuildEnabled(projectId),
-    ensure.maybeEnableAR(projectId),
-  ]);
-  context.runtimeConfigEnabled = checkAPIsEnabled[1];
-  context.artifactRegistryEnabled = checkAPIsEnabled[3];
-
   // Get the Firebase Config, and set it on each function in the deployment.
   const firebaseConfig = await functionsConfig.getFirebaseConfig(options);
   context.firebaseConfig = firebaseConfig;
-  const runtimeConfig = await getFunctionsConfig(context);
+  let runtimeConfig: Record<string, unknown> = { firebase: firebaseConfig };
+  if (checkAPIsEnabled[1]) {
+    // If runtime config API is enabled, load the runtime config.
+    runtimeConfig = { ...runtimeConfig, ...(await getFunctionsConfig(projectId)) };
+  }
 
   const firebaseEnvs = functionsEnv.loadFirebaseEnvs(firebaseConfig, projectId);
   const userEnvOpt: functionsEnv.UserEnvsOpts = {
@@ -120,23 +122,8 @@ export async function prepare(
     endpoint.codebase = context.config.codebase;
   }
 
-  // Note: Some of these are premium APIs that require billing to be enabled.
-  // We'd eventually have to add special error handling for billing APIs, but
-  // enableCloudBuild is called above and has this special casing already.
-  if (backend.someEndpoint(wantBackend, (e) => e.platform === "gcfv2")) {
-    const V2_APIS = [
-      "artifactregistry.googleapis.com",
-      "run.googleapis.com",
-      "eventarc.googleapis.com",
-      "pubsub.googleapis.com",
-      "storage.googleapis.com",
-    ];
-    const enablements = V2_APIS.map((api) => {
-      return ensureApiEnabled.ensure(context.projectId, api, "functions");
-    });
-    await Promise.all(enablements);
-  }
-
+  // ===Phase 2. Prepare source for upload.
+  const source: args.Source = {};
   if (backend.someEndpoint(wantBackend, () => true)) {
     logLabeledBullet(
       "functions",
@@ -155,37 +142,25 @@ export async function prepare(
           "version of Firebse Tools with `npm i -g firebase-tools@latest`"
       );
     }
-    context.functionsSourceV2 = await prepareFunctionsUpload(sourceDir, context.config);
+    source.functionsSourceV2 = await prepareFunctionsUpload(sourceDir, context.config);
   }
   if (backend.someEndpoint(wantBackend, (e) => e.platform === "gcfv1")) {
-    context.functionsSourceV1 = await prepareFunctionsUpload(
+    source.functionsSourceV1 = await prepareFunctionsUpload(
       sourceDir,
       context.config,
       runtimeConfig
     );
   }
+  context.source = source;
 
-  // Enable required APIs. This may come implicitly from triggers (e.g. scheduled triggers
-  // require cloudscheudler and, in v1, require pub/sub), or can eventually come from
-  // explicit dependencies.
-  await Promise.all(
-    Object.values(wantBackend.requiredAPIs).map(({ api }) => {
-      return ensureApiEnabled.ensure(projectId, api, "functions", /* silent=*/ false);
-    })
-  );
+  // ===Phase 3. Fill in details and validate endpoints. We run the check for ALL endpoints - we think it's useful for
+  // validations to fail even for endpoints that aren't being deployed so any errors are caught early.
 
-  // Validate the function code that is being deployed.
-  validate.endpointsAreValid(wantBackend);
-
-  const matchingBackend = backend.matchingBackend(wantBackend, (endpoint) => {
-    return endpointMatchesAnyFilter(endpoint, context.filters);
-  });
-
-  // Load all endpoints for the project, then filter out functions from other codebases.
+  // Load all existing endpoints for the project, then filter out functions from other codebases.
   //
   // An endpoint is part a codebase if:
   //   1. Endpoint is associated w/ the current codebase (duh).
-  //   2. Endpoint name matches name of an endoint we want to deploy
+  //   2. Endpoint name matches name of an endpoint we want to deploy
   //
   //   Condition (2) might feel wrong but is a practical conflict resolution strategy. It allows user to "claim" an
   //   endpoint for current codebase without much hassel.
@@ -199,17 +174,51 @@ export async function prepare(
       return wantEndpointNames.includes(backend.functionName(endpoint));
     }
   );
-
-  payload.functions = { wantBackend: wantBackend, haveBackend: haveBackend };
-
-  await ensureServiceAgentRoles(projectNumber, wantBackend, haveBackend);
   inferDetailsFromExisting(wantBackend, haveBackend, usedDotenv);
   await ensureTriggerRegions(wantBackend);
+  validate.endpointsAreValid(wantBackend);
 
-  // Display a warning and prompt if any functions in the release have failurePolicies.
+  payload.codebase = { wantBackend: wantBackend, haveBackend: haveBackend };
+
+  // ===Phase 4. Enable APIs required by the deploying backend.
+
+  // Enable required APIs. This may come implicitly from triggers (e.g. scheduled triggers
+  // require cloudscheudler and, in v1, require pub/sub), or can eventually come from
+  // explicit dependencies.
+  await Promise.all(
+    Object.values(wantBackend.requiredAPIs).map(({ api }) => {
+      return ensureApiEnabled.ensure(projectId, api, "functions", /* silent=*/ false);
+    })
+  );
+  // Note: Some of these are premium APIs that require billing to be enabled.
+  // We'd eventually have to add special error handling for billing APIs, but
+  // enableCloudBuild is called above and has this special casing already.
+  if (backend.someEndpoint(wantBackend, (e) => e.platform === "gcfv2")) {
+    const V2_APIS = [
+      "artifactregistry.googleapis.com",
+      "run.googleapis.com",
+      "eventarc.googleapis.com",
+      "pubsub.googleapis.com",
+      "storage.googleapis.com",
+    ];
+    const enablements = V2_APIS.map((api) => {
+      return ensureApiEnabled.ensure(context.projectId, api, "functions");
+    });
+    await Promise.all(enablements);
+  }
+
+  // ===Phase 5. Ask for user prompts for things might warrant user attentions.
+  // We limit the scope endpoints being deployed.
+  const matchingBackend = backend.matchingBackend(wantBackend, (endpoint) => {
+    return endpointMatchesAnyFilter(endpoint, context.filters);
+  });
   await promptForFailurePolicies(options, matchingBackend, haveBackend);
   await promptForMinInstances(options, matchingBackend, haveBackend);
-  await backend.checkAvailability(context, wantBackend);
+
+  // ===Phase 6. Finalize preparation by "fixing" all extraneous environment issues like IAM policies.
+  // We limit the scope endpoints being deployed.
+  await backend.checkAvailability(context, matchingBackend);
+  await ensureServiceAgentRoles(projectNumber, matchingBackend, haveBackend);
   await validate.secretsAreValid(projectId, matchingBackend);
   await ensure.secretAccess(projectId, matchingBackend, haveBackend);
 }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -178,7 +178,7 @@ export async function prepare(
   await ensureTriggerRegions(wantBackend);
   validate.endpointsAreValid(wantBackend);
 
-  payload.function = { wantBackend: wantBackend, haveBackend: haveBackend };
+  payload.functions = { wantBackend: wantBackend, haveBackend: haveBackend };
 
   // ===Phase 4. Enable APIs required by the deploying backend.
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -178,7 +178,7 @@ export async function prepare(
   await ensureTriggerRegions(wantBackend);
   validate.endpointsAreValid(wantBackend);
 
-  payload.functions = { wantBackend: wantBackend, haveBackend: haveBackend };
+  payload.function = { wantBackend: wantBackend, haveBackend: haveBackend };
 
   // ===Phase 4. Enable APIs required by the deploying backend.
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -178,7 +178,7 @@ export async function prepare(
   await ensureTriggerRegions(wantBackend);
   validate.endpointsAreValid(wantBackend);
 
-  payload.codebase = { wantBackend: wantBackend, haveBackend: haveBackend };
+  payload.functions = { wantBackend: wantBackend, haveBackend: haveBackend };
 
   // ===Phase 4. Enable APIs required by the deploying backend.
 

--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -18,32 +18,26 @@ import * as projectConfig from "../../functions/projectConfig";
 const CONFIG_DEST_FILE = ".runtimeconfig.json";
 
 // TODO(inlined): move to a file that's not about uploading source code
-export async function getFunctionsConfig(context: args.Context): Promise<{ [key: string]: any }> {
-  let config: Record<string, any> = {};
-  if (context.runtimeConfigEnabled) {
-    try {
-      config = await functionsConfig.materializeAll(context.firebaseConfig!.projectId);
-    } catch (err: any) {
-      logger.debug(err);
-      let errorCode = err?.context?.response?.statusCode;
-      if (!errorCode) {
-        logger.debug("Got unexpected error from Runtime Config; it has no status code:", err);
-        errorCode = 500;
-      }
-      if (errorCode === 500 || errorCode === 503) {
-        throw new FirebaseError(
-          "Cloud Runtime Config is currently experiencing issues, " +
-            "which is preventing your functions from being deployed. " +
-            "Please wait a few minutes and then try to deploy your functions again." +
-            "\nRun `firebase deploy --except functions` if you want to continue deploying the rest of your project."
-        );
-      }
-      config = {};
+export async function getFunctionsConfig(projectId: string): Promise<Record<string, unknown>> {
+  try {
+    return await functionsConfig.materializeAll(projectId);
+  } catch (err: any) {
+    logger.debug(err);
+    let errorCode = err?.context?.response?.statusCode;
+    if (!errorCode) {
+      logger.debug("Got unexpected error from Runtime Config; it has no status code:", err);
+      errorCode = 500;
+    }
+    if (errorCode === 500 || errorCode === 503) {
+      throw new FirebaseError(
+        "Cloud Runtime Config is currently experiencing issues, " +
+          "which is preventing your functions from being deployed. " +
+          "Please wait a few minutes and then try to deploy your functions again." +
+          "\nRun `firebase deploy --except functions` if you want to continue deploying the rest of your project."
+      );
     }
   }
-
-  config.firebase = context.firebaseConfig;
-  return config;
+  return {};
 }
 
 async function pipeAsync(from: archiver.Archiver, to: fs.WriteStream) {

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -30,7 +30,7 @@ function assertPreconditions(context: args.Context, options: Options, payload: a
   };
   assertExists(context.config, "Functions config unexpectedly empty.");
   assertExists(context.source, "Functions sources unexpectedly empty.");
-  assertExists(payload.function, "Functions payload unexpectedly empty.");
+  assertExists(payload.functions, "Functions payload unexpectedly empty.");
 }
 /** Releases new versions of functions to prod. */
 export async function release(
@@ -40,7 +40,7 @@ export async function release(
 ): Promise<void> {
   assertPreconditions(context, options, payload);
 
-  const { wantBackend, haveBackend } = payload.function!;
+  const { wantBackend, haveBackend } = payload.functions!;
   const plan = planner.createDeploymentPlan(wantBackend, haveBackend, context.filters);
 
   const fnsToDelete = Object.values(plan)
@@ -81,9 +81,9 @@ export async function release(
   // uri field. createDeploymentPlan copies endpoints by reference. Both of these
   // subtleties are so we can take out a round trip API call to get the latest
   // trigger URLs by calling existingBackend again.
-  printTriggerUrls(payload.function!.wantBackend);
+  printTriggerUrls(payload.functions!.wantBackend);
 
-  const haveEndpoints = backend.allEndpoints(payload.function!.wantBackend);
+  const haveEndpoints = backend.allEndpoints(payload.functions!.wantBackend);
   const deletedEndpoints = Object.values(plan)
     .map((r) => r.endpointsToDelete)
     .reduce(reduceFlat, []);

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -30,7 +30,7 @@ function assertPreconditions(context: args.Context, options: Options, payload: a
   };
   assertExists(context.config, "Functions config unexpectedly empty.");
   assertExists(context.source, "Functions sources unexpectedly empty.");
-  assertExists(payload.codebase, "Functions payload unexpectedly empty.");
+  assertExists(payload.functions, "Functions payload unexpectedly empty.");
 }
 /** Releases new versions of functions to prod. */
 export async function release(
@@ -40,7 +40,7 @@ export async function release(
 ): Promise<void> {
   assertPreconditions(context, options, payload);
 
-  const { wantBackend, haveBackend } = payload.codebase!;
+  const { wantBackend, haveBackend } = payload.functions!;
   const plan = planner.createDeploymentPlan(wantBackend, haveBackend, context.filters);
 
   const fnsToDelete = Object.values(plan)
@@ -81,9 +81,9 @@ export async function release(
   // uri field. createDeploymentPlan copies endpoints by reference. Both of these
   // subtleties are so we can take out a round trip API call to get the latest
   // trigger URLs by calling existingBackend again.
-  printTriggerUrls(payload.codebase!.wantBackend);
+  printTriggerUrls(payload.functions!.wantBackend);
 
-  const haveEndpoints = backend.allEndpoints(payload.codebase!.wantBackend);
+  const haveEndpoints = backend.allEndpoints(payload.functions!.wantBackend);
   const deletedEndpoints = Object.values(plan)
     .map((r) => r.endpointsToDelete)
     .reduce(reduceFlat, []);

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -18,27 +18,18 @@ import { FirebaseError } from "../../../error";
 import { needProjectId, needProjectNumber } from "../../../projectUtils";
 import { logLabeledBullet, logLabeledWarning } from "../../../utils";
 
-function assertPreconditions(context: args.Context, options: Options, payload: args.Payload): void {
-  const assertExists = function (v: unknown, msg?: string): void {
-    const errMsg = `${msg || "Value unexpectedly empty."}`;
-    if (!v) {
-      throw new FirebaseError(
-        errMsg +
-          "This should never happen. Please file a bug at https://github.com/firebase/firebase-tools"
-      );
-    }
-  };
-  assertExists(context.config, "Functions config unexpectedly empty.");
-  assertExists(context.source, "Functions sources unexpectedly empty.");
-  assertExists(payload.functions, "Functions payload unexpectedly empty.");
-}
 /** Releases new versions of functions to prod. */
 export async function release(
   context: args.Context,
   options: Options,
   payload: args.Payload
 ): Promise<void> {
-  assertPreconditions(context, options, payload);
+  if (!context.config) {
+    return;
+  }
+  if (!payload.functions) {
+    return;
+  }
 
   const { wantBackend, haveBackend } = payload.functions!;
   const plan = planner.createDeploymentPlan(wantBackend, haveBackend, context.filters);

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -30,7 +30,7 @@ function assertPreconditions(context: args.Context, options: Options, payload: a
   };
   assertExists(context.config, "Functions config unexpectedly empty.");
   assertExists(context.source, "Functions sources unexpectedly empty.");
-  assertExists(payload.functions, "Functions payload unexpectedly empty.");
+  assertExists(payload.function, "Functions payload unexpectedly empty.");
 }
 /** Releases new versions of functions to prod. */
 export async function release(
@@ -40,7 +40,7 @@ export async function release(
 ): Promise<void> {
   assertPreconditions(context, options, payload);
 
-  const { wantBackend, haveBackend } = payload.functions!;
+  const { wantBackend, haveBackend } = payload.function!;
   const plan = planner.createDeploymentPlan(wantBackend, haveBackend, context.filters);
 
   const fnsToDelete = Object.values(plan)
@@ -81,9 +81,9 @@ export async function release(
   // uri field. createDeploymentPlan copies endpoints by reference. Both of these
   // subtleties are so we can take out a round trip API call to get the latest
   // trigger URLs by calling existingBackend again.
-  printTriggerUrls(payload.functions!.wantBackend);
+  printTriggerUrls(payload.function!.wantBackend);
 
-  const haveEndpoints = backend.allEndpoints(payload.functions!.wantBackend);
+  const haveEndpoints = backend.allEndpoints(payload.function!.wantBackend);
   const deletedEndpoints = Object.values(plan)
     .map((r) => r.endpointsToDelete)
     .reduce(reduceFlat, []);


### PR DESCRIPTION
Just moving around code in `prepare.ts` phase of the function deploy to make it easy to support multi-codebase deploys. This is a simple refactor that should introduces no change to deploy behavior. I've added annotation to each section to make it slightly easier to understand what'a going on in each section.

There are few light changes:

* We reduce scope of `backend.checkAvailability` check to just the endpoints that's being deployed (to allow deploy to proceed even if region of endpoint NOT being deployed is down).  
* We reduce scope `ensureServiceAgentRoles`  check to just the endpoints that's being deployed (to reduce IAM calls to bare minimum)
