### PR TITLE
Make grantToken tenant-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Updates `superstatic` to `v8` to fix audit issues.
+- Make grantToken tenant-aware (#4475)

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1704,7 +1704,6 @@ function grantToken(
   assert(reqBody.refreshToken, "MISSING_REFRESH_TOKEN");
 
   const refreshTokenRecord = state.validateRefreshToken(reqBody.refreshToken);
-  assert(refreshTokenRecord, "INVALID_REFRESH_TOKEN");
   assert(!refreshTokenRecord.user.disabled, "USER_DISABLED");
   const tokens = issueTokens(state, refreshTokenRecord.user, refreshTokenRecord.provider, {
     extraClaims: refreshTokenRecord.extraClaims,

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -389,7 +389,7 @@ export abstract class ProjectState {
   ): string {
     const localId = userInfo.localId;
     const refreshTokenRecord = {
-      _AuthEmulatorRefreshTokenRecord: "DO NOT MODIFY",
+      _AuthEmulatorRefreshToken: "DO NOT MODIFY",
       localId,
       provider,
       extraClaims,
@@ -854,8 +854,8 @@ export type Config = {
   blockingFunctions: BlockingFunctionsConfig;
 };
 
-interface RefreshTokenRecord {
-  _AuthEmulatorRefreshTokenRecord: string;
+export interface RefreshTokenRecord {
+  _AuthEmulatorRefreshToken: string;
   localId: string;
   provider: string;
   extraClaims: Record<string, unknown>;
@@ -912,12 +912,15 @@ export function encodeRefreshToken(refreshTokenRecord: RefreshTokenRecord): stri
 }
 
 export function decodeRefreshToken(refreshTokenString: string): RefreshTokenRecord {
+  let refreshTokenRecord: RefreshTokenRecord;
   try {
     const json = Buffer.from(refreshTokenString, "base64").toString("utf8");
-    return JSON.parse(json) as RefreshTokenRecord;
+    refreshTokenRecord = JSON.parse(json) as RefreshTokenRecord;
   } catch {
     throw new BadRequestError("INVALID_REFRESH_TOKEN");
   }
+  assert(refreshTokenRecord._AuthEmulatorRefreshToken, "INVALID_REFRESH_TOKEN");
+  return refreshTokenRecord;
 }
 
 function getProviderEmailsForUser(user: UserInfo): Set<string> {

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
-import { UserInfo } from "../../../emulator/auth/state";
+import { decodeRefreshToken, UserInfo } from "../../../emulator/auth/state";
 import {
   deleteAccount,
   getAccountInfoByIdToken,
@@ -47,6 +47,40 @@ describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
       });
   });
 
+  it("should exchange refresh tokens for new tokens in a tenant project", async () => {
+    const tenant = await registerTenant(authApi(), PROJECT_ID, {
+      disableAuth: false,
+      allowPasswordSignup: true,
+    });
+    const { refreshToken, localId } = await registerUser(authApi(), {
+      email: "alice@example.com",
+      password: "notasecret",
+      tenantId: tenant.tenantId,
+    });
+
+    await authApi()
+      .post("/securetoken.googleapis.com/v1/token")
+      .type("form")
+      // snake_case parameters also work, per OAuth 2.0 spec.
+      .send({ refresh_token: refreshToken, grantType: "refresh_token" })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.id_token).to.be.a("string");
+        expect(res.body.access_token).to.equal(res.body.id_token);
+        expect(res.body.refresh_token).to.be.a("string");
+        expect(res.body.expires_in)
+          .to.be.a("string")
+          .matches(/[0-9]+/);
+        expect(res.body.project_id).to.equal("12345");
+        expect(res.body.token_type).to.equal("Bearer");
+        expect(res.body.user_id).to.equal(localId);
+
+        const refreshTokenRecord = decodeRefreshToken(res.body.refresh_token);
+        expect(refreshTokenRecord.tenantId).to.equal(tenant.tenantId);
+      });
+  });
+
   it("should populate auth_time to match lastLoginAt (in seconds since epoch)", async () => {
     getClock().tick(444); // Make timestamps a bit more interesting (non-zero).
     const emailUser = { email: "alice@example.com", password: "notasecret" };
@@ -73,6 +107,62 @@ describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
     expect(decoded!.header.alg).to.eql("none");
     // This should match login time, not token refresh time.
     expect(decoded!.payload.auth_time).to.equal(lastLoginAtSeconds);
+  });
+
+  it("should error if grant type is missing", async () => {
+    const { refreshToken } = await registerAnonUser(authApi());
+
+    await authApi()
+      .post("/securetoken.googleapis.com/v1/token")
+      .type("form")
+      // snake_case parameters also work, per OAuth 2.0 spec.
+      .send({ refresh_token: refreshToken })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.contain("MISSING_GRANT_TYPE");
+      });
+  });
+
+  it("should error if grant type is not refresh_token", async () => {
+    const { refreshToken } = await registerAnonUser(authApi());
+
+    await authApi()
+      .post("/securetoken.googleapis.com/v1/token")
+      .type("form")
+      // snake_case parameters also work, per OAuth 2.0 spec.
+      .send({ refresh_token: refreshToken, grantType: "other_grant_type" })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.contain("INVALID_GRANT_TYPE");
+      });
+  });
+
+  it("should error if refresh token is missing", async () => {
+    await authApi()
+      .post("/securetoken.googleapis.com/v1/token")
+      .type("form")
+      // snake_case parameters also work, per OAuth 2.0 spec.
+      .send({ grantType: "refresh_token" })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.contain("MISSING_REFRESH_TOKEN");
+      });
+  });
+
+  it("should error on malformed refresh tokens", async () => {
+    await authApi()
+      .post("/securetoken.googleapis.com/v1/token")
+      .type("form")
+      // snake_case parameters also work, per OAuth 2.0 spec.
+      .send({ refresh_token: "malformedToken", grantType: "refresh_token" })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).to.contain("INVALID_REFRESH_TOKEN");
+      });
   });
 
   it("should error if user is disabled", async () => {

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -1,6 +1,11 @@
 import { expect } from "chai";
 import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
-import { decodeRefreshToken, encodeRefreshToken, UserInfo } from "../../../emulator/auth/state";
+import {
+  decodeRefreshToken,
+  encodeRefreshToken,
+  RefreshTokenRecord,
+  UserInfo,
+} from "../../../emulator/auth/state";
 import {
   deleteAccount,
   getAccountInfoByIdToken,
@@ -200,13 +205,33 @@ describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
 
   it("should error when refresh tokens are from a different project", async () => {
     const refreshTokenRecord = {
-      _AuthEmulatorRefreshTokenRecord: "DO NOT MODIFY",
+      _AuthEmulatorRefreshToken: "DO NOT MODIFY",
       localId: "localId",
       provider: "provider",
       extraClaims: {},
       projectId: "notMatchingProjectId",
     };
     const refreshToken = encodeRefreshToken(refreshTokenRecord);
+
+    await authApi()
+      .post("/securetoken.googleapis.com/v1/token")
+      .type("form")
+      .send({ refresh_token: refreshToken, grantType: "refresh_token" })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("INVALID_REFRESH_TOKEN");
+      });
+  });
+
+  it("should error on refresh tokens without required fields", async () => {
+    const refreshTokenRecord = {
+      localId: "localId",
+      provider: "provider",
+      extraClaims: {},
+      projectId: "notMatchingProjectId",
+    };
+    const refreshToken = encodeRefreshToken(refreshTokenRecord as RefreshTokenRecord);
 
     await authApi()
       .post("/securetoken.googleapis.com/v1/token")

--- a/src/test/emulators/auth/rest.spec.ts
+++ b/src/test/emulators/auth/rest.spec.ts
@@ -180,7 +180,7 @@ describeAuthEmulator("authentication", ({ authApi }) => {
       });
   });
 
-  it("should deny requests where tenant IDs do not match in the token and path", async () => {
+  it("should deny requests where tenant IDs do not match in the ID token and path", async () => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, {
       disableAuth: false,
       allowPasswordSignup: true,
@@ -203,12 +203,12 @@ describeAuthEmulator("authentication", ({ authApi }) => {
       });
   });
 
-  it("should deny requests where tenant IDs do not match in the token and request body", async () => {
+  it("should deny requests where tenant IDs do not match in the ID token and request body", async () => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, {
       disableAuth: false,
       allowPasswordSignup: true,
     });
-    const { idToken, localId } = await registerUser(authApi(), {
+    const { idToken } = await registerUser(authApi(), {
       email: "alice@example.com",
       password: "notasecret",
       tenantId: tenant.tenantId,


### PR DESCRIPTION
### Description

Adds multi-tenancy support on grantToken endpoint by pulling tenant ID from refresh token. Changes include:
- Make refresh token minting / validating stateless by serializing RefreshTokenRecord instead of representing with random string 
- Changing server side logic to check request body's refresh token for tenant ID (note that `grantToken` is the only endpoint in which the tenant ID cannot be obtained from the request path, query params, or ID token in the request body)
- Added additional unit tests for `grantToken` edge cases

Fixes https://github.com/firebase/firebase-tools/issues/4414. 

### Scenarios Tested

`npm test` passes

### Sample Commands

N/A