### PR TITLE
Increase time to wait for function to spin up and be ready to accept requets.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug where secrets were not attached to functions when using older Functions SDK (#4797).
+- Increase timeout of the Functions Emulator to wait for spawned process to initialize (#4944).

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -178,7 +178,7 @@ export class RuntimeWorker {
     const timeout = new Promise<never>((resolve, reject) => {
       setTimeout(() => {
         reject(new FirebaseError("Failed to load function."));
-      }, 10_000);
+      }, 30_000);
     });
     while (true) {
       try {


### PR DESCRIPTION
In https://github.com/firebase/firebase-tools/pull/4693, I changed how the Functions Emulator waited for the spawned process of an emulated HTTP function to spin up a server and become ready to accept client requests.

Before, the Functions Emulator waited indefinitely for a specific log entry (e.g. "runtime-status: READY!") to be emitted by the spawned process.

After, the Functions Emulator made a GET request to the `/__/health` endpoint every 100ms for 7 seconds.

Many users have complained that their Functions Emulator are timing out on HTTP requests since the change (https://github.com/firebase/firebase-tools/issues/4807). Sadly, I nor other members of the team haven't been able to reproduce the error locally (it doesn't seem to be a problem for CI too - both Linux and Windows CI tests doesn't have a problem) making it pretty hard to debug the problem.

The best clue we have so far is from comment made by @rawatnaresh in https://github.com/firebase/firebase-tools/issues/4807#issuecomment-1229108620. Based on the debug log they posted, it looks like `spawn()`, which asynchronously starts a process, took more than 7 seconds to actually spawn and start an function runtime process.

It's pretty strange that it took ~7 seconds - precisely the timeout that I arbitrary set to wait for the server to spin up on the spawned process - before the spawned process started to execute its main function. As with most things with computers, I can't imagine this being coincidentally. But I don't understand why this is.

So for now, I'm suggesting that we increase the timeout from 7s to 30s, which is a bit closer to "indefinite" wait we had before https://github.com/firebase/firebase-tools/pull/4693. I'm hopeful that this will help, but I'd sure love to find out what missing in my mental model of `spawn()`.