### PR TITLE
Reduce functions deployment concurrency to 10

### DIFF
--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -62,7 +62,7 @@ export async function release(
   const functionExecutor: executor.QueueExecutor = new executor.QueueExecutor({
     retries: 30,
     backoff: 20000,
-    concurrency: 40,
+    concurrency: 10,
     maxBackoff: 40000,
   });
 


### PR DESCRIPTION
### Description

There is an old issue we were facing with functions deployments reaching quotas: #3919. 

From Firebase [documentation](https://firebase.google.com/docs/functions/manage-functions#deploy_functions):

> When deploying large numbers of functions, you may exceed the standard quota and receive HTTP 429 or 500 error messages. To solve this, deploy functions in groups of 10 or fewer.

So why don't we just update this concurrency value from 40 to 10?

### Scenarios Tested

Deployed 90 functions with:

```sh
firebase deploy --only functions
```
