### PR TITLE
Run tests on CI with --forbid-only

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -50,7 +50,7 @@ jobs:
 
       - run: npm i -g npm@8.7
       - run: npm ci
-      - run: npm test
+      - run: npm test -- -- --forbid-only
 
       - uses: codecov/codecov-action@v3
         if: matrix.node-version == '14'


### PR DESCRIPTION
### Description
Tests will now fail on CI if you accidentally leave a describe.only in your tests - not that I would ever do that...

### Scenarios Tested
Verified that the tests fail if I add a .only
<img width="1015" alt="Screen Shot 2022-07-11 at 10 14 42 AM" src="https://user-images.githubusercontent.com/4635763/178320839-234b70ac-a625-4b4f-a80c-1c0143bb401f.png">
