### PR TITLE
Fix Storage import failure due to missing directories from export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Adds check for callable functions when discovering Hosting rewrite endpoints. (#4792)
+- Fixes Storage import failure due to missing directories. (#3823)

--- a/scripts/storage-emulator-integration/import/flattened-emulator-data-missing-blobs-and-metadata/firebase-export-metadata.json
+++ b/scripts/storage-emulator-integration/import/flattened-emulator-data-missing-blobs-and-metadata/firebase-export-metadata.json
@@ -1,0 +1,7 @@
+{
+  "version": "10.4.2",
+  "storage": {
+    "version": "10.4.2",
+    "path": "storage_export"
+  }
+}

--- a/scripts/storage-emulator-integration/import/flattened-emulator-data-missing-blobs-and-metadata/storage_export/buckets.json
+++ b/scripts/storage-emulator-integration/import/flattened-emulator-data-missing-blobs-and-metadata/storage_export/buckets.json
@@ -1,0 +1,7 @@
+{
+  "buckets": [
+    {
+      "id": "fake-project-id.appspot.com"
+    }
+  ]
+}

--- a/scripts/storage-emulator-integration/import/tests.ts
+++ b/scripts/storage-emulator-integration/import/tests.ts
@@ -36,6 +36,16 @@ describe("Import Emulator Data", () => {
       .expect(200);
   });
 
+  it("imports directory that is missing blobs and metadata directories", async function (this) {
+    this.timeout(TEST_SETUP_TIMEOUT);
+    await test.startEmulators([
+      "--only",
+      Emulators.STORAGE,
+      "--import",
+      path.join(__dirname, "flattened-emulator-data-missing-blobs-and-metadata"),
+    ]);
+  });
+
   it("stores only the files as blobs when importing emulator data", async function (this) {
     this.timeout(TEST_SETUP_TIMEOUT);
     const exportedData = createTmpDir("exported-emulator-data");

--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -556,6 +556,12 @@ export class StorageLayer {
     const metadataDir = path.join(storageExportPath, "metadata");
     const blobsDir = path.join(storageExportPath, "blobs");
 
+    // Handle case where export contained empty metadata or blobs
+    if (!existsSync(metadataDir) || !existsSync(blobsDir)) {//
+      logger.warn(`Could not find metadata directory at "${metadataDir}" and/or blobs directory at "${blobsDir}".`);
+      return;
+    }
+
     // Restore all metadata
     const metadataList = this.walkDirSync(metadataDir);
 

--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -557,8 +557,10 @@ export class StorageLayer {
     const blobsDir = path.join(storageExportPath, "blobs");
 
     // Handle case where export contained empty metadata or blobs
-    if (!existsSync(metadataDir) || !existsSync(blobsDir)) {//
-      logger.warn(`Could not find metadata directory at "${metadataDir}" and/or blobs directory at "${blobsDir}".`);
+    if (!existsSync(metadataDir) || !existsSync(blobsDir)) {
+      logger.warn(
+        `Could not find metadata directory at "${metadataDir}" and/or blobs directory at "${blobsDir}".`
+      );
       return;
     }
 


### PR DESCRIPTION
### Description

When exporting the storage emulator, if a directory is empty we never write it to the export folder. This causes a bug when importing as these folders are missing, causing the emulator to terminate prematurely.

Fix in response to #3823 

### Scenarios Tested

Manually tested this change with local `firebase-tools` build against both populated exports and empty exports generated by the emulator. 