### PR TITLE
Custom emulator auth handler support

### DIFF
--- a/scripts/gen-auth-api-spec.ts
+++ b/scripts/gen-auth-api-spec.ts
@@ -456,6 +456,17 @@ function addEmulatorOperations(openapi3: any): void {
         },
         type: "object",
       },
+      notification: {
+        properties: {
+          sendEmail: {
+            properties: { 
+              callbackUri: { type: "string" },
+            },
+            type: "object",
+          },
+        },
+        type: "object",
+      },
     },
   };
   openapi3.paths["/emulator/v1/projects/{targetProjectId}/oobCodes"] = {

--- a/src/emulator/auth/apiSpec.ts
+++ b/src/emulator/auth/apiSpec.ts
@@ -7614,6 +7614,12 @@ export default {
         description: "Emulator-specific configuration.",
         properties: {
           signIn: { properties: { allowDuplicateEmails: { type: "boolean" } }, type: "object" },
+          notification: {
+            properties: {
+              sendEmail: { properties: { callbackUri: { type: "string" } }, type: "object" },
+            },
+            type: "object",
+          },
         },
       },
       EmulatorV1ProjectsOobCodes: {

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1231,11 +1231,11 @@ function createOobRecord(
   }
 ): OobRecord {
   const oobRecord = state.createOob(email, params.requestType, (oobCode) => {
+    if (state.customAuthActionUri) url = new URL(state.customAuthActionUri);
     url.pathname = "/emulator/action";
     url.searchParams.set("mode", params.mode);
     url.searchParams.set("lang", "en");
     url.searchParams.set("oobCode", oobCode);
-    // TODO: Support custom handler links.
 
     // This doesn't matter for now, since any API key works for defaultProject.
     // TODO: What if reqBody.targetProjectId is set?

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1232,7 +1232,7 @@ function createOobRecord(
 ): OobRecord {
   const oobRecord = state.createOob(email, params.requestType, (oobCode) => {
     if (state.customAuthActionUri) url = new URL(state.customAuthActionUri);
-    url.pathname = "/emulator/action";
+    else url.pathname = "/emulator/action";
     url.searchParams.set("mode", params.mode);
     url.searchParams.set("lang", "en");
     url.searchParams.set("oobCode", oobCode);
@@ -1902,6 +1902,11 @@ function getEmulatorProjectConfig(state: ProjectState): Schemas["EmulatorV1Proje
     signIn: {
       allowDuplicateEmails: !state.oneAccountPerEmail,
     },
+    notification: {
+      sendEmail: {
+        callbackUri: state.customAuthActionUri,
+      },
+    },
   };
 }
 
@@ -1911,10 +1916,13 @@ function updateEmulatorProjectConfig(
   ctx: ExegesisContext
 ): Schemas["EmulatorV1ProjectsConfig"] {
   // New developers should not use updateEmulatorProjectConfig to update the
-  // allowDuplicateEmails setting and should instead use updateConfig to do so.
+  // allowDuplicateEmails or callbackUri settings and should instead use updateConfig to do so.
   const updateMask = [];
   if (reqBody.signIn?.allowDuplicateEmails != null) {
     updateMask.push("signIn.allowDuplicateEmails");
+  }
+  if (reqBody.notification?.sendEmail?.callbackUri != null) {
+    updateMask.push("notification.sendEmail.callbackUri");
   }
   ctx.params.query.updateMask = updateMask.join();
 

--- a/src/emulator/auth/schema.ts
+++ b/src/emulator/auth/schema.ts
@@ -3021,7 +3021,10 @@ export interface components {
     /**
      * Emulator-specific configuration.
      */
-    EmulatorV1ProjectsConfig: { signIn?: { allowDuplicateEmails?: boolean } };
+    EmulatorV1ProjectsConfig: {
+      signIn?: { allowDuplicateEmails?: boolean };
+      notification?: { sendEmail?: { callbackUri?: string } };
+    };
     /**
      * Details of all pending confirmation codes.
      */

--- a/src/test/emulators/auth/config.spec.ts
+++ b/src/test/emulators/auth/config.spec.ts
@@ -6,7 +6,7 @@ describeAuthEmulator("config management", ({ authApi }) => {
   describe("updateConfig", () => {
     it("updates the project level config", async () => {
       const updateMask =
-        "signIn.allowDuplicateEmails,blockingFunctions.forwardInboundCredentials.idToken";
+        "signIn.allowDuplicateEmails,notification.sendEmail.callbackUri,blockingFunctions.forwardInboundCredentials.idToken";
 
       await authApi()
         .patch(`/identitytoolkit.googleapis.com/v2/projects/${PROJECT_ID}/config`)
@@ -14,11 +14,15 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .query({ updateMask })
         .send({
           signIn: { allowDuplicateEmails: true },
+          notification: { sendEmail: { callbackUri: "https://example.com" } },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
         })
         .then((res) => {
           expectStatusCode(200, res);
           expect(res.body.signIn?.allowDuplicateEmails).to.be.true;
+          expect(res.body.notification).to.eql({
+            sendEmail: { callbackUri: "https://example.com" },
+          });
           expect(res.body.blockingFunctions).to.eql({
             forwardInboundCredentials: { idToken: true },
           });
@@ -43,11 +47,15 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .set("Authorization", "Bearer owner")
         .send({
           signIn: { allowDuplicateEmails: true },
+          notification: { sendEmail: { callbackUri: "https://example.com" } },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
         })
         .then((res) => {
           expectStatusCode(200, res);
           expect(res.body.signIn?.allowDuplicateEmails).to.be.true;
+          expect(res.body.notification).to.eql({
+            sendEmail: { callbackUri: "https://example.com" },
+          });
           expect(res.body.blockingFunctions).to.eql({
             forwardInboundCredentials: { idToken: true },
           });
@@ -61,11 +69,15 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .set("Authorization", "Bearer owner")
         .send({
           signIn: { allowDuplicateEmails: true },
+          notification: { sendEmail: { callbackUri: "https://example.com" } },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
         })
         .then((res) => {
           expectStatusCode(200, res);
           expect(res.body.signIn?.allowDuplicateEmails).to.be.true;
+          expect(res.body.notification).to.eql({
+            sendEmail: { callbackUri: "https://example.com" },
+          });
           expect(res.body.blockingFunctions).to.eql({
             forwardInboundCredentials: { idToken: true },
           });
@@ -79,6 +91,9 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .then((res) => {
           expectStatusCode(200, res);
           expect(res.body.signIn?.allowDuplicateEmails).to.be.false;
+          expect(res.body.notification).to.eql({
+            sendEmail: { callbackUri: "" },
+          });
           expect(res.body.blockingFunctions).to.eql({});
         });
     });
@@ -133,6 +148,11 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expect(res.body).to.have.property("signIn").eql({
             allowDuplicateEmails: false /* default value */,
           });
+          expect(res.body)
+            .to.have.property("notification")
+            .eql({
+              sendEmail: { callbackUri: "" },
+            });
           expect(res.body).to.have.property("blockingFunctions").eql({});
         });
     });
@@ -144,6 +164,7 @@ describeAuthEmulator("config management", ({ authApi }) => {
         .send({
           signIn: { allowDuplicateEmails: true },
           blockingFunctions: { forwardInboundCredentials: { idToken: true } },
+          notification: { sendEmail: { callbackUri: "https://example.com" } },
         });
 
       await authApi()
@@ -155,6 +176,11 @@ describeAuthEmulator("config management", ({ authApi }) => {
           expect(res.body).to.have.property("signIn").eql({
             allowDuplicateEmails: true,
           });
+          expect(res.body)
+            .to.have.property("notification")
+            .eql({
+              sendEmail: { callbackUri: "https://example.com" },
+            });
           expect(res.body)
             .to.have.property("blockingFunctions")
             .eql({

--- a/src/test/emulators/auth/misc.spec.ts
+++ b/src/test/emulators/auth/misc.spec.ts
@@ -552,6 +552,9 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
         expect(res.body).to.have.property("signIn").eql({
           allowDuplicateEmails: false /* default value */,
         });
+        expect(res.body.notification).to.eql({
+          sendEmail: { callbackUri: "" },
+        });
       });
   });
 
@@ -564,24 +567,40 @@ describeAuthEmulator("emulator utility APIs", ({ authApi }) => {
       });
   });
 
-  it("should update allowDuplicateEmails on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
+  it("should update allowDuplicateEmails and callbackUri on PATCH /emulator/v1/projects/{PROJECT_ID}/config", async () => {
     await authApi()
       .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ signIn: { allowDuplicateEmails: true } })
+      .send({
+        signIn: { allowDuplicateEmails: true },
+        notification: { sendEmail: { callbackUri: "https://example.com" } },
+      })
       .then((res) => {
         expectStatusCode(200, res);
         expect(res.body).to.have.property("signIn").eql({
           allowDuplicateEmails: true,
         });
+        expect(res.body)
+          .to.have.property("notification")
+          .eql({
+            sendEmail: { callbackUri: "https://example.com" },
+          });
       });
     await authApi()
       .patch(`/emulator/v1/projects/${PROJECT_ID}/config`)
-      .send({ signIn: { allowDuplicateEmails: false } })
+      .send({
+        signIn: { allowDuplicateEmails: false },
+        notification: { sendEmail: { callbackUri: "" } },
+      })
       .then((res) => {
         expectStatusCode(200, res);
         expect(res.body).to.have.property("signIn").eql({
           allowDuplicateEmails: false,
         });
+        expect(res.body)
+          .to.have.property("notification")
+          .eql({
+            sendEmail: { callbackUri: "" }
+          });
       });
   });
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This adds support for custom auth handlers. A custom auth handler can be set by updating the emulator config through the REST api. It's used when [outputting auth action urls to the terminal](https://firebase.google.com/docs/emulator-suite/connect_auth#emulated_email_email_link_and_anonymous_authentication)

I created a related PR in firebase-tools-ui for adding a way to change this through the emulator UI

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

* Developers can update the custom auth handler url through the REST api and Emulator UI
* Setting the handler url to an empty string will once again make the emulator output urls using the default auth handler (typically "localhost:9099/emulator/action")
<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

No commands changed

Sample request to update handler URL:
`PATCH http://localhost:9099/emulator/v1/projects/:targetProjectId/config`
body:
```json
{
  "notification": {
    "sendEmail": {
      "callbackUri": "https://example.com/auth/handler"
    }
  }
}
```
<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
