### PR TITLE
bumb node version to min 14; tooling at 16

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
       - run: npm ci
@@ -53,7 +53,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
       - run: npm ci
@@ -96,7 +96,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - name: Cache firebase emulators
         uses: actions/cache@v3
@@ -134,7 +134,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm i -g npm@8.5
       # --ignore-scripts prevents the `prepare` script from being run.
       - run: npm install --package-lock-only --ignore-scripts
@@ -160,7 +160,7 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
+          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm install
       - run: npm run generate:json-schema
       - run: "git diff --exit-code -- schema/*.json || (echo 'Error: JSON schema is changed! Please run npm run generate:json-schema and commit the results.' && false)"

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '16'
+          - "16"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -34,9 +34,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '14'
-          - '16'
-          - '18'
+          - "14"
+          - "16"
+          - "18"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - '14'
+          - "14"
         script:
           - npm run test:hosting
           - npm run test:client-integration
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '14'
+          - "14"
 
     steps:
       - uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - '14'
+          - "14"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -24,11 +24,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
       - run: npm ci

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
+          - 14.x
     steps:
       - uses: actions/checkout@v2
         with:
@@ -34,9 +34,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
           - 14.x
           - 16.x
+          - 18.x
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 12.x
+          - 14.x
         script:
           - npm run test:hosting
           - npm run test:client-integration
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
+          - 14.x
 
     steps:
       - uses: actions/checkout@v2
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
+          - 14.x
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - "14"
+          - "16"
         script:
           - npm run test:hosting
           - npm run test:client-integration
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "14"
+          - "16"
 
     steps:
       - uses: actions/checkout@v3
@@ -124,7 +124,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "14"
+          - "16"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: node_modules
+          path: "**/node_modules"
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
@@ -50,7 +50,7 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: node_modules
+          path: "**/node_modules"
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
@@ -92,7 +92,7 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: node_modules
+          path: "**/node_modules"
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - name: Cache firebase emulators
@@ -129,7 +129,7 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: node_modules
+          path: "**/node_modules"
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm i -g npm@8.5
       # --ignore-scripts prevents the `prepare` script from being run.
@@ -154,7 +154,7 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: node_modules
+          path: "**/node_modules"
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm install
       - run: npm run generate:json-schema

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -14,12 +14,12 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - '16'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -34,12 +34,12 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
-          - 16.x
-          - 18.x
+          - '14'
+          - '16'
+          - '18'
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14.x
+          - '14'
         script:
           - npm run test:hosting
           - npm run test:client-integration
@@ -76,15 +76,15 @@ jobs:
           - npm run test:storage-deploy
           - npm run test:storage-emulator-integration
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
 
       - name: Cache firebase emulators
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.FIREBASE_EMULATORS_PATH }}
           key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('emulator-cache/**') }}
@@ -105,12 +105,12 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - '14'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm i -g npm@8.5
@@ -124,12 +124,12 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 14.x
+          - '14'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -24,6 +24,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
+      - uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
       - run: npm ci
@@ -44,6 +48,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
+      - uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
       - run: npm ci
@@ -82,6 +90,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
+      - uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - name: Cache firebase emulators
         uses: actions/cache@v3
@@ -113,6 +125,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: npm-shrinkwrap.json
+      - uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm i -g npm@8.5
       # --ignore-scripts prevents the `prepare` script from being run.
       - run: npm install --package-lock-only --ignore-scripts
@@ -132,6 +150,12 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+          cache: npm
+          cache-dependency-path: npm-shrinkwrap.json
+      - uses: actions/cache@v3
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm install
       - run: npm run generate:json-schema
       - run: "git diff --exit-code -- schema/*.json || (echo 'Error: JSON schema is changed! Please run npm run generate:json-schema and commit the results.' && false)"

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -49,11 +49,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
       - run: npm ci
@@ -92,11 +87,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - name: Cache firebase emulators
         uses: actions/cache@v3
@@ -130,11 +120,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm i -g npm@8.5
       # --ignore-scripts prevents the `prepare` script from being run.
       - run: npm install --package-lock-only --ignore-scripts
@@ -156,11 +141,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
-      - uses: actions/cache@v3
-        with:
-          path: |
-            **/node_modules
-          key: ${{ runner.os }}-cache-${{ secrets.CACHE_VERSION }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm install
       - run: npm run generate:json-schema
       - run: "git diff --exit-code -- schema/*.json || (echo 'Error: JSON schema is changed! Please run npm run generate:json-schema and commit the results.' && false)"

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -26,7 +26,8 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: "**/node_modules"
+          path: |
+            **/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
@@ -50,7 +51,8 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: "**/node_modules"
+          path: |
+            **/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - run: npm i -g npm@8.5
@@ -92,7 +94,8 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: "**/node_modules"
+          path: |
+            **/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
 
       - name: Cache firebase emulators
@@ -129,7 +132,8 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: "**/node_modules"
+          path: |
+            **/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm i -g npm@8.5
       # --ignore-scripts prevents the `prepare` script from being run.
@@ -154,7 +158,8 @@ jobs:
           cache-dependency-path: npm-shrinkwrap.json
       - uses: actions/cache@v3
         with:
-          path: "**/node_modules"
+          path: |
+            **/node_modules
           key: ${{ runner.os }}-node-${{ matrix.node-version }}-${{ hashFiles('**/npm-shrinkwrap.json') }}
       - run: npm install
       - run: npm run generate:json-schema

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -149,7 +149,7 @@
         "typescript-json-schema": "^0.50.1"
       },
       "engines": {
-        "node": ">= 12"
+        "node": ">= 14.6.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   ],
   "preferGlobal": true,
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14.6.0"
   },
   "author": "Firebase (https://firebase.google.com/)",
   "license": "MIT",

--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 # Install dependencies
 RUN apt-get update && \

--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14
 
 # Install dependencies
 RUN apt-get update && \

--- a/scripts/firepit-builder/Dockerfile
+++ b/scripts/firepit-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:16
 
 # Install dependencies
 RUN apt-get update && \

--- a/scripts/firepit-builder/Dockerfile
+++ b/scripts/firepit-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:14
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

All testing passes and such. Setting min node version to `>= 14.6.0` to be the earliest version of 14 that supports all of 14's feature set, per https://node.green/

Upgraded the actions as well while I was there.