### PR TITLE
[Feat] Support extensions with scheduled triggers

### DIFF
--- a/src/extensions/emulator/triggerHelper.ts
+++ b/src/extensions/emulator/triggerHelper.ts
@@ -1,17 +1,18 @@
-import {
-  ParsedTriggerDefinition,
-  getServiceFromEventType,
-} from "../../emulator/functionsEmulatorShared";
+import * as backend from "../../deploy/functions/backend";
 import { EmulatorLogger } from "../../emulator/emulatorLogger";
-import { Emulators } from "../../emulator/types";
 import {
-  Resource,
+  EventSchedule,
+  getServiceFromEventType,
+  ParsedTriggerDefinition
+} from "../../emulator/functionsEmulatorShared";
+import { Emulators } from "../../emulator/types";
+import { FirebaseError } from "../../error";
+import {
   FUNCTIONS_RESOURCE_TYPE,
   FUNCTIONS_V2_RESOURCE_TYPE,
+  Resource
 } from "../../extensions/types";
-import * as backend from "../../deploy/functions/backend";
 import * as proto from "../../gcp/proto";
-import { FirebaseError } from "../../error";
 
 /**
  * Convert a Resource into a ParsedTriggerDefinition
@@ -38,6 +39,15 @@ export function functionResourceToEmulatedTriggerDefintion(
         eventType: properties.eventTrigger.eventType,
         resource: properties.eventTrigger.resource,
         service: getServiceFromEventType(properties.eventTrigger.eventType),
+      };
+    } else if (properties.scheduleTrigger) {
+      const schedule: EventSchedule = {
+        schedule: properties.scheduleTrigger.schedule,
+      };
+      etd.schedule = schedule;
+      etd.eventTrigger = {
+        eventType: "google.pubsub.topic.publish",
+        resource: "",
       };
     } else {
       EmulatorLogger.forEmulator(Emulators.FUNCTIONS).log(

--- a/src/extensions/emulator/triggerHelper.ts
+++ b/src/extensions/emulator/triggerHelper.ts
@@ -3,14 +3,14 @@ import { EmulatorLogger } from "../../emulator/emulatorLogger";
 import {
   EventSchedule,
   getServiceFromEventType,
-  ParsedTriggerDefinition
+  ParsedTriggerDefinition,
 } from "../../emulator/functionsEmulatorShared";
 import { Emulators } from "../../emulator/types";
 import { FirebaseError } from "../../error";
 import {
   FUNCTIONS_RESOURCE_TYPE,
   FUNCTIONS_V2_RESOURCE_TYPE,
-  Resource
+  Resource,
 } from "../../extensions/types";
 import * as proto from "../../gcp/proto";
 

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -1,7 +1,7 @@
+import { MemoryOptions } from "../deploy/functions/backend";
+import { Runtime } from "../deploy/functions/runtimes";
 import * as proto from "../gcp/proto";
 import { SpecParamType } from "./extensionsHelper";
-import { Runtime } from "../deploy/functions/runtimes";
-import { MemoryOptions } from "../deploy/functions/backend";
 
 export enum RegistryLaunchStage {
   EXPERIMENTAL = "EXPERIMENTAL",
@@ -139,6 +139,7 @@ export interface FunctionResourceProperties {
     availableMemoryMb?: MemoryOptions;
     runtime?: Runtime;
     httpsTrigger?: Record<string, never>;
+    scheduleTrigger?: Record<string, string>;
     taskQueueTrigger?: {
       rateLimits?: {
         maxConcurrentDispatchs?: number;

--- a/src/test/extensions/emulator/triggerHelper.spec.ts
+++ b/src/test/extensions/emulator/triggerHelper.spec.ts
@@ -135,6 +135,35 @@ describe("triggerHelper", () => {
       expect(result).to.eql(expected);
     });
 
+    it("should handle scheduled triggers", () => {
+      const testResource: Resource = {
+        name: "test-resource",
+        entryPoint: "functionName",
+        type: "firebaseextensions.v1beta.function",
+        properties: {
+          scheduleTrigger: {
+            schedule: "every 5 minutes",
+          },
+        },
+      };
+      const expected = {
+        platform: "gcfv1",
+        entryPoint: "test-resource",
+        name: "test-resource",
+        eventTrigger: {
+          eventType: "google.pubsub.topic.publish",
+          resource: "",
+        },
+        schedule: {
+          schedule: "every 5 minutes",
+        },
+      };
+
+      const result = triggerHelper.functionResourceToEmulatedTriggerDefintion(testResource);
+
+      expect(result).to.eql(expected);
+    });
+
     it("should handle v2 custom event triggers", () => {
       const testResource: Resource = {
         name: "test-resource",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
Firebase counter extension used a scheduled function to manage shards: https://github.com/firebase/extensions/blob/bb0b6f24479b20c21d3b9da6a9fea518ae66f0aa/firestore-counter/extension.yaml#L47-L56

The `scheduledTrigger` is not supported by the emulator. This PR adds support by converting the scheduled trigger to a pubsub trigger. 
<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested
Manual tests with latest https://github.com/firebase/extensions/tree/master/firestore-counter extension
<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
