### PR TITLE
Fix check valid target filters bug

### DIFF
--- a/src/checkValidTargetFilters.ts
+++ b/src/checkValidTargetFilters.ts
@@ -28,7 +28,7 @@ function targetsHaveNoFilters(...targets: string[]): boolean {
  * Throws an error (rejects) if it is invalid.
  */
 export async function checkValidTargetFilters(options: Options): Promise<void> {
-  const only = (options.only || "").split(",");
+  const only = !options.only ? [] : options.only.split(",");
 
   return new Promise<void>((resolve, reject) => {
     if (!only.length) {

--- a/src/test/checkValidTargetFilters.spec.ts
+++ b/src/test/checkValidTargetFilters.spec.ts
@@ -1,6 +1,4 @@
-import * as chai from "chai";
-chai.use(require("chai-as-promised"));
-const expect = chai.expect;
+import { expect } from "chai";
 
 import { Options } from "../options";
 import { RC } from "../rc";

--- a/src/test/checkValidTargetFilters.spec.ts
+++ b/src/test/checkValidTargetFilters.spec.ts
@@ -1,0 +1,73 @@
+import * as chai from "chai";
+chai.use(require("chai-as-promised"));
+const expect = chai.expect;
+
+import { Options } from "../options";
+import { RC } from "../rc";
+
+import { checkValidTargetFilters } from "../checkValidTargetFilters";
+// import { FirebaseError } from "../error";
+
+const SAMPLE_OPTIONS: Options = {
+  cwd: "/",
+  configPath: "/",
+  /* eslint-disable-next-line */
+  config: {} as any,
+  only: "",
+  except: "",
+  nonInteractive: false,
+  json: false,
+  interactive: false,
+  debug: false,
+  force: false,
+  filteredTargets: [],
+  rc: new RC(),
+};
+const UNFILTERABLE_TARGETS = ["database", "storage", "firestore", "remoteconfig", "extensions"];
+
+describe("checkValidTargetFilters", () => {
+  it("should resolve", async () => {
+    const options = Object.assign(SAMPLE_OPTIONS, {
+      only: "functions",
+    });
+    await expect(checkValidTargetFilters(options)).to.be.fulfilled;
+  });
+
+  it("should resolve if there are no 'only' targets specified", async () => {
+    const options = Object.assign(SAMPLE_OPTIONS, {
+      only: null,
+    });
+    await expect(checkValidTargetFilters(options)).to.be.fulfilled;
+  });
+
+  it("should error if an only option and except option have been provided", async () => {
+    const options = Object.assign(SAMPLE_OPTIONS, {
+      only: "functions",
+      except: "hosting",
+    });
+    await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
+      "Cannot specify both --only and --except"
+    );
+  });
+
+  UNFILTERABLE_TARGETS.forEach((target) => {
+    it(`should error if non-filter-type target (${target}) has filters`, async () => {
+      const options = Object.assign(SAMPLE_OPTIONS, {
+        only: `${target}:filter`,
+        except: null,
+      });
+      await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
+        "Filters specified with colons (e.g. --only functions:func1,functions:func2) are only supported for functions and hosting"
+      );
+    });
+  });
+
+  it("should error if the same target is specified with and without a filter", async () => {
+    const options = Object.assign(SAMPLE_OPTIONS, {
+      only: "functions,functions:filter",
+    });
+    await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
+      'Cannot specify "--only functions" and "--only functions:<filter>" at the same time'
+    );
+  });
+});

--- a/src/test/checkValidTargetFilters.spec.ts
+++ b/src/test/checkValidTargetFilters.spec.ts
@@ -6,7 +6,6 @@ import { Options } from "../options";
 import { RC } from "../rc";
 
 import { checkValidTargetFilters } from "../checkValidTargetFilters";
-// import { FirebaseError } from "../error";
 
 const SAMPLE_OPTIONS: Options = {
   cwd: "/",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This addresses a bug introduced in 11.2.0 where only options are parsed incorrectly and when specifying "except" targets "only" targets are always determined to be present.

The following error began to propagate on a build pipeline that had no changes to the deploy scripts. The only change was the 11.2.0 release of`firebase-tools`. Downgrading to 11.1.0 resolved the issue.
```
Error: Cannot specify both --only and --except
```
<img width="400" alt="Screen Shot 2022-07-06 at 9 00 01 AM" src="https://user-images.githubusercontent.com/3148935/177556134-52c37237-cdfc-408a-8f88-36b6f4ade01d.png">

This also adds test coverage to `checkValidTargetFilters.ts`.

Closes: #4703 

### Scenarios Tested

Unit test coverage.

### Sample Commands

N/A
