### PR TITLE
Update custom_claims type to match production

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -3174,7 +3174,7 @@ function generateBlockingFunctionJwt(
       photo_url: user.photoUrl,
       disabled: user.disabled,
       phone_number: user.phoneNumber,
-      custom_claims: user.customAttributes,
+      custom_claims: JSON.parse(user.customAttributes || "{}") as Record<string, unknown>,
     },
     sub: user.localId,
     sign_in_method: options.signInMethod,
@@ -3473,7 +3473,7 @@ export interface BlockingFunctionsJwtPayload {
       last_sign_in_time?: string;
       creation_time?: string;
     };
-    custom_claims?: string;
+    custom_claims?: Record<string, unknown>;
     tenant_id?: string; // should match top level tenant_id
   };
   tenant_id?: string; // `tenantId` if present

--- a/src/test/emulators/auth/emailLink.spec.ts
+++ b/src/test/emulators/auth/emailLink.spec.ts
@@ -538,9 +538,7 @@ describeAuthEmulator("email link sign-in", ({ authApi }) => {
       expect(jwt.user_record).to.have.property("email_verified").to.be.false;
       expect(jwt.user_record).to.have.property("display_name").eql(DISPLAY_NAME);
       expect(jwt.user_record).to.have.property("photo_url").eql(PHOTO_URL);
-      expect(jwt.user_record)
-        .to.have.property("custom_claims")
-        .eql(JSON.stringify({ customAttribute: "custom" }));
+      expect(jwt.user_record).to.have.property("custom_claims").eql({ customAttribute: "custom" });
       expect(jwt.user_record).to.have.property("metadata");
       expect(jwt.user_record.metadata).to.have.property("creation_time").that.is.a("string");
     });


### PR DESCRIPTION
### Description

Should address https://github.com/firebase/firebase-tools/issues/5327. Fixes the type of `custom_claims` in the JWT that is passed to the blocking function. Firebase Functions directly unpacks the `custom_claims` from the payload and uses it as `customClaims` of type `Record<string, any>` (see [ref](https://github.com/firebase/firebase-functions/blob/0ec98958a74172ef03c885ff90579aeb2a71b00f/src/common/providers/identity.ts#L611) and [ref](https://github.com/firebase/firebase-functions/blob/0ec98958a74172ef03c885ff90579aeb2a71b00f/src/common/providers/identity.ts#L292)) that gets used in the blocking function handlers (see [ref](https://github.com/firebase/firebase-functions/blob/0ec98958a74172ef03c885ff90579aeb2a71b00f/src/common/providers/identity.ts#L805)). For reference, this ([go/firebase-tools-5353-prod](http://go/firebase-tools-5353-prod)) is what is done in prod. 

### Scenarios Tested

Bit of manual testing:
- Running against https://github.com/firebase/codelab-friendlychat-web/tree/security in directory `security-solution/` with these blocking functions ([go/firebase-tools-5353-fns](http://go/firebase-tools-5353-fns)). The console output is ([go/firebase-tools-5353-output](http://go/firebase-tools-5353-output)).

### Sample Commands

n/a
