### PR TITLE
Expose Firestore WebSocket port in hub. Fixes #5051.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Enables single project mode for the auth emulator (#5068).
 - Fixes issue deploying to Hosting with i18n enabled.
 - Fixes issue where deploying to Hosting without Functions permissions would cause deployments to fail with 403 "Permission Denied" errors. (#5071)
+- Fixes issue where Firestore Emulator UI Requests tab wrongly show error requiring updates (#5051)

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -24,6 +24,14 @@ export interface FirestoreEmulatorArgs {
   single_project_mode_error?: boolean;
 }
 
+export interface FirestoreEmulatorInfo extends EmulatorInfo {
+  // Used for the Emulator UI to connect to the WebSocket server.
+  // The casing of the fields below are sensitive and important.
+  // https://github.com/firebase/firebase-tools-ui/blob/2de1e80cce28454da3afeeb373fbbb45a67cb5ef/src/store/config/types.ts#L26-L27
+  webSocketHost?: string;
+  webSocketPort?: number;
+}
+
 export class FirestoreEmulator implements EmulatorInstance {
   static FIRESTORE_EMULATOR_ENV_ALT = "FIREBASE_FIRESTORE_EMULATOR_ADDRESS";
 
@@ -77,7 +85,7 @@ export class FirestoreEmulator implements EmulatorInstance {
     return downloadableEmulators.stop(Emulators.FIRESTORE);
   }
 
-  getInfo(): EmulatorInfo {
+  getInfo(): FirestoreEmulatorInfo {
     const host = this.args.host || Constants.getDefaultHost();
     const port = this.args.port || Constants.getDefaultPort(Emulators.FIRESTORE);
     const reservedPorts = this.args.websocket_port ? [this.args.websocket_port] : [];
@@ -88,6 +96,8 @@ export class FirestoreEmulator implements EmulatorInstance {
       port,
       pid: downloadableEmulators.getPID(Emulators.FIRESTORE),
       reservedPorts: reservedPorts,
+      webSocketHost: this.args.websocket_port ? host : undefined,
+      webSocketPort: this.args.websocket_port ? this.args.websocket_port : undefined,
     };
   }
 

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -26,7 +26,7 @@ export interface FirestoreEmulatorArgs {
 
 export interface FirestoreEmulatorInfo extends EmulatorInfo {
   // Used for the Emulator UI to connect to the WebSocket server.
-  // The casing of the fields below are sensitive and important.
+  // The casing of the fields below is sensitive and important.
   // https://github.com/firebase/firebase-tools-ui/blob/2de1e80cce28454da3afeeb373fbbb45a67cb5ef/src/store/config/types.ts#L26-L27
   webSocketHost?: string;
   webSocketPort?: number;


### PR DESCRIPTION
### Description

Fixes #5051
Fixes https://github.com/firebase/firebase-tools-ui/issues/863

### Scenarios Tested

Manually started the suite + UI, and tested on UI. The Requests tab no longer show errors and can display operations again.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
