### PR TITLE
error out on old java versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-- Remove `params` flag from ext:install, ext:update, ext:configure commands as they are replaced by the Extensions Manifest. See https://firebase.google.com/docs/extensions/manifest for more details.
+- Removes support for running the emulators with Java versions prior to 11.
+- Removes `params` flag from ext:install, ext:update, ext:configure commands as they are replaced by the Extensions Manifest. See https://firebase.google.com/docs/extensions/manifest for more details.

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -530,5 +530,5 @@ export async function checkJavaSupported(): Promise<boolean> {
 }
 
 export const JAVA_DEPRECATION_WARNING =
-  "Support for Java version <= 10 will be dropped soon in firebase-tools@11. " +
+  "firebase-tools no longer supports Java version before 11. " +
   "Please upgrade to Java version 11 or above to continue using the emulators.";

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -356,11 +356,11 @@ export async function startAll(
       `No emulators to start, run ${clc.bold("firebase init emulators")} to get started.`
     );
   }
-  const deprecationNotices = [];
+  const deprecationNotices: string[] = [];
   if (targets.some(requiresJava)) {
     if (!(await commandUtils.checkJavaSupported())) {
-      utils.logLabeledWarning("emulators", JAVA_DEPRECATION_WARNING, "warn");
-      deprecationNotices.push(JAVA_DEPRECATION_WARNING);
+      utils.logLabeledError("emulators", JAVA_DEPRECATION_WARNING, "warn");
+      throw new FirebaseError(JAVA_DEPRECATION_WARNING);
     }
   }
   const hubLogger = EmulatorLogger.forEmulator(Emulators.HUB);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

No longer supporting java < 11.

### Scenarios Tested

Ran locally (with min version set to 12)

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/160236/168698203-1f0c7787-3dfa-4b1c-aed8-442a6bb075c9.png">
