### PR TITLE
Fix.

### DIFF
--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -348,11 +348,17 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
     // macs and older Node versions; either way, we should avoid taking on any deps in firebase-tools
     // Alternatively I tried using @swc/spack and the webpack bundled into Next.js but was
     // encountering difficulties with both of those
-    const dependencyTree: NpmLsReturn = JSON.parse(
+    /*const dependencyTree: NpmLsReturn = JSON.parse(
       spawnSync("npm", ["ls", "--omit=dev", "--all", "--json"], {
         cwd: sourceDir,
       }).stdout.toString()
-    );
+    );*/ //  does not work with large application. will not resevie the correct buffer 
+
+
+  const dependencyTree = await readJSON(join(sourceDir, "package-lock.json"));
+
+
+
     // Mark all production deps as externals, so they aren't bundled
     // DevDeps won't be included in the Cloud Function, so they should be bundled
     const esbuildArgs = allDependencyNames(dependencyTree)


### PR DESCRIPTION
from this issue:
[https://github.com/firebase/firebase-tools/issues/5369](https://github.com/firebase/firebase-tools/issues/5369
)
Its trying to run `npm ls --omit=dev --all --json` in a command line but the output is tooo large for the buffer. this makes the JSON parse fail.

this fix will make it read from where is getting its data from and not from a limited buffer

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
