### PR TITLE
Adds emulator support for v2 rtdb triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Add functions emulator support for RTDB v2 triggers (#5045).

--- a/scripts/integration-helpers/framework.ts
+++ b/scripts/integration-helpers/framework.ts
@@ -23,6 +23,10 @@ const STORAGE_BUCKET_FUNCTION_V2_FINALIZED_LOG =
   "========== STORAGE BUCKET V2 FUNCTION FINALIZED ==========";
 const STORAGE_BUCKET_FUNCTION_V2_METADATA_LOG =
   "========== STORAGE BUCKET V2 FUNCTION METADATA ==========";
+const RTDB_V2_WRITTEN_LOG = "========== RTDB V2 FUNCTION WRITTEN ==========";
+const RTDB_V2_CREATED_LOG = "========== RTDB V2 FUNCTION CREATED ==========";
+const RTDB_V2_UPDATED_LOG = "========== RTDB V2 FUNCTION UPDATED ==========";
+const RTDB_V2_DELETED_LOG = "========== RTDB V2 FUNCTION DELETED ==========";
 /* Functions V1 */
 const RTDB_FUNCTION_LOG = "========== RTDB FUNCTION ==========";
 const FIRESTORE_FUNCTION_LOG = "========== FIRESTORE FUNCTION ==========";
@@ -141,6 +145,10 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
   storageBucketV2MetadataTriggerCount = 0;
   authBlockingCreateV2TriggerCount = 0;
   authBlockingSignInV2TriggerCount = 0;
+  rtdbV2WrittenTriggerCount = 0;
+  rtdbV2CreatedTriggerCount = 0;
+  rtdbV2UpdatedTriggerCount = 0;
+  rtdbV2DeletedTriggerCount = 0;
 
   rtdbFromFirestore = false;
   firestoreFromRtdb = false;
@@ -176,6 +184,10 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
     this.storageBucketV2MetadataTriggerCount = 0;
     this.authBlockingCreateV2TriggerCount = 0;
     this.authBlockingSignInV2TriggerCount = 0;
+    this.rtdbV2WrittenTriggerCount = 0;
+    this.rtdbV2CreatedTriggerCount = 0;
+    this.rtdbV2UpdatedTriggerCount = 0;
+    this.rtdbV2DeletedTriggerCount = 0;
   }
 
   /*
@@ -268,6 +280,18 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
       if (data.includes(AUTH_BLOCKING_SIGN_IN_V2_LOG)) {
         this.authBlockingSignInV2TriggerCount++;
       }
+      if (data.includes(RTDB_V2_WRITTEN_LOG)) {
+        this.rtdbV2WrittenTriggerCount++;
+      }
+      if (data.includes(RTDB_V2_CREATED_LOG)) {
+        this.rtdbV2CreatedTriggerCount++;
+      }
+      if (data.includes(RTDB_V2_UPDATED_LOG)) {
+        this.rtdbV2UpdatedTriggerCount++;
+      }
+      if (data.includes(RTDB_V2_DELETED_LOG)) {
+        this.rtdbV2DeletedTriggerCount++;
+      }
     });
 
     return startEmulators;
@@ -338,8 +362,8 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
     return this.invokeHttpFunction("signInUserFromAuth");
   }
 
-  writeToRtdb(): Promise<Response> {
-    return this.invokeHttpFunction("writeToRtdb");
+  writeUpdateDeleteToRtdb(): Promise<Response> {
+    return this.invokeHttpFunction("writeUpdateDeleteToRtdb");
   }
 
   writeToFirestore(): Promise<Response> {

--- a/scripts/integration-helpers/framework.ts
+++ b/scripts/integration-helpers/framework.ts
@@ -23,10 +23,7 @@ const STORAGE_BUCKET_FUNCTION_V2_FINALIZED_LOG =
   "========== STORAGE BUCKET V2 FUNCTION FINALIZED ==========";
 const STORAGE_BUCKET_FUNCTION_V2_METADATA_LOG =
   "========== STORAGE BUCKET V2 FUNCTION METADATA ==========";
-const RTDB_V2_WRITTEN_LOG = "========== RTDB V2 FUNCTION WRITTEN ==========";
-const RTDB_V2_CREATED_LOG = "========== RTDB V2 FUNCTION CREATED ==========";
-const RTDB_V2_UPDATED_LOG = "========== RTDB V2 FUNCTION UPDATED ==========";
-const RTDB_V2_DELETED_LOG = "========== RTDB V2 FUNCTION DELETED ==========";
+const RTDB_V2_FUNCTION_LOG = "========== RTDB V2 FUNCTION ==========";
 /* Functions V1 */
 const RTDB_FUNCTION_LOG = "========== RTDB FUNCTION ==========";
 const FIRESTORE_FUNCTION_LOG = "========== FIRESTORE FUNCTION ==========";
@@ -145,10 +142,7 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
   storageBucketV2MetadataTriggerCount = 0;
   authBlockingCreateV2TriggerCount = 0;
   authBlockingSignInV2TriggerCount = 0;
-  rtdbV2WrittenTriggerCount = 0;
-  rtdbV2CreatedTriggerCount = 0;
-  rtdbV2UpdatedTriggerCount = 0;
-  rtdbV2DeletedTriggerCount = 0;
+  rtdbV2TriggerCount = 0;
 
   rtdbFromFirestore = false;
   firestoreFromRtdb = false;
@@ -184,10 +178,7 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
     this.storageBucketV2MetadataTriggerCount = 0;
     this.authBlockingCreateV2TriggerCount = 0;
     this.authBlockingSignInV2TriggerCount = 0;
-    this.rtdbV2WrittenTriggerCount = 0;
-    this.rtdbV2CreatedTriggerCount = 0;
-    this.rtdbV2UpdatedTriggerCount = 0;
-    this.rtdbV2DeletedTriggerCount = 0;
+    this.rtdbV2TriggerCount = 0;
   }
 
   /*
@@ -280,17 +271,8 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
       if (data.includes(AUTH_BLOCKING_SIGN_IN_V2_LOG)) {
         this.authBlockingSignInV2TriggerCount++;
       }
-      if (data.includes(RTDB_V2_WRITTEN_LOG)) {
-        this.rtdbV2WrittenTriggerCount++;
-      }
-      if (data.includes(RTDB_V2_CREATED_LOG)) {
-        this.rtdbV2CreatedTriggerCount++;
-      }
-      if (data.includes(RTDB_V2_UPDATED_LOG)) {
-        this.rtdbV2UpdatedTriggerCount++;
-      }
-      if (data.includes(RTDB_V2_DELETED_LOG)) {
-        this.rtdbV2DeletedTriggerCount++;
+      if (data.includes(RTDB_V2_FUNCTION_LOG)) {
+        this.rtdbV2TriggerCount++;
       }
     });
 
@@ -362,8 +344,8 @@ export class TriggerEndToEndTest extends EmulatorEndToEndTest {
     return this.invokeHttpFunction("signInUserFromAuth");
   }
 
-  writeUpdateDeleteToRtdb(): Promise<Response> {
-    return this.invokeHttpFunction("writeUpdateDeleteToRtdb");
+  writeToRtdb(): Promise<Response> {
+    return this.invokeHttpFunction("writeToRtdb");
   }
 
   writeToFirestore(): Promise<Response> {

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -126,7 +126,7 @@ describe("function triggers", () => {
     it("should write to the database emulator", async function (this) {
       this.timeout(EMULATOR_TEST_TIMEOUT);
 
-      const response = await test.writeToRtdb();
+      const response = await test.writeUpdateDeleteToRtdb();
       expect(response.status).to.equal(200);
     });
 
@@ -148,6 +148,10 @@ describe("function triggers", () => {
 
     it("should have have triggered cloud functions", () => {
       expect(test.rtdbTriggerCount).to.equal(1);
+      expect(test.rtdbV2WrittenTriggerCount).to.eq(1);
+      expect(test.rtdbV2CreatedTriggerCount).to.eq(1);
+      expect(test.rtdbV2UpdatedTriggerCount).to.eq(1);
+      expect(test.rtdbV2DeletedTriggerCount).to.eq(1);
       expect(test.firestoreTriggerCount).to.equal(1);
       /*
        * Check for the presence of all expected documents in the firestore

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -115,7 +115,7 @@ describe("function triggers", () => {
   });
 
   after(async function (this) {
-    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS * 2);
+    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
     database?.goOffline();
     for (const fn of firestoreUnsub) fn();
     await firestore?.terminate();
@@ -126,7 +126,7 @@ describe("function triggers", () => {
     it("should write to the database emulator", async function (this) {
       this.timeout(EMULATOR_TEST_TIMEOUT);
 
-      const response = await test.writeUpdateDeleteToRtdb();
+      const response = await test.writeToRtdb();
       expect(response.status).to.equal(200);
     });
 
@@ -148,10 +148,7 @@ describe("function triggers", () => {
 
     it("should have have triggered cloud functions", () => {
       expect(test.rtdbTriggerCount).to.equal(1);
-      expect(test.rtdbV2WrittenTriggerCount).to.eq(1);
-      expect(test.rtdbV2CreatedTriggerCount).to.eq(1);
-      expect(test.rtdbV2UpdatedTriggerCount).to.eq(1);
-      expect(test.rtdbV2DeletedTriggerCount).to.eq(1);
+      expect(test.rtdbV2TriggerCount).to.eq(1);
       expect(test.firestoreTriggerCount).to.equal(1);
       /*
        * Check for the presence of all expected documents in the firestore

--- a/scripts/triggers-end-to-end-tests/tests.ts
+++ b/scripts/triggers-end-to-end-tests/tests.ts
@@ -115,7 +115,7 @@ describe("function triggers", () => {
   });
 
   after(async function (this) {
-    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS);
+    this.timeout(EMULATORS_SHUTDOWN_DELAY_MS * 2);
     database?.goOffline();
     for (const fn of firestoreUnsub) fn();
     await firestore?.terminate();

--- a/scripts/triggers-end-to-end-tests/triggers/index.js
+++ b/scripts/triggers-end-to-end-tests/triggers/index.js
@@ -61,12 +61,15 @@ exports.writeToFirestore = functions.https.onRequest(async (req, res) => {
   });
 });
 
-exports.writeToRtdb = functions.https.onRequest(async (req, res) => {
+exports.writeUpdateDeleteToRtdb = functions.https.onRequest(async (req, res) => {
   const ref = admin.database().ref(START_DOCUMENT_NAME);
   await ref.set({ start: new Date().toISOString() });
-  ref.once("value", (snap) => {
-    res.json({ data: snap });
-  });
+  console.log("Wrote to RTDB");
+  await ref.update({ start: new Date().toISOString() });
+  console.log("Update to RTDB");
+  await ref.remove();
+  console.log("Delete from RTDB");
+  res.json({ status: "done" });
 });
 
 exports.writeToPubsub = functions.https.onRequest(async (req, res) => {

--- a/scripts/triggers-end-to-end-tests/triggers/index.js
+++ b/scripts/triggers-end-to-end-tests/triggers/index.js
@@ -61,15 +61,12 @@ exports.writeToFirestore = functions.https.onRequest(async (req, res) => {
   });
 });
 
-exports.writeUpdateDeleteToRtdb = functions.https.onRequest(async (req, res) => {
+exports.writeToRtdb = functions.https.onRequest(async (req, res) => {
   const ref = admin.database().ref(START_DOCUMENT_NAME);
   await ref.set({ start: new Date().toISOString() });
-  console.log("Wrote to RTDB");
-  await ref.update({ start: new Date().toISOString() });
-  console.log("Update to RTDB");
-  await ref.remove();
-  console.log("Delete from RTDB");
-  res.json({ status: "done" });
+  ref.once("value", (snap) => {
+    res.json({ data: snap });
+  });
 });
 
 exports.writeToPubsub = functions.https.onRequest(async (req, res) => {

--- a/scripts/triggers-end-to-end-tests/triggers/package-lock.json
+++ b/scripts/triggers-end-to-end-tests/triggers/package-lock.json
@@ -10,7 +10,7 @@
         "@google-cloud/pubsub": "^3.0.1",
         "firebase": "^9.9.0",
         "firebase-admin": "^11.0.0",
-        "firebase-functions": "^3.22.0"
+        "firebase-functions": "^3.24.1"
       },
       "devDependencies": {
         "firebase-functions-test": "^0.2.0"
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
+      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -4589,9 +4589,9 @@
       }
     },
     "firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
+      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",

--- a/scripts/triggers-end-to-end-tests/triggers/package.json
+++ b/scripts/triggers-end-to-end-tests/triggers/package.json
@@ -10,7 +10,7 @@
     "@google-cloud/pubsub": "^3.0.1",
     "firebase": "^9.9.0",
     "firebase-admin": "^11.0.0",
-    "firebase-functions": "^3.22.0"
+    "firebase-functions": "^3.24.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"

--- a/scripts/triggers-end-to-end-tests/v1/package-lock.json
+++ b/scripts/triggers-end-to-end-tests/v1/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@firebase/database-compat": "0.1.2",
         "firebase-admin": "^11.0.0",
-        "firebase-functions": "^3.22.0"
+        "firebase-functions": "^3.24.1"
       },
       "devDependencies": {
         "firebase-functions-test": "^0.2.0"
@@ -993,9 +993,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
+      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -3272,9 +3272,9 @@
       }
     },
     "firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
+      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",

--- a/scripts/triggers-end-to-end-tests/v1/package.json
+++ b/scripts/triggers-end-to-end-tests/v1/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@firebase/database-compat": "0.1.2",
     "firebase-admin": "^11.0.0",
-    "firebase-functions": "^3.22.0"
+    "firebase-functions": "^3.24.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"

--- a/scripts/triggers-end-to-end-tests/v2/index.js
+++ b/scripts/triggers-end-to-end-tests/v2/index.js
@@ -22,8 +22,13 @@ const AUTH_BLOCKING_CREATE_V2_LOG =
   "========== AUTH BLOCKING CREATE V2 FUNCTION METADATA ==========";
 const AUTH_BLOCKING_SIGN_IN_V2_LOG =
   "========== AUTH BLOCKING SIGN IN V2 FUNCTION METADATA ==========";
+const RTDB_WRITTEN_LOG = "========== RTDB V2 FUNCTION WRITTEN ==========";
+const RTDB_CREATED_LOG = "========== RTDB V2 FUNCTION CREATED ==========";
+const RTDB_UPDATED_LOG = "========== RTDB V2 FUNCTION UPDATED ==========";
+const RTDB_DELETED_LOG = "========== RTDB V2 FUNCTION DELETED ==========";
 
 const PUBSUB_TOPIC = "test-topic";
+const START_DOCUMENT_NAME = "test/start";
 
 admin.initializeApp();
 
@@ -124,4 +129,24 @@ exports.onreqv2timeout = functionsV2.https.onRequest({ timeoutSeconds: 1 }, asyn
       resolve();
     }, 3_000);
   });
+});
+
+exports.rtdbv2writtenreaction = functionsV2.database.onValueWritten(START_DOCUMENT_NAME, (event) => {
+  console.log(RTDB_WRITTEN_LOG);
+  return;
+});
+
+exports.rtdbv2createdreaction = functionsV2.database.onValueCreated(START_DOCUMENT_NAME, (event) => {
+  console.log(RTDB_CREATED_LOG);
+  return;
+});
+
+exports.rtdbv2updatedreaction = functionsV2.database.onValueUpdated(START_DOCUMENT_NAME, (event) => {
+  console.log(RTDB_UPDATED_LOG);
+  return;
+});
+
+exports.rtdbv2deletedreaction = functionsV2.database.onValueDeleted(START_DOCUMENT_NAME, (event) => {
+  console.log(RTDB_DELETED_LOG);
+  return;
 });

--- a/scripts/triggers-end-to-end-tests/v2/index.js
+++ b/scripts/triggers-end-to-end-tests/v2/index.js
@@ -131,22 +131,34 @@ exports.onreqv2timeout = functionsV2.https.onRequest({ timeoutSeconds: 1 }, asyn
   });
 });
 
-exports.rtdbv2writtenreaction = functionsV2.database.onValueWritten(START_DOCUMENT_NAME, (event) => {
-  console.log(RTDB_WRITTEN_LOG);
-  return;
-});
+exports.rtdbv2writtenreaction = functionsV2.database.onValueWritten(
+  START_DOCUMENT_NAME,
+  (event) => {
+    console.log(RTDB_WRITTEN_LOG);
+    return;
+  }
+);
 
-exports.rtdbv2createdreaction = functionsV2.database.onValueCreated(START_DOCUMENT_NAME, (event) => {
-  console.log(RTDB_CREATED_LOG);
-  return;
-});
+exports.rtdbv2createdreaction = functionsV2.database.onValueCreated(
+  START_DOCUMENT_NAME,
+  (event) => {
+    console.log(RTDB_CREATED_LOG);
+    return;
+  }
+);
 
-exports.rtdbv2updatedreaction = functionsV2.database.onValueUpdated(START_DOCUMENT_NAME, (event) => {
-  console.log(RTDB_UPDATED_LOG);
-  return;
-});
+exports.rtdbv2updatedreaction = functionsV2.database.onValueUpdated(
+  START_DOCUMENT_NAME,
+  (event) => {
+    console.log(RTDB_UPDATED_LOG);
+    return;
+  }
+);
 
-exports.rtdbv2deletedreaction = functionsV2.database.onValueDeleted(START_DOCUMENT_NAME, (event) => {
-  console.log(RTDB_DELETED_LOG);
-  return;
-});
+exports.rtdbv2deletedreaction = functionsV2.database.onValueDeleted(
+  START_DOCUMENT_NAME,
+  (event) => {
+    console.log(RTDB_DELETED_LOG);
+    return;
+  }
+);

--- a/scripts/triggers-end-to-end-tests/v2/index.js
+++ b/scripts/triggers-end-to-end-tests/v2/index.js
@@ -22,10 +22,7 @@ const AUTH_BLOCKING_CREATE_V2_LOG =
   "========== AUTH BLOCKING CREATE V2 FUNCTION METADATA ==========";
 const AUTH_BLOCKING_SIGN_IN_V2_LOG =
   "========== AUTH BLOCKING SIGN IN V2 FUNCTION METADATA ==========";
-const RTDB_WRITTEN_LOG = "========== RTDB V2 FUNCTION WRITTEN ==========";
-const RTDB_CREATED_LOG = "========== RTDB V2 FUNCTION CREATED ==========";
-const RTDB_UPDATED_LOG = "========== RTDB V2 FUNCTION UPDATED ==========";
-const RTDB_DELETED_LOG = "========== RTDB V2 FUNCTION DELETED ==========";
+const RTDB_LOG = "========== RTDB V2 FUNCTION ==========";
 
 const PUBSUB_TOPIC = "test-topic";
 const START_DOCUMENT_NAME = "test/start";
@@ -131,34 +128,7 @@ exports.onreqv2timeout = functionsV2.https.onRequest({ timeoutSeconds: 1 }, asyn
   });
 });
 
-exports.rtdbv2writtenreaction = functionsV2.database.onValueWritten(
-  START_DOCUMENT_NAME,
-  (event) => {
-    console.log(RTDB_WRITTEN_LOG);
-    return;
-  }
-);
-
-exports.rtdbv2createdreaction = functionsV2.database.onValueCreated(
-  START_DOCUMENT_NAME,
-  (event) => {
-    console.log(RTDB_CREATED_LOG);
-    return;
-  }
-);
-
-exports.rtdbv2updatedreaction = functionsV2.database.onValueUpdated(
-  START_DOCUMENT_NAME,
-  (event) => {
-    console.log(RTDB_UPDATED_LOG);
-    return;
-  }
-);
-
-exports.rtdbv2deletedreaction = functionsV2.database.onValueDeleted(
-  START_DOCUMENT_NAME,
-  (event) => {
-    console.log(RTDB_DELETED_LOG);
-    return;
-  }
-);
+exports.rtdbv2reaction = functionsV2.database.onValueWritten(START_DOCUMENT_NAME, (event) => {
+  console.log(RTDB_LOG);
+  return;
+});

--- a/scripts/triggers-end-to-end-tests/v2/package-lock.json
+++ b/scripts/triggers-end-to-end-tests/v2/package-lock.json
@@ -7,7 +7,7 @@
       "name": "functions",
       "dependencies": {
         "firebase-admin": "^11.0.0",
-        "firebase-functions": "^3.22.0"
+        "firebase-functions": "^3.24.1"
       },
       "devDependencies": {
         "firebase-functions-test": "^0.2.0"
@@ -870,9 +870,9 @@
       }
     },
     "node_modules/firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
+      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
       "dependencies": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",
@@ -3016,9 +3016,9 @@
       }
     },
     "firebase-functions": {
-      "version": "3.22.0",
-      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.22.0.tgz",
-      "integrity": "sha512-d1BxBpT95MhvVqXkpLWDvWbyuX7e2l69cFAiqG3U1XQDaMV88bM9S+Zg7H8i9pitEGFr+76ErjKgrY0n+g3ZDA==",
+      "version": "3.24.1",
+      "resolved": "https://registry.npmjs.org/firebase-functions/-/firebase-functions-3.24.1.tgz",
+      "integrity": "sha512-GYhoyOV0864HFMU1h/JNBXYNmDk2MlbvU7VO/5qliHX6u/6vhSjTJjlyCG4leDEI8ew8IvmkIC5QquQ1U8hAuA==",
       "requires": {
         "@types/cors": "^2.8.5",
         "@types/express": "4.17.3",

--- a/scripts/triggers-end-to-end-tests/v2/package.json
+++ b/scripts/triggers-end-to-end-tests/v2/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "firebase-admin": "^11.0.0",
-    "firebase-functions": "^3.22.0"
+    "firebase-functions": "^3.24.1"
   },
   "devDependencies": {
     "firebase-functions-test": "^0.2.0"

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -771,6 +771,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       throw new FirebaseError("A database reference must be supplied.");
     }
 
+    // The 'namespacePattern' determines that we are using the v2 interface
     const bundle = JSON.stringify({
       name: `projects/${projectId}/locations/${region}/triggers/${key}`,
       path: ref,
@@ -779,6 +780,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       namespacePattern: instance,
     });
 
+    // The query parameter '?ns=${instance}' is ignored in v2
     const apiPath = "/.settings/functionTriggers.json";
 
     return { bundle, apiPath, instance };

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1048,11 +1048,9 @@ async function main(): Promise<void> {
         case "cloudevent":
           const rawBody = (req as RequestWithRawBody).rawBody;
           let reqBody = JSON.parse(rawBody.toString());
-          if (req.headers["content-type"]?.includes("cloudevent")) {
-            if (EventUtils.isBinaryCloudEvent(req)) {
-              reqBody = EventUtils.extractBinaryCloudEventContext(req);
-              reqBody.data = req.body;
-            }
+          if (EventUtils.isBinaryCloudEvent(req)) {
+            reqBody = EventUtils.extractBinaryCloudEventContext(req);
+            reqBody.data = req.body;
           }
           await processBackground(trigger, reqBody, FUNCTION_SIGNATURE);
           res.send({ status: "acknowledged" });

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -19,7 +19,7 @@ import * as events from "../functions/events";
 
 /** The current v2 events that are implemented in the emulator */
 const V2_EVENTS = [
-  ...events.v2.PUBSUB_PUBLISH_EVENT,
+  events.v2.PUBSUB_PUBLISH_EVENT,
   ...events.v2.STORAGE_EVENTS,
   ...events.v2.DATABASE_EVENTS,
 ];
@@ -188,13 +188,12 @@ export function emulatedFunctionsFromEndpoints(
           resource: eventTrigger.eventFilters!.resource,
         };
       } else {
-        // v2 events allowed: pubsub, storage, rtdb, custom events
+        // TODO(colerogers): v2 events implemented are pubsub, storage, rtdb, and custom events
         if (!eventServiceImplemented(eventTrigger.eventType) && !eventTrigger.channel) {
           continue;
         }
 
-        // Only pubsub and storage events are supported for gcfv2.
-        // Custom events require a channel.
+        // We use resource for pubsub & storage
         const { resource, topic, bucket } = endpoint.eventTrigger.eventFilters as any;
         const eventResource = resource || topic || bucket;
 

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -58,7 +58,7 @@ export interface EventSchedule {
 }
 
 export interface EventTrigger {
-  resource: string | undefined;
+  resource?: string;
   eventType: string;
   channel?: string;
   eventFilters?: Record<string, string>;

--- a/src/functions/events/v2.ts
+++ b/src/functions/events/v2.ts
@@ -1,4 +1,4 @@
-export const PUBSUB_PUBLISH_EVENT = "google.cloud.pubsub.topic.v1.messagePublished" as const;
+export const PUBSUB_PUBLISH_EVENT = "google.cloud.pubsub.topic.v1.messagePublished";
 
 export const STORAGE_EVENTS = [
   "google.cloud.storage.object.v1.finalized",


### PR DESCRIPTION
This change tries to make the minimum amount of changes to the functions emulator to support v2 rtdb triggers. Once we get some breathing room in the future, I'd like to refactor how triggers are added and possibly merge some of the deploy/emulator code so we aren't re-building similar logic.