### PR TITLE
Stop using github flavored markdown for warnings

### DIFF
--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -102,7 +102,8 @@ export async function displayWarningsForDeploy(instancesToCreate: InstanceSpec[]
       marked(
         `The following are instances of ${clc.bold(
           "experimental"
-        )} extensions.They may not be production-ready. Their functionality may change in backward-incompatible ways before their official release, or they may be discontinued.\n${humanReadableList}\n`
+        )} extensions.They may not be production-ready. Their functionality may change in backward-incompatible ways before their official release, or they may be discontinued.\n${humanReadableList}\n`,
+        { gfm: false }
       )
     );
   }
@@ -112,9 +113,10 @@ export async function displayWarningsForDeploy(instancesToCreate: InstanceSpec[]
     utils.logLabeledBullet(
       logPrefix,
       marked(
-        `These extensions are in preview and are built by a developer in the Extensions Publisher Early Access Program (http://bit.ly/firex-provider. Their functionality might change in backwards-incompatible ways. Since these extensions aren't built by Firebase, reach out to their publisher with questions about them.` +
+        `These extensions are in preview and are built by a developer in the Extensions Publisher Early Access Program (http://bit.ly/firex-provider). Their functionality might change in backwards-incompatible ways. Since these extensions aren't built by Firebase, reach out to their publisher with questions about them.` +
           ` They are provided “AS IS”, without any warranty, express or implied, from Google.` +
-          ` Google disclaims all liability for any damages, direct or indirect, resulting from the use of these extensions\n${humanReadableList}`
+          ` Google disclaims all liability for any damages, direct or indirect, resulting from the use of these extensions\n${humanReadableList}`,
+        { gfm: false }
       )
     );
   }


### PR DESCRIPTION
### Description
Marked uses Github flavored markdown by default, which is extremely aggressive about turning anything that looks like an email into a mailto: autolink (https://github.github.com/gfm/#extended-email-autolink). Incidentally, extensions version refs look a bit like emails (specifically the extensionName@versionNumber part), and so GFM was turning them into unreadable blobs of URL encoded text:
<img width="1440" alt="Screen Shot 2022-05-04 at 10 29 57 AM" src="https://user-images.githubusercontent.com/4635763/166746615-236c7a96-a455-4776-b746-863e6ba5da7d.png">

### Scenarios Tested
Now, they look normal:
<img width="1440" alt="Screen Shot 2022-05-04 at 10 29 47 AM" src="https://user-images.githubusercontent.com/4635763/166746658-e19c51b2-ec6e-4c00-b1dc-e3dda8cb3261.png">

