### PR TITLE
fix(webframeworks) Force webframeworks functions to lowercase

### DIFF
--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -292,7 +292,7 @@ export async function prepareFrameworks(
     if (publicDir)
       throw new Error(`hosting.public and hosting.source cannot both be set in firebase.json`);
     const getProjectPath = (...args: string[]) => join(projectRoot, source, ...args);
-    const functionName = `ssr${site.replace(/-/g, "")}`;
+    const functionName = `ssr${site.toLowerCase().replace(/-/g, "")}`;
     const usesFirebaseAdminSdk = !!findDependency("firebase-admin", { cwd: getProjectPath() });
     const usesFirebaseJsSdk = !!findDependency("@firebase/app", { cwd: getProjectPath() });
     if (usesFirebaseAdminSdk) {


### PR DESCRIPTION
Fix an issue where uppercaes sites would be converted to v2 upper case functions.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fix an issue where uppercaes sites would be converted to v2 upper case functions.