### PR TITLE
Add total events count when displaying allowed events prompt

### DIFF
--- a/src/extensions/askUserForEventsConfig.ts
+++ b/src/extensions/askUserForEventsConfig.ts
@@ -67,7 +67,7 @@ export async function askForAllowedEventTypes(
       default: preselectedTypes ?? [],
       // @TODO(b/229170748): Link to docs / audit the copy with UX.
       message:
-        "Please select the events that this extension is permitted to emit. " +
+        `Please select the events [${eventTypes.length} types total] that this extension is permitted to emit. ` +
         "You can implement your own handlers that trigger when these events are emitted to customize the extension's behavior. ",
       choices: eventTypes,
       pageSize: 20,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

For large # of events, user doesn't know how many events there are and it can get overwhelming. A total count helps this.

<img width="1677" alt="Screen Shot 2022-04-29 at 12 30 38 PM" src="https://user-images.githubusercontent.com/64040981/165985839-f909cf13-2e4f-4e48-bcc8-036e9705f485.png">

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
