### PR TITLE
Implement removing Endpoint from Backend

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -654,6 +654,23 @@ export function findEndpoint(
   }
 }
 
+/** A helper utility for removing endpoints that match a predicate. */
+export function removeEndpoints(
+  backend: Backend,
+  predicate: (endpoint: Endpoint) => boolean
+): boolean {
+  let removed = false;
+  for (const endpoints of Object.values(backend.endpoints)) {
+    for (const [id, endpoint] of Object.entries(endpoints)) {
+      if (predicate(endpoint)) {
+        removed = true;
+        delete endpoints[id];
+      }
+    }
+  }
+  return removed;
+}
+
 /** A helper utility function that returns a subset of the backend that includes only matching endpoints */
 export function matchingBackend(
   backend: Backend,

--- a/src/test/deploy/functions/backend.spec.ts
+++ b/src/test/deploy/functions/backend.spec.ts
@@ -597,6 +597,12 @@ describe("Backend", () => {
       region: "europe-west1",
     };
 
+    const endpointREMOVED: backend.Endpoint = {
+      ...endpointUS,
+      id: "endpointREMOVED",
+      region: "europe-west1",
+    };
+
     const bkend: backend.Backend = {
       ...backend.empty(),
     };
@@ -627,6 +633,19 @@ describe("Backend", () => {
     it("someEndpoint", () => {
       expect(backend.someEndpoint(bkend, (fn) => fn.id === "endpointUS")).to.be.true;
       expect(backend.someEndpoint(bkend, (fn) => fn.id === "missing")).to.be.false;
+    });
+
+    it("removeEndpoints", () => {
+      // Add our endpoint
+      bkend.endpoints[endpointEU.region] = { [endpointREMOVED.id]: endpointREMOVED };
+      // Verify its there given our someEndpoint check
+      expect(backend.someEndpoint(bkend, (fn) => fn.id === "endpointREMOVED")).to.be.true;
+
+      // Test
+      backend.removeEndpoints(bkend, (fn) => fn.id === "endpointREMOVED");
+
+      // Verify removal was successful
+      expect(backend.someEndpoint(bkend, (fn) => fn.id === "endpointREMOVED")).to.be.false;
     });
 
     it("findEndpoint", () => {


### PR DESCRIPTION
### Description

This commit implements removing an endpoint from a backend.
Useful for instances where we would want to... remove an endpoint, from Backend.

Possibly in the `prepare` step.:wq

### Scenarios Tested

- [x] Test removing an endpoint from a backend