### PR TITLE
[Function-NoOp] Enable Skipping NoOp Deploys by Default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Add the "experiments" family of commands (#4994)
+- Enable detecting and skipping no-op function deploys (#5032).

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -29,7 +29,6 @@ import { FirebaseError } from "../../error";
 import { configForCodebase, normalizeAndValidate } from "../../functions/projectConfig";
 import { AUTH_BLOCKING_EVENTS } from "../../functions/events/v1";
 import { generateServiceIdentity } from "../../gcp/serviceusage";
-import * as experiments from "../../experiments";
 import { applyBackendHashToBackends } from "./cache/applyHash";
 import { allEndpoints, Backend } from "./backend";
 
@@ -272,9 +271,7 @@ export async function prepare(
    * This must be called after `await validate.secretsAreValid`.
    */
   updateEndpointTargetedStatus(wantBackends, context.filters || []);
-  if (experiments.isEnabled("skipdeployingnoopfunctions")) {
-    applyBackendHashToBackends(wantBackends, context);
-  }
+  applyBackendHashToBackends(wantBackends, context);
 }
 
 /**

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -10,7 +10,6 @@ import { FirebaseError } from "../../../error";
 import * as utils from "../../../utils";
 import * as backend from "../backend";
 import * as v2events from "../../../functions/events/v2";
-import * as experiments from "../../../experiments";
 
 export interface EndpointUpdate {
   endpoint: backend.Endpoint;
@@ -56,12 +55,9 @@ export function calculateChangesets(
     keyFn
   );
 
-  const skipdeployingnoopfunctions = experiments.isEnabled("skipdeployingnoopfunctions");
-
   // If the hashes are matching, that means the local function is the same as the server copy.
   const toSkipPredicate = (id: string): boolean =>
     !!(
-      skipdeployingnoopfunctions &&
       !want[id].targetedByOnly && // Don't skip the function if its --only targeted.
       have[id].hash &&
       want[id].hash &&

--- a/src/test/deploy/functions/release/planner.spec.ts
+++ b/src/test/deploy/functions/release/planner.spec.ts
@@ -6,7 +6,6 @@ import * as planner from "../../../../deploy/functions/release/planner";
 import * as deploymentTool from "../../../../deploymentTool";
 import * as utils from "../../../../utils";
 import * as v2events from "../../../../functions/events/v2";
-import * as experiments from "../../../../experiments";
 
 describe("planner", () => {
   let logLabeledBullet: sinon.SinonStub;
@@ -16,12 +15,10 @@ describe("planner", () => {
   }
 
   beforeEach(() => {
-    experiments.setEnabled("skipdeployingnoopfunctions", true);
     logLabeledBullet = sinon.stub(utils, "logLabeledBullet");
   });
 
   afterEach(() => {
-    experiments.setEnabled("skipdeployingnoopfunctions", false);
     sinon.verifyAndRestore();
   });
 
@@ -225,33 +222,6 @@ describe("planner", () => {
       });
     });
 
-    it("does not add endpoints to skip list if preview flag is false", () => {
-      // Note: the two functions share the same id
-      const updatedWant = func("updated", "region");
-      const updatedHave = func("updated", "region");
-      // But their hash are the same (aka a no-op function)
-      updatedWant.hash = "to_skip";
-      updatedHave.hash = "to_skip";
-
-      experiments.setEnabled("skipdeployingnoopfunctions", false);
-
-      const want = { updated: updatedWant };
-      const have = { updated: updatedHave };
-
-      expect(planner.calculateChangesets(want, have, (e) => e.region)).to.deep.equal({
-        region: {
-          endpointsToCreate: [],
-          endpointsToUpdate: [
-            {
-              endpoint: updatedWant,
-            },
-          ],
-          endpointsToDelete: [],
-          endpointsToSkip: [],
-        },
-      });
-    });
-
     it("does not add endpoints to skip list if not targeted for deploy", () => {
       // Note: the two functions share the same id
       const updatedWant = func("updated", "region");
@@ -260,8 +230,6 @@ describe("planner", () => {
       updatedWant.hash = "to_skip";
       updatedHave.hash = "to_skip";
       updatedWant.targetedByOnly = true;
-
-      experiments.setEnabled("skipdeployingnoopfunctions", true);
 
       const want = { updated: updatedWant };
       const have = { updated: updatedHave };


### PR DESCRIPTION
### Description

This commit flips the "skip no-op deploys" flag to default to `true`.

When enabled, `firebase deploy` will compare the last deployed instances of a function with the current copy and, if they are the same, will skip uploading and deploying the function.