### PR TITLE
Writing params to .env.local in emulator mode should not error if param exists in .env.projectId

### DIFF
--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
-import { logBullet } from "../utils";
+import { logBullet, logWarning } from "../utils";
 
 const FUNCTIONS_EMULATOR_DOTENV = ".env.local";
 
@@ -264,20 +264,19 @@ export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvs
   if (Object.keys(toWrite).length === 0) {
     return;
   }
-
   const { functionsSource, projectId, projectAlias, isEmulator } = envOpts;
-  const envFiles = findEnvfiles(functionsSource, projectId, projectAlias, isEmulator);
-  const projectScopedFileName = `.env.${projectId}`;
 
-  const projectScopedFileExists = envFiles.includes(projectScopedFileName);
-  if (!projectScopedFileExists) {
-    createEnvFile(envOpts);
+  const allEnvFiles = findEnvfiles(functionsSource, projectId, projectAlias, isEmulator);
+  const targetEnvFile = envOpts.isEmulator ? FUNCTIONS_EMULATOR_DOTENV : `.env.${envOpts.projectId}`;
+  const targetEnvFileExists = allEnvFiles.includes(targetEnvFile);
+  if (!targetEnvFileExists) {
+    logger.debug(`Creating ${targetEnvFile}...`);
+    fs.writeFileSync(path.join(envOpts.functionsSource, targetEnvFile), "", { flag: "wx" });
   }
 
-  const currentEnvs = loadUserEnvs(envOpts);
   for (const k of Object.keys(toWrite)) {
     validateKey(k);
-    if (currentEnvs.hasOwnProperty(k)) {
+    if (isAlreadyDefinedWrite(k, envOpts)) {
       throw new FirebaseError(
         `Attempted to write param-defined key ${k} to .env files, but it was already defined.`
       );
@@ -286,22 +285,38 @@ export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvs
 
   logBullet(
     clc.cyan(clc.bold("functions: ")) +
-      `Writing new parameter values to disk: ${projectScopedFileName}`
+      `Writing new parameter values to disk: ${targetEnvFile}`
   );
   for (const k of Object.keys(toWrite)) {
     fs.appendFileSync(
-      path.join(functionsSource, projectScopedFileName),
+      path.join(functionsSource, targetEnvFile),
       formatUserEnvForWrite(k, toWrite[k])
     );
   }
 }
 
-function createEnvFile(envOpts: UserEnvsOpts): string {
-  const fileToWrite = envOpts.isEmulator ? FUNCTIONS_EMULATOR_DOTENV : `.env.${envOpts.projectId}`;
-  logger.debug(`Creating ${fileToWrite}...`);
+/**
+ * Returns whether we should error on trying to write a key because it's already
+ * defined in the .env fields. This seems like a simple presence, check, but...
+ * 
+ * For emulator deploys, it's legal to write a key to .env.local even if it's
+ * already defined in .env.projectId. This is a special case designed to follow
+ * the principle of least surprise for emulator users.
+ */
+export function isAlreadyDefinedWrite(key: string, envOpts: UserEnvsOpts): boolean {
+  const definedInEnv = loadUserEnvs(envOpts).hasOwnProperty(key);
 
-  fs.writeFileSync(path.join(envOpts.functionsSource, fileToWrite), "", { flag: "wx" });
-  return fileToWrite;
+  if (envOpts.isEmulator) {
+    const stillDefinedWithoutLocal = loadUserEnvs({...envOpts, isEmulator: false}).hasOwnProperty(key)
+    if (definedInEnv && stillDefinedWithoutLocal) {
+      logWarning(
+        clc.cyan(clc.yellow("functions: ")) +
+          `Writing parameter ${key} to emulator-specific config .env.local. This will overwrite your existing definition only when emulating.`
+      );
+      return false;
+    }
+  }
+  return definedInEnv;
 }
 
 function formatUserEnvForWrite(key: string, value: string): string {

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -307,12 +307,27 @@ FOO=foo
         {},
         { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
       );
-      expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).throw;
+      env.writeUserEnvs(
+        {},
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true }
+      );
+      expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
+      expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
+      expect(() => fs.statSync(path.join(tmpdir, ".env.local"))).to.throw;
     });
 
     it("touches .env.projectId if it doesn't already exist", () => {
       env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir });
+      expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(!!fs.statSync(path.join(tmpdir, ".env.project"))).to.be.true;
+      expect(() => fs.statSync(path.join(tmpdir, ".env.local"))).to.throw;
+    });
+
+    it("touches .env.local if it doesn't already exist in emulator mode", () => {
+      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir, isEmulator: true });
+      expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
+      expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
+      expect(!!fs.statSync(path.join(tmpdir, ".env.local"))).to.be.true;
     });
 
     it("throws if asked to write a key that already exists in .env.projectId", () => {
@@ -324,15 +339,50 @@ FOO=foo
       ).to.throw(FirebaseError);
     });
 
+    it("is fine writing a key that already exists in .env.projectId but not .env.local, in emulator mode", () => {
+      createEnvFiles(tmpdir, {
+        [".env.project"]: "FOO=foo",
+      });
+      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir, isEmulator: true })
+      expect(
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true })[
+          "FOO"
+        ]
+      ).to.equal("bar");
+    });
+
     it("throws if asked to write a key that already exists in any .env", () => {
       createEnvFiles(tmpdir, {
-        [".env.alias"]: "BAR=foo",
+        [".env"]: "FOO=bar",
       });
       expect(() =>
         env.writeUserEnvs(
-          { FOO: "bar" },
+          { FOO: "baz" },
           { projectId: "project", projectAlias: "alias", functionsSource: tmpdir }
         )
+      ).to.throw(FirebaseError);
+    });
+
+    it("is fine writing a key that already exists in any .env not not .env.local, in emulator mode", () => {
+      createEnvFiles(tmpdir, {
+        [".env"]: "FOO=bar",
+      });
+      env.writeUserEnvs(
+        { FOO: "baz" },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true }
+      )
+      expect(        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true })[
+        "FOO"
+      ]
+      ).to.equal("baz");
+    });
+
+    it("throws if asked to write a key that already exists in .env.local, in emulator mode", () => {
+      createEnvFiles(tmpdir, {
+        [".env.local"]: "ASDF=foo",
+      });
+      expect(() =>
+        env.writeUserEnvs({ ASDF: "bar" }, { projectId: "project", functionsSource: tmpdir, isEmulator: true })
       ).to.throw(FirebaseError);
     });
 


### PR DESCRIPTION
This is kind of an ugly special case, but the previous behavior got flagged as surprising during a bugbash and on reflection I think they're right. Also, bulking out the test cases, including fixing one test that just was not testing what it was purporting to.