### PR TITLE
fix: prevent lint from failing

### DIFF
--- a/src/functional.ts
+++ b/src/functional.ts
@@ -52,8 +52,8 @@ export function flatten<T extends unknown[] | object>(objOrArr: T): unknown {
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 type RecursiveElems<T extends unknown[]> = {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   [Key in keyof T]: T[Key] extends unknown[] ? T[Key] | RecursiveElems<T[Key]> : T[Key];
 }[number];
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
At least on my Windows macine, linting fails because the RecursiveElement type is unused. I move the alraedy existing `eslint disable ..` comment one line up to prevent linting from failing.
<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested
Ran lint command on WIndows machine.
<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
