### PR TITLE
Ability to push updates to hosting without having all files on disk

### DIFF
--- a/src/deploy/hosting/deploy.ts
+++ b/src/deploy/hosting/deploy.ts
@@ -84,6 +84,7 @@ export async function deploy(
       cwd: options.cwd,
       projectRoot: detectProjectRoot(options),
       uploadConcurrency: concurrency,
+      skipHashCheckOnEmptyFile: deploy.config?.skip_hash_check_on_empty_file || false,
     });
 
     const progressInterval = setInterval(

--- a/src/deploy/hosting/hostingDeploy.ts
+++ b/src/deploy/hosting/hostingDeploy.ts
@@ -12,6 +12,7 @@ export interface HostingConfig {
     source: string;
   }[];
   i18n?: { root: string };
+  skip_hash_check_on_empty_file?: boolean;
 }
 
 export interface HostingDeploy {

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -175,8 +175,7 @@ export class Uploader {
         this.addHash(filePath, cached.hash);
         return;
       }
-  
-      if (this.skipHashCheckOnEmptyFile && stats.size == 0) {
+      if (this.skipHashCheckOnEmptyFile && stats.size === 0) {
         this.cacheNew.set(filePath, cached);
         this.addHash(filePath, cached.hash);
         return;


### PR DESCRIPTION
A number of developers were using a script to push single file artifacts to hosting. Their script recently broke due to the removal of an internal API it relied on. I happened to need this functionality for a project today and figured it'd take the opportunity to get something into the actual CLI to support this use case.

Link to previous discussion: https://github.com/firebase/firebase-tools/pull/4629#issuecomment-1155638320

It seems most were using this script to avoid having their entire repo in place at the time of running `firebase deploy`. I'm in a the same boat, I want to be able to save disk space as the content going into hosting grows.

My solution adds a new flag to `firebase.json` called `skip_hash_check_on_empty_file`. A better name suggestion would be appreciated.

Example: 

```json
{
  "hosting": {
    "skip_hash_check_on_empty_file": true,
    "public": "public",
    "ignore": [
      "firebase.json",
      "**/.*",
      "**/node_modules/**"
    ]
  }
}
```

The default value is `false`. When enabled, the hash check for all empty files will be skipped. This means if you have a 50 mb video called `myvideo.mov` that you uploaded to hosting, you can then replace that file with an empty one (with the same `myvideo.mov`). The next time `firebase deploy` is run, `myvideo.mov` will be reported to the `populateFiles` API as having the same hash as the last time it was uploaded.

Updating files still works, as this hash skip only occurs when the file is 0 bytes in length. Deleting files also still works.

Look forward to seeing your thoughts.