### PR TITLE
batchCreate should not error with empty MFA info

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -464,7 +464,7 @@ function batchCreate(
       fields.disabled = !!userInfo.disabled;
 
       // MFA
-      if (userInfo.mfaInfo) {
+      if (userInfo.mfaInfo && userInfo.mfaInfo.length > 0) {
         fields.mfaInfo = [];
         assert(fields.email, "Second factor account requires email to be presented.");
         assert(fields.emailVerified, "Second factor account requires email to be verified.");

--- a/src/test/emulators/auth/batch.spec.ts
+++ b/src/test/emulators/auth/batch.spec.ts
@@ -423,6 +423,19 @@ describeAuthEmulator("accounts:batchCreate", ({ authApi }) => {
       });
   });
 
+  it("should not error for empty MFA info", async () => {
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:batchCreate`)
+      .set("Authorization", "Bearer owner")
+      .send({
+        users: [{ localId: "test1", mfaInfo: [] }],
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.error || []).to.have.length(0);
+      });
+  });
+
   it("should return error for individual invalid entries", async () => {
     const longString = new Array(999).join("x");
 


### PR DESCRIPTION
### Description

`batchCreate` erroneously throws an error for when `mfaInfo` is an empty list. This adds a bit of edge case checking that should resolve https://github.com/firebase/firebase-tools/issues/4772. Referenced [go/firebase-tools-4772-mfa](http://go/firebase-tools-4772-mfa) for this bit of logic.

### Scenarios Tested

`npm test` passes

### Sample Commands

N/A