### PR TITLE
Fix update flow such that users can turn off events

### DIFF
--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -185,11 +185,14 @@ export default new Command("ext:configure <extensionInstanceId>")
         instanceId,
         params: paramBindings,
       };
-      if (existingInstance.config.eventarcChannel !== eventsConfig?.channel) {
-        configureOptions.eventarcChannel = eventsConfig?.channel;
-      }
-      if (existingInstance.config.allowedEventTypes !== eventsConfig?.allowedEventTypes) {
-        configureOptions.allowedEventTypes = eventsConfig?.allowedEventTypes;
+      if (eventsConfig) {
+        configureOptions.canEmitEvents = true;
+        configureOptions.eventarcChannel = eventsConfig.channel;
+        configureOptions.allowedEventTypes = eventsConfig.allowedEventTypes;
+      } else {
+        configureOptions.canEmitEvents = false;
+        configureOptions.eventarcChannel = undefined;
+        configureOptions.allowedEventTypes = undefined;
       }
       const res = await extensionsApi.configureInstance(configureOptions);
       spinner.stop();

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -184,16 +184,10 @@ export default new Command("ext:configure <extensionInstanceId>")
         projectId: pId,
         instanceId,
         params: paramBindings,
+        canEmitEvents: eventsConfig ? true : false,
+        eventarcChannel: eventsConfig?.channel,
+        allowedEventTypes: eventsConfig?.allowedEventTypes,
       };
-      if (eventsConfig) {
-        configureOptions.canEmitEvents = true;
-        configureOptions.eventarcChannel = eventsConfig.channel;
-        configureOptions.allowedEventTypes = eventsConfig.allowedEventTypes;
-      } else {
-        configureOptions.canEmitEvents = false;
-        configureOptions.eventarcChannel = undefined;
-        configureOptions.allowedEventTypes = undefined;
-      }
       const res = await extensionsApi.configureInstance(configureOptions);
       spinner.stop();
       utils.logLabeledSuccess(logPrefix, `successfully configured ${clc.bold(instanceId)}.`);

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -418,7 +418,6 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
           paramsEnvPath,
           instanceId,
         });
-        const existingInstance = await extensionsApi.getInstance(projectId, instanceId);
         eventsConfig = spec.events
           ? await askUserForEventsConfig.askForEventsConfig(spec.events, projectId, instanceId)
           : undefined;
@@ -429,18 +428,12 @@ async function installExtension(options: InstallExtensionOptions): Promise<void>
           projectId,
           instanceId,
           source,
+          canEmitEvents: eventsConfig ? true : false,
+          eventarcChannel: eventsConfig?.channel,
+          allowedEventTypes: eventsConfig?.allowedEventTypes,
           extRef: extVersion?.ref,
           params: paramBindings,
         };
-        if (existingInstance.config.eventarcChannel !== eventsConfig?.channel) {
-          updateOptions.eventarcChannel = eventsConfig?.channel;
-        }
-        if (
-          JSON.stringify((existingInstance.config.allowedEventTypes || []).sort()) !==
-          JSON.stringify((eventsConfig?.allowedEventTypes || []).sort())
-        ) {
-          updateOptions.allowedEventTypes = eventsConfig?.allowedEventTypes;
-        }
         await update(updateOptions);
         spinner.stop();
         utils.logLabeledSuccess(

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -352,6 +352,9 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
       const updateOptions: UpdateOptions = {
         projectId,
         instanceId,
+        canEmitEvents: eventsConfig ? true : false,
+        eventarcChannel: eventsConfig?.channel,
+        allowedEventTypes: eventsConfig?.allowedEventTypes,
       };
       if (newSourceName.includes("publisher")) {
         updateOptions.extRef = refs.toExtensionVersionRef(refs.parse(newSourceName));
@@ -360,12 +363,6 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
       }
       if (!_.isEqual(newParams, oldParamValues)) {
         updateOptions.params = newParams;
-      }
-      if (existingInstance.config.eventarcChannel !== eventsConfig?.channel) {
-        updateOptions.eventarcChannel = eventsConfig?.channel;
-      }
-      if (existingInstance.config.allowedEventTypes !== eventsConfig?.allowedEventTypes) {
-        updateOptions.allowedEventTypes = eventsConfig?.allowedEventTypes;
       }
       await update(updateOptions);
       spinner.stop();

--- a/src/deploy/extensions/tasks.ts
+++ b/src/deploy/extensions/tasks.ts
@@ -50,6 +50,8 @@ export function createExtensionInstanceTask(
         instanceId: instanceSpec.instanceId,
         params: instanceSpec.params,
         extensionVersionRef: refs.toExtensionVersionRef(instanceSpec.ref),
+        allowedEventTypes: instanceSpec.allowedEventTypes,
+        eventarcChannel: instanceSpec.eventarcChannel,
         validateOnly,
       });
     } else if (instanceSpec.localPath) {
@@ -59,6 +61,8 @@ export function createExtensionInstanceTask(
         instanceId: instanceSpec.instanceId,
         params: instanceSpec.params,
         extensionSource,
+        allowedEventTypes: instanceSpec.allowedEventTypes,
+        eventarcChannel: instanceSpec.eventarcChannel,
         validateOnly,
       });
     } else {
@@ -88,6 +92,9 @@ export function updateExtensionInstanceTask(
         instanceId: instanceSpec.instanceId,
         extRef: refs.toExtensionVersionRef(instanceSpec.ref!),
         params: instanceSpec.params,
+        canEmitEvents: instanceSpec.allowedEventTypes !== null,
+        allowedEventTypes: instanceSpec.allowedEventTypes,
+        eventarcChannel: instanceSpec.eventarcChannel,
         validateOnly,
       });
     } else if (instanceSpec.localPath) {
@@ -97,6 +104,9 @@ export function updateExtensionInstanceTask(
         instanceId: instanceSpec.instanceId,
         extensionSource,
         validateOnly,
+        canEmitEvents: instanceSpec.allowedEventTypes !== null,
+        allowedEventTypes: instanceSpec.allowedEventTypes,
+        eventarcChannel: instanceSpec.eventarcChannel,
       });
     } else {
       throw new FirebaseError(
@@ -124,6 +134,9 @@ export function configureExtensionInstanceTask(
         projectId,
         instanceId: instanceSpec.instanceId,
         params: instanceSpec.params,
+        canEmitEvents: instanceSpec.allowedEventTypes !== null,
+        allowedEventTypes: instanceSpec.allowedEventTypes,
+        eventarcChannel: instanceSpec.eventarcChannel,
         validateOnly,
       });
     } else if (instanceSpec.localPath) {

--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -389,11 +389,7 @@ export async function configureInstance(args: {
       },
     },
   };
-  if (!args.canEmitEvents) {
-    reqBody.data.config.allowedEventTypes = undefined;
-    reqBody.data.config.eventarcChannel = undefined;
-    reqBody.updateMask += ",config.allowed_event_types,config.eventarc_channel";
-  } else {
+  if (args.canEmitEvents) {
     if (args.allowedEventTypes === undefined || args.eventarcChannel === undefined) {
       throw new FirebaseError(
         `This instance is configured to emit events, but either allowed event types or eventarc channel is undefined.`
@@ -401,8 +397,8 @@ export async function configureInstance(args: {
     }
     reqBody.data.config.allowedEventTypes = args.allowedEventTypes;
     reqBody.data.config.eventarcChannel = args.eventarcChannel;
-    reqBody.updateMask += ",config.allowed_event_types,config.eventarc_channel";
   }
+  reqBody.updateMask += ",config.allowed_event_types,config.eventarc_channel";
   return patchInstance(reqBody);
 }
 
@@ -437,12 +433,7 @@ export async function updateInstance(args: {
     body.config.params = args.params;
     updateMask += ",config.params";
   }
-
-  if (!args.canEmitEvents) {
-    body.config.allowedEventTypes = undefined;
-    body.config.eventarcChannel = undefined;
-    updateMask += ",config.allowed_event_types,config.eventarc_channel";
-  } else {
+  if (args.canEmitEvents) {
     if (args.allowedEventTypes === undefined || args.eventarcChannel === undefined) {
       throw new FirebaseError(
         `This instance is configured to emit events, but either allowed event types or eventarc channel is undefined.`
@@ -450,8 +441,8 @@ export async function updateInstance(args: {
     }
     body.config.allowedEventTypes = args.allowedEventTypes;
     body.config.eventarcChannel = args.eventarcChannel;
-    updateMask += ",config.allowed_event_types,config.eventarc_channel";
   }
+  updateMask += ",config.allowed_event_types,config.eventarc_channel";
   return patchInstance({
     projectId: args.projectId,
     instanceId: args.instanceId,
@@ -494,11 +485,7 @@ export async function updateInstanceFromRegistry(args: {
     body.config.params = args.params;
     updateMask += ",config.params";
   }
-  if (!args.canEmitEvents) {
-    body.config.allowedEventTypes = undefined;
-    body.config.eventarcChannel = undefined;
-    updateMask += ",config.allowed_event_types,config.eventarc_channel";
-  } else {
+  if (args.canEmitEvents) {
     if (args.allowedEventTypes === undefined || args.eventarcChannel === undefined) {
       throw new FirebaseError(
         `This instance is configured to emit events, but either allowed event types or eventarc channel is undefined.`
@@ -506,9 +493,8 @@ export async function updateInstanceFromRegistry(args: {
     }
     body.config.allowedEventTypes = args.allowedEventTypes;
     body.config.eventarcChannel = args.eventarcChannel;
-    updateMask += ",config.allowed_event_types,config.eventarc_channel";
   }
-
+  updateMask += ",config.allowed_event_types,config.eventarc_channel";
   return patchInstance({
     projectId: args.projectId,
     instanceId: args.instanceId,

--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -373,6 +373,7 @@ export async function configureInstance(args: {
   projectId: string;
   instanceId: string;
   params: { [option: string]: string };
+  canEmitEvents: boolean;
   allowedEventTypes?: string[];
   eventarcChannel?: string;
   validateOnly?: boolean;
@@ -388,14 +389,19 @@ export async function configureInstance(args: {
       },
     },
   };
-  if (args.allowedEventTypes !== undefined) {
+  if (!args.canEmitEvents) {
+    reqBody.data.config.allowedEventTypes = undefined;
+    reqBody.data.config.eventarcChannel = undefined;
+    reqBody.updateMask += ",config.allowed_event_types,config.eventarc_channel";
+  } else {
+    if (args.allowedEventTypes === undefined || args.eventarcChannel === undefined) {
+      throw new FirebaseError(
+        `This instance is configured to emit events, but either allowed event types or eventarc channel is undefined.`
+      );
+    }
     reqBody.data.config.allowedEventTypes = args.allowedEventTypes;
-    reqBody.updateMask += ",config.allowed_event_types";
-  }
-
-  if (args.eventarcChannel !== undefined) {
     reqBody.data.config.eventarcChannel = args.eventarcChannel;
-    reqBody.updateMask += ",config.eventarc_channel";
+    reqBody.updateMask += ",config.allowed_event_types,config.eventarc_channel";
   }
   return patchInstance(reqBody);
 }
@@ -416,6 +422,7 @@ export async function updateInstance(args: {
   instanceId: string;
   extensionSource: ExtensionSource;
   params?: { [option: string]: string };
+  canEmitEvents: boolean;
   allowedEventTypes?: string[];
   eventarcChannel?: string;
   validateOnly?: boolean;
@@ -430,14 +437,20 @@ export async function updateInstance(args: {
     body.config.params = args.params;
     updateMask += ",config.params";
   }
-  if (args.allowedEventTypes !== undefined) {
-    body.config.allowedEventTypes = args.allowedEventTypes;
-    updateMask += ",config.allowed_event_types";
-  }
 
-  if (args.eventarcChannel !== undefined) {
+  if (!args.canEmitEvents) {
+    body.config.allowedEventTypes = undefined;
+    body.config.eventarcChannel = undefined;
+    updateMask += ",config.allowed_event_types,config.eventarc_channel";
+  } else {
+    if (args.allowedEventTypes === undefined || args.eventarcChannel === undefined) {
+      throw new FirebaseError(
+        `This instance is configured to emit events, but either allowed event types or eventarc channel is undefined.`
+      );
+    }
+    body.config.allowedEventTypes = args.allowedEventTypes;
     body.config.eventarcChannel = args.eventarcChannel;
-    updateMask += ",config.eventarc_channel";
+    updateMask += ",config.allowed_event_types,config.eventarc_channel";
   }
   return patchInstance({
     projectId: args.projectId,
@@ -464,6 +477,7 @@ export async function updateInstanceFromRegistry(args: {
   instanceId: string;
   extRef: string;
   params?: { [option: string]: string };
+  canEmitEvents: boolean;
   allowedEventTypes?: string[];
   eventarcChannel?: string;
   validateOnly?: boolean;
@@ -480,15 +494,21 @@ export async function updateInstanceFromRegistry(args: {
     body.config.params = args.params;
     updateMask += ",config.params";
   }
-  if (args.allowedEventTypes !== undefined) {
+  if (!args.canEmitEvents) {
+    body.config.allowedEventTypes = undefined;
+    body.config.eventarcChannel = undefined;
+    updateMask += ",config.allowed_event_types,config.eventarc_channel";
+  } else {
+    if (args.allowedEventTypes === undefined || args.eventarcChannel === undefined) {
+      throw new FirebaseError(
+        `This instance is configured to emit events, but either allowed event types or eventarc channel is undefined.`
+      );
+    }
     body.config.allowedEventTypes = args.allowedEventTypes;
-    updateMask += ",config.allowed_event_types";
+    body.config.eventarcChannel = args.eventarcChannel;
+    updateMask += ",config.allowed_event_types,config.eventarc_channel";
   }
 
-  if (args.eventarcChannel !== undefined) {
-    body.config.eventarcChannel = args.eventarcChannel;
-    updateMask += ",config.eventarc_channel";
-  }
   return patchInstance({
     projectId: args.projectId,
     instanceId: args.instanceId,

--- a/src/extensions/updateHelper.ts
+++ b/src/extensions/updateHelper.ts
@@ -122,6 +122,7 @@ export interface UpdateOptions {
   source?: extensionsApi.ExtensionSource;
   extRef?: string;
   params?: { [key: string]: string };
+  canEmitEvents: boolean;
   allowedEventTypes?: string[];
   eventarcChannel?: string;
 }
@@ -135,14 +136,23 @@ export interface UpdateOptions {
  * @param updateOptions Info on the instance and associated resources to update
  */
 export async function update(updateOptions: UpdateOptions): Promise<any> {
-  const { projectId, instanceId, source, extRef, params, allowedEventTypes, eventarcChannel } =
-    updateOptions;
+  const {
+    projectId,
+    instanceId,
+    source,
+    extRef,
+    params,
+    canEmitEvents,
+    allowedEventTypes,
+    eventarcChannel,
+  } = updateOptions;
   if (extRef) {
     return await extensionsApi.updateInstanceFromRegistry({
       projectId,
       instanceId,
       extRef,
       params,
+      canEmitEvents,
       allowedEventTypes,
       eventarcChannel,
     });
@@ -152,6 +162,7 @@ export async function update(updateOptions: UpdateOptions): Promise<any> {
       instanceId,
       extensionSource: source,
       params,
+      canEmitEvents,
       allowedEventTypes,
       eventarcChannel,
     });

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -310,7 +310,10 @@ describe("extensions", () => {
     it("should make a PATCH call to the correct endpoint, and then poll on the returned operation", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.params", validateOnly: "false" })
+        .query({
+          updateMask: "config.params,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: "false",
+        })
         .reply(200, { name: "operations/abc123" });
       nock(api.extensionsOrigin)
         .get(`/${VERSION}/operations/abc123`)
@@ -322,6 +325,7 @@ describe("extensions", () => {
         projectId: PROJECT_ID,
         instanceId: INSTANCE_ID,
         params: { MY_PARAM: "value" },
+        canEmitEvents: false,
       });
       expect(nock.isDone()).to.be.true;
     });
@@ -329,7 +333,10 @@ describe("extensions", () => {
     it("should make a PATCH and not poll if validateOnly=true", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.params", validateOnly: "true" })
+        .query({
+          updateMask: "config.params,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: "true",
+        })
         .reply(200, { name: "operations/abc123", done: true });
 
       await extensionsApi.configureInstance({
@@ -337,6 +344,7 @@ describe("extensions", () => {
         instanceId: INSTANCE_ID,
         params: { MY_PARAM: "value" },
         validateOnly: true,
+        canEmitEvents: false,
       });
       expect(nock.isDone()).to.be.true;
     });
@@ -344,7 +352,10 @@ describe("extensions", () => {
     it("should throw a FirebaseError if update returns an error response", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.params", validateOnly: false })
+        .query({
+          updateMask: "config.params,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: false,
+        })
         .reply(500);
 
       await expect(
@@ -352,6 +363,7 @@ describe("extensions", () => {
           projectId: PROJECT_ID,
           instanceId: INSTANCE_ID,
           params: { MY_PARAM: "value" },
+          canEmitEvents: false,
         })
       ).to.be.rejectedWith(FirebaseError, "HTTP Error: 500");
       expect(nock.isDone()).to.be.true;
@@ -406,7 +418,11 @@ describe("extensions", () => {
     it("should include config.param in updateMask is params are changed", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.source.name,config.params", validateOnly: "false" })
+        .query({
+          updateMask:
+            "config.source.name,config.params,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: "false",
+        })
         .reply(200, { name: "operations/abc123" });
       nock(api.extensionsOrigin).get(`/${VERSION}/operations/abc123`).reply(200, { done: true });
 
@@ -417,6 +433,7 @@ describe("extensions", () => {
         params: {
           MY_PARAM: "value",
         },
+        canEmitEvents: false,
       });
 
       expect(nock.isDone()).to.be.true;
@@ -425,7 +442,10 @@ describe("extensions", () => {
     it("should not include config.param in updateMask is params aren't changed", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.source.name", validateOnly: "false" })
+        .query({
+          updateMask: "config.source.name,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: "false",
+        })
         .reply(200, { name: "operations/abc123" });
       nock(api.extensionsOrigin).get(`/${VERSION}/operations/abc123`).reply(200, { done: true });
 
@@ -433,15 +453,43 @@ describe("extensions", () => {
         projectId: PROJECT_ID,
         instanceId: INSTANCE_ID,
         extensionSource: testSource,
+        canEmitEvents: false,
       });
+      expect(nock.isDone()).to.be.true;
+    });
 
+    it("should include config.allowed_event_types and config.eventarc_Channel in updateMask if events config is provided", async () => {
+      nock(api.extensionsOrigin)
+        .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
+        .query({
+          updateMask:
+            "config.source.name,config.params,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: "false",
+        })
+        .reply(200, { name: "operations/abc123" });
+      nock(api.extensionsOrigin).get(`/${VERSION}/operations/abc123`).reply(200, { done: true });
+
+      await extensionsApi.updateInstance({
+        projectId: PROJECT_ID,
+        instanceId: INSTANCE_ID,
+        extensionSource: testSource,
+        params: {
+          MY_PARAM: "value",
+        },
+        canEmitEvents: true,
+        eventarcChannel: "projects/${PROJECT_ID}/locations/us-central1/channels/firebase",
+        allowedEventTypes: ["google.firebase.custom-events-occurred"],
+      });
       expect(nock.isDone()).to.be.true;
     });
 
     it("should make a PATCH and not poll if validateOnly=true", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.source.name", validateOnly: "true" })
+        .query({
+          updateMask: "config.source.name,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: "true",
+        })
         .reply(200, { name: "operations/abc123", done: true });
 
       await extensionsApi.updateInstance({
@@ -449,6 +497,7 @@ describe("extensions", () => {
         instanceId: INSTANCE_ID,
         extensionSource: testSource,
         validateOnly: true,
+        canEmitEvents: false,
       });
       expect(nock.isDone()).to.be.true;
     });
@@ -456,7 +505,10 @@ describe("extensions", () => {
     it("should make a PATCH and not poll if validateOnly=true", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.source.name", validateOnly: "true" })
+        .query({
+          updateMask: "config.source.name,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: "true",
+        })
         .reply(200, { name: "operations/abc123", done: true });
 
       await extensionsApi.updateInstance({
@@ -464,6 +516,7 @@ describe("extensions", () => {
         instanceId: INSTANCE_ID,
         extensionSource: testSource,
         validateOnly: true,
+        canEmitEvents: false,
       });
       expect(nock.isDone()).to.be.true;
     });
@@ -471,7 +524,11 @@ describe("extensions", () => {
     it("should throw a FirebaseError if update returns an error response", async () => {
       nock(api.extensionsOrigin)
         .patch(`/${VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
-        .query({ updateMask: "config.source.name,config.params", validateOnly: false })
+        .query({
+          updateMask:
+            "config.source.name,config.params,config.allowed_event_types,config.eventarc_channel",
+          validateOnly: false,
+        })
         .reply(500);
 
       await expect(
@@ -482,6 +539,7 @@ describe("extensions", () => {
           params: {
             MY_PARAM: "value",
           },
+          canEmitEvents: false,
         })
       ).to.be.rejectedWith(FirebaseError, "HTTP Error: 500");
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

While testing I noticed some weirdness where events could not be turned off via CLI. After digging deeper I tried to simplify the logic such that:

- if events are turned off, it always includes allowed_event_types/eventarc_channel the update mask but undefined fields in the body, so those fields get emptied out in Spanner.
- if events are turned on, it always includes allowed_event_types/eventarc_channel 

If the extension doesn't emit extensions in general, the update flow will still pass allowed_event_types/eventarc_channel in the update mask + undefined fields in the body. This isn't ideal from a code cleanliness standpoint but seems like it will require a bigger refactor to explicitly handle this differently.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Verified by testing on autopush
firebase update firestore-stripe-payments-autopush1  firebase-internal-testing/firestore-stripe-payments --project=pavelj-extensions1


### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
