### PR TITLE
add x-goog-quota-user for serviceusage calls

### DIFF
--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -30,6 +30,7 @@ export async function check(
   silent = false
 ): Promise<boolean> {
   const res = await apiClient.get<{ state: string }>(`/projects/${projectId}/services/${apiName}`, {
+    headers: { "x-goog-quota-user": `projects/${projectId}` },
     skipLog: { resBody: true },
   });
   const isEnabled = res.body.state === "ENABLED";
@@ -54,6 +55,7 @@ async function enable(projectId: string, apiName: string): Promise<void> {
       `/projects/${projectId}/services/${apiName}:enable`,
       undefined,
       {
+        headers: { "x-goog-quota-user": `projects/${projectId}` },
         skipLog: { resBody: true },
       }
     );

--- a/src/test/ensureApiEnabled.spec.ts
+++ b/src/test/ensureApiEnabled.spec.ts
@@ -19,6 +19,7 @@ describe("ensureApiEnabled", () => {
     it("should call the API to check if it's enabled", async () => {
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .reply(200, { state: "ENABLED" });
 
       await check(FAKE_PROJECT_ID, FAKE_API, "", true);
@@ -29,6 +30,7 @@ describe("ensureApiEnabled", () => {
     it("should return the value from the API", async () => {
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "ENABLED" });
 
@@ -36,6 +38,7 @@ describe("ensureApiEnabled", () => {
 
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "DISABLED" });
 
@@ -61,6 +64,7 @@ describe("ensureApiEnabled", () => {
     it("should verify that the API is enabled, and stop if it is", async () => {
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "ENABLED" });
 
@@ -70,6 +74,7 @@ describe("ensureApiEnabled", () => {
     it("should attempt to enable the API if it is not enabled", async () => {
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "DISABLED" });
 
@@ -80,6 +85,7 @@ describe("ensureApiEnabled", () => {
 
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "ENABLED" });
 
@@ -91,21 +97,25 @@ describe("ensureApiEnabled", () => {
     it("should retry enabling the API if it does not enable in time", async () => {
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "DISABLED" });
 
       nock("https://serviceusage.googleapis.com")
         .post(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}:enable`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .twice()
         .reply(200);
 
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "DISABLED" });
 
       nock("https://serviceusage.googleapis.com")
         .get(`/v1/projects/${FAKE_PROJECT_ID}/services/${FAKE_API}`)
+        .matchHeader("x-goog-quota-user", `projects/${FAKE_PROJECT_ID}`)
         .once()
         .reply(200, { state: "ENABLED" });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Does what it says on the box! Running a functions deploy that checks a few APIs showed the usage on my project, which is what we want.