### PR TITLE
Refactor mechanism for health checking emulated functions process.

### DIFF
--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -781,7 +781,6 @@ function rawBodySaver(req: express.Request, res: express.Response, buf: Buffer):
 
 async function processHTTPS(trigger: CloudFunction<any>): Promise<void> {
   const ephemeralServer = express();
-  const functionRouter = express.Router(); // eslint-disable-line new-cap
 
   await new Promise<void>((resolveEphemeralServer, rejectEphemeralServer) => {
     const handler = async (req: express.Request, res: express.Response) => {
@@ -830,10 +829,10 @@ async function processHTTPS(trigger: CloudFunction<any>): Promise<void> {
         verify: rawBodySaver,
       })
     );
-
-    functionRouter.all("*", handler);
-
-    ephemeralServer.use([`/`, `/*`], functionRouter);
+    ephemeralServer.all("/favicon.ico|/robots.txt", (req, res) => {
+      res.status(404).send(null);
+    });
+    ephemeralServer.all(`/*`, handler);
 
     logDebug(`Attempting to listen to port: ${process.env.PORT}`);
     const instance = ephemeralServer.listen(process.env.PORT, () => {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1,3 +1,4 @@
+import * as http from "http";
 import * as fs from "fs";
 
 import { CloudFunction, DeploymentOptions, https } from "firebase-functions";
@@ -783,25 +784,6 @@ async function processHTTPS(trigger: CloudFunction<any>): Promise<void> {
   const ephemeralServer = express();
 
   await new Promise<void>((resolveEphemeralServer, rejectEphemeralServer) => {
-    const handler = async (req: express.Request, res: express.Response) => {
-      try {
-        logDebug(`Ephemeral server handling ${req.method} request`);
-        res.on("finish", () => {
-          instance.close((err) => {
-            if (err) {
-              rejectEphemeralServer(err);
-            } else {
-              resolveEphemeralServer();
-            }
-          });
-        });
-
-        await runHTTPS(trigger, [req, res]);
-      } catch (err: any) {
-        rejectEphemeralServer(err);
-      }
-    };
-
     ephemeralServer.enable("trust proxy");
     ephemeralServer.use(
       bodyParser.json({
@@ -829,18 +811,43 @@ async function processHTTPS(trigger: CloudFunction<any>): Promise<void> {
         verify: rawBodySaver,
       })
     );
-    ephemeralServer.all("/favicon.ico|/robots.txt", (req, res) => {
-      res.status(404).send(null);
+
+    // eslint-disable-next-line prefer-const
+    let server: http.Server;
+    function closeServer() {
+      if (server) {
+        server.close((err) => {
+          if (err) {
+            rejectEphemeralServer(err);
+          } else {
+            resolveEphemeralServer();
+          }
+        });
+      }
+    }
+    // Endpoint used by the Functions Emulator to check if runtime process is ready to accept requests.
+    // Notice that unlike other endpoints, this route does not call closeServer() at the end of request since
+    // we expect one additional request that actually invokes the handler.
+    ephemeralServer.get("/__/health", (req, res) => {
+      res.status(200).send();
     });
-    ephemeralServer.all(`/*`, handler);
+    ephemeralServer.all("/favicon.ico|/robots.txt", (req, res) => {
+      res.on("finish", closeServer);
+      res.status(404).send();
+    });
+    ephemeralServer.all(`/*`, async (req: express.Request, res: express.Response) => {
+      try {
+        logDebug(`Ephemeral server handling ${req.method} request`);
+        res.on("finish", closeServer);
+        await runHTTPS(trigger, [req, res]);
+      } catch (err: any) {
+        rejectEphemeralServer(err);
+      }
+    });
 
     logDebug(`Attempting to listen to port: ${process.env.PORT}`);
-    const instance = ephemeralServer.listen(process.env.PORT, () => {
-      logDebug(`Listening to port: ${process.env.PORT}`);
-      new EmulatorLog("SYSTEM", "runtime-status", "ready", { state: "ready" }).log();
-    });
-
-    instance.on("error", rejectEphemeralServer);
+    server = ephemeralServer.listen(process.env.PORT);
+    server.on("error", rejectEphemeralServer);
   });
 }
 


### PR DESCRIPTION
Today, the Functions Emulator and Emulated Function process makes use of structured IPC so that the emulator can keep track of the state of the process. This is important to make sure only one request is handled at a time.

As another step towards replacing IPC-based comms to HTTP, we change the logic of health checking to see if an emulated HTTP function is ready to receive a request at given socket path. We now create a new `/__/health` route that is used to check if the emulated process's server is up and running.

I also added additional `/robots.txt` and `/favicon.ico` routes that always received 404 as suggested in the [Functions Framework contract](https://github.com/GoogleCloudPlatform/functions-framework/blob/master/README.md#url-space)