### PR TITLE
Start eventarc emulator using default settings whenever functions emulator is started

### DIFF
--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -2,7 +2,7 @@ import * as url from "url";
 
 import { Emulators } from "./types";
 
-const DEFAULT_PORTS: { [s in Emulators]: number } = {
+export const DEFAULT_PORTS: { [s in Emulators]: number } = {
   ui: 4000,
   hub: 4400,
   logging: 4500,
@@ -47,7 +47,7 @@ export const EMULATOR_DESCRIPTION: Record<Emulators, string> = {
   eventarc: "Eventarc Emulator",
 };
 
-const DEFAULT_HOST = "localhost";
+export const DEFAULT_HOST = "localhost";
 
 export class Constants {
   // GCP projects cannot start with 'demo' so we use 'demo-' as a prefix to denote

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -539,19 +539,16 @@ export async function startAll(
   // Since the functions emulator will always be started by default, and the eventarc emulator
   // is only used by the functions emulator, we will start them in conjunction (using the default host/port)
   // even if the app developer has not explicitly configured the eventarc emulator.
-  let eventarcEmulator;
-  if (shouldStart(options, Emulators.EVENTARC)) {
-    const eventarcAddr = await getAndCheckAddress(Emulators.EVENTARC, options);
-    eventarcEmulator = new EventarcEmulator({
-      host: eventarcAddr.host,
-      port: eventarcAddr.port,
-    });
-  } else {
-    eventarcEmulator = new EventarcEmulator({
-      host: DEFAULT_HOST,
-      port: DEFAULT_PORTS.eventarc,
-    });
+  if (!shouldStart(options, Emulators.EVENTARC)) {
+    if (options.config.src.emulators) {
+      options.config.src.emulators.eventarc = {host: DEFAULT_HOST, port: DEFAULT_PORTS.eventarc};
+    }
   }
+  const eventarcAddr = await getAndCheckAddress(Emulators.EVENTARC, options);
+  const eventarcEmulator = new EventarcEmulator({
+    host: eventarcAddr.host,
+    port: eventarcAddr.port,
+  });
   await startEmulator(eventarcEmulator);
 
   if (shouldStart(options, Emulators.FIRESTORE)) {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -541,7 +541,7 @@ export async function startAll(
   // even if the app developer has not explicitly configured the eventarc emulator.
   if (!shouldStart(options, Emulators.EVENTARC)) {
     if (options.config.src.emulators) {
-      options.config.src.emulators.eventarc = {host: DEFAULT_HOST, port: DEFAULT_PORTS.eventarc};
+      options.config.src.emulators.eventarc = { host: DEFAULT_HOST, port: DEFAULT_PORTS.eventarc };
     }
   }
   const eventarcAddr = await getAndCheckAddress(Emulators.EVENTARC, options);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

If the user emulates an extension that emits events and eventarc emulator isn't configured, they will accidentally be emitting events to prod. This code prevents that, and also makes it simpler for people who have already set up their project to try emulating extensions with events seamlessly (no need to do additional set up to configure the eventarc emulator, which might not be obvious).

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
