### PR TITLE
Filters out local source extensions when deploying

### DIFF
--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -3,7 +3,11 @@ import * as semver from "semver";
 import * as extensionsApi from "../../extensions/extensionsApi";
 import * as refs from "../../extensions/refs";
 import { FirebaseError } from "../../error";
-import { getFirebaseProjectParams, substituteParams } from "../../extensions/extensionsHelper";
+import {
+  getFirebaseProjectParams,
+  isLocalPath,
+  substituteParams,
+} from "../../extensions/extensionsHelper";
 import { logger } from "../../logger";
 import { readInstanceParam } from "../../extensions/manifest";
 import { ParamBindingOptions } from "../../extensions/paramHelper";
@@ -134,6 +138,13 @@ export async function want(args: {
   for (const e of Object.entries(args.extensions)) {
     try {
       const instanceId = e[0];
+      // TODO(lihes): Remove once firebase deploy supports ext with local source.
+      if (isLocalPath(e[1])) {
+        logger.warn(
+          `Unable to deploy instance ${instanceId} because it has a local source, please use "firebase ext:install" instead.`
+        );
+        continue;
+      }
       const ref = refs.parse(e[1]);
       ref.version = await resolveVersion(ref);
 


### PR DESCRIPTION
### Description

Filters out local source extensions when deploying. Unbreak deploy while we work on deploying local source extensions.

### Scenarios Tested

![Screen Shot 2022-04-07 at 2 06 19 PM](https://user-images.githubusercontent.com/6955348/162268760-e7dbd6cc-3d5a-4dec-aa55-d21c8797a3db.png)

