### PR TITLE
Add events config logic to ext:configure flow

### DIFF
--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -131,7 +131,9 @@ export default new Command("ext:configure <extensionInstanceId>")
       return;
     }
     if (!projectId) {
-      throw new FirebaseError(`Project ID must be provided when re-configuring an instance outside of local mode.`);
+      throw new FirebaseError(
+        `Project ID must be provided when re-configuring an instance outside of local mode.`
+      );
     }
     // TODO(b/220900194): Remove everything below and make --local the default behavior.
     const spinner = ora(

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -172,14 +172,16 @@ export default new Command("ext:configure <extensionInstanceId>")
             ", uninstall the extension, then install a new instance of this extension."
         );
       }
+      // Call needProjectId to guarantee that project ID exists, or this errors out.
+      const pId = needProjectId({ projectId });
       const spec = existingInstance ? existingInstance.config.source.spec : undefined;
       const eventsConfig = spec.events
-        ? await askUserForEventsConfig.askForEventsConfig(spec.events, projectId, instanceId)
+        ? await askUserForEventsConfig.askForEventsConfig(spec.events, pId, instanceId)
         : undefined;
       spinner.start();
 
       const configureOptions: any = {
-        projectId: needProjectId({ projectId }),
+        projectId: pId,
         instanceId,
         params: paramBindings,
       };

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -47,9 +47,6 @@ export default new Command("ext:configure <extensionInstanceId>")
   .before(diagnoseAndFixProject)
   .action(async (instanceId: string, options: Options) => {
     const projectId = getProjectId(options);
-    if (!projectId) {
-      throw new FirebaseError(`Project ID must be provided when re-configuring an instance.`);
-    }
 
     if (options.local) {
       if (options.nonInteractive) {
@@ -133,7 +130,9 @@ export default new Command("ext:configure <extensionInstanceId>")
       manifest.showPreviewWarning();
       return;
     }
-
+    if (!projectId) {
+      throw new FirebaseError(`Project ID must be provided when re-configuring an instance outside of local mode.`);
+    }
     // TODO(b/220900194): Remove everything below and make --local the default behavior.
     const spinner = ora(
       `Configuring ${clc.bold(instanceId)}. This usually takes 3 to 5 minutes...`
@@ -176,6 +175,7 @@ export default new Command("ext:configure <extensionInstanceId>")
         ? await askUserForEventsConfig.askForEventsConfig(spec.events, projectId, instanceId)
         : undefined;
       spinner.start();
+
       const configureOptions: any = {
         projectId: needProjectId({ projectId }),
         instanceId,

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -172,14 +172,15 @@ export default new Command("ext:configure <extensionInstanceId>")
         );
       }
       const spec = existingInstance ? existingInstance.config.source.spec : undefined;
-      const eventsConfig = spec.events ? await askUserForEventsConfig.askForEventsConfig(spec.events, projectId, instanceId)
-      : undefined;
+      const eventsConfig = spec.events
+        ? await askUserForEventsConfig.askForEventsConfig(spec.events, projectId, instanceId)
+        : undefined;
       spinner.start();
       const configureOptions: any = {
         projectId: needProjectId({ projectId }),
         instanceId,
         params: paramBindings,
-      }
+      };
       if (existingInstance.config.eventarcChannel !== eventsConfig?.channel) {
         configureOptions.eventarcChannel = eventsConfig?.channel;
       }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

In CLI we have an explicit reconfigure flow. We need to make this work with events (i.e. end user can change allowed event types + location)

<img width="1674" alt="Screen Shot 2022-04-29 at 12 32 18 PM" src="https://user-images.githubusercontent.com/64040981/165986055-3251c3c5-b62f-49d9-a93c-4dae8b6e078f.png">

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
