### PR TITLE
Enhance the IAM role binding process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Add support for secrets to v2 functions (#4451).
 - Fixes an issue where `ext:export` would write different param values than what it displayed in the prompt (#4515).
+- Enhances the functions IAM permission process and updates the error messages (#4511).

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -116,12 +116,12 @@ export async function checkHttpIam(
 }
 
 /** obtain the pubsub service agent */
-function getPubsubServiceAgent(projectNumber: string) {
+function getPubsubServiceAgent(projectNumber: string): string {
   return `serviceAccount:service-${projectNumber}@gcp-sa-pubsub.iam.gserviceaccount.com`;
 }
 
 /** obtain the default compute service agent */
-function getDefaultComputeServiceAgent(projectNumber: string) {
+function getDefaultComputeServiceAgent(projectNumber: string): string {
   return `serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`;
 }
 
@@ -200,13 +200,15 @@ function printManualIamConfig(requiredBindings: iam.Binding[], projectId: string
     "warn"
   );
   for (const binding of requiredBindings) {
-    utils.logLabeledBullet(
-      "functions",
-      `\`gcloud projects add-iam-policy-binding ${projectId} ` +
-        `--member=${binding.members} ` +
-        `--role=${binding.role}\``,
-      "warn"
-    );
+    for (const member of binding.members) {
+      utils.logLabeledBullet(
+        "functions",
+        `\`gcloud projects add-iam-policy-binding ${projectId} ` +
+          `--member=${member} ` +
+          `--role=${binding.role}\``,
+        "warn"
+      );
+    }
   }
 }
 

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -115,6 +115,16 @@ export async function checkHttpIam(
   logger.debug("[functions] found setIamPolicy permission, proceeding with deploy");
 }
 
+/** obtain the pubsub service agent */
+function getPubsubServiceAgent(projectNumber: string) {
+  return `serviceAccount:service-${projectNumber}@gcp-sa-pubsub.iam.gserviceaccount.com`;
+}
+
+/** obtain the default compute service agent */
+function getDefaultComputeServiceAgent(projectNumber: string) {
+  return `serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`;
+}
+
 /** Callback reducer function */
 function reduceEventsToServices(services: Array<Service>, endpoint: backend.Endpoint) {
   const service = serviceForEndpoint(endpoint);
@@ -125,42 +135,17 @@ function reduceEventsToServices(services: Array<Service>, endpoint: backend.Endp
 }
 
 /**
- * Returns the IAM bindings that grants the role to the service account
- * @param existingPolicy the project level IAM policy
- * @param serviceAccount the IAM service account
- * @param role the role you want to grant
- * @return the correct IAM binding
- */
-export function obtainBinding(
-  existingPolicy: iam.Policy,
-  serviceAccount: string,
-  role: string
-): iam.Binding {
-  let binding = existingPolicy.bindings.find((b) => b.role === role);
-  if (!binding) {
-    binding = {
-      role,
-      members: [],
-    };
-  }
-  if (!binding.members.find((m) => m === serviceAccount)) {
-    binding.members.push(serviceAccount);
-  }
-  return binding;
-}
-
-/**
  * Finds the required project level IAM bindings for the Pub/Sub service agent.
  * If the user enabled Pub/Sub on or before April 8, 2021, then we must enable the token creator role.
  * @param projectNumber project number
  * @param existingPolicy the project level IAM policy
  */
-export function obtainPubSubServiceAgentBindings(
-  projectNumber: string,
-  existingPolicy: iam.Policy
-): iam.Binding[] {
-  const pubsubServiceAgent = `serviceAccount:service-${projectNumber}@gcp-sa-pubsub.iam.gserviceaccount.com`;
-  return [obtainBinding(existingPolicy, pubsubServiceAgent, SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE)];
+export function obtainPubSubServiceAgentBindings(projectNumber: string): iam.Binding[] {
+  const serviceAccountTokenCreatorBinding: iam.Binding = {
+    role: SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE,
+    members: [getPubsubServiceAgent(projectNumber)],
+  };
+  return [serviceAccountTokenCreatorBinding];
 }
 
 /**
@@ -169,57 +154,75 @@ export function obtainPubSubServiceAgentBindings(
  * @param projectNumber project number
  * @param existingPolicy the project level IAM policy
  */
-export function obtainDefaultComputeServiceAgentBindings(
-  projectNumber: string,
-  existingPolicy: iam.Policy
-): iam.Binding[] {
-  const defaultComputeServiceAgent = `serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`;
-  const invokerBinding = obtainBinding(
-    existingPolicy,
-    defaultComputeServiceAgent,
-    RUN_INVOKER_ROLE
-  );
-  const eventReceiverBinding = obtainBinding(
-    existingPolicy,
-    defaultComputeServiceAgent,
-    EVENTARC_EVENT_RECEIVER_ROLE
-  );
-  return [invokerBinding, eventReceiverBinding];
+export function obtainDefaultComputeServiceAgentBindings(projectNumber: string): iam.Binding[] {
+  const defaultComputeServiceAgent = getDefaultComputeServiceAgent(projectNumber);
+  const runInvokerBinding: iam.Binding = {
+    role: RUN_INVOKER_ROLE,
+    members: [defaultComputeServiceAgent],
+  };
+  const eventarcEventReceiverBinding: iam.Binding = {
+    role: EVENTARC_EVENT_RECEIVER_ROLE,
+    members: [defaultComputeServiceAgent],
+  };
+  return [runInvokerBinding, eventarcEventReceiverBinding];
 }
 
-/** Helper to merge all required bindings into the IAM policy */
-export function mergeBindings(policy: iam.Policy, allRequiredBindings: iam.Binding[][]) {
-  for (const requiredBindings of allRequiredBindings) {
-    if (requiredBindings.length === 0) {
+/** Helper to merge all required bindings into the IAM policy, returns boolean if the policy has been updated */
+export function mergeBindings(policy: iam.Policy, requiredBindings: iam.Binding[]): boolean {
+  let updated = false;
+  for (const requiredBinding of requiredBindings) {
+    const match = policy.bindings.find((b) => b.role === requiredBinding.role);
+    if (!match) {
+      updated = true;
+      policy.bindings.push(requiredBinding);
       continue;
     }
-    for (const requiredBinding of requiredBindings) {
-      const ndx = policy.bindings.findIndex(
-        (policyBinding) => policyBinding.role === requiredBinding.role
-      );
-      if (ndx === -1) {
-        policy.bindings.push(requiredBinding);
-        continue;
+    for (const requiredMember of requiredBinding.members) {
+      if (!match.members.find((m) => m === requiredMember)) {
+        updated = true;
+        match.members.push(requiredMember);
       }
-      requiredBinding.members.forEach((updatedMember) => {
-        if (!policy.bindings[ndx].members.find((member) => member === updatedMember)) {
-          policy.bindings[ndx].members.push(updatedMember);
-        }
-      });
     }
+  }
+  return updated;
+}
+
+/** Utility to print the required binding commands */
+function printManualIamConfig(requiredBindings: iam.Binding[], projectId: string) {
+  utils.logLabeledBullet(
+    "functions",
+    "Failed to verify the project has the correct IAM bindings for a successful deployment.",
+    "warn"
+  );
+  utils.logLabeledBullet(
+    "functions",
+    "You can either re-run `firebase deploy` as a project owner or manually run the following set of `gcloud` commands:",
+    "warn"
+  );
+  for (const binding of requiredBindings) {
+    utils.logLabeledBullet(
+      "functions",
+      `\`gcloud projects add-iam-policy-binding ${projectId} ` +
+        `--member=${binding.members} ` +
+        `--role=${binding.role}\``,
+      "warn"
+    );
   }
 }
 
 /**
  * Checks and sets the roles for specific resource service agents
+ * @param projectId human readable project id
  * @param projectNumber project number
  * @param want backend that we want to deploy
  * @param have backend that we have currently deployed
  */
 export async function ensureServiceAgentRoles(
+  projectId: string,
   projectNumber: string,
   want: backend.Backend,
-  have: backend.Backend
+  have: backend.Backend,
+  skipSleep = false
 ): Promise<void> {
   // find new services
   const wantServices = backend.allEndpoints(want).reduce(reduceEventsToServices, []);
@@ -230,11 +233,31 @@ export async function ensureServiceAgentRoles(
   if (newServices.length === 0) {
     return;
   }
+
+  // obtain all the bindings we need to have active in the project
+  const requiredBindingsPromises: Array<Promise<Array<iam.Binding>>> = [];
+  for (const service of newServices) {
+    requiredBindingsPromises.push(service.requiredProjectBindings!(projectNumber));
+  }
+  const nestedRequiredBindings = await Promise.all(requiredBindingsPromises);
+  const requiredBindings = nestedRequiredBindings.reduce((requiredBindings, binding) => {
+    requiredBindings.push(...binding);
+    return requiredBindings;
+  }, []);
+  if (haveServices.length === 0) {
+    requiredBindings.push(...obtainPubSubServiceAgentBindings(projectNumber));
+    requiredBindings.push(...obtainDefaultComputeServiceAgentBindings(projectNumber));
+  }
+  if (requiredBindings.length === 0) {
+    return;
+  }
+
   // get the full project iam policy
   let policy: iam.Policy;
   try {
     policy = await getIamPolicy(projectNumber);
   } catch (err: any) {
+    printManualIamConfig(requiredBindings, projectId);
     utils.logLabeledBullet(
       "functions",
       "Could not verify the necessary IAM configuration for the following newly-integrated services: " +
@@ -244,29 +267,27 @@ export async function ensureServiceAgentRoles(
     );
     return;
   }
-  // run in parallel all the missingProjectBindings jobs
-  const findRequiredBindings: Array<Promise<Array<iam.Binding>>> = [];
-  newServices.forEach((service) =>
-    findRequiredBindings.push(service.requiredProjectBindings!(projectNumber, policy))
-  );
-  const allRequiredBindings = await Promise.all(findRequiredBindings);
-  if (haveServices.length === 0) {
-    allRequiredBindings.push(obtainPubSubServiceAgentBindings(projectNumber, policy));
-    allRequiredBindings.push(obtainDefaultComputeServiceAgentBindings(projectNumber, policy));
-  }
-  if (!allRequiredBindings.find((bindings) => bindings.length > 0)) {
+  const hasUpdatedBindings = mergeBindings(policy, requiredBindings);
+  if (!hasUpdatedBindings) {
     return;
   }
-  mergeBindings(policy, allRequiredBindings);
+
   // set the updated policy
   try {
     await setIamPolicy(projectNumber, policy, "bindings");
   } catch (err: any) {
+    printManualIamConfig(requiredBindings, projectId);
     throw new FirebaseError(
       "We failed to modify the IAM policy for the project. The functions " +
         "deployment requires specific roles to be granted to service agents," +
         " otherwise the deployment will fail.",
       { original: err }
     );
+  }
+
+  if (!skipSleep) {
+    // sleep for 60 seconds to give time for role grants & enablement to propagate
+    utils.logLabeledBullet("functions", "Waiting for newly enabled services to catch up...");
+    await new Promise((r) => setTimeout(r, 60000));
   }
 }

--- a/src/deploy/functions/services/index.ts
+++ b/src/deploy/functions/services/index.ts
@@ -20,10 +20,7 @@ export interface Service {
   readonly api: string;
 
   // dispatch functions
-  requiredProjectBindings?: (
-    projectNumber: string,
-    policy: iam.Policy
-  ) => Promise<Array<iam.Binding>>;
+  requiredProjectBindings?: (projectNumber: string) => Promise<Array<iam.Binding>>;
   ensureTriggerRegion: (ep: backend.Endpoint & backend.EventTriggered) => Promise<void>;
   validateTrigger: (ep: backend.Endpoint, want: backend.Backend) => void;
   registerTrigger: (ep: backend.Endpoint) => Promise<void>;

--- a/src/deploy/functions/services/storage.ts
+++ b/src/deploy/functions/services/storage.ts
@@ -12,23 +12,15 @@ const PUBSUB_PUBLISHER_ROLE = "roles/pubsub.publisher";
  * @param projectId project identifier
  * @param existingPolicy the project level IAM policy
  */
-export async function obtainStorageBindings(
-  projectNumber: string,
-  existingPolicy: iam.Policy
-): Promise<Array<iam.Binding>> {
+export async function obtainStorageBindings(projectNumber: string): Promise<Array<iam.Binding>> {
   const storageResponse = await storage.getServiceAccount(projectNumber);
   const storageServiceAgent = `serviceAccount:${storageResponse.email_address}`;
-  let pubsubBinding = existingPolicy.bindings.find((b) => b.role === PUBSUB_PUBLISHER_ROLE);
-  if (!pubsubBinding) {
-    pubsubBinding = {
-      role: PUBSUB_PUBLISHER_ROLE,
-      members: [],
-    };
-  }
-  if (!pubsubBinding.members.find((m) => m === storageServiceAgent)) {
-    pubsubBinding.members.push(storageServiceAgent); // add service agent to role
-  }
-  return [pubsubBinding];
+
+  const pubsubPublisherBinding = {
+    role: PUBSUB_PUBLISHER_ROLE,
+    members: [storageServiceAgent],
+  };
+  return [pubsubPublisherBinding];
 }
 
 /**

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -225,14 +225,24 @@ export function mebibytes(memory: string): number {
  * @param err The error returned from the operation.
  */
 function functionsOpLogReject(funcName: string, type: string, err: any): void {
+  utils.logWarning(clc.bold.yellow("functions:") + ` ${err?.message}`);
   if (err?.context?.response?.statusCode === 429) {
     utils.logWarning(
       `${clc.bold.yellow(
         "functions:"
       )} got "Quota Exceeded" error while trying to ${type} ${funcName}. Waiting to retry...`
     );
+  } else if (
+    err?.message.includes(
+      "If you recently started to use Eventarc, it may take a few minutes before all necessary permissions are propagated to the Service Agent"
+    )
+  ) {
+    utils.logWarning(
+      `${clc.bold.yellow(
+        "functions:"
+      )} since this is your first time using functions v2, we need a little bit longer to finish setting everything up, please retry the deployment in a few minutes.`
+    );
   } else {
-    utils.logWarning(clc.bold.yellow("functions:") + ` ${err?.message}`);
     utils.logWarning(
       clc.bold.yellow("functions:") + " failed to " + type + " function " + funcName
     );

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -232,6 +232,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
       )} got "Quota Exceeded" error while trying to ${type} ${funcName}. Waiting to retry...`
     );
   } else {
+    utils.logWarning(clc.bold.yellow("functions:") + ` ${err?.message}`);
     utils.logWarning(
       clc.bold.yellow("functions:") + " failed to " + type + " function " + funcName
     );

--- a/src/gcp/serviceusage.ts
+++ b/src/gcp/serviceusage.ts
@@ -1,0 +1,33 @@
+import { bold } from "cli-color";
+import { serviceUsageOrigin } from "../api";
+import { Client } from "../apiv2";
+import { FirebaseError } from "../error";
+import * as utils from "../utils";
+
+const apiClient = new Client({
+  urlPrefix: serviceUsageOrigin,
+  apiVersion: "v1beta1",
+});
+
+/**
+ * Generate the service account for the service. Note: not every service uses the endpoint.
+ * @param projectNumber gcp project number
+ * @param service the service api (ex~ pubsub.googleapis.com)
+ * @returns
+ */
+export async function generateServiceIdentity(
+  projectNumber: string,
+  service: string,
+  prefix: string
+) {
+  utils.logLabeledBullet(prefix, `generating the service identity for ${bold(service)}...`);
+  try {
+    return await apiClient.post<unknown, unknown>(
+      `projects/${projectNumber}/services/${service}:generateServiceIdentity`
+    );
+  } catch (err: unknown) {
+    throw new FirebaseError(`Error generating the service identity for ${service}.`, {
+      original: err as Error,
+    });
+  }
+}

--- a/src/test/deploy/functions/checkIam.spec.ts
+++ b/src/test/deploy/functions/checkIam.spec.ts
@@ -5,6 +5,7 @@ import * as storage from "../../../gcp/storage";
 import * as rm from "../../../gcp/resourceManager";
 import * as backend from "../../../deploy/functions/backend";
 
+const projectId = "my-project";
 const projectNumber = "123456789";
 
 const STORAGE_RES = {
@@ -61,105 +62,9 @@ describe("checkIam", () => {
     ],
   };
 
-  describe("obtainBinding", () => {
-    it("should assign the service account the role if they don't exist in the policy", () => {
-      const policy = { ...iamPolicy };
-      const serviceAccount = "myServiceAccount";
-      const role = "role/myrole";
-
-      const bindings = checkIam.obtainBinding(policy, serviceAccount, role);
-
-      expect(bindings).to.deep.equal({
-        role,
-        members: [serviceAccount],
-      });
-    });
-
-    it("should append the service account as a member of the role when the role exists in the policy", () => {
-      const policy = { ...iamPolicy };
-      const serviceAccount = "myServiceAccount";
-      const role = "role/myrole";
-      policy.bindings = [
-        {
-          role,
-          members: ["someuser"],
-        },
-      ];
-
-      const bindings = checkIam.obtainBinding(policy, serviceAccount, role);
-
-      expect(bindings).to.deep.equal({
-        role,
-        members: ["someuser", serviceAccount],
-      });
-    });
-
-    it("should not add the role or service account if the policy already has the binding", () => {
-      const policy = { ...iamPolicy };
-      const serviceAccount = "myServiceAccount";
-      const role = "role/myrole";
-      policy.bindings = [
-        {
-          role,
-          members: [serviceAccount],
-        },
-      ];
-
-      const bindings = checkIam.obtainBinding(policy, serviceAccount, role);
-
-      expect(bindings).to.deep.equal({
-        role,
-        members: [serviceAccount],
-      });
-    });
-  });
-
   describe("obtainPubSubServiceAgentBindings", () => {
-    it("should add the binding", () => {
-      const policy = { ...iamPolicy };
-
-      const bindings = checkIam.obtainPubSubServiceAgentBindings(projectNumber, policy);
-
-      expect(bindings.length).to.equal(1);
-      expect(bindings[0]).to.deep.equal({
-        role: checkIam.SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE,
-        members: [`serviceAccount:service-${projectNumber}@gcp-sa-pubsub.iam.gserviceaccount.com`],
-      });
-    });
-
-    it("should add the service agent as a member", () => {
-      const policy = { ...iamPolicy };
-      policy.bindings = [
-        {
-          role: checkIam.SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE,
-          members: ["someuser"],
-        },
-      ];
-
-      const bindings = checkIam.obtainPubSubServiceAgentBindings(projectNumber, policy);
-
-      expect(bindings.length).to.equal(1);
-      expect(bindings[0]).to.deep.equal({
-        role: checkIam.SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE,
-        members: [
-          "someuser",
-          `serviceAccount:service-${projectNumber}@gcp-sa-pubsub.iam.gserviceaccount.com`,
-        ],
-      });
-    });
-
-    it("should do nothing if we have the binding", () => {
-      const policy = { ...iamPolicy };
-      policy.bindings = [
-        {
-          role: checkIam.SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE,
-          members: [
-            `serviceAccount:service-${projectNumber}@gcp-sa-pubsub.iam.gserviceaccount.com`,
-          ],
-        },
-      ];
-
-      const bindings = checkIam.obtainPubSubServiceAgentBindings(projectNumber, policy);
+    it("should obtain the bindings", () => {
+      const bindings = checkIam.obtainPubSubServiceAgentBindings(projectNumber);
 
       expect(bindings.length).to.equal(1);
       expect(bindings[0]).to.deep.equal({
@@ -170,10 +75,8 @@ describe("checkIam", () => {
   });
 
   describe("obtainDefaultComputeServiceAgentBindings", () => {
-    it("should add both bindings", () => {
-      const policy = { ...iamPolicy };
-
-      const bindings = checkIam.obtainDefaultComputeServiceAgentBindings(projectNumber, policy);
+    it("should obtain the bindings", () => {
+      const bindings = checkIam.obtainDefaultComputeServiceAgentBindings(projectNumber);
 
       expect(bindings.length).to.equal(2);
       expect(bindings).to.include.deep.members([
@@ -190,27 +93,29 @@ describe("checkIam", () => {
   });
 
   describe("mergeBindings", () => {
-    it("should skip empty or duplicate bindings", () => {
+    it("should not update the policy when the bindings are present", () => {
       const policy = {
         etag: "etag",
         version: 3,
         bindings: [BINDING],
       };
 
-      checkIam.mergeBindings(policy, [[], [BINDING]]);
+      const updated = checkIam.mergeBindings(policy, [BINDING]);
 
+      expect(updated).to.be.false;
       expect(policy.bindings).to.deep.equal([BINDING]);
     });
 
-    it("should update current binding", () => {
+    it("should update the members of a binding in the policy", () => {
       const policy = {
         etag: "etag",
         version: 3,
         bindings: [BINDING],
       };
 
-      checkIam.mergeBindings(policy, [[{ role: "some/role", members: ["newuser"] }]]);
+      const updated = checkIam.mergeBindings(policy, [{ role: "some/role", members: ["newuser"] }]);
 
+      expect(updated).to.be.true;
       expect(policy.bindings).to.deep.equal([
         {
           role: "some/role",
@@ -219,44 +124,22 @@ describe("checkIam", () => {
       ]);
     });
 
-    it("should add the binding", () => {
+    it("should add a new binding to the policy", () => {
       const policy = {
         etag: "etag",
         version: 3,
         bindings: [],
       };
 
-      checkIam.mergeBindings(policy, [[BINDING]]);
+      const updated = checkIam.mergeBindings(policy, [BINDING]);
 
+      expect(updated).to.be.true;
       expect(policy.bindings).to.deep.equal([BINDING]);
     });
   });
 
   describe("ensureServiceAgentRoles", () => {
-    it("should return early if we fail to get the IAM policy", async () => {
-      getIamStub.rejects("Failed to get the IAM policy");
-      const wantFn: backend.Endpoint = {
-        id: "wantFn",
-        entryPoint: "wantFn",
-        platform: "gcfv2",
-        eventTrigger: {
-          eventType: "google.cloud.storage.object.v1.finalized",
-          eventFilters: { bucket: "my-bucket" },
-          retry: false,
-        },
-        ...SPEC,
-      };
-
-      await expect(
-        checkIam.ensureServiceAgentRoles(projectNumber, backend.of(wantFn), backend.empty())
-      ).to.not.be.rejected;
-      expect(getIamStub).to.have.been.calledOnce;
-      expect(getIamStub).to.have.been.calledWith(projectNumber);
-      expect(storageStub).to.not.have.been.called;
-      expect(setIamStub).to.not.have.been.called;
-    });
-
-    it("should skip v1, callable, and deployed functions", async () => {
+    it("should return early if we do not have new services", async () => {
       const v1EventFn: backend.Endpoint = {
         id: "v1eventfn",
         entryPoint: "v1Fn",
@@ -288,9 +171,11 @@ describe("checkIam", () => {
       };
 
       await checkIam.ensureServiceAgentRoles(
+        projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.of(v1EventFn, v2CallableFn, wantFn)
+        backend.of(v1EventFn, v2CallableFn, wantFn),
+        true
       );
 
       expect(storageStub).to.not.have.been.called;
@@ -298,7 +183,9 @@ describe("checkIam", () => {
       expect(setIamStub).to.not.have.been.called;
     });
 
-    it("should skip if we have a deployed event fn of the same kind", async () => {
+    it("should return early if we fail to get the IAM policy", async () => {
+      storageStub.resolves(STORAGE_RES);
+      getIamStub.rejects("Failed to get the IAM policy");
       const wantFn: backend.Endpoint = {
         id: "wantFn",
         entryPoint: "wantFn",
@@ -310,23 +197,58 @@ describe("checkIam", () => {
         },
         ...SPEC,
       };
-      const haveFn: backend.Endpoint = {
-        id: "haveFn",
-        entryPoint: "haveFn",
+
+      await expect(
+        checkIam.ensureServiceAgentRoles(
+          projectId,
+          projectNumber,
+          backend.of(wantFn),
+          backend.empty(),
+          true
+        )
+      ).to.not.be.rejected;
+      expect(storageStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledWith(projectNumber);
+      expect(setIamStub).to.not.have.been.called;
+    });
+
+    it("should error if we fail to set the IAM policy", async () => {
+      storageStub.resolves(STORAGE_RES);
+      getIamStub.resolves({
+        etag: "etag",
+        version: 3,
+        bindings: [BINDING],
+      });
+      const wantFn: backend.Endpoint = {
+        id: "wantFn",
+        entryPoint: "wantFn",
         platform: "gcfv2",
         eventTrigger: {
-          eventType: "google.cloud.storage.object.v1.metadataUpdated",
+          eventType: "google.cloud.storage.object.v1.finalized",
           eventFilters: { bucket: "my-bucket" },
           retry: false,
         },
         ...SPEC,
       };
 
-      await checkIam.ensureServiceAgentRoles(projectNumber, backend.of(wantFn), backend.of(haveFn));
-
-      expect(storageStub).to.not.have.been.called;
-      expect(getIamStub).to.not.have.been.called;
-      expect(setIamStub).to.not.have.been.called;
+      await expect(
+        checkIam.ensureServiceAgentRoles(
+          projectId,
+          projectNumber,
+          backend.of(wantFn),
+          backend.empty(),
+          true
+        )
+      ).to.be.rejectedWith(
+        "We failed to modify the IAM policy for the project. The functions " +
+          "deployment requires specific roles to be granted to service agents," +
+          " otherwise the deployment will fail."
+      );
+      expect(storageStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledWith(projectNumber);
+      expect(setIamStub).to.have.been.calledOnce;
     });
 
     it("should add the pubsub publisher role and all default bindings for a new v2 storage function without v2 deployed functions", async () => {
@@ -374,7 +296,13 @@ describe("checkIam", () => {
         ...SPEC,
       };
 
-      await checkIam.ensureServiceAgentRoles(projectNumber, backend.of(wantFn), backend.empty());
+      await checkIam.ensureServiceAgentRoles(
+        projectId,
+        projectNumber,
+        backend.of(wantFn),
+        backend.empty(),
+        true
+      );
 
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -425,7 +353,13 @@ describe("checkIam", () => {
       ...SPEC,
     };
 
-    await checkIam.ensureServiceAgentRoles(projectNumber, backend.of(wantFn), backend.of(haveFn));
+    await checkIam.ensureServiceAgentRoles(
+      projectId,
+      projectNumber,
+      backend.of(wantFn),
+      backend.of(haveFn),
+      true
+    );
 
     expect(storageStub).to.have.been.calledOnce;
     expect(getIamStub).to.have.been.calledOnce;
@@ -473,7 +407,13 @@ describe("checkIam", () => {
       ...SPEC,
     };
 
-    await checkIam.ensureServiceAgentRoles(projectNumber, backend.of(wantFn), backend.empty());
+    await checkIam.ensureServiceAgentRoles(
+      projectId,
+      projectNumber,
+      backend.of(wantFn),
+      backend.empty(),
+      true
+    );
 
     expect(getIamStub).to.have.been.calledOnce;
     expect(setIamStub).to.have.been.calledOnce;
@@ -481,17 +421,6 @@ describe("checkIam", () => {
   });
 
   it("should not add bindings for a new v2 alerts function with v2 deployed functions", async () => {
-    const newIamPolicy = {
-      etag: "etag",
-      version: 3,
-      bindings: [BINDING],
-    };
-    getIamStub.resolves({
-      etag: "etag",
-      version: 3,
-      bindings: [BINDING],
-    });
-    setIamStub.resolves(newIamPolicy);
     const wantFn: backend.Endpoint = {
       id: "wantFn",
       entryPoint: "wantFn",
@@ -515,9 +444,15 @@ describe("checkIam", () => {
       ...SPEC,
     };
 
-    await checkIam.ensureServiceAgentRoles(projectNumber, backend.of(wantFn), backend.of(haveFn));
+    await checkIam.ensureServiceAgentRoles(
+      projectId,
+      projectNumber,
+      backend.of(wantFn),
+      backend.of(haveFn),
+      true
+    );
 
-    expect(getIamStub).to.have.been.calledOnce;
+    expect(getIamStub).to.not.have.been.called;
     expect(setIamStub).to.not.have.been.called;
   });
 });

--- a/src/test/deploy/functions/checkIam.spec.ts
+++ b/src/test/deploy/functions/checkIam.spec.ts
@@ -174,8 +174,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.of(v1EventFn, v2CallableFn, wantFn),
-        true
+        backend.of(v1EventFn, v2CallableFn, wantFn)
       );
 
       expect(storageStub).to.not.have.been.called;
@@ -203,8 +202,7 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty(),
-          true
+          backend.empty()
         )
       ).to.not.be.rejected;
       expect(storageStub).to.have.been.calledOnce;
@@ -237,8 +235,7 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty(),
-          true
+          backend.empty()
         )
       ).to.be.rejectedWith(
         "We failed to modify the IAM policy for the project. The functions " +
@@ -300,8 +297,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.empty(),
-        true
+        backend.empty()
       );
 
       expect(storageStub).to.have.been.calledOnce;
@@ -357,8 +353,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
-      true
+      backend.of(haveFn)
     );
 
     expect(storageStub).to.have.been.calledOnce;
@@ -411,8 +406,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
-      true
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -448,8 +442,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
-      true
+      backend.of(haveFn)
     );
 
     expect(getIamStub).to.not.have.been.called;

--- a/src/test/deploy/functions/services/storage.spec.ts
+++ b/src/test/deploy/functions/services/storage.spec.ts
@@ -10,11 +10,6 @@ const STORAGE_RES = {
   kind: "storage#serviceAccount",
 };
 
-const BINDING = {
-  role: "some/role",
-  members: ["someuser"],
-};
-
 describe("obtainStorageBindings", () => {
   let storageStub: sinon.SinonStub;
 
@@ -28,55 +23,11 @@ describe("obtainStorageBindings", () => {
     sinon.verifyAndRestore();
   });
 
-  it("should return pubsub binding when missing from the policy", async () => {
+  it("should return the correct storage binding", async () => {
     storageStub.resolves(STORAGE_RES);
-    const existingPolicy = {
-      etag: "etag",
-      version: 3,
-      bindings: [BINDING],
-    };
 
-    const bindings = await obtainStorageBindings(projectNumber, existingPolicy);
+    const bindings = await obtainStorageBindings(projectNumber);
 
-    expect(bindings.length).to.equal(1);
-    expect(bindings[0]).to.deep.equal({
-      role: "roles/pubsub.publisher",
-      members: [`serviceAccount:${STORAGE_RES.email_address}`],
-    });
-  });
-
-  it("should return the updated pubsub binding from the policy", async () => {
-    storageStub.resolves(STORAGE_RES);
-    const existingPolicy = {
-      etag: "etag",
-      version: 3,
-      bindings: [BINDING, { role: "roles/pubsub.publisher", members: ["someuser"] }],
-    };
-
-    const bindings = await obtainStorageBindings(projectNumber, existingPolicy);
-
-    expect(bindings.length).to.equal(1);
-    expect(bindings[0]).to.deep.equal({
-      role: "roles/pubsub.publisher",
-      members: ["someuser", `serviceAccount:${STORAGE_RES.email_address}`],
-    });
-  });
-
-  it("should return the binding from policy if already present", async () => {
-    storageStub.resolves(STORAGE_RES);
-    const existingPolicy = {
-      etag: "etag",
-      version: 3,
-      bindings: [
-        BINDING,
-        {
-          role: "roles/pubsub.publisher",
-          members: [`serviceAccount:${STORAGE_RES.email_address}`],
-        },
-      ],
-    };
-
-    const bindings = await obtainStorageBindings(projectNumber, existingPolicy);
     expect(bindings.length).to.equal(1);
     expect(bindings[0]).to.deep.equal({
       role: "roles/pubsub.publisher",


### PR DESCRIPTION
- Changes up the ordering of `ensureServiceAgentRoles`
- Creates jump out points so we don't re-try to set permissions
- Adds better logging & warnings
- Adds a 60 second sleep to the process