### PR TITLE
+ Fix empty request body

### DIFF
--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -1047,7 +1047,7 @@ async function main(): Promise<void> {
         case "event":
         case "cloudevent":
           const rawBody = (req as RequestWithRawBody).rawBody;
-          let reqBody = JSON.parse(rawBody.toString());
+          let reqBody = rawBody ? JSON.parse(rawBody.toString()) : {};
           if (EventUtils.isBinaryCloudEvent(req)) {
             reqBody = EventUtils.extractBinaryCloudEventContext(req);
             reqBody.data = req.body;


### PR DESCRIPTION
### Description

When running function emulator and make request to that function with empty request body will throw error because trying to read rawBody ( which will be undefined )

### Scenarios Tested

Having this simple function :
```js
const callTestCron = () => {
  console.log("ok got called?")
}

const testCron = functions
  .pubsub
  .schedule('every day 00:00')
  .timeZone('America/Sao_Paulo')
  .onRun(callTestCron)

module.exports = {
  testCron
}
```

Now try to call this function without any body will throw this error:
```bash
⚠  functions: TypeError: Cannot read properties of undefined (reading 'toString')
    at /Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:685:54
    at Layer.handle [as handle_request] (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/layer.js:95:5)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:137:13)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:131:14)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:131:14)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:131:14)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:131:14)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:131:14)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:131:14)
    at next (/Users/hemasama/.nvm/versions/node/v16.15.1/lib/node_modules/firebase-tools/node_modules/express/lib/router/route.js:131:14)
⚠  Your function was killed because it raised an unhandled error.
```

This commit will fix this error.
