### PR TITLE
Remove serializedTrigger from emulator runtime

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -153,7 +153,6 @@ export interface FunctionsRuntimeInstance {
 
 export interface InvokeRuntimeOpts {
   nodeBinary: string;
-  serializedTriggers?: string;
   extensionTriggers?: ParsedTriggerDefinition[];
   ignore_warnings?: boolean;
 }


### PR DESCRIPTION
With https://github.com/firebase/firebase-tools/pull/4750, we no longer need `serializedTrigger` from Functions Emulator Runtime!

One step closer to isolating Functions Emulator Runtime component from the Functions Emulator.
