### PR TITLE
Provide a backup when implicitInit fails

### DIFF
--- a/src/hosting/implicitInit.ts
+++ b/src/hosting/implicitInit.ts
@@ -18,7 +18,7 @@ export interface TemplateServerResponse {
   emulatorsJs: string;
 
   // firebaseConfig JSON
-  json: string;
+  json?: string;
 }
 
 /**

--- a/src/serve/hosting.ts
+++ b/src/serve/hosting.ts
@@ -16,6 +16,7 @@ import { Emulators } from "../emulator/types";
 import { createDestroyer } from "../utils";
 import { execSync } from "child_process";
 import { requireHostingSite } from "../requireHostingSite";
+import { getProjectId } from "../projectUtils";
 
 const MAX_PORT_ATTEMPTS = 10;
 let attempts = 0;
@@ -154,7 +155,7 @@ export async function start(options: any): Promise<void> {
       if (init.json) {
         options.site = JSON.parse(init.json).projectId;
       } else {
-        options.site = "site";
+        options.site = getProjectId(options) || "site";
       }
     }
   }

--- a/src/serve/hosting.ts
+++ b/src/serve/hosting.ts
@@ -151,7 +151,11 @@ export async function start(options: any): Promise<void> {
     try {
       await requireHostingSite(options);
     } catch {
-      options.site = JSON.parse(init.json).projectId;
+      if (init.json) {
+        options.site = JSON.parse(init.json).projectId;
+      } else {
+        options.site = "site";
+      }
     }
   }
   const configs = config.hostingConfig(options);


### PR DESCRIPTION
The return value of implicitInit did not correctly annotate that the json field could be undefined, which caused #5114. This adds the annotation and handles the newly-popping undefined value case.