### PR TITLE
Pubsub2

### DIFF
--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -489,16 +489,17 @@ export function functionFromEndpoint(
       eventType: endpoint.eventTrigger.eventType,
     };
     if (gcfFunction.eventTrigger.eventType === PUBSUB_PUBLISH_EVENT) {
-      if (!endpoint.eventTrigger.eventFilters?.topic) {
+      if (!endpoint.eventTrigger.eventFilters?.topic && !endpoint.eventTrigger.eventFilters?.resource) {
         throw new FirebaseError(
           "Error: Pub/Sub event trigger is missing topic: " +
             JSON.stringify(endpoint.eventTrigger, null, 2)
         );
       }
-      gcfFunction.eventTrigger.pubsubTopic = endpoint.eventTrigger.eventFilters.topic;
+      gcfFunction.eventTrigger.pubsubTopic =
+        endpoint.eventTrigger.eventFilters.topic || endpoint.eventTrigger.eventFilters.resource;
       gcfFunction.eventTrigger.eventFilters = [];
       for (const [attribute, value] of Object.entries(endpoint.eventTrigger.eventFilters)) {
-        if (attribute === "topic") continue;
+        if (attribute === "topic" || attribute === "resource") continue;
         gcfFunction.eventTrigger.eventFilters.push({ attribute, value });
       }
     } else {
@@ -598,6 +599,7 @@ export function endpointFromFunction(gcfFunction: CloudFunction): backend.Endpoi
     const eventFilterPathPatterns: Record<string, string> = {};
     if (gcfFunction.eventTrigger.pubsubTopic) {
       eventFilters.topic = gcfFunction.eventTrigger.pubsubTopic;
+      eventFilters.resource = gcfFunction.eventTrigger.pubsubTopic;
     } else {
       for (const eventFilter of gcfFunction.eventTrigger.eventFilters || []) {
         if (eventFilter.operator === "match-path-pattern") {

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -489,17 +489,16 @@ export function functionFromEndpoint(
       eventType: endpoint.eventTrigger.eventType,
     };
     if (gcfFunction.eventTrigger.eventType === PUBSUB_PUBLISH_EVENT) {
-      if (!endpoint.eventTrigger.eventFilters?.topic && !endpoint.eventTrigger.eventFilters?.resource) {
+      if (!endpoint.eventTrigger.eventFilters?.resource) {
         throw new FirebaseError(
           "Error: Pub/Sub event trigger is missing topic: " +
             JSON.stringify(endpoint.eventTrigger, null, 2)
         );
       }
-      gcfFunction.eventTrigger.pubsubTopic =
-        endpoint.eventTrigger.eventFilters.topic || endpoint.eventTrigger.eventFilters.resource;
+      gcfFunction.eventTrigger.pubsubTopic = endpoint.eventTrigger.eventFilters.resource;
       gcfFunction.eventTrigger.eventFilters = [];
       for (const [attribute, value] of Object.entries(endpoint.eventTrigger.eventFilters)) {
-        if (attribute === "topic" || attribute === "resource") continue;
+        if (attribute === "resource") continue;
         gcfFunction.eventTrigger.eventFilters.push({ attribute, value });
       }
     } else {
@@ -598,7 +597,6 @@ export function endpointFromFunction(gcfFunction: CloudFunction): backend.Endpoi
     const eventFilters: Record<string, string> = {};
     const eventFilterPathPatterns: Record<string, string> = {};
     if (gcfFunction.eventTrigger.pubsubTopic) {
-      eventFilters.topic = gcfFunction.eventTrigger.pubsubTopic;
       eventFilters.resource = gcfFunction.eventTrigger.pubsubTopic;
     } else {
       for (const eventFilter of gcfFunction.eventTrigger.eventFilters || []) {


### PR DESCRIPTION
### Description

This change solves the bug with pub/sub function v2 deployment caused by the `eventFilters` missing `topic` field:

```
FirebaseError Error: Pub/Sub event trigger is missing topic: {
  "eventType": "google.cloud.pubsub.topic.v1.messagePublished",
  "retry": false,
  "eventFilters": {
    "resource": "projects/XXX/topics/edit-delayed2"
  }
}
```

During the deployment, the API also needs the `resource` field:

```
⚠  functions: HTTP Error: 400, Cannot create trigger projects/chirrapp-staging/locations/us-central1/triggers/publishdelayed2-555223: The request was invalid: generic::invalid_argument: event type google.cloud.pubsub.topic.v1.messagePublished not supported: attribute resource not found within event type
```

I split the PR into two commits, [one adds fallback to `resource`](https://github.com/firebase/firebase-tools/commit/d0dca6cd6973e299e5f19164f4e5116d58ef75c3), and [another that renames `topic` to `resource`](https://github.com/firebase/firebase-tools/commit/d0bb14e6a3b38053cfc9cf475aa03d4618f9b1d6).

I'm not sure if it worked before.

### Scenarios Tested

I've changed this in my local `node_modules` and managed to deploy the function.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
