### PR TITLE
Update storage.rules template to block all access by default

### DIFF
--- a/templates/init/storage/storage.rules
+++ b/templates/init/storage/storage.rules
@@ -2,7 +2,7 @@ rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
     match /{allPaths=**} {
-      allow read, write: if request.auth!=null;
+      allow read, write: if false;
     }
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This updates the Firebase CLI to create storage rules that block all access by default, matching console behavior introduced in b/154635692.

### Scenarios Tested

* Ran `npm test`. Results: 2229 passing (14s), 4 pending
* Ran `firebase init`, selected **Storage: Configure a security rules file for Cloud Storage**, and verified that `storage.rules` contained the following: 

```
rules_version = '2';
service firebase.storage {
  match /b/{bucket}/o {
    match /{allPaths=**} {
      allow read, write: if false;
    }
  }
}
```

### Sample Commands

N/A