### PR TITLE
Use one preview flag for all of extensionsemulator

### DIFF
--- a/scripts/storage-emulator-integration/internals.test.ts
+++ b/scripts/storage-emulator-integration/internals.test.ts
@@ -126,7 +126,7 @@ describe("Emulator Internals", function (this) {
     const smallFilePath = createRandomFile("testFile", SMALL_FILE_SIZE);
     await testGcsBucket.upload(smallFilePath, { destination: "public/testFile" });
 
-    const downloadUrl = await page.evaluate(async () => {
+    const downloadUrl = await page.evaluate(() => {
       return firebase.storage().ref("public/testFile").getDownloadURL();
     });
     const requestClient = http;

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -62,36 +62,53 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
       namePrefix: "cloud-storage-rules-emulator",
     },
   },
-  ui: previews.emulatoruisnapshot
-    ? {
-        version: "SNAPSHOT",
-        downloadPath: path.join(CACHE_DIR, "ui-vSNAPSHOT.zip"),
-        unzipDir: path.join(CACHE_DIR, "ui-vSNAPSHOT"),
-        binaryPath: path.join(CACHE_DIR, "ui-vSNAPSHOT", "server.bundle.js"),
-        opts: {
-          cacheDir: CACHE_DIR,
-          remoteUrl:
-            "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vSNAPSHOT.zip",
-          expectedSize: -1,
-          expectedChecksum: "",
-          skipCache: true,
-          skipChecksumAndSize: true,
-          namePrefix: "ui",
-        },
-      }
-    : {
-        version: "1.6.5",
-        downloadPath: path.join(CACHE_DIR, "ui-v1.6.5.zip"),
-        unzipDir: path.join(CACHE_DIR, "ui-v1.6.5"),
-        binaryPath: path.join(CACHE_DIR, "ui-v1.6.5", "server.bundle.js"),
-        opts: {
-          cacheDir: CACHE_DIR,
-          remoteUrl: "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.6.5.zip",
-          expectedSize: 3816994,
-          expectedChecksum: "92dfff4b2ef8ab616e8a60cc93e0a00b",
-          namePrefix: "ui",
-        },
+  ui: previews.extensionsemulator ?
+    {
+      version: "EXTENSIONS",
+      downloadPath: path.join(CACHE_DIR, "ui-vEXTENSIONS.zip"),
+      unzipDir: path.join(CACHE_DIR, "ui-vEXTENSIONS"),
+      binaryPath: path.join(CACHE_DIR, "ui-vEXTENSIONS", "server.bundle.js"),
+      opts: {
+        cacheDir: CACHE_DIR,
+        remoteUrl:
+          "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vEXTENSIONS.zip",
+        expectedSize: -1,
+        expectedChecksum: "",
+        skipCache: true,
+        skipChecksumAndSize: true,
+        namePrefix: "ui",
       },
+    } :
+    previews.emulatoruisnapshot
+      ? {
+          version: "SNAPSHOT",
+          downloadPath: path.join(CACHE_DIR, "ui-vSNAPSHOT.zip"),
+          unzipDir: path.join(CACHE_DIR, "ui-vSNAPSHOT"),
+          binaryPath: path.join(CACHE_DIR, "ui-vSNAPSHOT", "server.bundle.js"),
+          opts: {
+            cacheDir: CACHE_DIR,
+            remoteUrl:
+              "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vSNAPSHOT.zip",
+            expectedSize: -1,
+            expectedChecksum: "",
+            skipCache: true,
+            skipChecksumAndSize: true,
+            namePrefix: "ui",
+          },
+        }
+      : {
+          version: "1.6.5",
+          downloadPath: path.join(CACHE_DIR, "ui-v1.6.5.zip"),
+          unzipDir: path.join(CACHE_DIR, "ui-v1.6.5"),
+          binaryPath: path.join(CACHE_DIR, "ui-v1.6.5", "server.bundle.js"),
+          opts: {
+            cacheDir: CACHE_DIR,
+            remoteUrl: "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.6.5.zip",
+            expectedSize: 3816994,
+            expectedChecksum: "92dfff4b2ef8ab616e8a60cc93e0a00b",
+            namePrefix: "ui",
+          },
+        },
   pubsub: {
     downloadPath: path.join(CACHE_DIR, "pubsub-emulator-0.1.0.zip"),
     version: "0.1.0",

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -62,53 +62,53 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
       namePrefix: "cloud-storage-rules-emulator",
     },
   },
-  ui: previews.extensionsemulator ?
-    {
-      version: "EXTENSIONS",
-      downloadPath: path.join(CACHE_DIR, "ui-vEXTENSIONS.zip"),
-      unzipDir: path.join(CACHE_DIR, "ui-vEXTENSIONS"),
-      binaryPath: path.join(CACHE_DIR, "ui-vEXTENSIONS", "server.bundle.js"),
-      opts: {
-        cacheDir: CACHE_DIR,
-        remoteUrl:
-          "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vEXTENSIONS.zip",
-        expectedSize: -1,
-        expectedChecksum: "",
-        skipCache: true,
-        skipChecksumAndSize: true,
-        namePrefix: "ui",
-      },
-    } :
-    previews.emulatoruisnapshot
-      ? {
-          version: "SNAPSHOT",
-          downloadPath: path.join(CACHE_DIR, "ui-vSNAPSHOT.zip"),
-          unzipDir: path.join(CACHE_DIR, "ui-vSNAPSHOT"),
-          binaryPath: path.join(CACHE_DIR, "ui-vSNAPSHOT", "server.bundle.js"),
-          opts: {
-            cacheDir: CACHE_DIR,
-            remoteUrl:
-              "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vSNAPSHOT.zip",
-            expectedSize: -1,
-            expectedChecksum: "",
-            skipCache: true,
-            skipChecksumAndSize: true,
-            namePrefix: "ui",
-          },
-        }
-      : {
-          version: "1.6.5",
-          downloadPath: path.join(CACHE_DIR, "ui-v1.6.5.zip"),
-          unzipDir: path.join(CACHE_DIR, "ui-v1.6.5"),
-          binaryPath: path.join(CACHE_DIR, "ui-v1.6.5", "server.bundle.js"),
-          opts: {
-            cacheDir: CACHE_DIR,
-            remoteUrl: "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.6.5.zip",
-            expectedSize: 3816994,
-            expectedChecksum: "92dfff4b2ef8ab616e8a60cc93e0a00b",
-            namePrefix: "ui",
-          },
+  ui: previews.extensionsemulator
+    ? {
+        version: "EXTENSIONS",
+        downloadPath: path.join(CACHE_DIR, "ui-vEXTENSIONS.zip"),
+        unzipDir: path.join(CACHE_DIR, "ui-vEXTENSIONS"),
+        binaryPath: path.join(CACHE_DIR, "ui-vEXTENSIONS", "server.bundle.js"),
+        opts: {
+          cacheDir: CACHE_DIR,
+          remoteUrl:
+            "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vEXTENSIONS.zip",
+          expectedSize: -1,
+          expectedChecksum: "",
+          skipCache: true,
+          skipChecksumAndSize: true,
+          namePrefix: "ui",
         },
+      }
+    : previews.emulatoruisnapshot
+    ? {
+        version: "SNAPSHOT",
+        downloadPath: path.join(CACHE_DIR, "ui-vSNAPSHOT.zip"),
+        unzipDir: path.join(CACHE_DIR, "ui-vSNAPSHOT"),
+        binaryPath: path.join(CACHE_DIR, "ui-vSNAPSHOT", "server.bundle.js"),
+        opts: {
+          cacheDir: CACHE_DIR,
+          remoteUrl:
+            "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vSNAPSHOT.zip",
+          expectedSize: -1,
+          expectedChecksum: "",
+          skipCache: true,
+          skipChecksumAndSize: true,
+          namePrefix: "ui",
+        },
+      }
+    : {
+        version: "1.6.5",
+        downloadPath: path.join(CACHE_DIR, "ui-v1.6.5.zip"),
+        unzipDir: path.join(CACHE_DIR, "ui-v1.6.5"),
+        binaryPath: path.join(CACHE_DIR, "ui-v1.6.5", "server.bundle.js"),
+        opts: {
+          cacheDir: CACHE_DIR,
+          remoteUrl: "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.6.5.zip",
+          expectedSize: 3816994,
+          expectedChecksum: "92dfff4b2ef8ab616e8a60cc93e0a00b",
+          namePrefix: "ui",
+        },
+      },
   pubsub: {
     downloadPath: path.join(CACHE_DIR, "pubsub-emulator-0.1.0.zip"),
     version: "0.1.0",


### PR DESCRIPTION
### Description
Use the 'extensionemulator' flag to fetch a preview build of the emulator UI. We need to cut that version before we merge this.
