### PR TITLE
Strip quotes in storage emulator header boundaryId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Replaces underlying terminal coloring library.
+- Make storage emulator multipart parsing handle quotes in boundary header #3953

--- a/src/emulator/storage/multipart.ts
+++ b/src/emulator/storage/multipart.ts
@@ -51,7 +51,9 @@ function splitBufferByDelimiter(buffer: Buffer, delimiter: string, maxResults = 
  * @param body multipart request body as a Buffer
  */
 function parseMultipartRequestBody(boundaryId: string, body: Buffer): MultipartRequestBody {
-  const boundaryString = `--${boundaryId}`;
+  // strip additional surrounding single and double quotes, cloud sdks have additional quote here
+  const cleanBoundaryId = boundaryId.replace(/^["'](.+(?=["']$))["']$/, "$1");
+  const boundaryString = `--${cleanBoundaryId}`;
   const bodyParts = splitBufferByDelimiter(body, boundaryString).map((buf) => {
     // Remove the \r\n and the beginning of each part left from the boundary line.
     return Buffer.from(buf.slice(2));

--- a/src/test/emulators/storage/multipart.spec.ts
+++ b/src/test/emulators/storage/multipart.spec.ts
@@ -59,6 +59,28 @@ Content-Type: text/plain\r
       );
     });
 
+    it("parses an upload object multipart request with additional quotes in the boundary value", () => {
+      const contentTypeHeaderWithDoubleQuotes = `multipart/related; boundary="b1d5b2e3-1845-4338-9400-6ac07ce53c1e"`;
+
+      let { metadataRaw, dataRaw } = parseObjectUploadMultipartRequest(
+        contentTypeHeaderWithDoubleQuotes,
+        BODY
+      );
+
+      expect(metadataRaw).to.equal('{"contentType":"text/plain"}');
+      expect(dataRaw.toString()).to.equal("hello there!\n");
+
+      const contentTypeHeaderWithSingleQuotes = `multipart/related; boundary='b1d5b2e3-1845-4338-9400-6ac07ce53c1e'`;
+
+      ({ metadataRaw, dataRaw } = parseObjectUploadMultipartRequest(
+        contentTypeHeaderWithSingleQuotes,
+        BODY
+      ));
+
+      expect(metadataRaw).to.equal('{"contentType":"text/plain"}');
+      expect(dataRaw.toString()).to.equal("hello there!\n");
+    });
+
     it("fails to parse when body has wrong number of parts", () => {
       const invalidBody = Buffer.from(`--b1d5b2e3-1845-4338-9400-6ac07ce53c1e\r
 Content-Type: application/json\r


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Strip quotes in storage emulator header boundaryId since some gcs sdks send in additional quotes. Fixes part of #3953

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
Manual testing with the setup described in #3953 and also added unit test for this specific case