### PR TITLE
Parallelize hosting-rewrites tests

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -86,7 +86,7 @@ jobs:
           - npm run test:extensions-emulator
           - npm run test:frameworks
           - npm run test:hosting
-          # - npm run test:hosting-rewrites # Long-running test that might conflict across test runs. Run this manually.
+          - npm run test:hosting-rewrites
           - npm run test:import-export
           - npm run test:storage-deploy
           - npm run test:storage-emulator-integration
@@ -137,7 +137,7 @@ jobs:
           - "16"
         script:
           - npm run test:hosting
-          # - npm run test:hosting-rewrites # Long-running test that might conflict across test runs. Run this manually.
+          - npm run test:hosting-rewrites
           - npm run test:client-integration
           - npm run test:emulator
           # - npm run test:import-export # Fails becuase port 4000 is taken after first run - hub not shhutting down?

--- a/scripts/hosting-tests/rewrites-tests/tests.ts
+++ b/scripts/hosting-tests/rewrites-tests/tests.ts
@@ -6,24 +6,27 @@ import * as tmp from "tmp";
 import * as firebase from "../../../src";
 import { execSync } from "child_process";
 import { command as functionsDelete } from "../../../src/commands/functions-delete";
+import { command as sitesCreate } from "../../../src/commands/hosting-sites-create";
+import { command as sitesList } from "../../../src/commands/hosting-sites-list";
+import { command as sitesDelete } from "../../../src/commands/hosting-sites-delete";
 import fetch, { Request } from "node-fetch";
 import { FirebaseError } from "../../../src/error";
+import { QueueExecutor } from "../../../src/deploy/functions/release/executor";
 
 tmp.setGracefulCleanup();
+
+const siteNamePrefixLabel = "rwtestsite";
+const testConcurrency = 6;
 
 // Run this test manually by:
 // - Setting the target project to any project that can create publicly invokable functions.
 // - Disabling mockAuth in .mocharc
 
-const functionName = `helloWorld_${process.env.CI_RUN_ID || "XX"}_${
-  process.env.CI_RUN_ATTEMPT || "YY"
-}`;
-
 // Typescript doesn't like calling functions on `firebase`.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const client: any = firebase;
 
-function writeFirebaseRc(firebasercFilePath: string): void {
+function writeFirebaseRc(firebasercFilePath: string, siteName: string): void {
   const config = {
     projects: {
       default: process.env.FBTOOLS_TARGET_PROJECT,
@@ -31,7 +34,7 @@ function writeFirebaseRc(firebasercFilePath: string): void {
     targets: {
       [process.env.FBTOOLS_TARGET_PROJECT as string]: {
         hosting: {
-          "client-integration-site": [process.env.FBTOOLS_CLIENT_INTEGRATION_SITE],
+          [siteName]: [siteName],
         },
       },
     },
@@ -39,14 +42,33 @@ function writeFirebaseRc(firebasercFilePath: string): void {
   writeFileSync(firebasercFilePath, JSON.stringify(config));
 }
 
-async function deleteDeployedFunctions(): Promise<void> {
+async function createSite(siteName: string): Promise<void> {
+  await sitesCreate.runner()([siteName], {
+    projectId: process.env.FBTOOLS_TARGET_PROJECT,
+    force: true,
+  });
+}
+
+async function deleteSite(siteName: string, cwd: string): Promise<void> {
+  try {
+    await sitesDelete.runner()([siteName], {
+      projectId: process.env.FBTOOLS_TARGET_PROJECT,
+      force: true,
+      cwd: cwd,
+    });
+  } catch (e) {
+    // site might not exist
+  }
+}
+
+async function deleteDeployedFunctions(functionName: string): Promise<void> {
   try {
     await functionsDelete.runner()([functionName], {
       projectId: process.env.FBTOOLS_TARGET_PROJECT,
       force: true,
     });
-  } catch (FirebaseError) {
-    // do nothing if the function doesn't match.
+  } catch (e) {
+    // function might not exist
   }
 }
 
@@ -111,624 +133,697 @@ class TempDirectoryInfo {
   tempDir = tmp.dirSync({ prefix: "hosting_rewrites_tests_" });
   firebasercFilePath = join(this.tempDir.name, ".", ".firebaserc");
   hostingDirPath = join(this.tempDir.name, ".", "hosting");
+  functionsDirPath = join(this.tempDir.name, ".", "functions");
 }
 
-describe("deploy function-targeted rewrites And functions", () => {
-  let tempDirInfo = new TempDirectoryInfo();
+const functionNamePrefix = `helloworld_${process.env.CI_RUN_ID || "xx"}_${
+  process.env.CI_RUN_ATTEMPT || "yy"
+}_${Date.now()}`;
 
-  // eslint-disable-next-line prefer-arrow-callback
-  beforeEach(async function () {
-    tempDirInfo = new TempDirectoryInfo();
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this
-    this.timeout(100 * 1e3);
-    await deleteDeployedFunctions();
-    emptyDirSync(tempDirInfo.tempDir.name);
-    writeFirebaseRc(tempDirInfo.firebasercFilePath);
+const siteNamePrefix = `${siteNamePrefixLabel}-${process.env.CI_RUN_ID || "xx"}-${
+  process.env.CI_RUN_ATTEMPT || "yy"
+}-${Date.now()}`;
+
+async function deleteOldSites(): Promise<void> {
+  const sites = await sitesList.runner()({
+    projectId: process.env.FBTOOLS_TARGET_PROJECT as string,
   });
 
-  afterEach(async function () {
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this
-    this.timeout(100 * 1e3);
-    await deleteDeployedFunctions();
-  });
-
-  after(async function () {
-    // eslint-disable-next-line @typescript-eslint/no-invalid-this
-    this.timeout(100 * 1e3);
-    await deleteDeployedFunctions();
-  });
-
-  it("should deploy with default function region", async () => {
+  const validDateCutoff = new Date("2021-06-01");
+  for (const site of sites) {
+    if (!site.name.includes(siteNamePrefixLabel)) {
+      continue;
+    }
+    const siteName = site.name.substring(site.name.lastIndexOf(siteNamePrefixLabel));
+    const siteNameParts = siteName.split("-");
+    if (siteNameParts.length !== 5) {
+      throw new FirebaseError(
+        `Found a site that begins with '${siteNamePrefixLabel}' but the name looks malformed: ${site.name}`
+      );
+    }
+    const siteTimestamp = parseInt(siteNameParts[3]);
+    if (siteTimestamp < validDateCutoff.getSeconds() || siteTimestamp > Date.now()) {
+      // Date doesn't make sense and we don't know what's going on.
+      throw new FirebaseError(
+        `Parsed a date for an existing site that looks unexpected: ${siteTimestamp.toString()}`
+      );
+    }
+    if (siteTimestamp > Date.now() - 3600) {
+      // Don't delete sites less than an hour old.
+      continue;
+    }
+    const tempDirInfo = new TempDirectoryInfo();
     const firebaseJson = {
       hosting: {
         public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-          },
-        ],
+        target: siteName,
       },
     };
-
     const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
     writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
+    await deleteSite(siteName, tempDirInfo.tempDir.name);
+  }
+}
 
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions")
-    );
+class TestCase {
+  private static testNumbering = 1;
+  private testNumber = TestCase.testNumbering++;
+  private tempDirInfo = new TempDirectoryInfo();
 
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
+  siteName = siteNamePrefix + "-" + this.testNumber.toString();
+  functionName = functionNamePrefix + "_" + this.testNumber.toString();
+
+  description: string;
+
+  constructor(
+    description: string,
+    testFunction: (
+      siteName: string,
+      functionName: string,
+      tempDirInfo: TempDirectoryInfo
+    ) => Promise<void>
+  ) {
+    this.description = description;
+    this.testFn = testFunction;
+  }
+
+  private doneLock = Promise.resolve();
+  // doneLock: AsyncLock = new AsyncLock();
+  donePromise: Promise<void> | undefined;
+  async getDonePromise(): Promise<void> {
+    return await this.doneLock.then(() => {
+      if (this.donePromise === undefined) {
+        this.donePromise = this.testFunction();
+      }
+      return this.donePromise;
     });
+  }
 
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
+  private testFn: (
+    siteName: string,
+    functionName: string,
+    tempDirInfo: TempDirectoryInfo
+  ) => Promise<void>;
 
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
+  private async cleanup(): Promise<void> {
+    await deleteDeployedFunctions(this.functionName);
+    await deleteSite(this.siteName, this.tempDirInfo.tempDir.name);
+  }
 
-    const functionsResponse = await fetch(functionsRequest);
+  private async testFunction(): Promise<void> {
+    try {
+      await deleteDeployedFunctions(this.functionName);
+      emptyDirSync(this.tempDirInfo.tempDir.name);
+      await createSite(this.siteName);
+      writeFirebaseRc(this.tempDirInfo.firebasercFilePath, this.siteName);
+      await this.testFn(this.siteName, this.functionName, this.tempDirInfo);
+    } finally {
+      await this.cleanup();
+    }
+  }
+}
 
-    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
-  }).timeout(1000 * 1e3);
+const testCases: TestCase[] = [];
 
-  it("should deploy with default function region explicitly specified in rewrite", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
+testCases.push(
+  new TestCase(
+    "should deploy with default function region",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+            },
+          ],
+        },
+        functions: [
           {
-            source: "/helloWorld",
-            function: functionName,
-            region: "us-central1",
+            source: "functions",
+            codebase: functionName,
           },
         ],
-      },
-    };
+      };
 
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
 
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions")
-    );
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath);
 
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    const functionsResponse = await fetch(functionsRequest);
-
-    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
-  }).timeout(1000 * 1e3);
-
-  it("should deploy with autodetected (not us-central1) function region", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["europe-west1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    const functionsResponse = await fetch(functionsRequest);
-
-    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
-  }).timeout(1000 * 1e3);
-
-  it("should deploy rewrites and functions with function region specified in both", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    const functionsResponse = await fetch(functionsRequest);
-
-    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
-  }).timeout(1000 * 1e3);
-
-  it("should fail to deploy rewrites with the wrong function region", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["europe-west2"]
-    );
-
-    await expect(
-      client.deploy({
-        project: process.env.FBTOOLS_TARGET_PROJECT,
-        cwd: tempDirInfo.tempDir.name,
-        only: "hosting,functions",
-        force: true,
-      })
-    ).to.eventually.be.rejectedWith(FirebaseError, "Unable to find a valid endpoint for function");
-  }).timeout(1000 * 1e3);
-
-  it("should fail to deploy rewrites to a function being deleted in a region", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "functions",
-      force: true,
-    });
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["europe-west1"]
-    );
-    await expect(
-      client.deploy({
-        project: process.env.FBTOOLS_TARGET_PROJECT,
-        cwd: tempDirInfo.tempDir.name,
-        only: "functions,hosting",
-        force: true,
-      })
-    ).to.eventually.be.rejectedWith(FirebaseError, "Unable to find a valid endpoint for function");
-  }).timeout(1000 * 1e3);
-
-  it("should deploy when a rewrite points to a non-existent function", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: "function-that-doesnt-exist",
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
-  }).timeout(1000 * 1e3);
-
-  it("should rewrite using a specified function region for a function with multiple regions", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1", "europe-west1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    const functionsResponse = await fetch(functionsRequest);
-
-    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
-  }).timeout(1000 * 1e3);
-
-  it("should rewrite to the default of us-central1 if multiple regions including us-central1 are available", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1", "us-central1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    const functionsResponse = await fetch(functionsRequest);
-
-    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
-  }).timeout(1000 * 1e3);
-
-  it("should fail when rewrite points to an invalid region for a function with multiple regions", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "us-east1",
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1", "europe-west1"]
-    );
-
-    await expect(
-      client.deploy({
-        project: process.env.FBTOOLS_TARGET_PROJECT,
-        cwd: tempDirInfo.tempDir.name,
-        only: "hosting,functions",
-      })
-    ).to.eventually.be.rejectedWith(FirebaseError, "Unable to find a valid endpoint for function");
-  }).timeout(1000 * 1e3);
-
-  it("should fail when rewrite has no region specified for a function with multiple regions", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1", "europe-west1"]
-    );
-
-    await expect(
-      client.deploy({
-        project: process.env.FBTOOLS_TARGET_PROJECT,
-        cwd: tempDirInfo.tempDir.name,
-        only: "hosting,functions",
-        force: true,
-      })
-    ).to.eventually.be.rejectedWith(FirebaseError, "More than one backend found for function");
-  }).timeout(1000 * 1e3);
-
-  it("should deploy with autodetected function region when function region is changed", async () => {
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["europe-west1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse.text()).to.contain("Rabbit");
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    const functionsResponse = await fetch(functionsRequest);
-    const responseText = await functionsResponse.text();
-    expect(responseText).to.contain("Hello from Firebase");
-    expect(responseText).to.contain("europe-west1");
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting,functions",
-      force: true,
-    });
-
-    const staticResponse2 = await fetch(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-    );
-    expect(await staticResponse2.text()).to.contain("Rabbit");
-    const functionsResponse2 = await fetch(functionsRequest);
-    const responseText2 = await functionsResponse2.text();
-
-    expect(responseText2).to.contain("Hello from Firebase");
-    expect(responseText2).to.contain("asia-northeast1");
-    expect(responseText2).not.to.contain("europe-west1");
-  }).timeout(1000 * 1e3);
-
-  it("should deploy with specified function region when function region is changed", async () => {
-    let firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "europe-west1",
-          },
-        ],
-      },
-    };
-
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
-
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["europe-west1"]
-    );
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    {
       await client.deploy({
         project: process.env.FBTOOLS_TARGET_PROJECT,
         cwd: tempDirInfo.tempDir.name,
         only: "hosting,functions",
+        force: true,
       });
 
-      const staticResponse = await fetch(
-        `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-      );
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
       expect(await staticResponse.text()).to.contain("Rabbit");
 
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
       const functionsResponse = await fetch(functionsRequest);
+      expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+    }
+  )
+);
 
+testCases.push(
+  new TestCase(
+    "should deploy with default function region explicitly specified in rewrite",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "us-central1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting,functions",
+        force: true,
+      });
+
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse.text()).to.contain("Rabbit");
+
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+      const functionsResponse = await fetch(functionsRequest);
+      expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should deploy with autodetected (not us-central1) function region",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "europe-west1",
+      ]);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting,functions",
+        force: true,
+      });
+
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse.text()).to.contain("Rabbit");
+
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+      const functionsResponse = await fetch(functionsRequest);
+      expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should deploy rewrites and functions with function region specified in both",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+      ]);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting,functions",
+        force: true,
+      });
+
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse.text()).to.contain("Rabbit");
+
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+      const functionsResponse = await fetch(functionsRequest);
+      expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should fail to deploy rewrites with the wrong function region",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "europe-west2",
+      ]);
+
+      await expect(
+        client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "hosting,functions",
+          force: true,
+        })
+      ).to.eventually.be.rejectedWith(
+        FirebaseError,
+        "Unable to find a valid endpoint for function"
+      );
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should fail to deploy rewrites to a function being deleted in a region",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(
+        functionName,
+        join(tempDirInfo.tempDir.name, ".", "functions"),
+        ["asia-northeast1"]
+      );
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "functions",
+        force: true,
+      });
+
+      writeHelloWorldFunctionWithRegions(
+        functionName,
+        join(tempDirInfo.tempDir.name, ".", "functions"),
+        ["europe-west1"]
+      );
+      await expect(
+        client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "functions,hosting",
+          force: true,
+        })
+      ).to.eventually.be.rejectedWith(
+        FirebaseError,
+        "Unable to find a valid endpoint for function"
+      );
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should deploy when a rewrite points to a non-existent function",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: "function-that-doesnt-exist",
+            },
+          ],
+        },
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting,functions",
+        force: true,
+      });
+
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse.text()).to.contain("Rabbit");
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should rewrite using a specified function region for a function with multiple regions",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+        "europe-west1",
+      ]);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting,functions",
+        force: true,
+      });
+
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse.text()).to.contain("Rabbit");
+
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+      const functionsResponse = await fetch(functionsRequest);
+      expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should rewrite to the default of us-central1 if multiple regions including us-central1 are available",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+        "us-central1",
+      ]);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting,functions",
+        force: true,
+      });
+
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse.text()).to.contain("Rabbit");
+
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+      const functionsResponse = await fetch(functionsRequest);
+      expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should fail when rewrite points to an invalid region for a function with multiple regions",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "us-east1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+        "europe-west1",
+      ]);
+
+      await expect(
+        client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "hosting,functions",
+        })
+      ).to.eventually.be.rejectedWith(
+        FirebaseError,
+        "Unable to find a valid endpoint for function"
+      );
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should fail when rewrite has no region specified for a function with multiple regions",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+        "europe-west1",
+      ]);
+
+      await expect(
+        client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "hosting,functions",
+          force: true,
+        })
+      ).to.eventually.be.rejectedWith(FirebaseError, "More than one backend found for function");
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should deploy with autodetected function region when function region is changed",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "europe-west1",
+      ]);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting,functions",
+        force: true,
+      });
+
+      const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse.text()).to.contain("Rabbit");
+
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+
+      const functionsResponse = await fetch(functionsRequest);
       const responseText = await functionsResponse.text();
       expect(responseText).to.contain("Hello from Firebase");
       expect(responseText).to.contain("europe-west1");
-    }
 
-    // Change function region in both firebase.json and function definition.
-    firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
-          },
-        ],
-      },
-    };
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1"]
-    );
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+      ]);
 
-    {
       await client.deploy({
         project: process.env.FBTOOLS_TARGET_PROJECT,
         cwd: tempDirInfo.tempDir.name,
@@ -736,83 +831,254 @@ describe("deploy function-targeted rewrites And functions", () => {
         force: true,
       });
 
-      const staticResponse = await fetch(
-        `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-      );
-      expect(await staticResponse.text()).to.contain("Rabbit");
-      const functionsResponse = await fetch(functionsRequest);
-      const responseText = await functionsResponse.text();
+      const staticResponse2 = await fetch(`https://${siteName}.web.app/index.html`);
+      expect(await staticResponse2.text()).to.contain("Rabbit");
+      const functionsResponse2 = await fetch(functionsRequest);
+      const responseText2 = await functionsResponse2.text();
 
-      expect(responseText).to.contain("Hello from Firebase");
-      expect(responseText).to.contain("asia-northeast1");
-      expect(responseText).not.to.contain("europe-west1");
+      expect(responseText2).to.contain("Hello from Firebase");
+      expect(responseText2).to.contain("asia-northeast1");
+      expect(responseText2).not.to.contain("europe-west1");
     }
-  }).timeout(1000 * 1e3);
+  )
+);
 
-  it("should fail to deploy when rewrite function region changes and actual function region doesn't", async () => {
-    let firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
+testCases.push(
+  new TestCase(
+    "should deploy with specified function region when function region is changed",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      let firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "europe-west1",
+            },
+          ],
+        },
+        functions: [
           {
-            source: "/helloWorld",
-            function: functionName,
-            region: "europe-west1",
+            source: "functions",
+            codebase: functionName,
           },
         ],
-      },
-    };
+      };
 
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
 
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["europe-west1"]
-    );
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "europe-west1",
+      ]);
 
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
 
-    {
+      {
+        await client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "hosting,functions",
+        });
+
+        const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+        expect(await staticResponse.text()).to.contain("Rabbit");
+
+        const functionsResponse = await fetch(functionsRequest);
+
+        const responseText = await functionsResponse.text();
+        expect(responseText).to.contain("Hello from Firebase");
+        expect(responseText).to.contain("europe-west1");
+      }
+
+      // Change function region in both firebase.json and function definition.
+      firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+      ]);
+
+      {
+        await client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "hosting,functions",
+          force: true,
+        });
+
+        const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+        expect(await staticResponse.text()).to.contain("Rabbit");
+        const functionsResponse = await fetch(functionsRequest);
+        const responseText = await functionsResponse.text();
+
+        expect(responseText).to.contain("Hello from Firebase");
+        expect(responseText).to.contain("asia-northeast1");
+        expect(responseText).not.to.contain("europe-west1");
+      }
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should fail to deploy when rewrite function region changes and actual function region doesn't",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      let firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "europe-west1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "europe-west1",
+      ]);
+
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+
+      {
+        await client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "hosting,functions",
+          force: true,
+        });
+
+        const staticResponse = await fetch(`https://${siteName}.web.app/index.html`);
+        expect(await staticResponse.text()).to.contain("Rabbit");
+
+        const functionsResponse = await fetch(functionsRequest);
+
+        const responseText = await functionsResponse.text();
+        expect(responseText).to.contain("Hello from Firebase");
+        expect(responseText).to.contain("europe-west1");
+      }
+
+      // Change function region in both firebase.json.
+      firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      {
+        await expect(
+          client.deploy({
+            project: process.env.FBTOOLS_TARGET_PROJECT,
+            cwd: tempDirInfo.tempDir.name,
+            only: "hosting",
+            force: true,
+          })
+        ).to.eventually.be.rejectedWith(FirebaseError);
+      }
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should fail to deploy when target function doesn't exist in specified region and isn't being deployed to that region",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+
+      const functionsOnlyfirebaseJson = {
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(functionsOnlyfirebaseJson));
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "europe-west1",
+      ]);
+
       await client.deploy({
         project: process.env.FBTOOLS_TARGET_PROJECT,
         cwd: tempDirInfo.tempDir.name,
-        only: "hosting,functions",
+        only: "functions",
         force: true,
       });
 
-      const staticResponse = await fetch(
-        `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/index.html`
-      );
-      expect(await staticResponse.text()).to.contain("Rabbit");
-
-      const functionsResponse = await fetch(functionsRequest);
-
-      const responseText = await functionsResponse.text();
-      expect(responseText).to.contain("Hello from Firebase");
-      expect(responseText).to.contain("europe-west1");
-    }
-
-    // Change function region in both firebase.json.
-    firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
+      const fullFirebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+        functions: [
           {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
+            source: "functions",
+            codebase: functionName,
           },
         ],
-      },
-    };
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    {
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(fullFirebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      writeBasicHostingFile(tempDirInfo.hostingDirPath);
+
       await expect(
         client.deploy({
           project: process.env.FBTOOLS_TARGET_PROJECT,
@@ -822,186 +1088,231 @@ describe("deploy function-targeted rewrites And functions", () => {
         })
       ).to.eventually.be.rejectedWith(FirebaseError);
     }
-  }).timeout(1000 * 1e3);
+  )
+);
 
-  it("should fail to deploy when target function doesn't exist in specified region and isn't being deployed to that region", async () => {
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, "{}");
+testCases.push(
+  new TestCase(
+    "should deploy when target function exists in prod but code isn't available",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
 
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["europe-west1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "functions",
-      force: true,
-    });
-
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
+      const functionsOnlyfirebaseJson = {
+        functions: [
           {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
+            source: "functions",
+            codebase: functionName,
           },
         ],
-      },
-    };
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    writeBasicHostingFile(tempDirInfo.hostingDirPath);
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(functionsOnlyfirebaseJson));
 
-    await expect(
-      client.deploy({
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath);
+
+      await client.deploy({
         project: process.env.FBTOOLS_TARGET_PROJECT,
         cwd: tempDirInfo.tempDir.name,
-        only: "hosting",
+        only: "functions",
         force: true,
-      })
-    ).to.eventually.be.rejectedWith(FirebaseError);
-  }).timeout(1000 * 1e3);
+      });
 
-  it("should deploy when target function exists in prod but code isn't available", async () => {
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, "{}");
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions")
-    );
+      emptyDirSync(tempDirInfo.functionsDirPath);
+      ensureDirSync(tempDirInfo.hostingDirPath);
 
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "functions",
-      force: true,
-    });
-
-    emptyDirSync(join(tempDirInfo.tempDir.name, ".", "functions"));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+            },
+          ],
+        },
+        functions: [
           {
-            source: "/helloWorld",
-            function: functionName,
+            source: "functions",
+            codebase: functionName,
           },
         ],
-      },
-    };
+      };
 
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    emptyDirSync(join(tempDirInfo.tempDir.name, ".", "functions"));
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting", // Including functions here will prompt for deletion.
-      // Forcing the prompt will delete the function.
-    });
-
-    const functionsRequest = new Request(
-      `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-    );
-
-    const functionsResponse = await fetch(functionsRequest);
-    expect(await functionsResponse.text()).to.contain("Hello from Firebase");
-  }).timeout(1000 * 1e3);
-
-  it("should fail to deploy when target function exists in prod, code isn't available, and rewrite region is specified incorrectly", async () => {
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1"]
-    );
-    writeFileSync(firebaseJsonFilePath, "{}");
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "functions",
-      force: true,
-    });
-
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "europe-west1",
-          },
-        ],
-      },
-    };
-
-    emptyDirSync(join(tempDirInfo.tempDir.name, ".", "functions"));
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-
-    await expect(
-      client.deploy({
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      emptyDirSync(tempDirInfo.functionsDirPath);
+      await client.deploy({
         project: process.env.FBTOOLS_TARGET_PROJECT,
         cwd: tempDirInfo.tempDir.name,
         only: "hosting", // Including functions here will prompt for deletion.
         // Forcing the prompt will delete the function.
-      })
-    ).to.eventually.be.rejectedWith(FirebaseError);
-  }).timeout(1000 * 1e3);
+      });
 
-  it("should deploy when target function exists in prod, codebase isn't available, and region matches", async () => {
-    const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
-    writeFileSync(firebaseJsonFilePath, "{}");
-    writeHelloWorldFunctionWithRegions(
-      functionName,
-      join(tempDirInfo.tempDir.name, ".", "functions"),
-      ["asia-northeast1"]
-    );
-
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "functions",
-      force: true,
-    });
-
-    emptyDirSync(join(tempDirInfo.tempDir.name, ".", "functions"));
-    const firebaseJson = {
-      hosting: {
-        public: "hosting",
-        rewrites: [
-          {
-            source: "/helloWorld",
-            function: functionName,
-            region: "asia-northeast1",
-          },
-        ],
-      },
-    };
-    writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
-    ensureDirSync(tempDirInfo.hostingDirPath);
-    await client.deploy({
-      project: process.env.FBTOOLS_TARGET_PROJECT,
-      cwd: tempDirInfo.tempDir.name,
-      only: "hosting", // Including functions here will prompt for deletion.
-      // Forcing the prompt will delete the function.
-    });
-
-    {
-      const functionsRequest = new Request(
-        `https://${process.env.FBTOOLS_CLIENT_INTEGRATION_SITE}.web.app/helloWorld`
-      );
+      const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
 
       const functionsResponse = await fetch(functionsRequest);
       expect(await functionsResponse.text()).to.contain("Hello from Firebase");
     }
-  }).timeout(1000 * 1e3);
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should fail to deploy when target function exists in prod, code isn't available, and rewrite region is specified incorrectly",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+      const functionsOnlyfirebaseJson = {
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(functionsOnlyfirebaseJson));
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+      ]);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "functions",
+        force: true,
+      });
+
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "europe-west1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+
+      emptyDirSync(tempDirInfo.functionsDirPath);
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+
+      await expect(
+        client.deploy({
+          project: process.env.FBTOOLS_TARGET_PROJECT,
+          cwd: tempDirInfo.tempDir.name,
+          only: "hosting", // Including functions here will prompt for deletion.
+          // Forcing the prompt will delete the function.
+        })
+      ).to.eventually.be.rejectedWith(FirebaseError);
+    }
+  )
+);
+
+testCases.push(
+  new TestCase(
+    "should deploy when target function exists in prod, codebase isn't available, and region matches",
+    async (siteName: string, functionName: string, tempDirInfo: TempDirectoryInfo) => {
+      const firebaseJsonFilePath = join(tempDirInfo.tempDir.name, ".", "firebase.json");
+
+      const functionsOnlyfirebaseJson = {
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(functionsOnlyfirebaseJson));
+
+      writeHelloWorldFunctionWithRegions(functionName, tempDirInfo.functionsDirPath, [
+        "asia-northeast1",
+      ]);
+
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "functions",
+        force: true,
+      });
+
+      emptyDirSync(tempDirInfo.functionsDirPath);
+      const firebaseJson = {
+        hosting: {
+          public: "hosting",
+          target: siteName,
+          rewrites: [
+            {
+              source: "/helloWorld",
+              function: functionName,
+              region: "asia-northeast1",
+            },
+          ],
+        },
+        functions: [
+          {
+            source: "functions",
+            codebase: functionName,
+          },
+        ],
+      };
+      writeFileSync(firebaseJsonFilePath, JSON.stringify(firebaseJson));
+      ensureDirSync(tempDirInfo.hostingDirPath);
+      await client.deploy({
+        project: process.env.FBTOOLS_TARGET_PROJECT,
+        cwd: tempDirInfo.tempDir.name,
+        only: "hosting", // Including functions here will prompt for deletion.
+        // Forcing the prompt will delete the function.
+      });
+
+      {
+        const functionsRequest = new Request(`https://${siteName}.web.app/helloWorld`);
+
+        const functionsResponse = await fetch(functionsRequest);
+        expect(await functionsResponse.text()).to.contain("Hello from Firebase");
+      }
+    }
+  )
+);
+
+describe("deploy function-targeted rewrites and functions", () => {
+  before("clean up failed test runs", async function (this: Mocha.Context) {
+    this.timeout(1000 * 1e3);
+    await deleteOldSites();
+  });
+
+  // All test cases run concurrently. Isolation is handled by creating separate hosting
+  // sites and deploying to separate functions codebases.
+  const executor = new QueueExecutor({ concurrency: testConcurrency });
+  const testQueue = testCases.map((testCase) => {
+    return executor.run(() => {
+      return testCase.getDonePromise();
+    });
+  });
+
+  testCases.forEach((testCase) => {
+    it(testCase.description, async () => {
+      try {
+        await Promise.allSettled(testQueue);
+      } catch (e) {
+        // We want to wait for all tests to be finished, but don't care if any fail.
+      }
+      await testCase.getDonePromise();
+    }).timeout(900 * 1e3);
+  });
+
+  // For serial execution, comment the block above and uncomment the block below:
+  // testCases.forEach((testCase) => {
+  //   it(testCase.description, async () => {
+  //     await testCase.getDonePromise();
+  //   }).timeout(900 * 1e3);
+  // });
 }).timeout(1000 * 1e3);

--- a/src/commands/hosting-sites-list.ts
+++ b/src/commands/hosting-sites-list.ts
@@ -9,13 +9,13 @@ import { logger } from "../logger";
 
 const TABLE_HEAD = ["Site ID", "Default URL", "App ID (if set)"];
 
-export const command = new Command("hosting:sites:list")
+export const command = new Command<Promise<Site[]>>("hosting:sites:list")
   .description("list Firebase Hosting sites")
   .before(requirePermissions, ["firebasehosting.sites.get"])
   .action(
     async (
       options: any // eslint-disable-line @typescript-eslint/no-explicit-any
-    ): Promise<{ sites: Site[] }> => {
+    ): Promise<Site[]> => {
       const projectId = needProjectId(options);
       const sites = await listSites(projectId);
       const table = new Table({ head: TABLE_HEAD, style: { head: ["green"] } });
@@ -29,6 +29,6 @@ export const command = new Command("hosting:sites:list")
       logger.info();
       logger.info(table.toString());
 
-      return { sites };
+      return sites;
     }
   );

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -34,7 +34,7 @@ export const command = new Command("serve")
     "--except <targets>",
     "serve all except specified targets (valid targets are: " + VALID_TARGETS.join(", ") + ")"
   )
-  .before((options) => {
+  .before(async (options) => {
     if (
       options.only &&
       options.only.length > 0 &&
@@ -42,9 +42,9 @@ export const command = new Command("serve")
     ) {
       return Promise.resolve();
     }
-    return requireConfig(options)
-      .then(() => requirePermissions(options))
-      .then(() => needProjectNumber(options));
+    await requireConfig(options);
+    await requirePermissions(options);
+    await needProjectNumber(options);
   })
   .action((options) => {
     options.targets = filterOnly(ALL_TARGETS, options.only);

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -19,6 +19,7 @@ import * as versioning from "./versioning";
 import * as parseTriggers from "./parseTriggers";
 
 const MIN_FUNCTIONS_SDK_VERSION = "3.20.0";
+const NUM_RETRIES = 3;
 
 /**
  *
@@ -92,7 +93,7 @@ export class Delegate {
     return Promise.resolve(() => Promise.resolve());
   }
 
-  serve(
+  async serve(
     port: number,
     config: backend.RuntimeConfigValues,
     envs: backend.EnvironmentVariables
@@ -116,6 +117,13 @@ export class Delegate {
     childProcess.stdout?.on("data", (chunk) => {
       logger.debug(chunk.toString());
     });
+
+    // Assuming here that startup errors manifest in less than 5 seconds.
+    await new Promise((resolve, reject) => {
+      childProcess.once("error", reject);
+      setTimeout(resolve, 5_000);
+    });
+
     return Promise.resolve(async () => {
       const p = new Promise<void>((resolve, reject) => {
         childProcess.once("exit", resolve);
@@ -132,7 +140,18 @@ export class Delegate {
     });
   }
 
-  // eslint-disable-next-line require-await
+  async findRandomOpenPort(): Promise<number> {
+    return new Promise<number>((resolve, reject) => {
+      const basePort = Math.floor(Math.random() * 40000 + 10000);
+      portfinder.getPort({ port: basePort }, (err, port) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(port);
+      });
+    });
+  }
+
   async discoverBuild(
     config: backend.RuntimeConfigValues,
     env: backend.EnvironmentVariables
@@ -154,9 +173,17 @@ export class Delegate {
 
     let discovered = await discovery.detectFromYaml(this.sourceDir, this.projectId, this.runtime);
     if (!discovered) {
-      const getPort = promisify(portfinder.getPort) as () => Promise<number>;
-      const port = await getPort();
-      const kill = await this.serve(port, config, env);
+      const port = await this.findRandomOpenPort();
+      const kill = await (async () => {
+        for (let i = 0; i < NUM_RETRIES; i++) {
+          try {
+            return await this.serve(port, config, env);
+          } catch (e) {
+            logger.debug(`Failed to bring up server with error: ${e}`);
+          }
+        }
+        throw new FirebaseError(`Failed to bring up server after ${NUM_RETRIES} attempts.`);
+      })();
       try {
         discovered = await discovery.detectFromPort(port, this.projectId, this.runtime);
       } finally {


### PR DESCRIPTION
### Description

Parallelize hosting-rewrites tests. Add hosting-rewrites to Github workflow. Change command library so actions can have a return type. Start up node discovery server on a random port, with a retry for server startup.

### Sample Commands

npm run test:hosting-rewrites