### PR TITLE
Bump frameworks

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -30,7 +30,7 @@
         "exit-code": "^1.0.2",
         "express": "^4.16.4",
         "filesize": "^6.1.0",
-        "firebase-frameworks": "^0.4.0",
+        "firebase-frameworks": "^0.4.1",
         "fs-extra": "^5.0.0",
         "glob": "^7.1.2",
         "google-auth-library": "^7.11.0",
@@ -6059,9 +6059,9 @@
       }
     },
     "node_modules/firebase-frameworks": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/firebase-frameworks/-/firebase-frameworks-0.4.0.tgz",
-      "integrity": "sha512-Seu+1dKNo3AacMrOHb1V0F41DfCKiM6gW4Go/34z78WtuBkzKNSUOUI+w8XCH7A96QGZRbNbGwt33BiSXEb2xQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/firebase-frameworks/-/firebase-frameworks-0.4.1.tgz",
+      "integrity": "sha512-JozphW1LOwHrN38Die5uj+eCZ9rOdGDKVwYlivvj9yp06U/mV8JsjEna+F8h3sSLuiO4JjFWrh1kwVXQpBi34w==",
       "dependencies": {
         "fs-extra": "^10.1.0",
         "jsonc-parser": "^3.0.0",
@@ -18454,9 +18454,9 @@
       }
     },
     "firebase-frameworks": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/firebase-frameworks/-/firebase-frameworks-0.4.0.tgz",
-      "integrity": "sha512-Seu+1dKNo3AacMrOHb1V0F41DfCKiM6gW4Go/34z78WtuBkzKNSUOUI+w8XCH7A96QGZRbNbGwt33BiSXEb2xQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/firebase-frameworks/-/firebase-frameworks-0.4.1.tgz",
+      "integrity": "sha512-JozphW1LOwHrN38Die5uj+eCZ9rOdGDKVwYlivvj9yp06U/mV8JsjEna+F8h3sSLuiO4JjFWrh1kwVXQpBi34w==",
       "requires": {
         "fs-extra": "^10.1.0",
         "jsonc-parser": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "exit-code": "^1.0.2",
     "express": "^4.16.4",
     "filesize": "^6.1.0",
-    "firebase-frameworks": "^0.4.0",
+    "firebase-frameworks": "^0.4.1",
     "fs-extra": "^5.0.0",
     "glob": "^7.1.2",
     "google-auth-library": "^7.11.0",

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -56,7 +56,7 @@ export const deploy = async function (
   const postdeploys: Chain = [];
   const startTime = Date.now();
 
-  if (previews.frameworkawareness && targetNames.includes("hosting")) {
+  if (targetNames.includes("hosting")) {
     const config = options.config.get("hosting");
     if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
       await prepareFrameworks(targetNames, context, options);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -404,11 +404,9 @@ export async function startAll(
     }
   }
 
-  if (previews.frameworkawareness) {
-    const config = options.config.get("hosting");
-    if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
-      await prepareFrameworks(targets, options, options);
-    }
+  const config = options.config.get("hosting");
+  if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
+    await prepareFrameworks(targets, options, options);
   }
 
   if (shouldStart(options, Emulators.HUB)) {

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -95,8 +95,17 @@ export const prepareFrameworks = async (targetNames: string[], context: any, opt
             firebaseProjectConfig = await getAppConfig(appId, AppPlatform.WEB);
           } else {
             console.warn(
-              `No Firebase app associated with site ${site}, unable to provide authenticated server context`
+              `No Firebase app associated with site ${site}, unable to provide authenticated server context.
+You can link a Web app to a Hosting site here https://console.firebase.google.com/project/_/settings/general/web`
             );
+            if (!options.nonInteractive) {
+              const continueDeploy = await promptOnce({
+                type: "confirm",
+                default: true,
+                message: "Would you like to continue with the deploy?",
+              });
+              if (!continueDeploy) exit(1);
+            }
           }
         }
       }

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -23,7 +23,6 @@ export async function serve(options: any): Promise<void> {
   const targetNames = options.targets;
   options.port = parseInt(options.port, 10);
   if (
-    previews.frameworkawareness &&
     targetNames.includes("hosting") &&
     [].concat(options.config.get("hosting")).some((it: any) => it.source)
   ) {


### PR DESCRIPTION
* Bump frameworks to 0.4.1 to address some issues identified in last minute testing
* Remove the feature flag check
  * will still use that for upcoming experiences (namely init), so not removing entirely
  * already effectively gated behind the source option in firebase.json
* Stronger error and give an option to bail if no associated web app
* Adding source to the firebase json schema
  * both source and public should not be present

I'm supposed to be OOO 🤣 so I need someone else to champion.