### PR TITLE
[Fix] Extension dependencies do not get installed on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/node_modules/*
+src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package.json
+src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package-lock.json
+
 /.vscode
 node_modules
 /coverage

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -5,7 +5,6 @@ import * as os from "os";
 import * as path from "path";
 import Table = require("cli-table");
 
-import { resolve } from "path";
 import * as planner from "../deploy/extensions/planner";
 import { enableApiURI } from "../ensureApiEnabled";
 import { FirebaseError } from "../error";
@@ -171,7 +170,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
   installAndBuildSourceCode(sourceCodePath: string): void {
     // TODO: Add logging during this so it is clear what is happening.
     this.logger.logLabeled("DEBUG", "Extensions", `Running "npm install" for ${sourceCodePath}`);
-    const functionsDirectory = resolve(sourceCodePath, "functions");
+    const functionsDirectory = path.resolve(sourceCodePath, "functions");
     const npmInstall = spawn.sync("npm", ["install"], {
       encoding: "utf8",
       cwd: functionsDirectory,

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -1,24 +1,25 @@
+import * as clc from "colorette";
+import * as spawn from "cross-spawn";
 import * as fs from "fs-extra";
 import * as os from "os";
 import * as path from "path";
-import * as clc from "colorette";
 import Table = require("cli-table");
-import * as spawn from "cross-spawn";
 
+import { resolve } from "path";
 import * as planner from "../deploy/extensions/planner";
-import { Options } from "../options";
-import { FirebaseError } from "../error";
-import { toExtensionVersionRef } from "../extensions/refs";
-import { downloadExtensionVersion } from "./download";
-import { EmulatableBackend } from "./functionsEmulator";
-import { getExtensionFunctionInfo } from "../extensions/emulator/optionsHelper";
-import { EmulatorLogger } from "./emulatorLogger";
-import { EmulatorInfo, EmulatorInstance, Emulators } from "./types";
-import { checkForUnemulatedTriggerTypes, getUnemulatedAPIs } from "./extensions/validation";
 import { enableApiURI } from "../ensureApiEnabled";
+import { FirebaseError } from "../error";
+import { getExtensionFunctionInfo } from "../extensions/emulator/optionsHelper";
+import { toExtensionVersionRef } from "../extensions/refs";
+import { Options } from "../options";
 import { shortenUrl } from "../shortenUrl";
 import { Constants } from "./constants";
+import { downloadExtensionVersion } from "./download";
+import { EmulatorLogger } from "./emulatorLogger";
+import { checkForUnemulatedTriggerTypes, getUnemulatedAPIs } from "./extensions/validation";
+import { EmulatableBackend } from "./functionsEmulator";
 import { EmulatorRegistry } from "./registry";
+import { EmulatorInfo, EmulatorInstance, Emulators } from "./types";
 
 export interface ExtensionEmulatorArgs {
   projectId: string;
@@ -167,11 +168,13 @@ export class ExtensionsEmulator implements EmulatorInstance {
     return true;
   }
 
-  private installAndBuildSourceCode(sourceCodePath: string): void {
+  installAndBuildSourceCode(sourceCodePath: string): void {
     // TODO: Add logging during this so it is clear what is happening.
     this.logger.logLabeled("DEBUG", "Extensions", `Running "npm install" for ${sourceCodePath}`);
-    const npmInstall = spawn.sync("npm", ["--prefix", `/${sourceCodePath}/functions/`, "install"], {
+    const functionsDirectory = resolve(sourceCodePath, "functions");
+    const npmInstall = spawn.sync("npm", ["install"], {
       encoding: "utf8",
+      cwd: functionsDirectory,
     });
     if (npmInstall.error) {
       throw npmInstall.error;
@@ -183,11 +186,10 @@ export class ExtensionsEmulator implements EmulatorInstance {
       "Extensions",
       `Running "npm run gcp-build" for ${sourceCodePath}`
     );
-    const npmRunGCPBuild = spawn.sync(
-      "npm",
-      ["--prefix", `/${sourceCodePath}/functions/`, "run", "gcp-build"],
-      { encoding: "utf8" }
-    );
+    const npmRunGCPBuild = spawn.sync("npm", ["run", "gcp-build"], {
+      encoding: "utf8",
+      cwd: functionsDirectory,
+    });
     if (npmRunGCPBuild.error) {
       // TODO: Make sure this does not error out if "gcp-build" is not defined, but does error if it fails otherwise.
       throw npmRunGCPBuild.error;

--- a/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/node_modules/test_data.text
+++ b/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/node_modules/test_data.text
@@ -1,1 +1,0 @@
-Empty file to hold the directory.

--- a/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package.json
+++ b/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package.json
@@ -1,3 +1,8 @@
-{ 
-    "what's this": "Empty file for testing"
+{
+    "name": "storage-resize-images",
+    "vresion": "0.1.18",
+    "description": "Package file for testing only",
+    "dependencies": {
+        "firebase-tools": "file:../../../../../../.."
+    }
 }

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -9,7 +9,7 @@ import {
   Extension,
   ExtensionVersion,
   RegistryLaunchStage,
-  Visibility
+  Visibility,
 } from "../../extensions/types";
 
 const TEST_EXTENSION: Extension = {
@@ -65,68 +65,68 @@ describe("Extensions Emulator", () => {
       input: planner.DeploymentInstanceSpec;
       expected: EmulatableBackend;
     }[] = [
-        {
-          desc: "should transform a instance spec to a backend",
-          input: {
-            instanceId: "ext-test",
-            ref: {
-              publisherId: "firebase",
-              extensionId: "storage-resize-images",
-              version: "0.1.18",
-            },
-            params: {
-              LOCATION: "us-west1",
-              ALLOWED_EVENT_TYPES:
-                "google.firebase.image-resize-started,google.firebase.image-resize-completed",
-              EVENTARC_CHANNEL: "projects/test-project/locations/us-central1/channels/firebase",
-            },
-            allowedEventTypes: [
-              "google.firebase.image-resize-started",
-              "google.firebase.image-resize-completed",
-            ],
-            eventarcChannel: "projects/test-project/locations/us-central1/channels/firebase",
-            extension: TEST_EXTENSION,
-            extensionVersion: TEST_EXTENSION_VERSION,
+      {
+        desc: "should transform a instance spec to a backend",
+        input: {
+          instanceId: "ext-test",
+          ref: {
+            publisherId: "firebase",
+            extensionId: "storage-resize-images",
+            version: "0.1.18",
           },
-          expected: {
-            env: {
-              LOCATION: "us-west1",
-              DATABASE_INSTANCE: "test-project",
-              DATABASE_URL: "https://test-project.firebaseio.com",
-              EXT_INSTANCE_ID: "ext-test",
-              PROJECT_ID: "test-project",
-              STORAGE_BUCKET: "test-project.appspot.com",
-              ALLOWED_EVENT_TYPES:
-                "google.firebase.image-resize-started,google.firebase.image-resize-completed",
-              EVENTARC_CHANNEL: "projects/test-project/locations/us-central1/channels/firebase",
-              EVENTARC_CLOUD_EVENT_SOURCE: "projects/test-project/instances/ext-test",
-            },
-            secretEnv: [],
-            extensionInstanceId: "ext-test",
-            // use join to convert path to platform dependent path
-            // so test also runs on win machines
-            // eslint-disable-next-line prettier/prettier
-            functionsDir: join("src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions"),
-            nodeMajorVersion: 10,
-            predefinedTriggers: [
-              {
-                entryPoint: "generateResizedImage",
-                eventTrigger: {
-                  eventType: "google.storage.object.finalize",
-                  resource: "projects/_/buckets/${param:IMG_BUCKET}",
-                  service: "storage.googleapis.com",
-                },
-                name: "ext-ext-test-generateResizedImage",
-                platform: "gcfv1",
-                regions: ["us-west1"],
-              },
-            ],
-            extension: TEST_EXTENSION,
-            extensionVersion: TEST_EXTENSION_VERSION,
-            codebase: "ext-test",
+          params: {
+            LOCATION: "us-west1",
+            ALLOWED_EVENT_TYPES:
+              "google.firebase.image-resize-started,google.firebase.image-resize-completed",
+            EVENTARC_CHANNEL: "projects/test-project/locations/us-central1/channels/firebase",
           },
+          allowedEventTypes: [
+            "google.firebase.image-resize-started",
+            "google.firebase.image-resize-completed",
+          ],
+          eventarcChannel: "projects/test-project/locations/us-central1/channels/firebase",
+          extension: TEST_EXTENSION,
+          extensionVersion: TEST_EXTENSION_VERSION,
         },
-      ];
+        expected: {
+          env: {
+            LOCATION: "us-west1",
+            DATABASE_INSTANCE: "test-project",
+            DATABASE_URL: "https://test-project.firebaseio.com",
+            EXT_INSTANCE_ID: "ext-test",
+            PROJECT_ID: "test-project",
+            STORAGE_BUCKET: "test-project.appspot.com",
+            ALLOWED_EVENT_TYPES:
+              "google.firebase.image-resize-started,google.firebase.image-resize-completed",
+            EVENTARC_CHANNEL: "projects/test-project/locations/us-central1/channels/firebase",
+            EVENTARC_CLOUD_EVENT_SOURCE: "projects/test-project/instances/ext-test",
+          },
+          secretEnv: [],
+          extensionInstanceId: "ext-test",
+          // use join to convert path to platform dependent path
+          // so test also runs on win machines
+          // eslint-disable-next-line prettier/prettier
+            functionsDir: join("src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions"),
+          nodeMajorVersion: 10,
+          predefinedTriggers: [
+            {
+              entryPoint: "generateResizedImage",
+              eventTrigger: {
+                eventType: "google.storage.object.finalize",
+                resource: "projects/_/buckets/${param:IMG_BUCKET}",
+                service: "storage.googleapis.com",
+              },
+              name: "ext-ext-test-generateResizedImage",
+              platform: "gcfv1",
+              regions: ["us-west1"],
+            },
+          ],
+          extension: TEST_EXTENSION,
+          extensionVersion: TEST_EXTENSION_VERSION,
+          codebase: "ext-test",
+        },
+      },
+    ];
     for (const testCase of testCases) {
       it(testCase.desc, async () => {
         const e = new ExtensionsEmulator({

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -1,14 +1,15 @@
 import { expect } from "chai";
+import { join } from "node:path";
 
+import * as planner from "../../deploy/extensions/planner";
 import { ExtensionsEmulator } from "../../emulator/extensionsEmulator";
 import { EmulatableBackend } from "../../emulator/functionsEmulator";
 import {
   Extension,
   ExtensionVersion,
   RegistryLaunchStage,
-  Visibility,
+  Visibility
 } from "../../extensions/types";
-import * as planner from "../../deploy/extensions/planner";
 
 const TEST_EXTENSION: Extension = {
   name: "publishers/firebase/extensions/storage-resize-images",
@@ -101,8 +102,10 @@ describe("Extensions Emulator", () => {
           },
           secretEnv: [],
           extensionInstanceId: "ext-test",
-          functionsDir:
-            "src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions",
+          // use join to convert path to platform dependent path
+          // so test also runs on win machines
+          // eslint-disable-next-line prettier/prettier
+          functionsDir: join("src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions"),
           nodeMajorVersion: 10,
           predefinedTriggers: [
             {
@@ -134,7 +137,6 @@ describe("Extensions Emulator", () => {
         });
 
         const result = await e.toEmulatableBackend(testCase.input);
-
         expect(result).to.deep.equal(testCase.expected);
       });
     }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
On Windows machines, dependencies of firebase extensions do not get installed. Normally node has abstractions for this kind of platform differencies, however, in this case a constructed path was directly passed to `child_process.spawn`. The path was correct for *NIX and did not work on WIN machines. 

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested
Added a new unit testcase to verify npm install was executed in the extension's functions directory. 

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
