### PR TITLE
[Post summit] Fix run tag pinning

### DIFF
--- a/src/deploy/hosting/convertConfig.ts
+++ b/src/deploy/hosting/convertConfig.ts
@@ -119,6 +119,7 @@ export async function convertConfig(
     }
   }
 
+  // TODO: Track the use of pin in functions/run rewrites.
   config.rewrites = deploy.config.rewrites?.map((rewrite) => {
     const target = extractPattern("rewrite", rewrite);
     if ("destination" in rewrite) {
@@ -199,12 +200,13 @@ export async function convertConfig(
       const apiRewrite: api.Rewrite = {
         ...target,
         run: {
-          region: "us-central1",
-          ...rewrite.run,
+          serviceId: rewrite.run.serviceId,
+          region: rewrite.run.region || "us-central1",
         },
       };
-      if (apiRewrite.run.tag) {
+      if (rewrite.run.pinTag) {
         experiments.assertEnabled("pintags", "pin to a run service revision");
+        apiRewrite.run.tag = runTags.TODO_TAG_NAME;
       }
       return apiRewrite;
     }


### PR DESCRIPTION
This is not for a feature launching at the summit and does not need to be checked in until after we thaw.

Previously the run rewrites used a splat operator to convert from firebase.json to api types but they're no longer compatible. Instead I need to set tag to the TODO_TAG_NAME when pinTags is true explicitly.

Verified with firebase.json:
```
{
  "hosting": {
    "public": "public",
    "rewrites": [
        {
            "source": "/latest",
            "run": {
                "serviceId": "tags-test"
            }
        },
        {
            "source": "/tagged",
            "run": {
                "serviceId": "tags-test",
                "pinTag": true
            }
        }
    ],
    "ignore": [
      "firebase.json",
      "**/.*",
      "**/node_modules/**"
    ]
  }
}
```

Deployed the site and then redeployed to tags-test. You can verify at:
at:
https://inlined-junkdrawer.web.app/tagged
https://inlined-junkdrawer.web.app/latest