### PR TITLE
Fix function deploy test

### DIFF
--- a/scripts/functions-deploy-tests/tests.ts
+++ b/scripts/functions-deploy-tests/tests.ts
@@ -10,8 +10,7 @@ import * as proto from "../../src/gcp/proto";
 import * as tasks from "../../src/gcp/cloudtasks";
 import * as scheduler from "../../src/gcp/cloudscheduler";
 import { Endpoint } from "../../src/deploy/functions/backend";
-import { getGlobalDefaultAccount } from "../../src/auth";
-import { setRefreshToken } from "../../src/apiv2";
+import { requireAuth } from "../../src/requireAuth";
 
 const FIREBASE_PROJECT = process.env.GCLOUD_PROJECT || "";
 const FIREBASE_DEBUG = process.env.FIREBASE_DEBUG || "";
@@ -117,10 +116,7 @@ describe("firebase deploy", function (this) {
   before(async () => {
     expect(FIREBASE_PROJECT).to.not.be.empty;
 
-    const account = getGlobalDefaultAccount();
-    if (account?.tokens.refresh_token) {
-      setRefreshToken(account.tokens.refresh_token);
-    }
+    await requireAuth({});
     // write up index.js to import trigger definition using unique group identifier.
     // All exported functions will have name {hash}-{trigger} e.g. 'abcdefg-v1storage'.
     await fs.writeFile(

--- a/src/gcp/cloudscheduler.ts
+++ b/src/gcp/cloudscheduler.ts
@@ -102,7 +102,7 @@ export function deleteJob(name: string): Promise<any> {
  * If no job with that name exists, this will return a 404.
  * @param name The name of the job to get.
  */
-function getJob(name: string): Promise<any> {
+export function getJob(name: string): Promise<any> {
   return apiClient.get(`/${name}`, {
     resolveOnHTTPError: true,
   });


### PR DESCRIPTION
Function deploy test is stuck in a broken state again. Few changes:

1) Use `requireAuth` to prepare correct authentication context to call GCP API throughout the test

2) Re-export function from cloudscheduler.ts that was being used in test

Manually triggered test on this branch succeeded! https://github.com/firebase/firebase-tools/actions/runs/2879014832