### PR TITLE
Fixes a bug where extensions emulator was not appearing in the registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,5 @@
 - Fixes gzipped file handling in Storage Emulator.
 - Add support for object list using certain Admin SDKs (#5208)
 - Fixes source token expiration issue by acquiring new source token upon expiration.
-- Fix bug where emulated event triggered function broke in debug mode (#5211)
+- Fixes bug where emulated event triggered function broke in debug mode (#5211)
+- Fixes bug that caused the Extensions Emulator to always appear to be inactive in the Emulator UI.

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -67,7 +67,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
         "Extensions Emulator is running but Functions emulator is not. This should never happen."
       );
     }
-    return functionsEmulator.getInfo();
+    return { ...functionsEmulator.getInfo(), name: this.getName() };
   }
 
   public getName(): Emulators {


### PR DESCRIPTION
### Description
Fixes a bug where extensions emulator was not appearing in the registry.
#5079 subtly changed the configs/ endpoint to use EmulatorInfo.name instead of emulator (https://github.com/firebase/firebase-tools/pull/5079/files#diff-07ee97578863300681bbd61b6886c20684286a13f3c6c6404176f48f66b22f36). ExtensionsEmulator.getInfo() was returning the info of the functions emulator, which meant that the extensions emulator would no longer be listed. This PR fixes getInfo to return the correct name
### Scenarios Tested
Extensions emulator tab is now active when extensions are running:
<img width="1438" alt="Screen Shot 2022-11-15 at 9 37 17 AM" src="https://user-images.githubusercontent.com/4635763/201988462-d7616456-3d1b-46aa-9ec1-b06e23f85a02.png">
Instance info pages work too:
<img width="1434" alt="Screen Shot 2022-11-15 at 9 38 37 AM" src="https://user-images.githubusercontent.com/4635763/201988538-7968ec5d-f2dd-4965-8436-1eaf565e4257.png">

