### PR TITLE
Fix bug with undefined variables

### DIFF
--- a/src/functionsConfig.ts
+++ b/src/functionsConfig.ts
@@ -127,6 +127,9 @@ export async function materializeConfig(configName: string, output: any): Promis
   };
 
   const variables = await runtimeconfig.variables.list(configName);
+
+  if (!variables) return output;
+
   await traverseVariables(variables);
   return output;
 }


### PR DESCRIPTION
### Description

A bug related to this [issue](https://github.com/firebase/firebase-tools/issues/4706) has been fixed.

### Scenarios Tested

When running command: `firebase functions:config:get` get an error: 
![image](https://user-images.githubusercontent.com/51034456/177142651-af5070be-f7ec-4000-8913-5bb4a0d32f81.png)

I found out that I have 2 configurations, but 1(configs/stripe) does not have a variable values(it is empty config).

<img width="604" alt="Screen Shot 2022-07-04 at 14 08 37" src="https://user-images.githubusercontent.com/51034456/177143072-5acd60b9-3a89-4118-9df2-6f4654ce85ff.png">

After that, I added a check in the function materializeConfig check for this case

### Sample Commands

```
firebase login
firebase init
firebase functions:config:get
```
