### PR TITLE
Update refresh token validation so it throws INVALID_REFRESH_TOKEN when user is not found

### DIFF
--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -417,8 +417,10 @@ export abstract class ProjectState {
       // Shouldn't ever reach this assertion, but adding for completeness
       assert(record.tenantId === this.tenantId, "TENANT_ID_MISMATCH");
     }
+    const user = this.getUserByLocalId(record.localId);
+    assert(user, "INVALID_REFRESH_TOKEN");
     return {
-      user: this.getUserByLocalIdAssertingExists(record.localId),
+      user,
       provider: record.provider,
       extraClaims: record.extraClaims,
       secondFactor: record.secondFactor,


### PR DESCRIPTION
### Description

As the title suggests. Currently, when user is not found, it throws `Error: Internal state invariant broken: no user with ID: {userId}`. This fixes a regression that was introduced by https://github.com/firebase/firebase-tools/pull/4475 

Also filed [b/247157333](https://b.corp.google.com/247157333) for further investigation about any other deviations from prod

### Scenarios Tested

`npm run test` passes

### Sample Commands

N/A