### PR TITLE
better handle failed requests when listing functions for backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where errors were not properly propagating when listing backends. (#5071)

--- a/src/deploy/hosting/convertConfig.ts
+++ b/src/deploy/hosting/convertConfig.ts
@@ -112,9 +112,9 @@ export async function convertConfig(
             `Deploying hosting site ${deploy.config.site}, did not have permissions to check for backends: `,
             err
           );
-        } else {
-          throw err;
         }
+      } else {
+        throw err;
       }
     }
   }

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -423,6 +423,7 @@ async function list(projectId: string, region: string): Promise<ListFunctionsRes
     logger.debug(`[functions] ${err?.message}`);
     throw new FirebaseError(`Failed to list functions for ${projectId}`, {
       original: err,
+      status: err instanceof FirebaseError ? err.status : undefined,
     });
   }
 }

--- a/src/test/gcp/cloudfunctions.spec.ts
+++ b/src/test/gcp/cloudfunctions.spec.ts
@@ -8,6 +8,7 @@ import { BEFORE_CREATE_EVENT, BEFORE_SIGN_IN_EVENT } from "../../functions/event
 import * as cloudfunctions from "../../gcp/cloudfunctions";
 import * as projectConfig from "../../functions/projectConfig";
 import { BLOCKING_LABEL, CODEBASE_LABEL, HASH_LABEL } from "../../functions/constants";
+import { FirebaseError } from "../../error";
 
 describe("cloudfunctions", () => {
   const FUNCTION_NAME: backend.TargetIds = {
@@ -718,6 +719,26 @@ describe("cloudfunctions", () => {
           "service-account1@",
         ])
       ).to.not.be.rejected;
+    });
+  });
+
+  describe("listFunctions", () => {
+    it("should pass back an error with the correct status", async () => {
+      nock(functionsOrigin)
+        .get("/v1/projects/foo/locations/-/functions")
+        .reply(403, { error: "You don't have permissions." });
+
+      let errCaught = false;
+      try {
+        await cloudfunctions.listFunctions("foo", "-");
+      } catch (err: unknown) {
+        errCaught = true;
+        expect(err).instanceOf(FirebaseError);
+        expect(err).has.property("status", 403);
+      }
+
+      expect(errCaught, "should have caught an error").to.be.true;
+      expect(nock.isDone()).to.be.true;
     });
   });
 });

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -1,10 +1,13 @@
 import { expect } from "chai";
+import * as nock from "nock";
 
 import * as cloudfunctionsv2 from "../../gcp/cloudfunctionsv2";
 import * as backend from "../../deploy/functions/backend";
 import * as events from "../../functions/events";
 import * as projectConfig from "../../functions/projectConfig";
 import { BLOCKING_LABEL, CODEBASE_LABEL, HASH_LABEL } from "../../functions/constants";
+import { functionsV2Origin } from "../../api";
+import { FirebaseError } from "../../error";
 
 describe("cloudfunctionsv2", () => {
   const FUNCTION_NAME: backend.TargetIds = {
@@ -659,6 +662,27 @@ describe("cloudfunctionsv2", () => {
         codebase: "my-codebase",
         hash: "my-hash",
       });
+    });
+  });
+
+  describe("listFunctions", () => {
+    it("should pass back an error with the correct status", async () => {
+      nock(functionsV2Origin)
+        .get("/v2/projects/foo/locations/-/functions")
+        .query({ filter: `environment="GEN_2"` })
+        .reply(403, { error: "You don't have permissions." });
+
+      let errCaught = false;
+      try {
+        await cloudfunctionsv2.listFunctions("foo", "-");
+      } catch (err: unknown) {
+        errCaught = true;
+        expect(err).instanceOf(FirebaseError);
+        expect(err).has.property("status", 403);
+      }
+
+      expect(errCaught, "should have caught an error").to.be.true;
+      expect(nock.isDone()).to.be.true;
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

The check that was added to catch permissions issues had a little problem _and_ the status wasn't being properly passed through and checked. This CL fixes both and adds additional tests.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Deploying with the cloud functions API turned off when including rewrite functions works correctly.

Fixes #5071.

Hopefully for real.