### PR TITLE
Added INVALID_EMAIL to signInWithPassword

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1708,7 +1708,8 @@ async function signInWithPassword(
 ): Promise<Schemas["GoogleCloudIdentitytoolkitV1SignInWithPasswordResponse"]> {
   assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.allowPasswordSignup, "PASSWORD_LOGIN_DISABLED");
-  assert(reqBody.email, "MISSING_EMAIL");
+  assert("email" in reqBody, "MISSING_EMAIL");
+  assert(reqBody.email && isValidEmailAddress(reqBody.email), "INVALID_EMAIL");
   assert(reqBody.password, "MISSING_PASSWORD");
   if (reqBody.captchaResponse || reqBody.captchaChallenge) {
     throw new NotImplementedError("captcha unimplemented");

--- a/src/test/emulators/auth/password.spec.ts
+++ b/src/test/emulators/auth/password.spec.ts
@@ -82,7 +82,18 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
       });
   });
 
-  it("should error if email or password is missing", async () => {
+  it("should error if password is missing", async () => {
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
+      .query({ key: "fake-api-key" })
+      .send({ email: "nosuchuser@example.com" /* no password */ })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).equals("MISSING_PASSWORD");
+      });
+  });
+
+  it("should error if email is missing", async () => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
       .query({ key: "fake-api-key" })
@@ -91,13 +102,24 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
         expectStatusCode(400, res);
         expect(res.body.error.message).equals("MISSING_EMAIL");
       });
+  });
+
+  it("should error if email is invalid", async () => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
       .query({ key: "fake-api-key" })
-      .send({ email: "nosuchuser@example.com" /* no password */ })
+      .send({ email: "", password: "notasecret" })
       .then((res) => {
         expectStatusCode(400, res);
-        expect(res.body.error.message).equals("MISSING_PASSWORD");
+        expect(res.body.error.message).equals("INVALID_EMAIL");
+      });
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
+      .query({ key: "fake-api-key" })
+      .send({ email: "example.com", password: "notasecret" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).equals("INVALID_EMAIL");
       });
   });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Auth emulator currently does not match the identity toolkit API.

#### Against the API

##### Empty string

`curl -i 'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=<REDACTED>' -X POST -H 'content-type:application/json' --data-raw '{"email":""}'`

```
HTTP/2 400 
pragma: no-cache
cache-control: no-cache, no-store, max-age=0, must-revalidate
date: Thu, 17 Nov 2022 12:12:48 GMT
expires: Mon, 01 Jan 1990 00:00:00 GMT
vary: X-Origin
vary: Referer
vary: Origin,Accept-Encoding
content-type: application/json; charset=UTF-8
server: ESF
x-xss-protection: 0
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
accept-ranges: none

{
  "error": {
    "code": 400,
    "message": "INVALID_EMAIL",
    "errors": [
      {
        "message": "INVALID_EMAIL",
        "domain": "global",
        "reason": "invalid"
      }
    ]
  }
}
```

##### Invalid email

`curl -i 'https://identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=<REDACTED>' -X POST -H 'content-type:application/json' --data-raw '{"email":"blah"}'`

```
HTTP/2 400 
cache-control: no-cache, no-store, max-age=0, must-revalidate
date: Thu, 17 Nov 2022 12:26:49 GMT
expires: Mon, 01 Jan 1990 00:00:00 GMT
pragma: no-cache
vary: X-Origin
vary: Referer
vary: Origin,Accept-Encoding
content-type: application/json; charset=UTF-8
server: ESF
x-xss-protection: 0
x-frame-options: SAMEORIGIN
x-content-type-options: nosniff
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443"; ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
accept-ranges: none

{
  "error": {
    "code": 400,
    "message": "INVALID_EMAIL",
    "errors": [
      {
        "message": "INVALID_EMAIL",
        "domain": "global",
        "reason": "invalid"
      }
    ]
  }
}
```

#### Against the emulator

##### Empty string

`curl -i 'http://${FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=<REDACTED>' -X POST -H 'content-type:application/json' --data-raw '{"email":""}'`

```
HTTP/1.1 400 Bad Request
X-Powered-By: Express
Vary: Origin
Content-Type: application/json; charset=utf-8
Content-Length: 199
ETag: W/"c7-QMJ9wBehaN48AzNb0hKJn6UdTT8"
Date: Thu, 17 Nov 2022 12:25:51 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{
  "error": {
    "code": 400,
    "message": "MISSING_EMAIL",
    "errors": [
      {
        "message": "MISSING_EMAIL",
        "reason": "invalid",
        "domain": "global"
      }
    ]
  }
}
```

##### Invalid email

`curl -i 'http://${FIREBASE_AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=<REDACTED>' -X POST -H 'content-type:application/json' --data-raw '{"email":"blah"}'`

```
HTTP/1.1 400 Bad Request
X-Powered-By: Express
Vary: Origin
Content-Type: application/json; charset=utf-8
Content-Length: 205
ETag: W/"cd-0JYghHL+cORBSUZggCdEJkfW1z8"
Date: Thu, 17 Nov 2022 12:27:40 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{
  "error": {
    "code": 400,
    "message": "MISSING_PASSWORD",
    "errors": [
      {
        "message": "MISSING_PASSWORD",
        "reason": "invalid",
        "domain": "global"
      }
    ]
  }
}
```

### Scenarios Tested

Added unit tests for:

* Empty `email`
* Invalid `email`

### Sample Commands

See above.
