### PR TITLE
Fixing invalid version error when emulating functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Make grantToken tenant-aware (#4475)
 - Fix database emulator rules error parsing (#4454).
 - Fix timestamp format in Auth Emulator events (#3093).
+- Fix `TypeError: Invalid Version:` error when emulating functions (#4403).

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -129,6 +129,18 @@ export class Delegate {
     env: backend.EnvironmentVariables
   ): Promise<backend.Backend> {
     if (previews.functionsv2) {
+      if (semver.valid(this.sdkVersion)) {
+        logger.debug(
+          `Could not parse firebase-functions version '${this.sdkVersion}' into semver. Falling back to parseTriggers.`
+        );
+        return parseTriggers.discoverBackend(
+          this.projectId,
+          this.sourceDir,
+          this.runtime,
+          config,
+          env
+        );
+      }
       if (semver.lt(this.sdkVersion, MIN_FUNCTIONS_SDK_VERSION)) {
         logLabeledWarning(
           "functions",

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -129,7 +129,7 @@ export class Delegate {
     env: backend.EnvironmentVariables
   ): Promise<backend.Backend> {
     if (previews.functionsv2) {
-      if (semver.valid(this.sdkVersion)) {
+      if (!semver.valid(this.sdkVersion)) {
         logger.debug(
           `Could not parse firebase-functions version '${this.sdkVersion}' into semver. Falling back to parseTriggers.`
         );


### PR DESCRIPTION
### Description
When unable to identify the version of firebase-functions in use, we were throwing `TypeError: Invalid Version:` errors due to trying to parse "" into Semver. This should fix #4403, where some users are experiencing this when trying to emulate functions.