### PR TITLE
fix filter check to allow firestore targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where `firestore:*` did not work with `--only` in `deploy`. (#4698)

--- a/src/checkValidTargetFilters.ts
+++ b/src/checkValidTargetFilters.ts
@@ -44,7 +44,7 @@ export async function checkValidTargetFilters(options: Options): Promise<void> {
     if (targetsForNonFilteredTypes.length && targetsHaveFilters(...targetsForNonFilteredTypes)) {
       return reject(
         new FirebaseError(
-          "Filters specified with colons (e.g. --only functions:func1,functions:func2) are only supported for functions and hosting"
+          "Filters specified with colons (e.g. --only functions:func1,functions:func2) are only supported for functions, hosting, and firestore"
         )
       );
     }

--- a/src/checkValidTargetFilters.ts
+++ b/src/checkValidTargetFilters.ts
@@ -38,7 +38,7 @@ export async function checkValidTargetFilters(options: Options): Promise<void> {
       return reject(new FirebaseError("Cannot specify both --only and --except"));
     }
     const nonFilteredTypes = VALID_DEPLOY_TARGETS.filter(
-      (t) => !["hosting", "functions"].includes(t)
+      (t) => !["hosting", "functions", "firestore"].includes(t)
     );
     const targetsForNonFilteredTypes = targetsForTypes(only, ...nonFilteredTypes);
     if (targetsForNonFilteredTypes.length && targetsHaveFilters(...targetsForNonFilteredTypes)) {

--- a/src/test/checkValidTargetFilters.spec.ts
+++ b/src/test/checkValidTargetFilters.spec.ts
@@ -20,7 +20,7 @@ const SAMPLE_OPTIONS: Options = {
   filteredTargets: [],
   rc: new RC(),
 };
-const UNFILTERABLE_TARGETS = ["database", "storage", "firestore", "remoteconfig", "extensions"];
+const UNFILTERABLE_TARGETS = ["database", "storage", "remoteconfig", "extensions"];
 
 describe("checkValidTargetFilters", () => {
   it("should resolve", async () => {

--- a/src/test/checkValidTargetFilters.spec.ts
+++ b/src/test/checkValidTargetFilters.spec.ts
@@ -54,7 +54,7 @@ describe("checkValidTargetFilters", () => {
         except: null,
       });
       await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
-        "Filters specified with colons (e.g. --only functions:func1,functions:func2) are only supported for functions and hosting"
+        /Filters specified with colons (e.g. --only functions:func1,functions:func2) are only supported for .*/
       );
     });
   });

--- a/src/test/checkValidTargetFilters.spec.ts
+++ b/src/test/checkValidTargetFilters.spec.ts
@@ -54,7 +54,7 @@ describe("checkValidTargetFilters", () => {
         except: null,
       });
       await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
-        /Filters specified with colons (e.g. --only functions:func1,functions:func2) are only supported for .*/
+        /Filters specified with colons \(e.g. --only functions:func1,functions:func2\) are only supported for .*/
       );
     });
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #4698

`--only firestore:rules` was not working (or `:indexes`) because the check only allowed `hosting` or `functions` to specify targets like that. This check was *fixed* when it was rewritten to actually return errors, but it didn't include `firestore` in the allowed list for targets.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

* `firebase deploy --only firestore:rules`
* `firebase deploy --except firestore:rules`
* `firebase deploy --only hosting`
* `firebase deploy --only hosting:main`