### PR TITLE
removing request and api from functions shell

### DIFF
--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -1,4 +1,4 @@
-import fetch from "node-fetch";
+import fetch, { Response } from "node-fetch";
 import * as fs from "fs";
 import * as path from "path";
 import * as yaml from "js-yaml";
@@ -62,8 +62,7 @@ export async function detectFromPort(
   runtime: runtimes.Runtime,
   timeout = 30_000 /* 30s to boot up */
 ): Promise<backend.Backend> {
-  // The result type of fetch isn't exported
-  let res: { text(): Promise<string> };
+  let res: Response;
   const timedOut = new Promise<never>((resolve, reject) => {
     setTimeout(() => {
       reject(new FirebaseError("User code failed to load. Cannot determine backend specification"));

--- a/src/functionsShellCommandAction.ts
+++ b/src/functionsShellCommandAction.ts
@@ -1,21 +1,18 @@
-/* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as clc from "cli-color";
 import * as repl from "repl";
 import * as _ from "lodash";
-import * as request from "request";
 import * as util from "util";
 
-import { FunctionsServer } from "./serve/functions";
-import * as LocalFunction from "./localFunction";
-import * as utils from "./utils";
-import { logger } from "./logger";
-import * as shell from "./emulator/functionsEmulatorShell";
-import * as commandUtils from "./emulator/commandUtils";
-import { EMULATORS_SUPPORTED_BY_FUNCTIONS, EmulatorInfo, Emulators } from "./emulator/types";
 import { EmulatorHubClient } from "./emulator/hubClient";
-import { Constants } from "./emulator/constants";
+import { EMULATORS_SUPPORTED_BY_FUNCTIONS, EmulatorInfo, Emulators } from "./emulator/types";
 import { findAvailablePort } from "./emulator/portUtils";
+import { FunctionsServer } from "./serve/functions";
+import { logger } from "./logger";
 import { Options } from "./options";
+import * as commandUtils from "./emulator/commandUtils";
+import * as LocalFunction from "./localFunction";
+import * as shell from "./emulator/functionsEmulatorShell";
+import * as utils from "./utils";
 
 const serveFunctions = new FunctionsServer();
 
@@ -111,11 +108,6 @@ export const actionFunction = async (options: Options) => {
       );
 
       const writer = (output: any) => {
-        // Prevent full print out of Request object when a request is made
-        // @ts-ignore
-        if (output instanceof request.Request) {
-          return "Sent request to function.";
-        }
         return util.inspect(output);
       };
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Oh boy this part is fun. We're not keeping `request` around just to do a type check (and it's not right anyway with these changes), and we're moving the actual calls to apiv2.

This is a fuuunky bit of code, and having "just used request" as the wrapper for https functions makes it trickier to "just" replace the code paths, but I think this is a reasonable start. Would like some feedback.

### Scenarios Tested

I can invoke my basic functions now, but I'm not sure if the experience is perfect.