### PR TITLE
update emulator usage of api to apiv2

### DIFF
--- a/scripts/triggers-end-to-end-tests/triggers/package.json
+++ b/scripts/triggers-end-to-end-tests/triggers/package.json
@@ -3,7 +3,7 @@
   "description": "Cloud Functions for Firebase",
   "scripts": {},
   "engines": {
-    "node": "12"
+    "node": "16"
   },
   "dependencies": {
     "@google-cloud/pubsub": "^1.1.5",

--- a/scripts/triggers-end-to-end-tests/v1/package.json
+++ b/scripts/triggers-end-to-end-tests/v1/package.json
@@ -3,7 +3,7 @@
   "description": "Cloud Functions for Firebase",
   "scripts": {},
   "engines": {
-    "node": "12"
+    "node": "16"
   },
   "dependencies": {
     "firebase-admin": "^9.3.0",

--- a/scripts/triggers-end-to-end-tests/v2/package.json
+++ b/scripts/triggers-end-to-end-tests/v2/package.json
@@ -3,7 +3,7 @@
   "description": "Cloud Functions for Firebase",
   "scripts": {},
   "engines": {
-    "node": "12"
+    "node": "16"
   },
   "dependencies": {
     "firebase-admin": "^9.3.0",

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -4,7 +4,6 @@ import * as fs from "fs";
 import * as path from "path";
 import * as http from "http";
 
-import * as api from "../api";
 import * as downloadableEmulators from "./downloadableEmulators";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "../emulator/types";
 import { Constants } from "./constants";
@@ -12,6 +11,7 @@ import { EmulatorRegistry } from "./registry";
 import { EmulatorLogger } from "./emulatorLogger";
 import { FirebaseError } from "../error";
 import * as parseBoltRules from "../parseBoltRules";
+import { Client } from "../apiv2";
 
 export interface DatabaseEmulatorArgs {
   port?: number;
@@ -170,12 +170,14 @@ export class DatabaseEmulator implements EmulatorInstance {
 
     const info = this.getInfo();
     try {
-      await api.request("PUT", `/.settings/rules.json?ns=${instance}`, {
-        origin: `http://${EmulatorRegistry.getInfoHostString(info)}`,
-        headers: { Authorization: "Bearer owner" },
-        data: content,
-        json: false,
+      const client = new Client({
+        urlPrefix: `http://${EmulatorRegistry.getInfoHostString(info)}`,
+        auth: false,
       });
+      await client.put(`/.settings/rules.json`, content, {
+        headers: { Authorization: "Bearer owner" },
+        queryParams: { ns: instance },
+      })
     } catch (e: any) {
       // The body is already parsed as JSON
       if (e.context && e.context.body) {

--- a/src/emulator/databaseEmulator.ts
+++ b/src/emulator/databaseEmulator.ts
@@ -177,7 +177,7 @@ export class DatabaseEmulator implements EmulatorInstance {
       await client.put(`/.settings/rules.json`, content, {
         headers: { Authorization: "Bearer owner" },
         queryParams: { ns: instance },
-      })
+      });
     } catch (e: any) {
       // The body is already parsed as JSON
       if (e.context && e.context.body) {

--- a/src/emulator/hubClient.ts
+++ b/src/emulator/hubClient.ts
@@ -1,43 +1,31 @@
-import * as api from "../api";
 import { EmulatorHub, Locator, GetEmulatorsResponse } from "./hub";
 import { FirebaseError } from "../error";
+import { Client } from "../apiv2";
 
 export class EmulatorHubClient {
   private locator: Locator | undefined;
+  private apiClient: Client;
 
   constructor(private projectId: string) {
     this.locator = EmulatorHub.readLocatorFile(projectId);
+    this.apiClient = new Client({ urlPrefix: this.origin, auth: false });
   }
 
   foundHub(): boolean {
     return this.locator !== undefined;
   }
 
-  getStatus(): Promise<void> {
-    return api.request("GET", "/", {
-      origin: this.origin,
-    });
+  async getStatus(): Promise<void> {
+    await this.apiClient.get("/");
   }
 
-  getEmulators(): Promise<GetEmulatorsResponse> {
-    return api
-      .request("GET", EmulatorHub.PATH_EMULATORS, {
-        origin: this.origin,
-        json: true,
-      })
-      .then((res) => {
-        return res.body as GetEmulatorsResponse;
-      });
+  async getEmulators(): Promise<GetEmulatorsResponse> {
+    const res = await this.apiClient.get<GetEmulatorsResponse>(EmulatorHub.PATH_EMULATORS);
+    return res.body;
   }
 
-  postExport(path: string): Promise<void> {
-    return api.request("POST", EmulatorHub.PATH_EXPORT, {
-      origin: this.origin,
-      json: true,
-      data: {
-        path,
-      },
-    });
+  async postExport(path: string): Promise<void> {
+    await this.apiClient.post(EmulatorHub.PATH_EXPORT, { path });
   }
 
   get origin(): string {

--- a/src/emulator/hubClient.ts
+++ b/src/emulator/hubClient.ts
@@ -4,11 +4,9 @@ import { Client } from "../apiv2";
 
 export class EmulatorHubClient {
   private locator: Locator | undefined;
-  private apiClient: Client;
 
   constructor(private projectId: string) {
     this.locator = EmulatorHub.readLocatorFile(projectId);
-    this.apiClient = new Client({ urlPrefix: this.origin, auth: false });
   }
 
   foundHub(): boolean {
@@ -16,16 +14,19 @@ export class EmulatorHubClient {
   }
 
   async getStatus(): Promise<void> {
-    await this.apiClient.get("/");
+    const apiClient = new Client({ urlPrefix: this.origin, auth: false });
+    await apiClient.get("/");
   }
 
   async getEmulators(): Promise<GetEmulatorsResponse> {
-    const res = await this.apiClient.get<GetEmulatorsResponse>(EmulatorHub.PATH_EMULATORS);
+    const apiClient = new Client({ urlPrefix: this.origin, auth: false });
+    const res = await apiClient.get<GetEmulatorsResponse>(EmulatorHub.PATH_EMULATORS);
     return res.body;
   }
 
   async postExport(path: string): Promise<void> {
-    await this.apiClient.post(EmulatorHub.PATH_EXPORT, { path });
+    const apiClient = new Client({ urlPrefix: this.origin, auth: false });
+    await apiClient.post(EmulatorHub.PATH_EXPORT, { path });
   }
 
   get origin(): string {

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -248,7 +248,17 @@ export class HubExport {
     };
 
     const client = new Client({ urlPrefix: storageHost, auth: false });
-    await client.post("/internal/export", storageExportBody);
+    const res = await client.request({
+      method: "POST",
+      path: "/internal/export",
+      headers: { "Content-Type": "application/json" },
+      body: storageExportBody,
+      responseType: "stream",
+      resolveOnHTTPError: true,
+    });
+    if (res.status >= 400) {
+      throw new FirebaseError(`Failed to export storage: ${await res.response.text()}`);
+    }
   }
 }
 

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -140,7 +140,7 @@ export class HubExport {
   private async exportDatabase(metadata: ExportMetadata): Promise<void> {
     const databaseEmulator = EmulatorRegistry.get(Emulators.DATABASE) as DatabaseEmulator;
     const databaseAddr = `http://${EmulatorRegistry.getInfoHostString(databaseEmulator.getInfo())}`;
-    const client = new Client({ urlPrefix: databaseAddr, auth: false });
+    const client = new Client({ urlPrefix: databaseAddr, auth: true });
 
     // Get the list of namespaces
     const inspectURL = `/.inspect/databases.json`;

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -3,7 +3,6 @@ import * as fs from "fs";
 import * as fse from "fs-extra";
 import * as http from "http";
 
-import * as api from "../api";
 import { logger } from "../logger";
 import { IMPORT_EXPORT_EMULATORS, Emulators, ALL_EMULATORS } from "./types";
 import { EmulatorRegistry } from "./registry";
@@ -13,6 +12,7 @@ import { getDownloadDetails } from "./downloadableEmulators";
 import { DatabaseEmulator } from "./databaseEmulator";
 import { StorageEmulator } from "./storage";
 import * as rimraf from "rimraf";
+import { Client } from "../apiv2";
 
 export interface FirestoreExportMetadata {
   version: string;
@@ -133,29 +133,32 @@ export class HubExport {
       export_name: metadata.firestore!!.path,
     };
 
-    return api.request("POST", `/emulator/v1/projects/${this.projectId}:export`, {
-      origin: firestoreHost,
-      json: true,
-      data: firestoreExportBody,
-    });
+    const client = new Client({ urlPrefix: firestoreHost, auth: false });
+    await client.post(`/emulator/v1/projects/${this.projectId}:export`, firestoreExportBody);
   }
 
   private async exportDatabase(metadata: ExportMetadata): Promise<void> {
     const databaseEmulator = EmulatorRegistry.get(Emulators.DATABASE) as DatabaseEmulator;
     const databaseAddr = `http://${EmulatorRegistry.getInfoHostString(databaseEmulator.getInfo())}`;
+    const client = new Client({ urlPrefix: databaseAddr, auth: false });
 
     // Get the list of namespaces
-    const inspectURL = `/.inspect/databases.json?ns=${this.projectId}`;
-    const inspectRes = await api.request("GET", inspectURL, { origin: databaseAddr, auth: true });
+    const inspectURL = `/.inspect/databases.json`;
+    const inspectRes = await client.get<Array<{ name: string }>>(inspectURL, {
+      queryParams: { ns: this.projectId },
+    });
     const namespaces = inspectRes.body.map((instance: any) => instance.name);
 
     // Check each one for actual data
     const namespacesToExport: string[] = [];
     for (const ns of namespaces) {
-      const checkDataPath = `/.json?ns=${ns}&shallow=true&limitToFirst=1`;
-      const checkDataRes = await api.request("GET", checkDataPath, {
-        origin: databaseAddr,
-        auth: true,
+      const checkDataPath = `/.json`;
+      const checkDataRes = await client.get(checkDataPath, {
+        queryParams: {
+          ns,
+          shallow: "true",
+          limitToFirst: 1,
+        },
       });
       if (checkDataRes.body !== null) {
         namespacesToExport.push(ns);
@@ -244,11 +247,8 @@ export class HubExport {
       path: storageExportPath,
     };
 
-    return api.request("POST", "/internal/export", {
-      origin: storageHost,
-      json: true,
-      data: storageExportBody,
-    });
+    const client = new Client({ urlPrefix: storageHost, auth: false });
+    await client.post("/internal/export", storageExportBody);
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Updates the locations where api.request was used to use apiv2's client instead.

### Scenarios Tested

Planning on having all the tests pass, but will poke around the emulators manually as well.