### PR TITLE
Fix "bug" where function timeout option did not apply to Functions Emulator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where function timeout couldn't be configured in the Functions Emulator. (#4745)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1073,6 +1073,12 @@ export class FunctionsEmulator implements EmulatorInstance {
     envs.K_REVISION = "1";
     envs.PORT = "80";
 
+    // TODO(danielylee): Later, we want timeout to be enforce by the data plane. For now, we rely on the runtime to
+    // enforce timeout.
+    if (trigger?.timeoutSeconds) {
+      envs.FUNCTIONS_EMULATOR_TIMEOUT_SECONDS = trigger.timeoutSeconds.toString();
+    }
+
     if (trigger) {
       const target = trigger.entryPoint;
       envs.FUNCTION_TARGET = target;
@@ -1092,8 +1098,6 @@ export class FunctionsEmulator implements EmulatorInstance {
       skipTokenVerification: true,
       enableCors: true,
     });
-    // TODO(danielylee): Support timeouts. Temporarily dropping the feature until we finish refactoring.
-
     // Make firebase-admin point at the Firestore emulator
     const firestoreEmulator = this.getEmulatorInfo(Emulators.FIRESTORE);
     if (firestoreEmulator != null) {


### PR DESCRIPTION
Several months ago, we started to refactor the Functions Emulator with the goal of the Emulator implement more closely resembling how GCF works.

One way the Emulator and GCF differed was how timeout was enforced - in GCF that work was done outside of the runtime process whereas in the emulated environment it was enforced by the runtime process itself.

Our work on redesigning the emulator still has much more work to do. It was premature of me to remove a well working feature - again, hubris got the best of me ("I'll add the feature back in just a week or two!".

Many users have spoken out - so I'm proposing here we bring back the timeout feature I ripped out few months ago. It'll be our responsibility to preserve this feature in the redesign-ed the Emulator.

Fixes https://github.com/firebase/firebase-tools/issues/2837