### PR TITLE
Statically allocate socket path for each function emulator runtime process.

### DIFF
--- a/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
+++ b/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
@@ -102,11 +102,6 @@ async function callHTTPSFunction(
 ): Promise<string> {
   await worker.waitForSocketReady();
 
-  if (!worker.lastArgs) {
-    throw new Error("Can't talk to worker with undefined args");
-  }
-
-  const socketPath = worker.lastArgs.frb.socketPath;
   const path = options.path || "/";
 
   const res = await new Promise<IncomingMessage>((resolve, reject) => {
@@ -114,7 +109,7 @@ async function callHTTPSFunction(
       {
         method: "POST",
         headers: options.headers,
-        socketPath,
+        socketPath: worker.runtime.socketPath,
         path,
       },
       resolve

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -43,6 +43,7 @@ import {
   toBackendInfo,
   prepareEndpoints,
   BlockingTrigger,
+  getTemporarySocketPath,
 } from "./functionsEmulatorShared";
 import { EmulatorRegistry } from "./registry";
 import { EmulatorLogger, Verbosity } from "./emulatorLogger";
@@ -139,6 +140,8 @@ export interface FunctionsRuntimeInstance {
   exit: Promise<number>;
   // A cwd of the process
   cwd: string;
+  // Path to socket file used for HTTP-over-IPC comms.
+  socketPath: string;
 
   // A function to manually kill the child process as normal cleanup
   shutdown(): void;
@@ -1275,10 +1278,17 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     const runtimeEnv = this.getRuntimeEnvs(backend, trigger);
     const secretEnvs = await this.resolveSecretEnvs(backend, trigger);
+    const socketPath = getTemporarySocketPath();
 
     const childProcess = spawn(opts.nodeBinary, args, {
       cwd: backend.functionsDir,
-      env: { node: opts.nodeBinary, ...process.env, ...runtimeEnv, ...secretEnvs },
+      env: {
+        node: opts.nodeBinary,
+        ...process.env,
+        ...runtimeEnv,
+        ...secretEnvs,
+        PORT: socketPath,
+      },
       stdio: ["pipe", "pipe", "pipe", "ipc"],
     });
 
@@ -1320,6 +1330,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       }),
       events: emitter,
       cwd: backend.functionsDir,
+      socketPath,
       shutdown: () => {
         childProcess.kill();
       },
@@ -1522,17 +1533,7 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     void track(EVENT_INVOKE, "https");
 
-    this.logger.log("DEBUG", `[functions] Runtime ready! Sending request!`);
-
-    if (!worker.lastArgs) {
-      throw new FirebaseError("Cannot execute on a worker with no arguments");
-    }
-
-    if (!worker.lastArgs.frb.socketPath) {
-      throw new FirebaseError(
-        `Cannot execute on a worker without a socketPath: ${JSON.stringify(worker.lastArgs)}`
-      );
-    }
+    this.logger.log("INFO", `[functions] Runtime ready! Sending request!`);
 
     // To match production behavior we need to drop the path prefix
     // req.url = /:projectId/:region/:trigger_name/*
@@ -1551,7 +1552,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         method,
         path,
         headers: req.headers,
-        socketPath: worker.lastArgs.frb.socketPath,
+        socketPath: worker.runtime.socketPath,
       },
       (runtimeRes: http.IncomingMessage) => {
         function forwardStatusAndHeaders(): void {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1533,7 +1533,7 @@ export class FunctionsEmulator implements EmulatorInstance {
 
     void track(EVENT_INVOKE, "https");
 
-    this.logger.log("INFO", `[functions] Runtime ready! Sending request!`);
+    this.logger.log("DEBUG", `[functions] Runtime ready! Sending request!`);
 
     // To match production behavior we need to drop the path prefix
     // req.url = /:projectId/:region/:trigger_name/*

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -779,18 +779,9 @@ function rawBodySaver(req: express.Request, res: express.Response, buf: Buffer):
   (req as any).rawBody = buf;
 }
 
-async function processHTTPS(
-  trigger: CloudFunction<any>,
-  frb: FunctionsRuntimeBundle
-): Promise<void> {
+async function processHTTPS(trigger: CloudFunction<any>): Promise<void> {
   const ephemeralServer = express();
   const functionRouter = express.Router(); // eslint-disable-line new-cap
-  const socketPath = frb.socketPath;
-
-  if (!socketPath) {
-    new EmulatorLog("FATAL", "runtime-error", "Called processHTTPS with no socketPath").log();
-    return;
-  }
 
   await new Promise<void>((resolveEphemeralServer, rejectEphemeralServer) => {
     const handler = async (req: express.Request, res: express.Response) => {
@@ -844,8 +835,9 @@ async function processHTTPS(
 
     ephemeralServer.use([`/`, `/*`], functionRouter);
 
-    logDebug(`Attempting to listen to socketPath: ${socketPath}`);
-    const instance = ephemeralServer.listen(socketPath, () => {
+    logDebug(`Attempting to listen to port: ${process.env.PORT}`);
+    const instance = ephemeralServer.listen(process.env.PORT, () => {
+      logDebug(`Listening to port: ${process.env.PORT}`);
       new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready" }).log();
     });
 
@@ -999,7 +991,7 @@ async function invokeTrigger(
       await processBackground(trigger, frb, FUNCTION_SIGNATURE);
       break;
     case "http":
-      await processHTTPS(trigger, frb);
+      await processHTTPS(trigger);
       break;
   }
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -1,9 +1,11 @@
-import * as _ from "lodash";
-import { CloudFunction } from "firebase-functions";
 import * as os from "os";
 import * as path from "path";
-import * as express from "express";
 import * as fs from "fs";
+import { randomBytes } from "crypto";
+
+import * as _ from "lodash";
+import * as express from "express";
+import { CloudFunction } from "firebase-functions";
 
 import * as backend from "../deploy/functions/backend";
 import { Constants } from "./constants";
@@ -270,7 +272,7 @@ export function getEmulatedTriggersFromDefinitions(
   );
 }
 
-export function getTemporarySocketPath(pid: number, cwd: string): string {
+export function getTemporarySocketPath(): string {
   // See "net" package docs for information about IPC pipes on Windows
   // https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections
   //
@@ -284,10 +286,11 @@ export function getTemporarySocketPath(pid: number, cwd: string): string {
   //   /var/folders/xl/6lkrzp7j07581mw8_4dlt3b000643s/T/{...}.sock
   // Since the system prefix is about ~50 chars we only have about ~50 more to work with
   // before we will get truncated socket names and then undefined behavior.
+  const rand = randomBytes(8).toString("hex");
   if (process.platform === "win32") {
-    return path.join("\\\\?\\pipe", cwd, pid.toString());
+    return path.join("\\\\?\\pipe", `fire_emu_${rand}`);
   } else {
-    return path.join(os.tmpdir(), `fire_emu_${pid.toString()}.sock`);
+    return path.join(os.tmpdir(), `fire_emu_${rand}.sock`);
   }
 }
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -69,12 +69,6 @@ export interface FunctionsRuntimeArgs {
 
 export interface FunctionsRuntimeBundle {
   proto: any;
-  // TODO(danielylee): One day, we hope to get rid of all of the following properties.
-  // Our goal is for the emulator environment to mimic the production environment as much
-  // as possible, and that includes how the emulated functions are called. In prod,
-  // the calls are made over HTTP which provides only the uri path, payload, headers, etc
-  // and none of these extra properties.
-  socketPath?: string;
   disabled_features?: FunctionsRuntimeFeatures;
   // TODO(danielylee): To make debugging in Functions Emulator w/ --inspect-functions flag a good experience, we run
   // all functions in a single runtime process. This is drastically different to production environment where each

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -2,7 +2,6 @@ import * as os from "os";
 import * as path from "path";
 import * as fs from "fs";
 import { randomBytes } from "crypto";
-
 import * as _ from "lodash";
 import * as express from "express";
 import { CloudFunction } from "firebase-functions";

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -1,11 +1,7 @@
 import * as uuid from "uuid";
 import { FunctionsRuntimeInstance, InvokeRuntimeOpts } from "./functionsEmulator";
 import { EmulatorLog, Emulators, FunctionsExecutionMode } from "./types";
-import {
-  FunctionsRuntimeArgs,
-  FunctionsRuntimeBundle,
-  getTemporarySocketPath,
-} from "./functionsEmulatorShared";
+import { FunctionsRuntimeArgs, FunctionsRuntimeBundle } from "./functionsEmulatorShared";
 import { EventEmitter } from "events";
 import { EmulatorLogger, ExtensionLogInfo } from "./emulatorLogger";
 import { FirebaseError } from "../error";
@@ -32,7 +28,6 @@ export class RuntimeWorker {
   readonly key: string;
   readonly runtime: FunctionsRuntimeInstance;
 
-  lastArgs?: FunctionsRuntimeArgs;
   stateEvents: EventEmitter = new EventEmitter();
 
   private socketReady?: Promise<any>;
@@ -66,16 +61,8 @@ export class RuntimeWorker {
   execute(frb: FunctionsRuntimeBundle, opts?: InvokeRuntimeOpts): void {
     // Make a copy so we don't edit it
     const execFrb: FunctionsRuntimeBundle = { ...frb };
-
-    // TODO(samstern): I would like to do this elsewhere...
-    if (!execFrb.socketPath) {
-      execFrb.socketPath = getTemporarySocketPath(this.runtime.pid, this.runtime.cwd);
-      this.log(`Assigning socketPath: ${execFrb.socketPath}`);
-    }
-
     const args: FunctionsRuntimeArgs = { frb: execFrb, opts };
     this.state = RuntimeWorkerState.BUSY;
-    this.lastArgs = args;
     this.runtime.send(args);
   }
 

--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -19,6 +19,7 @@ class MockRuntimeInstance implements FunctionsRuntimeInstance {
   events: EventEmitter = new EventEmitter();
   exit: Promise<number>;
   cwd = "/home/users/dir";
+  socketPath = "/path/to/socket/foo.sock";
 
   constructor(private success: boolean) {
     this.exit = new Promise((res) => {


### PR DESCRIPTION
This is first of several refactoring change we plan on making on the Functions Emulator to migrate bespoke IPC protocol between the emulator and the emulated functions.

Today, the invoking an HTTP function involves an intricate dance between the emulator and the emulated function:

1) On HTTP function invocation, Functions Emulator designates a socket path ([node doc](https://nodejs.org/api/net.html#net_identifying_paths_for_ipc_connections)). The chosen socket path is passed to the emulated process via IPC message sends.

2) Emulated function spins up an ephemeral express server, binds to the socket path, and responds to the HTTP requests.

This change proposes that instead of generating the socket path on _every_ request, we do it once at the emulated function process creation time.

FWIW, the sock path that was being "dynamically" generated at function invocation already generates the same socket path for each emulated function anyway. The change here simply generates a random socket path and saves it along with other metadata associated with the emulated function process.

There are obvious follow ups to this change (e.g. why do we spin up an ephemeral server on every function call?). This PR intentionally isn't tackling them to make the PR small. You can expect them on later PRs.