### PR TITLE
Change signInWithPassword error handling for empty string emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug where disabling background triggers did nothing. (#5221)
+- Fix bug in auth emulator where empty string should throw invalid email instead of missing email. (#3898)

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1708,7 +1708,8 @@ async function signInWithPassword(
 ): Promise<Schemas["GoogleCloudIdentitytoolkitV1SignInWithPasswordResponse"]> {
   assert(!state.disableAuth, "PROJECT_DISABLED");
   assert(state.allowPasswordSignup, "PASSWORD_LOGIN_DISABLED");
-  assert(reqBody.email, "MISSING_EMAIL");
+  assert(reqBody.email !== undefined, "MISSING_EMAIL");
+  assert(isValidEmailAddress(reqBody.email), "INVALID_EMAIL");
   assert(reqBody.password, "MISSING_PASSWORD");
   if (reqBody.captchaResponse || reqBody.captchaChallenge) {
     throw new NotImplementedError("captcha unimplemented");

--- a/src/test/emulators/auth/password.spec.ts
+++ b/src/test/emulators/auth/password.spec.ts
@@ -101,6 +101,25 @@ describeAuthEmulator("accounts:signInWithPassword", ({ authApi, getClock }) => {
       });
   });
 
+  it("should error if email is invalid", async () => {
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
+      .query({ key: "fake-api-key" })
+      .send({ email: "ill-formatted-email", password: "notasecret" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).equals("INVALID_EMAIL");
+      });
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")
+      .query({ key: "fake-api-key" })
+      .send({ email: "", password: "notasecret" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error.message).equals("INVALID_EMAIL");
+      });
+  });
+
   it("should error if email is not found", async () => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword")


### PR DESCRIPTION
### Description

Updates error handling for email cases. Reference for how the backend handles email validation: [link](http://go/firebase-tools-5258-source). 

Fixes https://github.com/firebase/firebase-tools/issues/3898

### Scenarios Tested

* `npm test` passes
* Verified against JSSDK Auth Demo App. See [screenshot](http://go/firebase-tools-5258-screenshot).

### Sample Commands

N/A
