### PR TITLE
Include $schema property in firebase-config.json

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -8,6 +8,9 @@
         }
     },
     "properties": {
+        "$schema": {
+            "type": "string"
+        },
         "database": {
             "anyOf": [
                 {


### PR DESCRIPTION
By adding the $schema property, we allow users to add e.g. the following property to their firebase.json file.
    "$schema": "./node_modules/firebase-tools/schema/firebase-config.json",
This allows the IDE to do live validation and code completion in the firebase-config.json file.