### PR TITLE
Single project mode for the auth emulator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Enable single project mode for the auth emulator (#5068).

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -13,6 +13,8 @@ export interface AuthEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
+  singleProjectModeWarning?: boolean;
+  singleProjectModeError?: boolean;
 }
 
 export class AuthEmulator implements EmulatorInstance {
@@ -22,7 +24,11 @@ export class AuthEmulator implements EmulatorInstance {
 
   async start(): Promise<void> {
     const { host, port } = this.getInfo();
-    const app = await createApp(this.args.projectId);
+    const app = await createApp(
+      this.args.projectId,
+      this.args.singleProjectModeWarning,
+      this.args.singleProjectModeError
+    );
     const server = app.listen(port, host);
     this.destroyServer = utils.createDestroyer(server);
   }

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -13,8 +13,13 @@ export interface AuthEmulatorArgs {
   projectId: string;
   port?: number;
   host?: string;
-  singleProjectModeWarning?: boolean;
-  singleProjectModeError?: boolean;
+  singleProjectMode?: SingleProjectMode;
+}
+
+export enum SingleProjectMode {
+  NO_WARNING,
+  WARNING,
+  ERROR,
 }
 
 export class AuthEmulator implements EmulatorInstance {
@@ -24,11 +29,7 @@ export class AuthEmulator implements EmulatorInstance {
 
   async start(): Promise<void> {
     const { host, port } = this.getInfo();
-    const app = await createApp(
-      this.args.projectId,
-      this.args.singleProjectModeWarning,
-      this.args.singleProjectModeError
-    );
+    const app = await createApp(this.args.projectId, this.args.singleProjectMode);
     const server = app.listen(port, host);
     this.destroyServer = utils.createDestroyer(server);
   }

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -16,6 +16,10 @@ export interface AuthEmulatorArgs {
   singleProjectMode?: SingleProjectMode;
 }
 
+/**
+ * An enum that dictates the behavior when the project ID in the request doesn't match the
+ * defaultProjectId.
+ */
 export enum SingleProjectMode {
   NO_WARNING,
   WARNING,

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -381,9 +381,6 @@ export async function createApp(
         throw new BadRequestError(errorString);
       }
     }
-    if (defaultProjectId !== projectId) {
-      throw new Error("exploding");
-    }
     if (!agentState) {
       agentState = new AgentProjectState(projectId);
       projectStateForId.set(projectId, agentState);

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -3,6 +3,7 @@ import * as express from "express";
 import * as exegesisExpress from "exegesis-express";
 import { ValidationError } from "exegesis/lib/errors";
 import * as _ from "lodash";
+import { SingleProjectMode } from "./index";
 import { OpenAPIObject, PathsObject, ServerObject, OperationObject } from "openapi3-ts";
 import { EmulatorLogger } from "../emulatorLogger";
 import { Emulators } from "../types";
@@ -116,8 +117,7 @@ function specWithEmulatorServer(protocol: string, host: string | undefined): Ope
  */
 export async function createApp(
   defaultProjectId: string,
-  singleProjectModeWarning = false,
-  singleProjectModeError = false,
+  singleProjectMode = SingleProjectMode.NO_WARNING,
   projectStateForId = new Map<string, AgentProjectState>()
 ): Promise<express.Express> {
   const app = express();
@@ -366,7 +366,7 @@ export async function createApp(
     let agentState = projectStateForId.get(projectId);
 
     if (
-      (singleProjectModeWarning || singleProjectModeError) &&
+      singleProjectMode !== SingleProjectMode.NO_WARNING &&
       projectId &&
       defaultProjectId !== projectId
     ) {
@@ -377,7 +377,7 @@ export async function createApp(
         `single project mode add/set the \'"single_project_mode"\' false' property in the` +
         ` firebase.json emulators config.`;
       EmulatorLogger.forEmulator(Emulators.AUTH).log("WARN", errorString);
-      if (singleProjectModeError) {
+      if (singleProjectMode === SingleProjectMode.ERROR) {
         throw new BadRequestError(errorString);
       }
     }

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -18,7 +18,7 @@ import {
 import { Constants, FIND_AVAILBLE_PORT_BY_DEFAULT } from "./constants";
 import { EmulatableBackend, FunctionsEmulator } from "./functionsEmulator";
 import { parseRuntimeVersion } from "./functionsEmulatorUtils";
-import { AuthEmulator } from "./auth";
+import { AuthEmulator, SingleProjectMode } from "./auth";
 import { DatabaseEmulator, DatabaseEmulatorArgs } from "./databaseEmulator";
 import { FirestoreEmulator, FirestoreEmulatorArgs } from "./firestoreEmulator";
 import { HostingEmulator } from "./hostingEmulator";
@@ -390,6 +390,9 @@ export async function startAll(
   // 2) If the --only flag is passed, then this list is the intersection
   const targets = filterEmulatorTargets(options);
   options.targets = targets;
+  const singleProjectModeEnabled =
+    options.config.src.emulators?.singleProjectMode === undefined ||
+    options.config.src.emulators?.singleProjectMode;
 
   if (targets.length === 0) {
     throw new FirebaseError(
@@ -678,10 +681,7 @@ export async function startAll(
     }
 
     // undefined in the config defaults to setting single_project_mode.
-    if (
-      options.config.src.emulators?.singleProjectMode === undefined ||
-      options.config.src.emulators?.singleProjectMode
-    ) {
+    if (singleProjectModeEnabled) {
       if (projectId) {
         args.single_project_mode = true;
         args.single_project_mode_error = false;
@@ -792,6 +792,9 @@ export async function startAll(
       host: authAddr.host,
       port: authAddr.port,
       projectId,
+      singleProjectMode: singleProjectModeEnabled
+        ? SingleProjectMode.WARNING
+        : SingleProjectMode.NO_WARNING,
     });
     await startEmulator(authEmulator);
 

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -345,12 +345,45 @@ describeAuthEmulator("createSessionCookie", ({ authApi }) => {
   });
 });
 
+describeAuthEmulator(
+  "accounts:lookup",
+  ({ authApi }) => {
+    it("should throw exception when project ID doesn't match the defaultProjectId", async () => {
+      const { localId } = await registerAnonUser(authApi());
+
+      await authApi()
+        .post(`/identitytoolkit.googleapis.com/v1/projects/someprojectid/accounts:lookup`)
+        .set("Authorization", "Bearer owner")
+        .send({ localId: [localId] })
+        .then((res) => {
+          expectStatusCode(400, res);
+          expect(res.body.error.message).to.contain("Single project mode enabled");
+        });
+    });
+  },
+  /* singleProjectMode= */ true
+);
+
 describeAuthEmulator("accounts:lookup", ({ authApi }) => {
   it("should return user by localId when privileged", async () => {
     const { localId } = await registerAnonUser(authApi());
 
     await authApi()
       .post(`/identitytoolkit.googleapis.com/v1/projects/${PROJECT_ID}/accounts:lookup`)
+      .set("Authorization", "Bearer owner")
+      .send({ localId: [localId] })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.users).to.have.length(1);
+        expect(res.body.users[0].localId).to.equal(localId);
+      });
+  });
+
+  it("should not throw an exception on project ID mismatch if singleProjectMode is false", async () => {
+    const { localId } = await registerAnonUser(authApi());
+
+    await authApi()
+      .post(`/identitytoolkit.googleapis.com/v1/projects/someprojectid/accounts:lookup`)
       .set("Authorization", "Bearer owner")
       .send({ localId: [localId] })
       .then((res) => {

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -27,6 +27,7 @@ import {
   SESSION_COOKIE_MAX_VALID_DURATION,
 } from "../../../emulator/auth/operations";
 import { toUnixTimestamp } from "../../../emulator/auth/utils";
+import { SingleProjectMode } from "../../../emulator/auth";
 
 describeAuthEmulator("token refresh", ({ authApi, getClock }) => {
   it("should exchange refresh token for new tokens", async () => {
@@ -554,7 +555,7 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
       });
   });
 
-  it("should not throw an exception on project ID mismatch if singleProjectMode is false", async () => {
+  it("should not throw an exception on project ID mismatch if singleProjectMode is NO_WARNING", async () => {
     await authApi()
       .get(`/emulator/v1/projects/someproject/config`) // note the "wrong" project ID here
       .send()
@@ -586,9 +587,9 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
 });
 
 describeAuthEmulator(
-  "emulator utility API; singleProjectMode=true",
+  "emulator utility API; singleProjectMode=ERROR",
   ({ authApi }) => {
-    it("should throw an exception on project ID mismatch if singleProjectMode is true", async () => {
+    it("should throw an exception on project ID mismatch if singleProjectMode is ERROR", async () => {
       await authApi()
         .get(`/emulator/v1/projects/someproject/config`) // note the "wrong" project ID here
         .send()
@@ -598,5 +599,5 @@ describeAuthEmulator(
         });
     });
   },
-  /* singleProjectMode= */ true
+  SingleProjectMode.ERROR
 );

--- a/src/test/emulators/auth/setup.ts
+++ b/src/test/emulators/auth/setup.ts
@@ -41,17 +41,19 @@ export type AuthTestUtils = {
 };
 
 // Keep a global auth server since start-up takes too long:
-let cachedAuthApp: Express.Application;
+const cachedAuthAppMap = new Map<boolean, Express.Application>();
 const projectStateForId = new Map<string, AgentProjectState>();
 
 async function createOrReuseApp(singleProjectMode: boolean): Promise<Express.Application> {
-  if (!cachedAuthApp) {
+  let cachedAuthApp: Express.Application | undefined = cachedAuthAppMap.get(singleProjectMode);
+  if (cachedAuthApp === undefined) {
     cachedAuthApp = await createApp(
       PROJECT_ID,
       singleProjectMode,
       singleProjectMode,
       projectStateForId
     );
+    cachedAuthAppMap.set(singleProjectMode, cachedAuthApp);
   }
   // Clear the state every time to make it work like brand new.
   // NOTE: This probably won't work with parallel mode if we ever enable it.

--- a/src/test/emulators/auth/setup.ts
+++ b/src/test/emulators/auth/setup.ts
@@ -14,13 +14,14 @@ export const PROJECT_ID = "example";
  */
 export function describeAuthEmulator(
   title: string,
-  fn: (this: Suite, utils: AuthTestUtils) => void
+  fn: (this: Suite, utils: AuthTestUtils) => void,
+  singleProjectMode = false
 ): Suite {
   return describe(`Auth Emulator: ${title}`, function (this) {
     let authApp: Express.Application;
     beforeEach("setup or reuse auth server", async function (this) {
       this.timeout(20000);
-      authApp = await createOrReuseApp();
+      authApp = await createOrReuseApp(singleProjectMode);
     });
 
     let clock: sinon.SinonFakeTimers;
@@ -43,9 +44,14 @@ export type AuthTestUtils = {
 let cachedAuthApp: Express.Application;
 const projectStateForId = new Map<string, AgentProjectState>();
 
-async function createOrReuseApp(): Promise<Express.Application> {
+async function createOrReuseApp(singleProjectMode: boolean): Promise<Express.Application> {
   if (!cachedAuthApp) {
-    cachedAuthApp = await createApp(PROJECT_ID, projectStateForId);
+    cachedAuthApp = await createApp(
+      PROJECT_ID,
+      singleProjectMode,
+      singleProjectMode,
+      projectStateForId
+    );
   }
   // Clear the state every time to make it work like brand new.
   // NOTE: This probably won't work with parallel mode if we ever enable it.


### PR DESCRIPTION
Single project mode for the Auth emulator. If singleProjectMode is set, the emulator will reject calls for project IDs that aren't the default project ID.

