### PR TITLE
Fixes issue where --local flag would cause extensions commands to error out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where `ext:*` commands would error out if the `--local` flag was included. This flag is deprecated because it is now the default behavior (#4577).

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -34,6 +34,7 @@ marked.setOptions({
 export default new Command("ext:configure <extensionInstanceId>")
   .description("configure an existing extension instance")
   .withForce()
+  .option("--local", "deprecated")
   .before(requirePermissions, [
     "firebaseextensions.instances.update",
     "firebaseextensions.instances.get",

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -50,6 +50,9 @@ export default new Command("ext:configure <extensionInstanceId>")
           `See https://firebase.google.com/docs/extensions/manifest for more details.`
       );
     }
+    if (options.local) {
+      utils.logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+    }
 
     const config = manifest.loadConfig(options);
 

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -51,7 +51,10 @@ export default new Command("ext:configure <extensionInstanceId>")
       );
     }
     if (options.local) {
-      utils.logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+      utils.logLabeledWarning(
+        logPrefix,
+        "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior."
+      );
     }
 
     const config = manifest.loadConfig(options);

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -48,6 +48,7 @@ export default new Command("ext:install [extensionName]")
         : "") +
       "or run with `-i` to see all available extensions."
   )
+  .option("--local", "deprecated")
   .withForce()
   .before(requirePermissions, ["firebaseextensions.instances.create"])
   .before(ensureExtensionsApiEnabled)

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -85,6 +85,9 @@ export default new Command("ext:install [extensionName]")
         `Installing with a source url is no longer supported in the CLI. Please use Firebase Console instead.`
       );
     }
+    if (options.local) {
+      utils.logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+    }
 
     // If the user types in a local path (prefixed with ~/, ../, or ./), install from local source.
     // Otherwise, treat the input as an extension reference and proceed with reference-based installation.

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -86,7 +86,10 @@ export default new Command("ext:install [extensionName]")
       );
     }
     if (options.local) {
-      utils.logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+      utils.logLabeledWarning(
+        logPrefix,
+        "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior."
+      );
     }
 
     // If the user types in a local path (prefixed with ~/, ../, or ./), install from local source.

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -4,7 +4,11 @@ import TerminalRenderer = require("marked-terminal");
 
 import { checkMinRequiredVersion } from "../checkMinRequiredVersion";
 import { Command } from "../command";
-import { ensureExtensionsApiEnabled, diagnoseAndFixProject, logPrefix, } from "../extensions/extensionsHelper";
+import {
+  ensureExtensionsApiEnabled,
+  diagnoseAndFixProject,
+  logPrefix,
+} from "../extensions/extensionsHelper";
 import { requirePermissions } from "../requirePermissions";
 import { logLabeledWarning } from "../utils";
 import * as manifest from "../extensions/manifest";
@@ -24,7 +28,10 @@ export default new Command("ext:uninstall <extensionInstanceId>")
   .before(diagnoseAndFixProject)
   .action((instanceId: string, options: Options) => {
     if (options.local) {
-      logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+      logLabeledWarning(
+        logPrefix,
+        "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior."
+      );
     }
     const config = manifest.loadConfig(options);
     manifest.removeFromManifest(instanceId, config);

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -4,8 +4,9 @@ import TerminalRenderer = require("marked-terminal");
 
 import { checkMinRequiredVersion } from "../checkMinRequiredVersion";
 import { Command } from "../command";
-import { ensureExtensionsApiEnabled, diagnoseAndFixProject } from "../extensions/extensionsHelper";
+import { ensureExtensionsApiEnabled, diagnoseAndFixProject, logPrefix, } from "../extensions/extensionsHelper";
 import { requirePermissions } from "../requirePermissions";
+import { logLabeledWarning } from "../utils";
 import * as manifest from "../extensions/manifest";
 import { Options } from "../options";
 
@@ -22,6 +23,9 @@ export default new Command("ext:uninstall <extensionInstanceId>")
   .before(checkMinRequiredVersion, "extMinVersion")
   .before(diagnoseAndFixProject)
   .action((instanceId: string, options: Options) => {
+    if (options.local) {
+      logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+    }
     const config = manifest.loadConfig(options);
     manifest.removeFromManifest(instanceId, config);
     manifest.showPostDeprecationNotice();

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -15,6 +15,7 @@ marked.setOptions({
 
 export default new Command("ext:uninstall <extensionInstanceId>")
   .description("uninstall an extension that is installed in your Firebase project by instance ID")
+  .option("--local", "deprecated")
   .withForce()
   .before(requirePermissions, ["firebaseextensions.instances.delete"])
   .before(ensureExtensionsApiEnabled)

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -53,6 +53,10 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
     const projectId = getProjectId(options);
     const config = manifest.loadConfig(options);
 
+    if (options.local) {
+      utils.logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+    }
+
     const oldRefOrPath = manifest.getInstanceTarget(instanceId, config);
     if (isLocalPath(oldRefOrPath)) {
       throw new FirebaseError(

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -47,6 +47,7 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
   .before(ensureExtensionsApiEnabled)
   .before(checkMinRequiredVersion, "extMinVersion")
   .before(diagnoseAndFixProject)
+  .option("--local", "deprecated")
   .withForce()
   .action(async (instanceId: string, updateSource: string, options: Options) => {
     const projectId = getProjectId(options);

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -54,7 +54,10 @@ export default new Command("ext:update <extensionInstanceId> [updateSource]")
     const config = manifest.loadConfig(options);
 
     if (options.local) {
-      utils.logLabeledWarning(logPrefix, "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior.")
+      utils.logLabeledWarning(
+        logPrefix,
+        "As of firebase-tools@11.0.0, the `--local` flag is no longer required, as it is the default behavior."
+      );
     }
 
     const oldRefOrPath = manifest.getInstanceTarget(instanceId, config);


### PR DESCRIPTION
### Description
`ext:*` commands should not error out when run with --local, even though it was deprecated (fixes #4577)

### Scenarios Tested
Now with a warning message
<img width="904" alt="Screen Shot 2022-05-24 at 1 29 57 PM" src="https://user-images.githubusercontent.com/4635763/170126699-1d6c196b-73cb-47e8-b7cf-096d43267cca.png">


