### PR TITLE
Fix test by relaxing regex condition of the error message.

### DIFF
--- a/src/test/rulesDeploy.spec.ts
+++ b/src/test/rulesDeploy.spec.ts
@@ -128,7 +128,7 @@ describe("RulesDeploy", () => {
       const result = rd.compile();
       await expect(result).to.eventually.be.rejectedWith(
         Error,
-        /Compilation error in .+storage.rules.+:\n\[E\] 0:0 - oopsie/
+        /Compilation error in .*storage.rules.*:\n\[E\] 0:0 - oopsie/
       );
     });
 
@@ -159,7 +159,7 @@ describe("RulesDeploy", () => {
       const result = rd.compile();
       await expect(result).to.eventually.be.rejectedWith(
         Error,
-        /Compilation errors in .+storage.rules.+:\n\[E\] 0:0 - oopsie\n\[E\] 1:1 - daisey/
+        /Compilation errors in .*storage.rules.*:\n\[E\] 0:0 - oopsie\n\[E\] 1:1 - daisey/
       );
     });
 


### PR DESCRIPTION
Couple of test case breaks when running in Cloud Build environment:

```
Step #11:   2200 passing (17s)
Step #11:   6 pending
Step #11:   2 failing
Step #11:
Step #11:   1) RulesDeploy
Step #11:        compile
Step #11:          should fail if one file fails to compile (returned an error in the response):
Step #11:      AssertionError: expected promise to be rejected with an error matching /Compilation error in .+storage.rules.+:\n\[E\] 0:0 - oopsie/ but got 'Compilation error in storage.rules:\n[E] 0:0 - oopsie'
Step #11:
Step #11:
Step #11:   2) RulesDeploy
Step #11:        compile
Step #11:          should fail if one file fails to compile (returned multiple errors in the response):
Step #11:      AssertionError: expected promise to be rejected with an error matching /Compilation errors in .+storage.rules.+:\n\[E\] 0:0 - oopsie\n\[E\] 1:1 - daisey/ but got 'Compilation errors in storage.rules:\n[E] 0:0 - oopsie\n[E] 1:1 - daisey'
```

Not sure exactly why, but modifying regex to be less greedy should fix the test cases without affecting the test scenario.