### PR TITLE
Stop pruning secrets on function deploys/secret updates.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Add support for secrets to v2 functions (#4451).
 - Fixes an issue where `ext:export` would write different param values than what it displayed in the prompt (#4515).
 - Enhances the functions IAM permission process and updates the error messages (#4511).
+- Removes logic for automatically pruning stale secrets after function deploys (#4519).

--- a/src/commands/functions-secrets-set.ts
+++ b/src/commands/functions-secrets-set.ts
@@ -103,25 +103,5 @@ export default new Command("functions:secrets:set <KEY>")
       logBullet(`Updated function ${e.id}(${e.region}).`);
       return updated;
     });
-    const updatedEndpoints = await Promise.all(updateOps);
-
-    logBullet(`Pruning stale secrets...`);
-    const prunedResult = await pruneAndDestroySecrets(
-      { projectId, projectNumber },
-      updatedEndpoints
-    );
-    if (prunedResult.destroyed.length > 0) {
-      logBullet(
-        `Detroyed unused secret versions: ${prunedResult.destroyed
-          .map((s) => `${s.secret}@${s.version}`)
-          .join(", ")}`
-      );
-    }
-    if (prunedResult.erred.length > 0) {
-      logWarning(
-        `Failed to destroy unused secret versions:\n\t${prunedResult.erred
-          .map((err) => err.message)
-          .join("\n\t")}`
-      );
-    }
+    await Promise.all(updateOps);
   });

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -101,36 +101,6 @@ export async function release(
   if (allErrors.length) {
     const opts = allErrors.length === 1 ? { original: allErrors[0] } : { children: allErrors };
     throw new FirebaseError("There was an error deploying functions", { ...opts, exit: 2 });
-  } else {
-    if (secrets.of(haveEndpoints).length > 0) {
-      const projectId = needProjectId(options);
-      const projectNumber = await needProjectNumber(options);
-      // Re-load backend with all endpoints, not just the ones deployed.
-      const reloadedBackend = await backend.existingBackend(
-        { projectId } as args.Context,
-        /* forceRefresh= */ true
-      );
-      const prunedResult = await secrets.pruneAndDestroySecrets(
-        { projectId, projectNumber },
-        backend.allEndpoints(reloadedBackend)
-      );
-      if (prunedResult.destroyed.length > 0) {
-        logLabeledBullet(
-          "functions",
-          `Destroyed unused secret versions: ${prunedResult.destroyed
-            .map((s) => `${s.secret}@${s.version}`)
-            .join(", ")}`
-        );
-      }
-      if (prunedResult.erred.length > 0) {
-        logLabeledWarning(
-          "functions",
-          `Failed to destroy unused secret versions:\n\t${prunedResult.erred
-            .map((err) => err.message)
-            .join("\n\t")}`
-        );
-      }
-    }
   }
 }
 


### PR DESCRIPTION
These pruning are surprising users (see https://github.com/firebase/firebase-tools/issues/4459). I'm going to work on improving the UX of the pruning.

Until then, users can still prune unused secrets via `functions:secrets:prune` command.