### PR TITLE
Remove references to usageMode from auth emulator

### DIFF
--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -448,10 +448,6 @@ function addEmulatorOperations(openapi3: any): void {
         },
         type: "object",
       },
-      usageMode: {
-        enum: ["USAGE_MODE_UNSPECIFIED", "DEFAULT", "PASSTHROUGH"],
-        type: "string",
-      },
     },
   };
   openapi3.paths["/emulator/v1/projects/{targetProjectId}/oobCodes"] = {

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -689,7 +689,6 @@ describe("import/export end to end", () => {
         signIn: {
           allowDuplicateEmails: false,
         },
-        usageMode: "DEFAULT",
       });
 
       const accountsPath = path.join(exportPath, "auth_export", "accounts.json");
@@ -795,7 +794,6 @@ describe("import/export end to end", () => {
         signIn: {
           allowDuplicateEmails: false,
         },
-        usageMode: "DEFAULT",
       });
 
       const accountsPath = path.join(exportPath, "auth_export", "accounts.json");
@@ -861,7 +859,6 @@ describe("import/export end to end", () => {
       signIn: {
         allowDuplicateEmails: false,
       },
-      usageMode: "DEFAULT",
     });
 
     const accountsPath = path.join(exportPath, "auth_export", "accounts.json");

--- a/src/emulator/auth/apiSpec.js
+++ b/src/emulator/auth/apiSpec.js
@@ -5011,8 +5011,8 @@ export default {
       GoogleCloudIdentitytoolkitV1SetAccountInfoResponse: {
         description: "Response message for SetAccountInfo",
         properties: {
-          displayName: { type: "string" },
-          email: { type: "string" },
+          displayName: { description: "The account's display name.", type: "string" },
+          email: { description: "The account's email address.", type: "string" },
           emailVerified: {
             description: "Whether the account's email has been verified.",
             type: "boolean",
@@ -5033,8 +5033,14 @@ export default {
             description: "The new email that has been set on the user's account attributes.",
             type: "string",
           },
-          passwordHash: { type: "string" },
-          photoUrl: { type: "string" },
+          passwordHash: {
+            description: "Deprecated. No actual password hash is currently returned.",
+            type: "string",
+          },
+          photoUrl: {
+            description: "The user's photo URL for the account's profile photo.",
+            type: "string",
+          },
           providerUserInfo: {
             description: "The linked Identity Providers on the account.",
             items: { $ref: "#/components/schemas/GoogleCloudIdentitytoolkitV1ProviderUserInfo" },
@@ -6013,32 +6019,6 @@ export default {
         },
         type: "object",
       },
-      GoogleCloudIdentitytoolkitAdminV2AllowByDefault: {
-        description:
-          "Defines a policy of allowing every region by default and adding disallowed regions to a disallow list.",
-        properties: {
-          disallowedRegions: {
-            description:
-              "Two letter unicode region codes to disallow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json",
-            items: { type: "string" },
-            type: "array",
-          },
-        },
-        type: "object",
-      },
-      GoogleCloudIdentitytoolkitAdminV2AllowlistOnly: {
-        description:
-          "Defines a policy of only allowing regions by explicitly adding them to an allowlist.",
-        properties: {
-          allowedRegions: {
-            description:
-              "Two letter unicode region codes to allow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json",
-            items: { type: "string" },
-            type: "array",
-          },
-        },
-        type: "object",
-      },
       GoogleCloudIdentitytoolkitAdminV2Anonymous: {
         description: "Configuration options related to authenticating an anonymous user.",
         properties: {
@@ -6683,19 +6663,6 @@ export default {
         },
         type: "object",
       },
-      GoogleCloudIdentitytoolkitAdminV2SmsRegionConfig: {
-        description:
-          "Configures the regions where users are allowed to send verification SMS for the project or tenant. This is based on the calling code of the destination phone number.",
-        properties: {
-          allowByDefault: {
-            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2AllowByDefault",
-          },
-          allowlistOnly: {
-            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2AllowlistOnly",
-          },
-        },
-        type: "object",
-      },
       GoogleCloudIdentitytoolkitAdminV2SmsTemplate: {
         description: "The template to use when sending an SMS.",
         properties: {
@@ -6810,9 +6777,6 @@ export default {
               'Output only. Resource name of a tenant. For example: "projects/{project-id}/tenants/{tenant-id}"',
             readOnly: true,
             type: "string",
-          },
-          smsRegionConfig: {
-            $ref: "#/components/schemas/GoogleCloudIdentitytoolkitAdminV2SmsRegionConfig",
           },
           testPhoneNumbers: {
             additionalProperties: { type: "string" },
@@ -7074,7 +7038,7 @@ export default {
       },
       GoogleIamV1AuditConfig: {
         description:
-          'Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { "audit_configs": [ { "service": "allServices", "audit_log_configs": [ { "log_type": "DATA_READ", "exempted_members": [ "user:jose@example.com" ] }, { "log_type": "DATA_WRITE" }, { "log_type": "ADMIN_READ" } ] }, { "service": "sampleservice.googleapis.com", "audit_log_configs": [ { "log_type": "DATA_READ" }, { "log_type": "DATA_WRITE", "exempted_members": [ "user:aliya@example.com" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts jose@example.com from DATA_READ logging, and aliya@example.com from DATA_WRITE logging.',
+          'Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { "audit_configs": [ { "service": "allServices", "audit_log_configs": [ { "log_type": "DATA_READ", "exempted_members": [ "user:jose@example.com" ] }, { "log_type": "DATA_WRITE" }, { "log_type": "ADMIN_READ" } ] }, { "service": "sampleservice.googleapis.com", "audit_log_configs": [ { "log_type": "DATA_READ" }, { "log_type": "DATA_WRITE", "exempted_members": [ "user:aliya@example.com" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts `jose@example.com` from DATA_READ logging, and `aliya@example.com` from DATA_WRITE logging.',
         properties: {
           auditLogConfigs: {
             description: "The configuration for logging of each type of permission.",
@@ -7113,7 +7077,7 @@ export default {
           condition: { $ref: "#/components/schemas/GoogleTypeExpr" },
           members: {
             description:
-              "Specifies the principals requesting access for a Cloud Platform resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. ",
+              "Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`. ",
             items: { type: "string" },
             type: "array",
           },
@@ -7190,7 +7154,7 @@ export default {
         properties: {
           permissions: {
             description:
-              "The set of permissions to check for the `resource`. Permissions with wildcards (such as '*' or 'storage.*') are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+              "The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
             items: { type: "string" },
             type: "array",
           },
@@ -7211,7 +7175,7 @@ export default {
       },
       GoogleProtobufEmpty: {
         description:
-          "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); } The JSON representation for `Empty` is empty JSON object `{}`.",
+          "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }",
         properties: {},
         type: "object",
       },
@@ -7295,7 +7259,6 @@ export default {
         description: "Emulator-specific configuration.",
         properties: {
           signIn: { properties: { allowDuplicateEmails: { type: "boolean" } }, type: "object" },
-          usageMode: { enum: ["USAGE_MODE_UNSPECIFIED", "DEFAULT", "PASSTHROUGH"], type: "string" },
         },
       },
       EmulatorV1ProjectsOobCodes: {

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -975,7 +975,13 @@ export interface components {
      * Response message for SetAccountInfo
      */
     GoogleCloudIdentitytoolkitV1SetAccountInfoResponse: {
+      /**
+       * The account's display name.
+       */
       displayName?: string;
+      /**
+       * The account's email address.
+       */
       email?: string;
       /**
        * Whether the account's email has been verified.
@@ -998,7 +1004,13 @@ export interface components {
        * The new email that has been set on the user's account attributes.
        */
       newEmail?: string;
+      /**
+       * Deprecated. No actual password hash is currently returned.
+       */
       passwordHash?: string;
+      /**
+       * The user's photo URL for the account's profile photo.
+       */
       photoUrl?: string;
       /**
        * The linked Identity Providers on the account.
@@ -1858,24 +1870,6 @@ export interface components {
       suggestedTimeout?: string;
     };
     /**
-     * Defines a policy of allowing every region by default and adding disallowed regions to a disallow list.
-     */
-    GoogleCloudIdentitytoolkitAdminV2AllowByDefault: {
-      /**
-       * Two letter unicode region codes to disallow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json
-       */
-      disallowedRegions?: string[];
-    };
-    /**
-     * Defines a policy of only allowing regions by explicitly adding them to an allowlist.
-     */
-    GoogleCloudIdentitytoolkitAdminV2AllowlistOnly: {
-      /**
-       * Two letter unicode region codes to allow as defined by https://cldr.unicode.org/ The full list of these region codes is here: https://github.com/unicode-cldr/cldr-localenames-full/blob/master/main/en/territories.json
-       */
-      allowedRegions?: string[];
-    };
-    /**
      * Configuration options related to authenticating an anonymous user.
      */
     GoogleCloudIdentitytoolkitAdminV2Anonymous: {
@@ -2427,13 +2421,6 @@ export interface components {
       phoneNumber?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2PhoneNumber"];
     };
     /**
-     * Configures the regions where users are allowed to send verification SMS for the project or tenant. This is based on the calling code of the destination phone number.
-     */
-    GoogleCloudIdentitytoolkitAdminV2SmsRegionConfig: {
-      allowByDefault?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2AllowByDefault"];
-      allowlistOnly?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2AllowlistOnly"];
-    };
-    /**
      * The template to use when sending an SMS.
      */
     GoogleCloudIdentitytoolkitAdminV2SmsTemplate: {
@@ -2549,7 +2536,6 @@ export interface components {
        * Output only. Resource name of a tenant. For example: "projects/{project-id}/tenants/{tenant-id}"
        */
       name?: string;
-      smsRegionConfig?: components["schemas"]["GoogleCloudIdentitytoolkitAdminV2SmsRegionConfig"];
       /**
        * A map of pairs that can be used for MFA. The phone number should be in E.164 format (https://www.itu.int/rec/T-REC-E.164/) and a maximum of 10 pairs can be added (error will be thrown once exceeded).
        */
@@ -2785,7 +2771,7 @@ export interface components {
       refreshToken?: string;
     };
     /**
-     * Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { "audit_configs": [ { "service": "allServices", "audit_log_configs": [ { "log_type": "DATA_READ", "exempted_members": [ "user:jose@example.com" ] }, { "log_type": "DATA_WRITE" }, { "log_type": "ADMIN_READ" } ] }, { "service": "sampleservice.googleapis.com", "audit_log_configs": [ { "log_type": "DATA_READ" }, { "log_type": "DATA_WRITE", "exempted_members": [ "user:aliya@example.com" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts jose@example.com from DATA_READ logging, and aliya@example.com from DATA_WRITE logging.
+     * Specifies the audit configuration for a service. The configuration determines which permission types are logged, and what identities, if any, are exempted from logging. An AuditConfig must have one or more AuditLogConfigs. If there are AuditConfigs for both `allServices` and a specific service, the union of the two AuditConfigs is used for that service: the log_types specified in each AuditConfig are enabled, and the exempted_members in each AuditLogConfig are exempted. Example Policy with multiple AuditConfigs: { "audit_configs": [ { "service": "allServices", "audit_log_configs": [ { "log_type": "DATA_READ", "exempted_members": [ "user:jose@example.com" ] }, { "log_type": "DATA_WRITE" }, { "log_type": "ADMIN_READ" } ] }, { "service": "sampleservice.googleapis.com", "audit_log_configs": [ { "log_type": "DATA_READ" }, { "log_type": "DATA_WRITE", "exempted_members": [ "user:aliya@example.com" ] } ] } ] } For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts `jose@example.com` from DATA_READ logging, and `aliya@example.com` from DATA_WRITE logging.
      */
     GoogleIamV1AuditConfig: {
       /**
@@ -2816,7 +2802,7 @@ export interface components {
     GoogleIamV1Binding: {
       condition?: components["schemas"]["GoogleTypeExpr"];
       /**
-       * Specifies the principals requesting access for a Cloud Platform resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`.
+       * Specifies the principals requesting access for a Google Cloud resource. `members` can have the following values: * `allUsers`: A special identifier that represents anyone who is on the internet; with or without a Google account. * `allAuthenticatedUsers`: A special identifier that represents anyone who is authenticated with a Google account or a service account. * `user:{emailid}`: An email address that represents a specific Google account. For example, `alice@example.com` . * `serviceAccount:{emailid}`: An email address that represents a service account. For example, `my-other-app@appspot.gserviceaccount.com`. * `group:{emailid}`: An email address that represents a Google group. For example, `admins@example.com`. * `deleted:user:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a user that has been recently deleted. For example, `alice@example.com?uid=123456789012345678901`. If the user is recovered, this value reverts to `user:{emailid}` and the recovered user retains the role in the binding. * `deleted:serviceAccount:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a service account that has been recently deleted. For example, `my-other-app@appspot.gserviceaccount.com?uid=123456789012345678901`. If the service account is undeleted, this value reverts to `serviceAccount:{emailid}` and the undeleted service account retains the role in the binding. * `deleted:group:{emailid}?uid={uniqueid}`: An email address (plus unique identifier) representing a Google group that has been recently deleted. For example, `admins@example.com?uid=123456789012345678901`. If the group is recovered, this value reverts to `group:{emailid}` and the recovered group retains the role in the binding. * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`.
        */
       members?: string[];
       /**
@@ -2875,7 +2861,7 @@ export interface components {
      */
     GoogleIamV1TestIamPermissionsRequest: {
       /**
-       * The set of permissions to check for the `resource`. Permissions with wildcards (such as '*' or 'storage.*') are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
+       * The set of permissions to check for the `resource`. Permissions with wildcards (such as `*` or `storage.*`) are not allowed. For more information see [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
        */
       permissions?: string[];
     };
@@ -2889,7 +2875,7 @@ export interface components {
       permissions?: string[];
     };
     /**
-     * A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); } The JSON representation for `Empty` is empty JSON object `{}`.
+     * A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); }
      */
     GoogleProtobufEmpty: { [key: string]: any };
     /**
@@ -2960,10 +2946,7 @@ export interface components {
     /**
      * Emulator-specific configuration.
      */
-    EmulatorV1ProjectsConfig: {
-      signIn?: { allowDuplicateEmails?: boolean };
-      usageMode?: "USAGE_MODE_UNSPECIFIED" | "DEFAULT" | "PASSTHROUGH";
-    };
+    EmulatorV1ProjectsConfig: { signIn?: { allowDuplicateEmails?: boolean } };
     /**
      * Details of all pending confirmation codes.
      */

--- a/src/test/emulators/auth/batch.spec.ts
+++ b/src/test/emulators/auth/batch.spec.ts
@@ -3,7 +3,6 @@ import { decode as decodeJwt } from "jsonwebtoken";
 import { describeAuthEmulator } from "./setup";
 import {
   enrollPhoneMfa,
-  deleteAccount,
   expectStatusCode,
   getAccountInfoByIdToken,
   getAccountInfoByLocalId,
@@ -17,7 +16,6 @@ import {
   signInWithPhoneNumber,
   TEST_PHONE_NUMBER,
   updateAccountByLocalId,
-  updateProjectConfig,
   registerTenant,
 } from "./helpers";
 import { UserInfo } from "../../../emulator/auth/state";
@@ -620,27 +618,6 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
     });
     // A mfaEnrollmentId should be automatically generated if not provided.
     expect(user1Info.mfaInfo![0].mfaEnrollmentId).to.be.a("string").and.not.empty;
-  });
-
-  it("should error if usageMode is passthrough", async () => {
-    const user1 = { localId: "foo", email: "foo@example.com", rawPassword: "notasecret" };
-    const user2 = {
-      localId: "bar",
-      phoneNumber: TEST_PHONE_NUMBER,
-      customAttributes: '{"hello": "world"}',
-    };
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
-      .set("Authorization", "Bearer owner")
-      .send({ users: [user1, user2] })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
   });
 
   it("should error if auth is disabled", async () => {

--- a/src/test/emulators/auth/config.spec.ts
+++ b/src/test/emulators/auth/config.spec.ts
@@ -6,7 +6,7 @@ describeAuthEmulator("config management", ({ authApi }) => {
   describe("updateConfig", () => {
     it("updates the project level config", async () => {
       const updateMask =
-        "signIn.allowDuplicateEmails,blockingFunctions.forwardInboundCredentials.idToken,usageMode";
+        "signIn.allowDuplicateEmails,blockingFunctions.forwardInboundCredentials.idToken";
 
       await authApi()
         .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
@@ -15,7 +15,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .send({
           signIn: { allowDuplicateEmails: true },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
-          usageMode: "PASSTHROUGH",
         })
         .then((res) => {
           expectStatusCode(200, res);
@@ -23,7 +22,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expect(res.body.blockingFunctions).to.eql({
             forwardInboundCredentials: { idToken: true },
           });
-          expect(res.body.usageMode).to.eql("PASSTHROUGH");
         });
     });
 
@@ -46,7 +44,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .send({
           signIn: { allowDuplicateEmails: true },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
-          usageMode: "PASSTHROUGH",
         })
         .then((res) => {
           expectStatusCode(200, res);
@@ -54,7 +51,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expect(res.body.blockingFunctions).to.eql({
             forwardInboundCredentials: { idToken: true },
           });
-          expect(res.body.usageMode).to.eql("PASSTHROUGH");
         });
     });
 
@@ -66,7 +62,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .send({
           signIn: { allowDuplicateEmails: true },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
-          usageMode: "PASSTHROUGH",
         })
         .then((res) => {
           expectStatusCode(200, res);
@@ -74,7 +69,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expect(res.body.blockingFunctions).to.eql({
             forwardInboundCredentials: { idToken: true },
           });
-          expect(res.body.usageMode).to.eql("PASSTHROUGH");
         });
 
       // Perform a full update and check that production defaults are set
@@ -86,35 +80,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expectStatusCode(200, res);
           expect(res.body.signIn?.allowDuplicateEmails).to.be.false;
           expect(res.body.blockingFunctions).to.eql({});
-          expect(res.body.usageMode).to.eql("DEFAULT");
-        });
-    });
-
-    it("should error on unspecified usageMode", async () => {
-      await authApi()
-        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
-        .set("Authorization", "Bearer owner")
-        .send({
-          usageMode: "USAGE_MODE_UNSPECIFIED",
-        })
-        .then((res) => {
-          expectStatusCode(400, res);
-          expect(res.body.error).to.have.property("message").contains("INVALID_USAGE_MODE");
-        });
-    });
-
-    it("should error when users are present for passthrough mode", async () => {
-      await registerAnonUser(authApi());
-
-      await authApi()
-        .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
-        .set("Authorization", "Bearer owner")
-        .send({
-          usageMode: "PASSTHROUGH",
-        })
-        .then((res) => {
-          expectStatusCode(400, res);
-          expect(res.body.error).to.have.property("message").contains("USERS_STILL_EXIST");
         });
     });
 
@@ -168,7 +133,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expect(res.body).to.have.property("signIn").eql({
             allowDuplicateEmails: false /* default value */,
           });
-          expect(res.body).to.have.property("usageMode").eql("DEFAULT");
           expect(res.body).to.have.property("blockingFunctions").eql({});
         });
     });
@@ -180,7 +144,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .send({
           signIn: { allowDuplicateEmails: true },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
-          usageMode: "PASSTHROUGH",
         });
 
       await authApi()
@@ -192,7 +155,6 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expect(res.body).to.have.property("signIn").eql({
             allowDuplicateEmails: true,
           });
-          expect(res.body).to.have.property("usageMode").eql("PASSTHROUGH");
           expect(res.body)
             .to.have.property("blockingFunctions")
             .eql({

--- a/src/test/emulators/auth/createAuthUri.spec.ts
+++ b/src/test/emulators/auth/createAuthUri.spec.ts
@@ -184,21 +184,6 @@ describeAuthEmulator("accounts:createAuthUri", ({ authApi }) => {
       });
   });
 
-  it("should error if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:createAuthUri")
-      .send({ continueUri: "http://example.com/", identifier: "notregistered@example.com" })
-      .query({ key: "fake-api-key" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
-  });
-
   it("should error if auth is disabled", async () => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
 

--- a/src/test/emulators/auth/customToken.spec.ts
+++ b/src/test/emulators/auth/customToken.spec.ts
@@ -8,7 +8,6 @@ import {
   getAccountInfoByIdToken,
   updateAccountByLocalId,
   signInWithEmailLink,
-  updateProjectConfig,
   registerTenant,
 } from "./helpers";
 
@@ -113,45 +112,6 @@ describeAuthEmulator("sign-in with custom token", ({ authApi }) => {
           ...customClaims,
           ...claims,
         });
-      });
-  });
-
-  it("should not issue a refresh token in passthrough mode", async () => {
-    const uid = "someuid";
-    const claims = { abc: "def", ultimate: { answer: 42 } };
-    const token = signJwt({ uid, claims }, "", {
-      algorithm: "none",
-      expiresIn: 3600,
-
-      subject: "fake-service-account@example.com",
-      issuer: "fake-service-account@example.com",
-      audience: CUSTOM_TOKEN_AUDIENCE,
-    });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken")
-      .query({ key: "fake-api-key" })
-      .send({ token })
-      .then((res) => {
-        expectStatusCode(200, res);
-        expect(res.body.isNewUser).to.equal(false);
-        expect(res.body).not.to.have.property("refreshToken");
-
-        const idToken = res.body.idToken as string;
-        const decoded = decodeJwt(idToken, { complete: true }) as {
-          header: JwtHeader;
-          payload: FirebaseJwtPayload;
-        } | null;
-        expect(decoded, "JWT returned by emulator is invalid").not.to.be.null;
-        expect(decoded!.header.alg).to.eql("none");
-        expect(decoded!.payload).not.to.have.property("provider_id");
-        expect(decoded!.payload.firebase)
-          .to.have.property("sign_in_provider")
-          .equals(PROVIDER_CUSTOM);
-        expect(decoded!.payload.firebase).to.have.property("usage_mode").equals("passthrough");
-        expect(decoded!.payload).deep.include(claims);
-        return idToken;
       });
   });
 

--- a/src/test/emulators/auth/deleteAccount.spec.ts
+++ b/src/test/emulators/auth/deleteAccount.spec.ts
@@ -6,8 +6,6 @@ import {
   signInWithFakeClaims,
   getSigninMethods,
   expectUserNotExistsForIdToken,
-  updateProjectConfig,
-  deleteAccount,
   registerTenant,
 } from "./helpers";
 
@@ -104,39 +102,6 @@ describeAuthEmulator("accounts:delete", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equals("MISSING_LOCAL_ID");
-      });
-  });
-
-  it("should error on delete with idToken if usageMode is passthrough", async () => {
-    const { idToken } = await registerUser(authApi(), {
-      email: "alice@example.com",
-      password: "notasecret",
-    });
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:delete")
-      .send({ idToken })
-      .query({ key: "fake-api-key" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
-  });
-
-  it("should return not found on delete with localId if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:delete")
-      .set("Authorization", "Bearer owner")
-      .send({ localId: "does-not-exist" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error).to.have.property("message").equals("USER_NOT_FOUND");
       });
   });
 

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -12,7 +12,6 @@ import {
   createEmailSignInOob,
   TEST_PHONE_NUMBER,
   TEST_MFA_INFO,
-  updateProjectConfig,
   registerTenant,
   getAccountInfoByLocalId,
 } from "./helpers";
@@ -81,23 +80,6 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
       "password",
       "emailLink",
     ]);
-  });
-
-  it("should error on signInWithEmailLink if usageMode is passthrough", async () => {
-    const user = { email: "bob@example.com", password: "notasecret" };
-    const { oobCode } = await createEmailSignInOob(authApi(), user.email);
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithEmailLink")
-      .query({ key: "fake-api-key" })
-      .send({ email: user.email, oobCode })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
   });
 
   it("should error on invalid oobCode", async () => {

--- a/src/test/emulators/auth/idp.spec.ts
+++ b/src/test/emulators/auth/idp.spec.ts
@@ -18,7 +18,6 @@ import {
   TEST_PHONE_NUMBER,
   FAKE_GOOGLE_ACCOUNT,
   REAL_GOOGLE_ACCOUNT,
-  TEST_MFA_INFO,
   enrollPhoneMfa,
   getAccountInfoByLocalId,
   registerTenant,
@@ -898,26 +897,6 @@ describeAuthEmulator("sign-in with credential", ({ authApi, getClock }) => {
       .then((res) => {
         expectStatusCode(200, res);
         expect(res.body.localId).to.equal(localId);
-      });
-  });
-
-  it("should error if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithIdp")
-      .query({ key: "fake-api-key" })
-      .send({
-        postBody: `providerId=google.com&id_token=${FAKE_GOOGLE_ACCOUNT.idToken}`,
-        requestUri: "http://localhost",
-        returnIdpCredential: true,
-        returnSecureToken: true,
-      })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -7,13 +7,11 @@ import {
   UserInfo,
 } from "../../../emulator/auth/state";
 import {
-  deleteAccount,
   getAccountInfoByIdToken,
   PROJECT_ID,
   registerTenant,
   signInWithPhoneNumber,
   TEST_PHONE_NUMBER,
-  updateProjectConfig,
 } from "./helpers";
 import { describeAuthEmulator } from "./setup";
 import {
@@ -185,24 +183,6 @@ describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
       });
   });
 
-  it("should error if usageMode is passthrough", async () => {
-    const { refreshToken, idToken } = await registerAnonUser(authApi());
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/securetoken.googleapis.com/v1/token")
-      .type("form")
-      .send({ refresh_token: refreshToken, grantType: "refresh_token" })
-      .query({ key: "fake-api-key" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
-  });
-
   it("should error when refresh tokens are from a different project", async () => {
     const refreshTokenRecord = {
       _AuthEmulatorRefreshToken: "DO NOT MODIFY",
@@ -346,24 +326,6 @@ describeAuthEmulator("createSessionCookie", ({ authApi }) => {
         expect(res.body.error.message).to.equal("INVALID_DURATION");
       });
   });
-
-  it("should error if usageMode is passthrough", async () => {
-    const { idToken } = await registerAnonUser(authApi());
-    const validDuration = 7777; /* seconds */
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}:createSessionCookie`)
-      .set("Authorization", "Bearer owner")
-      .send({ idToken, validDuration: validDuration.toString() })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
-  });
 });
 
 describeAuthEmulator("accounts:lookup", ({ authApi }) => {
@@ -426,19 +388,6 @@ describeAuthEmulator("accounts:lookup", ({ authApi }) => {
       });
   });
 
-  it("should return empty result for admin lookup if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:lookup`)
-      .set("Authorization", "Bearer owner")
-      .send({ localId: ["noSuchId"] })
-      .then((res) => {
-        expectStatusCode(200, res);
-        expect(res.body).not.to.have.property("users");
-      });
-  });
-
   it("should return user by tenantId in idToken", async () => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, {
       disableAuth: false,
@@ -458,23 +407,6 @@ describeAuthEmulator("accounts:lookup", ({ authApi }) => {
         expectStatusCode(200, res);
         expect(res.body.users).to.have.length(1);
         expect(res.body.users[0].localId).to.equal(localId);
-      });
-  });
-
-  it("should error for lookup using idToken if usageMode is passthrough", async () => {
-    const { idToken } = await registerAnonUser(authApi());
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post(`/identitytoolkit.googleapis.com/v1/accounts:lookup`)
-      .send({ idToken })
-      .query({ key: "fake-api-key" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 
@@ -623,67 +555,6 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
         expect(res.body).to.have.property("signIn").eql({
           allowDuplicateEmails: false,
         });
-      });
-  });
-
-  it("should update usageMode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
-    await authApi()
-      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ usageMode: "PASSTHROUGH" })
-      .then((res) => {
-        expectStatusCode(200, res);
-        expect(res.body).to.have.property("usageMode").equals("PASSTHROUGH");
-      });
-    await authApi()
-      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ usageMode: "DEFAULT" })
-      .then((res) => {
-        expectStatusCode(200, res);
-        expect(res.body).to.have.property("usageMode").equals("DEFAULT");
-      });
-  });
-
-  it("should default to DEFAULT usageMode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
-    await authApi()
-      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ usageMode: undefined })
-      .then((res) => {
-        expectStatusCode(200, res);
-        expect(res.body).to.have.property("usageMode").equals("DEFAULT");
-      });
-  });
-
-  it("should error for unspecified usageMode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
-    await authApi()
-      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ usageMode: "USAGE_MODE_UNSPECIFIED" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error).to.have.property("message").contains("INVALID_USAGE_MODE");
-      });
-  });
-
-  it("should error for invalid usageMode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
-    await authApi()
-      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ usageMode: "NOT_AN_ACTUAL_USAGE_MODE" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .contains("Invalid JSON payload received");
-      });
-  });
-
-  it("should error when users are present for passthrough mode on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
-    await registerAnonUser(authApi());
-
-    await authApi()
-      .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ usageMode: "PASSTHROUGH" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error).to.have.property("message").contains("USERS_STILL_EXIST");
       });
   });
 });

--- a/src/test/emulators/auth/oob.spec.ts
+++ b/src/test/emulators/auth/oob.spec.ts
@@ -7,8 +7,6 @@ import {
   updateAccountByLocalId,
   expectIdTokenExpired,
   inspectOobs,
-  updateProjectConfig,
-  deleteAccount,
   registerTenant,
 } from "./helpers";
 
@@ -211,24 +209,6 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
     expect(oobs).to.have.length(0);
   });
 
-  it("should error if usageMode is passthrough", async () => {
-    const user = { email: "alice@example.com", password: "notasecret" };
-    const { idToken } = await registerUser(authApi(), user);
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
-      .query({ key: "fake-api-key" })
-      .send({ idToken, requestType: "VERIFY_EMAIL" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
-  });
-
   it("should error if auth is disabled", async () => {
     const tenant = await registerTenant(authApi(), PROJECT_ID, { disableAuth: true });
 
@@ -347,33 +327,6 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
     // OOB codes are not consumed by the lookup above.
     const oobs2 = await inspectOobs(authApi());
     expect(oobs2).to.have.length(3);
-  });
-
-  it("should error on resetPassword endpoint if usageMode is passthrough", async () => {
-    const user = { email: "alice@example.com", password: "notasecret" };
-    const { idToken } = await registerUser(authApi(), user);
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
-      .query({ key: "fake-api-key" })
-      .send({ requestType: "PASSWORD_RESET", email: user.email })
-      .then((res) => {
-        expectStatusCode(200, res);
-        expect(res.body.email).to.equal(user.email);
-      });
-    const oobs = await inspectOobs(authApi());
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:resetPassword")
-      .query({ key: "fake-api-key" })
-      .send({ oobCode: oobs[0].oobCode, newPassword: "notasecret2" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
   });
 
   it("should error on resetPassword if auth is disabled", async () => {

--- a/src/test/emulators/auth/password.spec.ts
+++ b/src/test/emulators/auth/password.spec.ts
@@ -3,14 +3,12 @@ import { decode as decodeJwt, JwtHeader } from "jsonwebtoken";
 import { FirebaseJwtPayload } from "../../../emulator/auth/operations";
 import { describeAuthEmulator, PROJECT_ID } from "./setup";
 import {
-  deleteAccount,
   expectStatusCode,
   getAccountInfoByLocalId,
   registerTenant,
   registerUser,
   TEST_MFA_INFO,
   updateAccountByLocalId,
-  updateProjectConfig,
 } from "./helpers";
 
 describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
@@ -154,24 +152,6 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
         expect(res.body).not.to.have.property("refreshToken");
         expect(res.body.mfaPendingCredential).to.be.a("string");
         expect(res.body.mfaInfo).to.be.an("array").with.lengthOf(1);
-      });
-  });
-
-  it("should error if usageMode is passthrough", async () => {
-    const user = { email: "alice@example.com", password: "notasecret" };
-    const { localId, idToken } = await registerUser(authApi(), user);
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
-      .query({ key: "fake-api-key" })
-      .send({ email: user.email, password: user.password })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 

--- a/src/test/emulators/auth/phone.spec.ts
+++ b/src/test/emulators/auth/phone.spec.ts
@@ -13,7 +13,6 @@ import {
   TEST_PHONE_NUMBER,
   TEST_PHONE_NUMBER_2,
   enrollPhoneMfa,
-  updateProjectConfig,
   registerTenant,
 } from "./helpers";
 
@@ -73,22 +72,6 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
         expect(res.body.error)
           .to.have.property("message")
           .equals("INVALID_PHONE_NUMBER : Invalid format.");
-      });
-  });
-
-  it("should error on sendVerificationMode if usageMode is passthrough", async () => {
-    const phoneNumber = TEST_PHONE_NUMBER;
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    const sessionInfo = await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:sendVerificationCode")
-      .query({ key: "fake-api-key" })
-      .send({ phoneNumber, recaptchaToken: "ignored" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 
@@ -401,32 +384,6 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equals("PHONE_NUMBER_EXISTS");
-      });
-  });
-
-  it("should error on signInWithPhoneNumber if usageMode is passthrough", async () => {
-    const phoneNumber = TEST_PHONE_NUMBER;
-    const sessionInfo = await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:sendVerificationCode")
-      .query({ key: "fake-api-key" })
-      .send({ phoneNumber, recaptchaToken: "ignored" })
-      .then((res) => {
-        expectStatusCode(200, res);
-        return res.body.sessionInfo;
-      });
-    const codes = await inspectVerificationCodes(authApi());
-    const code = codes[0].code;
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPhoneNumber")
-      .query({ key: "fake-api-key" })
-      .send({ sessionInfo, code })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 

--- a/src/test/emulators/auth/setAccountInfo.spec.ts
+++ b/src/test/emulators/auth/setAccountInfo.spec.ts
@@ -20,8 +20,6 @@ import {
   TEST_PHONE_NUMBER_2,
   TEST_PHONE_NUMBER_3,
   TEST_INVALID_PHONE_NUMBER,
-  deleteAccount,
-  updateProjectConfig,
   registerTenant,
 } from "./helpers";
 
@@ -1137,25 +1135,6 @@ describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error.message).to.equal("CLAIMS_TOO_LARGE");
-      });
-  });
-
-  it("should error if usageMode is passthrough", async () => {
-    const user = { email: "alice@example.com", password: "notasecret" };
-    const { idToken } = await registerUser(authApi(), user);
-    const newPassword = "notasecreteither";
-    await deleteAccount(authApi(), { idToken });
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
-      .query({ key: "fake-api-key" })
-      .send({ idToken, password: newPassword })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
       });
   });
 

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -16,7 +16,6 @@ import {
   TEST_PHONE_NUMBER,
   TEST_PHONE_NUMBER_2,
   TEST_INVALID_PHONE_NUMBER,
-  updateProjectConfig,
   registerTenant,
 } from "./helpers";
 
@@ -516,21 +515,6 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
     expect(savedMfaInfo).to.include(TEST_MFA_INFO);
     expect(savedMfaInfo.mfaEnrollmentId).to.be.a("string").and.not.empty;
     expect([mfaEnrollmentId1, mfaEnrollmentId2]).not.to.include(savedMfaInfo.mfaEnrollmentId);
-  });
-
-  it("should error on signUp if usageMode is passthrough", async () => {
-    await updateProjectConfig(authApi(), { usageMode: "PASSTHROUGH" });
-
-    await authApi()
-      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
-      .send({ returnSecureToken: true })
-      .query({ key: "fake-api-key" })
-      .then((res) => {
-        expectStatusCode(400, res);
-        expect(res.body.error)
-          .to.have.property("message")
-          .equals("UNSUPPORTED_PASSTHROUGH_OPERATION");
-      });
   });
 
   it("should error if auth is disabled", async () => {


### PR DESCRIPTION
### Description

Removes all references of `usageMode` and `passthrough` from auth emulator. Regenerates apiSpec.js and schema.ts from changes too.

Corresponding internal bug: [b/192387797](http://b/192387797)

### Scenarios Tested

`npm test` passes

### Sample Commands

N/A
