### PR TITLE
WIP: Use Build-to-Backend instead of Backend in the main CF3v2 deploy path.

### DIFF
--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -331,6 +331,8 @@ export function resolveBackend(build: Build, userEnvs: Record<string, string>): 
       }
       if (bdEndpoint.serviceAccount) {
         bkEndpoint.serviceAccountEmail = bdEndpoint.serviceAccount;
+      } else {
+        bkEndpoint.serviceAccountEmail = undefined;
       }
 
       bkEndpoints.push(bkEndpoint);

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -113,14 +113,8 @@ export async function prepare(
     };
     const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
     const envs = { ...userEnvs, ...firebaseEnvs };
-    let wantBackend: backend.Backend;
-    if (previews.functionsparams) {
-      const wantBuild = await runtimeDelegate.discoverBuild(runtimeConfig, firebaseEnvs);
-      wantBackend = build.resolveBackend(wantBuild, userEnvs);
-    } else {
-      logger.debug(`Analyzing ${runtimeDelegate.name} backend spec`);
-      wantBackend = await runtimeDelegate.discoverSpec(runtimeConfig, firebaseEnvs);
-    }
+    const wantBuild: build.Build = await runtimeDelegate.discoverBuild(runtimeConfig, firebaseEnvs);
+    const wantBackend: backend.Backend = build.resolveBackend(wantBuild, userEnvs);
     wantBackend.environmentVariables = envs;
     for (const endpoint of backend.allEndpoints(wantBackend)) {
       endpoint.environmentVariables = wantBackend.environmentVariables;

--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -7,6 +7,7 @@ import { promisify } from "util";
 import { logger } from "../../../../logger";
 import * as api from "../../.../../../../api";
 import * as backend from "../../backend";
+import * as build from "../../build";
 import * as runtimes from "..";
 import * as v1alpha1 from "./v1alpha1";
 import { FirebaseError } from "../../../../error";
@@ -34,11 +35,32 @@ export function yamlToBackend(
   }
 }
 
+export function yamlToBuild(
+  yaml: any,
+  project: string,
+  region: string,
+  runtime: runtimes.Runtime
+): build.Build {
+  try {
+    if (!yaml.specVersion) {
+      throw new FirebaseError("Expect manifest yaml to specify a version number");
+    }
+    if (yaml.specVersion === "v1alpha1") {
+      return v1alpha1.buildFromV1Alpha1(yaml, project, region, runtime);
+    }
+    throw new FirebaseError(
+      "It seems you are using a newer SDK than this version of the CLI can handle. Please update your CLI with `npm install -g firebase-tools`"
+    );
+  } catch (err: any) {
+    throw new FirebaseError("Failed to parse build specification", { children: [err] });
+  }
+}
+
 export async function detectFromYaml(
   directory: string,
   project: string,
   runtime: runtimes.Runtime
-): Promise<backend.Backend | undefined> {
+): Promise<build.Build | undefined> {
   let text: string;
   try {
     text = await exports.readFileAsync(path.join(directory, "functions.yaml"), "utf8");
@@ -53,7 +75,7 @@ export async function detectFromYaml(
 
   logger.debug("Found functions.yaml. Got spec:", text);
   const parsed = yaml.load(text);
-  return yamlToBackend(parsed, project, api.functionsDefaultRegion, runtime);
+  return yamlToBuild(parsed, project, api.functionsDefaultRegion, runtime);
 }
 
 export async function detectFromPort(
@@ -61,7 +83,7 @@ export async function detectFromPort(
   project: string,
   runtime: runtimes.Runtime,
   timeout = 30_000 /* 30s to boot up */
-): Promise<backend.Backend> {
+): Promise<build.Build> {
   // The result type of fetch isn't exported
   let res: { text(): Promise<string> };
   const timedOut = new Promise<never>((resolve, reject) => {
@@ -94,5 +116,5 @@ export async function detectFromPort(
     throw new FirebaseError(`Failed to load function definition from source: ${text}`);
   }
 
-  return yamlToBackend(parsed, project, api.functionsDefaultRegion, runtime);
+  return yamlToBuild(parsed, project, api.functionsDefaultRegion, runtime);
 }

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -312,7 +312,7 @@ function parseEndpointForBuild(
     project,
     runtime,
     entryPoint: ep.entryPoint,
-    serviceAccount: ep.serviceAccountEmail || "default",
+    serviceAccount: ep.serviceAccountEmail || null,
     ...triggered,
   };
   copyIfPresent(

--- a/src/deploy/functions/runtimes/golang/index.ts
+++ b/src/deploy/functions/runtimes/golang/index.ts
@@ -153,26 +153,4 @@ export class Delegate {
     // Unimplemented. Build discovery is not currently supported in Go.
     return { requiredAPIs: [], endpoints: {}, params: [] };
   }
-
-  async discoverSpec(
-    configValues: backend.RuntimeConfigValues,
-    envs: backend.EnvironmentVariables
-  ): Promise<backend.Backend> {
-    let discovered = await discovery.detectFromYaml(this.sourceDir, this.projectId, this.runtime);
-    if (!discovered) {
-      const getPort = promisify(portfinder.getPort) as () => Promise<number>;
-      const port = await getPort();
-      (portfinder as any).basePort = port + 1;
-      const adminPort = await getPort();
-
-      const kill = await this.serve(port, adminPort, envs);
-      try {
-        discovered = await discovery.detectFromPort(adminPort, this.projectId, this.runtime);
-      } finally {
-        await kill();
-      }
-    }
-    discovered.environmentVariables = envs;
-    return discovered;
-  }
 }

--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -98,11 +98,6 @@ export interface RuntimeDelegate {
     configValues: backend.RuntimeConfigValues,
     envs: backend.EnvironmentVariables
   ): Promise<build.Build>;
-
-  discoverSpec(
-    configValues: backend.RuntimeConfigValues,
-    envs: backend.EnvironmentVariables
-  ): Promise<backend.Backend>;
 }
 
 export interface DelegateContext {

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -131,21 +131,16 @@ export class Delegate {
     });
   }
 
-  async discoverSpec(
+  // eslint-disable-next-line require-await
+  async discoverBuild(
     config: backend.RuntimeConfigValues,
     env: backend.EnvironmentVariables
-  ): Promise<backend.Backend> {
+  ): Promise<build.Build> {
     if (!semver.valid(this.sdkVersion)) {
       logger.debug(
         `Could not parse firebase-functions version '${this.sdkVersion}' into semver. Falling back to parseTriggers.`
       );
-      return parseTriggers.discoverBackend(
-        this.projectId,
-        this.sourceDir,
-        this.runtime,
-        config,
-        env
-      );
+      return parseTriggers.discoverBuild(this.projectId, this.sourceDir, this.runtime, config, env);
     }
     if (semver.lt(this.sdkVersion, MIN_FUNCTIONS_SDK_VERSION)) {
       logLabeledWarning(
@@ -153,14 +148,9 @@ export class Delegate {
         `You are using an old version of firebase-functions SDK (${this.sdkVersion}). ` +
           `Please update firebase-functions SDK to >=${MIN_FUNCTIONS_SDK_VERSION}`
       );
-      return parseTriggers.discoverBackend(
-        this.projectId,
-        this.sourceDir,
-        this.runtime,
-        config,
-        env
-      );
+      return parseTriggers.discoverBuild(this.projectId, this.sourceDir, this.runtime, config, env);
     }
+
     let discovered = await discovery.detectFromYaml(this.sourceDir, this.projectId, this.runtime);
     if (!discovered) {
       const getPort = promisify(portfinder.getPort) as () => Promise<number>;
@@ -172,15 +162,6 @@ export class Delegate {
         await kill();
       }
     }
-    discovered.environmentVariables = env;
     return discovered;
-  }
-
-  // eslint-disable-next-line require-await
-  async discoverBuild(
-    config: backend.RuntimeConfigValues,
-    env: backend.EnvironmentVariables
-  ): Promise<build.Build> {
-    return parseTriggers.discoverBuild(this.projectId, this.sourceDir, this.runtime, config, env);
   }
 }

--- a/src/test/deploy/functions/runtimes/discovery/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/index.spec.ts
@@ -7,19 +7,20 @@ import * as api from "../../../../../api";
 import { FirebaseError } from "../../../../../error";
 import * as discovery from "../../../../../deploy/functions/runtimes/discovery";
 import * as backend from "../../../../../deploy/functions/backend";
+import * as build from "../../../../../deploy/functions/build";
 
 const MIN_ENDPOINT = {
   entryPoint: "entrypoint",
   httpsTrigger: {},
 };
 
-const ENDPOINT: backend.Endpoint = {
+const ENDPOINT: build.Endpoint = {
   ...MIN_ENDPOINT,
-  id: "id",
   platform: "gcfv2",
   project: "project",
-  region: api.functionsDefaultRegion,
   runtime: "nodejs16",
+  region: ["us-central1"],
+  serviceAccount: null,
 };
 
 const YAML_OBJ = {
@@ -29,24 +30,25 @@ const YAML_OBJ = {
 
 const YAML_TEXT = yaml.dump(YAML_OBJ);
 
-const BACKEND: backend.Backend = backend.of(ENDPOINT);
+//const BACKEND: backend.Backend = backend.of(ENDPOINT);
+const BUILD: build.Build = build.of({"id": ENDPOINT});
 
-describe("yamlToBackend", () => {
+describe("yamlToBuild", () => {
   it("Accepts a valid v1alpha1 spec", () => {
-    const parsed = discovery.yamlToBackend(
+    const parsed = discovery.yamlToBuild(
       YAML_OBJ,
       "project",
       api.functionsDefaultRegion,
       "nodejs16"
     );
-    expect(parsed).to.deep.equal(BACKEND);
+    expect(parsed).to.deep.equal(BUILD);
   });
 
   it("Requires a spec version", () => {
     const flawed: Record<string, unknown> = { ...YAML_OBJ };
     delete flawed.specVersion;
     expect(() =>
-      discovery.yamlToBackend(flawed, "project", api.functionsDefaultRegion, "nodejs16")
+      discovery.yamlToBuild(flawed, "project", api.functionsDefaultRegion, "nodejs16")
     ).to.throw(FirebaseError);
   });
 
@@ -56,7 +58,7 @@ describe("yamlToBackend", () => {
       specVersion: "32767beta2",
     };
     expect(() =>
-      discovery.yamlToBackend(flawed, "project", api.functionsDefaultRegion, "nodejs16")
+      discovery.yamlToBuild(flawed, "project", api.functionsDefaultRegion, "nodejs16")
     ).to.throw(FirebaseError);
   });
 });
@@ -77,7 +79,7 @@ describe("detectFromYaml", () => {
 
     await expect(
       discovery.detectFromYaml("directory", "project", "nodejs16")
-    ).to.eventually.deep.equal(BACKEND);
+    ).to.eventually.deep.equal(BUILD);
   });
 
   it("returns undefined when YAML cannot be found", async () => {
@@ -106,6 +108,6 @@ describe("detectFromPort", () => {
     nock("http://localhost:8080").get("/__/functions.yaml").reply(200, YAML_TEXT);
 
     const parsed = await discovery.detectFromPort(8080, "project", "nodejs16");
-    expect(parsed).to.deep.equal(BACKEND);
+    expect(parsed).to.deep.equal(BUILD);
   });
 });

--- a/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -26,7 +26,7 @@ describe("buildFromV1Alpha", () => {
       project: PROJECT,
       region: REGION,
       runtime: RUNTIME,
-      serviceAccountEmail: "default",
+      serviceAccountEmail: undefined,
       timeoutSeconds: 60,
     };
     const DEFAULTED_ENDPOINT: Omit<build.Endpoint, "httpsTrigger" | "secretEnvironmentVariables"> =
@@ -36,7 +36,7 @@ describe("buildFromV1Alpha", () => {
         project: PROJECT,
         region: [REGION],
         runtime: RUNTIME,
-        serviceAccount: "default",
+        serviceAccount: null,
       };
 
     it("fills default backend and function fields", () => {


### PR DESCRIPTION
This PR does 3 fairly spicy things:

1) Sets the behavior of serviceAccountEmail in the build type to at least something which seems to work when I tested locally. The last time this change came up, there were suggestions that this behavior (setting serviceAccountEmail to `undefined` in the backend if not otherwise present to force the default service account) would result in incorrect behavior, but I confess I didn't entirely follow why. I'll be following up on this one before this PR stops being a WIP.

2) Flips detectFromYaml to return Promise<build.Build> instead of Promise<backend.Backend>, and plumbs that changed type through the calls that it makes and its test suite. As a consequence, we can now remove the feature guard from Builds in deploy/prepare.ts. **Merging this PR will cause all CF3v2 deploys to use the Build type.**

3) Modifies the Functions emulator to also do a discoverBuild+resolveBackend instead of a discoverSpec.