### PR TITLE
Fix function deploy bug

### DIFF
--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -62,10 +62,10 @@ export async function deploy(
 
     // Choose one of the function region for source upload.
     const byPlatform = groupBy(backend.allEndpoints(want), (e) => e.platform);
-    if (byPlatform.gcfv1.length > 0) {
+    if (byPlatform.gcfv1?.length > 0) {
       uploads.push(uploadSourceV1(context, byPlatform.gcfv1[0].region));
     }
-    if (byPlatform.gcfv2.length > 0) {
+    if (byPlatform.gcfv2?.length > 0) {
       uploads.push(uploadSourceV2(context, byPlatform.gcfv2[0].region));
     }
     await Promise.all(uploads);


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/firebase/firebase-tools/pull/4431 where deployment will fail if the source doesn't specify both v1 and v2 triggers.

On one hand, I'm glad I running integrations test that catches issue like this. This also pushes me towards having multiple integration tests that test many different deployment scenario instead of having one gigantic deployment that tests all triggers?