### PR TITLE
Fix bug where task queue function params were incorrectly copied.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Adds warnings about upcoming deprecation of `--token`, `FIREBASE_TOKEN`, and `login:ci`.
+- Fix bug where task queue function configuration values were incorrectly resolved. (#4788)

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -115,7 +115,7 @@ export interface TaskQueueRateLimits {
 
 export interface TaskQueueRetryConfig {
   maxAttempts?: Field<number>;
-  maxRetryDurationSeconds?: Field<number>;
+  maxRetrySeconds?: Field<number>;
   minBackoffSeconds?: Field<number>;
   maxBackoffSeconds?: Field<number>;
   maxDoublings?: Field<number>;
@@ -436,27 +436,21 @@ function discoverTrigger(
         endpoint.taskQueueTrigger.retryConfig,
         "maxBackoffSeconds",
         "maxBackoffSeconds",
-        (from: number | Expression<number>): string => {
-          return proto.durationFromSeconds(resolveInt(from));
-        }
+        resolveInt
       );
       proto.renameIfPresent(
         bkRetryConfig,
         endpoint.taskQueueTrigger.retryConfig,
         "minBackoffSeconds",
         "minBackoffSeconds",
-        (from: number | Expression<number>): string => {
-          return proto.durationFromSeconds(resolveInt(from));
-        }
+        resolveInt
       );
       proto.renameIfPresent(
         bkRetryConfig,
         endpoint.taskQueueTrigger.retryConfig,
         "maxRetrySeconds",
-        "maxRetryDurationSeconds",
-        (from: number | Expression<number>): string => {
-          return proto.durationFromSeconds(resolveInt(from));
-        }
+        "maxRetrySeconds",
+        resolveInt
       );
       proto.renameIfPresent(
         bkRetryConfig,

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -295,7 +295,7 @@ function parseEndpointForBuild(
     };
     if (ep.taskQueueTrigger.retryConfig) {
       tq.retryConfig = {
-        maxRetryDurationSeconds: ep.taskQueueTrigger.retryConfig.maxRetrySeconds,
+        maxRetrySeconds: ep.taskQueueTrigger.retryConfig.maxRetrySeconds,
         maxBackoffSeconds: ep.taskQueueTrigger.retryConfig.maxBackoffSeconds,
         minBackoffSeconds: ep.taskQueueTrigger.retryConfig.minBackoffSeconds,
         maxDoublings: ep.taskQueueTrigger.retryConfig.maxDoublings,

--- a/src/test/deploy/functions/build.spec.ts
+++ b/src/test/deploy/functions/build.spec.ts
@@ -81,4 +81,47 @@ describe("toBackend", () => {
       ).to.have.members(["service-account-1@", "service-account-2@"]);
     }
   });
+
+  // Regression test for bug https://github.com/firebase/firebase-tools/issues/4730.
+  it("retains correct configuration value for task queue functions", () => {
+    const ep: build.Endpoint = {
+      platform: "gcfv1",
+      region: ["us-central1"],
+      project: "project",
+      runtime: "nodejs16",
+      entryPoint: "func",
+      serviceAccount: "service-account-1@",
+      timeoutSeconds: 60,
+      taskQueueTrigger: {
+        retryConfig: {
+          maxBackoffSeconds: 42,
+          maxAttempts: 42,
+          maxDoublings: 42,
+          maxRetrySeconds: 42,
+          minBackoffSeconds: 42,
+        },
+        rateLimits: {
+          maxConcurrentDispatches: 42,
+          maxDispatchesPerSecond: 42,
+        },
+      },
+    };
+
+    const desiredBuild: build.Build = build.of({ func: ep });
+    const bk = build.toBackend(desiredBuild, {});
+    expect(Object.keys(bk.endpoints).length).to.equal(1);
+    const bkendpoint = Object.values(bk.endpoints)[0];
+
+    // TODO: I'm not sure why this fields have different name between build vs backend endpoint definitions.
+    delete (ep as any).serviceAccount;
+
+    expect(bkendpoint).to.deep.equal({
+      func: {
+        ...ep,
+        id: "func",
+        region: "us-central1",
+        serviceAccountEmail: "service-account-1@",
+      },
+    });
+  });
 });


### PR DESCRIPTION
Originally, we ended up calling proto.durationFromSeconds twice on `*Seconds` configurations, leading to values like "42ss" being sent to Cloud Tasks API.

Also fix a typo - `maxRetryDurationSeconds` -> `maxRetrySeconds`.

Fixes #4730