### PR TITLE
allows defaulting rewrites to us-central1 for multi-region functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Adds check for callable functions when discovering Hosting rewrite endpoints. (#4792)
+- Allows defaulting to a `us-central1` instance of a rewrite function if that function is deployed in multiple regions including `us-central1`. (#4810)

--- a/scripts/hosting-tests/rewrites-tests/run.sh
+++ b/scripts/hosting-tests/rewrites-tests/run.sh
@@ -3,4 +3,3 @@
 source scripts/set-default-credentials.sh
 
 mocha scripts/hosting-tests/rewrites-tests/tests.ts
-

--- a/scripts/hosting-tests/rewrites-tests/tests.ts
+++ b/scripts/hosting-tests/rewrites-tests/tests.ts
@@ -430,6 +430,51 @@ describe("deploy function-targeted rewrites And functions", () => {
     expect(await functionsResponse.text()).to.contain("Hello from Firebase");
   }).timeout(1000 * 1e3);
 
+  it("should rewrite to the default of us-central1 if multiple regions including us-central1 are available", async () => {
+    const firebaseJson = {
+      hosting: {
+        public: "hosting",
+        rewrites: [
+          {
+            source: "/helloWorld",
+            function: functionName,
+          },
+        ],
+      },
+    };
+
+    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+    ensureDirSync(tempDirInfo.hostingDirPath);
+    writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+    writeHelloWorldFunctionWithRegions(
+      functionName,
+      join(tempDirInfo.tempDir.name, ".", "functions"),
+      ["asia-northeast1", "us-central1"]
+    );
+
+    await client.deploy({
+      project: process.env.FBTOOLS_TARGET_PROJECT,
+      cwd: tempDirInfo.tempDir.name,
+      only: "hosting,functions",
+      force: true,
+    });
+
+    const staticResponse = await fetch(
+      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
+    );
+    expect(await staticResponse.text()).to.contain("Rabbit");
+
+    const functionsRequest = new Request(
+      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
+    );
+
+    const functionsResponse = await fetch(functionsRequest);
+
+    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+  }).timeout(1000 * 1e3);
+
   it("should fail when rewrite points to an invalid region for a function with multiple regions", async () => {
     const firebaseJson = {
       hosting: {

--- a/src/deploy/hosting/convertConfig.ts
+++ b/src/deploy/hosting/convertConfig.ts
@@ -9,7 +9,7 @@ import {
 import { Payload } from "./args";
 import * as backend from "../functions/backend";
 import { Context } from "../functions/args";
-import { logLabeledWarning } from "../../utils";
+import { logLabeledBullet, logLabeledWarning } from "../../utils";
 
 function has(obj: { [k: string]: unknown }, k: string): boolean {
   return obj[k] !== undefined;
@@ -87,6 +87,17 @@ export async function convertConfig(
     });
 
     if (matchingBackends.length > 1) {
+      // For now, if `us-central1` is specified, allow that to keep working.
+      for (const endpoint of matchingBackends) {
+        if (endpoint.region === "us-central1") {
+          logLabeledBullet(
+            `hosting[${config.site}]`,
+            `Function \`${functionsEndpointInfo.serviceId}\` found in multiple regions, defaulting to \`us-central1\`. ` +
+              `To rewrite to a different region, specify a \`region\` for the rewrite in \`firebase.json\`.`
+          );
+          return endpoint;
+        }
+      }
       throw new FirebaseError(
         `More than one backend found for function name: ${functionsEndpointInfo.serviceId}. If the function is deployed in multiple regions, you must specify a region.`
       );

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -3,7 +3,6 @@ import { HostingConfig } from "../../../firebaseConfig";
 import { convertConfig } from "../../../deploy/hosting/convertConfig";
 import * as args from "../../../deploy/functions/args";
 import * as backend from "../../../deploy/functions/backend";
-import { FirebaseError } from "../../../error";
 
 const DEFAULT_CONTEXT = {
   loadedExistingBackend: true,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Since we had previously defaulted to `us-central1`, we should probably continue to default to `us-central1` if multiple regions for a rewrite function are available. Printing a nice note saying "hey, you can specify other regions now" as well, for visibility of that feature.

Added a test for this as well in the functional tests.

Fixes #4810