### PR TITLE
Add --force to storage-deploy tests since they run non-interactively

### DIFF
--- a/scripts/storage-deploy-tests/run.sh
+++ b/scripts/storage-deploy-tests/run.sh
@@ -48,7 +48,7 @@ EOM
 echo "Initialized temp directory."
 
 echo "Testing storage deployment..."
-firebase deploy --only storage --project "${FBTOOLS_TARGET_PROJECT}"
+firebase deploy --force --only storage --project "${FBTOOLS_TARGET_PROJECT}"
 RET_CODE="$?"
 test "${RET_CODE}" == "0" || (echo "Expected exit code ${RET_CODE} to equal 0." && false)
 echo "Tested storage deployment."


### PR DESCRIPTION
### Description
storage-deploy tests started failing with the following error: 
```

i storage: quota exceeded error while uploading rules
Error:Missing required options (force) while running in non-interactive mode:
- force You have 2501 rules, do you want to delete the oldest 10 to free up space?
```
Adds the --force flag to fix this.