### PR TITLE
build:publish should also run copyfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 Release RTDB Emulator v4.11.0: Wire protocol update for `startAfter`, `endBefore`.
+- Fixes internal library that was not being correctly published.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Releases RTDB Emulator v4.11.0: Wire protocol update for `startAfter`, `endBefore`.
-- Changes `superstatic` dependency to `v8`, addressing Hosting emulator issues in the Hosting emulator.
+- Changes `superstatic` dependency to `v8`, addressing Hosting emulator issues on Windows.
 - Fixes internal library that was not being correctly published.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 Release RTDB Emulator v4.11.0: Wire protocol update for `startAfter`, `endBefore`.
+
 - Fixes internal library that was not being correctly published.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "build": "tsc && npm run copyfiles",
-    "build:publish": "tsc --build tsconfig.publish.json",
+    "build:publish": "tsc --build tsconfig.publish.json && npm run copyfiles",
     "build:watch": "npm run build && tsc --watch",
     "clean": "rimraf lib dev",
     "copyfiles": "node -e \"const fs = require('fs'); fs.mkdirSync('./lib', {recursive:true}); fs.copyFileSync('./src/dynamicImport.js', './lib/dynamicImport.js')\"",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

The files are being rewritten today and they shouldn't be (because `tsc` will transpile them by default). This copies them over before publication.