### PR TITLE
v1alpha1 wire format needs to support Field types

### DIFF
--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -14,9 +14,8 @@ export interface Build {
   params: params.Param[];
 }
 
-/* A utility function that returns an empty Build. */
 /**
- *
+ *  A utility function that returns an empty Build.
  */
 export function empty(): Build {
   return {
@@ -26,9 +25,8 @@ export function empty(): Build {
   };
 }
 
-/* A utility function that creates a Build containing a map of IDs to Endpoints. */
 /**
- *
+ * A utility function that creates a Build containing a map of IDs to Endpoints
  */
 export function of(endpoints: Record<string, Endpoint>): Build {
   const build = empty();
@@ -209,7 +207,10 @@ export type Endpoint = Triggered & {
   labels?: Record<string, string | Expression<string>>;
 };
 
-function isMemoryOption(value: backend.MemoryOptions | any): value is backend.MemoryOptions {
+/**
+ *
+ */
+export function isMemoryOption(value: backend.MemoryOptions | any): value is backend.MemoryOptions {
   return value == null || [128, 256, 512, 1024, 2048, 4096, 8192].includes(value);
 }
 
@@ -250,7 +251,10 @@ export function toBackend(
       if (typeof bdEndpoint.platform === "undefined") {
         throw new FirebaseError("platform can't be undefined");
       }
-      if (!isMemoryOption(bdEndpoint.availableMemoryMb)) {
+      if (
+        bdEndpoint.availableMemoryMb &&
+        !isMemoryOption(params.resolveInt(bdEndpoint.availableMemoryMb, paramValues))
+      ) {
         throw new FirebaseError("available memory must be a supported value, if present");
       }
       let timeout: number;
@@ -297,11 +301,19 @@ export function toBackend(
           return params.resolveInt(from, paramValues);
         }
       );
+      proto.renameIfPresent(
+        bkEndpoint,
+        bdEndpoint,
+        "availableMemoryMb",
+        "availableMemoryMb",
+        (from: number | Expression<number>): number => {
+          return params.resolveInt(from, paramValues);
+        }
+      );
       proto.copyIfPresent(
         bkEndpoint,
         bdEndpoint,
         "ingressSettings",
-        "availableMemoryMb",
         "environmentVariables",
         "labels"
       );

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -243,9 +243,6 @@ export type Endpoint = Triggered & {
   labels?: Record<string, string | Expression<string>>;
 };
 
-/**
- *
- */
 export function isMemoryOption(value: backend.MemoryOptions | any): value is backend.MemoryOptions {
   return value == null || [128, 256, 512, 1024, 2048, 4096, 8192].includes(value);
 }

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -5,7 +5,7 @@ import * as params from "./params";
 import { previews } from "../../previews";
 import { FirebaseError } from "../../error";
 import { assertExhaustive } from "../../functional";
-import { UserEnvsOpts } from "../../functions/env";
+import { UserEnvsOpts, writeUserEnvs } from "../../functions/env";
 
 /* The union of a customer-controlled deployment and potentially deploy-time defined parameters */
 export interface Build {

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -5,7 +5,7 @@ import * as params from "./params";
 import { previews } from "../../previews";
 import { FirebaseError } from "../../error";
 import { assertExhaustive } from "../../functional";
-import { UserEnvsOpts, writeUserEnvs } from "../../functions/env";
+import { UserEnvsOpts } from "../../functions/env";
 
 /* The union of a customer-controlled deployment and potentially deploy-time defined parameters */
 export interface Build {
@@ -142,12 +142,48 @@ export interface ScheduleTrigger {
 }
 
 export type Triggered =
-  | { httpsTrigger: HttpsTrigger }
-  | { callableTrigger: CallableTrigger }
-  | { blockingTrigger: BlockingTrigger }
-  | { eventTrigger: EventTrigger }
-  | { scheduleTrigger: ScheduleTrigger }
-  | { taskQueueTrigger: TaskQueueTrigger };
+  | HttpsTriggered
+  | CallableTriggered
+  | BlockingTriggered
+  | EventTriggered
+  | ScheduleTriggered
+  | TaskQueueTriggered;
+export type HttpsTriggered = { httpsTrigger: HttpsTrigger };
+export type CallableTriggered = { callableTrigger: CallableTrigger };
+export type BlockingTriggered = { blockingTrigger: BlockingTrigger };
+export type EventTriggered = { eventTrigger: EventTrigger };
+export type ScheduleTriggered = { scheduleTrigger: ScheduleTrigger };
+export type TaskQueueTriggered = { taskQueueTrigger: TaskQueueTrigger };
+
+/** Whether something has an HttpsTrigger */
+export function isHttpsTriggered(triggered: Triggered): triggered is HttpsTriggered {
+  return {}.hasOwnProperty.call(triggered, "httpsTrigger");
+}
+
+/** Whether something has a CallableTrigger */
+export function isCallableTriggered(triggered: Triggered): triggered is CallableTriggered {
+  return {}.hasOwnProperty.call(triggered, "callableTrigger");
+}
+
+/** Whether something has an EventTrigger */
+export function isEventTriggered(triggered: Triggered): triggered is EventTriggered {
+  return {}.hasOwnProperty.call(triggered, "eventTrigger");
+}
+
+/** Whether something has a ScheduleTrigger */
+export function isScheduleTriggered(triggered: Triggered): triggered is ScheduleTriggered {
+  return {}.hasOwnProperty.call(triggered, "scheduleTrigger");
+}
+
+/** Whether something has a TaskQueueTrigger */
+export function isTaskQueueTriggered(triggered: Triggered): triggered is TaskQueueTriggered {
+  return {}.hasOwnProperty.call(triggered, "taskQueueTrigger");
+}
+
+/** Whether something has a BlockingTrigger */
+export function isBlockingTriggered(triggered: Triggered): triggered is BlockingTriggered {
+  return {}.hasOwnProperty.call(triggered, "blockingTrigger");
+}
 
 export interface VpcSettings {
   connector: string | Expression<string>;
@@ -348,17 +384,17 @@ function discoverTrigger(
     params.resolveBoolean(from, paramValues);
 
   let trigger: backend.Triggered;
-  if ("httpsTrigger" in endpoint) {
+  if (isHttpsTriggered(endpoint)) {
     const bkHttps: backend.HttpsTrigger = {};
     if (endpoint.httpsTrigger.invoker) {
       bkHttps.invoker = endpoint.httpsTrigger.invoker;
     }
     trigger = { httpsTrigger: bkHttps };
-  } else if ("callableTrigger" in endpoint) {
+  } else if (isCallableTriggered(endpoint)) {
     trigger = { callableTrigger: {} };
-  } else if ("blockingTrigger" in endpoint) {
+  } else if (isBlockingTriggered(endpoint)) {
     trigger = { blockingTrigger: endpoint.blockingTrigger };
-  } else if ("eventTrigger" in endpoint) {
+  } else if (isEventTriggered(endpoint)) {
     const bkEventFilters: Record<string, string> = {};
     for (const [key, value] of Object.entries(endpoint.eventTrigger.eventFilters)) {
       bkEventFilters[key] = params.resolveString(value, paramValues);

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -17,7 +17,6 @@ function dependenciesCEL(expr: CEL): string[] {
   while ((match = paramCapture.exec(expr)) != null) {
     deps.push(match[1]);
   }
-  // return /{{ params\.\w+ }}/.exec(expr)?.slice(1) || [];
   return deps;
 }
 
@@ -33,7 +32,7 @@ export function resolveInt(
   if (typeof from === "number") {
     return from;
   }
-  const match = /\A{{ params\.(\w+) }}\z/.exec(from);
+  const match = /{{ params\.(\w+) }}/.exec(from);
   if (!match) {
     throw new FirebaseError("CEL evaluation of expression '" + from + "' not yet supported");
   }
@@ -113,7 +112,7 @@ export function resolveBoolean(
 
 interface ParamBase<T extends string | number | boolean> {
   // name of the param. Will be exposed as an environment variable with this name
-  param: string;
+  name: string;
 
   // A human friendly name for the param. Will be used in install/configure flows to describe
   // what param is being updated. If omitted, UX will use the value of "param" instead.
@@ -232,30 +231,30 @@ export async function resolveParams(
 ): Promise<Record<string, ParamValue>> {
   const paramValues: Record<string, ParamValue> = {};
 
-  for (const param of params.filter((param) => userEnvs.hasOwnProperty(param.param))) {
-    if (!canSatisfyParam(param, userEnvs[param.param])) {
+  for (const param of params.filter((param) => userEnvs.hasOwnProperty(param.name))) {
+    if (!canSatisfyParam(param, userEnvs[param.name])) {
       throw new FirebaseError(
         "Parameter " +
-          param.param +
+          param.name +
           " resolved to value from dotenv files " +
-          userEnvs[param.param] +
+          userEnvs[param.name] +
           " of wrong type"
       );
     }
-    paramValues[param.param] = userEnvs[param.param];
+    paramValues[param.name] = userEnvs[param.name];
   }
 
-  for (const param of params.filter((param) => !userEnvs.hasOwnProperty(param.param))) {
+  for (const param of params.filter((param) => !userEnvs.hasOwnProperty(param.name))) {
     let paramDefault: ParamValue | undefined = param.default;
     if (paramDefault && isCEL(paramDefault)) {
       paramDefault = resolveDefaultCEL(param.type, paramDefault, paramValues);
     }
     if (paramDefault && !canSatisfyParam(param, paramDefault)) {
       throw new FirebaseError(
-        "Parameter " + param.param + " has default value " + paramDefault + " of wrong type"
+        "Parameter " + param.name + " has default value " + paramDefault + " of wrong type"
       );
     }
-    paramValues[param.param] = await promptParam(param, paramDefault);
+    paramValues[param.name] = await promptParam(param, paramDefault);
 
     // TODO(vsfan@): Once we have writeUserEnvs in functions/env.ts implemented, call it to persist user-provided params
   }
@@ -288,16 +287,16 @@ async function promptStringParam(param: StringParam, resolvedDefault?: string): 
   switch (param.input.type) {
     case "select":
       throw new FirebaseError(
-        "Build specified string parameter " + param.param + " with unsupported input type 'select'"
+        "Build specified string parameter " + param.name + " with unsupported input type 'select'"
       );
     case "text":
     default:
-      let prompt = `Enter a value for ${param.label || param.param}`;
+      let prompt = `Enter a value for ${param.label || param.name}:`;
       if (param.description) {
         prompt += ` \n(${param.description})`;
       }
       return await promptOnce({
-        name: param.param,
+        name: param.name,
         type: "input",
         default: resolvedDefault,
         message: prompt,
@@ -314,18 +313,18 @@ async function promptIntParam(param: IntParam, resolvedDefault?: number): Promis
   switch (param.input.type) {
     case "select":
       throw new FirebaseError(
-        "Build specified int parameter " + param.param + " with unsupported input type 'select'"
+        "Build specified int parameter " + param.name + " with unsupported input type 'select'"
       );
     case "text":
     default:
-      let prompt = `Enter a value for ${param.label || param.param}`;
+      let prompt = `Enter a value for ${param.label || param.name}:`;
       if (param.description) {
         prompt += ` \n(${param.description})`;
       }
       let res: number;
       while (true) {
         res = await promptOnce({
-          name: param.param,
+          name: param.name,
           type: "number",
           default: resolvedDefault,
           message: prompt,
@@ -333,7 +332,7 @@ async function promptIntParam(param: IntParam, resolvedDefault?: number): Promis
         if (Number.isInteger(res)) {
           return res;
         }
-        logger.error(`${param.label || param.param} must be an integer; retrying...`);
+        logger.error(`${param.label || param.name} must be an integer; retrying...`);
       }
   }
 }

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -36,31 +36,30 @@ export type ManifestEndpoint = Base &
     secretEnvironmentVariables?: Array<ManifestSecretEnv>;
   };
 
-export type V2Endpoint =
-  { httpsTrigger?: build.HttpsTrigger } & { callableTrigger?: {} } & {
-    eventTrigger?: build.EventTrigger;
-  } & { taskQueueTrigger?: build.TaskQueueTrigger } & {
-    blockingTrigger?: build.BlockingTrigger;
-  } & { scheduleTrigger?: build.ScheduleTrigger } & {
-    labels?: Record<string, string>;
-    environmentVariables?: Record<string, string>;
-    availableMemoryMb?: backend.MemoryOptions | build.Expression<number>;
-    concurrency?: number | build.Expression<number>;
-    cpu?: number | "gcf_gen1";
-    timeoutSeconds?: number | build.Expression<number>;
-    maxInstances?: number | build.Expression<number>;
-    minInstances?: number | build.Expression<number>;
-    vpc?: {
-      connector: string;
-      egressSettings?: backend.VpcEgressSettings;
-    };
-    ingressSettings?: backend.IngressSettings;
-    serviceAccountEmail?: string;
-    region?: string[];
-    entryPoint: string;
-    platform?: backend.FunctionsPlatform;
-    secretEnvironmentVariables?: Array<ManifestSecretEnv>;
+export type V2Endpoint = { httpsTrigger?: build.HttpsTrigger } & { callableTrigger?: {} } & {
+  eventTrigger?: build.EventTrigger;
+} & { taskQueueTrigger?: build.TaskQueueTrigger } & {
+  blockingTrigger?: build.BlockingTrigger;
+} & { scheduleTrigger?: build.ScheduleTrigger } & {
+  labels?: Record<string, string>;
+  environmentVariables?: Record<string, string>;
+  availableMemoryMb?: backend.MemoryOptions | build.Expression<number>;
+  concurrency?: number | build.Expression<number>;
+  cpu?: number | "gcf_gen1";
+  timeoutSeconds?: number | build.Expression<number>;
+  maxInstances?: number | build.Expression<number>;
+  minInstances?: number | build.Expression<number>;
+  vpc?: {
+    connector: string;
+    egressSettings?: backend.VpcEgressSettings;
   };
+  ingressSettings?: backend.IngressSettings;
+  serviceAccountEmail?: string;
+  region?: string[];
+  entryPoint: string;
+  platform?: backend.FunctionsPlatform;
+  secretEnvironmentVariables?: Array<ManifestSecretEnv>;
+};
 
 export interface Manifest {
   specVersion: string;
@@ -83,6 +82,7 @@ export function buildFromV1Alpha1(
   region: string,
   runtime: runtimes.Runtime
 ): build.Build {
+  const oldManifest = JSON.parse(JSON.stringify(yaml)) as Manifest;
   const manifest = JSON.parse(JSON.stringify(yaml)) as V2Manifest;
   requireKeys("", manifest, "endpoints");
   assertKeyTypes("", manifest, {
@@ -95,8 +95,8 @@ export function buildFromV1Alpha1(
   bd.params = manifest.params || [];
   bd.requiredAPIs = parseRequiredAPIs(manifest);
   for (const id of Object.keys(manifest.endpoints)) {
+    assertManifestEndpoint(oldManifest.endpoints[id], id);
     const me: V2Endpoint = manifest.endpoints[id];
-    assertBuildEndpoint(me, id);
     const be: build.Endpoint = parseEndpointForBuild(id, me, project, region, runtime);
     bd.endpoints[id] = be;
   }
@@ -266,133 +266,6 @@ function assertManifestEndpoint(ep: ManifestEndpoint, id: string): void {
   }
 }
 
-function assertBuildEndpoint(ep: V2Endpoint, id: string): void {
-  const prefix = `endpoints[${id}]`;
-  assertKeyTypes(prefix, ep, {
-    region: "array",
-    platform: (platform) => backend.AllFunctionsPlatforms.includes(platform),
-    entryPoint: "string",
-    availableMemoryMb: (mem) => typeof mem === "string" || build.isMemoryOption(mem),
-    maxInstances: "Field<number>",
-    minInstances: "Field<number>",
-    concurrency: "Field<number>",
-    serviceAccountEmail: "string",
-    timeoutSeconds: "Field<number>",
-    vpc: "object",
-    labels: "object",
-    ingressSettings: (setting) => backend.AllIngressSettings.includes(setting),
-    environmentVariables: "object",
-    secretEnvironmentVariables: "array",
-    httpsTrigger: "object",
-    callableTrigger: "object",
-    eventTrigger: "object",
-    scheduleTrigger: "object",
-    taskQueueTrigger: "object",
-    blockingTrigger: "object",
-    cpu: (cpu: backend.Endpoint["cpu"]) => typeof cpu === "number" || cpu === "gcf_gen1",
-  });
-  if (ep.vpc) {
-    assertKeyTypes(prefix + ".vpc", ep.vpc, {
-      connector: "string",
-      egressSettings: (setting) => backend.AllVpcEgressSettings.includes(setting),
-    });
-    requireKeys(prefix + ".vpc", ep.vpc, "connector");
-  }
-  let triggerCount = 0;
-  if (ep.httpsTrigger) {
-    triggerCount++;
-  }
-  if (ep.callableTrigger) {
-    triggerCount++;
-  }
-  if (ep.eventTrigger) {
-    triggerCount++;
-  }
-  if (ep.scheduleTrigger) {
-    triggerCount++;
-  }
-  if (ep.taskQueueTrigger) {
-    triggerCount++;
-  }
-  if (ep.blockingTrigger) {
-    triggerCount++;
-  }
-  if (!triggerCount) {
-    throw new FirebaseError("Expected trigger in endpoint " + id);
-  }
-  if (triggerCount > 1) {
-    throw new FirebaseError("Multiple triggers defined for endpoint" + id);
-  }
-
-  if (ep.eventTrigger) {
-    requireKeys(prefix + ".eventTrigger", ep.eventTrigger, "eventType", "eventFilters");
-    assertKeyTypes(prefix + ".eventTrigger", ep.eventTrigger, {
-      eventFilters: "object",
-      eventFilterPathPatterns: "object",
-      eventType: "string",
-      retry: "Field<boolean>",
-      region: "Field<string>",
-      serviceAccount: "string",
-      channel: "string",
-    });
-  } else if (ep.httpsTrigger) {
-    assertKeyTypes(prefix + ".httpsTrigger", ep.httpsTrigger, {
-      invoker: "array",
-    });
-  } else if (ep.callableTrigger) {
-    // no-op
-  } else if (ep.scheduleTrigger) {
-    assertKeyTypes(prefix + ".scheduleTrigger", ep.scheduleTrigger, {
-      schedule: "Field<string>",
-      timeZone: "Field<string>",
-      retryConfig: "object",
-    });
-    assertKeyTypes(prefix + ".scheduleTrigger.retryConfig", ep.scheduleTrigger.retryConfig, {
-      retryCount: "Field<number>",
-      maxDoublings: "Field<number>",
-      minBackoffSeconds: "Field<string>",
-      maxBackoffSeconds: "Field<string>",
-      maxRetrySeconds: "Field<number>",
-    });
-  } else if (ep.taskQueueTrigger) {
-    assertKeyTypes(prefix + ".taskQueueTrigger", ep.taskQueueTrigger, {
-      rateLimits: "object",
-      retryConfig: "object",
-      invoker: "array",
-    });
-    if (ep.taskQueueTrigger.rateLimits) {
-      assertKeyTypes(prefix + ".taskQueueTrigger.rateLimits", ep.taskQueueTrigger.rateLimits, {
-        maxConcurrentDispatches: "Field<number>",
-        maxDispatchesPerSecond: "Field<number>",
-      });
-    }
-    if (ep.taskQueueTrigger.retryConfig) {
-      assertKeyTypes(
-        prefix + ".taskQueueTrigger.retryConfig",
-        ep.taskQueueTrigger.retryConfig as build.TaskQueueRetryConfig,
-        {
-          maxAttempts: "Field<number>",
-          maxRetryDurationSeconds: "Field<number>",
-          minBackoffSeconds: "Field<number>",
-          maxBackoffSeconds: "Field<number>",
-          maxDoublings: "Field<number>",
-        }
-      );
-    }
-  } else if (ep.blockingTrigger) {
-    requireKeys(prefix + ".blockingTrigger", ep.blockingTrigger, "eventType");
-    assertKeyTypes(prefix + ".blockingTrigger", ep.blockingTrigger, {
-      eventType: "string",
-      options: "object",
-    });
-  } else {
-    throw new FirebaseError(
-      `Do not recognize trigger type for endpoint ${id}. Try upgrading ` +
-        "firebase-tools with npm install -g firebase-tools@latest"
-    );
-  }
-}
-
 function parseEndpointForBuild(
   id: string,
   ep: V2Endpoint,
@@ -402,10 +275,10 @@ function parseEndpointForBuild(
 ): build.Endpoint {
   let triggered: build.Triggered;
   if (ep.eventTrigger) {
-    const { ...newTrigger } = ep.eventTrigger;
-    delete newTrigger.serviceAccount;
+    const wireEventTrigger = ep.eventTrigger as backend.EventTrigger;
+    const { serviceAccountEmail, ...newTrigger } = wireEventTrigger;
     triggered = { eventTrigger: newTrigger };
-    triggered.eventTrigger.serviceAccount = ep.eventTrigger.serviceAccount;
+    triggered.eventTrigger.serviceAccount = serviceAccountEmail;
     renameIfPresent(triggered.eventTrigger, ep.eventTrigger, "channel", "channel", (c) =>
       resolveChannelName(project, c, defaultRegion)
     );
@@ -427,20 +300,19 @@ function parseEndpointForBuild(
       retryConfig: {},
     };
     if (ep.scheduleTrigger.retryConfig) {
+      const wireRetryConfig = ep.scheduleTrigger.retryConfig as backend.ScheduleRetryConfig;
       st.retryConfig = {
         retryCount: ep.scheduleTrigger.retryConfig.retryCount,
         maxDoublings: ep.scheduleTrigger.retryConfig.maxDoublings,
       };
-      if (ep.scheduleTrigger.retryConfig.maxRetrySeconds) {
-        st.retryConfig.maxRetrySeconds = 
-          ep.scheduleTrigger.retryConfig.maxRetrySeconds;
+      if (wireRetryConfig.maxRetryDuration) {
+        st.retryConfig.maxRetrySeconds = secondsFromDuration(wireRetryConfig.maxRetryDuration);
       }
-      if (ep.scheduleTrigger.retryConfig.maxBackoffSeconds) {
-        st.retryConfig.maxBackoffSeconds = 
-          ep.scheduleTrigger.retryConfig.maxBackoffSeconds;
+      if (wireRetryConfig.maxBackoffDuration) {
+        st.retryConfig.maxBackoffSeconds = secondsFromDuration(wireRetryConfig.maxBackoffDuration);
       }
-      if (ep.scheduleTrigger.retryConfig.minBackoffSeconds) {
-          ep.scheduleTrigger.retryConfig.minBackoffSeconds;
+      if (wireRetryConfig.minBackoffDuration) {
+        st.retryConfig.minBackoffSeconds = secondsFromDuration(wireRetryConfig.minBackoffDuration);
       }
     }
     triggered = { scheduleTrigger: st };

--- a/src/test/deploy/functions/params.spec.ts
+++ b/src/test/deploy/functions/params.spec.ts
@@ -43,11 +43,11 @@ describe("resolveParams", () => {
   it("can pull a literal value out of the dotenvs", async () => {
     const paramsToResolve: params.Param[] = [
       {
-        param: "foo",
+        name: "foo",
         type: "string",
       },
       {
-        param: "bar",
+        name: "bar",
         type: "int",
       },
     ];
@@ -64,7 +64,7 @@ describe("resolveParams", () => {
   it("errors when the dotenvs provide a value of the wrong type", async () => {
     const paramsToResolve: params.Param[] = [
       {
-        param: "foo",
+        name: "foo",
         type: "string",
       },
     ];
@@ -77,7 +77,7 @@ describe("resolveParams", () => {
   it("can use a provided literal", async () => {
     const paramsToResolve: params.Param[] = [
       {
-        param: "foo",
+        name: "foo",
         default: "bar",
         type: "string",
         input: { type: "text", text: {} },
@@ -92,13 +92,13 @@ describe("resolveParams", () => {
   it("can resolve a CEL identity expression", async () => {
     const paramsToResolve: params.Param[] = [
       {
-        param: "foo",
+        name: "foo",
         default: "baz",
         type: "string",
         input: { type: "text", text: {} },
       },
       {
-        param: "bar",
+        name: "bar",
         default: "{{ params.foo }}",
         type: "string",
         input: { type: "text", text: {} },
@@ -112,13 +112,13 @@ describe("resolveParams", () => {
   it("can resolve a CEL expression containing only identities", async () => {
     const paramsToResolve: params.Param[] = [
       {
-        param: "foo",
+        name: "foo",
         default: "baz",
         type: "string",
         input: { type: "text", text: {} },
       },
       {
-        param: "bar",
+        name: "bar",
         default: "{{ params.foo }}/quox",
         type: "string",
         input: { type: "text", text: {} },
@@ -132,7 +132,7 @@ describe("resolveParams", () => {
   it("errors when the default is an unresolvable CEL expression", async () => {
     const paramsToResolve: params.Param[] = [
       {
-        param: "bar",
+        name: "bar",
         default: "{{ params.foo }}",
         type: "string",
         input: { type: "text", text: {} },
@@ -145,13 +145,13 @@ describe("resolveParams", () => {
   it("errors when the default is a CEL expression that resolves to the wrong type", async () => {
     const paramsToResolve: params.Param[] = [
       {
-        param: "foo",
+        name: "foo",
         default: "22",
         type: "string",
         input: { type: "text", text: {} },
       },
       {
-        param: "bar",
+        name: "bar",
         default: "{{ params.foo }}",
         type: "int",
         input: { type: "text", text: {} },

--- a/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -16,7 +16,7 @@ const MIN_ENDPOINT: Omit<v1alpha1.ManifestEndpoint, "httpsTrigger"> = {
 };
 const MIN_BUILD_ENDPOINT: Omit<v1alpha1.V2Endpoint, "httpsTrigger"> = {
   entryPoint: "entryPoint",
-}
+};
 
 async function resolveBackend(bd: build.Build): Promise<backend.Backend> {
   return build.resolveBackend(bd, { functionsSource: "", projectId: PROJECT }, {});
@@ -105,7 +105,14 @@ describe("buildFromV1Alpha", () => {
         },
       };
       const parsed = v1alpha1.buildFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
-      const expected: build.Build = build.of({ id: { ...DEFAULTED_ENDPOINT, httpsTrigger: {} } });
+      const expected: build.Build = build.of({
+        id: {
+          ...DEFAULTED_ENDPOINT,
+          concurrency: "{{ params.CONCURRENCY }}",
+          availableMemoryMb: "{{ params.MEMORY }}",
+          httpsTrigger: {},
+        },
+      });
       expect(parsed).to.deep.equal(expected);
     });
 

--- a/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -23,14 +23,14 @@ describe("buildFromV1Alpha", () => {
   describe("Params", () => {
     it("copies param fields", () => {
       const testParams: Param[] = [
-        { param: "FOO", type: "string" },
+        { name: "FOO", type: "string" },
         {
-          param: "ASDF",
+          name: "ASDF",
           type: "string",
           default: "{{ params.FOO }}",
           description: "another test param",
         },
-        { param: "BAR", type: "int" },
+        { name: "BAR", type: "int" },
       ];
 
       const yaml: v1alpha1.Manifest = {


### PR DESCRIPTION
The overarching problem we need to solve here is that v1alpha1's parser worked by converting the wire format YAML into an object of type Manifest, which is defined using types imported from Backend (i.e backend.ServiceConfiguration and backend.Triggered), which naturally do not support CEL expression types in its various fields. Therefore, the type checking in `assertKeyTypes` would break any attempts by the SDK to actually send Fields to the CLI.