### PR TITLE
Adding support for emulating local extensions

### DIFF
--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -11,7 +11,7 @@ import {
 import { logger } from "../../logger";
 import { readInstanceParam } from "../../extensions/manifest";
 import { ParamBindingOptions } from "../../extensions/paramHelper";
-import { readExtensionYaml } from "../../extensions/emulator/specHelper";
+import { readExtensionYaml, readPostinstall } from "../../extensions/emulator/specHelper";
 
 export interface InstanceSpec {
   instanceId: string;
@@ -69,7 +69,7 @@ export async function getExtensionVersion(
  */
 export async function getExtension(i: InstanceSpec): Promise<extensionsApi.Extension> {
   if (!i.ref) {
-    throw new FirebaseError(`Can't get Extensionfor ${i.instanceId} because it has no ref`);
+    throw new FirebaseError(`Can't get Extension for ${i.instanceId} because it has no ref`);
   }
   if (!i.extension) {
     i.extension = await extensionsApi.getExtension(refs.toExtensionRef(i.ref));
@@ -86,6 +86,7 @@ export async function getExtensionSpec(i: InstanceSpec): Promise<extensionsApi.E
       i.extensionSpec = extensionVersion.spec;
     } else if (i.localPath) {
       i.extensionSpec = await readExtensionYaml(i.localPath);
+      i.extensionSpec.postinstallContent = await readPostinstall(i.localPath);
     } else {
       throw new FirebaseError("InstanceSpec had no ref or localPath, unable to get extensionSpec");
     }
@@ -138,15 +139,6 @@ export async function want(args: {
   for (const e of Object.entries(args.extensions)) {
     try {
       const instanceId = e[0];
-      // TODO(lihes): Remove once firebase deploy supports ext with local source.
-      if (isLocalPath(e[1])) {
-        logger.warn(
-          `Unable to deploy instance ${instanceId} because it has a local source, please use "firebase ext:install" instead.`
-        );
-        continue;
-      }
-      const ref = refs.parse(e[1]);
-      ref.version = await resolveVersion(ref);
 
       const params = readInstanceParam({
         projectDir: args.projectDir,
@@ -159,11 +151,33 @@ export async function want(args: {
       const autoPopulatedParams = await getFirebaseProjectParams(args.projectId, args.emulatorMode);
       const subbedParams = substituteParams(params, autoPopulatedParams);
 
-      instanceSpecs.push({
-        instanceId,
-        ref,
-        params: subbedParams,
-      });
+      let localPath: string;
+      // TODO(lihes): Remove once firebase deploy supports ext with local source.
+      if (isLocalPath(e[1])) {
+        if (!args.emulatorMode) {
+        logger.warn(
+          `Unable to deploy instance ${instanceId} because it has a local source, please use "firebase ext:install" instead.`
+        );
+        continue;
+        } else {
+          instanceSpecs.push({
+            instanceId,
+            localPath: e[1],
+            params: subbedParams,
+          });
+        }
+      } else {
+        const ref = refs.parse(e[1]);
+        ref.version = await resolveVersion(ref);
+        instanceSpecs.push({
+          instanceId,
+          ref,
+          params: subbedParams,
+        });
+      }
+
+
+      
     } catch (err: any) {
       logger.debug(`Got error reading extensions entry ${e}: ${err}`);
       errors.push(err as FirebaseError);

--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -155,10 +155,10 @@ export async function want(args: {
       // TODO(lihes): Remove once firebase deploy supports ext with local source.
       if (isLocalPath(e[1])) {
         if (!args.emulatorMode) {
-        logger.warn(
-          `Unable to deploy instance ${instanceId} because it has a local source, please use "firebase ext:install" instead.`
-        );
-        continue;
+          logger.warn(
+            `Unable to deploy instance ${instanceId} because it has a local source, please use "firebase ext:install" instead.`
+          );
+          continue;
         } else {
           instanceSpecs.push({
             instanceId,
@@ -175,9 +175,6 @@ export async function want(args: {
           params: subbedParams,
         });
       }
-
-
-      
     } catch (err: any) {
       logger.debug(`Got error reading extensions entry ${e}: ${err}`);
       errors.push(err as FirebaseError);

--- a/src/emulator/extensions/validation.ts
+++ b/src/emulator/extensions/validation.ts
@@ -31,8 +31,8 @@ export async function getUnemulatedAPIs(
 ): Promise<APIInfo[]> {
   const unemulatedAPIs: Record<string, APIInfo> = {};
   for (const i of instances) {
-    const extensionVersion = await planner.getExtensionVersion(i);
-    for (const api of extensionVersion.spec.apis ?? []) {
+    const extensionSpec = await planner.getExtensionSpec(i);
+    for (const api of extensionSpec.apis ?? []) {
       if (!EMULATED_APIS.includes(api.apiName)) {
         if (unemulatedAPIs[api.apiName]) {
           unemulatedAPIs[api.apiName].instanceIds.push(i.instanceId);

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -94,8 +94,10 @@ export class ExtensionsEmulator implements EmulatorInstance {
   private async ensureSourceCode(instance: planner.InstanceSpec): Promise<string> {
     // TODO(b/213335255): Handle local extensions.
     if (instance.localPath) {
-      if (!this.hasValidSource({path: instance.localPath, extTarget: instance.localPath})){
-        throw new FirebaseError(`Tried to emulate local extension at ${instance.localPath}, but it was missing required files.`)
+      if (!this.hasValidSource({ path: instance.localPath, extTarget: instance.localPath })) {
+        throw new FirebaseError(
+          `Tried to emulate local extension at ${instance.localPath}, but it was missing required files.`
+        );
       }
       return instance.localPath;
     } else if (instance.ref) {
@@ -120,7 +122,9 @@ export class ExtensionsEmulator implements EmulatorInstance {
       }
       return sourceCodePath;
     } else {
-      throw new FirebaseError("Tried to emulate an extension instance without a ref or localPath. This should never happen.");
+      throw new FirebaseError(
+        "Tried to emulate an extension instance without a ref or localPath. This should never happen."
+      );
     }
   }
 

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -93,33 +93,35 @@ export class ExtensionsEmulator implements EmulatorInstance {
   // downloads and builds it if it is not found, then returns the path to that source code.
   private async ensureSourceCode(instance: planner.InstanceSpec): Promise<string> {
     // TODO(b/213335255): Handle local extensions.
-    if (!instance.ref) {
-      throw new FirebaseError(
-        `No ref found for ${instance.instanceId}. Emulating local extensions is not yet supported.`
-      );
-    }
-    // TODO: If ref contains 'latest', we need to resolve that to a real version.
+    if (instance.localPath) {
+      if (!this.hasValidSource({path: instance.localPath, extTarget: instance.localPath})){
+        throw new FirebaseError(`Tried to emulate local extension at ${instance.localPath}, but it was missing required files.`)
+      }
+      return instance.localPath;
+    } else if (instance.ref) {
+      const ref = toExtensionVersionRef(instance.ref);
+      const cacheDir =
+        process.env.FIREBASE_EXTENSIONS_CACHE_PATH ||
+        path.join(os.homedir(), ".cache", "firebase", "extensions");
+      const sourceCodePath = path.join(cacheDir, ref);
 
-    const ref = toExtensionVersionRef(instance.ref);
-    const cacheDir =
-      process.env.FIREBASE_EXTENSIONS_CACHE_PATH ||
-      path.join(os.homedir(), ".cache", "firebase", "extensions");
-    const sourceCodePath = path.join(cacheDir, ref);
+      // Wait for previous download promise to resolve before we check source validity.
+      // This avoids racing to download the same source multiple times.
+      // Note: The below will not work because it throws the thread to the back of the message queue.
+      // await (this.pendingDownloads.get(ref) ?? Promise.resolve());
+      if (this.pendingDownloads.get(ref)) {
+        await this.pendingDownloads.get(ref);
+      }
 
-    // Wait for previous download promise to resolve before we check source validity.
-    // This avoids racing to download the same source multiple times.
-    // Note: The below will not work because it throws the thread to the back of the message queue.
-    // await (this.pendingDownloads.get(ref) ?? Promise.resolve());
-    if (this.pendingDownloads.get(ref)) {
-      await this.pendingDownloads.get(ref);
+      if (!this.hasValidSource({ path: sourceCodePath, extTarget: ref })) {
+        const promise = this.downloadSource(instance, ref, sourceCodePath);
+        this.pendingDownloads.set(ref, promise);
+        await promise;
+      }
+      return sourceCodePath;
+    } else {
+      throw new FirebaseError("Tried to emulate an extension instance without a ref or localPath. This should never happen.");
     }
-
-    if (!this.hasValidSource({ path: sourceCodePath, extRef: ref })) {
-      const promise = this.downloadSource(instance, ref, sourceCodePath);
-      this.pendingDownloads.set(ref, promise);
-      await promise;
-    }
-    return sourceCodePath;
   }
 
   private async downloadSource(
@@ -137,7 +139,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
    *
    * Checks against a list of required files or directories that need to be present.
    */
-  private hasValidSource(args: { path: string; extRef: string }): boolean {
+  private hasValidSource(args: { path: string; extTarget: string }): boolean {
     // TODO(lihes): Source code can technically exist in other than "functions" dir.
     // https://source.corp.google.com/piper///depot/google3/firebase/mods/go/worker/fetch_mod_source.go;l=451
     const requiredFiles = [
@@ -152,10 +154,10 @@ export class ExtensionsEmulator implements EmulatorInstance {
     for (const requiredFile of requiredFiles) {
       const f = path.join(args.path, requiredFile);
       if (!fs.existsSync(f)) {
-        EmulatorLogger.forExtension({ ref: args.extRef }).logLabeled(
+        EmulatorLogger.forExtension({ ref: args.extTarget }).logLabeled(
           "BULLET",
           "extensions",
-          `Detected invalid source code for ${args.extRef}, expected to find ${f}`
+          `Detected invalid source code for ${args.extTarget}, expected to find ${f}`
         );
         return false;
       }
@@ -215,18 +217,21 @@ export class ExtensionsEmulator implements EmulatorInstance {
     const env = Object.assign(this.autoPopulatedParams(instance), instance.params);
     const { extensionTriggers, nodeMajorVersion, nonSecretEnv, secretEnvVariables } =
       await getExtensionFunctionInfo(instance, env);
-    const extension = await planner.getExtension(instance);
-    const extensionVersion = await planner.getExtensionVersion(instance);
-    return {
+    const emulatableBackend: EmulatableBackend = {
       functionsDir,
       env: nonSecretEnv,
       secretEnv: secretEnvVariables,
       predefinedTriggers: extensionTriggers,
       nodeMajorVersion: nodeMajorVersion,
       extensionInstanceId: instance.instanceId,
-      extension,
-      extensionVersion,
     };
+    if (instance.ref) {
+      emulatableBackend.extension = await planner.getExtension(instance);
+      emulatableBackend.extensionVersion = await planner.getExtensionVersion(instance);
+    } else if (instance.localPath) {
+      emulatableBackend.extensionSpec = await planner.getExtensionSpec(instance);
+    }
+    return emulatableBackend;
   }
 
   private autoPopulatedParams(instance: planner.InstanceSpec): Record<string, string> {

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -9,6 +9,7 @@ import { substituteParams } from "../extensionsHelper";
 import { parseRuntimeVersion } from "../../emulator/functionsEmulatorUtils";
 
 const SPEC_FILE = "extension.yaml";
+const POSTINSTALL_FILE = "POSTINSTALL.md"
 const validFunctionTypes = [
   "firebaseextensions.v1beta.function",
   "firebaseextensions.v1beta.scheduledFunction",
@@ -40,12 +41,21 @@ export async function readExtensionYaml(directory: string): Promise<ExtensionSpe
 }
 
 /**
+ * Reads a POSTINSTALL file and returns its content as a string
+ * @param directory the directory to look for POSTINSTALL.md in.
+ */
+export async function readPostinstall(directory: string): Promise<string> {
+  const content = await readFileFromDirectory(directory, POSTINSTALL_FILE);
+  return content.source;
+}
+
+/**
  * Retrieves a file from the directory.
  */
 export function readFileFromDirectory(
   directory: string,
   file: string
-): Promise<{ [key: string]: any }> {
+): Promise<{ source: string, sourceDirectory: string }> {
   return new Promise<string>((resolve, reject) => {
     fs.readFile(path.resolve(directory, file), "utf8", (err, data) => {
       if (err) {

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -9,7 +9,7 @@ import { substituteParams } from "../extensionsHelper";
 import { parseRuntimeVersion } from "../../emulator/functionsEmulatorUtils";
 
 const SPEC_FILE = "extension.yaml";
-const POSTINSTALL_FILE = "POSTINSTALL.md"
+const POSTINSTALL_FILE = "POSTINSTALL.md";
 const validFunctionTypes = [
   "firebaseextensions.v1beta.function",
   "firebaseextensions.v1beta.scheduledFunction",
@@ -55,7 +55,7 @@ export async function readPostinstall(directory: string): Promise<string> {
 export function readFileFromDirectory(
   directory: string,
   file: string
-): Promise<{ source: string, sourceDirectory: string }> {
+): Promise<{ source: string; sourceDirectory: string }> {
   return new Promise<string>((resolve, reject) => {
     fs.readFile(path.resolve(directory, file), "utf8", (err, data) => {
       if (err) {

--- a/src/extensions/refs.ts
+++ b/src/extensions/refs.ts
@@ -65,7 +65,7 @@ export function toExtensionRef(ref: Ref): string {
 }
 
 /**
- * To an extension bersion ref: publisherId/extensionId@version
+ * To an extension version ref: publisherId/extensionId@version
  */
 export function toExtensionVersionRef(ref: Ref): string {
   if (!ref.version) {

--- a/src/test/emulators/extensions/validation.spec.ts
+++ b/src/test/emulators/extensions/validation.spec.ts
@@ -30,6 +30,11 @@ function fakeInstanceSpecWithAPI(instanceId: string, apiName: string): Deploymen
   return {
     instanceId,
     params: {},
+    ref: {
+      publisherId: "test",
+      extensionId: "test",
+      version: "0.1.0",
+    },
     extensionVersion: {
       name: "publishers/test/extensions/test/versions/0.1.0",
       ref: "test/test@0.1.0",


### PR DESCRIPTION
### Description
Adding support for emulating local extensions by providing a path to the extension code in lieu of a extension ref in firebase.json

### Scenarios Tested
I tested this by adding a local extension to the manifest (`firebase ext:install /Users/joehanley/Workspace/extensions/storage-resize-images --local`), then running `firebase emulators:start`. The emulator correctly reads the function from that extension & prints a UI link:
<img width="953" alt="Screen Shot 2022-04-11 at 5 07 29 PM" src="https://user-images.githubusercontent.com/4635763/162852739-581e1a51-fbe1-4719-9925-5ae9bf9f89c1.png">
The emulator UI is working 95% correctly. All 4 tabs of the Extension details page work as expected, and all the POSTINSTALL substitution works:
<img width="1308" alt="Screen Shot 2022-04-11 at 5 09 28 PM" src="https://user-images.githubusercontent.com/4635763/162852902-eeba8199-a7fd-4f5b-8158-b19e8b3639fc.png">
The extension details page works but does not display an icon:
<img width="1302" alt="Screen Shot 2022-04-11 at 5 10 37 PM" src="https://user-images.githubusercontent.com/4635763/162852992-f042ade0-a3bc-4d1b-a9dc-6d4976617c51.png">
I also tested that the emulated functions are working as expected by successfully resizing an image.
We need some minor changes to the UI to polish up the visuals, but this is functioning fully!
