### PR TITLE
Crash emulator when an invalid function is emulated

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -576,7 +576,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         // To match prod behavior, only validate functionName
         functionIdsAreValid([{ ...definition, id: definition.name }]);
       } catch (e: any) {
-        throw new FirebaseError(`functions[${definition.id}]: Invalid function id: ${e.message}`)
+        throw new FirebaseError(`functions[${definition.id}]: Invalid function id: ${e.message}`);
       }
 
       let added = false;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Currently, if we try to emulate an invalid function and we detect things like formatting issues, we will catch the issue without processing the function. This isn't ideal... it's easy for those issues to get lost in the logs and for users to spend unnecessary time debugging.

We ran into this a couple times with the extension events emulator work; we weren't sure why our custom event handler wasn't firing (it didn't follow the strict cf3v2 naming conventions) and realized that it wasn't being registered in the first place. Now we'll throw an explicit error and force the user to handle it before starting emulators.

<img width="1335" alt="Screen Shot 2022-06-02 at 1 05 00 PM" src="https://user-images.githubusercontent.com/64040981/171685090-5f74662c-9d85-4565-bb18-643881c9fecf.png">

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
