### PR TITLE
Auto-upgrade/downgrade implicit concurrency with CPU changes

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -327,10 +327,7 @@ export function inferDetailsFromExisting(
 
     // N.B. concurrency has different defaults based on CPU. If the customer
     // only specifies CPU and they change that specification to < 1, we should
-    // turn off concurrency. We'll not do the opposite and turn on concurrency
-    // if there are >1 CPU because this could expose race conditions. They
-    // either need to start on concurrency where they've always needed to
-    // handle race conditions, or they should explicitly enable.
+    // turn off concurrency.
     // We'll hanndle this in setCpuAndConcurrency
 
     wantE.securityLevel = haveE.securityLevel ? haveE.securityLevel : "SECURE_ALWAYS";

--- a/src/test/deploy/functions/prepare.spec.ts
+++ b/src/test/deploy/functions/prepare.spec.ts
@@ -123,7 +123,7 @@ describe("prepare", () => {
       expect(want.availableMemoryMb).to.equal(512);
     });
 
-    it("downgrades concurrency if necessary", () => {
+    it("downgrades concurrency if necessary (explicit)", () => {
       const have: backend.Endpoint = {
         ...ENDPOINT_BASE,
         httpsTrigger: {},
@@ -137,6 +137,42 @@ describe("prepare", () => {
       };
 
       prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* useDotEnv= */ false);
+      prepare.resolveCpuAndConcurrency(backend.of(want));
+      expect(want.concurrency).to.equal(1);
+    });
+
+    it("downgrades concurrency if necessary (implicit)", () => {
+      const have: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+        concurrency: 80,
+        cpu: 1,
+      };
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+        cpu: "gcf_gen1",
+      };
+
+      prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* useDotEnv= */ false);
+      prepare.resolveCpuAndConcurrency(backend.of(want));
+      expect(want.concurrency).to.equal(1);
+    });
+
+    it("upgrades default concurrency with CPU upgrades", () => {
+      const have: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+        availableMemoryMb: 256,
+        cpu: "gcf_gen1",
+      };
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+      };
+
+      prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* useDotEnv= */ false);
+      prepare.resolveCpuAndConcurrency(backend.of(want));
       expect(want.concurrency).to.equal(1);
     });
   });

--- a/src/test/deploy/functions/prepare.spec.ts
+++ b/src/test/deploy/functions/prepare.spec.ts
@@ -122,6 +122,23 @@ describe("prepare", () => {
       prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* usedDotEnv= */ false);
       expect(want.availableMemoryMb).to.equal(512);
     });
+
+    it("downgrades concurrency if necessary", () => {
+      const have: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+        concurrency: 80,
+        cpu: 1,
+      };
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+        cpu: 0.5,
+      };
+
+      prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* useDotEnv= */ false);
+      expect(want.concurrency).to.equal(1);
+    });
   });
 
   describe("inferBlockingDetails", () => {

--- a/src/test/deploy/functions/validate.spec.ts
+++ b/src/test/deploy/functions/validate.spec.ts
@@ -8,7 +8,7 @@ import * as projectPath from "../../../projectPath";
 import * as secretManager from "../../../gcp/secretManager";
 import * as backend from "../../../deploy/functions/backend";
 import { BEFORE_CREATE_EVENT, BEFORE_SIGN_IN_EVENT } from "../../../functions/events/v1";
-import { resolveCpu } from "../../../deploy/functions/prepare";
+import { resolveCpuAndConcurrency } from "../../../deploy/functions/prepare";
 
 describe("validate", () => {
   describe("functionsDirectoryExists", () => {
@@ -331,7 +331,7 @@ describe("validate", () => {
           availableMemoryMb: mem,
           cpu: "gcf_gen1",
         };
-        resolveCpu(backend.of(ep));
+        resolveCpuAndConcurrency(backend.of(ep));
         expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw;
       }
     });
@@ -344,7 +344,7 @@ describe("validate", () => {
           cpu: "gcf_gen1",
           concurrency: 42,
         };
-        resolveCpu(backend.of(ep));
+        resolveCpuAndConcurrency(backend.of(ep));
         expect(() => validate.endpointsAreValid(backend.of(ep))).to.not.throw;
       }
     });
@@ -356,7 +356,7 @@ describe("validate", () => {
         concurrency: 2,
         cpu: "gcf_gen1",
       };
-      resolveCpu(backend.of(ep));
+      resolveCpuAndConcurrency(backend.of(ep));
       expect(() => validate.endpointsAreValid(backend.of(ep))).to.throw(
         /concurrent execution and less than one full CPU/
       );


### PR DESCRIPTION
Potential fix for #1288 if we decide to take it. We can decide to:

1. Auto downgrade from 80 concurrents to 1 concurrent, but not auto-upgrade (may confuse users, but avoids race condition bugs)
2. Apply the 1/80 concurrent defaults whenever concurrency is not specified (most in-line with other fields)
3. Keep the current behavior that concurrency is only set implicitly on first deploy