### PR TITLE
Define updateService to make run updates feel strongly consistent

### DIFF
--- a/src/gcp/run.ts
+++ b/src/gcp/run.ts
@@ -3,6 +3,8 @@ import { FirebaseError } from "../error";
 import { runOrigin } from "../api";
 import * as proto from "./proto";
 import * as iam from "./iam";
+import { backoff } from "../throttler/throttler";
+import { logger } from "../logger";
 
 const API_VERSION = "v1";
 
@@ -104,12 +106,12 @@ export interface RevisionTemplate {
 }
 
 export interface TrafficTarget {
-  configurationName: string;
+  configurationName?: string;
   // RevisionName can be used to target a specific revision,
   // or customers can set latestRevision = true
-  revisionName?: string;
+  revisionName: string;
   latestRevision?: boolean;
-  percent: number;
+  percent?: number; // optional when tagged
   tag?: string;
 
   // Output only:
@@ -140,14 +142,68 @@ export async function getService(name: string): Promise<Service> {
 }
 
 /**
- * Replaces a service spec.
+ * Update a service and wait for changes to replicate.
+ */
+export async function updateService(name: string, service: Service): Promise<Service> {
+  delete service.status;
+  delete (service.spec.template.metadata as any).name;
+  service = await exports.replaceService(name, service);
+
+  // Now we need to wait for reconciliation or we might delete the docker
+  // image while the service is still rolling out a new revision.
+  let retry = 0;
+  while (!exports.serviceIsResolved(service)) {
+    await backoff(retry, 2, 30);
+    retry = retry + 1;
+    service = await exports.getService(name);
+  }
+  return service;
+}
+
+/**
+ * Returns whether a service is resolved (all transitions have completed).
+ */
+export function serviceIsResolved(service: Service): boolean {
+  if (service.status?.observedGeneration !== service.metadata.generation) {
+    logger.debug(
+      `Service ${service.metadata.name} is not resolved because` +
+        `observed generation ${service.status?.observedGeneration} does not ` +
+        `match spec generation ${service.metadata.generation}`
+    );
+    return false;
+  }
+  const readyCondition = service.status?.conditions?.find((condition) => {
+    return condition.type === "Ready";
+  });
+
+  if (readyCondition?.status === "Unknown") {
+    logger.debug(
+      `Waiting for service ${service.metadata.name} to be ready. ` +
+        `Status is ${JSON.stringify(service.status?.conditions)}`
+    );
+    return false;
+  } else if (readyCondition?.status === "True") {
+    return true;
+  }
+  logger.debug(
+    `Service ${service.metadata.name} has unexpected ready status ${JSON.stringify(
+      readyCondition
+    )}. It may have failed rollout.`
+  );
+  throw new FirebaseError(
+    `Unexpected Status ${readyCondition?.status} for service ${service.metadata.name}`
+  );
+}
+
+/**
+ * Replaces a service spec. Prefer updateService to block on replication.
  */
 export async function replaceService(name: string, service: Service): Promise<Service> {
   try {
     const response = await client.put<Service, Service>(name, service);
     return response.body;
   } catch (err: any) {
-    throw new FirebaseError(`Failed to update Run service ${name}`, {
+    throw new FirebaseError(`Failed to replace Run service ${name}`, {
       original: err,
     });
   }

--- a/src/test/gcp/run.spec.ts
+++ b/src/test/gcp/run.spec.ts
@@ -270,4 +270,186 @@ describe("run", () => {
       });
     });
   });
+  describe("updateService", () => {
+    let service: run.Service;
+    let serviceIsResolved: sinon.SinonStub;
+    let replaceService: sinon.SinonStub;
+    let getService: sinon.SinonStub;
+
+    beforeEach(() => {
+      serviceIsResolved = sinon
+        .stub(run, "serviceIsResolved")
+        .throws(new Error("Unexpected serviceIsResolved call"));
+      replaceService = sinon
+        .stub(run, "replaceService")
+        .throws(new Error("Unexpected replaceService call"));
+      getService = sinon.stub(run, "getService").throws(new Error("Unexpected getService call"));
+
+      service = {
+        apiVersion: "serving.knative.dev/v1",
+        kind: "Service",
+        metadata: {
+          name: "service",
+          namespace: "project",
+        },
+        spec: {
+          template: {
+            metadata: {
+              name: "service",
+              namespace: "project",
+            },
+            spec: {
+              containerConcurrency: 1,
+              containers: [
+                {
+                  image: "image",
+                  ports: [
+                    {
+                      name: "main",
+                      containerPort: 8080,
+                    },
+                  ],
+                  env: {},
+                  resources: {
+                    limits: {
+                      memory: "256M",
+                      cpu: "0.1667",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          traffic: [],
+        },
+      };
+    });
+
+    afterEach(() => {
+      serviceIsResolved.restore();
+      getService.restore();
+      replaceService.restore();
+    });
+
+    it("handles noops immediately", async () => {
+      replaceService.resolves(service);
+      getService.resolves(service);
+      serviceIsResolved.returns(true);
+      await run.updateService("name", service);
+
+      expect(replaceService).to.have.been.calledOnce;
+      expect(serviceIsResolved).to.have.been.calledOnce;
+      expect(getService).to.not.have.been.called;
+    });
+
+    it("loops on ready status", async () => {
+      replaceService.resolves(service);
+      getService.resolves(service);
+      serviceIsResolved.onFirstCall().returns(false);
+      serviceIsResolved.onSecondCall().returns(true);
+      await run.updateService("name", service);
+
+      expect(replaceService).to.have.been.calledOnce;
+      expect(serviceIsResolved).to.have.been.calledTwice;
+      expect(getService).to.have.been.calledOnce;
+    });
+  });
+
+  describe("serviceIsResolved", () => {
+    let service: run.Service;
+    beforeEach(() => {
+      service = {
+        apiVersion: "serving.knative.dev/v1",
+        kind: "Service",
+        metadata: {
+          name: "service",
+          namespace: "project",
+          generation: 2,
+        },
+        spec: {
+          template: {
+            metadata: {
+              name: "service",
+              namespace: "project",
+            },
+            spec: {
+              containerConcurrency: 1,
+              containers: [
+                {
+                  image: "image",
+                  ports: [
+                    {
+                      name: "main",
+                      containerPort: 8080,
+                    },
+                  ],
+                  env: {},
+                  resources: {
+                    limits: {
+                      memory: "256M",
+                      cpu: "0.1667",
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          traffic: [],
+        },
+        status: {
+          observedGeneration: 2,
+          conditions: [
+            {
+              status: "True",
+              type: "Ready",
+              reason: "Testing",
+              lastTransitionTime: "",
+              message: "",
+              severity: "Info",
+            },
+          ],
+          latestCreatedRevisionName: "",
+          latestRevisionName: "",
+          traffic: [],
+          url: "",
+          address: {
+            url: "",
+          },
+        },
+      };
+    });
+
+    it("returns false if the observed generation isn't the metageneration", () => {
+      service.status!.observedGeneration = 1;
+      service.metadata.generation = 2;
+      expect(run.serviceIsResolved(service)).to.be.false;
+    });
+
+    it("returns false if the status is not ready", () => {
+      service.status!.observedGeneration = 2;
+      service.metadata.generation = 2;
+      service.status!.conditions[0].status = "Unknown";
+      service.status!.conditions[0].type = "Ready";
+
+      expect(run.serviceIsResolved(service)).to.be.false;
+    });
+
+    it("throws if we have an failed status", () => {
+      service.status!.observedGeneration = 2;
+      service.metadata.generation = 2;
+      service.status!.conditions[0].status = "False";
+      service.status!.conditions[0].type = "Ready";
+
+      expect(() => run.serviceIsResolved(service)).to.throw;
+    });
+
+    it("returns true if resolved", () => {
+      service.status!.observedGeneration = 2;
+      service.metadata.generation = 2;
+      service.status!.conditions[0].status = "True";
+      service.status!.conditions[0].type = "Ready";
+
+      expect(run.serviceIsResolved(service)).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
This is a fragment of the monster monolith that is #5015. In that PR I want the ability to modify run instances and I need the ability to wait for changes to propagate. This is already part of `fabricator`, so I just move that utility into `gcp/run.ts`. I call it `updateService` since it acts like a normal GCP update command, but just manages the replaceService and eventual consistency delays.

Feel free to scan through this one. It's basically a cut & paste PR.