### PR TITLE
Misc bugfixes to trigger -> build -> backend chain

### DIFF
--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -12,9 +12,6 @@ export interface Build {
 }
 
 /* A utility function that returns an empty Build. */
-/**
- *
- */
 export function empty(): Build {
   return {
     requiredAPIs: [],
@@ -24,9 +21,6 @@ export function empty(): Build {
 }
 
 /* A utility function that creates a Build containing a map of IDs to Endpoints. */
-/**
- *
- */
 export function of(endpoints: Record<string, Endpoint>): Build {
   const build = empty();
   build.endpoints = endpoints;
@@ -174,6 +168,12 @@ interface VpcSettings {
   egressSettings?: "PRIVATE_RANGES_ONLY" | "ALL_TRAFFIC";
 }
 
+interface SecretEnvVar {
+  key: string; // The environment variable this secret is accessible at
+  secret: string; // The id of the SecretVersion - ie for projects/myproject/secrets/mysecret, this is 'mysecret'
+  projectId: string; // The project containing the Secret
+}
+
 export type Endpoint = Triggered & {
   // Defaults to "gcfv2". "Run" will be an additional option defined later
   platform?: "gcfv1" | "gcfv2";
@@ -217,6 +217,7 @@ export type Endpoint = Triggered & {
   ingressSettings?: "ALLOW_ALL" | "ALLOW_INTERNAL_ONLY" | "ALLOW_INTERNAL_AND_GCLB" | null;
 
   environmentVariables?: Record<string, string | Expression<string>>;
+  secretEnvironmentVariables?: SecretEnvVar[];
   labels?: Record<string, string | Expression<string>>;
 };
 
@@ -309,7 +310,7 @@ export function resolveBackend(build: Build, userEnvs: Record<string, string>): 
         "environmentVariables",
         "labels"
       );
-      // proto.copyIfPresent(bkEndpoint, endpoint, "secretEnvironmentVariables");
+      proto.copyIfPresent(bkEndpoint, endpoint, "secretEnvironmentVariables");
       if (endpoint.vpc) {
         bkEndpoint.vpc = {
           // $REGION is a token in the Build VPC connector because Build endpoints can have multiple regions, so we unroll here

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -114,7 +114,7 @@ export async function prepare(
     const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
     const envs = { ...userEnvs, ...firebaseEnvs };
     let wantBackend: backend.Backend;
-    if (previews.functionsparams) {
+    if (previews.functionsparams && !previews.functionsv2) {
       const wantBuild = await runtimeDelegate.discoverBuild(runtimeConfig, firebaseEnvs);
       wantBackend = build.resolveBackend(wantBuild, userEnvs);
     } else {

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -302,7 +302,7 @@ export function addResourcesToBuild(
     project: projectId,
     entryPoint: annotation.entryPoint,
     runtime: runtime,
-    serviceAccount: annotation.serviceAccountEmail || "default",
+    serviceAccount: annotation.serviceAccountEmail || null,
     ...triggered,
   };
   if (annotation.vpcConnector != null) {
@@ -313,6 +313,18 @@ export function addResourcesToBuild(
     endpoint.vpc = { connector: maybeId };
     proto.renameIfPresent(endpoint.vpc, annotation, "egressSettings", "vpcConnectorEgressSettings");
   }
+  if (annotation.secrets) {
+    const secretEnvs = [];
+    for (const secret of annotation.secrets) {
+      secretEnvs.push({
+        key: secret,
+        secret: secret,
+        projectId: projectId,
+      });
+    }
+    endpoint.secretEnvironmentVariables = secretEnvs;
+  }
+
   proto.copyIfPresent(
     endpoint,
     annotation,


### PR DESCRIPTION
Addresses some problems I noticed while testing locally:
1) To get the default serviceAccountEmail, you set the field to null in backend.backend, not "default"
2) I forgot about SecretEnvVariables entirely
3) None of this makes any sense in the context of CF3v2 (the code in runtimes/discovery should take care of that, right?)