### PR TITLE
[Function-NoOp] Update Fabricator to handle Endpoints to be Skipped

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -125,11 +125,11 @@ export class Fabricator {
       this.logOpStart("creating", endpoint);
       upserts.push(handle("create", endpoint, () => this.createEndpoint(endpoint, scraper)));
     }
-    for (const endpoint of changes.endpointsToSkip) {
-      upserts.push(handle("skip", endpoint, () => this.skipEndpoint(endpoint)));
-    }
     if (changes.endpointsToSkip.length) {
-      upserts.push(this.skipEndpointsCompleted(changes.endpointsToSkip));
+      for (const endpoint of changes.endpointsToSkip) {
+        utils.logSuccess(this.getLogSuccessMessage("skip", endpoint));
+      }
+      utils.logSuccess(this.getSkippedDeployingNopOpMessage(changes.endpointsToSkip));
     }
     for (const update of changes.endpointsToUpdate) {
       this.logOpStart("updating", update.endpoint);
@@ -171,15 +171,6 @@ export class Fabricator {
     }
 
     await this.setTrigger(endpoint);
-  }
-
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  async skipEndpoint(endpoint: backend.Endpoint): Promise<void> {
-    await Promise.resolve();
-  }
-
-  async skipEndpointsCompleted(endpointsToSkip: backend.Endpoint[]): Promise<void> {
-    await Promise.resolve(utils.logSuccess(this.getSkippedDeployingNopOpMessage(endpointsToSkip)));
   }
 
   async updateEndpoint(update: planner.EndpointUpdate, scraper: SourceTokenScraper): Promise<void> {

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -126,7 +126,7 @@ export class Fabricator {
       upserts.push(handle("create", endpoint, () => this.createEndpoint(endpoint, scraper)));
     }
     for (const endpoint of changes.endpointsToSkip) {
-      upserts.push(handle("skip", endpoint, () => this.skipEndpoint()));
+      upserts.push(handle("skip", endpoint, () => this.skipEndpoint(endpoint)));
     }
     if (changes.endpointsToSkip.length) {
       upserts.push(this.skipEndpointsCompleted(changes.endpointsToSkip));
@@ -173,14 +173,13 @@ export class Fabricator {
     await this.setTrigger(endpoint);
   }
 
-  async skipEndpoint(): Promise<void> {
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  async skipEndpoint(endpoint: backend.Endpoint): Promise<void> {
     await Promise.resolve();
   }
 
   async skipEndpointsCompleted(endpointsToSkip: backend.Endpoint[]): Promise<void> {
-    return await Promise.resolve(
-      utils.logSuccess(getSkippedDeployingNopOpMessage(endpointsToSkip))
-    );
+    await Promise.resolve(utils.logSuccess(this.getSkippedDeployingNopOpMessage(endpointsToSkip)));
   }
 
   async updateEndpoint(update: planner.EndpointUpdate, scraper: SourceTokenScraper): Promise<void> {
@@ -676,7 +675,32 @@ export class Fabricator {
   }
 
   logOpSuccess(op: string, endpoint: backend.Endpoint): void {
-    utils.logSuccess(getLogSuccessMessage(op, endpoint));
+    utils.logSuccess(this.getLogSuccessMessage(op, endpoint));
+  }
+
+  /**
+   * Returns the log messaging for a successful operation.
+   */
+  getLogSuccessMessage(op: string, endpoint: backend.Endpoint) {
+    const label = helper.getFunctionLabel(endpoint);
+    switch (op) {
+      case "skip":
+        return `Not deploying ${clc.bold(
+          clc.green(`functions[${label}]`)
+        )} - no change since last deploy (hash=${endpoint.hash})`;
+      default:
+        return `${clc.bold(clc.green(`functions[${label}]`))} Successful ${op} operation.`;
+    }
+  }
+
+  /**
+   * Returns the log messaging for no-op functions that were skipped.
+   */
+  getSkippedDeployingNopOpMessage(endpoints: backend.Endpoint[]) {
+    const functionNames = endpoints.map((endpoint) => endpoint.id).join(",");
+    return `To force deploy these functions, run command ${clc.bold(
+      `firebase deploy --only functions:${clc.green(functionNames)}`
+    )}`;
   }
 }
 
@@ -713,29 +737,4 @@ export function serviceIsResolved(service: run.Service): boolean {
   throw new FirebaseError(
     `Unexpected Status ${readyCondition?.status} for service ${service.metadata.name}`
   );
-}
-
-/**
- * Returns the Log Success Message
- */
-function getLogSuccessMessage(op: string, endpoint: backend.Endpoint) {
-  const label = helper.getFunctionLabel(endpoint);
-  switch (op) {
-    case "skip":
-      return `Not deploying ${clc.bold(
-        clc.green(`functions[${label}]`)
-      )} - no change since last deploy (hash=${endpoint.hash}`;
-    default:
-      return `${clc.bold(clc.green(`functions[${label}]`))} Successful ${op} operation.`;
-  }
-}
-
-/**
- * Returns the Log Success Message
- */
-function getSkippedDeployingNopOpMessage(endpoints: backend.Endpoint[]) {
-  const functionNames = endpoints.map((endpoint) => endpoint.id).join(",");
-  return `To force deploy these functions, run command ${clc.bold(
-    `firebase deploy --only functions:${clc.green(functionNames)}`
-  )}`;
 }

--- a/src/deploy/functions/release/reporter.ts
+++ b/src/deploy/functions/release/reporter.ts
@@ -19,6 +19,7 @@ export interface Summary {
 
 export type OperationType =
   | "create"
+  | "skip"
   | "update"
   | "delete"
   | "upsert schedule"

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1663,24 +1663,17 @@ describe("Fabricator", () => {
     updateEndpoint.resolves();
     const deleteEndpoint = sinon.stub(fab, "deleteEndpoint");
     deleteEndpoint.resolves();
-    const skipEndpoint = sinon.stub(fab, "skipEndpoint");
-    skipEndpoint.resolves();
-    const skipEndpointsCompleted = sinon.stub(fab, "skipEndpointsCompleted");
-    skipEndpointsCompleted.resolves();
 
     const results = await fab.applyChangeset(changes);
     expect(createEndpoint).to.have.been.calledWithMatch(createEP);
     expect(updateEndpoint).to.have.been.calledWithMatch(update);
     expect(deleteEndpoint).to.have.been.calledWith(deleteEP);
-    expect(skipEndpoint).to.have.been.calledWith(skipEP);
-    expect(skipEndpointsCompleted).to.have.been.calledWith([skipEP]);
 
     // We can't actually verify that the timing isn't zero because tests
     // have run in <1ms and failed.
     expect(results[0].error).to.be.undefined;
     expect(results[1].error).to.be.undefined;
     expect(results[2].error).to.be.undefined;
-    expect(results[3].error).to.be.undefined;
   });
 
   describe("applyPlan", () => {

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1592,6 +1592,41 @@ describe("Fabricator", () => {
     });
   });
 
+  describe("getLogSuccessMessage", () => {
+    it("should return appropriate messaging for create case", () => {
+      const ep = endpoint({ httpsTrigger: {} }, { id: "potato" });
+
+      const message = fab.getLogSuccessMessage("create", ep);
+
+      expect(message).to.contain(`functions[potato(us-central1)]`);
+      expect(message).to.contain(`Successful create operation`);
+    });
+
+    it("should return appropriate messaging for skip case", () => {
+      const ep = endpoint({ httpsTrigger: {} }, { id: "tomato" });
+      ep.hash = "hashyhash";
+
+      const message = fab.getLogSuccessMessage("skip", ep);
+
+      expect(message).to.contain(`Not deploying `);
+      expect(message).to.contain(`functions[tomato(us-central1)]`);
+      expect(message).to.contain(` - no change since last deploy (hash=hashyhash)`);
+    });
+  });
+
+  describe("getSkippedDeployingNopOpMessage", () => {
+    it("should return appropriate messaging", () => {
+      const ep1 = endpoint({ httpsTrigger: {} }, { id: "function1" });
+      const ep2 = endpoint({ httpsTrigger: {} }, { id: "function2" });
+
+      const message = fab.getSkippedDeployingNopOpMessage([ep1, ep2]);
+
+      expect(message).to.contain(`To force deploy these functions, run command `);
+      expect(message).to.contain(`firebase deploy --only functions:`);
+      expect(message).to.contain(`function1,function2`);
+    });
+  });
+
   it("does not delete if there are upsert errors", async () => {
     // when it hits a real API it will fail.
     const createEP = endpoint({ httpsTrigger: {} }, { id: "A" });

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1613,12 +1613,13 @@ describe("Fabricator", () => {
     const createEP = endpoint({ httpsTrigger: {} }, { id: "A" });
     const updateEP = endpoint({ httpsTrigger: {} }, { id: "B" });
     const deleteEP = endpoint({ httpsTrigger: {} }, { id: "C" });
+    const skipEP = endpoint({ httpsTrigger: {} }, { id: "D" });
     const update: planner.EndpointUpdate = { endpoint: updateEP };
     const changes: planner.Changeset = {
       endpointsToCreate: [createEP],
       endpointsToUpdate: [update],
       endpointsToDelete: [deleteEP],
-      endpointsToSkip: [],
+      endpointsToSkip: [skipEP],
     };
 
     const createEndpoint = sinon.stub(fab, "createEndpoint");
@@ -1627,17 +1628,24 @@ describe("Fabricator", () => {
     updateEndpoint.resolves();
     const deleteEndpoint = sinon.stub(fab, "deleteEndpoint");
     deleteEndpoint.resolves();
+    const skipEndpoint = sinon.stub(fab, "skipEndpoint");
+    skipEndpoint.resolves();
+    const skipEndpointsCompleted = sinon.stub(fab, "skipEndpointsCompleted");
+    skipEndpointsCompleted.resolves();
 
     const results = await fab.applyChangeset(changes);
     expect(createEndpoint).to.have.been.calledWithMatch(createEP);
     expect(updateEndpoint).to.have.been.calledWithMatch(update);
     expect(deleteEndpoint).to.have.been.calledWith(deleteEP);
+    expect(skipEndpoint).to.have.been.calledWith(skipEP);
+    expect(skipEndpointsCompleted).to.have.been.calledWith([skipEP]);
 
     // We can't actually verify that the timing isn't zero because tests
     // have run in <1ms and failed.
     expect(results[0].error).to.be.undefined;
     expect(results[1].error).to.be.undefined;
     expect(results[2].error).to.be.undefined;
+    expect(results[3].error).to.be.undefined;
   });
 
   describe("applyPlan", () => {


### PR DESCRIPTION
### Description

Updates `fabricator.ts` to handle log output for functions that should be skipped.

### Scenarios Tested

- [x] Given a changeset with an endpointToSkip, make sure the correct log output is returned