### PR TITLE
Add the ability to ability to skip deploying no-op functions

### DIFF
--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -27,7 +27,12 @@ async function generateSourceHash(source: args.Source): any {
       readStream.on("error", (err) => reject(err));
     });
   }
-  // TODO(tystark) Hash the contents of the .env files; discussion needed
+
+  // Hash any possible .env additions
+  hash.push({
+    ...process.env,
+  });
+
   // TODO(tystark) Hash the contents of the secret versions; rpc needed (unless we already made this call earlier)
   return hash.read();
 }

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -15,7 +15,7 @@ import crypto from "crypto";
 
 setGracefulCleanup();
 
-async function generateSourceHash(source: args.Source): any {
+async function generateSourceHash(source: args.Source): Promise<any> {
   const hash = crypto.createHash("sha256");
   const sourceFile = source.functionsSourceV2 || source.functionsSourceV1;
   // Hash the contents of the source file

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -24,7 +24,7 @@ async function generateSourceHash(source: args.Source): Promise<any> {
     readStream.pipe(hash);
     await new Promise((resolve, reject) => {
       hash.on("end", () => resolve(hash.read()));
-      readStream.on("error", (err) => reject(err));
+      readStream.on("error", reject);
     });
   }
 

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -166,6 +166,7 @@ export async function upload(
     body: source.stream,
     skipLog: { resBody: true },
   });
+  // TODO(tystark) - trigger a second rpc to add hash label; discussion needed
   return {
     generation: res.response.headers.get("x-goog-generation"),
   };


### PR DESCRIPTION
This function adds the ability to skip deploying functions that have
not changed.

A common usecase for this is a user that only updated their hosting
files (/public) and then ran `firebase deploy`.

**Actionable Items:**

- [x] Hash function
- [x] Hash used .env
- [x] Hash secret versions
- [ ] Add a `firebase-cli-upload-hash` label
- [ ] Fetch the labels of the latest uploaded function
- [ ] Short-circuit upload if hashes match
- [ ] Skip short-circuit if the user has `--force`
- [ ] Display cli messaging informing functions were not updated (but they can force it)