### PR TITLE
Get rid of _.isPlainObject

### DIFF
--- a/scripts/test-functions-config.js
+++ b/scripts/test-functions-config.js
@@ -18,7 +18,6 @@ var tmp = require("tmp");
 
 var api = require("../lib/api");
 var scopes = require("../lib/scopes");
-var { configstore } = require("../lib/configstore");
 
 var projectId = process.argv[2] || "functions-integration-test";
 var localFirebase = __dirname + "/../lib/bin/firebase.js";

--- a/scripts/test-functions-config.js
+++ b/scripts/test-functions-config.js
@@ -29,7 +29,6 @@ var preTest = function () {
   var dir = tmp.dirSync({ prefix: "cfgtest_" });
   tmpDir = dir.name;
   fs.copySync(projectDir, tmpDir);
-  api.setRefreshToken(configstore.get("tokens").refresh_token);
   api.setScopes(scopes.CLOUD_PLATFORM);
   execSync(`${localFirebase} functions:config:unset foo --project=${projectId}`, { cwd: tmpDir });
   console.log("Done pretest prep.");

--- a/src/deploy/storage/prepare.ts
+++ b/src/deploy/storage/prepare.ts
@@ -20,7 +20,7 @@ export default async function (context: any, options: Options): Promise<void> {
   const rulesDeploy = new RulesDeploy(options, RulesetServiceType.FIREBASE_STORAGE);
   _.set(context, "storage.rulesDeploy", rulesDeploy);
 
-  if (typeof rulesConfig === "object") {
+  if (typeof rulesConfig === "object" && rulesConfig !== null) {
     const defaultBucket = await gcp.storage.getDefaultBucket(options.project);
     rulesConfig = [Object.assign(rulesConfig, { bucket: defaultBucket })];
     _.set(context, "storage.rules", rulesConfig);

--- a/src/deploy/storage/prepare.ts
+++ b/src/deploy/storage/prepare.ts
@@ -20,7 +20,7 @@ export default async function (context: any, options: Options): Promise<void> {
   const rulesDeploy = new RulesDeploy(options, RulesetServiceType.FIREBASE_STORAGE);
   _.set(context, "storage.rulesDeploy", rulesDeploy);
 
-  if (_.isPlainObject(rulesConfig)) {
+  if (typeof rulesConfig === "object") {
     const defaultBucket = await gcp.storage.getDefaultBucket(options.project);
     rulesConfig = [Object.assign(rulesConfig, { bucket: defaultBucket })];
     _.set(context, "storage.rules", rulesConfig);

--- a/src/functionsConfig.ts
+++ b/src/functionsConfig.ts
@@ -97,7 +97,7 @@ export async function setVariablesRecursive(
     }
   }
   // If 'parsed' is object, call again
-  if (_.isPlainObject(parsed)) {
+  if (typeof parsed === "object") {
     return Promise.all(
       Object.entries(parsed).map(([key, item]) => {
         const newVarPath = varPath ? [varPath, key].join("/") : key;

--- a/src/functionsConfig.ts
+++ b/src/functionsConfig.ts
@@ -97,7 +97,7 @@ export async function setVariablesRecursive(
     }
   }
   // If 'parsed' is object, call again
-  if (typeof parsed === "object") {
+  if (typeof parsed === "object" && parsed !== null) {
     return Promise.all(
       Object.entries(parsed).map(([key, item]) => {
         const newVarPath = varPath ? [varPath, key].join("/") : key;

--- a/src/test/extensions/etags.spec.ts
+++ b/src/test/extensions/etags.spec.ts
@@ -23,7 +23,7 @@ function extensionInstanceHelper(instanceId: string, etag?: string) {
   return ret;
 }
 
-describe.only("detectEtagChanges", () => {
+describe("detectEtagChanges", () => {
   const testCases: {
     desc: string;
     rc: rc.RC;


### PR DESCRIPTION
### Description
Get rid of _.isPlainObject(). Also, fix test-functions-config so that I could verify that these changes were safe.

isPlainObject behaves slightly differently than `typeof == 'object' && !==null` - it returns false if the object prototype has a constructor. However, AFAICT, the difference isn't relevant in these 2 uses.

### Scenarios Tested
<img width="1015" alt="Screen Shot 2022-07-11 at 10 14 42 AM" src="https://user-images.githubusercontent.com/4635763/178356438-856db99a-1208-4507-9745-307b4b5b60b5.png">

