### PR TITLE
Serialize loading functions backend for Functions Emulator to avoid race conditions.

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -438,7 +438,6 @@ export class FunctionsEmulator implements EmulatorInstance {
   }
 
   async connect(): Promise<void> {
-    const loadTriggerPromises: Promise<void>[] = [];
     for (const backend of this.args.emulatableBackends) {
       this.logger.logLabeled(
         "BULLET",
@@ -461,9 +460,8 @@ export class FunctionsEmulator implements EmulatorInstance {
         return debouncedLoadTriggers();
       });
 
-      loadTriggerPromises.push(this.loadTriggers(backend, /* force= */ true));
+      await this.loadTriggers(backend, /* force= */ true);
     }
-    await Promise.all(loadTriggerPromises);
     await this.performPostLoadOperations();
     return;
   }
@@ -1358,11 +1356,9 @@ export class FunctionsEmulator implements EmulatorInstance {
 
   async reloadTriggers() {
     this.triggerGeneration++;
-    const loadTriggerPromises = [];
     for (const backend of this.args.emulatableBackends) {
-      loadTriggerPromises.push(this.loadTriggers(backend));
+      await this.loadTriggers(backend);
     }
-    await Promise.all(loadTriggerPromises);
     await this.performPostLoadOperations();
     return;
   }


### PR DESCRIPTION
Container contract based function trigger discovery process spins up a control API server to announce /functions.yaml. When we load multiple functions backend in parallel, they sometimes end up having conflict over port. Serializing the load resolves the issue, but slows down the overall loading process.

Slowdown may be a big hit to extensions emulator, delaying the emulator initialization by few more seconds. Setting up a PR to discuss changes.
