### PR TITLE
Enable webframework awareness for Github Action Deploys

### DIFF
--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -7,7 +7,6 @@ import { logBullet, logSuccess, consoleUrl, addSubdomain } from "../utils";
 import { FirebaseError } from "../error";
 import { track } from "../track";
 import { lifecycleHooks } from "./lifecycleHooks";
-import * as experiments from "../experiments";
 import * as HostingTarget from "./hosting";
 import * as DatabaseTarget from "./database";
 import * as FirestoreTarget from "./firestore";
@@ -15,7 +14,7 @@ import * as FunctionsTarget from "./functions";
 import * as StorageTarget from "./storage";
 import * as RemoteConfigTarget from "./remoteconfig";
 import * as ExtensionsTarget from "./extensions";
-import {assertWebframeworksEnabled, prepareFrameworks} from "../frameworks";
+import { assertWebframeworksEnabled, prepareFrameworks } from "../frameworks";
 
 const TARGETS = {
   hosting: HostingTarget,

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -15,7 +15,7 @@ import * as FunctionsTarget from "./functions";
 import * as StorageTarget from "./storage";
 import * as RemoteConfigTarget from "./remoteconfig";
 import * as ExtensionsTarget from "./extensions";
-import { prepareFrameworks } from "../frameworks";
+import {assertWebframeworksEnabled, prepareFrameworks} from "../frameworks";
 
 const TARGETS = {
   hosting: HostingTarget,
@@ -59,7 +59,7 @@ export const deploy = async function (
   if (targetNames.includes("hosting")) {
     const config = options.config.get("hosting");
     if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
-      experiments.assertEnabled("webframeworks", "deploy a web framework to hosting");
+      assertWebframeworksEnabled("deploy a web framework to hosting");
       await prepareFrameworks(targetNames, context, options);
     }
   }

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -51,7 +51,7 @@ import { ParsedTriggerDefinition } from "./functionsEmulatorShared";
 import { ExtensionsEmulator } from "./extensionsEmulator";
 import { normalizeAndValidate } from "../functions/projectConfig";
 import { requiresJava } from "./downloadableEmulators";
-import { prepareFrameworks } from "../frameworks";
+import {assertWebframeworksEnabled, isWebframeworksEnabled, prepareFrameworks} from "../frameworks";
 import * as experiments from "../experiments";
 
 const START_LOGGING_EMULATOR = utils.envOverride(
@@ -498,9 +498,9 @@ export async function startAll(
   if (
     Array.isArray(hostingConfig) ? hostingConfig.some((it) => it.source) : hostingConfig?.source
   ) {
-    experiments.assertEnabled("webframeworks", "emulate a web framework");
+    assertWebframeworksEnabled("emulate a web framework");
     const emulators: EmulatorInfo[] = [];
-    if (experiments.isEnabled("webframeworks")) {
+    if (isWebframeworksEnabled()) {
       for (const e of EMULATORS_SUPPORTED_BY_UI) {
         const info = EmulatorRegistry.getInfo(e);
         if (info) emulators.push(info);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -51,8 +51,11 @@ import { ParsedTriggerDefinition } from "./functionsEmulatorShared";
 import { ExtensionsEmulator } from "./extensionsEmulator";
 import { normalizeAndValidate } from "../functions/projectConfig";
 import { requiresJava } from "./downloadableEmulators";
-import {assertWebframeworksEnabled, isWebframeworksEnabled, prepareFrameworks} from "../frameworks";
-import * as experiments from "../experiments";
+import {
+  assertWebframeworksEnabled,
+  isWebframeworksEnabled,
+  prepareFrameworks,
+} from "../frameworks";
 
 const START_LOGGING_EMULATOR = utils.envOverride(
   "START_LOGGING_EMULATOR",

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -21,6 +21,7 @@ import { getProjectDefaultAccount } from "../auth";
 import { formatHost } from "../emulator/functionsEmulatorShared";
 import { Constants } from "../emulator/constants";
 import { FirebaseError } from "../error";
+import * as experiments from "../experiments";
 
 // Use "true &&"" to keep typescript from compiling this file and rewriting
 // the import statement into a require
@@ -553,4 +554,28 @@ export function createServerResponseProxy(
     },
   });
   return proxiedRes;
+}
+
+/**
+ * Checks if Webframeworks are enabled, either by feature-flag or by
+ * checking if we are in the Github action deploy workflow.
+ */
+export function isWebframeworksEnabled(): boolean {
+  return (
+    experiments.isEnabled("webframeworks") ||
+    process.env.FIREBASE_DEPLOY_AGENT === "action-hosting-deploy"
+  );
+}
+
+/**
+ *
+ * Assert if the webframework feature is enabled... with a slight twist
+ * of skipping assertion if this flow is being triggered by a Github Action.
+ */
+export function assertWebframeworksEnabled(task: string) {
+  // CI/CD flows should not assert to enable a feature.
+  if (process.env.FIREBASE_DEPLOY_AGENT === "action-hosting-deploy") {
+    return;
+  }
+  experiments.assertEnabled("webframeworks", task);
 }

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -561,10 +561,7 @@ export function createServerResponseProxy(
  * checking if we are in the Github action deploy workflow.
  */
 export function isWebframeworksEnabled(): boolean {
-  return (
-    experiments.isEnabled("webframeworks") ||
-    process.env.FIREBASE_DEPLOY_AGENT === "action-hosting-deploy"
-  );
+  return !!(experiments.isEnabled("webframeworks") || isEnabledForCli());
 }
 
 /**
@@ -574,8 +571,15 @@ export function isWebframeworksEnabled(): boolean {
  */
 export function assertWebframeworksEnabled(task: string) {
   // CI/CD flows should not assert to enable a feature.
-  if (process.env.FIREBASE_DEPLOY_AGENT === "action-hosting-deploy") {
+  if (isEnabledForCli()) {
     return;
   }
   experiments.assertEnabled("webframeworks", task);
+}
+
+function isEnabledForCli() {
+  return (
+    process.env.FIREBASE_CLI_EXPERIMENTS &&
+    process.env.FIREBASE_CLI_EXPERIMENTS.includes("webframeworks")
+  );
 }

--- a/src/init/features/hosting/index.ts
+++ b/src/init/features/hosting/index.ts
@@ -6,7 +6,7 @@ import { Client } from "../../../apiv2";
 import { initGitHub } from "./github";
 import { prompt, promptOnce } from "../../../prompt";
 import { logger } from "../../../logger";
-import { discover, WebFrameworks } from "../../../frameworks";
+import {discover, isWebframeworksEnabled, WebFrameworks} from "../../../frameworks";
 import * as experiments from "../../../experiments";
 
 const INDEX_TEMPLATE = fs.readFileSync(
@@ -25,11 +25,11 @@ const DEFAULT_IGNORES = ["firebase.json", "**/.*", "**/node_modules/**"];
 export async function doSetup(setup: any, config: any): Promise<void> {
   setup.hosting = {};
 
-  let discoveredFramework = experiments.isEnabled("webframeworks")
+  let discoveredFramework = isWebframeworksEnabled()
     ? await discover(config.projectDir, false)
     : undefined;
 
-  if (experiments.isEnabled("webframeworks")) {
+  if (isWebframeworksEnabled()) {
     if (discoveredFramework) {
       const name = WebFrameworks[discoveredFramework.framework].name;
       await promptOnce(

--- a/src/init/features/hosting/index.ts
+++ b/src/init/features/hosting/index.ts
@@ -6,8 +6,7 @@ import { Client } from "../../../apiv2";
 import { initGitHub } from "./github";
 import { prompt, promptOnce } from "../../../prompt";
 import { logger } from "../../../logger";
-import {discover, isWebframeworksEnabled, WebFrameworks} from "../../../frameworks";
-import * as experiments from "../../../experiments";
+import { discover, isWebframeworksEnabled, WebFrameworks } from "../../../frameworks";
 
 const INDEX_TEMPLATE = fs.readFileSync(
   __dirname + "/../../../../templates/init/hosting/index.html",

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -1,7 +1,6 @@
 import { EmulatorServer } from "../emulator/emulatorServer";
 import { logger } from "../logger";
-import {assertWebframeworksEnabled, prepareFrameworks} from "../frameworks";
-import * as experiments from "../experiments";
+import { assertWebframeworksEnabled, prepareFrameworks } from "../frameworks";
 import { trackEmulator } from "../track";
 import { getProjectId } from "../projectUtils";
 import { Constants } from "../emulator/constants";

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -1,6 +1,6 @@
 import { EmulatorServer } from "../emulator/emulatorServer";
 import { logger } from "../logger";
-import { prepareFrameworks } from "../frameworks";
+import {assertWebframeworksEnabled, prepareFrameworks} from "../frameworks";
 import * as experiments from "../experiments";
 import { trackEmulator } from "../track";
 import { getProjectId } from "../projectUtils";
@@ -28,7 +28,7 @@ export async function serve(options: any): Promise<void> {
     targetNames.includes("hosting") &&
     [].concat(options.config.get("hosting")).some((it: any) => it.source)
   ) {
-    experiments.assertEnabled("webframeworks", "emulate a web framework");
+    assertWebframeworksEnabled("emulate a web framework");
     await prepareFrameworks(targetNames, options, options);
   }
   const isDemoProject = Constants.isDemoProject(getProjectId(options) || "");


### PR DESCRIPTION
### Description

This commit enables webframework awareness for Github Action Deploys.

In addition, places where we assert the end-user to enable a feature are omitted when deploying using the Github Action.