### PR TITLE
Fix Blocking Function signature in Emulator 

### DIFF
--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -382,7 +382,7 @@ export function formatHost(info: { host: string; port: number }): string {
 }
 
 export function getSignatureType(def: EmulatedTriggerDefinition): SignatureType {
-  if (def.httpsTrigger) {
+  if (def.httpsTrigger || def.blockingTrigger) {
     return "http";
   }
   // TODO: As implemented, emulated CF3v1 functions cannot receive events in CloudEvent format, and emulated CF3v2


### PR DESCRIPTION
- Fixes a small bug where blocking functions treated as an `event` function instead of an `http` function.