### PR TITLE
[Function-NoOp] Stop uploading to gcs if no-op

### DIFF
--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -131,11 +131,15 @@ export function shouldUploadBeSkipped(
   const haveEndpoints = backend.allEndpoints(haveBackend);
 
   // Mismatching length immediately tells us they are different, and we should not skip.
-  if (wantEndpoints.length !== haveEndpoints.length) return false;
+  if (wantEndpoints.length !== haveEndpoints.length) {
+    return false;
+  }
 
   return wantEndpoints.every((wantEndpoint) => {
     const haveEndpoint = findEndpoint(haveBackend, (endpoint) => endpoint.id === wantEndpoint.id);
-    if (!haveEndpoint) return false;
+    if (!haveEndpoint) {
+      return false;
+    }
     return haveEndpoint.hash && wantEndpoint.hash && haveEndpoint.hash === wantEndpoint.hash;
   });
 }

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -120,7 +120,13 @@ export async function deploy(
   await Promise.all(uploads);
 }
 
-export function shouldUploadBeSkipped(wantBackend: backend.Backend, haveBackend: backend.Backend) {
+/**
+ * @return True IFF wantBackend + haveBackend are the same
+ */
+export function shouldUploadBeSkipped(
+  wantBackend: backend.Backend,
+  haveBackend: backend.Backend
+): boolean {
   const wantEndpoints = backend.allEndpoints(wantBackend);
   const haveEndpoints = backend.allEndpoints(haveBackend);
 

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -11,6 +11,7 @@ import * as gcs from "../../gcp/storage";
 import * as gcf from "../../gcp/cloudfunctions";
 import * as gcfv2 from "../../gcp/cloudfunctionsv2";
 import * as backend from "./backend";
+import { findEndpoint } from "./backend";
 
 setGracefulCleanup();
 
@@ -110,8 +111,25 @@ export async function deploy(
 
   await checkHttpIam(context, options, payload);
   const uploads: Promise<void>[] = [];
-  for (const [codebase, { wantBackend }] of Object.entries(payload.functions)) {
+  for (const [codebase, { wantBackend, haveBackend }] of Object.entries(payload.functions)) {
+    if (shouldUploadBeSkipped(wantBackend, haveBackend)) {
+      continue;
+    }
     uploads.push(uploadCodebase(context, codebase, wantBackend));
   }
   await Promise.all(uploads);
+}
+
+export function shouldUploadBeSkipped(wantBackend: backend.Backend, haveBackend: backend.Backend) {
+  const wantEndpoints = backend.allEndpoints(wantBackend);
+  const haveEndpoints = backend.allEndpoints(haveBackend);
+
+  // Mismatching length immediately tells us they are different, and we should not skip.
+  if (wantEndpoints.length !== haveEndpoints.length) return false;
+
+  return wantEndpoints.every((wantEndpoint) => {
+    const haveEndpoint = findEndpoint(haveBackend, (endpoint) => endpoint.id === wantEndpoint.id);
+    if (!haveEndpoint) return false;
+    return haveEndpoint.hash && wantEndpoint.hash && haveEndpoint.hash === wantEndpoint.hash;
+  });
 }

--- a/src/test/deploy/functions/deploy.spec.ts
+++ b/src/test/deploy/functions/deploy.spec.ts
@@ -1,0 +1,117 @@
+import { expect } from "chai";
+
+import * as backend from "../../../deploy/functions/backend";
+import * as deploy from "../../../deploy/functions/deploy";
+
+describe("deploy", () => {
+  const ENDPOINT_BASE: Omit<backend.Endpoint, "httpsTrigger"> = {
+    platform: "gcfv2",
+    id: "id",
+    region: "region",
+    project: "project",
+    entryPoint: "entry",
+    runtime: "nodejs16",
+  };
+
+  const ENDPOINT: backend.Endpoint = {
+    ...ENDPOINT_BASE,
+    httpsTrigger: {},
+  };
+  describe("shouldUploadBeSkipped", () => {
+    let endpoint1InWantBackend: backend.Endpoint;
+    let endpoint2InWantBackend: backend.Endpoint;
+    let endpoint1InHaveBackend: backend.Endpoint;
+    let endpoint2InHaveBackend: backend.Endpoint;
+
+    let wantBackend: backend.Backend;
+    let haveBackend: backend.Backend;
+
+    beforeEach(() => {
+      endpoint1InWantBackend = {
+        ...ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv1",
+        codebase: "backend1",
+      };
+      endpoint2InWantBackend = {
+        ...ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv1",
+        codebase: "backend1",
+      };
+      endpoint1InHaveBackend = {
+        ...ENDPOINT,
+        id: "endpoint1",
+        platform: "gcfv2",
+        codebase: "backend2",
+      };
+      endpoint2InHaveBackend = {
+        ...ENDPOINT,
+        id: "endpoint2",
+        platform: "gcfv2",
+        codebase: "backend2",
+      };
+
+      wantBackend = backend.of(endpoint1InWantBackend, endpoint2InWantBackend);
+      haveBackend = backend.of(endpoint1InHaveBackend, endpoint2InHaveBackend);
+    });
+
+    it("should skip if all endpoints are identical", () => {
+      endpoint1InWantBackend.hash = "1";
+      endpoint2InWantBackend.hash = "2";
+      endpoint1InHaveBackend.hash = endpoint1InWantBackend.hash;
+      endpoint2InHaveBackend.hash = endpoint2InWantBackend.hash;
+
+      // Execute
+      const result = deploy.shouldUploadBeSkipped(wantBackend, haveBackend);
+
+      // Expect
+      expect(result).to.be.true;
+    });
+
+    it("should not skip if hashes don't match", () => {
+      endpoint1InWantBackend.hash = "1";
+      endpoint2InWantBackend.hash = "2";
+      endpoint1InHaveBackend.hash = endpoint1InWantBackend.hash;
+      endpoint2InHaveBackend.hash = "No_match";
+
+      // Execute
+      const result = deploy.shouldUploadBeSkipped(wantBackend, haveBackend);
+
+      // Expect
+      expect(result).to.be.false;
+    });
+
+    it("should not skip if haveBackend is missing", () => {
+      endpoint1InWantBackend.hash = "1";
+      endpoint2InWantBackend.hash = "2";
+      endpoint1InHaveBackend.hash = endpoint1InWantBackend.hash;
+      endpoint2InHaveBackend.hash = endpoint2InWantBackend.hash;
+
+      wantBackend = backend.of(endpoint1InWantBackend, endpoint2InWantBackend);
+      haveBackend = backend.of(endpoint1InHaveBackend);
+
+      // Execute
+      const result = deploy.shouldUploadBeSkipped(wantBackend, haveBackend);
+
+      // Expect
+      expect(result).to.be.false;
+    });
+
+    it("should not skip if wantBackend is missing", () => {
+      endpoint1InWantBackend.hash = "1";
+      endpoint2InWantBackend.hash = "2";
+      endpoint1InHaveBackend.hash = endpoint1InWantBackend.hash;
+      endpoint2InHaveBackend.hash = endpoint2InWantBackend.hash;
+
+      wantBackend = backend.of(endpoint1InWantBackend);
+      haveBackend = backend.of(endpoint1InHaveBackend, endpoint2InHaveBackend);
+
+      // Execute
+      const result = deploy.shouldUploadBeSkipped(wantBackend, haveBackend);
+
+      // Expect
+      expect(result).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
### Description

This function updates the behavior of the deploy-phase by skipping GCS uploads if we are already tracking a backend to be skipped.

### Scenarios Tested

* want + have backends are no-ops
* want + have backends have a mismatching hash (not a no-op)
* want + have backends have different number of endpoints