### PR TITLE
Make storage emulator content type parser case insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Replaces underlying terminal coloring library.
+- Make storage emulator content type case insensitive #3953

--- a/src/emulator/storage/multipart.ts
+++ b/src/emulator/storage/multipart.ts
@@ -91,8 +91,8 @@ function parseMultipartRequestBodyPart(bodyPart: Buffer): MultipartRequestBodyPa
   // splitting the entire body part buffer.
   const sections = splitBufferByDelimiter(bodyPart, LINE_SEPARATOR, /* maxResults = */ 3);
 
-  const contentTypeRaw = sections[0].toString();
-  if (!contentTypeRaw.startsWith("Content-Type: ")) {
+  const contentTypeRaw = sections[0].toString().toLowerCase();
+  if (!contentTypeRaw.startsWith("content-type: ")) {
     throw new Error(`Failed to parse multipart request body part. Missing content type.`);
   }
 

--- a/src/test/emulators/storage/multipart.spec.ts
+++ b/src/test/emulators/storage/multipart.spec.ts
@@ -45,6 +45,25 @@ Content-Type: text/plain\r
       expect(dataRaw.byteLength).to.equal(data.byteLength);
     });
 
+    it("parses an upload object multipart request with lowercase content-type", () => {
+      const body = Buffer.from(`--b1d5b2e3-1845-4338-9400-6ac07ce53c1e\r
+content-type: application/json\r
+\r
+{"contentType":"text/plain"}\r
+--b1d5b2e3-1845-4338-9400-6ac07ce53c1e\r
+content-type: text/plain\r
+\r
+hello there!
+\r
+--b1d5b2e3-1845-4338-9400-6ac07ce53c1e--\r
+`);
+
+      const { metadataRaw, dataRaw } = parseObjectUploadMultipartRequest(CONTENT_TYPE_HEADER, body);
+
+      expect(metadataRaw).to.equal('{"contentType":"text/plain"}');
+      expect(dataRaw.toString()).to.equal("hello there!\n");
+    });
+
     it("fails to parse with invalid Content-Type value", () => {
       const invalidContentTypeHeader = "blah";
       expect(() => parseObjectUploadMultipartRequest(invalidContentTypeHeader, BODY)).to.throw(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
Make storage emulator content type parser case insensitive, fixes part of #3953
<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested
Manual testing with the setup described in #3953 and also added unit test for this specific case
<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
