### PR TITLE
Update GitHub Action envrionment to match Cloud Build environment.

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -6,6 +6,7 @@ on:
 
 env:
   CI: true
+  NO_COLOR: true
 
 permissions:
   contents: read


### PR DESCRIPTION
More than once we've been bitten with Cloud Build release environment setting `NO_COLORS` environment variable to suppress output coloring. Release script halt because of unit test failure whereas the team happily merged the  breaking changes with passing test results.

Let's match the Cloud Build and GitHub Actions environment to avoid this problem.