### PR TITLE
Ensure APIs before calling them during provisioning checks

### DIFF
--- a/src/extensions/provisioningHelper.ts
+++ b/src/extensions/provisioningHelper.ts
@@ -6,6 +6,7 @@ import { firebaseStorageOrigin, firedataOrigin } from "../api";
 import { Client } from "../apiv2";
 import { flattenArray } from "../functional";
 import { FirebaseError } from "../error";
+import { ensure } from "../ensureApiEnabled";
 import { getExtensionSpec, InstanceSpec } from "../deploy/extensions/planner";
 
 /** Product for which provisioning can be (or is) deferred */
@@ -119,6 +120,7 @@ function getTriggerType(propertiesYaml: string | undefined) {
 }
 
 async function isStorageProvisioned(projectId: string): Promise<boolean> {
+  await ensure(projectId, firebaseStorageOrigin, "extensions", true);
   const client = new Client({ urlPrefix: firebaseStorageOrigin, apiVersion: "v1beta" });
   const resp = await client.get<{ buckets: { name: string }[] }>(`/projects/${projectId}/buckets`);
   return !!resp.body?.buckets?.find((bucket: any) => {
@@ -132,6 +134,7 @@ async function isStorageProvisioned(projectId: string): Promise<boolean> {
 }
 
 async function isAuthProvisioned(projectId: string): Promise<boolean> {
+  await ensure(projectId, firedataOrigin, "extensions", true);
   const client = new Client({ urlPrefix: firedataOrigin, apiVersion: "v1" });
   const resp = await client.get<{ activation: { service: string }[] }>(
     `/projects/${projectId}/products`

--- a/src/test/extensions/provisioningHelper.spec.ts
+++ b/src/test/extensions/provisioningHelper.spec.ts
@@ -1,9 +1,11 @@
 import * as nock from "nock";
 import { expect } from "chai";
+import * as sinon from "sinon";
 
 import * as api from "../../api";
 import * as provisioningHelper from "../../extensions/provisioningHelper";
 import { Api, ExtensionSpec, Resource, Role } from "../../extensions/types";
+import * as ensureApiEnabled from "../../ensureApiEnabled";
 import { FirebaseError } from "../../error";
 
 const PROJECT_ID = "test-project";
@@ -82,8 +84,14 @@ const instanceSpec = (version: string) => {
 };
 
 describe("provisioningHelper", () => {
+  let ensureStub: sinon.SinonStub;
+  beforeEach(() => {
+    ensureStub = sinon.stub(ensureApiEnabled, "ensure").resolves();
+  });
+
   afterEach(() => {
     nock.cleanAll();
+    ensureStub.restore();
   });
 
   describe("getUsedProducts", () => {


### PR DESCRIPTION
### Description
Ensure that the APIs we call to check product provisioning are enabled before we call them. Fixes #5074 