### PR TITLE
Track which web framework is deployed

### DIFF
--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -61,10 +61,11 @@ export const deploy = async function (
 
   if (targetNames.includes("hosting")) {
     const config = options.config.get("hosting");
+    let deployedFrameworks: string[] = [];
     if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
       experiments.assertEnabled("webframeworks", "deploy a web framework to hosting");
       const usedToTargetFunctions = targetNames.includes("functions");
-      await prepareFrameworks(targetNames, context, options);
+      deployedFrameworks = await prepareFrameworks(targetNames, context, options);
       const nowTargetsFunctions = targetNames.includes("functions");
       if (nowTargetsFunctions && !usedToTargetFunctions) {
         if (context.hostingChannel && !experiments.isEnabled("pintags")) {
@@ -74,7 +75,11 @@ export const deploy = async function (
         }
         await requirePermissions(TARGET_PERMISSIONS["functions"]);
       }
+    } else {
+      const count = Array.isArray(config) ? config.length : 1;
+      deployedFrameworks = Array<string>(count).fill("classic");
     }
+    await Promise.all(deployedFrameworks.map((framework) => track("hosting_deploy", framework)));
   }
 
   for (const targetName of targetNames) {


### PR DESCRIPTION
Adds a track command for the "hosting_deploy" metric with a label for the kind of site deployed. If it's not a web framework, we use "classic" as a sentinel. If there is a function related to the framework, we add "_ssr".