### PR TITLE
Update link used in firebase open crash

### DIFF
--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -22,7 +22,7 @@ const LINKS: Link[] = [
   { name: "Analytics", arg: "analytics", consolePath: "/analytics" },
   { name: "Authentication: Providers", arg: "auth", consolePath: "/authentication/providers" },
   { name: "Authentication: Users", arg: "auth:users", consolePath: "/authentication/users" },
-  { name: "Crash Reporting", arg: "crash", consolePath: "/monitoring" },
+  { name: "Crash Reporting", arg: "crash", consolePath: "/crashlytics" },
   { name: "Database: Data", arg: "database", consolePath: "/database/data" },
   { name: "Database: Rules", arg: "database:rules", consolePath: "/database/rules" },
   { name: "Docs", arg: "docs", url: "https://firebase.google.com/docs" },


### PR DESCRIPTION
### Description
Changed src/commands/open.ts LINKS Crash Reporting consolePath from `/monitoring` to `/crashlytics`

Updating the link produced by firebase open crash from `https://console.firebase.google.com/project/<project_id>/monitoring` -> `https://console.firebase.google.com/project/<project_id>/crashlytics`

The link `https://console.firebase.google.com/project/<project_id>/monitoring` redirects to `https://console.firebase.google.com/project/<project_id>/overview` instead of Crashlytics dashboard

### Scenarios Tested
```
$ firebase open crash
Opening Crash Reporting link in your default browser:
https://console.firebase.google.com/project/<project_id>/monitoring
```
### Sample Commands
```
$ firebase open crash
```