### PR TITLE
Support relative paths when emulating local extensions

### DIFF
--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -92,14 +92,13 @@ export class ExtensionsEmulator implements EmulatorInstance {
   // ensureSourceCode checks the cache for the source code for a given extension version,
   // downloads and builds it if it is not found, then returns the path to that source code.
   private async ensureSourceCode(instance: planner.InstanceSpec): Promise<string> {
-    // TODO(b/213335255): Handle local extensions.
     if (instance.localPath) {
       if (!this.hasValidSource({ path: instance.localPath, extTarget: instance.localPath })) {
         throw new FirebaseError(
           `Tried to emulate local extension at ${instance.localPath}, but it was missing required files.`
         );
       }
-      return instance.localPath;
+      return path.resolve(instance.localPath);
     } else if (instance.ref) {
       const ref = toExtensionVersionRef(instance.ref);
       const cacheDir =
@@ -158,7 +157,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
     for (const requiredFile of requiredFiles) {
       const f = path.join(args.path, requiredFile);
       if (!fs.existsSync(f)) {
-        EmulatorLogger.forExtension({ ref: args.extTarget }).logLabeled(
+        this.logger.logLabeled(
           "BULLET",
           "extensions",
           `Detected invalid source code for ${args.extTarget}, expected to find ${f}`
@@ -166,7 +165,11 @@ export class ExtensionsEmulator implements EmulatorInstance {
         return false;
       }
     }
-
+    this.logger.logLabeled(
+      "DEBUG",
+      "extensions",
+      `Source code valid for ${args.extTarget}`
+    );
     return true;
   }
 

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -165,11 +165,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
         return false;
       }
     }
-    this.logger.logLabeled(
-      "DEBUG",
-      "extensions",
-      `Source code valid for ${args.extTarget}`
-    );
+    this.logger.logLabeled("DEBUG", "extensions", `Source code valid for ${args.extTarget}`);
     return true;
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1012,6 +1012,7 @@ export class FunctionsEmulator implements EmulatorInstance {
   }
 
   getNodeBinary(backend: EmulatableBackend): string {
+    this.logger.log("DEBUG", `We're at ${__dirname}`);
     const pkg = require(path.join(backend.functionsDir, "package.json"));
     // If the developer hasn't specified a Node to use, inform them that it's an option and use default
     if ((!pkg.engines || !pkg.engines.node) && !backend.nodeMajorVersion) {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1012,7 +1012,6 @@ export class FunctionsEmulator implements EmulatorInstance {
   }
 
   getNodeBinary(backend: EmulatableBackend): string {
-    this.logger.log("DEBUG", `We're at ${__dirname}`);
     const pkg = require(path.join(backend.functionsDir, "package.json"));
     // If the developer hasn't specified a Node to use, inform them that it's an option and use default
     if ((!pkg.engines || !pkg.engines.node) && !backend.nodeMajorVersion) {


### PR DESCRIPTION
### Description
Support relative paths when emulating local extensions. Turns out we needed to resolve this to an absolute path so that the functions emulator can require it from a separate process consistently.

### Scenarios Tested
I was able to emulate an extension located at "../"