### PR TITLE
Fix bug where failed function discovery crashed the entire emulator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Replaces underlying terminal coloring library.
+- Fix bug where failed function discovery crashed the entire emulator. #4826


### PR DESCRIPTION
Functions Emulator features "hot-reloading" of users source to enable rapid iteration.

Today, when users edits their function code that produces runtime error (bound to happen during development), the entire Emulator Suite crashes! This problem gets worse if you are running other emulators like Auth and Firestore since the subprocesses are not cleaned up during the crash.

We modify the behavior of the Functions Emulator to simply emit an error log when we can't load function triggers from source code. This means that when an invalid source code for functions is used to start the Emulator, the Emulator will start and report an error instead of crashing immediately. Arguably, the latter is desirable since it makes their mistake more obvious, but I think the overall improvement in DevX is worth the change.

Example:

```
$ firebase emulators:start
i  emulators: Starting emulators: functions
⚠  functions: The following emulators are not running, calls to these services from the Functions emulator will affect production: auth, firestore, database, hosting, pubsub, storage
⚠  Your requested "node" version "14" doesn't match your global version "16". Using node@16 from host.
⚠  ui: Emulator UI unable to start on port 4000, starting on 4001 instead.
i  ui: Emulator UI logging to ui-debug.log
i  functions: Watching "/Users/danielylee/google/cf3-vpc/functions" for Cloud Functions...
⬢  functions: Failed to load function definition from source: FirebaseError: Failed to load function definition from source: Failed to generate manifest from function source: ReferenceError: aa is not defined

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://localhost:4001                │
└─────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Functions │ localhost:5001 │ http://localhost:4001/functions │
└───────────┴────────────────┴─────────────────────────────────┘
  Emulator Hub running at localhost:4400
  Other reserved ports: 4500

Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.

✔  functions: Loaded functions definitions from source: vpc.
✔  functions[us-central1-vpc]: http function initialized (http://localhost:5001/danielylee-test-6/us-central1/vpc).
i  functions: Beginning execution of "vpc"
>  {"structuredData":true,"severity":"INFO","message":"Hello logs!"}
i  functions: Finished "vpc" in ~1s

## Make a change to the source code that produces runtime error:
⬢  functions: Failed to load function definition from source: FirebaseError: Failed to load function definition from source: Failed to generate manifest from function source: ReferenceError: aa is not defined

## You can still invoke existing function w/o problems
i  functions: Beginning execution of "vpc"
>  {"structuredData":true,"severity":"INFO","message":"Hello logs!"}
i  functions: Finished "vpc" in ~1s
```

Partially address https://github.com/firebase/firebase-tools/issues/4613