### PR TITLE
Add `--disable-triggers` flag to database write commands

### DIFF
--- a/src/commands/database-push.ts
+++ b/src/commands/database-push.ts
@@ -21,6 +21,7 @@ export const command = new Command("database:push <path> [infile]")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
+  .option("--disable-triggers", "suppress any Cloud functions triggered by this operation")
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireDatabaseInstance)
   .before(populateInstanceDetails)
@@ -33,6 +34,9 @@ export const command = new Command("database:push <path> [infile]")
       utils.stringToStream(options.data) || (infile ? fs.createReadStream(infile) : process.stdin);
     const origin = realtimeOriginOrEmulatorOrCustomUrl(options.instanceDetails.databaseUrl);
     const u = new URL(utils.getDatabaseUrl(origin, options.instance, path + ".json"));
+    if (options.disableTriggers) {
+      u.searchParams.set("disableTriggers", "true");
+    }
 
     if (!infile && !options.data) {
       utils.explainStdin();
@@ -46,6 +50,7 @@ export const command = new Command("database:push <path> [infile]")
         method: "POST",
         path: u.pathname,
         body: inStream,
+        queryParams: u.searchParams,
       });
     } catch (err: any) {
       logger.debug(err);

--- a/src/commands/database-remove.ts
+++ b/src/commands/database-remove.ts
@@ -17,6 +17,7 @@ export const command = new Command("database:remove <path>")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
+  .option("--disable-triggers", "suppress any Cloud functions triggered by this operation")
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireDatabaseInstance)
   .before(populateInstanceDetails)
@@ -40,7 +41,7 @@ export const command = new Command("database:remove <path>")
       return utils.reject("Command aborted.", { exit: 1 });
     }
 
-    const removeOps = new DatabaseRemove(options.instance, path, origin);
+    const removeOps = new DatabaseRemove(options.instance, path, origin, !!options.disableTriggers);
     await removeOps.execute();
     utils.logSuccess("Data removed successfully");
   });

--- a/src/commands/database-set.ts
+++ b/src/commands/database-set.ts
@@ -23,6 +23,7 @@ export const command = new Command("database:set <path> [infile]")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
+  .option("--disable-triggers", "suppress any Cloud functions triggered by this operation")
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireDatabaseInstance)
   .before(populateInstanceDetails)
@@ -34,6 +35,9 @@ export const command = new Command("database:set <path> [infile]")
     const origin = realtimeOriginOrEmulatorOrCustomUrl(options.instanceDetails.databaseUrl);
     const dbPath = utils.getDatabaseUrl(origin, options.instance, path);
     const dbJsonURL = new URL(utils.getDatabaseUrl(origin, options.instance, path + ".json"));
+    if (options.disableTriggers) {
+      dbJsonURL.searchParams.set("disableTriggers", "true");
+    }
 
     const confirm = await promptOnce(
       {
@@ -61,6 +65,7 @@ export const command = new Command("database:set <path> [infile]")
         method: "PUT",
         path: dbJsonURL.pathname,
         body: inStream,
+        queryParams: dbJsonURL.searchParams,
       });
     } catch (err: any) {
       logger.debug(err);

--- a/src/commands/database-update.ts
+++ b/src/commands/database-update.ts
@@ -23,6 +23,7 @@ export const command = new Command("database:update <path> [infile]")
     "--instance <instance>",
     "use the database <instance>.firebaseio.com (if omitted, use default database instance)"
   )
+  .option("--disable-triggers", "suppress any Cloud functions triggered by this operation")
   .before(requirePermissions, ["firebasedatabase.instances.update"])
   .before(requireDatabaseInstance)
   .before(populateInstanceDetails)
@@ -51,6 +52,9 @@ export const command = new Command("database:update <path> [infile]")
       (infile && fs.createReadStream(infile)) ||
       process.stdin;
     const jsonUrl = new URL(utils.getDatabaseUrl(origin, options.instance, path + ".json"));
+    if (options.disableTriggers) {
+      jsonUrl.searchParams.set("disableTriggers", "true");
+    }
 
     if (!infile && !options.data) {
       utils.explainStdin();
@@ -62,6 +66,7 @@ export const command = new Command("database:update <path> [infile]")
         method: "PATCH",
         path: jsonUrl.pathname,
         body: inStream,
+        queryParams: jsonUrl.searchParams,
       });
     } catch (err: any) {
       throw new FirebaseError("Unexpected error while setting data");

--- a/src/database/remove.ts
+++ b/src/database/remove.ts
@@ -29,10 +29,11 @@ export default class DatabaseRemove {
    * @param instance RTBD instance ID.
    * @param path path to delete.
    * @param host db host.
+   * @param disableTriggers if true, suppresses any Cloud functions that would be triggered by this operation.
    */
-  constructor(instance: string, path: string, host: string) {
+  constructor(instance: string, path: string, host: string, disableTriggers: boolean = false) {
     this.path = path;
-    this.remote = new RTDBRemoveRemote(instance, host);
+    this.remote = new RTDBRemoveRemote(instance, host, disableTriggers);
     this.deleteJobStack = new Stack({
       name: "delete stack",
       concurrency: 1,

--- a/src/database/removeRemote.ts
+++ b/src/database/removeRemote.ts
@@ -22,10 +22,12 @@ export class RTDBRemoveRemote implements RemoveRemote {
   private instance: string;
   private host: string;
   private apiClient: Client;
+  private disableTriggers: boolean;
 
-  constructor(instance: string, host: string) {
+  constructor(instance: string, host: string, disableTriggers: boolean = false) {
     this.instance = instance;
     this.host = host;
+    this.disableTriggers = disableTriggers;
 
     const url = new URL(utils.getDatabaseUrl(this.host, this.instance, "/"));
     this.apiClient = new Client({ urlPrefix: url.origin, auth: true });
@@ -46,7 +48,11 @@ export class RTDBRemoveRemote implements RemoveRemote {
   private async patch(path: string, body: any, note: string): Promise<boolean> {
     const t0 = Date.now();
     const url = new URL(utils.getDatabaseUrl(this.host, this.instance, path + ".json"));
-    const queryParams = { print: "silent", writeSizeLimit: "tiny" };
+    const queryParams = {
+      print: "silent",
+      writeSizeLimit: "tiny",
+      disableTriggers: this.disableTriggers.toString(),
+    };
     const res = await this.apiClient.request({
       method: "PATCH",
       path: url.pathname,


### PR DESCRIPTION
### Description
[b/233759622](http://b/233759622)

API Proposal: [go/fbi-disable-triggers-api](http://go/fbi-disable-triggers-api)

Based on https://github.com/FirebasePrivate/firebase-tools/pull/539

### Sample Commands
```
firebase database:push /some/path --data '{"foo": "bar"}' --disable-triggers
firebase database:set /some/path --data '{"foo": "bar"}' --disable-triggers
firebase database:update /some/path --data '{"foo": "bar"}' --disable-triggers
firebase database:remove /some/path --data '{"foo": "bar"}' --disable-triggers
```