### PR TITLE
Populate resource correctly in storage rules evaluation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Replaces underlying terminal coloring library.
-- Make storage emulator multipart parsing handle quotes in boundary header #3953
-- Make storage emulator content type case insensitive #3953)
-- Add storage emulator support to init.js useEmulator flag #4805
+- Make storage emulator multipart parsing handle quotes in boundary header. (#3953)
+- Make storage emulator content type case insensitive. (#3953)
+- Add storage emulator support to init.js useEmulator flag. (#4805)
+- Populate resource correctly in storage rules evaluation. (#4329)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "lint:quiet": "npm run lint:ts -- --quiet && npm run lint:other",
     "lint:ts": "eslint --config .eslintrc.js --ext .ts,.js .",
     "mocha": "nyc mocha 'src/test/**/*.{ts,js}'",
+    "mocha:storage-spec": "mocha 'src/test/emulators/storage/*.spec.ts'",
+    "mocha:storage-emulator-integration": "mocha 'scripts/storage-emulator-integration/tests.ts'",
     "prepare": "npm run clean && npm run build -- --build tsconfig.publish.json",
     "test": "npm run lint:quiet && npm run test:compile && npm run mocha",
     "test:client-integration": "bash ./scripts/client-integration-tests/run.sh",

--- a/scripts/storage-emulator-integration/storage.rules
+++ b/scripts/storage-emulator-integration/storage.rules
@@ -35,6 +35,9 @@ service firebase.storage {
       match /replace.txt {
         allow read, create;
       }
+      match /allowIfNoExistingFile.txt {
+        allow create: if resource == null;
+      }
     }
 
     match /public/{allPaths=**} {

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -1422,13 +1422,13 @@ describe("Storage emulator", () => {
               throw err;
             }
           }
-          
+
           await uploadText(page, "upload/allowIfNoExistingFile.txt", "some-content");
 
           const uploadState = await shouldThrowOnUpload();
           expect(uploadState!).to.include("User does not have permission");
         });
-    });
+      });
 
       describe("#listAll()", () => {
         beforeEach(async function (this) {

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -2,7 +2,6 @@ import { Bucket, CopyOptions } from "@google-cloud/storage";
 import { expect } from "chai";
 import * as firebase from "firebase";
 import * as admin from "firebase-admin";
-import { TaskQueueBuilder } from "firebase-functions/v1/tasks";
 import * as fs from "fs";
 import * as http from "http";
 import * as https from "https";

--- a/src/emulator/storage/files.ts
+++ b/src/emulator/storage/files.ts
@@ -285,6 +285,7 @@ export class StorageLayer {
       throw new Error(`Unexpected upload status encountered: ${upload.status}.`);
     }
 
+    const storedMetadata = this.getMetadata(upload.bucketId, upload.objectId);
     const filePath = this.path(upload.bucketId, upload.objectId);
     const metadata = new StoredFileMetadata(
       {
@@ -306,7 +307,10 @@ export class StorageLayer {
       ["b", upload.bucketId, "o", upload.objectId].join("/"),
       upload.bucketId,
       RulesetOperationMethod.CREATE,
-      { after: metadata?.asRulesResource() },
+      {
+        before: storedMetadata?.asRulesResource(),
+        after: metadata?.asRulesResource(),
+      },
       upload.authorization
     );
     if (!authorized) {


### PR DESCRIPTION
### Description

Fix an error (#4329) where resource was not populate correctly during rules evaluation.

### Scenarios Tested

Tested locally against local emulator codebase before and after the change. The repro'd error is now no longer present.
