### PR TITLE
Ensure artifact registry API on function deploys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where Artifact Registry API was not enabled on function deploy (#4715).

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -64,7 +64,7 @@ export async function prepare(
       /* silent=*/ true
     ),
     ensure.cloudBuildEnabled(projectId),
-    ensureApiEnabled.check(projectId, "artifactregistry.googleapis.com", "artifactregistry"),
+    ensureApiEnabled.ensure(projectId, "artifactregistry.googleapis.com", "artifactregistry"),
   ]);
 
   // Get the Firebase Config, and set it on each function in the deployment.


### PR DESCRIPTION
We only check but not enable Artifact Registry API on function deploys. Since our last release, all Function deploys requires AR API.