### PR TITLE
add better messaging when the emulator UI isn't started

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,7 @@ module.exports = {
         "no-invalid-this": "off", // Turned off in favor of @typescript-eslint/no-invalid-this.
         "@typescript-eslint/no-invalid-this": ["error"],
         eqeqeq: ["error", "always", { null: "ignore" }],
+        "no-unused-vars": "off", // Off in favor of @typescript-eslint/no-unused-vars.
 
         "@typescript-eslint/ban-types": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/explicit-function-return-type": ["warn", { allowExpressions: true }], // TODO(bkendall): SET to error.
@@ -52,6 +53,7 @@ module.exports = {
         "@typescript-eslint/no-unsafe-call": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/no-unsafe-member-access": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/no-unsafe-return": "warn", // TODO(bkendall): remove, allow to error.
+        "@typescript-eslint/no-unused-vars": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/no-use-before-define": ["warn", { functions: false, typedefs: false }], // TODO(bkendall): change to error.
         "@typescript-eslint/no-var-requires": "warn", // TODO(bkendall): remove, allow to error.
         "@typescript-eslint/prefer-includes": "warn", // TODO(bkendall): remove, allow to error.
@@ -62,7 +64,6 @@ module.exports = {
         "no-case-declarations": "warn", // TODO(bkendall): remove, allow to error.
         "no-constant-condition": "warn", // TODO(bkendall): remove, allow to error.
         "no-fallthrough": "warn", // TODO(bkendall): remove, allow to error.
-        "no-unused-vars": "warn", // TODO(bkendall): remove, allow to error.
         camelcase: ["warn", { ignoreDestructuring: true }], // TODO(bkendall): remove, allow to error.
       },
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes Auth Blocking Trigger registration in the Emulator (#4592).
+- Adds better messaging when the Emulator UI isn't started (#3781).

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -747,7 +747,10 @@ export async function startAll(
     hubLogger.logLabeled(
       "WARN",
       "emulators",
-      "The Emulator UI requires a project ID to start. Configure your default project with 'firebase use' or pass the --project flag."
+      "The Emulator UI is not starting, either because none of the emulated " +
+        "features interact with the Emulator UI or it cannot determine the " +
+        "Project ID. Configure your default project with 'firebase use' or " +
+        "pass the --project flag"
     );
   }
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -1,6 +1,5 @@
 import { ChildProcess } from "child_process";
 import { EventEmitter } from "events";
-import { previews } from "../previews";
 
 export enum Emulators {
   AUTH = "auth",
@@ -46,7 +45,7 @@ export const ALL_SERVICE_EMULATORS = [
   Emulators.HOSTING,
   Emulators.PUBSUB,
   Emulators.STORAGE,
-].filter((v) => v) as Emulators[];
+].filter((v) => v);
 
 export const EMULATORS_SUPPORTED_BY_FUNCTIONS = [
   Emulators.FIRESTORE,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Adds better messaging when the emulator UI isn't started.

Also, uses the typescript version of `no-unused-vars` to turn off the irritating "ENUM value isn't used" warnings.

Fixes #3781