### PR TITLE
removes warning when rewriting to a callable function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Adds check for callable functions when discovering Hosting rewrite endpoints. (#4792)

--- a/src/deploy/hosting/convertConfig.ts
+++ b/src/deploy/hosting/convertConfig.ts
@@ -1,6 +1,11 @@
 import { FirebaseError } from "../../error";
 import { HostingConfig, HostingRewrites, HostingHeaders } from "../../firebaseConfig";
-import { existingBackend, allEndpoints, isHttpsTriggered } from "../functions/backend";
+import {
+  existingBackend,
+  allEndpoints,
+  isHttpsTriggered,
+  isCallableTriggered,
+} from "../functions/backend";
 import { Payload } from "./args";
 import * as backend from "../functions/backend";
 import { Context } from "../functions/args";
@@ -50,17 +55,17 @@ interface FunctionsEndpointInfo {
  * the valid format for sending to the Firebase Hosting REST API
  */
 export async function convertConfig(
-  context: any,
+  context: Context,
   payload: Payload,
   config: HostingConfig | undefined,
   finalize: boolean
-): Promise<{ [k: string]: any }> {
+): Promise<Record<string, any>> {
   if (Array.isArray(config)) {
     throw new FirebaseError(`convertConfig should be given a single configuration, not an array.`, {
       exit: 2,
     });
   }
-  const out: { [k: string]: any } = {};
+  const out: Record<string, any> = {};
 
   if (!config) {
     return out;
@@ -89,7 +94,7 @@ export async function convertConfig(
 
     if (matchingBackends.length === 1) {
       const endpoint = matchingBackends[0];
-      if (endpoint && isHttpsTriggered(endpoint)) {
+      if (endpoint && (isHttpsTriggered(endpoint) || isCallableTriggered(endpoint))) {
         return endpoint;
       }
     }

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -61,6 +61,27 @@ describe("convertConfig", () => {
       },
     },
     {
+      name: "discovers the function region of a callable function",
+      input: { rewrites: [{ glob: "/foo", function: "foofn" }] },
+      want: { rewrites: [{ glob: "/foo", function: "foofn", functionRegion: "us-central2" }] },
+      payload: {
+        functions: {
+          default: {
+            wantBackend: backend.of({
+              id: "foofn",
+              project: "my-project",
+              entryPoint: "foofn",
+              runtime: "nodejs14",
+              region: "us-central2",
+              platform: "gcfv1",
+              callableTrigger: {},
+            }),
+            haveBackend: backend.empty(),
+          },
+        },
+      },
+    },
+    {
       name: "returns rewrites for glob CF3",
       input: { rewrites: [{ glob: "/foo", function: "foofn", region: "europe-west2" }] },
       want: { rewrites: [{ glob: "/foo", function: "foofn", functionRegion: "europe-west2" }] },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

#4799 fixed an issue where a Hosting deploy would fail if it could not discover a rewrite target by simply logging a message in that case. Technically, it fixed rewrites to callable functions because it won't fail any more.

But, to fully close out #4792 with the callable functions, we need to allow callable functions to be rewrite targets. This removes that warning from the output.