### PR TITLE
Improve error message when parsing function source fails.

### DIFF
--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -34,6 +34,9 @@ export function yamlToBackend(
   }
 }
 
+/**
+ *
+ */
 export async function detectFromYaml(
   directory: string,
   project: string,
@@ -60,7 +63,7 @@ export async function detectFromPort(
   port: number,
   project: string,
   runtime: runtimes.Runtime,
-  timeout: number = 30_000 /* 30s to boot up */
+  timeout = 30_000 /* 30s to boot up */
 ): Promise<backend.Backend> {
   // The result type of fetch isn't exported
   let res: { text(): Promise<string> };
@@ -90,7 +93,8 @@ export async function detectFromPort(
   try {
     parsed = yaml.load(text);
   } catch (err: any) {
-    throw new FirebaseError("Failed to parse backend specification", { children: [err] });
+    logger.debug("Failed to parse functions.yaml", err);
+    throw new FirebaseError(`Failed to load function definition from source: ${text}`);
   }
 
   return yamlToBackend(parsed, project, api.functionsDefaultRegion, runtime);

--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -34,9 +34,6 @@ export function yamlToBackend(
   }
 }
 
-/**
- *
- */
 export async function detectFromYaml(
   directory: string,
   project: string,


### PR DESCRIPTION
Previously, an invalid function source would show error message like this:

```bash
$ firebase deploy --only functions

i  deploying functions
...
Error: Failed to parse backend specification:
- YAMLException incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line at line 1, column 65:
     ...  function source: ReferenceError: aa is not defined
```

This is surprising - a YAMLException? A backend specification? Often times, the full error message would curt short, and debugging the issue required the user to carefully inspect the debug log.

We improve the error message to the following:

```bash
$ firebase deploy --only functions

i  deploying functions
...
Error: Failed to load function definition from source: Failed to generate manifest from function source: ReferenceError: aa is not defined
```

We hid the YAML portion of the error and make sure to relay the full error message returned from the underlying Functions Control API (i.e. the serve responsible for loading and advertising the `functions.yaml` baked into the Functions SDK)