### PR TITLE
SSR sites only force deploy the SSR function

### DIFF
--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -24,6 +24,7 @@ import { FirebaseError } from "../error";
 import { requireHostingSite } from "../requireHostingSite";
 import { HostingRewrites } from "../firebaseConfig";
 import * as experiments from "../experiments";
+import { ensureTargeted } from "../functions/ensureTargeted";
 
 // Use "true &&"" to keep typescript from compiling this file and rewriting
 // the import statement into a require
@@ -400,6 +401,7 @@ You can link a Web app to a Hosting site here https://console.firebase.google.co
       }
       config.rewrites.push(rewrite);
 
+      const codebase = `firebase-frameworks-${site}`;
       const existingFunctionsConfig = options.config.get("functions")
         ? [].concat(options.config.get("functions"))
         : [];
@@ -407,15 +409,15 @@ You can link a Web app to a Hosting site here https://console.firebase.google.co
         ...existingFunctionsConfig,
         {
           source: relative(projectRoot, functionsDist),
-          codebase: `firebase-frameworks-${site}`,
+          codebase,
         },
       ]);
 
       if (!targetNames.includes("functions")) {
         targetNames.unshift("functions");
-        if (options.only) {
-          options.only = `${options.only},functions:firebase-frameworks-${site}`;
-        }
+      }
+      if (options.only) {
+        options.only = ensureTargeted(options.only, codebase);
       }
 
       // if exists, delete everything but the node_modules directory and package-lock.json

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -27,7 +27,6 @@ import * as experiments from "../experiments";
 import { ensureTargeted } from "../functions/ensureTargeted";
 import { implicitInit } from "../hosting/implicitInit";
 
-
 // Use "true &&"" to keep typescript from compiling this file and rewriting
 // the import statement into a require
 const { dynamicImport } = require(true && "../dynamicImport");

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -411,7 +411,12 @@ You can link a Web app to a Hosting site here https://console.firebase.google.co
         },
       ]);
 
-      if (!targetNames.includes("functions")) targetNames.unshift("functions");
+      if (!targetNames.includes("functions")) {
+        targetNames.unshift("functions");
+        if (options.only) {
+          options.only = `${options.only},functions:firebase-frameworks-${site}`;
+        }
+      }
 
       // if exists, delete everything but the node_modules directory and package-lock.json
       // this should speed up repeated NPM installs

--- a/src/functions/ensureTargeted.ts
+++ b/src/functions/ensureTargeted.ts
@@ -1,0 +1,29 @@
+/**
+ * Ensures than an only string is modified so that it will enclude a function
+ * in its target. This is useful for making sure that an SSR function is included
+ * with a web framework, or that a traditional hosting site includes its pinned
+ * functions
+ * @param only original only string
+ * @param id function ID
+ * @param codebase function codebase
+ * @return new only string
+ */
+export function ensureTargeted(only: string, codebase: string, id?: string): string {
+  const parts = only.split(",");
+  if (parts.includes("functions")) {
+    return only;
+  }
+
+  let newTarget = `functions:${codebase}`;
+  if (parts.includes(newTarget)) {
+    return only;
+  }
+  if (id) {
+    newTarget = `${newTarget}:${id}`;
+    if (parts.includes(newTarget)) {
+      return only;
+    }
+  }
+
+  return `${only},${newTarget}`;
+}

--- a/src/test/functions/ensureTargeted.spec.ts
+++ b/src/test/functions/ensureTargeted.spec.ts
@@ -3,8 +3,8 @@ import { ensureTargeted } from "../../functions/ensureTargeted";
 
 describe("ensureTargeted", () => {
   it("does nothing if 'functions' is included", () => {
-    expect(ensureTargeted("hosting,functions", "codeebase")).to.equal("hosting,functions");
-    expect(ensureTargeted("hosting,functions", "codeebase", "id")).to.equal("hosting,functions");
+    expect(ensureTargeted("hosting,functions", "codebase")).to.equal("hosting,functions");
+    expect(ensureTargeted("hosting,functions", "codebase", "id")).to.equal("hosting,functions");
   });
 
   it("does nothing if the codebase is targeted", () => {

--- a/src/test/functions/ensureTargeted.spec.ts
+++ b/src/test/functions/ensureTargeted.spec.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { ensureTargeted } from "../../functions/ensureTargeted";
+
+describe("ensureTargeted", () => {
+  it("does nothing if 'functions' is included", () => {
+    expect(ensureTargeted("hosting,functions", "codeebase")).to.equal("hosting,functions");
+    expect(ensureTargeted("hosting,functions", "codeebase", "id")).to.equal("hosting,functions");
+  });
+
+  it("does nothing if the codebase is targeted", () => {
+    expect(ensureTargeted("hosting,functions:codebase", "codebase")).to.equal(
+      "hosting,functions:codebase"
+    );
+    expect(ensureTargeted("hosting,functions:codebase", "codebase", "id")).to.equal(
+      "hosting,functions:codebase"
+    );
+  });
+
+  it("does nothing if the function is targeted", () => {
+    expect(ensureTargeted("functions:codebase:id", "codebase", "id"));
+  });
+
+  it("adds the codebase if missing and no id is provided", () => {
+    expect(ensureTargeted("hosting", "codebase")).to.equal("hosting,functions:codebase");
+  });
+
+  it("adds the function if missing", () => {
+    expect(ensureTargeted("hosting", "codebase", "id")).to.equal("hosting,functions:codebase:id");
+  });
+});

--- a/src/test/functions/ensureTargeted.spec.ts
+++ b/src/test/functions/ensureTargeted.spec.ts
@@ -17,7 +17,9 @@ describe("ensureTargeted", () => {
   });
 
   it("does nothing if the function is targeted", () => {
-    expect(ensureTargeted("functions:codebase:id", "codebase", "id"));
+    expect(ensureTargeted("hosting,functions:codebase:id", "codebase", "id")).to.equal(
+      "hosting,functions:codebase:id"
+    );
   });
 
   it("adds the codebase if missing and no id is provided", () => {


### PR DESCRIPTION
Steps to reproduce:

1. Create a function
2. Create the sample Next.js app
3. Call `firebase deploy --only hosting`

Expected: hosting and `firebase-frameworks-${site}` function are deployed
Actual: All hosting and functions are deployed.