### PR TITLE
[Function-NoOp] Add a preview flag for skipping no-op function deploys

### DIFF
--- a/src/previews.ts
+++ b/src/previews.ts
@@ -12,7 +12,7 @@ interface PreviewFlags {
   frameworkawareness: boolean;
   functionsparams: boolean;
   crossservicerules: boolean;
-  skipnoopfunctiondeploy: boolean;
+  skipdeployingnoopfunctions: boolean;
 }
 
 export const previews: PreviewFlags = {
@@ -27,7 +27,7 @@ export const previews: PreviewFlags = {
   frameworkawareness: false,
   functionsparams: false,
   crossservicerules: false,
-  skipnoopfunctiondeploy: false,
+  skipdeployingnoopfunctions: false,
 
   ...(configstore.get("previews") as Partial<PreviewFlags>),
 };

--- a/src/previews.ts
+++ b/src/previews.ts
@@ -12,6 +12,7 @@ interface PreviewFlags {
   frameworkawareness: boolean;
   functionsparams: boolean;
   crossservicerules: boolean;
+  skipnoopfunctiondeploy: boolean;
 }
 
 export const previews: PreviewFlags = {
@@ -26,6 +27,7 @@ export const previews: PreviewFlags = {
   frameworkawareness: false,
   functionsparams: false,
   crossservicerules: false,
+  skipnoopfunctiondeploy: false,
 
   ...(configstore.get("previews") as Partial<PreviewFlags>),
 };


### PR DESCRIPTION
Adding `skipdeployingnoopfunctions ` as a preview flag.

Eventually, when `skipdeployingnoopfunctions ` is enabled, functions that are detected to be no-ops will not be re-deployed.

Example usage:

```
$ FIREBASE_CLI_PREVIEWS=skipdeployingnoopfunctions; firebase deploy
```