### PR TITLE
use concurrency to automatically cancel older runs on branches

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -11,6 +11,11 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  # node-test-[branch], typically. Will cancel previous runs that match.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 concurrency:
-  # node-test-[pull_request|push]-[branch], typically. Will cancel previous runs that match.
+  # node-test-[pull_request|push]-[branch], typically. Will cancel previous runs that match!
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -12,8 +12,8 @@ permissions:
   contents: read
 
 concurrency:
-  # node-test-[branch], typically. Will cancel previous runs that match.
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  # node-test-[pull_request|push]-[branch], typically. Will cancel previous runs that match.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Does what it says on the box.  https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency

Will cancel already running workflows when a new commit is pushed either for a branch or PR