### PR TITLE
Make FirebaseConfig properties available as internal parameters

### DIFF
--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -6,6 +6,7 @@ import { assertExhaustive, partition } from "../../functional";
 import * as secretManager from "../../gcp/secretManager";
 import { listBuckets } from "../../gcp/storage";
 import { isCelExpression, resolveExpression } from "./cel";
+import { FirebaseConfig } from "./args";
 
 // A convinience type containing options for Prompt's select
 interface ListItem {
@@ -199,7 +200,7 @@ export class ParamValue {
 
   constructor(
     private readonly rawValue: string,
-    readonly secret: boolean,
+    readonly internal: boolean,
     types: { string?: boolean; boolean?: boolean; number?: boolean }
   ) {
     this.legalString = types.string || false;
@@ -236,8 +237,7 @@ function resolveDefaultCEL(
 ): RawParamValue {
   const deps = dependenciesCEL(expr);
   const allDepsFound = deps.every((dep) => !!currentEnv[dep]);
-  const dependsOnSecret = deps.some((dep) => currentEnv[dep].secret);
-  if (!allDepsFound || dependsOnSecret) {
+  if (!allDepsFound) {
     throw new FirebaseError(
       "Build specified parameter with un-resolvable default value " +
         expr +
@@ -288,11 +288,11 @@ function canSatisfyParam(param: Param, value: RawParamValue): boolean {
  */
 export async function resolveParams(
   params: Param[],
-  projectId: string,
+  firebaseConfig: FirebaseConfig,
   userEnvs: Record<string, ParamValue>,
   nonInteractive?: boolean
 ): Promise<Record<string, ParamValue>> {
-  const paramValues: Record<string, ParamValue> = {};
+  const paramValues: Record<string, ParamValue> = populateDefaultParams(firebaseConfig);
 
   // TODO(vsfan@): should we ever reject param values from .env files based on the appearance of the string?
   const [resolved, outstanding] = partition(params, (param) => {
@@ -304,7 +304,7 @@ export async function resolveParams(
 
   const [needSecret, needPrompt] = partition(outstanding, (param) => param.type === "secret");
   for (const param of needSecret) {
-    await handleSecret(param as SecretParam, projectId);
+    await handleSecret(param as SecretParam, firebaseConfig.projectId);
   }
 
   if (nonInteractive && needPrompt.length > 0) {
@@ -326,10 +326,35 @@ export async function resolveParams(
         "Parameter " + param.name + " has default value " + paramDefault + " of wrong type"
       );
     }
-    paramValues[param.name] = await promptParam(param, projectId, paramDefault);
+    paramValues[param.name] = await promptParam(param, firebaseConfig.projectId, paramDefault);
   }
 
   return paramValues;
+}
+
+function populateDefaultParams(config: FirebaseConfig): Record<string, ParamValue> {
+  const defaultParams: Record<string, ParamValue> = {};
+  defaultParams["DATABASE_URL"] = new ParamValue(config.databaseURL, true, {
+    string: true,
+    boolean: false,
+    number: false,
+  });
+  defaultParams["PROJECT_ID"] = new ParamValue(config.projectId, true, {
+    string: true,
+    boolean: false,
+    number: false,
+  });
+  defaultParams["GCLOUD_PROJECT"] = new ParamValue(config.projectId, true, {
+    string: true,
+    boolean: false,
+    number: false,
+  });
+  defaultParams["STORAGE_BUCKET"] = new ParamValue(config.storageBucket, true, {
+    string: true,
+    boolean: false,
+    number: false,
+  });
+  return defaultParams;
 }
 
 /**

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -495,10 +495,11 @@ export class FunctionsEmulator implements EmulatorInstance {
       await runtimeDelegate.build();
       logger.debug(`Analyzing ${runtimeDelegate.name} backend spec`);
       // Don't include user envs when parsing triggers, but we need some of the options for handling params
+      const firebaseConfig = this.getFirebaseConfig();
       const environment = {
         ...this.getSystemEnvs(),
         ...this.getEmulatorEnvs(),
-        FIREBASE_CONFIG: this.getFirebaseConfig(),
+        FIREBASE_CONFIG: firebaseConfig,
         ...emulatableBackend.env,
       };
       const userEnvOpt: functionsEnv.UserEnvsOpts = {
@@ -507,7 +508,12 @@ export class FunctionsEmulator implements EmulatorInstance {
         projectAlias: this.args.projectAlias,
       };
       const discoveredBuild = await runtimeDelegate.discoverBuild(runtimeConfig, environment);
-      const resolution = await resolveBackend(discoveredBuild, userEnvOpt, environment);
+      const resolution = await resolveBackend(
+        discoveredBuild,
+        JSON.parse(firebaseConfig),
+        userEnvOpt,
+        environment
+      );
       const discoveredBackend = resolution.backend;
       const endpoints = backend.allEndpoints(discoveredBackend);
       prepareEndpoints(endpoints);


### PR DESCRIPTION
Based on bugbash feedback from @taeold and @colerogers.

We repurpose the `.secret` field of ParamValue (which wasn't being used anyway after we washed our hands of handling Secrets ourselves) to be `.internal`, which designates a param that we generated which shouldn't be written to disk or the runtime process.env.

We make the fields of FirebaseConfig--project id, RTDB URL, and storage bucket--available as internal params to the resolution process.

In order for this to do anything useful, the SDK will have to export corresponding special Expressions that users can use in their Functions; these Expressions will not add anything to the manifest (since they'll be generated by this code anyway) but will have to have their .value() function special cased to read from process.env.firebase_config instead.