### PR TITLE
allow missing public folders when validating Hosting config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Fixes issue deploying to Hosting with i18n enabled.
 - Fixes issue where deploying to Hosting without Functions permissions would cause deployments to fail with 403 "Permission Denied" errors. (#5071)
 - Fixes issue where Firestore Emulator UI Requests tab wrongly show error requiring updates (#5051)
+- Fixes issue where Hosting configurations were being validated before predeploys could have been run (#5072).

--- a/src/deploy/hosting/deploy.ts
+++ b/src/deploy/hosting/deploy.ts
@@ -8,6 +8,8 @@ import { bold, cyan } from "colorette";
 import * as ora from "ora";
 import { Context, HostingDeploy } from "./context";
 import { Options } from "../../options";
+import { dirExistsSync } from "../../fsutils";
+import { FirebaseError } from "../../error";
 
 /**
  * Uploads static assets to the upcoming Hosting versions.
@@ -46,6 +48,9 @@ export async function deploy(context: Context, options: Options): Promise<void> 
     const t0 = Date.now();
 
     const publicDir = options.config.path(deploy.config.public);
+    if (!dirExistsSync(`${publicDir}`)) {
+      throw new FirebaseError(`Directory '${deploy.config.public}' for Hosting does not exist.`);
+    }
     const files = listFiles(publicDir, deploy.config.ignore);
 
     logLabeledBullet(

--- a/src/hosting/config.ts
+++ b/src/hosting/config.ts
@@ -18,6 +18,7 @@ import { resolveProjectPath } from "../projectPath";
 import { HostingOptions } from "./options";
 import * as path from "node:path";
 import * as experiments from "../experiments";
+import { logger } from "../logger";
 
 // assertMatches allows us to throw when an --only flag doesn't match a target
 // but an --except flag doesn't. Is this desirable behavior?
@@ -167,12 +168,12 @@ function validateOne(config: HostingMultiple[number], options: HostingOptions): 
   }
 
   if (root && !dirExistsSync(resolveProjectPath(options, root))) {
-    throw new FirebaseError(
+    logger.debug(
       `Specified "${
         config.source ? "source" : "public"
-      }" directory "${root}" does not exist, can't deploy hosting to site "${
+      }" directory "${root}" does not exist; Deploy to Hosting site "${
         config.site || config.target || ""
-      }"`
+      }" may fail or be empty.`
     );
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When the Hosting config was being parsed, a check was added that enforced that the `public` directory was present. If a developer had a `predeploy` hook that would have made it, that hook never run before the presence of that directory was checked, causing failures.

I've removed the check and moved it deeper into the Hosting deploy step.

Fixes #5072