### PR TITLE
Refactor functions emulator to handle all functions through HTTP interface.

### DIFF
--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -408,4 +408,10 @@ describe("function triggers", () => {
       expect(body).to.deep.equal({ result: "foobar" });
     });
   });
+
+  it.skip("should enforce timeout", async function (this) {
+    this.timeout(TEST_SETUP_TIMEOUT);
+    const v2response = await test.invokeHttpFunction("onreqv2timeout");
+    expect(v2response.status).to.equal(500);
+  });
 });

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -409,7 +409,7 @@ describe("function triggers", () => {
     });
   });
 
-  it.skip("should enforce timeout", async function (this) {
+  it("should enforce timeout", async function (this) {
     this.timeout(TEST_SETUP_TIMEOUT);
     const v2response = await test.invokeHttpFunction("onreqv2timeout");
     expect(v2response.status).to.equal(500);

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -293,7 +293,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       const { host, port } = this.getInfo();
       triggers.forEach((triggerId) => {
         this.workQueue.submit(() => {
-          return new Promise(async (resolve, reject) => {
+          return new Promise((resolve, reject) => {
             const trigReq = http.request(
               {
                 host,
@@ -307,7 +307,6 @@ export class FunctionsEmulator implements EmulatorInstance {
             trigReq.on("error", reject);
             trigReq.write(rawBody);
             trigReq.end();
-            return;
           });
         });
       });

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -40,13 +40,6 @@ let developerPkgJSON: PackageJSON | undefined;
 // eslint-disable-next-line @typescript-eslint/no-implied-eval
 const dynamicImport = new Function("modulePath", "return import(modulePath)");
 
-function isFeatureEnabled(
-  frb: FunctionsRuntimeBundle,
-  feature: keyof FunctionsRuntimeFeatures
-): boolean {
-  return frb.disabled_features ? !frb.disabled_features[feature] : true;
-}
-
 function noOp(): false {
   return false;
 }

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -300,6 +300,9 @@ export function getFunctionService(def: ParsedTriggerDefinition): string {
   if (def.blockingTrigger) {
     return def.blockingTrigger.eventType;
   }
+  if (def.httpsTrigger) {
+    return "https";
+  }
 
   return "unknown";
 }

--- a/src/emulator/functionsEmulatorShell.ts
+++ b/src/emulator/functionsEmulatorShell.ts
@@ -64,7 +64,9 @@ export class FunctionsEmulatorShell implements FunctionsShellController {
       data,
     };
 
-    this.emu.invokeTrigger(trigger, proto);
+    this.emu.invokeTrigger(trigger).then((worker) => {
+      this.emu.sendRequest(worker, proto);
+    });
   }
 
   private getTrigger(name: string): EmulatedTriggerDefinition {

--- a/src/test/emulators/functionsEmulatorShared.spec.ts
+++ b/src/test/emulators/functionsEmulatorShared.spec.ts
@@ -31,12 +31,12 @@ describe("FunctionsEmulatorShared", () => {
       expect(functionsEmulatorShared.getFunctionService(def)).to.be.eql("pubsub.googleapis.com");
     });
 
-    it("should return unknown if trigger definition is not event-based", () => {
+    it("should infer https service from http trigger", () => {
       const def = {
         ...baseDef,
         httpsTrigger: {},
       };
-      expect(functionsEmulatorShared.getFunctionService(def)).to.be.eql("unknown");
+      expect(functionsEmulatorShared.getFunctionService(def)).to.be.eql("https");
     });
 
     it("should infer pubsub service based on eventType", () => {


### PR DESCRIPTION
Lets invoke Background functions exactly the same way HTTP functions are triggered.

Instead of sending event data/context over IPC, we instead have the Functions Emulator make HTTP request to the server the runtime process is listening over the socket path. Everything is just as before - we are talking over the unix domain sockets but now using HTTP protocol to communicate.

This gives us chance to move some of the logic for transforming event payload into the runtime which is what happens on production (by functions framework) and makes it possible to enforce timeout on per-request basis!