### PR TITLE
Make web frameworks public

### DIFF
--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -81,10 +81,12 @@ export const ALL_EXPERIMENTS = experiments({
     shortDescription: "Native support for popular web frameworks",
     fullDescription:
       "Adds support for popular web frameworks such as Next.js " +
-      "Nuxt, Netlify, Angular, and Vite-compatible frameworks. Firebase is " +
+      "Angular, React, Svelte, and Vite-compatible frameworks. Firebase is " +
       "committed to support these platforms long-term, but a manual migration " +
       "may be required when the non-experimental support for these frameworks " +
       "is released",
+    docsUri: "https://firebase.google.com/docs/hosting/frameworks-overview",
+    public: true,
   },
   pintags: {
     shortDescription: "Adds the pinTag option to Run and Functions rewrites",


### PR DESCRIPTION
Modify the experiment to actually make sense (e.g. not conflate web frameworks and their companies), add docs URL, and make the experiment public.