### PR TITLE
assign Hosting port using portUtils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes issue where errors were not properly propagating when listing backends. (#5071)
 - Fixes issue where message from `-m` on deploy was not being properly applied. (#5107)
 - Fixes error `EADDRNOTAVAIL` when running emulators in Docker.
+- Fixes further issues where ports were not correctly recognized as unavailable.

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -19,7 +19,7 @@ export const FIND_AVAILBLE_PORT_BY_DEFAULT: Record<Emulators, boolean> = {
   ui: true,
   hub: true,
   logging: true,
-  hosting: false,
+  hosting: true,
   functions: false,
   firestore: false,
   database: false,

--- a/src/emulator/hostingEmulator.ts
+++ b/src/emulator/hostingEmulator.ts
@@ -9,13 +9,19 @@ interface HostingEmulatorArgs {
 }
 
 export class HostingEmulator implements EmulatorInstance {
+  private reservedPorts?: number[];
+
   constructor(private args: HostingEmulatorArgs) {}
 
-  start(): Promise<void> {
+  async start(): Promise<void> {
     this.args.options.host = this.args.host;
     this.args.options.port = this.args.port;
 
-    return serveHosting.start(this.args.options);
+    const { ports } = await serveHosting.start(this.args.options);
+    this.args.port = ports[0];
+    if (ports.length > 1) {
+      this.reservedPorts = ports.slice(1);
+    }
   }
 
   connect(): Promise<void> {
@@ -34,6 +40,7 @@ export class HostingEmulator implements EmulatorInstance {
       name: this.getName(),
       host,
       port,
+      reservedPorts: this.reservedPorts,
     };
   }
 

--- a/src/serve/hosting.ts
+++ b/src/serve/hosting.ts
@@ -133,14 +133,7 @@ export async function start(options: any): Promise<{ ports: number[] }> {
   for (let i = 0; i < configs.length; i++) {
     // skip over the functions emulator ports to avoid breaking changes
     let port = i === 0 ? options.port : options.port + 4 + i;
-    while (
-      assignedPorts.has(port) ||
-      !(await checkListenable({
-        address: options.host,
-        port,
-        family: isIPv4(options.host) ? "IPv4" : "IPv6",
-      }))
-    ) {
+    while (assignedPorts.has(port) || !(await availablePort(options.host, port))) {
       port += 1;
     }
     assignedPorts.add(port);
@@ -158,4 +151,12 @@ export async function start(options: any): Promise<{ ports: number[] }> {
  */
 export async function connect(): Promise<void> {
   await Promise.resolve();
+}
+
+function availablePort(host: string, port: number): Promise<boolean> {
+  return checkListenable({
+    address: host,
+    port,
+    family: isIPv4(host) ? "IPv4" : "IPv6",
+  });
 }

--- a/src/serve/hosting.ts
+++ b/src/serve/hosting.ts
@@ -2,6 +2,7 @@ const morgan = require("morgan");
 import { IncomingMessage, ServerResponse } from "http";
 import { server as superstatic } from "superstatic";
 import * as clc from "colorette";
+import { isIPv4 } from "net";
 
 import { detectProjectRoot } from "../detectProjectRoot";
 import { FirebaseError } from "../error";
@@ -14,12 +15,10 @@ import { Writable } from "stream";
 import { EmulatorLogger } from "../emulator/emulatorLogger";
 import { Emulators } from "../emulator/types";
 import { createDestroyer } from "../utils";
-import { execSync } from "child_process";
 import { requireHostingSite } from "../requireHostingSite";
 import { getProjectId } from "../projectUtils";
+import { checkListenable } from "../emulator/portUtils";
 
-const MAX_PORT_ATTEMPTS = 10;
-let attempts = 0;
 let destroyServer: undefined | (() => Promise<void>) = undefined;
 
 const logger = EmulatorLogger.forEmulator(Emulators.HOSTING);
@@ -45,34 +44,6 @@ function startServer(options: any, config: any, port: number, init: TemplateServ
   const morganMiddleware = morgan("combined", {
     stream: morganStream,
   });
-
-  const portInUse = () => {
-    const message = "Port " + options.port + " is not available.";
-    logger.log("WARN", clc.yellow("hosting: ") + message + " Trying another port...");
-    if (attempts < MAX_PORT_ATTEMPTS) {
-      // Another project that's running takes up to 4 ports: 1 hosting port and 3 functions ports
-      attempts++;
-      startServer(options, config, port + 5, init);
-    } else {
-      logger.log("WARN", message);
-      throw new FirebaseError("Could not find an open port for hosting development server.", {
-        exit: 1,
-      });
-    }
-  };
-
-  // On OSX, some ports may be reserved by the OS in a way that node http doesn't detect.
-  // Starting in MacOS 12.3 it does this with port 5000 our default port. This is a bad
-  // enough devexp that we should special case and ensure it's available.
-  if (process.platform === "darwin") {
-    try {
-      execSync(`lsof -i :${port} -sTCP:LISTEN`);
-      portInUse();
-      return;
-    } catch (e) {
-      // if lsof errored the port is NOT in use, continue
-    }
-  }
 
   const after = options.frameworksDevModeHandle && {
     files: options.frameworksDevModeHandle,
@@ -114,16 +85,11 @@ function startServer(options: any, config: any, port: number, init: TemplateServ
 
   destroyServer = createDestroyer(server);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  server.on("error", (err: any) => {
-    if (err.code === "EADDRINUSE") {
-      portInUse();
-    } else {
-      throw new FirebaseError(
-        "An error occurred while starting the hosting development server:\n\n" + err.toString(),
-        { exit: 1 }
-      );
-    }
+  server.on("error", (err: Error) => {
+    logger.log("DEBUG", `Error from superstatic server: ${err.stack || ""}`);
+    throw new FirebaseError(
+      `An error occurred while starting the hosting development server:\n\n${err.message}`
+    );
   });
 }
 
@@ -139,7 +105,7 @@ export function stop(): Promise<void> {
  * @param options the Firebase CLI options.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export async function start(options: any): Promise<void> {
+export async function start(options: any): Promise<{ ports: number[] }> {
   const init = await implicitInit(options);
   // N.B. Originally we didn't call this method because it could try to resolve
   // targets and cause us to fail. But we might be calling prepareFrameworks,
@@ -161,11 +127,30 @@ export async function start(options: any): Promise<void> {
   }
   const configs = config.hostingConfig(options);
 
+  // We never want to try and take port 5001 because Functions likes that port
+  // quite a bit, and we don't want to make Functions mad.
+  const assignedPorts = new Set<number>([5001]);
   for (let i = 0; i < configs.length; i++) {
     // skip over the functions emulator ports to avoid breaking changes
-    const port = i === 0 ? options.port : options.port + 4 + i;
+    let port = i === 0 ? options.port : options.port + 4 + i;
+    while (
+      assignedPorts.has(port) ||
+      !(await checkListenable({
+        address: options.host,
+        port,
+        family: isIPv4(options.host) ? "IPv4" : "IPv6",
+      }))
+    ) {
+      port += 1;
+    }
+    assignedPorts.add(port);
     startServer(options, configs[i], port, init);
   }
+
+  // We are not actually reserving 5001, so remove it from our set before
+  // returning.
+  assignedPorts.delete(5001);
+  return { ports: Array.from(assignedPorts) };
 }
 
 /**


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Instead of relying on custom port-finding logic in the Hosting emulator, utilize the portUtils from the emulator to get a port. Additionally, report back the port that _is_ used to the Hosting emulator's registry information, which will allow the registry to correctly see that the Hosting emulator has started.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

A setup with Hosting + Functions works wonderfully, so does a Next.js app that starts functions along side Hosting. (all on macOS)