### PR TITLE
Fix #4966 - Larger releases were failing to deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Add v2 Remote Config triggers to deploy (#4937).
-- Fix deployment failure for larger releases (#4969)
+- Fixes issue where large CF3 releases were failing to deploy (#4969)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Add v2 Remote Config triggers to deploy (#4937).
+- Fix deployment failure for larger releases (#4969)

--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -45,13 +45,12 @@ export async function getFunctionsConfig(projectId: string): Promise<Record<stri
 }
 
 async function pipeAsync(from: archiver.Archiver, to: fs.WriteStream) {
-  const promise = new Promise((resolve, reject) => {
+  from.pipe(to);
+  await from.finalize();
+  return new Promise((resolve, reject) => {
     to.on("finish", resolve);
     to.on("error", reject);
   });
-  from.pipe(to);
-  await from.finalize();
-  return promise;
 }
 
 async function packageSource(

--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -45,11 +45,13 @@ export async function getFunctionsConfig(projectId: string): Promise<Record<stri
 }
 
 async function pipeAsync(from: archiver.Archiver, to: fs.WriteStream) {
-  return new Promise((resolve, reject) => {
+  const promise = new Promise((resolve, reject) => {
     to.on("finish", resolve);
     to.on("error", reject);
-    from.pipe(to);
   });
+  from.pipe(to);
+  await from.finalize();
+  return promise;
 }
 
 async function packageSource(
@@ -94,7 +96,6 @@ async function packageSource(
         mode: 420 /* 0o644 */,
       });
     }
-    await archive.finalize();
     await pipeAsync(archive, fileStream);
   } catch (err: any) {
     throw new FirebaseError(


### PR DESCRIPTION
### Description

This commit fixes an issue where larger functions were not getting deployed.

`#4940` Added `await archiver.finalize()`, which meant function file contents were being stored in-memory instead of being piped to the tmp file.

The main fix in this commit is calling `pipe` before we `await archiver.finalize()`.