### PR TITLE
Fix bug where function deployment failed when service account is not specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where function deployed failed with message "Invalid function service account requested: default." (#4714).

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -324,7 +324,7 @@ export function addResourcesToBuild(
     project: projectId,
     entryPoint: annotation.entryPoint,
     runtime: runtime,
-    serviceAccount: annotation.serviceAccountEmail || "default",
+    serviceAccount: annotation.serviceAccountEmail || null,
     ...triggered,
   };
   if (annotation.vpcConnector != null) {

--- a/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -13,9 +13,6 @@ function applyBuildDefaults(
   if (!endpoint.timeoutSeconds) {
     endpoint.timeoutSeconds = 60;
   }
-  if (!endpoint.serviceAccountEmail) {
-    endpoint.serviceAccountEmail = "default";
-  }
   return endpoint;
 }
 
@@ -40,7 +37,7 @@ describe("addResourcesToBuild", () => {
     project: "project",
     runtime: "nodejs16",
     entryPoint: "func",
-    serviceAccount: "default",
+    serviceAccount: null,
   });
 
   const BASIC_FUNCTION_NAME: backend.TargetIds = Object.freeze({


### PR DESCRIPTION
This bug affects projects using Firebase Functions SDK version 3.19.0 and below.

The CLI incorrectly sets `serviceAccountEmail` to "default" when no service account is specified in user code. Going forward, we should probably just remove the "default" as a shorthand - users can just set serviceAccount to undefined.

Fixes https://github.com/firebase/firebase-tools/issues/4697