### PR TITLE
Add missing space between error and exit code

### DIFF
--- a/src/deploy/lifecycleHooks.ts
+++ b/src/deploy/lifecycleHooks.ts
@@ -31,7 +31,7 @@ function runCommand(command: string, childOptions: childProcess.SpawnOptions) {
       if (signal) {
         reject(new Error("Command terminated with signal " + signal));
       } else if (code !== 0) {
-        reject(new Error("Command terminated with non-zero exit code" + code));
+        reject(new Error("Command terminated with non-zero exit code " + code));
       } else {
         resolve();
       }


### PR DESCRIPTION


<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes current output of `"Command terminated with non-zero exit code1"` to `"Command terminated with non-zero exit code 1"` when the deploy command fails.
