### PR TITLE
Web Frameworks support: Use ES6 module syntax and use main file in express integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Support the x-goog-api-key header in auth emulator. (#5249)
 - Fix bug in deploying web frameworks when a predeploy hook was configured in firebase.json (#5199)
 - Fix bug where function deployments using --only filter sometimes failed deployments. (#5280)
+- Support custom web framework support for projects using ESM. (#5158)

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -523,10 +523,9 @@ ${firebaseDefaults ? `__FIREBASE_DEFAULTS__=${JSON.stringify(firebaseDefaults)}\
       // TODO move to templates
       await writeFile(
         join(functionsDist, "server.js"),
-        `const { onRequest } = require('firebase-functions/v2/https');
-const server = import('firebase-frameworks');
-exports.ssr = onRequest((req, res) => server.then(it => it.handle(req, res)));
-`
+        `import { onRequest } from 'firebase-functions/v2/https';
+         const server = import('firebase-frameworks');
+         export const ssr = onRequest((req, res) => server.then(it => it.handle(req, res)));`
       );
     } else {
       // No function, treat as an SPA


### PR DESCRIPTION
### Description

This should fix two issues:  
- When trying to integrate custom web frameworks through express the generated handle function tries to import the root path (where the `package.json` lies). Actually, it should import the file specified in the  `main` property of the `package.json`
- When trying to integrate custom web frameworks through express with `"type": "module"` in `package.json` the generated function fails to execute since the generated code contains a `require(...)` statement.

Should close:  
 - [Issue in firebase-framework-tools repo](https://github.com/FirebaseExtended/firebase-framework-tools/issues/53)
 - #5158

### Scenarios Tested

I linked the `firebase-tools` to my branch using `npm link` and ran the tests in the [firebase-framework-tools repo](https://github.com/FirebaseExtended/firebase-framework-tools). Is this how it should be done? I needed to replace the site ID in a couple of files to a site ID which I have access to. 

This was also tested in the branch of the [web framework support PR](https://github.com/simonnepomuk/monorepo/pull/2) of my SvelteKit adapter with `emulators:start` and `deploy`.


