### PR TITLE
fix(test) Fix broken test

### DIFF
--- a/src/test/hosting/config.spec.ts
+++ b/src/test/hosting/config.spec.ts
@@ -6,6 +6,7 @@ import * as config from "../../hosting/config";
 import { HostingOptions } from "../../hosting/options";
 import { RequireAtLeastOne } from "../../metaprogramming";
 import { cloneDeep } from "../../utils";
+import { setEnabled } from "../../experiments";
 
 function options(
   hostingConfig: HostingConfig,
@@ -326,7 +327,7 @@ describe("config", () => {
       wantErr?: RegExp;
     }> = [
       {
-        desc: "should error out if there is no puyblic directory but a 'destination' rewrite",
+        desc: "should error out if there is no public directory but a 'destination' rewrite",
         site: {
           rewrites: [
             { source: "/foo", destination: "/bar.html" },
@@ -336,7 +337,7 @@ describe("config", () => {
         wantErr: PUBLIC_DIR_ERROR_PREFIX,
       },
       {
-        desc: "should error out if htere is no public directory and an i18n with root",
+        desc: "should error out if there is no public directory and an i18n with root",
         site: {
           i18n: { root: "/foo" },
           rewrites: [{ source: "/foo", function: "pass" }],
@@ -402,6 +403,9 @@ describe("config", () => {
 
     for (const t of tests) {
       it(t.desc, () => {
+        // Setting experiment to "false" to handle mismatched error message.
+        setEnabled("webframeworks", false);
+
         const configs: HostingMultiple = [{ site: "site", ...t.site }];
         if (t.wantErr) {
           expect(() => config.validate(configs, options(t.site))).to.throw(


### PR DESCRIPTION
### Description

This PR fixes config.spec.ts when the  `webframeworks` experiment is enabled.

The error messaging informs the user either their "public", or their "pulic or source" directory is compatible with other configs.

The "fix" is simply turn off webframeworks in the test (doesn't actually save the user's state.)