### PR TITLE
Update GCF v2 API call to include filter condition for listing v2 functions

### DIFF
--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -1,6 +1,6 @@
 import * as clc from "colorette";
 
-import { Client } from "../apiv2";
+import { Client, ClientVerbOptions } from "../apiv2";
 import { FirebaseError } from "../error";
 import { functionsV2Origin } from "../api";
 import { logger } from "../logger";
@@ -19,7 +19,7 @@ import {
   HASH_LABEL,
 } from "../functions/constants";
 
-export const API_VERSION = "v2alpha";
+export const API_VERSION = "v2";
 
 const client = new Client({
   urlPrefix: functionsV2Origin,
@@ -351,7 +351,11 @@ async function listFunctionsInternal(
   let pageToken = "";
   while (true) {
     const url = `projects/${projectId}/locations/${region}/functions`;
-    const opts = pageToken === "" ? {} : { queryParams: { pageToken } };
+    // V2 API returns both V1 and V2 Functions. Add filter condition to return only V2 functions.
+    const opts: ClientVerbOptions = { queryParams: { filter: `environment="GEN_2"` } };
+    if (pageToken !== "") {
+      opts.queryParams = { ...opts.queryParams, pageToken };
+    }
     const res = await client.get<Response>(url, opts);
     functions.push(...(res.body.functions || []));
     for (const region of res.body.unreachable || []) {


### PR DESCRIPTION
GCF CP is going to return both 1st Gen and 2nd Gen functions (2-3 weeks) in the ListFunctions API and now require specific filter condition for the API to return only the V2 functions as before.

We update the listFunctions API to include a filter condition to fetch only the v2 functions as done prior to the change. 

Consequently making an update to use the latest, stable v2 api endpoint for GCF V2 calls.
