### PR TITLE
Add function to programmatically write to .env files

### DIFF
--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -252,24 +252,6 @@ export function hasUserEnvs({
   return findEnvfiles(functionsSource, projectId, projectAlias, isEmulator).length > 0;
 }
 
-/* eslint-disable */
-/**
- * Write new environment variables into a dotenv file.
- *
- * Identifies one and only one dotenv file to touch using the same rules as loadUserEnvs().
- * It is an error to provide a key-value pair which is already in the file.
- * Not actually implemented yet.
- */
-export function writeUserEnvs(
-  toWrite: Record<string, string>,
-  envOpts: UserEnvsOpts
-) {
-  throw new FirebaseError(
-    "Persisting user-defined parameters to .env files is not yet implemented."
-  );
-}
-/* eslint-enable */
-
 /**
  * Write new environment variables into a dotenv file.
  *

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -78,7 +78,7 @@ const CHARACTERS_TO_ESCAPE_SEQUENCES: Record<string, string> = {
   "'": "\\'",
   '"': '\\"',
 };
-const ALL_ESCAPABLE_CHARACTERS = /[\n\r\t\v\\'"]/g;
+const ALL_ESCAPABLE_CHARACTERS_RE = /[\n\r\t\v\\'"]/g;
 
 interface ParseResult {
   envs: Record<string, string>;
@@ -299,7 +299,7 @@ function createEnvFile(envOpts: UserEnvsOpts) {
 
 function formatUserEnvForWrite(key: string, value: string): string {
   const escapedValue = value.replace(
-    ALL_ESCAPABLE_CHARACTERS,
+    ALL_ESCAPABLE_CHARACTERS_RE,
     (match) => CHARACTERS_TO_ESCAPE_SEQUENCES[match]
   );
   if (escapedValue !== value) {

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -67,6 +67,18 @@ const ESCAPE_SEQUENCES_TO_CHARACTERS: Record<string, string> = {
   "\\'": "'",
   '\\"': '"',
 };
+const ALL_ESCAPE_SEQUENCES_RE = /\\[nrtv\\'"]/g;
+
+const CHARACTERS_TO_ESCAPE_SEQUENCES: Record<string, string> = {
+  "\n": "\\n",
+  "\r": "\\r",
+  "\t": "\\t",
+  "\v": "\\v",
+  "\\": "\\\\",
+  "'": "\\'",
+  '"': '\\"',
+};
+const ALL_ESCAPABLE_CHARACTERS = /[\n\r\t\v\\'"]/g;
 
 interface ParseResult {
   envs: Record<string, string>;
@@ -116,7 +128,7 @@ export function parse(data: string): ParseResult {
       if (quotesMatch[1] === '"') {
         // Substitute escape sequences. The regex passed to replace() must
         // match every key in ESCAPE_SEQUENCES_TO_CHARACTERS.
-        v = v.replace(/\\[nrtv\\'"]/g, (match) => ESCAPE_SEQUENCES_TO_CHARACTERS[match]);
+        v = v.replace(ALL_ESCAPE_SEQUENCES_RE, (match) => ESCAPE_SEQUENCES_TO_CHARACTERS[match]);
       }
     }
 
@@ -238,6 +250,62 @@ export function hasUserEnvs({
   isEmulator,
 }: UserEnvsOpts): boolean {
   return findEnvfiles(functionsSource, projectId, projectAlias, isEmulator).length > 0;
+}
+
+/**
+ * Write new environment variables into a dotenv file.
+ *
+ * Identifies one and only one dotenv file to touch using the same rules as loadUserEnvs().
+ * It is an error to provide a key-value pair which is already in the file.
+ * Not actually implemented yet.
+ */
+export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvsOpts) {
+  const { functionsSource, projectId, projectAlias, isEmulator } = envOpts;
+  let envFiles = findEnvfiles(functionsSource, projectId, projectAlias, isEmulator);
+  if (envFiles.length === 0) {
+    createEnvFile(envOpts);
+    envFiles = findEnvfiles(functionsSource, projectId, projectAlias, isEmulator);
+  }
+
+  const currentEnvs = loadUserEnvs(envOpts);
+  for (const k of Object.keys(toWrite)) {
+    validateKey(k);
+    if (currentEnvs.hasOwnProperty(k)) {
+      throw new KeyValidationError(
+        k,
+        `Attempted to write param-defined key ${k} to .env files, but it was already defined.`
+      );
+    }
+  }
+
+  const mostSpecificEnv = path.join(functionsSource, envFiles[envFiles.length - 1]);
+  for (const k of Object.keys(toWrite)) {
+    fs.appendFileSync(mostSpecificEnv, formatUserEnvForWrite(k, toWrite[k]));
+  }
+}
+
+function createEnvFile(envOpts: UserEnvsOpts) {
+  let fileToWrite: string;
+  if (envOpts.isEmulator) {
+    fileToWrite = FUNCTIONS_EMULATOR_DOTENV;
+  }
+  fileToWrite = envOpts.isEmulator
+    ? FUNCTIONS_EMULATOR_DOTENV
+    : `.env.${envOpts.projectAlias || envOpts.projectId}`;
+  logger.debug(`No .env file detected to write to; creating ${fileToWrite}`);
+
+  fs.writeFileSync(path.join(envOpts.functionsSource, fileToWrite), "", { flag: "wx" });
+}
+
+function formatUserEnvForWrite(key: string, value: string): string {
+  const escapedValue = value.replace(
+    ALL_ESCAPABLE_CHARACTERS,
+    (match) => CHARACTERS_TO_ESCAPE_SEQUENCES[match]
+  );
+  if (escapedValue !== value) {
+    return `${key}="${escapedValue}"\n`;
+  }
+  return `${key}=${escapedValue}\n`;
 }
 
 /**

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -280,20 +280,19 @@ export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvs
   }
 
   const mostSpecificEnv = path.join(functionsSource, envFiles[envFiles.length - 1]);
+  logBullet(
+    clc.cyan.bold("functions: ") + `Writing new parameter values to disk: ${mostSpecificEnv}`
+  );
   for (const k of Object.keys(toWrite)) {
     fs.appendFileSync(mostSpecificEnv, formatUserEnvForWrite(k, toWrite[k]));
   }
 }
 
 function createEnvFile(envOpts: UserEnvsOpts): string {
-  let fileToWrite: string;
-  if (envOpts.isEmulator) {
-    fileToWrite = FUNCTIONS_EMULATOR_DOTENV;
-  }
-  fileToWrite = envOpts.isEmulator
+  const fileToWrite = envOpts.isEmulator
     ? FUNCTIONS_EMULATOR_DOTENV
     : `.env.${envOpts.projectAlias || envOpts.projectId}`;
-  logger.debug(`No .env file detected to write to; creating ${fileToWrite}`);
+  logger.debug(`Creating ${fileToWrite}...`);
 
   fs.writeFileSync(path.join(envOpts.functionsSource, fileToWrite), "", { flag: "wx" });
   return fileToWrite;

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -259,7 +259,7 @@ export function hasUserEnvs({
  * It is an error to provide a key-value pair which is already in the file.
  */
 export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvsOpts) {
-  if (toWrite.empty) {
+  if (Object.keys(toWrite).length === 0) {
     return;
   }
 

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -5,6 +5,7 @@ import { sync as rimraf } from "rimraf";
 import { expect } from "chai";
 
 import * as env from "../../functions/env";
+import { FirebaseError } from "../../error";
 
 describe("functions/env", () => {
   describe("parse", () => {
@@ -306,7 +307,7 @@ FOO=foo
         {},
         { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
       );
-      expect(!!fs.statSync(path.join(tmpdir, ".env.alias"))).to.be.false;
+      expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).throw;
     });
 
     it("touches .env.projectAlias if there are no .env files and project alias is available", () => {
@@ -318,7 +319,7 @@ FOO=foo
     });
 
     it("touches .env.projectId if there are no .env files and project alias is not available", () => {
-      env.writeUserEnvs({}, { projectId: "project", functionsSource: tmpdir });
+      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir });
       expect(!!fs.statSync(path.join(tmpdir, ".env.project"))).to.be.true;
     });
 
@@ -331,7 +332,7 @@ FOO=foo
           { FOO: "bar" },
           { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
         )
-      ).to.throw(env.KeyValidationError);
+      ).to.throw(FirebaseError);
     });
 
     it("throws if asked to write a key that already exists in any .env", () => {
@@ -344,7 +345,7 @@ FOO=foo
           { FOO: "bar" },
           { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
         )
-      ).to.throw(env.KeyValidationError);
+      ).to.throw(FirebaseError);
     });
 
     it("throws if asked to write a key that fails key format validation", () => {

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -301,9 +301,17 @@ FOO=foo
       }).to.throw();
     });
 
-    it("touches .env.projectAlias if there are no .env files and project alias is available", () => {
+    it("never affects the filesystem if the list of keys to write is empty", () => {
       env.writeUserEnvs(
         {},
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+      );
+      expect(!!fs.statSync(path.join(tmpdir, ".env.alias"))).to.be.false;
+    });
+
+    it("touches .env.projectAlias if there are no .env files and project alias is available", () => {
+      env.writeUserEnvs(
+        { FOO: "bar" },
         { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
       );
       expect(!!fs.statSync(path.join(tmpdir, ".env.alias"))).to.be.true;

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -282,6 +282,161 @@ FOO=foo
     });
   });
 
+  describe("writeUserEnvs", () => {
+    const createEnvFiles = (sourceDir: string, envs: Record<string, string>): void => {
+      for (const [filename, data] of Object.entries(envs)) {
+        fs.writeFileSync(path.join(sourceDir, filename), data);
+      }
+    };
+    let tmpdir: string;
+
+    beforeEach(() => {
+      tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "test"));
+    });
+
+    afterEach(() => {
+      rimraf(tmpdir);
+      expect(() => {
+        fs.statSync(tmpdir);
+      }).to.throw();
+    });
+
+    it("touches .env.projectAlias if there are no .env files and project alias is available", () => {
+      env.writeUserEnvs(
+        {},
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+      );
+      expect(!!fs.statSync(path.join(tmpdir, ".env.alias"))).to.be.true;
+    });
+
+    it("touches .env.projectId if there are no .env files and project alias is not available", () => {
+      env.writeUserEnvs({}, { projectId: "project", functionsSource: tmpdir });
+      expect(!!fs.statSync(path.join(tmpdir, ".env.project"))).to.be.true;
+    });
+
+    it("throws if asked to write a key that already exists in the most specific .env", () => {
+      createEnvFiles(tmpdir, {
+        [".env.alias"]: "FOO=foo",
+      });
+      expect(() =>
+        env.writeUserEnvs(
+          { FOO: "bar" },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+        )
+      ).to.throw(env.KeyValidationError);
+    });
+
+    it("throws if asked to write a key that already exists in any .env", () => {
+      createEnvFiles(tmpdir, {
+        [".env.alias"]: "BAR=foo",
+        ".env": "FOO=foo",
+      });
+      expect(() =>
+        env.writeUserEnvs(
+          { FOO: "bar" },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+        )
+      ).to.throw(env.KeyValidationError);
+    });
+
+    it("throws if asked to write a key that fails key format validation", () => {
+      expect(() =>
+        env.writeUserEnvs(
+          { lowercase: "bar" },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+        )
+      ).to.throw(env.KeyValidationError);
+      expect(() =>
+        env.writeUserEnvs(
+          { GCP_PROJECT: "bar" },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+        )
+      ).to.throw(env.KeyValidationError);
+      expect(() =>
+        env.writeUserEnvs(
+          { FIREBASE_KEY: "bar" },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+        )
+      ).to.throw(env.KeyValidationError);
+    });
+
+    it("writes the specified key to a .env that it created", () => {
+      env.writeUserEnvs(
+        { FOO: "bar" },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+      );
+      expect(
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
+          "FOO"
+        ]
+      ).to.equal("bar");
+    });
+
+    it("writes the specified key to a .env that already existed", () => {
+      createEnvFiles(tmpdir, {
+        [".env.alias"]: "",
+      });
+      env.writeUserEnvs(
+        { FOO: "bar" },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+      );
+      expect(
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
+          "FOO"
+        ]
+      ).to.equal("bar");
+    });
+
+    it("writes multiple keys at once", () => {
+      env.writeUserEnvs(
+        { FOO: "foo", BAR: "bar" },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+      );
+      const envs = env.loadUserEnvs({
+        projectId: "project",
+        projectAlias: "alias",
+        functionsSource: tmpdir,
+      });
+      expect(envs["FOO"]).to.equal("foo");
+      expect(envs["BAR"]).to.equal("bar");
+    });
+
+    it("escapes special characters so that parse() can reverse them", () => {
+      env.writeUserEnvs(
+        {
+          ESCAPES: "\n\r\t\v",
+          WITH_SLASHES: "\n\\\r\\\t\\\v",
+          QUOTES: "'\"'",
+        },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+      );
+      const envs = env.loadUserEnvs({
+        projectId: "project",
+        projectAlias: "alias",
+        functionsSource: tmpdir,
+      });
+      expect(envs["ESCAPES"]).to.equal("\n\r\t\v");
+      expect(envs["WITH_SLASHES"]).to.equal("\n\\\r\\\t\\\v");
+      expect(envs["QUOTES"]).to.equal("'\"'");
+    });
+
+    it("shouldn't write anything if any of the keys fails key format validation", () => {
+      try {
+        env.writeUserEnvs(
+          { FOO: "bar", lowercase: "bar" },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
+        );
+      } catch (err: any) {
+        // no-op
+      }
+      expect(
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
+          "FOO"
+        ]
+      ).to.be.undefined;
+    });
+  });
+
   describe("loadUserEnvs", () => {
     const createEnvFiles = (sourceDir: string, envs: Record<string, string>): void => {
       for (const [filename, data] of Object.entries(envs)) {


### PR DESCRIPTION
Q1) I'm guessing it's not intentional for Functions params to only be allowed names that fit the current key format validation (i.e start with an uppercase letter or underscore). Should we coerce param names to start uppercase, hide them inside a reserved prefix, or do something else?

Q2) Is the file pointed to by FUNCTIONS_EMULATOR_DOTENV guaranteed to exist when running the emulator? If not, this code as written can cause writes to "real" dotenv files when running the emulator, which would be...bad.