### PR TITLE
Block deploying web frameworks' SSR to preview channels

### DIFF
--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -67,6 +67,11 @@ export const deploy = async function (
       await prepareFrameworks(targetNames, context, options);
       const nowTargetsFunctions = targetNames.includes("functions");
       if (nowTargetsFunctions && !usedToTargetFunctions) {
+        if (context.hostingChannel && !experiments.isEnabled("pintags")) {
+          throw new FirebaseError(
+            "Web frameworks with dynamic content do not yet support deploying to preview channels"
+          );
+        }
         await requirePermissions(TARGET_PERMISSIONS["functions"]);
       }
     }


### PR DESCRIPTION
Traditionally, hosting does not automatically deploy functions in rewrites. This means that when someone deploys to a preview channel, their static assets are deployed but their dynamic content still points to prod.

Unlike traditional hosting for the last 6 years, web frameworks _always deploy with their ssr function if necessary_. This means that deploying to a preview channel would modify prod!!

This quick PR blocks deploys of SSR'd hosting sites to preview channels to prevent this bug.