### PR TITLE
Refactor functions emulator to offload all process related logic to the worker class.

### DIFF
--- a/src/test/emulators/functionsRuntimeWorker.spec.ts
+++ b/src/test/emulators/functionsRuntimeWorker.spec.ts
@@ -7,14 +7,15 @@ import {
   RuntimeWorkerState,
   RuntimeWorkerPool,
 } from "../../emulator/functionsRuntimeWorker";
-import { FunctionsExecutionMode } from "../../emulator/types";
+import { EmulatorLog, FunctionsExecutionMode } from "../../emulator/types";
+import { ChildProcess } from "child_process";
 
 /**
  * Fake runtime instance we can use to simulate different subprocess conditions.
  * It automatically fails or succeeds 10ms after being given work to do.
  */
 class MockRuntimeInstance implements FunctionsRuntimeInstance {
-  pid: number = 12345;
+  process: ChildProcess;
   metadata: { [key: string]: any } = {};
   events: EventEmitter = new EventEmitter();
   exit: Promise<number>;
@@ -25,25 +26,22 @@ class MockRuntimeInstance implements FunctionsRuntimeInstance {
     this.exit = new Promise((res) => {
       this.events.on("exit", res);
     });
-  }
-
-  shutdown(): void {
-    this.events.emit("exit", { reason: "shutdown" });
-  }
-
-  kill(): void {
-    this.events.emit("exit", { reason: "kill" });
-  }
-
-  send(): boolean {
-    setTimeout(() => {
-      if (this.success) {
-        this.logRuntimeStatus({ state: "idle" });
-      } else {
-        this.kill();
-      }
-    }, 10);
-    return true;
+    this.process = new EventEmitter() as ChildProcess;
+    this.process.kill = () => {
+      this.events.emit("log", new EmulatorLog("SYSTEM", "runtime-status", "killed"));
+      this.process.emit("exit");
+      return true;
+    };
+    this.process.send = () => {
+      setTimeout(() => {
+        if (this.success) {
+          this.logRuntimeStatus({ state: "idle" });
+        } else {
+          this.process.kill();
+        }
+      }, 10);
+      return true;
+    };
   }
 
   logRuntimeStatus(data: any) {


### PR DESCRIPTION
Small refactor to move all process management logic from `FunctionsEmulator` to `FunctionsWorker`. I want to start moving all code pieces involved in management of a function process from the functions emulator (which I consider as control plane) to the worker (which I consider to be the data plane).

cc/ @joehan For visibility. Should not impact extensions emulator in any way.