### PR TITLE
'gracefully' handle cases when undefined is passed into resolveX

### DIFF
--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -30,7 +30,7 @@ export function resolveInt(
   from: number | build.Expression<number>,
   paramValues: Record<string, build.Field<string | number | boolean>>
 ): number {
-  if (typeof from === "number") {
+  if (typeof from === "number" || typeof from === "undefined") {
     return from;
   }
   const match = /\A{{ params\.(\w+) }}\z/.exec(from);
@@ -58,7 +58,7 @@ export function resolveString(
   from: string | build.Expression<string>,
   paramValues: Record<string, build.Field<string | number | boolean>>
 ): string {
-  if (!isCEL(from)) {
+  if (!isCEL(from) || typeof from === "undefined") {
     return from;
   }
   let output = from;
@@ -93,6 +93,9 @@ export function resolveBoolean(
   from: boolean | build.Expression<boolean>,
   paramValues: Record<string, build.Field<string | number | boolean>>
 ): boolean {
+  if (typeof from === "boolean" || typeof from === "undefined") {
+    return from;
+  }
   if (typeof from === "string" && /{{ params\.(\w+) }}/.test(from)) {
     const match = /{{ params\.(\w+) }}/.exec(from);
     const referencedParamValue = paramValues[match![1]];
@@ -105,10 +108,8 @@ export function resolveBoolean(
       );
     }
     return referencedParamValue;
-  } else if (typeof from === "string") {
-    throw new FirebaseError("CEL evaluation of expression '" + from + "' not yet supported");
   }
-  return from;
+  throw new FirebaseError("CEL evaluation of expression '" + from + "' not yet supported");
 }
 
 interface ParamBase<T extends string | number | boolean> {

--- a/src/test/deploy/functions/params.spec.ts
+++ b/src/test/deploy/functions/params.spec.ts
@@ -11,6 +11,13 @@ describe("CEL resolution", () => {
     expect(params.resolveString("{{ params.foo }} baz", { foo: "bar" })).to.equal("bar baz");
   });
 
+  it("doesn't explode when passed undefined", () => {
+    const undefCEL: string = undefined as unknown as string;
+    expect(params.resolveInt(undefCEL, {})).to.be.undefined;
+    expect(params.resolveString(undefCEL, {})).to.be.undefined;
+    expect(params.resolveBoolean(undefCEL, {})).to.be.undefined;
+  });
+
   it("can interpolate multiple params into a CEL expression", () => {
     expect(
       params.resolveString("{{ params.foo }} {{ params.bar }}", { foo: "asdf", bar: "jkl;" })


### PR DESCRIPTION
Speculative: this fix addresses the failure case in https://github.com/firebase/firebase-tools/issues/4735 where `undefined` is somehow getting passed into resolveInt or resolveBoolean at runtime in violation of the typescript annotations. While impossible to verify in light of the absence of a repro, we know that the corresponding functions looked like this in v12.2.1:

```
function resolveInt(from: number | Expression<number> | null): number {	
  if (from == null) {	
    return 0;	
  } else if (typeof from === "string") {	
    throw new FirebaseError("CEL evaluation of expression '" + from + "' not yet supported");	
  }	
  return from;	
}
```

meaning that plumbing `undefined` through the function is highly likely to reverse the regression.

However, this doesn't address the more fundamental problem that we don't _know where undefined is creeping in_ yet, which makes me cautious of a band-aid solution like this.