### PR TITLE
Upgrade ES UI to 1.11.2 to capture a set of accessibility improvements.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Fixes an issue where dependencies for emulated Extensions would not be installed on Windows - thanks @stfsy! (#5372)
 - Adds emulator support for Extensions with schedule triggers - thanks @stsfy! (#5374)
 - Fix bug where functions:delete command did not recognize '-' as delimiter. (#5290)
+- Update the Emulator Suite UI to v1.11.2 to capture a set of accessibility improvements. (#this)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 - Fixes an issue where dependencies for emulated Extensions would not be installed on Windows - thanks @stfsy! (#5372)
 - Adds emulator support for Extensions with schedule triggers - thanks @stsfy! (#5374)
 - Fix bug where functions:delete command did not recognize '-' as delimiter. (#5290)
-- Update the Emulator Suite UI to v1.11.2 to capture a set of accessibility improvements. (#this)
+- Update the Emulator Suite UI to v1.11.2 to capture a set of accessibility improvements. (#5394)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -46,8 +46,8 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     ? { version: "SNAPSHOT", expectedSize: -1, expectedChecksum: "" }
     : {
         version: "1.11.2",
-        expectedSize: 3062628,
-        expectedChecksum: "f12e7001aad7e314df01bb7fe87a9fef",
+        expectedSize: 3062873,
+        expectedChecksum: "fe7f668437d0e3c3b92677aaaade78bf",
       },
   pubsub: {
     version: "0.7.1",

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -45,9 +45,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
   ui: experiments.isEnabled("emulatoruisnapshot")
     ? { version: "SNAPSHOT", expectedSize: -1, expectedChecksum: "" }
     : {
-        version: "1.11.1",
-        expectedSize: 3061713,
-        expectedChecksum: "a4944414518be206280b495f526f18bf",
+        version: "1.11.2",
+        expectedSize: 3062628,
+        expectedChecksum: "f12e7001aad7e314df01bb7fe87a9fef",
       },
   pubsub: {
     version: "0.7.1",


### PR DESCRIPTION
Upgrade ES UI to 1.11.2.

Tests passing, skipping checks due to a merge re-run:

skip-checks:true