### PR TITLE
Resolve relative paths for local extensions

### DIFF
--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -99,7 +99,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
           `Tried to emulate local extension at ${instance.localPath}, but it was missing required files.`
         );
       }
-      return instance.localPath;
+      return path.resolve(instance.localPath);
     } else if (instance.ref) {
       const ref = toExtensionVersionRef(instance.ref);
       const cacheDir =


### PR DESCRIPTION
### Description
When a relative path to a local extension is provided in firebase.json, resolve it to an absolute path so that it still points to the same location when `require` by the Functions emulator in a separate process.

### Scenarios Tested
I successfully emulated an extension located at "../"
