### PR TITLE
update pkg for node 16

### DIFF
--- a/standalone/package.json
+++ b/standalone/package.json
@@ -29,7 +29,7 @@
     ]
   },
   "devDependencies": {
-    "pkg": "^4.4.2",
+    "pkg": "^5.7.0",
     "prettier": "^1.15.3"
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

The old version of pkg doesn't support node 16, as far as I can tell.