### PR TITLE
Enable experiments that should have gone out with the 4.0 functions sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,3 @@
 - Adds `--disable-triggers` flag to RTDB write commands.
 - Default enables experiment to skip deploying unmodified functions (#5192)
 - Default enables experiment to allow parameterized functions codebases (#5192)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,6 @@
 - Changes `superstatic` dependency to `v8`, addressing Hosting emulator issues on Windows.
 - Fixes internal library that was not being correctly published.
 - Adds `--disable-triggers` flag to RTDB write commands.
+- Default enables experiment to skip deploying unmodified functions (#5192)
+- Default enables experiment to allow parameterized functions codebases (#5192)
+

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -68,10 +68,6 @@ export const ALL_EXPERIMENTS = experiments({
     shortDescription: "Adds support for paramaterizing functions deployments",
     default: true,
   },
-  skipdeployingnoopfunctions: {
-    shortDescription: "Detect that there have been no changes to a function and skip deployment",
-    default: true,
-  },
 
   // Emulator experiments
   emulatoruisnapshot: {

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -66,9 +66,11 @@ export const ALL_EXPERIMENTS = experiments({
   },
   functionsparams: {
     shortDescription: "Adds support for paramaterizing functions deployments",
+    default: true,
   },
   skipdeployingnoopfunctions: {
     shortDescription: "Detect that there have been no changes to a function and skip deployment",
+    default: true,
   },
 
   // Emulator experiments


### PR DESCRIPTION
Fixes #5186

the experiments `functionsparams` and `skipdeployingnoopfunctions` should have been enabled with the Firebase Summit release of the CLI.