### PR TITLE
Fixes error `EADDRNOTAVAIL` in portUtils.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes issue where errors were not properly propagating when listing backends. (#5071)
 - Fixes issue where message from `-m` on deploy was not being properly applied. (#5107)
+- Fixes error `EADDRNOTAVAIL` when running emulators in Docker.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Addresses https://github.com/firebase/firebase-tools/issues/4741#issuecomment-1275318134 (I think)

### Scenarios Tested

See https://github.com/firebase/firebase-tools/issues/4741#issuecomment-1275318134

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
