### PR TITLE
Load secrets when emulating functions with --inspect-function flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Add support for Firestore TTL (#5267)
+- Fix bug where secrets were not loaded when emulating functions with `--inpsect-functions`. (#4605)

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -234,7 +234,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
     const emulatableBackend: EmulatableBackend = {
       functionsDir,
       env: nonSecretEnv,
-      codebase: "",
+      codebase: instance.instanceId, // Give each extension its own codebase name so that they don't share workerPools.
       secretEnv: secretEnvVariables,
       predefinedTriggers: extensionTriggers,
       nodeMajorVersion: nodeMajorVersion,

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -119,7 +119,7 @@ describe("Extensions Emulator", () => {
           ],
           extension: TEST_EXTENSION,
           extensionVersion: TEST_EXTENSION_VERSION,
-          codebase: "",
+          codebase: "ext-test",
         },
       },
     ];


### PR DESCRIPTION
### Description
Load secrets when emulating functions with --inspect-function flag. Fixes https://github.com/firebase/firebase-tools/issues/4605 and #5062 
### Scenarios Tested
Tested that extensions and CF3 codebases correctly load secrets, both with and without the --inspect-functions flag.
