### PR TITLE
Fix bug where invalid CPU was set for 16GiB functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Replaces underlying terminal coloring library.
+- Fix bug where invalid CPU was set for 16GiB functions. (#4823)

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -228,7 +228,7 @@ export function memoryToGen2Cpu(memory: MemoryOptions): number {
     2048: 1,
     4096: 2,
     8192: 2,
-    16384: 3,
+    16384: 2,
     32768: 4,
   }[memory];
 }

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -293,11 +293,22 @@ describe("validate", () => {
       });
     }
 
-    it("Allows endpoints with no mem and no concurrency", () => {
+    for (const mem of [128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768] as const) {
+      it(`allows gcfv2 endpoints with mem ${mem} and no cpu`, () => {
+        const ep: backend.Endpoint = {
+          ...ENDPOINT_BASE,
+          platform: "gcfv2",
+          availableMemoryMb: mem,
+        };
+        expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw();
+      });
+    }
+
+    it("allows endpoints with no mem and no concurrency", () => {
       expect(() => validate.endpointsAreValid(backend.of(ENDPOINT_BASE))).to.not.throw();
     });
 
-    it("Allows endpoints with mem and no concurrency", () => {
+    it("allows endpoints with mem and no concurrency", () => {
       const ep: backend.Endpoint = {
         ...ENDPOINT_BASE,
         availableMemoryMb: 256,
@@ -305,7 +316,7 @@ describe("validate", () => {
       expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw();
     });
 
-    it("Allows explicitly one concurrent", () => {
+    it("allows explicitly one concurrent", () => {
       const ep: backend.Endpoint = {
         ...ENDPOINT_BASE,
         concurrency: 1,
@@ -313,7 +324,7 @@ describe("validate", () => {
       expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw();
     });
 
-    it("Allows endpoints with enough mem and no concurrency", () => {
+    it("allows endpoints with enough mem and no concurrency", () => {
       for (const mem of [2 << 10, 4 << 10, 8 << 10] as backend.MemoryOptions[]) {
         const ep: backend.Endpoint = {
           ...ENDPOINT_BASE,
@@ -325,7 +336,7 @@ describe("validate", () => {
       }
     });
 
-    it("Allows endpoints with enough mem and explicit concurrency", () => {
+    it("allows endpoints with enough mem and explicit concurrency", () => {
       for (const mem of [2 << 10, 4 << 10, 8 << 10] as backend.MemoryOptions[]) {
         const ep: backend.Endpoint = {
           ...ENDPOINT_BASE,


### PR DESCRIPTION
Today, Firebase CLI fails to deploy cf3v2 function w/ 16GiB and no cpu setting:

```js
export const fn = onCall({ memory: "16GiB"}, () => "hello");
```

```
$ firebase deploy

Error: The following functions have invalid CPU settings fn. Valid CPU options are (0.08, 1], 2, 4, 6, 8, or "gcf_gen1"
```

Found that we are mapping 16GiB => 3 CPU which then fails to validate. Proposing that we map the CPU setting to 2 CPU instead.