### PR TITLE
Remove duplicate call to track

### DIFF
--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -483,8 +483,6 @@ export async function startAll(
       extensionsBackends
     );
     emulatableBackends.push(...filteredExtensionsBackends);
-    // Log the command for analytics
-    void track("Emulator Run", Emulators.EXTENSIONS);
     await startEmulator(extensionEmulator);
   }
 


### PR DESCRIPTION
This call is duplicated in startEmulator, so I'm removing it to give us accurate usage stats.