### PR TITLE
[Function-NoOp] Apply Hash to wantBackend's endpoints

### DIFF
--- a/src/deploy/functions/cache/applyHash.ts
+++ b/src/deploy/functions/cache/applyHash.ts
@@ -1,0 +1,56 @@
+import { Backend, allEndpoints } from "../backend";
+import * as args from "../args";
+import {
+  getEndpointHash,
+  getEnvironmentVariablesHash,
+  getSecretsHash,
+  getSourceHash,
+} from "./hash";
+
+/**
+ *
+ * Updates all the CodeBase {@link Backend}, applying a hash to each of their {@link Endpoint}.
+ */
+export async function applyBackendHashToBackends(
+  wantBackends: Record<string, Backend>,
+  context: args.Context
+): Promise<void> {
+  // envHash
+  const envHash = getEnvHash(wantBackends);
+  for (const [codebase, wantBackend] of Object.entries(wantBackends)) {
+    const source = context?.sources?.[codebase]; // populated earlier in prepare flow
+    const sourceV1Hash = source?.functionsSourceV1
+      ? await getSourceHash(source?.functionsSourceV1)
+      : undefined;
+    const sourceV2Hash = source?.functionsSourceV2
+      ? await getSourceHash(source?.functionsSourceV2)
+      : undefined;
+    applyBackendHashToBackend(wantBackend, envHash, sourceV1Hash, sourceV2Hash);
+  }
+}
+
+/**
+ * Updates {@link Backend}, applying a unique hash to each {@link Endpoint}.
+ */
+export function applyBackendHashToBackend(
+  wantBackend: Backend,
+  envHash: string,
+  sourceV1Hash?: string,
+  sourceV2Hash?: string
+): void {
+  for (const endpoint of allEndpoints(wantBackend)) {
+    const secretsHash = getSecretsHash(endpoint);
+    const isV2 = endpoint.platform === "gcfv2";
+    const sourceHash = isV2 ? sourceV2Hash : sourceV1Hash;
+    endpoint.hash = getEndpointHash(sourceHash, envHash, secretsHash);
+  }
+}
+
+/** @returns hash of first wantBackend */
+function getEnvHash(wantBackends: Record<string, Backend>): string {
+  const backends = Object.values(wantBackends);
+  if (backends.length) {
+    return getEnvironmentVariablesHash(backends[0]);
+  }
+  return "";
+}

--- a/src/deploy/functions/cache/applyHash.ts
+++ b/src/deploy/functions/cache/applyHash.ts
@@ -15,8 +15,6 @@ export async function applyBackendHashToBackends(
   wantBackends: Record<string, Backend>,
   context: args.Context
 ): Promise<void> {
-  // envHash
-  const envHash = getEnvHash(wantBackends);
   for (const [codebase, wantBackend] of Object.entries(wantBackends)) {
     const source = context?.sources?.[codebase]; // populated earlier in prepare flow
     const sourceV1Hash = source?.functionsSourceV1
@@ -25,6 +23,7 @@ export async function applyBackendHashToBackends(
     const sourceV2Hash = source?.functionsSourceV2
       ? await getSourceHash(source?.functionsSourceV2)
       : undefined;
+    const envHash = getEnvironmentVariablesHash(wantBackend);
     applyBackendHashToBackend(wantBackend, envHash, sourceV1Hash, sourceV2Hash);
   }
 }
@@ -44,13 +43,4 @@ export function applyBackendHashToBackend(
     const sourceHash = isV2 ? sourceV2Hash : sourceV1Hash;
     endpoint.hash = getEndpointHash(sourceHash, envHash, secretsHash);
   }
-}
-
-/** @returns hash of first wantBackend */
-function getEnvHash(wantBackends: Record<string, Backend>): string {
-  const backends = Object.values(wantBackends);
-  if (backends.length) {
-    return getEnvironmentVariablesHash(backends[0]);
-  }
-  return "";
 }

--- a/src/deploy/functions/cache/applyHash.ts
+++ b/src/deploy/functions/cache/applyHash.ts
@@ -24,14 +24,14 @@ export async function applyBackendHashToBackends(
       ? await getSourceHash(source?.functionsSourceV2)
       : undefined;
     const envHash = getEnvironmentVariablesHash(wantBackend);
-    applyBackendHashToBackend(wantBackend, envHash, sourceV1Hash, sourceV2Hash);
+    applyBackendHashToEndpoints(wantBackend, envHash, sourceV1Hash, sourceV2Hash);
   }
 }
 
 /**
  * Updates {@link Backend}, applying a unique hash to each {@link Endpoint}.
  */
-export function applyBackendHashToBackend(
+function applyBackendHashToEndpoints(
   wantBackend: Backend,
   envHash: string,
   sourceV1Hash?: string,

--- a/src/test/deploy/functions/cache/applyHash.spec.ts
+++ b/src/test/deploy/functions/cache/applyHash.spec.ts
@@ -36,7 +36,7 @@ describe("applyHash", () => {
           },
         },
       };
-      const endpoint1 = {
+      const endpoint1: backend.Endpoint = {
         ...EMPTY_ENDPOINT,
         id: "endpoint1",
         platform: "gcfv1",
@@ -49,8 +49,8 @@ describe("applyHash", () => {
             version: "1",
           },
         ],
-      } as backend.Endpoint;
-      const endpoint2 = {
+      };
+      const endpoint2: backend.Endpoint = {
         ...EMPTY_ENDPOINT,
         id: "endpoint2",
         platform: "gcfv2",
@@ -63,7 +63,7 @@ describe("applyHash", () => {
             version: "2",
           },
         ],
-      } as backend.Endpoint;
+      };
 
       const backend1 = backend.of(endpoint1);
       const backend2 = backend.of(endpoint2);

--- a/src/test/deploy/functions/cache/applyHash.spec.ts
+++ b/src/test/deploy/functions/cache/applyHash.spec.ts
@@ -1,0 +1,118 @@
+import * as hash from "../../../../deploy/functions/cache/hash";
+import { applyBackendHashToBackends } from "../../../../deploy/functions/cache/applyHash";
+import * as backend from "../../../../deploy/functions/backend";
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+const EMPTY_ENDPOINT: backend.Endpoint = {
+  id: "id",
+  region: "region",
+  project: "project",
+  platform: "gcfv2",
+  runtime: "nodejs16",
+  entryPoint: "ep",
+  httpsTrigger: {},
+  secretEnvironmentVariables: [],
+};
+
+describe("applyHash", () => {
+  afterEach(() => {
+    sinon.verifyAndRestore();
+  });
+
+  describe("applyBackendHashToBackends", () => {
+    it("should applyHash to each endpoint of a given backend", async () => {
+      // Prepare
+      const context = {
+        projectId: "projectId",
+        sources: {
+          backend1: {
+            functionsSourceV1: "backend1_sourceV1",
+            functionsSourceV2: "backend1_sourceV2",
+          },
+          backend2: {
+            functionsSourceV1: "backend2_sourceV1",
+            functionsSourceV2: "backend2_sourceV2",
+          },
+        },
+      };
+      const endpoint1 = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      } as backend.Endpoint;
+      const endpoint2 = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      } as backend.Endpoint;
+
+      const backend1 = backend.of(endpoint1);
+      const backend2 = backend.of(endpoint2);
+
+      backend1.environmentVariables.test = "shared_environment_variables";
+      backend2.environmentVariables = backend1.environmentVariables;
+
+      const backends = { backend1, backend2 };
+
+      const getSourceHash = sinon.stub(hash, "getSourceHash");
+      getSourceHash.callsFake((path: string) => Promise.resolve("source=" + path));
+
+      const getEnvironmentVariablesHash = sinon.stub(hash, "getEnvironmentVariablesHash");
+      getEnvironmentVariablesHash.callsFake(
+        (backend: backend.Backend) => "env=" + backend.environmentVariables.test
+      );
+      const getSecretsHash = sinon.stub(hash, "getSecretsHash");
+      getSecretsHash.callsFake(
+        (endpoint: backend.Endpoint) => "secret=" + endpoint.secretEnvironmentVariables?.[0].secret
+      );
+
+      const getEndpointHash = sinon.stub(hash, "getEndpointHash");
+      getEndpointHash.callsFake((source?: string, env?: string, secrets?: string) =>
+        [source, env, secrets].join("&")
+      );
+
+      // Execute
+      await applyBackendHashToBackends(backends, context);
+
+      // Expect
+      expect(getEndpointHash).to.have.been.calledWith(
+        "source=backend1_sourceV1",
+        "env=shared_environment_variables",
+        "secret=secret1"
+      );
+      expect(endpoint1.hash).to.equal(
+        "source=backend1_sourceV1&env=shared_environment_variables&secret=secret1"
+      );
+      expect(getEndpointHash).to.have.been.calledWith(
+        "source=backend2_sourceV2",
+        "env=shared_environment_variables",
+        "secret=secret2"
+      );
+      expect(endpoint2.hash).to.equal(
+        "source=backend2_sourceV2&env=shared_environment_variables&secret=secret2"
+      );
+      // Note: env variables only derived from the first backend
+      // (since all backends in wantBackends shared the same environment variables)
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
+    });
+  });
+});

--- a/src/test/deploy/functions/cache/applyHash.spec.ts
+++ b/src/test/deploy/functions/cache/applyHash.spec.ts
@@ -68,8 +68,8 @@ describe("applyHash", () => {
       const backend1 = backend.of(endpoint1);
       const backend2 = backend.of(endpoint2);
 
-      backend1.environmentVariables.test = "shared_environment_variables";
-      backend2.environmentVariables = backend1.environmentVariables;
+      backend1.environmentVariables.test = "backend1_env_hash";
+      backend2.environmentVariables.test = "backend2_env_hash";
 
       const backends = { backend1, backend2 };
 
@@ -96,23 +96,22 @@ describe("applyHash", () => {
       // Expect
       expect(getEndpointHash).to.have.been.calledWith(
         "source=backend1_sourceV1",
-        "env=shared_environment_variables",
+        "env=backend1_env_hash",
         "secret=secret1"
       );
       expect(endpoint1.hash).to.equal(
-        "source=backend1_sourceV1&env=shared_environment_variables&secret=secret1"
+        "source=backend1_sourceV1&env=backend1_env_hash&secret=secret1"
       );
       expect(getEndpointHash).to.have.been.calledWith(
         "source=backend2_sourceV2",
-        "env=shared_environment_variables",
+        "env=backend2_env_hash",
         "secret=secret2"
       );
       expect(endpoint2.hash).to.equal(
-        "source=backend2_sourceV2&env=shared_environment_variables&secret=secret2"
+        "source=backend2_sourceV2&env=backend2_env_hash&secret=secret2"
       );
-      // Note: env variables only derived from the first backend
-      // (since all backends in wantBackends shared the same environment variables)
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
     });
   });
 });


### PR DESCRIPTION
### Description

This PR adds the functionality to generate hashes for each endpoint given a list of `Backends[]`

### Scenarios Tested

- [x] Test wantBackend with 1 endpoint
- [x] Test wantBackend with 2 endpoints
- [x] Test setting multiple wantBackends