### PR TITLE
Update customClaims and sessionClaims type to record

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -3088,8 +3088,9 @@ function processBlockingFunctionResponse(
           updates[field] = !!userRecord[field];
           break;
         case "customClaims":
-          validateSerializedCustomClaims(userRecord.customClaims!);
-          updates.customAttributes = userRecord.customClaims;
+          const customClaims = JSON.stringify(userRecord.customClaims!);
+          validateSerializedCustomClaims(customClaims);
+          updates.customAttributes = customClaims;
           break;
         // Session claims are only returned in beforeSignIn and will be ignored
         // otherwise. For more info, see
@@ -3099,7 +3100,7 @@ function processBlockingFunctionResponse(
             break;
           }
           try {
-            extraClaims = JSON.parse(userRecord.sessionClaims!);
+            extraClaims = userRecord.sessionClaims;
           } catch {
             throw new BadRequestError(
               "BLOCKING_FUNCTION_ERROR_RESPONSE: ((Response has malformed session claims.))"
@@ -3388,8 +3389,8 @@ export interface BlockingFunctionResponsePayload {
     photoUrl?: string;
     disabled?: boolean;
     emailVerified?: boolean;
-    customClaims?: string;
-    sessionClaims?: string;
+    customClaims?: Record<string, unknown>;
+    sessionClaims?: Record<string, unknown>;
   };
 }
 

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -346,7 +346,7 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
+            customClaims: { customAttribute: "custom" },
           },
         });
 
@@ -504,7 +504,7 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: false,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
+            customClaims: { customAttribute: "custom" },
           },
         })
         .post(BEFORE_SIGN_IN_PATH, (parsedBody) => {
@@ -568,8 +568,8 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
       const email = "alice@example.com";
@@ -627,7 +627,7 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
             displayName: "oldDisplayName",
             photoUrl: "oldPhotoUrl",
             emailVerified: false,
-            customClaims: JSON.stringify({ customAttribute: "oldCustom" }),
+            customClaims: { customAttribute: "oldCustom" },
           },
         })
         .post(BEFORE_SIGN_IN_PATH)
@@ -637,8 +637,8 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
       const email = "alice@example.com";
@@ -696,8 +696,8 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 

--- a/src/test/emulators/auth/idp.spec.ts
+++ b/src/test/emulators/auth/idp.spec.ts
@@ -1164,7 +1164,7 @@ describeAuthEmulator("sign-in with credential", ({ authApi, getClock }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
+            customClaims: { customAttribute: "custom" },
           },
         });
 
@@ -1225,8 +1225,8 @@ describeAuthEmulator("sign-in with credential", ({ authApi, getClock }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 
@@ -1291,7 +1291,7 @@ describeAuthEmulator("sign-in with credential", ({ authApi, getClock }) => {
             displayName: "oldDisplayName",
             photoUrl: "oldPhotoUrl",
             emailVerified: false,
-            customClaims: JSON.stringify({ customAttribute: "oldCustom" }),
+            customClaims: { customAttribute: "oldCustom" },
           },
         })
         .post(BEFORE_SIGN_IN_PATH)
@@ -1301,8 +1301,8 @@ describeAuthEmulator("sign-in with credential", ({ authApi, getClock }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 
@@ -1373,8 +1373,8 @@ describeAuthEmulator("sign-in with credential", ({ authApi, getClock }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 

--- a/src/test/emulators/auth/mfa.spec.ts
+++ b/src/test/emulators/auth/mfa.spec.ts
@@ -540,8 +540,8 @@ describeAuthEmulator("mfa enrollment", ({ authApi, getClock }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 

--- a/src/test/emulators/auth/password.spec.ts
+++ b/src/test/emulators/auth/password.spec.ts
@@ -251,8 +251,8 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 

--- a/src/test/emulators/auth/phone.spec.ts
+++ b/src/test/emulators/auth/phone.spec.ts
@@ -451,7 +451,7 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
+            customClaims: { customAttribute: "custom" },
           },
         });
       const phoneNumber = TEST_PHONE_NUMBER;
@@ -514,8 +514,8 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
       const phoneNumber = TEST_PHONE_NUMBER;
@@ -582,7 +582,7 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
             displayName: "oldDisplayName",
             photoUrl: "oldPhotoUrl",
             emailVerified: false,
-            customClaims: JSON.stringify({ customAttribute: "oldCustom" }),
+            customClaims: { customAttribute: "oldCustom" },
           },
         })
         .post(BEFORE_SIGN_IN_PATH)
@@ -592,8 +592,8 @@ describeAuthEmulator("phone auth sign-in", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
       const phoneNumber = TEST_PHONE_NUMBER;

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -611,7 +611,7 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
+            customClaims: { customAttribute: "custom" },
           },
         });
 
@@ -666,8 +666,8 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 
@@ -726,7 +726,7 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
             displayName: "oldDisplayName",
             photoUrl: "oldPhotoUrl",
             emailVerified: false,
-            customClaims: JSON.stringify({ customAttribute: "oldCustom" }),
+            customClaims: { customAttribute: "oldCustom" },
           },
         })
         .post(BEFORE_SIGN_IN_PATH)
@@ -736,8 +736,8 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
             displayName: DISPLAY_NAME,
             photoUrl: PHOTO_URL,
             emailVerified: true,
-            customClaims: JSON.stringify({ customAttribute: "custom" }),
-            sessionClaims: JSON.stringify({ sessionAttribute: "session" }),
+            customClaims: { customAttribute: "custom" },
+            sessionClaims: { sessionAttribute: "session" },
           },
         });
 


### PR DESCRIPTION
### Description

Confirmed w/ @colerogers that custom claims from blocking functions response would be an object. This change updates both custom and session claims to reflect that. 

Addresses https://github.com/firebase/firebase-tools/issues/4946

### Scenarios Tested

`npm run test` passes

### Sample Commands

N/A