### PR TITLE
Add `build:watch` to `package.json` when initing Typescript functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Add support for secrets to v2 functions (#4451).
 - Fixes an issue where `ext:export` would write different param values than what it displayed in the prompt (#4515).
 - Enhances the functions IAM permission process and updates the error messages (#4511).
+- Add 'build:watch' npm script to `firebase init` when initializing a project with Typescript functions.

--- a/templates/extensions/typescript/package.lint.json
+++ b/templates/extensions/typescript/package.lint.json
@@ -2,7 +2,8 @@
   "name": "functions",
   "scripts": {
     "lint": "eslint \"src/**/*\"",
-    "build": "tsc"
+    "build": "tsc",
+    "build:watch": "tsc --watch"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/templates/extensions/typescript/package.nolint.json
+++ b/templates/extensions/typescript/package.nolint.json
@@ -1,7 +1,8 @@
 {
   "name": "functions",
   "scripts": {
-    "build": "tsc"
+    "build": "tsc",
+    "build:watch": "tsc --watch"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -3,6 +3,7 @@
   "scripts": {
     "lint": "eslint --ext .js,.ts .",
     "build": "tsc",
+    "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -2,6 +2,7 @@
   "name": "functions",
   "scripts": {
     "build": "tsc",
+    "build:watch": "tsc --watch",
     "serve": "npm run build && firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",


### PR DESCRIPTION
### Description
By popular request (after everyone on the extensions team forgot to build their functions during a bug bash), adding a build:watch script to the default package.json for Typescript functions.

### Scenarios Tested
`firebase init` a project with typescript functions, then confirmed that `npm run build:watch` works as expected