### PR TITLE
Fix bug where storage emulator allowed non-string metadata values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fix bug where secrets were not attached to functions when using older Functions SDK (#4797).
 - Increase timeout of the Functions Emulator to wait for spawned process to initialize (#4944).
+- Fix bug where Storage Emulator did not convert non-string metadata value as key (#4955).

--- a/src/emulator/storage/metadata.ts
+++ b/src/emulator/storage/metadata.ts
@@ -57,12 +57,23 @@ export class StoredFileMetadata {
     this.contentLanguage = opts.contentLanguage;
     this.customTime = opts.customTime;
     this.contentEncoding = opts.contentEncoding;
-    this.customMetadata = opts.customMetadata;
     this.downloadTokens = opts.downloadTokens || [];
     if (opts.etag) {
       this.etag = opts.etag;
     } else {
       this.etag = generateETag(this.generation, this.metageneration);
+    }
+    if (opts.customMetadata) {
+      this.customMetadata = {};
+      for (const [k, v] of Object.entries(opts.customMetadata)) {
+        let stringVal = v;
+        if (typeof stringVal !== "string") {
+          stringVal = JSON.stringify(v);
+        }
+        if (stringVal) {
+          this.customMetadata[k] = stringVal;
+        }
+      }
     }
 
     // Special handling for date fields

--- a/src/emulator/storage/metadata.ts
+++ b/src/emulator/storage/metadata.ts
@@ -70,9 +70,7 @@ export class StoredFileMetadata {
         if (typeof stringVal !== "string") {
           stringVal = JSON.stringify(v);
         }
-        if (stringVal) {
-          this.customMetadata[k] = stringVal;
-        }
+        this.customMetadata[k] = stringVal || "";
       }
     }
 

--- a/src/test/emulators/storage/files.spec.ts
+++ b/src/test/emulators/storage/files.spec.ts
@@ -43,6 +43,27 @@ describe("files", () => {
     expect(deserialized).to.deep.equal(metadata);
   });
 
+  it("converts non-string custom metadata to string", () => {
+    const cf = new StorageCloudFunctions("demo-project");
+    const customMetadata = {
+      foo: true as unknown as string,
+    };
+    const metadata = new StoredFileMetadata(
+      {
+        customMetadata,
+        name: "name",
+        bucket: "bucket",
+        contentType: "mime/type",
+        downloadTokens: ["token123"],
+      },
+      cf,
+      Buffer.from("Hello, World!")
+    );
+    const json = StoredFileMetadata.toJSON(metadata);
+    const deserialized = StoredFileMetadata.fromJSON(json, cf);
+    expect(deserialized.customMetadata).to.deep.equal({ foo: "true" });
+  });
+
   describe("StorageLayer", () => {
     let _persistence: Persistence;
     let _uploadService: UploadService;


### PR DESCRIPTION
For example, storage emulator persists object metadata `{ foo: true }` as is.

In production, storage metadata is only allowed to be string key-value pair.

Interestingly, this fixes https://github.com/firebase/extensions/issues/1165 - [the condition](https://github.com/firebase/extensions/blame/8efd4e18afdb62218e1422deee1d60c89df9ebb9/storage-resize-images/functions/src/index.ts#L95-L98) for checking whether an object is already resized fails on Storage Emulator because it distinguishes the boolean `true` from string `'true'`.