### PR TITLE
Fix web framework options not applied in hosting emulator.

### DIFF
--- a/src/hosting/config.ts
+++ b/src/hosting/config.ts
@@ -289,7 +289,9 @@ export function normalize(configs: HostingMultiple): void {
 
 /**
  * Extract a validated normalized set of Hosting configs from the command options.
- * This also resolves targets, so it is not suitable for the emulator.
+ *
+ * This also resolves targets, so it is not suitable for the emulator. Use
+ * `hostingConfigForEmulator` for that.
  */
 export function hostingConfig(options: HostingOptions): HostingResolved[] {
   if (!options.normalizedHostingConfig) {
@@ -307,4 +309,20 @@ export function hostingConfig(options: HostingOptions): HostingResolved[] {
     options.normalizedHostingConfig = resolved;
   }
   return options.normalizedHostingConfig;
+}
+
+/**
+ * Extract a validated normalized set of Hosting configs from the command options for emulators.
+ */
+export function hostingConfigForEmulator(options: HostingOptions): HostingMultiple {
+  if (!options.normalizedHostingConfigForEmulator) {
+    let configs: HostingMultiple = extract(options);
+    configs = filterOnly(configs, options.only);
+    configs = filterExcept(configs, options.except);
+    normalize(configs);
+    validate(configs, options);
+    // Do not resolve targets for the emulator.
+    options.normalizedHostingConfigForEmulator = configs;
+  }
+  return options.normalizedHostingConfigForEmulator;
 }

--- a/src/hosting/options.ts
+++ b/src/hosting/options.ts
@@ -1,4 +1,4 @@
-import { FirebaseConfig, HostingResolved } from "../firebaseConfig";
+import { FirebaseConfig, HostingMultiple, HostingResolved } from "../firebaseConfig";
 import { Implements } from "../metaprogramming";
 import { Options } from "../options";
 
@@ -21,6 +21,7 @@ export interface HostingOptions {
   only?: string;
   except?: string;
   normalizedHostingConfig?: Array<HostingResolved>;
+  normalizedHostingConfigForEmulator?: HostingMultiple;
   expires?: `${number}${"h" | "d" | "m"}`;
 }
 

--- a/src/serve/hosting.ts
+++ b/src/serve/hosting.ts
@@ -7,7 +7,6 @@ import { detectProjectRoot } from "../detectProjectRoot";
 import { FirebaseError } from "../error";
 import { implicitInit, TemplateServerResponse } from "../hosting/implicitInit";
 import { initMiddleware } from "../hosting/initMiddleware";
-import * as config from "../hosting/config";
 import cloudRunProxy from "../hosting/cloudRunProxy";
 import { functionsProxy } from "../hosting/functionsProxy";
 import { Writable } from "stream";
@@ -15,6 +14,7 @@ import { EmulatorLogger } from "../emulator/emulatorLogger";
 import { Emulators } from "../emulator/types";
 import { createDestroyer } from "../utils";
 import { execSync } from "child_process";
+import { hostingConfigForEmulator } from "../hosting/config";
 
 const MAX_PORT_ATTEMPTS = 10;
 let attempts = 0;
@@ -139,13 +139,7 @@ export function stop(): Promise<void> {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export async function start(options: any): Promise<void> {
   const init = await implicitInit(options);
-  // Note: we cannot use the hostingConfig() method because it would resolve
-  // targets and we don't want to crash the emulator just because the target
-  // doesn't exist (nor do we want to depend on API calls);
-  let configs = config.extract(options);
-  configs = config.filterOnly(configs, options.only);
-  configs = config.filterExcept(configs, options.except);
-  config.validate(configs, options);
+  const configs = hostingConfigForEmulator(options);
 
   for (let i = 0; i < configs.length; i++) {
     // skip over the functions emulator ports to avoid breaking changes

--- a/src/serve/index.ts
+++ b/src/serve/index.ts
@@ -26,7 +26,8 @@ export async function serve(options: any): Promise<void> {
     [].concat(options.config.get("hosting")).some((it: any) => it.source)
   ) {
     experiments.assertEnabled("webframeworks", "emulate a web framework");
-    await prepareFrameworks(targetNames, options, options);
+    // TODO: Consider allocating a port for Functions emulator (if needed) and pass it in.
+    await prepareFrameworks(targetNames, options, options, /* emulators= */ []);
   }
   const isDemoProject = Constants.isDemoProject(getProjectId(options) || "");
   targetNames.forEach((targetName) => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fix a few webframeworks things like rewrites, redirects, and headers (including autoinit cookie) not working in the hosting emulator.

The previous implementation modifies the the result from `hostingConfig` (cached in `options.normalizedHostingConfig`), which is not used in the emulator code path. I've added a new codepath `hostingConfigForEmulator` in this PR and handles it correctly.

### Scenarios Tested

Started the emulator in a new Next.js app with the following code added:

```js
// ...
import { useEffect } from 'react'
import { getFunctions } from 'firebase/functions'
import { getAuth } from 'firebase/auth'

export default function Home() {
  useEffect(() => {
    console.log(getFunctions());
    console.log(getAuth());
  }, []);
  // ...
}
// ...
```

The app started just fine, and the console log indicates that the Auth emulator is used. `curl` to a JavaScript file shows the right cookie, and a non-existent path gets rewrited to the catch-all function (as indicated by CLI logs).

### Sample Commands

`firebase emulators:start`
