### PR TITLE
Fix database emulator rules error parsing. Fix #4454.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Updates `superstatic` to `v8` to fix audit issues.
 - Make grantToken tenant-aware (#4475)
+- Fix database emulator rules error parsing (#4454).

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -83,8 +83,16 @@ export class DatabaseEmulator implements EmulatorInstance {
         if (!c.instance) {
           continue;
         }
-
-        await this.updateRules(c.instance, c.rules);
+        try {
+          await this.updateRules(c.instance, c.rules);
+        } catch (e: any) {
+          const rulesError = this.prettyPrintRulesError(c.rules, e);
+          this.logger.logLabeled("WARN", "database", rulesError);
+          this.logger.logLabeled("WARN", "database", "Failed to update rules");
+          throw new FirebaseError(
+            `Failed to load initial ${Constants.description(this.getName())} rules:\n${rulesError}`
+          );
+        }
       }
     }
   }
@@ -173,12 +181,41 @@ export class DatabaseEmulator implements EmulatorInstance {
       if (e.context && e.context.body) {
         throw e.context.body.error;
       }
-      throw e.original;
+      if (e.original) {
+        throw e.original;
+      }
+      throw e;
     }
   }
 
-  private prettyPrintRulesError(filePath: string, error: string): string {
+  private prettyPrintRulesError(filePath: string, error: unknown): string {
+    let errStr;
+    switch (typeof error) {
+      case "string":
+        errStr = error;
+        break;
+      case "object":
+        if (error != null && "message" in error) {
+          const message = (error as { message: unknown }).message;
+          errStr = `${message}`;
+          if (typeof message === "string") {
+            try {
+              // message may be JSON with {error: string} in it
+              const parsed = JSON.parse(message);
+              if (typeof parsed === "object" && parsed.error) {
+                errStr = `${parsed.error}`;
+              }
+            } catch (_) {
+              // Probably not JSON, just output the string itself as above.
+            }
+          }
+          break;
+        }
+      // fallthrough
+      default:
+        errStr = `Unknown error: ${JSON.stringify(error)}`;
+    }
     const relativePath = path.relative(process.cwd(), filePath);
-    return `${clc.cyan(relativePath)}:${error.trim()}`;
+    return `${clc.cyan(relativePath)}:${errStr.trim()}`;
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fix #4454.

### Scenarios Tested

Manually started the emulator with invalid rules, and the CLI now nicely prints the error instead of unknown issue. Then it shuts down all emulators and exit with an error (as before).

Started emulator with valid rules, and edited it to invalid: The CLI now pretty-prints the error correct and won't crash.

Sample valid rules:

```js
{
  /* Visit https://firebase.google.com/docs/database/security to learn more about security rules. */
  "rules": {
    ".read": "true",
    ".write": false
  }
}
```

Sample invalid rules:

```js
{
  /* Visit https://firebase.google.com/docs/database/security to learn more about security rules. */
  1"rules": {  // <-- invalid JSON here
    ".read": "true",
    ".write": false
  }
}
```

```js
{
  /* Visit https://firebase.google.com/docs/database/security to learn more about security rules. */
  "rules": {
    ".read": "", // <-- empty here
    ".write": false
  }
}
```

### Sample Commands

`firebase emulators:start --only database`