### PR TITLE
Rename frameworkawareness to webframeworks

### DIFF
--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -59,7 +59,7 @@ export const deploy = async function (
   if (targetNames.includes("hosting")) {
     const config = options.config.get("hosting");
     if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
-      experiments.assertEnabled("frameworkawareness", "deploy a web framework to hosting");
+      experiments.assertEnabled("webframeworks", "deploy a web framework to hosting");
       await prepareFrameworks(targetNames, context, options);
     }
   }

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -498,9 +498,9 @@ export async function startAll(
   if (
     Array.isArray(hostingConfig) ? hostingConfig.some((it) => it.source) : hostingConfig?.source
   ) {
-    experiments.assertEnabled("frameworkawareness", "emulate a web framework");
+    experiments.assertEnabled("webframeworks", "emulate a web framework");
     const emulators: EmulatorInfo[] = [];
-    if (experiments.isEnabled("frameworkawareness")) {
+    if (experiments.isEnabled("webframeworks")) {
       for (const e of EMULATORS_SUPPORTED_BY_UI) {
         const info = EmulatorRegistry.getInfo(e);
         if (info) emulators.push(info);

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -77,7 +77,7 @@ export const ALL_EXPERIMENTS = experiments({
   },
 
   // Hosting experiments
-  frameworkawareness: {
+  webframeworks: {
     shortDescription: "Native support for popular web frameworks",
     fullDescription:
       "Adds support for popular web frameworks such as Next.js " +

--- a/src/init/features/hosting/index.ts
+++ b/src/init/features/hosting/index.ts
@@ -25,11 +25,11 @@ const DEFAULT_IGNORES = ["firebase.json", "**/.*", "**/node_modules/**"];
 export async function doSetup(setup: any, config: any): Promise<void> {
   setup.hosting = {};
 
-  let discoveredFramework = experiments.isEnabled("frameworkawareness")
+  let discoveredFramework = experiments.isEnabled("webframeworks")
     ? await discover(config.projectDir, false)
     : undefined;
 
-  if (experiments.isEnabled("frameworkawareness")) {
+  if (experiments.isEnabled("webframeworks")) {
     if (discoveredFramework) {
       const name = WebFrameworks[discoveredFramework.framework].name;
       await promptOnce(

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -28,7 +28,7 @@ export async function serve(options: any): Promise<void> {
     targetNames.includes("hosting") &&
     [].concat(options.config.get("hosting")).some((it: any) => it.source)
   ) {
-    experiments.assertEnabled("frameworkawareness", "emulate a web framework");
+    experiments.assertEnabled("webframeworks", "emulate a web framework");
     await prepareFrameworks(targetNames, options, options);
   }
   const isDemoProject = Constants.isDemoProject(getProjectId(options) || "");


### PR DESCRIPTION
What it says on the tin. Would like to get this in the same minor release as experiments since this is a pre-release breaking change which also implies minor.