### PR TITLE
Fix bug where CPU mapping for v2 16GiB function was incorrect.

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -228,7 +228,7 @@ export function memoryToGen2Cpu(memory: MemoryOptions): number {
     2048: 1,
     4096: 2,
     8192: 2,
-    16384: 2,
+    16384: 4,
     32768: 4,
   }[memory];
 }


### PR DESCRIPTION
Should be 4 CPU instead of 2 CPU according to what happens on GCF deploys.