### PR TITLE
[Function-NoOp] Implement an escape hatch

### DIFF
--- a/src/deploy/functions/cache/applyHash.ts
+++ b/src/deploy/functions/cache/applyHash.ts
@@ -19,11 +19,12 @@ export function applyBackendHashToBackends(
     }
     const source = context?.sources?.[codebase]; // populated earlier in prepare flow
     const envHash = getEnvironmentVariablesHash(wantBackend);
-    const codebaseFilters = context.filters?.filter((filter) => filter.codebase === codebase) || [];
+    const filtersFilteredByCodebase =
+      context.filters?.filter((filter) => filter.codebase === codebase) || [];
     applyBackendHashToEndpoints(
       wantBackend,
       envHash,
-      codebaseFilters,
+      filtersFilteredByCodebase,
       source?.functionsSourceV1Hash,
       source?.functionsSourceV2Hash
     );
@@ -36,7 +37,7 @@ export function applyBackendHashToBackends(
 function applyBackendHashToEndpoints(
   wantBackend: Backend,
   envHash: string,
-  codebaseFilters: EndpointFilter[],
+  endpointFilters: EndpointFilter[],
   sourceV1Hash?: string,
   sourceV2Hash?: string
 ): void {
@@ -45,7 +46,7 @@ function applyBackendHashToEndpoints(
     const isV2 = endpoint.platform === "gcfv2";
     const sourceHash = isV2 ? sourceV2Hash : sourceV1Hash;
     // If the endpoint is in the filtered list, then skip setting a hash (effectively forcing a deploy).
-    if (isEndpointFiltered(endpoint, codebaseFilters)) {
+    if (isEndpointFiltered(endpoint, endpointFilters)) {
       continue;
     }
     endpoint.hash = getEndpointHash(sourceHash, envHash, secretsHash);

--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -204,3 +204,17 @@ export function groupEndpointsByCodebase(
   // defined in other project repositories.
   return grouped;
 }
+
+/** Checks if a codebase should be filtered */
+export function isCodebaseFiltered(codebase: string, filters: EndpointFilter[]) {
+  return filters.some((filter) => {
+    // For a codebase to be filtered, the id chunks MUST be empty.
+    const noIdChunks = (filter.idChunks || []).length === 0;
+    return noIdChunks && filter.codebase === codebase;
+  });
+}
+
+/** Checks if a function should be filtered given a list of endpoints. */
+export function isEndpointFiltered(endpoint: backend.Endpoint, filters: EndpointFilter[]) {
+  return filters.some((filter) => endpointMatchesFilter(endpoint, filter));
+}

--- a/src/test/deploy/functions/cache/applyHash.spec.ts
+++ b/src/test/deploy/functions/cache/applyHash.spec.ts
@@ -106,5 +106,233 @@ describe("applyHash", () => {
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
       expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
     });
+
+    it("should skip filtered codebases", () => {
+      // Prepare
+      const context = {
+        projectId: "projectId",
+        sources: {
+          backend1: {
+            functionsSourceV1Hash: "backend1_sourceV1",
+            functionsSourceV2Hash: "backend1_sourceV2",
+          },
+          backend2: {
+            functionsSourceV1Hash: "backend2_sourceV1",
+            functionsSourceV2Hash: "backend2_sourceV2",
+          },
+        },
+        filters: [{ codebase: "backend1" }],
+      };
+      const endpoint1InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint2InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint3",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint1InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+
+      const backend1 = backend.of(endpoint1InBackend1, endpoint2InBackend1);
+      const backend2 = backend.of(endpoint1InBackend2);
+
+      backend1.environmentVariables.test = "backend1_env_hash";
+      backend2.environmentVariables.test = "backend2_env_hash";
+
+      const backends = { backend1, backend2 };
+
+      const getEnvironmentVariablesHash = sinon.stub(hash, "getEnvironmentVariablesHash");
+      getEnvironmentVariablesHash.callsFake(
+        (backend: backend.Backend) => "env=" + backend.environmentVariables.test
+      );
+      const getSecretsHash = sinon.stub(hash, "getSecretsHash");
+      getSecretsHash.callsFake(
+        (endpoint: backend.Endpoint) => "secret=" + endpoint.secretEnvironmentVariables?.[0].secret
+      );
+
+      const getEndpointHash = sinon.stub(hash, "getEndpointHash");
+      getEndpointHash.callsFake((source?: string, env?: string, secrets?: string) =>
+        [source, env, secrets].join("&")
+      );
+
+      // Execute
+      applyBackendHashToBackends(backends, context);
+
+      // Expect
+      expect(endpoint1InBackend1.hash).to.equal(undefined); // codebase match
+      expect(endpoint2InBackend1.hash).to.equal(undefined); // codebase match
+      expect(endpoint1InBackend2.hash).to.equal(
+        "backend2_sourceV2&env=backend2_env_hash&secret=secret2"
+      );
+      expect(getEndpointHash).to.have.been.calledWith(
+        "backend2_sourceV2",
+        "env=backend2_env_hash",
+        "secret=secret2"
+      );
+      expect(getEnvironmentVariablesHash).to.not.have.been.calledWith(backend1);
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
+    });
+
+    it("should skip filtered codebase + ids", () => {
+      // Prepare
+      const context = {
+        projectId: "projectId",
+        sources: {
+          backend1: {
+            functionsSourceV1Hash: "backend1_sourceV1",
+            functionsSourceV2Hash: "backend1_sourceV2",
+          },
+          backend2: {
+            functionsSourceV1Hash: "backend2_sourceV1",
+            functionsSourceV2Hash: "backend2_sourceV2",
+          },
+        },
+        filters: [{ codebase: "backend1", idChunks: ["endpoint1"] }],
+      };
+      const endpoint1InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv1",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint2InBackend1: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend1",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret1",
+            projectId: "projectId",
+            version: "1",
+          },
+        ],
+      };
+      const endpoint1InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+      const endpoint2InBackend2: backend.Endpoint = {
+        ...EMPTY_ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend2",
+        secretEnvironmentVariables: [
+          {
+            key: "key",
+            secret: "secret2",
+            projectId: "projectId",
+            version: "2",
+          },
+        ],
+      };
+
+      const backend1 = backend.of(endpoint1InBackend1, endpoint2InBackend1);
+      const backend2 = backend.of(endpoint2InBackend2, endpoint1InBackend2);
+
+      backend1.environmentVariables.test = "backend1_env_hash";
+      backend2.environmentVariables.test = "backend2_env_hash";
+
+      const backends = { backend1, backend2 };
+
+      const getEnvironmentVariablesHash = sinon.stub(hash, "getEnvironmentVariablesHash");
+      getEnvironmentVariablesHash.callsFake(
+        (backend: backend.Backend) => "env=" + backend.environmentVariables.test
+      );
+      const getSecretsHash = sinon.stub(hash, "getSecretsHash");
+      getSecretsHash.callsFake(
+        (endpoint: backend.Endpoint) => "secret=" + endpoint.secretEnvironmentVariables?.[0].secret
+      );
+
+      const getEndpointHash = sinon.stub(hash, "getEndpointHash");
+      getEndpointHash.callsFake((source?: string, env?: string, secrets?: string) =>
+        [source, env, secrets].join("&")
+      );
+
+      // Execute
+      applyBackendHashToBackends(backends, context);
+
+      // Expect
+      expect(endpoint1InBackend1.hash).to.equal(undefined);
+      expect(endpoint2InBackend1.hash).to.equal(
+        "backend1_sourceV2&env=backend1_env_hash&secret=secret1"
+      );
+      // Note: endpoint1Backend2 has an id match, but not a codebase match.
+      expect(endpoint1InBackend2.hash).to.equal(
+        "backend2_sourceV2&env=backend2_env_hash&secret=secret2"
+      );
+      expect(endpoint2InBackend2.hash).to.equal(
+        "backend2_sourceV2&env=backend2_env_hash&secret=secret2"
+      );
+      expect(getEndpointHash).to.not.have.been.calledWith(
+        "backend1_sourceV1",
+        "env=backend1_env_hash",
+        "secret=secret1"
+      );
+      expect(getEndpointHash).to.have.been.calledWith(
+        "backend1_sourceV2",
+        "env=backend1_env_hash",
+        "secret=secret1"
+      );
+      expect(getEndpointHash).to.have.been.calledWith(
+        "backend2_sourceV2",
+        "env=backend2_env_hash",
+        "secret=secret2"
+      );
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend1);
+      expect(getEnvironmentVariablesHash).to.have.been.calledWith(backend2);
+    });
   });
 });


### PR DESCRIPTION
### Description

This commit implements the `--only` escape hatch to force functions
to be deployed, even if they are identical to the copy found on gcf.

### Scenarios Tested

- [x] No filters
- [x] Codebase filter
- [x] Codebase + endpoint ids filter