### PR TITLE
Fixes a bug where paramaterized values were displayed but not written to .env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Add support for secrets to v2 functions (#4451).
+- Fixes an issue where `ext:export` would write different param values than what it displayed in the prompt (#4515).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Add support for secrets to v2 functions (#4451).
 - Fixes an issue where `ext:export` would write different param values than what it displayed in the prompt (#4515).

--- a/src/commands/ext-export.ts
+++ b/src/commands/ext-export.ts
@@ -64,7 +64,7 @@ module.exports = new Command("ext:export")
       return;
     }
 
-    const manifestSpecs = withRef.map((spec) => ({
+    const manifestSpecs = withRefSubbed.map((spec) => ({
       instanceId: spec.instanceId,
       ref: spec.ref,
       params: buildBindingOptionsWithBaseValue(spec.params),


### PR DESCRIPTION
### Description
Fixes a bug where ext:export would write unparameterized values to .env files.
### Scenarios Tested
I ext:exported a project, and confirmed that parameterized values were written to the .env file