### PR TITLE
Fix missing upload status header in resumable upload finalise response

### DIFF
--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -2105,14 +2105,17 @@ describe("Storage emulator", () => {
           })
           .expect(200);
 
-        await supertest(STORAGE_EMULATOR_HOST)
+        const uploadStatus = await supertest(STORAGE_EMULATOR_HOST)
           .put(uploadURL.pathname + uploadURL.search)
           .set({
             // No Authorization required in finalize
             "X-Goog-Upload-Protocol": "resumable",
             "X-Goog-Upload-Command": "upload, finalize",
           })
-          .expect(200);
+          .expect(200)
+          .then((res) => res.header["x-goog-upload-status"]);
+
+        expect(uploadStatus).to.equal("final");
 
         await supertest(STORAGE_EMULATOR_HOST)
           .get(`/v0/b/${storageBucket}/o/test_upload.jpg`)

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -346,6 +346,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
         throw err;
       }
 
+      res.header("x-goog-upload-status", "final");
       storedMetadata.addDownloadToken(/* shouldTrigger = */ false);
       return res.status(200).json(new OutgoingFirebaseMetadata(storedMetadata));
     }


### PR DESCRIPTION
### Description

#### Issue
This PR fixes #4346, #4364, and #4396.

Any large (> ~500kB) upload to the Storage Emulator gives a console error.

On web:
```
Uncaught (in promise) FirebaseError: Firebase Storage: An unknown error occurred, please check the error payload for server response. (storage/unknown)
```

On iOS:
```
2022-03-31 16:50:05.822789-0400 Example[51380:621771] offset 438491 exceeds data length 438491
2022-03-31 16:50:05.823434-0400 Example[51380:622628] Range invalid for upload data.  offset: 438491	length: 8491	dataLength: 438491	expected UploadLength: 438491
2022-03-31 16:50:08.017868-0400 Example[51380:622083] [javascript] Possible Unhandled Promise Rejection (id: 0):
```

On the emulator UI, the upload is shown with a loading spinner indefinitely. However, on refresh we see that the file was in fact uploaded successfully.

This issue started in v10.3.0.

#### Cause
In #4250 we refactored the upload logic. In doing so we forgot to include the header `X-Goog-Upload-Status` with value `final` in the response for the `finalize` request. My guess is that the client expects to make further `upload` requests and errors out when there are no more bytes to upload.

### Scenarios Tested
Tested on web and verified that console error no longer appears and that the header is included in the response. Also included a check for the latter in an existing integration test for resumable uploads.