### PR TITLE
[Function-NoOp] Updates the messaging to match existing logging conventions.

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -125,11 +125,8 @@ export class Fabricator {
       this.logOpStart("creating", endpoint);
       upserts.push(handle("create", endpoint, () => this.createEndpoint(endpoint, scraper)));
     }
-    if (changes.endpointsToSkip.length) {
-      for (const endpoint of changes.endpointsToSkip) {
-        utils.logSuccess(this.getLogSuccessMessage("skip", endpoint));
-      }
-      utils.logBullet(this.getSkippedDeployingNopOpMessage(changes.endpointsToSkip));
+    for (const endpoint of changes.endpointsToSkip) {
+      utils.logSuccess(this.getLogSuccessMessage("skip", endpoint));
     }
     for (const update of changes.endpointsToUpdate) {
       this.logOpStart("updating", update.endpoint);

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -129,7 +129,7 @@ export class Fabricator {
       for (const endpoint of changes.endpointsToSkip) {
         utils.logSuccess(this.getLogSuccessMessage("skip", endpoint));
       }
-      utils.logSuccess(this.getSkippedDeployingNopOpMessage(changes.endpointsToSkip));
+      utils.logBullet(this.getSkippedDeployingNopOpMessage(changes.endpointsToSkip));
     }
     for (const update of changes.endpointsToUpdate) {
       this.logOpStart("updating", update.endpoint);
@@ -676,9 +676,7 @@ export class Fabricator {
     const label = helper.getFunctionLabel(endpoint);
     switch (op) {
       case "skip":
-        return `Not deploying ${clc.bold(
-          clc.green(`functions[${label}]`)
-        )} - no change since last deploy (hash=${endpoint.hash})`;
+        return `${clc.bold(clc.magenta(`functions[${label}]`))} Skipped (No changes detected)`;
       default:
         return `${clc.bold(clc.green(`functions[${label}]`))} Successful ${op} operation.`;
     }
@@ -689,8 +687,9 @@ export class Fabricator {
    */
   getSkippedDeployingNopOpMessage(endpoints: backend.Endpoint[]) {
     const functionNames = endpoints.map((endpoint) => endpoint.id).join(",");
-    return `To force deploy these functions, run command ${clc.bold(
-      `firebase deploy --only functions:${clc.green(functionNames)}`
+    return `${clc.bold(clc.magenta(`functions:`))} You can re-deploy skipped functions with:
+              ${clc.bold(`firebase deploy --only functions:${functionNames}`)} or ${clc.bold(
+      `FUNCTIONS_DEPLOY_UNCHANGED=true; firebase deploy`
     )}`;
   }
 }

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -686,7 +686,7 @@ export class Fabricator {
     const functionNames = endpoints.map((endpoint) => endpoint.id).join(",");
     return `${clc.bold(clc.magenta(`functions:`))} You can re-deploy skipped functions with:
               ${clc.bold(`firebase deploy --only functions:${functionNames}`)} or ${clc.bold(
-      `FUNCTIONS_DEPLOY_UNCHANGED=true; firebase deploy`
+      `FUNCTIONS_DEPLOY_UNCHANGED=true firebase deploy`
     )}`;
   }
 }

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1623,7 +1623,7 @@ describe("Fabricator", () => {
       expect(message).to.contain(`functions:`);
       expect(message).to.contain(`You can re-deploy skipped functions with:`);
       expect(message).to.contain(`firebase deploy --only functions:function1,function2`);
-      expect(message).to.contain(`FUNCTIONS_DEPLOY_UNCHANGED=true; firebase deploy`);
+      expect(message).to.contain(`FUNCTIONS_DEPLOY_UNCHANGED=true firebase deploy`);
     });
   });
 

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1608,9 +1608,8 @@ describe("Fabricator", () => {
 
       const message = fab.getLogSuccessMessage("skip", ep);
 
-      expect(message).to.contain(`Not deploying `);
       expect(message).to.contain(`functions[tomato(us-central1)]`);
-      expect(message).to.contain(` - no change since last deploy (hash=hashyhash)`);
+      expect(message).to.contain(`Skipped (No changes detected)`);
     });
   });
 
@@ -1621,9 +1620,10 @@ describe("Fabricator", () => {
 
       const message = fab.getSkippedDeployingNopOpMessage([ep1, ep2]);
 
-      expect(message).to.contain(`To force deploy these functions, run command `);
-      expect(message).to.contain(`firebase deploy --only functions:`);
-      expect(message).to.contain(`function1,function2`);
+      expect(message).to.contain(`functions:`);
+      expect(message).to.contain(`You can re-deploy skipped functions with:`);
+      expect(message).to.contain(`firebase deploy --only functions:function1,function2`);
+      expect(message).to.contain(`FUNCTIONS_DEPLOY_UNCHANGED=true; firebase deploy`);
     });
   });
 


### PR DESCRIPTION
### Description

Updates the messaging to match existing logging conventions.

Example Output:

```
i  hosting[tystark-no-op-fns-test]: beginning deploy...
i  hosting[tystark-no-op-fns-test]: found 1 files in public
✔  hosting[tystark-no-op-fns-test]: file upload complete
✔  functions[helloWorld(us-central1)] Skipped (No changes detected)
i  functions: cleaning up build files...
i  hosting[tystark-no-op-fns-test]: finalizing version...
✔  hosting[tystark-no-op-fns-test]: version finalized
i  hosting[tystark-no-op-fns-test]: releasing new version...
✔  hosting[tystark-no-op-fns-test]: release complete
```

### Scenarios Tested

- [x] New messaging (and proposed escape commands)