### PR TITLE
cache the emulators that are downloaded

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -99,7 +99,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.FIREBASE_EMULATORS_PATH }}
-          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('emulator-cache/**') }}
+          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}
         continue-on-error: true
 
       - run: npm i -g npm@8.7
@@ -160,7 +160,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.FIREBASE_EMULATORS_PATH }}
-          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('emulator-cache/**') }}
+          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}
         continue-on-error: true
 
       - run: echo ${{ secrets.service_account_json_base64 }} > tmp.txt

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -100,6 +100,8 @@ jobs:
         with:
           path: ${{ env.FIREBASE_EMULATORS_PATH }}
           key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-firebase-emulators-
         continue-on-error: true
 
       - run: npm i -g npm@8.7
@@ -161,6 +163,8 @@ jobs:
         with:
           path: ${{ env.FIREBASE_EMULATORS_PATH }}
           key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}
+          restore-keys: |
+            ${{ runner.os }}-firebase-emulators-
         continue-on-error: true
 
       - run: echo ${{ secrets.service_account_json_base64 }} > tmp.txt

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -99,8 +99,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.FIREBASE_EMULATORS_PATH }}
-          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}
+          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}-${{ hashFiles('emulator-cache/**') }}
           restore-keys: |
+            ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}-
             ${{ runner.os }}-firebase-emulators-
         continue-on-error: true
 
@@ -162,8 +163,9 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{ env.FIREBASE_EMULATORS_PATH }}
-          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}
+          key: ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}-${{ hashFiles('emulator-cache/**') }}
           restore-keys: |
+            ${{ runner.os }}-firebase-emulators-${{ hashFiles('src/emulator/downloadableEmulators.ts') }}-
             ${{ runner.os }}-firebase-emulators-
         continue-on-error: true
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

The cache key, when there's no cache, is being generated with the hash being "", which isn't so useful. Since we specify what downloads we need in `downloadableEmulators.ts`, let's just use the hash of that file as the key!
