### PR TITLE
Show prereleases when resolving Extension versions.

### DIFF
--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -209,7 +209,7 @@ export async function want(args: {
  */
 export async function resolveVersion(ref: refs.Ref): Promise<string> {
   const extensionRef = refs.toExtensionRef(ref);
-  const versions = await extensionsApi.listExtensionVersions(extensionRef);
+  const versions = await extensionsApi.listExtensionVersions(extensionRef, undefined, true);
   if (versions.length === 0) {
     throw new FirebaseError(`No versions found for ${extensionRef}`);
   }


### PR DESCRIPTION
Currently it's not possible to install pre-release Extension versions (e.g. 1.0.0-rc.0) from the CLI because pre-release versions are ignored when resolving the ref to install.