### PR TITLE
Fixing an issue where not providing a value for optional secrets would cause TypeErrors

### DIFF
--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -78,7 +78,7 @@ export async function writeLocalSecrets(
 
     const writeBuffer: Record<string, string> = {};
     const locallyOverridenSecretParams = extensionSpec.params.filter(
-      (p) => p.type === ParamType.SECRET && spec.params[p.param].local
+      (p) => p.type === ParamType.SECRET && spec.params[p.param]?.local
     );
     for (const paramSpec of locallyOverridenSecretParams) {
       const key = paramSpec.param;


### PR DESCRIPTION
### Description
@huangjeff5 noticed that when no value was set for an optional secret, we would throw a 'TypeError: cannot access property of undefined' here.

Very brief fix, but I validated that this is the right spot in the code to handle it (we're just looking for the secrets that are locally overwritten here, so if no value was provided we can safely skip it)
