### PR TITLE
Inlined.cpu.3

### DIFF
--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -46,7 +46,7 @@ export function endpointsAreValid(wantBackend: backend.Backend): void {
   }
 
   const gcfV1WithCPU = endpoints
-    .filter((endpoint) => endpoint.platform === "gcfv1" && "cpu" in endpoint)
+    .filter((endpoint) => endpoint.platform === "gcfv1" && typeof endpoint["cpu"] !== "undefined")
     .map((endpoint) => endpoint.id);
   if (gcfV1WithCPU.length) {
     const msg = `Cannot set CPU on the functions ${gcfV1WithCPU.join(
@@ -69,7 +69,7 @@ export function endpointsAreValid(wantBackend: backend.Backend): void {
         return false;
       }
       // But whole CPU is limited to fixed sizes
-      return [1, 2, 4, 6, 8].includes(cpu);
+      return ![1, 2, 4, 6, 8].includes(cpu);
     })
     .map((endpoint) => endpoint.id);
   if (invalidCPU.length) {

--- a/src/test/accountExporter.spec.ts
+++ b/src/test/accountExporter.spec.ts
@@ -9,11 +9,11 @@ import { validateOptions, serialExportUsers } from "../accountExporter";
 describe("accountExporter", () => {
   describe("validateOptions", () => {
     it("should reject when no format provided", () => {
-      expect(() => validateOptions({}, "output_file")).to.throw;
+      expect(() => validateOptions({}, "output_file")).to.throw();
     });
 
     it("should reject when format is not csv or json", () => {
-      expect(() => validateOptions({ format: "txt" }, "output_file")).to.throw;
+      expect(() => validateOptions({ format: "txt" }, "output_file")).to.throw();
     });
 
     it("should ignore format param when implicitly specified in file name", () => {

--- a/src/test/accountImporter.spec.ts
+++ b/src/test/accountImporter.spec.ts
@@ -33,11 +33,11 @@ describe("accountImporter", () => {
 
   describe("validateOptions", () => {
     it("should reject when unsupported hash algorithm provided", () => {
-      expect(() => validateOptions({ hashAlgo: "MD2" })).to.throw;
+      expect(() => validateOptions({ hashAlgo: "MD2" })).to.throw();
     });
 
     it("should reject when missing parameters", () => {
-      expect(() => validateOptions({ hashAlgo: "HMAC_SHA1" })).to.throw;
+      expect(() => validateOptions({ hashAlgo: "HMAC_SHA1" })).to.throw();
     });
   });
 

--- a/src/test/checkMinRequiredVersion.spec.ts
+++ b/src/test/checkMinRequiredVersion.spec.ts
@@ -21,7 +21,7 @@ describe("checkMinRequiredVersion", () => {
 
     expect(() => {
       checkMinRequiredVersion({}, "key");
-    }).to.throw;
+    }).to.throw();
   });
 
   it("should not error if installed version is above the min required version", () => {
@@ -29,6 +29,6 @@ describe("checkMinRequiredVersion", () => {
 
     expect(() => {
       checkMinRequiredVersion({}, "key");
-    }).not.to.throw;
+    }).not.to.throw();
   });
 });

--- a/src/test/command.spec.ts
+++ b/src/test/command.spec.ts
@@ -26,7 +26,7 @@ describe("Command", () => {
       command.action(() => {
         // do nothing
       });
-    }).not.to.throw;
+    }).not.to.throw();
   });
 
   describe("runner", () => {

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -43,7 +43,7 @@ describe("planner", () => {
     it("throws on illegal updates", () => {
       const httpsFunc = func("a", "b", { httpsTrigger: {} });
       const scheduleFunc = func("a", "b", { scheduleTrigger: {} });
-      expect(() => planner.calculateUpdate(httpsFunc, scheduleFunc)).to.throw;
+      expect(() => planner.calculateUpdate(httpsFunc, scheduleFunc)).to.throw();
     });
 
     it("knows to delete & recreate for v2 topic changes", () => {
@@ -316,7 +316,7 @@ describe("planner", () => {
       const have: backend.Endpoint = { ...func("id", "region"), platform: "gcfv1" };
       const want: backend.Endpoint = { ...func("id", "region"), platform: "gcfv2" };
 
-      expect(() => planner.checkForIllegalUpdate(want, have)).to.throw;
+      expect(() => planner.checkForIllegalUpdate(want, have)).to.throw();
     });
 
     it("should throw if a https function would be changed into an event triggered function", () => {

--- a/src/test/deploy/functions/runtimes/discovery/parsing.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/parsing.spec.ts
@@ -51,7 +51,7 @@ describe("assertKeyTypes", () => {
       it(`handles a ${testType} when expecting a ${type}`, () => {
         const obj = { [type]: val };
         if (type === testType) {
-          expect(() => parsing.assertKeyTypes("", obj, schema)).not.to.throw;
+          expect(() => parsing.assertKeyTypes("", obj, schema)).not.to.throw();
         } else {
           expect(() => parsing.assertKeyTypes("", obj, schema)).to.throw(FirebaseError);
         }
@@ -79,9 +79,9 @@ describe("assertKeyTypes", () => {
     const schema = {
       cpu: (val: hasCPU["cpu"]) => typeof val === "number" || val === "gcf_gen1",
     };
-    expect(() => parsing.assertKeyTypes("", literalCPU, schema)).to.not.throw;
-    expect(() => parsing.assertKeyTypes("", symbolicCPU, schema)).to.not.throw;
-    expect(() => parsing.assertKeyTypes("", badCPU, schema)).to.throw;
+    expect(() => parsing.assertKeyTypes("", literalCPU, schema)).to.not.throw();
+    expect(() => parsing.assertKeyTypes("", symbolicCPU, schema)).to.not.throw();
+    expect(() => parsing.assertKeyTypes("", badCPU, schema)).to.throw();
   });
 
   it("Throws on superfluous keys", () => {

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -139,7 +139,7 @@ describe("validate", () => {
     });
 
     it("Allows endpoints with no mem and no concurrency", () => {
-      expect(() => validate.endpointsAreValid(backend.of(ENDPOINT_BASE))).to.not.throw;
+      expect(() => validate.endpointsAreValid(backend.of(ENDPOINT_BASE))).to.not.throw();
     });
 
     it("Allows endpionts with mem and no concurrency", () => {
@@ -147,7 +147,7 @@ describe("validate", () => {
         ...ENDPOINT_BASE,
         availableMemoryMb: 256,
       };
-      expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw;
+      expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw();
     });
 
     it("Allows explicitly one concurrent", () => {
@@ -155,7 +155,7 @@ describe("validate", () => {
         ...ENDPOINT_BASE,
         concurrency: 1,
       };
-      expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw;
+      expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw();
     });
 
     it("Allows endpoints with enough mem and no concurrency", () => {
@@ -164,7 +164,7 @@ describe("validate", () => {
           ...ENDPOINT_BASE,
           availableMemoryMb: mem,
         };
-        expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw;
+        expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw();
       }
     });
 
@@ -175,7 +175,7 @@ describe("validate", () => {
           availableMemoryMb: mem,
           concurrency: 42,
         };
-        expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw;
+        expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw();
       }
     });
 
@@ -294,6 +294,36 @@ describe("validate", () => {
 
       expect(() => validate.endpointsAreValid(want)).to.not.throw();
     });
+
+    for (const cpu of [undefined, "gcf_gen1", 0.1, 0.5, 1, 2, 4, 6, 8] as const) {
+      it(`does not throw for valid CPU ${cpu ?? "undefined"}`, () => {
+        const want = backend.of({
+          ...ENDPOINT_BASE,
+          platform: "gcfv2",
+          cpu,
+        });
+        expect(() => validate.endpointsAreValid(want)).to.not.throw();
+      });
+    }
+
+    it("throws for gcfv1 with CPU", () => {
+      const want = backend.of({
+        ...ENDPOINT_BASE,
+        platform: "gcfv1",
+        cpu: 1,
+      });
+      expect(() => validate.endpointsAreValid(want)).to.throw();
+    });
+
+    it("throws for invalid CPU", () => {
+      const want = backend.of({
+        ...ENDPOINT_BASE,
+        platform: "gcfv2",
+        // Fractional CPU is only valid for <1
+        cpu: 1.5,
+      });
+      expect(() => validate.endpointsAreValid(want)).to.throw();
+    });
   });
 
   describe("endpointsAreUnqiue", () => {
@@ -316,7 +346,7 @@ describe("validate", () => {
         { ...ENDPOINT_BASE, id: "i3", region: "r2" },
         { ...ENDPOINT_BASE, id: "i4", region: "r2" }
       );
-      expect(() => validate.endpointsAreUnique({ b1, b2 })).to.not.throw;
+      expect(() => validate.endpointsAreUnique({ b1, b2 })).to.not.throw();
     });
 
     it("passes given unique id, region pairs", () => {
@@ -328,7 +358,7 @@ describe("validate", () => {
         { ...ENDPOINT_BASE, id: "i1", region: "r2" },
         { ...ENDPOINT_BASE, id: "i2", region: "r2" }
       );
-      expect(() => validate.endpointsAreUnique({ b1, b2 })).to.not.throw;
+      expect(() => validate.endpointsAreUnique({ b1, b2 })).to.not.throw();
     });
 
     it("throws given non-unique id region pairs", () => {

--- a/src/test/deploy/hosting/hashcache.spec.ts
+++ b/src/test/deploy/hosting/hashcache.spec.ts
@@ -17,7 +17,7 @@ describe("hashcache", () => {
     const name = "testcache";
     const data = new Map<string, HashRecord>([["foo", { mtime: 0, hash: "deadbeef" }]]);
 
-    expect(dump(dir.name, name, data)).to.not.throw;
+    expect(() => dump(dir.name, name, data)).to.not.throw();
 
     expect(existsSync(join(dir.name, ".firebase", `hosting.${name}.cache`))).to.be.true;
     expect(readFileSync(join(dir.name, ".firebase", `hosting.${name}.cache`), "utf8")).to.equal(

--- a/src/test/emulators/storage/persistence.spec.ts
+++ b/src/test/emulators/storage/persistence.spec.ts
@@ -17,7 +17,7 @@ describe("Persistence", () => {
       _persistence.appendBytes(filename, Buffer.from("hello world"));
 
       _persistence.deleteFile(filename);
-      expect(() => _persistence.readBytes(filename, 10)).to.throw;
+      expect(() => _persistence.readBytes(filename, 10)).to.throw();
     });
   });
 

--- a/src/test/fsAsync.spec.ts
+++ b/src/test/fsAsync.spec.ts
@@ -46,7 +46,7 @@ describe("fsAsync", () => {
     rimraf(baseDir);
     expect(() => {
       fs.statSync(baseDir);
-    }).to.throw;
+    }).to.throw();
   });
 
   describe("readdirRecursive", () => {

--- a/src/test/functional.spec.ts
+++ b/src/test/functional.spec.ts
@@ -86,7 +86,7 @@ describe("functional", () => {
       expect([...f.zip([1], ["a"])]).to.deep.equal([[1, "a"]]);
     });
     it("throws on length mismatch", () => {
-      expect(() => f.zip([1], [])).to.throw;
+      expect(() => [...f.zip([1], [])]).to.throw();
     });
   });
 

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -302,7 +302,7 @@ FOO=foo
       rimraf(tmpdir);
       expect(() => {
         fs.statSync(tmpdir);
-      }).to.throw;
+      }).to.throw();
     });
 
     it("loads nothing if .env files are missing", () => {

--- a/src/test/gcp/cloudfunctions.spec.ts
+++ b/src/test/gcp/cloudfunctions.spec.ts
@@ -55,7 +55,7 @@ describe("cloudfunctions", () => {
           { ...ENDPOINT, platform: "gcfv2", httpsTrigger: {} },
           UPLOAD_URL
         );
-      }).to.throw;
+      }).to.throw();
     });
 
     it("should copy a minimal function", () => {

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -82,7 +82,7 @@ describe("cloudfunctionsv2", () => {
           { ...ENDPOINT, httpsTrigger: {}, platform: "gcfv1" },
           CLOUD_FUNCTION_V2_SOURCE
         );
-      }).to.throw;
+      }).to.throw();
     });
 
     it("should copy a minimal function", () => {

--- a/src/test/rulesDeploy.spec.ts
+++ b/src/test/rulesDeploy.spec.ts
@@ -29,7 +29,7 @@ describe("RulesDeploy", () => {
 
       expect(() => {
         rd.addFile("firestore.rules");
-      }).to.not.throw;
+      }).to.not.throw();
     });
 
     it("should throw an error if the file does not exist", () => {


### PR DESCRIPTION
1. Added validation to CPU config
2. When tests weren't failing, I realized you need to say `throw()` not `throw` in Chai Expect, which meant none of our throwing tests were actually testing anything. Used find + replace to turn all `throw;` into `throw();` and fixed broken tests.