### PR TITLE
[Function-NoOp] Update to sha1 and fix source hashing

### DIFF
--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -14,8 +14,6 @@ export interface Source {
   // Filled in the "prepare" phase.
   functionsSourceV1?: string;
   functionsSourceV2?: string;
-
-  // Filled in the "prepare" phase.
   functionsSourceV1Hash?: string;
   functionsSourceV2Hash?: string;
 

--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -15,6 +15,10 @@ export interface Source {
   functionsSourceV1?: string;
   functionsSourceV2?: string;
 
+  // Filled in the "prepare" phase.
+  functionsSourceV1Hash?: string;
+  functionsSourceV2Hash?: string;
+
   // Filled in the "deploy" phase.
   sourceUrl?: string;
   storage?: gcfV2.StorageSource;

--- a/src/deploy/functions/cache/applyHash.ts
+++ b/src/deploy/functions/cache/applyHash.ts
@@ -1,30 +1,24 @@
 import { Backend, allEndpoints } from "../backend";
 import * as args from "../args";
-import {
-  getEndpointHash,
-  getEnvironmentVariablesHash,
-  getSecretsHash,
-  getSourceHash,
-} from "./hash";
+import { getEndpointHash, getEnvironmentVariablesHash, getSecretsHash } from "./hash";
 
 /**
  *
  * Updates all the CodeBase {@link Backend}, applying a hash to each of their {@link Endpoint}.
  */
-export async function applyBackendHashToBackends(
+export function applyBackendHashToBackends(
   wantBackends: Record<string, Backend>,
   context: args.Context
-): Promise<void> {
+): void {
   for (const [codebase, wantBackend] of Object.entries(wantBackends)) {
     const source = context?.sources?.[codebase]; // populated earlier in prepare flow
-    const sourceV1Hash = source?.functionsSourceV1
-      ? await getSourceHash(source?.functionsSourceV1)
-      : undefined;
-    const sourceV2Hash = source?.functionsSourceV2
-      ? await getSourceHash(source?.functionsSourceV2)
-      : undefined;
     const envHash = getEnvironmentVariablesHash(wantBackend);
-    applyBackendHashToEndpoints(wantBackend, envHash, sourceV1Hash, sourceV2Hash);
+    applyBackendHashToEndpoints(
+      wantBackend,
+      envHash,
+      source?.functionsSourceV1Hash,
+      source?.functionsSourceV2Hash
+    );
   }
 }
 

--- a/src/deploy/functions/cache/applyHash.ts
+++ b/src/deploy/functions/cache/applyHash.ts
@@ -19,12 +19,10 @@ export function applyBackendHashToBackends(
     }
     const source = context?.sources?.[codebase]; // populated earlier in prepare flow
     const envHash = getEnvironmentVariablesHash(wantBackend);
-    const filtersFilteredByCodebase =
-      context.filters?.filter((filter) => filter.codebase === codebase) || [];
     applyBackendHashToEndpoints(
       wantBackend,
       envHash,
-      filtersFilteredByCodebase,
+      context.filters || [],
       source?.functionsSourceV1Hash,
       source?.functionsSourceV2Hash
     );

--- a/src/deploy/functions/cache/applyHash.ts
+++ b/src/deploy/functions/cache/applyHash.ts
@@ -1,6 +1,7 @@
 import { Backend, allEndpoints } from "../backend";
 import * as args from "../args";
 import { getEndpointHash, getEnvironmentVariablesHash, getSecretsHash } from "./hash";
+import { EndpointFilter, isCodebaseFiltered, isEndpointFiltered } from "../functionsDeployHelper";
 
 /**
  *
@@ -11,11 +12,19 @@ export function applyBackendHashToBackends(
   context: args.Context
 ): void {
   for (const [codebase, wantBackend] of Object.entries(wantBackends)) {
+    // If an entire codebase is filtered, then don't set the hash for the functions in the codebase.
+    // This effectively forces all the functions to deploy without the duplication check.
+    if (isCodebaseFiltered(codebase, context.filters || [])) {
+      continue;
+    }
     const source = context?.sources?.[codebase]; // populated earlier in prepare flow
     const envHash = getEnvironmentVariablesHash(wantBackend);
+    const filtersFilteredByCodebase =
+      context.filters?.filter((filter) => filter.codebase === codebase) || [];
     applyBackendHashToEndpoints(
       wantBackend,
       envHash,
+      filtersFilteredByCodebase,
       source?.functionsSourceV1Hash,
       source?.functionsSourceV2Hash
     );
@@ -28,6 +37,7 @@ export function applyBackendHashToBackends(
 function applyBackendHashToEndpoints(
   wantBackend: Backend,
   envHash: string,
+  endpointFilters: EndpointFilter[],
   sourceV1Hash?: string,
   sourceV2Hash?: string
 ): void {
@@ -35,6 +45,10 @@ function applyBackendHashToEndpoints(
     const secretsHash = getSecretsHash(endpoint);
     const isV2 = endpoint.platform === "gcfv2";
     const sourceHash = isV2 ? sourceV2Hash : sourceV1Hash;
+    // If the endpoint is in the filtered list, then skip setting a hash (effectively forcing a deploy).
+    if (isEndpointFiltered(endpoint, endpointFilters)) {
+      continue;
+    }
     endpoint.hash = getEndpointHash(sourceHash, envHash, secretsHash);
   }
 }

--- a/src/deploy/functions/cache/hash.ts
+++ b/src/deploy/functions/cache/hash.ts
@@ -8,7 +8,7 @@ import { getSecretVersions } from "../../../functions/secrets";
  * @param backend Backend of a set of functions
  */
 export function getEnvironmentVariablesHash(backend: Backend): string {
-  const hash = crypto.createHash("sha256");
+  const hash = crypto.createHash("sha1");
 
   // Hash the contents of the dotenv variables
   const hasEnvironmentVariables = !!Object.keys(backend.environmentVariables).length;
@@ -24,7 +24,7 @@ export function getEnvironmentVariablesHash(backend: Backend): string {
  * @param pathToGeneratedPackageFile Packaged file contents of functions
  */
 export async function getSourceHash(pathToGeneratedPackageFile: string): Promise<string> {
-  const hash = crypto.createHash("sha256");
+  const hash = crypto.createHash("sha1");
 
   // Hash the contents of the source file
   const data = await readFile(pathToGeneratedPackageFile);
@@ -38,7 +38,7 @@ export async function getSourceHash(pathToGeneratedPackageFile: string): Promise
  * @param endpoint Endpoint
  */
 export function getSecretsHash(endpoint: Endpoint): string {
-  const hash = crypto.createHash("sha256");
+  const hash = crypto.createHash("sha1");
 
   // Hash the secret versions.
   const secretVersions = getSecretVersions(endpoint);
@@ -62,7 +62,7 @@ export function getEndpointHash(
   envHash?: string,
   secretsHash?: string
 ): string {
-  const hash = crypto.createHash("sha256");
+  const hash = crypto.createHash("sha1");
 
   const combined = [sourceHash, envHash, secretsHash].filter((hash) => !!hash).join("");
   hash.update(combined);

--- a/src/deploy/functions/cache/hash.ts
+++ b/src/deploy/functions/cache/hash.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
 import * as crypto from "crypto";
+import { BinaryLike } from "crypto";
 import { Backend, Endpoint } from "../backend";
 import { getSecretVersions } from "../../../functions/secrets";
-import { BinaryLike } from "crypto";
 
 /**
  * Generates a hash from the environment variables of a {@link Backend}.
@@ -10,8 +10,7 @@ import { BinaryLike } from "crypto";
  */
 export function getEnvironmentVariablesHash(backend: Backend): string {
   // Hash the contents of the dotenv variables
-  const hasEnvironmentVariables = !!Object.keys(backend.environmentVariables).length;
-  return createHash(hasEnvironmentVariables ? JSON.stringify(backend.environmentVariables) : "");
+  return createHash(JSON.stringify(backend.environmentVariables || {}));
 }
 
 /**
@@ -33,8 +32,7 @@ export async function getSourceHash(pathToFile: string): Promise<string> {
 export function getSecretsHash(endpoint: Endpoint): string {
   // Hash the secret versions.
   const secretVersions = getSecretVersions(endpoint);
-  const hasSecretVersions = !!Object.keys(secretVersions).length;
-  return createHash(hasSecretVersions ? JSON.stringify(secretVersions) : "");
+  return createHash(JSON.stringify(secretVersions || {}));
 }
 
 /**

--- a/src/deploy/functions/cache/hash.ts
+++ b/src/deploy/functions/cache/hash.ts
@@ -2,35 +2,26 @@ import { readFile } from "node:fs/promises";
 import * as crypto from "crypto";
 import { Backend, Endpoint } from "../backend";
 import { getSecretVersions } from "../../../functions/secrets";
+import { BinaryLike } from "crypto";
 
 /**
  * Generates a hash from the environment variables of a {@link Backend}.
  * @param backend Backend of a set of functions
  */
 export function getEnvironmentVariablesHash(backend: Backend): string {
-  const hash = crypto.createHash("sha1");
-
   // Hash the contents of the dotenv variables
   const hasEnvironmentVariables = !!Object.keys(backend.environmentVariables).length;
-  if (hasEnvironmentVariables) {
-    hash.update(JSON.stringify(backend.environmentVariables));
-  }
-
-  return hash.digest("hex");
+  return createHash(hasEnvironmentVariables ? JSON.stringify(backend.environmentVariables) : "");
 }
 
 /**
- * Retrieves the unique hash given a pathToGeneratedPackageFile.
- * @param pathToGeneratedPackageFile Packaged file contents of functions
+ * Retrieves the unique hash given a pathToFile.
+ * @param pathToFile Packaged file contents of functions
  */
-export async function getSourceHash(pathToGeneratedPackageFile: string): Promise<string> {
-  const hash = crypto.createHash("sha1");
-
-  // Hash the contents of the source file
-  const data = await readFile(pathToGeneratedPackageFile);
-  hash.update(data);
-
-  return hash.digest("hex");
+export async function getSourceHash(pathToFile: string): Promise<string> {
+  // Hash the contents of a file
+  const data = await readFile(pathToFile);
+  return createHash(data);
 }
 
 /**
@@ -38,16 +29,10 @@ export async function getSourceHash(pathToGeneratedPackageFile: string): Promise
  * @param endpoint Endpoint
  */
 export function getSecretsHash(endpoint: Endpoint): string {
-  const hash = crypto.createHash("sha1");
-
   // Hash the secret versions.
   const secretVersions = getSecretVersions(endpoint);
   const hasSecretVersions = !!Object.keys(secretVersions).length;
-  if (hasSecretVersions) {
-    hash.update(JSON.stringify(secretVersions));
-  }
-
-  return hash.digest("hex");
+  return createHash(hasSecretVersions ? JSON.stringify(secretVersions) : "");
 }
 
 /**
@@ -62,10 +47,13 @@ export function getEndpointHash(
   envHash?: string,
   secretsHash?: string
 ): string {
-  const hash = crypto.createHash("sha1");
-
   const combined = [sourceHash, envHash, secretsHash].filter((hash) => !!hash).join("");
-  hash.update(combined);
+  return createHash(combined);
+}
 
+// Helper method to create hashes consistently
+function createHash(data: BinaryLike, algorithm = "sha1") {
+  const hash = crypto.createHash(algorithm);
+  hash.update(data);
   return hash.digest("hex");
 }

--- a/src/deploy/functions/cache/hash.ts
+++ b/src/deploy/functions/cache/hash.ts
@@ -19,7 +19,9 @@ export function getEnvironmentVariablesHash(backend: Backend): string {
  * @param pathToFile Packaged file contents of functions
  */
 export async function getSourceHash(pathToFile: string): Promise<string> {
-  // Hash the contents of a file
+  // Hash the contents of a file, ignoring metadata.
+  // Excluding metadata in the hash is important because some
+  // files are dynamically generated on deploy.
   const data = await readFile(pathToFile);
   return createHash(data);
 }

--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -204,3 +204,17 @@ export function groupEndpointsByCodebase(
   // defined in other project repositories.
   return grouped;
 }
+
+/** Checks if a codebase should be filtered */
+export function isCodebaseFiltered(codebase: string, filters: EndpointFilter[]) {
+  return filters.some((filter) => {
+    // For a codebase to be filtered, the id chunks MUST be empty.
+    const noIdChunks = (filter.idChunks || []).length === 0;
+    return noIdChunks && filter.codebase === codebase;
+  });
+}
+
+/** Checks if a function should be filtered given a list of endpoints. */
+export function isEndpointFiltered(endpoint: backend.Endpoint, filters: EndpointFilter[]) {
+  return filters.some((filter) => endpointMatchesFilter(endpoint, filter));
+}

--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -206,7 +206,7 @@ export function groupEndpointsByCodebase(
 }
 
 /** Checks if a codebase should be filtered */
-export function isCodebaseFiltered(codebase: string, filters: EndpointFilter[]) {
+export function isCodebaseFiltered(codebase: string, filters: EndpointFilter[]): boolean {
   return filters.some((filter) => {
     // For a codebase to be filtered, the id chunks MUST be empty.
     const noIdChunks = (filter.idChunks || []).length === 0;

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -170,10 +170,14 @@ export async function prepare(
       );
     }
     if (backend.someEndpoint(wantBackend, (e) => e.platform === "gcfv2")) {
-      source.functionsSourceV2 = await prepareFunctionsUpload(sourceDir, config);
+      const packagedSource = await prepareFunctionsUpload(sourceDir, config);
+      source.functionsSourceV2 = packagedSource?.pathToSource;
+      source.functionsSourceV2Hash = packagedSource?.hash;
     }
     if (backend.someEndpoint(wantBackend, (e) => e.platform === "gcfv1")) {
-      source.functionsSourceV1 = await prepareFunctionsUpload(sourceDir, config, runtimeConfig);
+      const packagedSource = await prepareFunctionsUpload(sourceDir, config, runtimeConfig);
+      source.functionsSourceV1 = packagedSource?.pathToSource;
+      source.functionsSourceV1Hash = packagedSource?.hash;
     }
     context.sources[codebase] = source;
   }
@@ -264,7 +268,7 @@ export async function prepare(
    * This must be called after `await validate.secretsAreValid`.
    */
   if (previews.skipdeployingnoopfunctions) {
-    await applyBackendHashToBackends(wantBackends, context);
+    applyBackendHashToBackends(wantBackends, context);
   }
 }
 

--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -56,7 +56,7 @@ async function packageSource(
   sourceDir: string,
   config: projectConfig.ValidatedSingle,
   runtimeConfig: any
-) {
+): Promise<PackagedSourceInfo | undefined> {
   const tmpFile = tmp.fileSync({ prefix: "firebase-functions-", postfix: ".zip" }).name;
   const fileStream = fs.createWriteStream(tmpFile, {
     flags: "w",
@@ -113,7 +113,7 @@ async function packageSource(
       ") for uploading"
   );
   const hash = fileHashes.join(".");
-  return { pathToSource: tmpFile, hash: hash };
+  return { pathToSource: tmpFile, hash };
 }
 
 export async function prepareFunctionsUpload(

--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -7,6 +7,7 @@ import * as tmp from "tmp";
 
 import { FirebaseError } from "../../error";
 import { logger } from "../../logger";
+import { getSourceHash } from "./cache/hash";
 import * as backend from "./backend";
 import * as functionsConfig from "../../functionsConfig";
 import * as utils from "../../utils";
@@ -14,6 +15,11 @@ import * as fsAsync from "../../fsAsync";
 import * as projectConfig from "../../functions/projectConfig";
 
 const CONFIG_DEST_FILE = ".runtimeconfig.json";
+
+interface PackagedSourceInfo {
+  pathToSource: string;
+  hash: string;
+}
 
 // TODO(inlined): move to a file that's not about uploading source code
 export async function getFunctionsConfig(projectId: string): Promise<Record<string, unknown>> {
@@ -57,6 +63,7 @@ async function packageSource(
     encoding: "binary",
   });
   const archive = archiver("zip");
+  const fileHashes: string[] = [];
 
   // We must ignore firebase-debug.log or weird things happen if
   // you're in the public dir when you deploy.
@@ -71,8 +78,11 @@ async function packageSource(
   try {
     const files = await fsAsync.readdirRecursive({ path: sourceDir, ignore: ignore });
     for (const file of files) {
+      const name = path.relative(sourceDir, file.name);
+      const fileHash = await getSourceHash(file.name);
+      fileHashes.push(fileHash);
       archive.file(file.name, {
-        name: path.relative(sourceDir, file.name),
+        name,
         mode: file.mode,
       });
     }
@@ -82,7 +92,7 @@ async function packageSource(
         mode: 420 /* 0o644 */,
       });
     }
-    archive.finalize();
+    await archive.finalize();
     await pipeAsync(archive, fileStream);
   } catch (err: any) {
     throw new FirebaseError(
@@ -102,13 +112,14 @@ async function packageSource(
       filesize(archive.pointer()) +
       ") for uploading"
   );
-  return tmpFile;
+  const hash = fileHashes.join(".");
+  return { pathToSource: tmpFile, hash: hash };
 }
 
 export async function prepareFunctionsUpload(
   sourceDir: string,
   config: projectConfig.ValidatedSingle,
   runtimeConfig?: backend.RuntimeConfigValues
-): Promise<string | undefined> {
+): Promise<PackagedSourceInfo | undefined> {
   return packageSource(sourceDir, config, runtimeConfig);
 }

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -125,11 +125,8 @@ export class Fabricator {
       this.logOpStart("creating", endpoint);
       upserts.push(handle("create", endpoint, () => this.createEndpoint(endpoint, scraper)));
     }
-    if (changes.endpointsToSkip.length) {
-      for (const endpoint of changes.endpointsToSkip) {
-        utils.logSuccess(this.getLogSuccessMessage("skip", endpoint));
-      }
-      utils.logSuccess(this.getSkippedDeployingNopOpMessage(changes.endpointsToSkip));
+    for (const endpoint of changes.endpointsToSkip) {
+      utils.logSuccess(this.getLogSuccessMessage("skip", endpoint));
     }
     for (const update of changes.endpointsToUpdate) {
       this.logOpStart("updating", update.endpoint);
@@ -676,9 +673,7 @@ export class Fabricator {
     const label = helper.getFunctionLabel(endpoint);
     switch (op) {
       case "skip":
-        return `Not deploying ${clc.bold(
-          clc.green(`functions[${label}]`)
-        )} - no change since last deploy (hash=${endpoint.hash})`;
+        return `${clc.bold(clc.magenta(`functions[${label}]`))} Skipped (No changes detected)`;
       default:
         return `${clc.bold(clc.green(`functions[${label}]`))} Successful ${op} operation.`;
     }
@@ -689,8 +684,9 @@ export class Fabricator {
    */
   getSkippedDeployingNopOpMessage(endpoints: backend.Endpoint[]) {
     const functionNames = endpoints.map((endpoint) => endpoint.id).join(",");
-    return `To force deploy these functions, run command ${clc.bold(
-      `firebase deploy --only functions:${clc.green(functionNames)}`
+    return `${clc.bold(clc.magenta(`functions:`))} You can re-deploy skipped functions with:
+              ${clc.bold(`firebase deploy --only functions:${functionNames}`)} or ${clc.bold(
+      `FUNCTIONS_DEPLOY_UNCHANGED=true firebase deploy`
     )}`;
   }
 }

--- a/src/test/deploy/functions/cache/applyHash.spec.ts
+++ b/src/test/deploy/functions/cache/applyHash.spec.ts
@@ -21,18 +21,18 @@ describe("applyHash", () => {
   });
 
   describe("applyBackendHashToBackends", () => {
-    it("should applyHash to each endpoint of a given backend", async () => {
+    it("should applyHash to each endpoint of a given backend", () => {
       // Prepare
       const context = {
         projectId: "projectId",
         sources: {
           backend1: {
-            functionsSourceV1: "backend1_sourceV1",
-            functionsSourceV2: "backend1_sourceV2",
+            functionsSourceV1Hash: "backend1_sourceV1",
+            functionsSourceV2Hash: "backend1_sourceV2",
           },
           backend2: {
-            functionsSourceV1: "backend2_sourceV1",
-            functionsSourceV2: "backend2_sourceV2",
+            functionsSourceV1Hash: "backend2_sourceV1",
+            functionsSourceV2Hash: "backend2_sourceV2",
           },
         },
       };
@@ -73,9 +73,6 @@ describe("applyHash", () => {
 
       const backends = { backend1, backend2 };
 
-      const getSourceHash = sinon.stub(hash, "getSourceHash");
-      getSourceHash.callsFake((path: string) => Promise.resolve("source=" + path));
-
       const getEnvironmentVariablesHash = sinon.stub(hash, "getEnvironmentVariablesHash");
       getEnvironmentVariablesHash.callsFake(
         (backend: backend.Backend) => "env=" + backend.environmentVariables.test
@@ -91,25 +88,21 @@ describe("applyHash", () => {
       );
 
       // Execute
-      await applyBackendHashToBackends(backends, context);
+      applyBackendHashToBackends(backends, context);
 
       // Expect
       expect(getEndpointHash).to.have.been.calledWith(
-        "source=backend1_sourceV1",
+        "backend1_sourceV1",
         "env=backend1_env_hash",
         "secret=secret1"
       );
-      expect(endpoint1.hash).to.equal(
-        "source=backend1_sourceV1&env=backend1_env_hash&secret=secret1"
-      );
+      expect(endpoint1.hash).to.equal("backend1_sourceV1&env=backend1_env_hash&secret=secret1");
       expect(getEndpointHash).to.have.been.calledWith(
-        "source=backend2_sourceV2",
+        "backend2_sourceV2",
         "env=backend2_env_hash",
         "secret=secret2"
       );
-      expect(endpoint2.hash).to.equal(
-        "source=backend2_sourceV2&env=backend2_env_hash&secret=secret2"
-      );
+      expect(endpoint2.hash).to.equal("backend2_sourceV2&env=backend2_env_hash&secret=secret2");
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
     });

--- a/src/test/deploy/functions/cache/applyHash.spec.ts
+++ b/src/test/deploy/functions/cache/applyHash.spec.ts
@@ -106,5 +106,233 @@ describe("applyHash", () => {
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
     });
+
+    it("should skip filtered codebases", () => {
+      // Prepare
+      const context = {
+        projectId: "projectId",
+        sources: {
+          backend1: {
+            functionsSourceV1Hash: "backend1_sourceV1",
+            functionsSourceV2Hash: "backend1_sourceV2",
+          },
+          backend2: {
+            functionsSourceV1Hash: "backend2_sourceV1",
+            functionsSourceV2Hash: "backend2_sourceV2",
+          },
+        },
+        filters: [{ codebase: "backend1" }],
+      };
+      const endpoint1InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint2InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint3",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint1InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+
+      const backend1 = backend.of(endpoint1InBackend1, endpoint2InBackend1);
+      const backend2 = backend.of(endpoint1InBackend2);
+
+      backend1.environmentVariables.test = "backend1_env_hash";
+      backend2.environmentVariables.test = "backend2_env_hash";
+
+      const backends = { backend1, backend2 };
+
+      const getEnvironmentVariablesHash = sinon.stub(hash, "getEnvironmentVariablesHash");
+      getEnvironmentVariablesHash.callsFake(
+        (backend: backend.Backend) => "env=" + backend.environmentVariables.test
+      );
+      const getSecretsHash = sinon.stub(hash, "getSecretsHash");
+      getSecretsHash.callsFake(
+        (endpoint: backend.Endpoint) => "secret=" + endpoint.secretEnvironmentVariables?.[0].secret
+      );
+
+      const getEndpointHash = sinon.stub(hash, "getEndpointHash");
+      getEndpointHash.callsFake((source?: string, env?: string, secrets?: string) =>
+        [source, env, secrets].join("&")
+      );
+
+      // Execute
+      applyBackendHashToBackends(backends, context);
+
+      // Expect
+      expect(endpoint1InBackend1.hash).to.equal(undefined); // codebase match
+      expect(endpoint2InBackend1.hash).to.equal(undefined); // codebase match
+      expect(endpoint1InBackend2.hash).to.equal(
+        "backend2_sourceV2&env=backend2_env_hash&secret=secret2"
+      );
+      expect(getEndpointHash).to.have.been.calledWith(
+        "backend2_sourceV2",
+        "env=backend2_env_hash",
+        "secret=secret2"
+      );
+      expect(getEnvironmentVariablesHash).to.not.have.been.calledWith(backend1);
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
+    });
+
+    it("should skip filtered codebase + ids", () => {
+      // Prepare
+      const context = {
+        projectId: "projectId",
+        sources: {
+          backend1: {
+            functionsSourceV1Hash: "backend1_sourceV1",
+            functionsSourceV2Hash: "backend1_sourceV2",
+          },
+          backend2: {
+            functionsSourceV1Hash: "backend2_sourceV1",
+            functionsSourceV2Hash: "backend2_sourceV2",
+          },
+        },
+        filters: [{ codebase: "backend1", idChunks: ["endpoint1"] }],
+      };
+      const endpoint1InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint2InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint1InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+      const endpoint2InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+
+      const backend1 = backend.of(endpoint1InBackend1, endpoint2InBackend1);
+      const backend2 = backend.of(endpoint2InBackend2, endpoint1InBackend2);
+
+      backend1.environmentVariables.test = "backend1_env_hash";
+      backend2.environmentVariables.test = "backend2_env_hash";
+
+      const backends = { backend1, backend2 };
+
+      const getEnvironmentVariablesHash = sinon.stub(hash, "getEnvironmentVariablesHash");
+      getEnvironmentVariablesHash.callsFake(
+        (backend: backend.Backend) => "env=" + backend.environmentVariables.test
+      );
+      const getSecretsHash = sinon.stub(hash, "getSecretsHash");
+      getSecretsHash.callsFake(
+        (endpoint: backend.Endpoint) => "secret=" + endpoint.secretEnvironmentVariables?.[0].secret
+      );
+
+      const getEndpointHash = sinon.stub(hash, "getEndpointHash");
+      getEndpointHash.callsFake((source?: string, env?: string, secrets?: string) =>
+        [source, env, secrets].join("&")
+      );
+
+      // Execute
+      applyBackendHashToBackends(backends, context);
+
+      // Expect
+      expect(endpoint1InBackend1.hash).to.equal(undefined);
+      expect(endpoint2InBackend1.hash).to.equal(
+        "backend1_sourceV2&env=backend1_env_hash&secret=secret1"
+      );
+      // Note: endpoint1Backend2 has an id match, but not a codebase match.
+      expect(endpoint1InBackend2.hash).to.equal(
+        "backend2_sourceV2&env=backend2_env_hash&secret=secret2"
+      );
+      expect(endpoint2InBackend2.hash).to.equal(
+        "backend2_sourceV2&env=backend2_env_hash&secret=secret2"
+      );
+      expect(getEndpointHash).to.not.have.been.calledWith(
+        "backend1_sourceV1",
+        "env=backend1_env_hash",
+        "secret=secret1"
+      );
+      expect(getEndpointHash).to.have.been.calledWith(
+        "backend1_sourceV2",
+        "env=backend1_env_hash",
+        "secret=secret1"
+      );
+      expect(getEndpointHash).to.have.been.calledWith(
+        "backend2_sourceV2",
+        "env=backend2_env_hash",
+        "secret=secret2"
+      );
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
+    });
   });
 });

--- a/src/test/deploy/functions/cache/applyHash.spec.ts
+++ b/src/test/deploy/functions/cache/applyHash.spec.ts
@@ -334,5 +334,114 @@ describe("applyHash", () => {
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
     });
+
+    it("should skip filtered ids", () => {
+      // Prepare
+      const context = {
+        projectId: "projectId",
+        sources: {
+          backend1: {
+            functionsSourceV1Hash: "backend1_sourceV1",
+            functionsSourceV2Hash: "backend1_sourceV2",
+          },
+          backend2: {
+            functionsSourceV1Hash: "backend2_sourceV1",
+            functionsSourceV2Hash: "backend2_sourceV2",
+          },
+        },
+        filters: [{ idChunks: ["endpoint1"] }],
+      };
+      const endpoint1InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint2InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint1InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+      const endpoint2InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+
+      const backend1 = backend.of(endpoint1InBackend1, endpoint2InBackend1);
+      const backend2 = backend.of(endpoint2InBackend2, endpoint1InBackend2);
+
+      backend1.environmentVariables.test = "backend1_env_hash";
+      backend2.environmentVariables.test = "backend2_env_hash";
+
+      const backends = { backend1, backend2 };
+
+      const getEnvironmentVariablesHash = sinon.stub(hash, "getEnvironmentVariablesHash");
+      getEnvironmentVariablesHash.callsFake(
+        (backend: backend.Backend) => "env=" + backend.environmentVariables.test
+      );
+      const getSecretsHash = sinon.stub(hash, "getSecretsHash");
+      getSecretsHash.callsFake(
+        (endpoint: backend.Endpoint) => "secret=" + endpoint.secretEnvironmentVariables?.[0].secret
+      );
+
+      const getEndpointHash = sinon.stub(hash, "getEndpointHash");
+      getEndpointHash.callsFake((source?: string, env?: string, secrets?: string) =>
+        [source, env, secrets].join("&")
+      );
+
+      // Execute
+      applyBackendHashToBackends(backends, context);
+
+      // Expect
+      expect(endpoint1InBackend1.hash).to.equal(undefined);
+      expect(endpoint1InBackend2.hash).to.equal(undefined);
+      expect(endpoint2InBackend1.hash).to.equal(
+        "backend1_sourceV2&env=backend1_env_hash&secret=secret1"
+      );
+      expect(endpoint2InBackend2.hash).to.equal(
+        "backend2_sourceV2&env=backend2_env_hash&secret=secret2"
+      );
+    });
   });
 });

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1608,9 +1608,8 @@ describe("Fabricator", () => {
 
       const message = fab.getLogSuccessMessage("skip", ep);
 
-      expect(message).to.contain(`Not deploying `);
       expect(message).to.contain(`functions[tomato(us-central1)]`);
-      expect(message).to.contain(` - no change since last deploy (hash=hashyhash)`);
+      expect(message).to.contain(`Skipped (No changes detected)`);
     });
   });
 
@@ -1621,9 +1620,10 @@ describe("Fabricator", () => {
 
       const message = fab.getSkippedDeployingNopOpMessage([ep1, ep2]);
 
-      expect(message).to.contain(`To force deploy these functions, run command `);
-      expect(message).to.contain(`firebase deploy --only functions:`);
-      expect(message).to.contain(`function1,function2`);
+      expect(message).to.contain(`functions:`);
+      expect(message).to.contain(`You can re-deploy skipped functions with:`);
+      expect(message).to.contain(`firebase deploy --only functions:function1,function2`);
+      expect(message).to.contain(`FUNCTIONS_DEPLOY_UNCHANGED=true firebase deploy`);
     });
   });
 


### PR DESCRIPTION
### Description

This commit fixes 2 bugs found during E2E testing of Skipping No-Op Functions.

2 Problems were discovered during local testing:

1. Using a sha256 exceeded the length requirements of labels. [More Info](https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements)
1. The package source file was different every time due to `.runtimeconfig.json` regeneration and metadata mismatching.

### Testing

Enable the preview feature

```
$ node path/to/bin/firebase.js --open-sesame skipdeployingnoopfunctions
```

Deploy some code

```
$ node path/to/bin/firebase.js deploy
```

Deploy some code again, without changes

```
$ node path/to/bin/firebase.js deploy
```

Deploy some code again, after changing some code

```
$ node path/to/bin/firebase.js deploy
```



### Scenarios Tested

- [x] Uploading Function that did not previously have a hash - should update
- [x] Uploading Function whose local hash matches the server copy - should skip
- [x] Uploading Function whose local hash does not match the server copy - should update

### Sample Commands

```
$ firebase --open-sesame skipdeployingnoopfunctions
$ firebase deploy
```