### PR TITLE
Read name from metadata as backup for gcs upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Make storage emulator content type case insensitive. (#3953)
 - Add storage emulator support to init.js useEmulator flag. (#4805)
 - Populate resource correctly in storage rules evaluation. (#4329)
+- Read name from metadata as backup for gcs upload into storage emulator. (#3953)

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -239,9 +239,7 @@ describe("Storage emulator", () => {
           expect(uploadURL.searchParams?.get("name")).to.equal(fileName);
         });
 
-        it.only("should handle multipart upload with name only in metadata", async () => {
-          const contentTypeHeader =
-            "multipart/related; boundary=b1d5b2e3-1845-4338-9400-6ac07ce53c1e";
+        it("should handle multipart upload with name only in metadata", async () => {
           const body = Buffer.from(`--b1d5b2e3-1845-4338-9400-6ac07ce53c1e\r
 content-type: application/json\r
 \r
@@ -259,7 +257,7 @@ hello there!
             .send(body)
             .set({
               Authorization: "Bearer owner",
-              "content-type": contentTypeHeader,
+              "content-type": "multipart/related; boundary=b1d5b2e3-1845-4338-9400-6ac07ce53c1e",
             })
             .expect(200)
             .then((res) => res.body.name);

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -225,10 +225,14 @@ describe("Storage emulator", () => {
 
           expect(fileMetadata).to.deep.include(metadata);
         });
-
+        // TODO(b/241151246): Fix conformance tests.
         it("should handle resumable upload with name only in metadata", async () => {
+          const expectedHost = TEST_CONFIG.useProductionServers
+            ? "https://firebasestorage.googleapis.com"
+            : STORAGE_EMULATOR_HOST;
+
           const fileName = "test_upload.jpg";
-          const uploadURL = await supertest(STORAGE_EMULATOR_HOST)
+          const uploadURL = await supertest(expectedHost)
             .post(`/upload/storage/v1/b/${storageBucket}/o?uploadType=resumable`)
             .send({ name: fileName })
             .set({
@@ -240,6 +244,10 @@ describe("Storage emulator", () => {
         });
 
         it("should handle multipart upload with name only in metadata", async () => {
+          const expectedHost = TEST_CONFIG.useProductionServers
+            ? "https://firebasestorage.googleapis.com"
+            : STORAGE_EMULATOR_HOST;
+
           const body = Buffer.from(`--b1d5b2e3-1845-4338-9400-6ac07ce53c1e\r
 content-type: application/json\r
 \r
@@ -252,7 +260,7 @@ hello there!
 --b1d5b2e3-1845-4338-9400-6ac07ce53c1e--\r
 `);
           const fileName = "test_upload.jpg";
-          const responseName = await supertest(STORAGE_EMULATOR_HOST)
+          const responseName = await supertest(expectedHost)
             .post(`/upload/storage/v1/b/${storageBucket}/o?uploadType=multipart`)
             .send(body)
             .set({

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -72,9 +72,9 @@ describe("Storage emulator", () => {
   const AUTH_EMULATOR_HOST = getAuthEmulatorHost(emulatorConfig);
 
   const expectedHost = TEST_CONFIG.useProductionServers
-  ? "https://firebasestorage.googleapis.com"
-  : STORAGE_EMULATOR_HOST;
-  
+    ? "https://firebasestorage.googleapis.com"
+    : STORAGE_EMULATOR_HOST;
+
   const emulatorSpecificDescribe = TEST_CONFIG.useProductionServers ? describe.skip : describe;
 
   async function resetEmulatorState(): Promise<void> {

--- a/scripts/storage-emulator-integration/tests.ts
+++ b/scripts/storage-emulator-integration/tests.ts
@@ -71,6 +71,10 @@ describe("Storage emulator", () => {
   const STORAGE_EMULATOR_HOST = getStorageEmulatorHost(emulatorConfig);
   const AUTH_EMULATOR_HOST = getAuthEmulatorHost(emulatorConfig);
 
+  const expectedHost = TEST_CONFIG.useProductionServers
+  ? "https://firebasestorage.googleapis.com"
+  : STORAGE_EMULATOR_HOST;
+  
   const emulatorSpecificDescribe = TEST_CONFIG.useProductionServers ? describe.skip : describe;
 
   async function resetEmulatorState(): Promise<void> {
@@ -227,10 +231,6 @@ describe("Storage emulator", () => {
         });
         // TODO(b/241151246): Fix conformance tests.
         it("should handle resumable upload with name only in metadata", async () => {
-          const expectedHost = TEST_CONFIG.useProductionServers
-            ? "https://firebasestorage.googleapis.com"
-            : STORAGE_EMULATOR_HOST;
-
           const fileName = "test_upload.jpg";
           const uploadURL = await supertest(expectedHost)
             .post(`/upload/storage/v1/b/${storageBucket}/o?uploadType=resumable`)
@@ -244,10 +244,6 @@ describe("Storage emulator", () => {
         });
 
         it("should handle multipart upload with name only in metadata", async () => {
-          const expectedHost = TEST_CONFIG.useProductionServers
-            ? "https://firebasestorage.googleapis.com"
-            : STORAGE_EMULATOR_HOST;
-
           const body = Buffer.from(`--b1d5b2e3-1845-4338-9400-6ac07ce53c1e\r
 content-type: application/json\r
 \r
@@ -1609,10 +1605,6 @@ hello there!
           const downloadUrl: string = await page.evaluate((filename) => {
             return firebase.storage().ref(filename).getDownloadURL();
           }, filename);
-          const expectedHost = TEST_CONFIG.useProductionServers
-            ? "https://firebasestorage.googleapis.com"
-            : STORAGE_EMULATOR_HOST;
-
           expect(downloadUrl).to.contain(
             `${expectedHost}/v0/b/${storageBucket}/o/testing%2Fstorage_ref%2Fimage.png?alt=media&token=`
           );

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -17,6 +17,7 @@ import { parseObjectUploadMultipartRequest } from "../multipart";
 import { Upload, UploadNotActiveError } from "../upload";
 import { ForbiddenError, NotFoundError } from "../errors";
 import { reqBodyToBuffer } from "../../shared/request";
+import { Query } from "express-serve-static-core";
 
 export function createCloudEndpoints(emulator: StorageEmulator): Router {
   // eslint-disable-next-line new-cap
@@ -199,18 +200,7 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
   });
 
   gcloudStorageAPI.post("/upload/storage/v1/b/:bucketId/o", async (req, res) => {
-    if (!req.query.name) {
-      res.sendStatus(400);
-      return;
-    }
-    let name = req.query.name.toString();
-
-    if (name.startsWith("/")) {
-      name = name.slice(1);
-    }
-
     const contentTypeHeader = req.header("content-type") || req.header("x-upload-content-type");
-
     if (!contentTypeHeader) {
       return res.sendStatus(400);
     }
@@ -218,6 +208,11 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
       const emulatorInfo = EmulatorRegistry.getInfo(Emulators.STORAGE);
       if (emulatorInfo === undefined) {
         return res.sendStatus(500);
+      }
+      const name = getValidName(req.query, req.body);
+      if (name == null) {
+        res.sendStatus(400);
+        return;
       }
       const upload = uploadService.startResumableUpload({
         bucketId: req.params.bucketId,
@@ -237,11 +232,17 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     // Multipart upload
     let metadataRaw: string;
     let dataRaw: Buffer;
+    let name: string | undefined;
     try {
       ({ metadataRaw, dataRaw } = parseObjectUploadMultipartRequest(
         contentTypeHeader!,
         await reqBodyToBuffer(req)
       ));
+      name = getValidName(req.query, JSON.parse(metadataRaw));
+      if (name == null) {
+        res.sendStatus(400);
+        return;
+      }
     } catch (err) {
       if (err instanceof Error) {
         return res.status(400).json({
@@ -410,4 +411,9 @@ function sendObjectNotFound(req: Request, res: Response): void {
       },
     });
   }
+}
+
+function getValidName(query: Query, metadata: IncomingMetadata): string | undefined {
+  const name = query?.name?.toString() || metadata?.name;
+  return name?.startsWith("/") ? name.slice(1) : name;
 }

--- a/src/emulator/storage/metadata.ts
+++ b/src/emulator/storage/metadata.ts
@@ -287,6 +287,7 @@ export interface RulesResourceMetadata {
 }
 
 export interface IncomingMetadata {
+  name?: string;
   contentType?: string;
   contentLanguage?: string;
   contentEncoding?: string;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
Uses metadata.name as a backup to query.name in gcs uploads, this makes the storage emulator compliant with gcs api spec, fixes #3953 
### Scenarios Tested
Tested via the python gcs sdk and also by adding two new integration tests here.
<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
