### PR TITLE
[Function-NoOp] Catch Endpoints that should be skipped

### DIFF
--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -53,10 +53,17 @@ export function calculateChangesets(
     keyFn
   );
 
+  // If the hashes are matching, that means our local function is different.
+  const toSkipPredicate = (id: string) =>
+    have[id].hash && want[id].hash && want[id].hash === have[id].hash;
+
+  /* previews.skipdeployingnoopfunctions && */
+  const skipdeployingnoopfunctions = true;
+
   const toUpdate = utils.groupBy(
     Object.keys(want)
       .filter((id) => have[id])
-      .filter((id) => want[id].hash && (want[id].hash !== have[id].hash))
+      .filter((id) => skipdeployingnoopfunctions && !toSkipPredicate(id))
       .map((id) => calculateUpdate(want[id], have[id])),
     (eu: EndpointUpdate) => keyFn(eu.endpoint)
   );
@@ -64,7 +71,7 @@ export function calculateChangesets(
   const toSkip = utils.groupBy(
     Object.keys(want)
       .filter((id) => have[id])
-      .filter((id) => want[id].hash && (want[id].hash === have[id].hash))
+      .filter((id) => skipdeployingnoopfunctions && toSkipPredicate(id))
       .map((id) => want[id]),
     keyFn
   );

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -8,6 +8,7 @@ import { FirebaseError } from "../../../error";
 import * as utils from "../../../utils";
 import * as backend from "../backend";
 import * as v2events from "../../../functions/events/v2";
+import { previews } from "../../../previews";
 
 export interface EndpointUpdate {
   endpoint: backend.Endpoint;
@@ -54,16 +55,15 @@ export function calculateChangesets(
   );
 
   // If the hashes are matching, that means the local function is the same as the server copy.
-  const toSkipPredicate = (id: string) =>
-    have[id].hash && want[id].hash && want[id].hash === have[id].hash;
+  const toSkipPredicate = (id: string): boolean =>
+    !!(have[id].hash && want[id].hash && want[id].hash === have[id].hash);
 
-  /* previews.skipdeployingnoopfunctions && */
-  const skipdeployingnoopfunctions = true;
+  const { skipdeployingnoopfunctions } = previews;
 
   const toUpdate = utils.groupBy(
     Object.keys(want)
       .filter((id) => have[id])
-      .filter((id) => skipdeployingnoopfunctions && !toSkipPredicate(id))
+      .filter((id) => !(skipdeployingnoopfunctions && toSkipPredicate(id)))
       .map((id) => calculateUpdate(want[id], have[id])),
     (eu: EndpointUpdate) => keyFn(eu.endpoint)
   );

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -53,7 +53,7 @@ export function calculateChangesets(
     keyFn
   );
 
-  // If the hashes are matching, that means our local function is different.
+  // If the hashes are matching, that means the local function is the same as the server copy.
   const toSkipPredicate = (id: string) =>
     have[id].hash && want[id].hash && want[id].hash === have[id].hash;
 

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1550,6 +1550,7 @@ describe("Fabricator", () => {
         endpointsToCreate: [ep1, ep2],
         endpointsToUpdate: [{ endpoint: ep3 }],
         endpointsToDelete: [],
+        endpointsToSkip: [],
       };
 
       let sourceTokenScraper: scraper.SourceTokenScraper | undefined;
@@ -1582,6 +1583,7 @@ describe("Fabricator", () => {
         endpointsToCreate: [ep],
         endpointsToUpdate: [],
         endpointsToDelete: [],
+        endpointsToSkip: [],
       };
 
       const results = await fab.applyChangeset(changes);
@@ -1598,6 +1600,7 @@ describe("Fabricator", () => {
       endpointsToCreate: [createEP],
       endpointsToUpdate: [],
       endpointsToDelete: [deleteEP],
+      endpointsToSkip: [],
     };
 
     const results = await fab.applyChangeset(changes);
@@ -1615,6 +1618,7 @@ describe("Fabricator", () => {
       endpointsToCreate: [createEP],
       endpointsToUpdate: [update],
       endpointsToDelete: [deleteEP],
+      endpointsToSkip: [],
     };
 
     const createEndpoint = sinon.stub(fab, "createEndpoint");
@@ -1645,11 +1649,13 @@ describe("Fabricator", () => {
           endpointsToCreate: [ep1],
           endpointsToUpdate: [],
           endpointsToDelete: [],
+          endpointsToSkip: [],
         },
         "us-west1": {
           endpointsToCreate: [],
           endpointsToUpdate: [],
           endpointsToDelete: [ep2],
+          endpointsToSkip: [],
         },
       };
 

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -182,8 +182,8 @@ describe("planner", () => {
       const updatedWant = func("updated", "region");
       const updatedHave = func("updated", "region");
       // But their hashes are the same (aka a no-op function)
-      updatedWant.hash = "to_skip";
-      updatedHave.hash = "to_skip";
+      updatedWant.hash = "local";
+      updatedHave.hash = "server";
 
       const want = { updated: updatedWant };
       const have = { updated: updatedHave };
@@ -202,7 +202,7 @@ describe("planner", () => {
       });
     });
 
-    it("does not add endpoints to skip list if they have same hashes", () => {
+    it("does not add endpoints to skip list if preview flag is false", () => {
       // Note: the two functions share the same id
       const updatedWant = func("updated", "region");
       const updatedHave = func("updated", "region");

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -144,6 +144,27 @@ describe("planner", () => {
             },
           ],
           endpointsToDelete: [deleted],
+          endpointsToSkip: [],
+        },
+      });
+    });
+
+    it("will add endpoints with matching hashes to skip list", () => {
+      const updatedWant = func("updated", "region");
+      updatedWant.hash = "local_hash";
+      const updatedHave = func("updated", "region");
+      updatedHave.hash = "server_hash";
+
+      const want = { updatedWant };
+      const have = { updatedHave };
+
+      // note: pantheon is not updated in any way
+      expect(planner.calculateChangesets(want, have, (e) => e.region)).to.deep.equal({
+        region: {
+          endpointsToCreate: [],
+          endpointsToUpdate: [],
+          endpointsToDelete: [],
+          endpointsToSkip: [updatedWant],
         },
       });
     });
@@ -168,6 +189,7 @@ describe("planner", () => {
             },
           ],
           endpointsToDelete: [deleted, pantheon],
+          endpointsToSkip: [],
         },
       });
     });

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -153,7 +153,7 @@ describe("planner", () => {
       });
     });
 
-    it("will add endpoints with matching hashes to skip list", () => {
+    it("adds endpoints with matching hashes to skip list", () => {
       // Note: the two functions share the same id
       const updatedWant = func("updated", "region");
       const updatedHave = func("updated", "region");

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -177,6 +177,29 @@ describe("planner", () => {
       });
     });
 
+    it("adds endpoints to update list if they dont have hashes", () => {
+      // Note: the two functions share the same id
+      const updatedWant = func("updated", "region");
+      const updatedHave = func("updated", "region");
+      // Their hashes are not set
+
+      const want = { updated: updatedWant };
+      const have = { updated: updatedHave };
+
+      expect(planner.calculateChangesets(want, have, (e) => e.region)).to.deep.equal({
+        region: {
+          endpointsToCreate: [],
+          endpointsToUpdate: [
+            {
+              endpoint: updatedWant,
+            },
+          ],
+          endpointsToDelete: [],
+          endpointsToSkip: [],
+        },
+      });
+    });
+
     it("adds endpoints to update list if they have different hashes", () => {
       // Note: the two functions share the same id
       const updatedWant = func("updated", "region");

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -226,11 +226,13 @@ describe("planner", () => {
             },
           ],
           endpointsToDelete: [],
+          endpointsToSkip: [],
         },
         "default-region2-default": {
           endpointsToCreate: [region2mem1Created],
           endpointsToUpdate: [],
           endpointsToDelete: [],
+          endpointsToSkip: [],
         },
         "default-region2-512": {
           endpointsToCreate: [],
@@ -240,6 +242,7 @@ describe("planner", () => {
             },
           ],
           endpointsToDelete: [region2mem2Deleted],
+          endpointsToSkip: [],
         },
       });
     });
@@ -275,6 +278,7 @@ describe("planner", () => {
             },
           ],
           endpointsToDelete: [group1Deleted],
+          endpointsToSkip: [],
         },
       });
     });


### PR DESCRIPTION
### Description

This commit updates the `calculateChangesets` method to capture
Endpoints that have a mismatched hash and add those Endpoints to a
`endpointsToSkip` list.

### Scenarios Tested

- [x] Updatable Function/Endpoints with a mismatching `hash` should go into the `endpointsToSkip` list
- [x] Updatable Function/Endpoints without a `hash` should go into the `endpointsToUpdate`