### PR TITLE
Add getConfig

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -74,6 +74,7 @@ export const authOperations: AuthOps = {
     projects: {
       createSessionCookie,
       queryAccounts,
+      getConfig,
       updateConfig,
       accounts: {
         _: signUp,
@@ -1998,6 +1999,19 @@ function mfaSignInFinalize(
     idToken,
     refreshToken,
   };
+}
+
+function getConfig(
+  state: ProjectState,
+  reqBody: unknown,
+  ctx: ExegesisContext
+): Schemas["GoogleCloudIdentitytoolkitAdminV2Config"] {
+  // Shouldn't error on this but need assertion for type checking
+  assert(
+    state instanceof AgentProjectState,
+    "((Can only get top-level configurations on agent projects.))"
+  );
+  return state.config;
 }
 
 function updateConfig(


### PR DESCRIPTION
### Description

Adds `projects.getConfig`, which corresponds to https://cloud.google.com/identity-platform/docs/reference/rest/v2/projects/getConfig. Note that the auth emulator only stores a subset of the `Config` fields (i.e. the configurable ones). For more info, check out: https://github.com/firebase/firebase-tools/blob/de4d7150c2bc95e04dd7cc00b38c3b457f51f496/src/emulator/auth/state.ts#L864-L872

Corresponding internal bug: b/192387243

WANT_LGTM=all

### Scenarios Tested

`npm test` passes 

### Sample Commands

N/A
