### PR TITLE
Check for functions permissions if web frameworks adds a functions dep

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,7 @@ export const VALID_DEPLOY_TARGETS = [
   "remoteconfig",
   "extensions",
 ];
-const TARGET_PERMISSIONS: Record<string, string[]> = {
+export const TARGET_PERMISSIONS: Record<string, string[]> = {
   database: ["firebasedatabase.instances.update"],
   hosting: ["firebasehosting.sites.update"],
   functions: [

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -17,6 +17,8 @@ import * as RemoteConfigTarget from "./remoteconfig";
 import * as ExtensionsTarget from "./extensions";
 import { prepareFrameworks } from "../frameworks";
 import { HostingDeploy } from "./hosting/context";
+import { requirePermissions } from "../requirePermissions";
+import { TARGET_PERMISSIONS } from "../commands/deploy";
 
 const TARGETS = {
   hosting: HostingTarget,
@@ -61,7 +63,12 @@ export const deploy = async function (
     const config = options.config.get("hosting");
     if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
       experiments.assertEnabled("webframeworks", "deploy a web framework to hosting");
+      const usedToTargetFunctions = targetNames.includes("functions");
       await prepareFrameworks(targetNames, context, options);
+      const nowTargetsFunctions = targetNames.includes("functions");
+      if (nowTargetsFunctions && !usedToTargetFunctions) {
+        await requirePermissions(TARGET_PERMISSIONS["functions"]);
+      }
     }
   }
 


### PR DESCRIPTION
Previously frameworks might add functions as a deploy target and we will not have called requirePermissions on the functions permissions. This ensures that those permissions are checked before we proceed with the deploy.