### PR TITLE
Update function label used to match the filter style.

### DIFF
--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -130,7 +130,7 @@ export function getEndpointFilters(options: { only?: string }): EndpointFilter[]
 export function getFunctionLabel(fn: backend.TargetIds & { codebase?: string }): string {
   let id = `${fn.id}(${fn.region})`;
   if (fn.codebase && fn.codebase !== DEFAULT_CODEBASE) {
-    id = `[${fn.codebase}]${id}`;
+    id = `${fn.codebase}:${id}`;
   }
   return id;
 }


### PR DESCRIPTION
Instead of outputting function name w/ in the following style:

  `[codebase]function(region)`

We will instead format the function name as follows:

  `codebase:function(region)`

This is nice since it matches the format expected by the --only filter.

Thanks @inlined for the suggestion!
