### PR TITLE
fix: send `x-goog-upload-status: final` in Firebase storage emulator `finalizeOneShotUpload`

### DIFF
--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -234,6 +234,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
       if (!metadata.contentDisposition) {
         metadata.contentDisposition = "inline";
       }
+      res.header("x-goog-upload-status", "final");
       return res.status(200).json(new OutgoingFirebaseMetadata(metadata));
     }
 
@@ -342,7 +343,6 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
           }
           throw err;
         }
-        res.header("x-goog-upload-status", "final");
         return await finalizeOneShotUpload(upload);
       }
     }


### PR DESCRIPTION
### Description

Fixes https://github.com/firebase/firebase-tools/issues/4959.

It appears the emulator doesn't send `x-goog-upload-status` in `finalizeOneShotUpload`, and the Firebase JS SDK expects this header to be set otherwise crashes with a "unknown error". This PR adds this header to make the uploads complete.

### Scenarios Tested

- Resumable upload against emulator
