### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ You can install the Firebase CLI using npm (the Node Package Manager). Note that
 
 To download and install the Firebase CLI run the following command:
 
-Nodejs v16 & later
 ```bash
+# Nodejs v16 & later
 npm install --location=global firebase-tools
-```
 
-Nodejs v14 & Older
-```bash
-npm install -g firebase-tools 
+OR
+
+# Nodejs v14 & older
+npm install -g firebase-tools
 ```
 
 This will provide you with the globally accessible `firebase` command.

--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ You can install the Firebase CLI using npm (the Node Package Manager). Note that
 
 To download and install the Firebase CLI run the following command:
 
+Nodejs v16 & later
 ```bash
-npm install -g firebase-tools
+npm install --location=global firebase-tools
+```
+
+Nodejs v14 & Older
+```bash
+npm install -g firebase-tools 
 ```
 
 This will provide you with the globally accessible `firebase` command.


### PR DESCRIPTION
For NPM 16 & later, the original 'npm install' with the '-g' has been deprecated and causes a warning flag to show up. Nodejs v14 and older does not show a flag.

This is a readme.md update only

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
