### PR TITLE
Fix incorrect warning for Firestore websocket in UI.

### DIFF
--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -80,15 +80,15 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
         },
       }
     : {
-        version: "1.11.0",
-        downloadPath: path.join(CACHE_DIR, "ui-v1.11.0.zip"),
-        unzipDir: path.join(CACHE_DIR, "ui-v1.11.0"),
-        binaryPath: path.join(CACHE_DIR, "ui-v1.11.0", "server", "server.js"),
+        version: "1.11.1",
+        downloadPath: path.join(CACHE_DIR, "ui-v1.11.1.zip"),
+        unzipDir: path.join(CACHE_DIR, "ui-v1.11.1"),
+        binaryPath: path.join(CACHE_DIR, "ui-v1.11.1", "server", "server.js"),
         opts: {
           cacheDir: CACHE_DIR,
-          remoteUrl: "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.11.0.zip",
-          expectedSize: 3061915,
-          expectedChecksum: "94679756dc270754e9a4dc9d1c6fc4e1",
+          remoteUrl: "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.11.1.zip",
+          expectedSize: 3061713,
+          expectedChecksum: "a4944414518be206280b495f526f18bf",
           namePrefix: "ui",
         },
       },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes an incorrect logic and warning https://github.com/firebase/firebase-tools-ui/pull/865 

No additional changelog needed since it is covered by the existing UI listen entry.

### Scenarios Tested

Started UI in a normal and a web frameworks repo, both seems working.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
