### PR TITLE
Fix invoker type mismatch for https functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix invoker type mismatch for https functions.

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -65,7 +65,7 @@ type ServiceAccount = string;
 export interface HttpsTrigger {
   // Which service account should be able to trigger this function. No value means "make public
   // on create and don't do anything on update." For more, see go/cf3-http-access-control
-  invoker?: ServiceAccount | null;
+  invoker?: ServiceAccount[];
 }
 
 // Trigger definitions for RPCs servers using the HTTP protocol defined at
@@ -338,7 +338,7 @@ function discoverTrigger(
   if ("httpsTrigger" in endpoint) {
     const bkHttps: backend.HttpsTrigger = {};
     if (endpoint.httpsTrigger.invoker) {
-      bkHttps.invoker = [endpoint.httpsTrigger.invoker];
+      bkHttps.invoker = endpoint.httpsTrigger.invoker;
     }
     trigger = { httpsTrigger: bkHttps };
   } else if ("callableTrigger" in endpoint) {

--- a/src/deploy/functions/runtimes/node/parseTriggers.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.ts
@@ -256,7 +256,7 @@ export function addResourcesToBuild(
         logger.warn(`Ignoring retry policy for HTTPS function ${annotation.name}`);
       }
       if (annotation.httpsTrigger.invoker) {
-        trigger.invoker = annotation.httpsTrigger.invoker[0];
+        trigger.invoker = annotation.httpsTrigger.invoker;
       }
       triggered = { httpsTrigger: trigger };
     }

--- a/src/test/deploy/functions/build.spec.ts
+++ b/src/test/deploy/functions/build.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+import * as build from "../../../deploy/functions/build";
+
+describe("toBackend", () => {
+  it("populates backend info from Build", () => {
+    const desiredBuild: build.Build = build.of({
+      func: {
+        platform: "gcfv1",
+        region: ["us-central1"],
+        project: "project",
+        runtime: "nodejs16",
+        entryPoint: "func",
+        maxInstances: 42,
+        minInstances: 1,
+        serviceAccount: "service-account-1@",
+        vpc: {
+          connector: "projects/project/locations/region/connectors/connector",
+          egressSettings: "PRIVATE_RANGES_ONLY",
+        },
+        ingressSettings: "ALLOW_ALL",
+        labels: {
+          test: "testing",
+        },
+        httpsTrigger: {
+          invoker: ["public"],
+        },
+      },
+    });
+    const backend = build.toBackend(desiredBuild, {});
+    expect(Object.keys(backend.endpoints).length).to.equal(1);
+    const endpointDef = Object.values(backend.endpoints)[0];
+    expect(endpointDef).to.not.equal(undefined);
+    if (endpointDef) {
+      expect(endpointDef.func.id).to.equal("func");
+      expect(endpointDef.func.project).to.equal("project");
+      expect(endpointDef.func.region).to.equal("us-central1");
+      expect(
+        "httpsTrigger" in endpointDef.func
+          ? endpointDef.func.httpsTrigger.invoker
+            ? endpointDef.func.httpsTrigger.invoker[0]
+            : ""
+          : ""
+      ).to.equal("public");
+    }
+  });
+
+  it("populates multiple specified invokers correctly", () => {
+    const desiredBuild: build.Build = build.of({
+      func: {
+        platform: "gcfv1",
+        region: ["us-central1"],
+        project: "project",
+        runtime: "nodejs16",
+        entryPoint: "func",
+        maxInstances: 42,
+        minInstances: 1,
+        serviceAccount: "service-account-1@",
+        vpc: {
+          connector: "projects/project/locations/region/connectors/connector",
+          egressSettings: "PRIVATE_RANGES_ONLY",
+        },
+        ingressSettings: "ALLOW_ALL",
+        labels: {
+          test: "testing",
+        },
+        httpsTrigger: {
+          invoker: ["service-account-1@", "service-account-2@"],
+        },
+      },
+    });
+    const backend = build.toBackend(desiredBuild, {});
+    expect(Object.keys(backend.endpoints).length).to.equal(1);
+    const endpointDef = Object.values(backend.endpoints)[0];
+    expect(endpointDef).to.not.equal(undefined);
+    if (endpointDef) {
+      expect(endpointDef.func.id).to.equal("func");
+      expect(endpointDef.func.project).to.equal("project");
+      expect(endpointDef.func.region).to.equal("us-central1");
+      expect(
+        "httpsTrigger" in endpointDef.func ? endpointDef.func.httpsTrigger.invoker : []
+      ).to.have.members(["service-account-1@", "service-account-2@"]);
+    }
+  });
+});

--- a/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -183,7 +183,7 @@ describe("addResourcesToBuild", () => {
         ...BASIC_ENDPOINT,
         ...config,
         httpsTrigger: {
-          invoker: "public",
+          invoker: ["public"],
         },
       },
     });
@@ -540,7 +540,7 @@ describe("addResourcesToBackend", () => {
     const trigger: parseTriggers.TriggerAnnotation = {
       ...BASIC_TRIGGER,
       httpsTrigger: {
-        invoker: ["public"],
+        invoker: ["public", "other", "serviceAccount@"],
       },
       maxInstances: 42,
       minInstances: 1,
@@ -572,7 +572,7 @@ describe("addResourcesToBackend", () => {
     const expected: backend.Backend = backend.of({
       ...BASIC_ENDPOINT,
       httpsTrigger: {
-        invoker: ["public"],
+        invoker: ["public", "other", "serviceAccount@"],
       },
       ...config,
     });


### PR DESCRIPTION
### Description

Fix invoker type mismatch for https functions. Invoker was string[] in TriggerAnnotation but ServiceAccount (a.k.a string) in build.HttpsTrigger. This was causing problems with explicitly set invokers.

### Scenarios Tested

- Deploying with no specified invoker.
- Deploying with invoker "public".
- Deploying with invoker "private".
- Deploying with invoker set to 1 service account.
- Deploying with invoker set to 2 service accounts.
