### PR TITLE
moves esbuild to an optional dependency; requires node 16 for frameworks

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -25,7 +25,6 @@
         "cross-env": "^5.1.3",
         "cross-spawn": "^7.0.3",
         "csv-parse": "^5.0.4",
-        "esbuild": "^0.15.7",
         "exegesis": "^4.1.0",
         "exegesis-express": "^4.0.0",
         "express": "^4.16.4",
@@ -160,6 +159,9 @@
       },
       "engines": {
         "node": "^14.18.0 || >=16.4.0"
+      },
+      "optionalDependencies": {
+        "esbuild": "^0.15.7"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5561,6 +5563,7 @@
       "version": "0.15.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.8.tgz",
       "integrity": "sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==",
+      "devOptional": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -19393,6 +19396,7 @@
       "version": "0.15.8",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.8.tgz",
       "integrity": "sha512-Remsk2dmr1Ia65sU+QasE6svJbsHe62lzR+CnjpUvbZ+uSYo1SitiOWPRfZQkCu82YWZBBKXiD/j0i//XWMZ+Q==",
+      "devOptional": true,
       "requires": {
         "@esbuild/android-arm": "0.15.8",
         "@esbuild/linux-loong64": "0.15.8",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "cross-env": "^5.1.3",
     "cross-spawn": "^7.0.3",
     "csv-parse": "^5.0.4",
-    "esbuild": "^0.15.7",
     "exegesis": "^4.1.0",
     "exegesis-express": "^4.0.0",
     "express": "^4.16.4",
@@ -235,5 +234,8 @@
     "typescript": "^4.5.4",
     "typescript-json-schema": "^0.50.1",
     "vite": "^3.1.0"
+  },
+  "optionalDependencies": {
+    "esbuild": "^0.15.7"
   }
 }

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -17,8 +17,9 @@ import {
 } from "..";
 import { promptOnce } from "../../prompt";
 import { gte } from "semver";
-import esbuild from "esbuild";
 import { IncomingMessage, ServerResponse } from "http";
+import { logger } from "../../logger";
+import { FirebaseError } from "../../error";
 
 // Next.js's exposed interface is incomplete here
 // TODO see if there's a better way to grab this
@@ -206,6 +207,16 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
   const packageJsonBuffer = await readFile(join(sourceDir, "package.json"));
   const packageJson = JSON.parse(packageJsonBuffer.toString());
   if (existsSync(join(sourceDir, "next.config.js"))) {
+    let esbuild;
+    try {
+      esbuild = await import("esbuild");
+    } catch (e: unknown) {
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      logger.debug(`Failed to load 'esbuild': ${e}`);
+      throw new FirebaseError(
+        `Unable to find 'esbuild'. Install it into your local dev dependencies with 'npm i --save-dev esbuild''`
+      );
+    }
     await esbuild.build({
       bundle: true,
       external: Object.keys(packageJson.dependencies),


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`esbuild` as a dependency causes issues with npm@6 since it will fail installs for optional dependencies where engines don't match (from npm-shrinkwrap). Moving `esbuild` to optionalDependencies allows node 14 installs (which default to npm@6) to continue working.

`firebase-frameworks` has a requirement of `node >= 16.0.0` and `npm` will complain if its codepaths are used on lower versions of node. Enforcing a requirement of node 16 or higher in the awareness codepaths will prevent issues from arising there _and_ should give us confidence that `npm` is >=8, where the optional dependencies issue above won't happen either (and therefore `esbuild` should have been installed with `firebase-tools`).

But, as a precaution, we must move and check the import for `esbuild` later in the runtime so that we don't try to load a dependency that may have failed to install (notably on node 14).

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

I've been testing with a local nextjs app on nodes 14 and 16 with npms 6 and 8. It's behaving correctly so far as I can tell and installing the package with this change on node 14 does work again.