### PR TITLE
Add tracking bug for GCFv1 => v2 upgrades

### DIFF
--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -262,6 +262,7 @@ export function checkForIllegalUpdate(want: backend.Endpoint, have: backend.Endp
 
   // We need to call from module exports so tests can stub this behavior, but that
   // breaks the type system.
+  // TODO(b/215563538): remove
   // eslint-disable-next-line
   exports.checkForV2Upgrade(want, have);
 }


### PR DESCRIPTION
Adding a todo with bug number to help make it obvious where to track progress for gen 1 => gen 2 upgrades.