### PR TITLE
sets groundwork for removing login with token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Adds warnings about upcoming deprecation of `--token`, `FIREBASE_TOKEN`, and `login:ci`.

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ Use `firebase:deploy --only remoteconfig` to update and publish a project's Fire
 
 The Firebase CLI can use one of four authentication methods listed in descending priority:
 
-- **User Token** - **DEPRECATED: this will be removed in a future major version of `firebase-tools`; prefer using a Service Account** - provide an explicit long-lived Firebase user token generated from `firebase login:ci`. Note that these tokens are extremely sensitive long-lived credentials and are not the right option for most cases. Consider using service account authorization instead. The token can be set in one of two ways:
+- **User Token** - **DEPRECATED: this authentication method will be removed in a future major version of `firebase-tools`; use a service account to authenticate instead** - provide an explicit long-lived Firebase user token generated from `firebase login:ci`. Note that these tokens are extremely sensitive long-lived credentials and are not the right option for most cases. Consider using service account authorization instead. The token can be set in one of two ways:
   - Set the `--token` flag on any command, for example `firebase --token="<token>" projects:list`.
   - Set the `FIREBASE_TOKEN` environment variable.
 - **Local Login** - run `firebase login` to log in to the CLI directly as yourself. The CLI will cache an authorized user credential on your machine.
-- **Service Account** - set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to the path of a JSON service account key file. See Cloud's [Getting started with authentication](https://cloud.google.com/docs/authentication/getting-started) page for more details.
+- **Service Account** - set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to the path of a JSON service account key file. For more details, see Google Cloud's [Getting started with authentication](https://cloud.google.com/docs/authentication/getting-started) guide.
 - **Application Default Credentials** - if you use the `gcloud` CLI and log in with `gcloud auth application-default login`, the Firebase CLI will use them if none of the above credentials are present.
 
 ### Multiple Accounts
@@ -224,12 +224,14 @@ or `HTTP_PROXY` value in your environment to the URL of your proxy (e.g.
 The Firebase CLI requires a browser to complete authentication, but is fully
 compatible with CI and other headless environments.
 
-1. Follow the steps on Google Cloud's [Getting started with authentication](https://cloud.google.com/docs/authentication/getting-started) guide to create a service account with the appropriate roles for your project.
+Complete the following steps to run Firebase commands in a CI environment. Find detailed instructions for each step in Google Cloud's [Getting started with authentication](https://cloud.google.com/docs/authentication/getting-started) guide.
+
+ 1. Create a service account and grant it the appropriate level of access to your project.
 1. Create a service account key (JSON file) for that service account.
 1. Store the key file in a secure, accessible way in your CI system.
 1. Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json` in your CI system when running Firebase commands.
 
-To disable access for the service account, [find the service account for your project](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?supportedpurview=project&_ga=2.200170598.975007307.1658357213-1037429834.1658357213) and either remove the key, or disable or delete the service account.
+To disable access for the service account, [find the service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts) for your project in the Google Cloud Console, and then either remove the key, or disable or delete the service account.
 
 ## Using as a Module
 

--- a/README.md
+++ b/README.md
@@ -174,11 +174,11 @@ Use `firebase:deploy --only remoteconfig` to update and publish a project's Fire
 
 The Firebase CLI can use one of four authentication methods listed in descending priority:
 
-- **User Token** - provide an explicit long-lived Firebase user token generated from `firebase login:ci`. Note that these tokens are extremely sensitive long-lived credentials and are not the right option for most cases. Consider using service account authorization instead. The token can be set in one of two ways:
+- **User Token** - **DEPRECATED: this will be removed in a future major version of `firebase-tools`; prefer using a Service Account** - provide an explicit long-lived Firebase user token generated from `firebase login:ci`. Note that these tokens are extremely sensitive long-lived credentials and are not the right option for most cases. Consider using service account authorization instead. The token can be set in one of two ways:
   - Set the `--token` flag on any command, for example `firebase --token="<token>" projects:list`.
   - Set the `FIREBASE_TOKEN` environment variable.
 - **Local Login** - run `firebase login` to log in to the CLI directly as yourself. The CLI will cache an authorized user credential on your machine.
-- **Service Account** - set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to the path of a JSON service account key file.
+- **Service Account** - set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to point to the path of a JSON service account key file. See Cloud's [Getting started with authentication](https://cloud.google.com/docs/authentication/getting-started) page for more details.
 - **Application Default Credentials** - if you use the `gcloud` CLI and log in with `gcloud auth application-default login`, the Firebase CLI will use them if none of the above credentials are present.
 
 ### Multiple Accounts
@@ -224,21 +224,12 @@ or `HTTP_PROXY` value in your environment to the URL of your proxy (e.g.
 The Firebase CLI requires a browser to complete authentication, but is fully
 compatible with CI and other headless environments.
 
-1. On a machine with a browser, install the Firebase CLI.
-2. Run `firebase login:ci` to log in and print out a new [refresh token](https://developers.google.com/identity/protocols/OAuth2)
-   (the current CLI session will not be affected).
-3. Store the output token in a secure but accessible way in your CI system.
+1. Follow the steps on Google Cloud's [Getting started with authentication](https://cloud.google.com/docs/authentication/getting-started) guide to create a service account with the appropriate roles for your project.
+1. Create a service account key (JSON file) for that service account.
+1. Store the key file in a secure, accessible way in your CI system.
+1. Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json` in your CI system when running Firebase commands.
 
-There are two ways to use this token when running Firebase commands:
-
-1. Store the token as the environment variable `FIREBASE_TOKEN` and it will
-   automatically be utilized.
-2. Run all commands with the `--token <token>` flag in your CI system.
-
-The order of precedence for token loading is flag, environment variable, active project.
-
-On any machine with the Firebase CLI, running `firebase logout --token <token>`
-will immediately revoke access for the specified token.
+To disable access for the service account, [find the service account for your project](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts/create?supportedpurview=project&_ga=2.200170598.975007307.1658357213-1037429834.1658357213) and either remove the key, or disable or delete the service account.
 
 ## Using as a Module
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ compatible with CI and other headless environments.
 
 Complete the following steps to run Firebase commands in a CI environment. Find detailed instructions for each step in Google Cloud's [Getting started with authentication](https://cloud.google.com/docs/authentication/getting-started) guide.
 
- 1. Create a service account and grant it the appropriate level of access to your project.
+1. Create a service account and grant it the appropriate level of access to your project.
 1. Create a service account key (JSON file) for that service account.
 1. Store the key file in a secure, accessible way in your CI system.
 1. Set `GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json` in your CI system when running Firebase commands.

--- a/src/commands/login-ci.ts
+++ b/src/commands/login-ci.ts
@@ -17,6 +17,11 @@ export const command = new Command("login:ci")
       throw new FirebaseError("Cannot run login:ci in non-interactive mode.");
     }
 
+    utils.logWarning(
+      "Authenticating with a `login:ci` token is deprecated and will be removed in a future major version of `firebase-tools`. " +
+        "Prefer using a service account key with GOOGLE_APPLICATION_CREDENTIALS: https://cloud.google.com/docs/authentication/getting-started"
+    );
+
     const userCredentials = await auth.loginGoogle(options.localhost);
     logger.info();
     utils.logSuccess(

--- a/src/commands/login-ci.ts
+++ b/src/commands/login-ci.ts
@@ -19,7 +19,7 @@ export const command = new Command("login:ci")
 
     utils.logWarning(
       "Authenticating with a `login:ci` token is deprecated and will be removed in a future major version of `firebase-tools`. " +
-        "Prefer using a service account key with GOOGLE_APPLICATION_CREDENTIALS: https://cloud.google.com/docs/authentication/getting-started"
+        "Instead, use a service account key with `GOOGLE_APPLICATION_CREDENTIALS`: https://cloud.google.com/docs/authentication/getting-started"
     );
 
     const userCredentials = await auth.loginGoogle(options.localhost);

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,10 @@ program.option(
 );
 program.option("--account <email>", "the Google account to use for authorization");
 program.option("-j, --json", "output JSON instead of text, also triggers non-interactive mode");
-program.option("--token <token>", "supply an auth token for this command");
+program.option(
+  "--token <token>",
+  "DEPRECATED - will be removed in a future major version - supply an auth token for this command"
+);
 program.option("--non-interactive", "error out of the command instead of waiting for prompts");
 program.option("-i, --interactive", "force prompts to be displayed");
 program.option("--debug", "print verbose debug output and keep a debug log file");

--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -53,8 +53,16 @@ export async function requireAuth(options: any): Promise<void> {
   let tokenOpt = utils.getInheritedOption(options, "token");
   if (tokenOpt) {
     logger.debug("> authorizing via --token option");
+    utils.logWarning(
+      "Authenticating with `--token` is deprecated and will be removed in a future major version of `firebase-tools`. " +
+        "Prefer using a service account key with GOOGLE_APPLICATION_CREDENTIALS: https://cloud.google.com/docs/authentication/getting-started"
+    );
   } else if (process.env.FIREBASE_TOKEN) {
     logger.debug("> authorizing via FIREBASE_TOKEN environment variable");
+    utils.logWarning(
+      "Authenticating with `FIREBASE_TOKEN` is deprecated and will be removed in a future major version of `firebase-tools`. " +
+        "Prefer using a service account key with GOOGLE_APPLICATION_CREDENTIALS: https://cloud.google.com/docs/authentication/getting-started"
+    );
   } else if (user) {
     logger.debug(`> authorizing via signed-in user (${user.email})`);
   } else {

--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -55,13 +55,13 @@ export async function requireAuth(options: any): Promise<void> {
     logger.debug("> authorizing via --token option");
     utils.logWarning(
       "Authenticating with `--token` is deprecated and will be removed in a future major version of `firebase-tools`. " +
-        "Prefer using a service account key with GOOGLE_APPLICATION_CREDENTIALS: https://cloud.google.com/docs/authentication/getting-started"
+        "Instead, use a service account key with `GOOGLE_APPLICATION_CREDENTIALS`: https://cloud.google.com/docs/authentication/getting-started"
     );
   } else if (process.env.FIREBASE_TOKEN) {
     logger.debug("> authorizing via FIREBASE_TOKEN environment variable");
     utils.logWarning(
       "Authenticating with `FIREBASE_TOKEN` is deprecated and will be removed in a future major version of `firebase-tools`. " +
-        "Prefer using a service account key with GOOGLE_APPLICATION_CREDENTIALS: https://cloud.google.com/docs/authentication/getting-started"
+        "Instead, use a service account key with `GOOGLE_APPLICATION_CREDENTIALS`: https://cloud.google.com/docs/authentication/getting-started"
     );
   } else if (user) {
     logger.debug(`> authorizing via signed-in user (${user.email})`);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Lays groundwork for fully deprecating token support, in favor of service accounts.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- Auth with `GOOGLE_APPLICATION_CREDENTIALS`
- `--token` still working (with warnings)
- `FIREBASE_TOKEN` still working (with warnings)
- `login:ci` still working (with warnings)