### PR TITLE
add additional site config information to hosting:sites:list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Enable single project mode for the database emulator (#5068).
 - Ravamp emulator networking to assign ports early and explictly listen on IP addresses (#5083).
+- Adds additional Hosting site information to `hosting:sites:list`.

--- a/src/commands/hosting-sites-list.ts
+++ b/src/commands/hosting-sites-list.ts
@@ -1,34 +1,52 @@
-import { bold } from "colorette";
+import { bold, green, red } from "colorette";
 import Table = require("cli-table");
 
 import { Command } from "../command";
-import { Site, listSites } from "../hosting/api";
+import { Site, listSites, SiteConfig, getSiteConfig } from "../hosting/api";
 import { requirePermissions } from "../requirePermissions";
 import { needProjectId } from "../projectUtils";
 import { logger } from "../logger";
+import { last } from "../utils";
+import { Options } from "../options";
 
-const TABLE_HEAD = ["Site ID", "Default URL", "App ID (if set)"];
+const TABLE_HEAD = [
+  "Site ID",
+  "Default URL",
+  "App ID (if set)",
+  "Logging Enabled",
+  "Retained Versions",
+];
 
 export const command = new Command("hosting:sites:list")
   .description("list Firebase Hosting sites")
   .before(requirePermissions, ["firebasehosting.sites.get"])
-  .action(
-    async (
-      options: any // eslint-disable-line @typescript-eslint/no-explicit-any
-    ): Promise<{ sites: Site[] }> => {
-      const projectId = needProjectId(options);
-      const sites = await listSites(projectId);
-      const table = new Table({ head: TABLE_HEAD, style: { head: ["green"] } });
-      for (const site of sites) {
-        const siteId = site.name.split("/").pop();
-        table.push([siteId, site.defaultUrl, site.appId || "--"]);
-      }
-
-      logger.info();
-      logger.info(`Sites for project ${bold(projectId)}`);
-      logger.info();
-      logger.info(table.toString());
-
-      return { sites };
+  .action(async (options: Options): Promise<{ sites: Site[] }> => {
+    const projectId = needProjectId(options);
+    const sites = await listSites(projectId);
+    const sitesWithConfig: Array<Site & SiteConfig> = [];
+    await Promise.all(
+      sites.map(async (site) => {
+        const config = await getSiteConfig(projectId, last(site.name.split("/")));
+        sitesWithConfig.push({ ...site, ...config });
+      })
+    );
+    const table = new Table({ head: TABLE_HEAD, style: { head: ["green"] } });
+    sitesWithConfig.sort((a, b) => (a.name < b.name ? -1 : 1));
+    for (const site of sitesWithConfig) {
+      const siteId = site.name.split("/").pop();
+      table.push([
+        siteId,
+        site.defaultUrl,
+        site.appId || "--",
+        site.cloudLoggingEnabled ? green("Yes") : red("No"),
+        `${typeof site.maxVersions === "number" ? site.maxVersions : "infinite"}`,
+      ]);
     }
-  );
+
+    logger.info();
+    logger.info(`Sites for project ${bold(projectId)}`);
+    logger.info();
+    logger.info(table.toString());
+
+    return { sites };
+  });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

There's useful information in Hosting's API that we can present in the CLI - specifically if Cloud Logging is enabled or how many versions are retained. We should display that!

![image](https://user-images.githubusercontent.com/160236/194661530-7f20f95d-3612-4b6e-8afc-0773267a5d82.png)

This is a tiny step towards addressing #215 which is _ooollllddddd_ haha. But to be able to view this in the CLI would be good.