### PR TITLE
use user-project quota to test IAM permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-- Fix bug where function timeout couldn't be configured in the Functions Emulator. (#4745)
+- Fixes bug where function timeout couldn't be configured in the Functions Emulator. (#4745)
+- Adjusts API call to test IAM permissions to use the users' project's quota.

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -18,6 +18,8 @@ import * as FormData from "form-data";
 const pkg = require("../package.json");
 const CLI_VERSION: string = pkg.version;
 
+const GOOG_QUOTA_USER = "x-goog-quota-user";
+
 export type HttpMethod = "GET" | "PUT" | "POST" | "DELETE" | "PATCH";
 
 interface BaseRequestOptions<T> extends VerbOptions {
@@ -465,6 +467,14 @@ export class Client {
     }
     const logURL = this.requestURL(options);
     logger.debug(`>>> [apiv2][query] ${options.method} ${logURL} ${queryParamsLog}`);
+    const headers = options.headers;
+    if (headers && headers.has(GOOG_QUOTA_USER)) {
+      logger.debug(
+        `>>> [apiv2][(partial)header] ${options.method} ${logURL} x-goog-quota-user=${
+          headers.get(GOOG_QUOTA_USER) || ""
+        }`
+      );
+    }
     if (options.body !== undefined) {
       let logBody = "[omitted]";
       if (!options.skipLog?.body) {

--- a/src/test/gcp/iam.spec.ts
+++ b/src/test/gcp/iam.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import * as nock from "nock";
+
+import { resourceManagerOrigin } from "../../api";
+import * as iam from "../../gcp/iam";
+
+describe("iam", () => {
+  describe("testIamPermissions", () => {
+    const tests: {
+      desc: string;
+      permissionsToCheck: string[];
+      permissionsToReturn: string[];
+      wantAllowedPermissions: string[];
+      wantMissingPermissions?: string[];
+      wantedPassed: boolean;
+    }[] = [
+      {
+        desc: "should pass if we have all permissions",
+        permissionsToCheck: ["foo", "bar"],
+        permissionsToReturn: ["foo", "bar"],
+        wantAllowedPermissions: ["foo", "bar"].sort(),
+        wantedPassed: true,
+      },
+      {
+        desc: "should fail if we don't have all permissions",
+        permissionsToCheck: ["foo", "bar"],
+        permissionsToReturn: ["foo"],
+        wantAllowedPermissions: ["foo"].sort(),
+        wantMissingPermissions: ["bar"].sort(),
+        wantedPassed: false,
+      },
+    ];
+
+    const TEST_RESOURCE = `projects/foo`;
+
+    for (const t of tests) {
+      it(t.desc, async () => {
+        nock(resourceManagerOrigin)
+          .post(`/v1/${TEST_RESOURCE}:testIamPermissions`)
+          .matchHeader("x-goog-quota-user", TEST_RESOURCE)
+          .reply(200, { permissions: t.permissionsToReturn });
+
+        const res = await iam.testIamPermissions("foo", t.permissionsToCheck);
+
+        expect(res.allowed).to.deep.equal(t.wantAllowedPermissions);
+        expect(res.missing).to.deep.equal(t.wantMissingPermissions || []);
+        expect(res.passed).to.equal(t.wantedPassed);
+
+        expect(nock.isDone()).to.be.true;
+      });
+    }
+  });
+});


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`x-goog-quota-user` is the [system parameter](https://cloud.google.com/apis/docs/system-parameters) that can be used to charge a specific user the quota for a call. Since the CLI does `testIamPermissions` quite a bit, the CLI's project uses quite a bit of this quota when we really should be 'charging' the user for it. Adding the header will do that.

I also cleaned up a few types and tiny bits of logic (no more lodash!) in the `iam.ts` file, but nothing drastic!

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Hosting and  Functions deploys.