### PR TITLE
Remove params in ext:* for v11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Remove `params` flag from ext:install, ext:update, ext:configure commands as they are replaced by the Extensions Manifest. See https://firebase.google.com/docs/extensions/manifest for more details.

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -33,7 +33,6 @@ marked.setOptions({
 export default new Command("ext:configure <extensionInstanceId>")
   .description("configure an existing extension instance")
   .withForce()
-  .option("--params <paramsFile>", "path of params file with .env format.")
   .before(requirePermissions, [
     "firebaseextensions.instances.update",
     "firebaseextensions.instances.get",
@@ -81,7 +80,8 @@ export default new Command("ext:configure <extensionInstanceId>")
       projectId,
       paramSpecs: tbdParams,
       nonInteractive: false,
-      paramsEnvPath: (options.params ?? "") as string,
+      // TODO(b/230598656): Clean up paramsEnvPath after v11 launch.
+      paramsEnvPath: "",
       instanceId,
       reconfiguring: true,
     });

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -48,15 +48,14 @@ export default new Command("ext:install [extensionName]")
       "or run with `-i` to see all available extensions."
   )
   .withForce()
-  // TODO(b/221037520): Deprecate the params flag then remove it in the next breaking version.
-  .option("--params <paramsFile>", "name of params variables file with .env format.")
   .before(requirePermissions, ["firebaseextensions.instances.create"])
   .before(ensureExtensionsApiEnabled)
   .before(checkMinRequiredVersion, "extMinVersion")
   .before(diagnoseAndFixProject)
   .action(async (extensionName: string, options: Options) => {
     const projectId = getProjectId(options);
-    const paramsEnvPath = (options.params ?? "") as string;
+    // TODO(b/230598656): Clean up paramsEnvPath after v11 launch.
+    const paramsEnvPath = "";
     let learnMore = false;
     if (!extensionName) {
       if (options.interactive) {

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -47,7 +47,6 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
   .before(checkMinRequiredVersion, "extMinVersion")
   .before(diagnoseAndFixProject)
   .withForce()
-  .option("--params <paramsFile>", "name of params variables file with .env format.")
   .action(async (instanceId: string, updateSource: string, options: Options) => {
     const projectId = getProjectId(options);
     const config = manifest.loadConfig(options);
@@ -117,7 +116,8 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
       newSpec: newExtensionVersion.spec,
       currentParams: oldParamValues,
       projectId,
-      paramsEnvPath: (options.params ?? "") as string,
+      // TODO(b/230598656): Clean up paramsEnvPath after v11 launch.
+      paramsEnvPath: "",
       nonInteractive: options.nonInteractive,
       instanceId,
     });


### PR DESCRIPTION
### Description

Remove options.params flags in v11. 

In order to minimize the merge conflicts we potentially need to deal with, only the most superficial cleanup is done in this PR. A separate bug is open to track the cleanup of relevant code path, and should be done after v11 is merged into master. 
https://b.corp.google.com/issues/230598656
