### PR TITLE
Upgrade Storage rules runtime to v1.1.3 (ternary operators)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 - Fixes a bug in the pubsub emulator by forcing a shutdown if it didn't end cleanly. (#5294)
 - Fixes an issue where dependencies for emulated Extensions would not be installed on Windows - thanks @stfsy! (#5372)
 - Adds emulator support for Extensions with schedule triggers - thanks @stsfy! (#5374)
+  <<<<<<< HEAD
 - Fixes an issue in the Functions emulator where secret values were undefined after hot reload with the `--inspect-functions` flag. (#5384)
 - Fixes a bug where functions:delete command did not recognize '-' as delimiter. (#5290)
 - Reintroduces an updated Hosting emulator with i18n (#4879) and Windows path (#5133) fixes.
+- Upgrade Storage Rules Runtime to v2.0.0 (Java 11)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 - Fixes a bug in the pubsub emulator by forcing a shutdown if it didn't end cleanly. (#5294)
 - Fixes an issue where dependencies for emulated Extensions would not be installed on Windows - thanks @stfsy! (#5372)
 - Adds emulator support for Extensions with schedule triggers - thanks @stsfy! (#5374)
-  <<<<<<< HEAD
 - Fixes an issue in the Functions emulator where secret values were undefined after hot reload with the `--inspect-functions` flag. (#5384)
 - Fixes a bug where functions:delete command did not recognize '-' as delimiter. (#5290)
 - Reintroduces an updated Hosting emulator with i18n (#4879) and Windows path (#5133) fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fix bug where CLI was unable to deploy Firebase Functions in some monorepo setups (#5391)
-- Upgrade Storage Rules Runtime to v2.0.0 (Java 11)
+- Upgrade Storage Rules Runtime to v1.1.3 to support ternary operators (#5370)

--- a/scripts/storage-emulator-integration/rules/runtime.test.ts
+++ b/scripts/storage-emulator-integration/rules/runtime.test.ts
@@ -345,6 +345,38 @@ describe("Storage Rules Runtime", function () {
       ).to.be.false;
     });
   });
+
+  describe("features", () => {
+    describe("ternary", () => {
+      it("should support ternary operators", async () => {
+        const rulesContent = `
+        rules_version = '2';
+        service firebase.storage {
+          match /b/{bucket}/o {
+            match /{file} {
+              allow read: if request.path[3] == "test" ? true : false;
+            }
+          }
+        }`;
+
+        expect(
+          await testIfPermitted(runtime, rulesContent, {
+            method: RulesetOperationMethod.GET,
+            path: "/b/BUCKET_NAME/o/test",
+            file: {},
+          })
+        ).to.be.true;
+
+        expect(
+          await testIfPermitted(runtime, rulesContent, {
+            method: RulesetOperationMethod.GET,
+            path: "/b/BUCKET_NAME/o/someRandomFile",
+            file: {},
+          })
+        ).to.be.false;
+      });
+    });
+  });
 });
 
 async function testIfPermitted(

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -38,9 +38,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "4f41d24a3c0f3b55ea22804a424cc0ee",
   },
   storage: {
-    version: "2.0.0",
-    expectedSize: 52893083,
-    expectedChecksum: "d498b9e34f718a76b6296428003442a6",
+    version: "1.1.3",
+    expectedSize: 52892936,
+    expectedChecksum: "2ca11ec1193003bea89f806cc085fa25",
   },
   ui: experiments.isEnabled("emulatoruisnapshot")
     ? { version: "SNAPSHOT", expectedSize: -1, expectedChecksum: "" }

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -38,9 +38,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "4f41d24a3c0f3b55ea22804a424cc0ee",
   },
   storage: {
-    version: "1.1.2",
-    expectedSize: 47028740,
-    expectedChecksum: "983b4415b1e72b109864f1b8e7ea7546",
+    version: "2.0.0",
+    expectedSize: 52893083,
+    expectedChecksum: "d498b9e34f718a76b6296428003442a6",
   },
   ui: experiments.isEnabled("emulatoruisnapshot")
     ? { version: "SNAPSHOT", expectedSize: -1, expectedChecksum: "" }

--- a/src/emulator/storage/rules/manager.ts
+++ b/src/emulator/storage/rules/manager.ts
@@ -110,7 +110,7 @@ class DefaultStorageRulesManager implements StorageRulesManager {
           }:${parsedIssue.sourcePosition_.line_}`
         );
       } catch {
-        this._logger.log("WARN", issue);
+        this._logger.logLabeled("WARN", "storage", issue);
       }
     });
     return issues;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Upgrades the storage rules emulator to v1.1.3 which supports use of the ternary operator. Fixes #5370

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

unit tests

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
