### PR TITLE
fix some _.map replacements

### DIFF
--- a/scripts/test-functions-deploy.js
+++ b/scripts/test-functions-deploy.js
@@ -98,7 +98,7 @@ var checkFunctionsListMatch = function (expectedFunctions) {
   return cloudfunctions
     .listFunctions(projectId, region)
     .then(function (result) {
-      deployedFunctions = result.map((fn) => last(fn.name.split("/")));
+      deployedFunctions = (result || []).map((fn) => last(fn.name.split("/")));
       expect(_.isEmpty(_.xor(expectedFunctions, deployedFunctions))).to.be.true;
       return true;
     })

--- a/src/functionsConfig.ts
+++ b/src/functionsConfig.ts
@@ -131,11 +131,14 @@ export async function materializeConfig(configName: string, output: any): Promis
   return output;
 }
 
-export async function materializeAll(projectId: string): Promise<{ [key: string]: any }> {
+export async function materializeAll(projectId: string): Promise<Record<string, any>> {
   const output = {};
   const configs = await runtimeconfig.configs.list(projectId);
+  if (!Array.isArray(configs) || !configs.length) {
+    return output;
+  }
   await Promise.all(
-    configs.map((config: any) => {
+    configs.map<Promise<any> | undefined>((config: any) => {
       if (config.name.match(new RegExp("configs/firebase"))) {
         // ignore firebase config
         return;

--- a/src/gcp/runtimeconfig.ts
+++ b/src/gcp/runtimeconfig.ts
@@ -7,9 +7,9 @@ import { logger } from "../logger";
 const API_VERSION = "v1beta1";
 const apiClient = new Client({ urlPrefix: runtimeconfigOrigin, apiVersion: API_VERSION });
 
-function listConfigs(projectId: string): Promise<any> {
+function listConfigs(projectId: string): Promise<unknown[] | undefined> {
   return apiClient
-    .get<{ configs: any }>(`/projects/${projectId}/configs`, {
+    .get<{ configs?: unknown[] }>(`/projects/${projectId}/configs`, {
       retryCodes: [500, 503],
     })
     .then((resp) => resp.body.configs);

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -19,7 +19,7 @@ const TARGETS: {
  * @param options Firebase CLI options.
  */
 export async function serve(options: any): Promise<void> {
-  const targetNames = options.targets;
+  const targetNames = options.targets || [];
   options.port = parseInt(options.port, 10);
   if (
     previews.frameworkawareness &&


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Unfortunately, in some cases where `_.map(undefined)` may have happened, `undefined.map` throws a worse error. I've gone through our couple PRs removing `map` and have fixed up places where that was an issue.