### PR TITLE
Fix bug where functions:secrets:get command did not call requirePermissions.

### DIFF
--- a/src/commands/functions-secrets-get.ts
+++ b/src/commands/functions-secrets-get.ts
@@ -5,9 +5,11 @@ import { logger } from "../logger";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
 import { listSecretVersions } from "../gcp/secretManager";
+import { requirePermissions } from "../requirePermissions";
 
 export const command = new Command("functions:secrets:get <KEY>")
   .description("Get metadata for secret and its versions")
+  .before(requirePermissions, ["secretmanager.secrets.get"])
   .action(async (key: string, options: Options) => {
     const projectId = needProjectId(options);
     const versions = await listSecretVersions(projectId, key);


### PR DESCRIPTION
`requirePermission` in turn calls `requireAuth` which ultimately executes to mint refresh token for the Firebase CLI to use to generate auth tokens. By not calling `requirePermission` in `functions:secrets:set` command, API calls to secret manager did not include Authorization token if not already cached locally. For CI systems, this meant that secret manager API calls always failed with 401.

Should fix broken functions integration test unless it is broken b/c other code changes.