### PR TITLE
Add createdAt time for signInWithIdp new users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fix bug where disabling background triggers did nothing. (#5221)
 - Fix bug in auth emulator where empty string should throw invalid email instead of missing email. (#3898)
+- Fix bug in auth emulator in which createdAt was not set for signInWithIdp new users. (#5203)

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1608,9 +1608,11 @@ async function signInWithIdp(
     oauthExpiresIn: coercePrimitiveToString(response.oauthExpireIn),
   };
   if (response.isNewUser) {
+    const timestamp = new Date();
     let updates: Partial<UserInfo> = {
       ...accountUpdates.fields,
-      lastLoginAt: Date.now().toString(),
+      createdAt: timestamp.getTime().toString(),
+      lastLoginAt: timestamp.getTime().toString(),
       providerUserInfo: [providerUserInfo],
       tenantId: state instanceof TenantProjectState ? state.tenantId : undefined,
     };


### PR DESCRIPTION
### Description

As the title suggests. Should fix https://github.com/firebase/firebase-tools/issues/5203. 

### Scenarios Tested

* `npm test` passes 
* Some manual verification (since unit testing this is a little difficult w/o time mocks aside from checking that the `createdAt` time is present):
  * [go/firebase-tools-5260-prod](http://go/firebase-tools-5260-prod): Behavior in prod, timestamp for `lastSignInTime` matches that of `createdAt`
  * [go/firebase-tools-5260-emulator](http://go/firebase-tools-5260-emulator): Behavior against emulator and test project with this fix, timestamp for `lastSignInTime` matches that of `createdAt`

### Sample Commands

N/A
