### PR TITLE
Filter out invalid prefixes and items from listing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Make grantToken tenant-aware (#4475)
 - Fix database emulator rules error parsing (#4454).
 - Fix timestamp format in Auth Emulator events (#3093).
+- Fix Storage Emulator showing folder placeholders in list results.

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -5,6 +5,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as http from "http";
 import * as https from "https";
+import fetch from "node-fetch";
 import * as puppeteer from "puppeteer";
 import { Bucket, Storage, CopyOptions } from "@google-cloud/storage";
 import supertest = require("supertest");
@@ -48,6 +49,16 @@ const TEST_CONFIG = {
   // (useful for checking browser logs for errors)
   keepBrowserOpen: false,
 };
+
+const EMPTY_FOLDER_DATA = `--boundary\r
+Content-Type: application/json\r
+\r
+{"contentType":"text/plain"}\r
+--boundary\r
+Content-Type: text/plain\r
+\r
+--boundary--\r
+`;
 
 // Temp directory to store generated files.
 let tmpDir: string;
@@ -1708,6 +1719,63 @@ describe("Storage emulator", () => {
           expect(listResult).to.deep.equal({
             prefixes: [],
             items: [],
+          });
+        });
+
+        context("with folder placeholders", () => {
+          beforeEach(async function (this) {
+            this.timeout(TEST_SETUP_TIMEOUT);
+
+            const refs = [
+              "testing/abc", // empty folder inside testing/
+              "testing/storage_ref", // also an implicit prefix with files
+            ];
+            for (const ref of refs) {
+              // Use REST API to create the folder placeholders since SDK won't
+              // allow refs with trailing slashes.
+              await fetch(
+                `${STORAGE_EMULATOR_HOST}/upload/storage/v1/b/${storageBucket}/o?name=${encodeURIComponent(
+                  ref
+                )}/`,
+                {
+                  headers: {
+                    "Content-Type": "multipart/related; boundary=boundary",
+                  },
+                  method: "POST",
+                  body: Buffer.from(EMPTY_FOLDER_DATA, "utf8"),
+                }
+              );
+            }
+          });
+
+          it("folder placeholder should not be listed under itself", async () => {
+            const listResult = await page.evaluate(async () => {
+              const list = await firebase.storage().ref("/testing/abc").listAll();
+              return {
+                prefixes: list.prefixes.map((prefix) => prefix.name),
+                items: list.items.map((item) => item.name),
+              };
+            });
+
+            expect(listResult).to.deep.equal({
+              prefixes: [],
+              items: [],
+            });
+          });
+
+          it("folder placeholder should be listed as a prefix but not an item under parent", async () => {
+            const listResult = await page.evaluate(async () => {
+              const list = await firebase.storage().ref("/testing").listAll();
+              return {
+                prefixes: list.prefixes.map((prefix) => prefix.name),
+                items: list.items.map((item) => item.name),
+              };
+            });
+
+            expect(listResult).to.deep.equal({
+              prefixes: ["abc", "somePathEndsWithDoubleSlash", "storage_ref"],
+              items: [],
+            });
           });
         });
       });

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -519,12 +519,12 @@ function setObjectHeaders(
   }
 }
 
-function validPrefix(prefix: string) {
+function validPrefix(prefix: string): boolean {
   // See go/firebase-storage-backend-valid-path
   return isValidNonEncodedPathString(removeAtMostOneTrailingSlash(prefix));
 }
 
-function isValidNonEncodedPathString(path: string) {
+function isValidNonEncodedPathString(path: string): boolean {
   // See go/firebase-storage-backend-valid-path
   if (path.startsWith("/")) {
     path = path.substring(1);

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -169,7 +169,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     }
     return res.status(200).json({
       nextPageToken: listResponse.nextPageToken,
-      prefixes: (listResponse.prefixes ?? []).filter(validPrefix),
+      prefixes: (listResponse.prefixes ?? []).filter(isValidPrefix),
       items: (listResponse.items ?? [])
         .filter((item) => isValidNonEncodedPathString(item.name))
         .map((item) => {
@@ -519,7 +519,7 @@ function setObjectHeaders(
   }
 }
 
-function validPrefix(prefix: string): boolean {
+function isValidPrefix(prefix: string): boolean {
   // See go/firebase-storage-backend-valid-path
   return isValidNonEncodedPathString(removeAtMostOneTrailingSlash(prefix));
 }

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -169,11 +169,12 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     }
     return res.status(200).json({
       nextPageToken: listResponse.nextPageToken,
-      prefixes: listResponse.prefixes ?? [],
-      items:
-        listResponse.items?.map((item) => {
+      prefixes: (listResponse.prefixes ?? []).filter(validPrefix),
+      items: (listResponse.items ?? [])
+        .filter((item) => isValidNonEncodedPathString(item.name))
+        .map((item) => {
           return { name: item.name, bucket: item.bucket };
-        }) ?? [],
+        }),
     });
   });
 
@@ -516,4 +517,29 @@ function setObjectHeaders(
   if (metadata.contentLanguage) {
     res.setHeader("Content-Language", metadata.contentLanguage);
   }
+}
+
+function validPrefix(prefix: string) {
+  // See go/firebase-storage-backend-valid-path
+  return isValidNonEncodedPathString(removeAtMostOneTrailingSlash(prefix));
+}
+
+function isValidNonEncodedPathString(path: string) {
+  // See go/firebase-storage-backend-valid-path
+  if (path.startsWith("/")) {
+    path = path.substring(1);
+  }
+  if (!path) {
+    return false;
+  }
+  for (const pathSegment of path.split("/")) {
+    if (!pathSegment) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function removeAtMostOneTrailingSlash(path: string): string {
+  return path.replace(/\/$/, "");
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This filters out invalid items and prefixes from Firebase Storage list API results. Similar to production logic at go/firebase-storage-backend-valid-path (Googler only).

### Scenarios Tested

See tests added. Manually tested in Emulator UI too: created a folder, and it shows up in parent folder correctly. Inside the new folder, the view is empty with no placeholder showing up as files.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
