### PR TITLE
Refactor how node binary is retrieved for functions/extensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Refactor Functions Emulator. (#5422)

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -37,9 +37,9 @@ const TEST_BACKEND = {
   env: {},
   secretEnv: [],
   codebase: "default",
-  nodeBinary: process.execPath,
-  // NOTE: Use the following nodeBinary path if you want to run test cases directly from your IDE.
-  // nodeBinary: path.join(MODULE_ROOT, "node_modules/.bin/ts-node"),
+  bin: process.execPath,
+  // NOTE: Use the following node bin path if you want to run test cases directly from your IDE.
+  // bin: path.join(MODULE_ROOT, "node_modules/.bin/ts-node"),
 };
 
 async function useFunction(

--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -63,6 +63,11 @@ export interface RuntimeDelegate {
   runtime: Runtime;
 
   /**
+   * Path to the bin used to run the source code.
+   */
+  bin: string;
+
+  /**
    * Validate makes sure the customers' code is actually viable.
    * This includes checks like making sure a package.json file is
    * well formed.

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -66,7 +66,6 @@ export class Delegate {
   // to decide whether to use the JS export method of discovery or the HTTP container contract
   // method of discovery.
   _sdkVersion: string | undefined = undefined;
-
   get sdkVersion(): string {
     if (this._sdkVersion === undefined) {
       this._sdkVersion = versioning.getFunctionsSDKVersion(this.sourceDir) || "";

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -103,35 +103,34 @@ export class Delegate {
       }
     }
 
-    // If the requested version is the same as the host, let's use that
     if (semver.major(requestedVersion) === semver.major(hostVersion)) {
       logLabeledSuccess("functions", `Using node@${semver.major(hostVersion)} from host.`);
-    } else {
-      // Otherwise we'll warn and use the version that is currently running this process.
-      if (process.env.FIREPIT_VERSION) {
-        logLabeledWarning(
-          "functions",
-          `You've requested "node" version "${semver.major(
-            requestedVersion
-          )}", but the standalone Firebase CLI comes with bundled Node "${semver.major(
-            hostVersion
-          )}".`
-        );
-        logLabeledSuccess(
-          "functions",
-          `To use a different Node.js version, consider removing the standalone Firebase CLI and switching to "firebase-tools" on npm.`
-        );
-      } else {
-        logLabeledWarning(
-          "functions",
-          `Your requested "node" version "${semver.major(
-            requestedVersion
-          )}" doesn't match your global version "${semver.major(
-            hostVersion
-          )}". Using node@${semver.major(hostVersion)} from host.`
-        );
-      }
+      return process.execPath;
     }
+
+    if (!process.env.FIREPIT_VERSION) {
+      logLabeledWarning(
+        "functions",
+        `Your requested "node" version "${semver.major(
+          requestedVersion
+        )}" doesn't match your global version "${semver.major(
+          hostVersion
+        )}". Using node@${semver.major(hostVersion)} from host.`
+      );
+      return process.execPath;
+    }
+
+    // Otherwise we'll warn and use the version that is currently running this process.
+    logLabeledWarning(
+      "functions",
+      `You've requested "node" version "${semver.major(
+        requestedVersion
+      )}", but the standalone Firebase CLI comes with bundled Node "${semver.major(hostVersion)}".`
+    );
+    logLabeledSuccess(
+      "functions",
+      `To use a different Node.js version, consider removing the standalone Firebase CLI and switching to "firebase-tools" on npm.`
+    );
     return process.execPath;
   }
 

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -155,14 +155,14 @@ export class Delegate {
     return Promise.resolve(() => Promise.resolve());
   }
 
-  serve(
-    port: number,
+  serveAdmin(
+    port: string,
     config: backend.RuntimeConfigValues,
     envs: backend.EnvironmentVariables
   ): Promise<() => Promise<void>> {
     const env: NodeJS.ProcessEnv = {
       ...envs,
-      PORT: port.toString(),
+      PORT: port,
       FUNCTIONS_CONTROL_API: "true",
       HOME: process.env.HOME,
       PATH: process.env.PATH,
@@ -224,7 +224,7 @@ export class Delegate {
     if (!discovered) {
       const getPort = promisify(portfinder.getPort) as () => Promise<number>;
       const port = await getPort();
-      const kill = await this.serve(port, config, env);
+      const kill = await this.serveAdmin(port.toString(), config, env);
       try {
         discovered = await discovery.detectFromPort(port, this.projectId, this.runtime);
       } finally {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -1,6 +1,7 @@
 import * as clc from "colorette";
 import * as fs from "fs";
 import * as path from "path";
+import * as semver from "semver";
 
 import { logger } from "../logger";
 import { track, trackEmulator } from "../track";
@@ -17,7 +18,6 @@ import {
 } from "./types";
 import { Constants, FIND_AVAILBLE_PORT_BY_DEFAULT } from "./constants";
 import { EmulatableBackend, FunctionsEmulator } from "./functionsEmulator";
-import { parseRuntimeVersion } from "./functionsEmulatorUtils";
 import { AuthEmulator, SingleProjectMode } from "./auth";
 import { DatabaseEmulator, DatabaseEmulatorArgs } from "./databaseEmulator";
 import { FirestoreEmulator, FirestoreEmulatorArgs } from "./firestoreEmulator";
@@ -476,8 +476,10 @@ export async function startAll(
 
     for (const cfg of functionsCfg) {
       const functionsDir = path.join(projectDir, cfg.source);
+      const runtime = (options.extDevRuntime as string | undefined) ?? cfg.runtime;
       emulatableBackends.push({
         functionsDir,
+        runtime,
         codebase: cfg.codebase,
         env: {
           ...options.extDevEnv,
@@ -486,7 +488,6 @@ export async function startAll(
         // TODO(b/213335255): predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
         // Ideally, we should handle that case via ExtensionEmulator.
         predefinedTriggers: options.extDevTriggers as ParsedTriggerDefinition[] | undefined,
-        nodeMajorVersion: parseRuntimeVersion((options.extDevNodeVersion as string) || cfg.runtime),
       });
     }
   }

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -1,7 +1,6 @@
 import * as clc from "colorette";
 import * as fs from "fs";
 import * as path from "path";
-import * as semver from "semver";
 
 import { logger } from "../logger";
 import { track, trackEmulator } from "../track";

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -235,6 +235,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
     const emulatableBackend: EmulatableBackend = {
       functionsDir,
       runtime,
+      bin: process.execPath,
       env: nonSecretEnv,
       codebase: instance.instanceId, // Give each extension its own codebase name so that they don't share workerPools.
       secretEnv: secretEnvVariables,

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -230,15 +230,15 @@ export class ExtensionsEmulator implements EmulatorInstance {
     const functionsDir = path.join(extensionDir, "functions");
     // TODO(b/213335255): For local extensions, this should include extensionSpec instead of extensionVersion
     const env = Object.assign(this.autoPopulatedParams(instance), instance.params);
-    const { extensionTriggers, nodeMajorVersion, nonSecretEnv, secretEnvVariables } =
+    const { extensionTriggers, runtime, nonSecretEnv, secretEnvVariables } =
       await getExtensionFunctionInfo(instance, env);
     const emulatableBackend: EmulatableBackend = {
       functionsDir,
+      runtime,
       env: nonSecretEnv,
       codebase: instance.instanceId, // Give each extension its own codebase name so that they don't share workerPools.
       secretEnv: secretEnvVariables,
       predefinedTriggers: extensionTriggers,
-      nodeMajorVersion: nodeMajorVersion,
       extensionInstanceId: instance.instanceId,
     };
     if (instance.ref) {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -463,7 +463,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       logger.debug(`Building ${runtimeDelegate.name} source`);
       await runtimeDelegate.build();
 
-      // Retrieve information from runtime delegate
+      // Retrieve information from the runtime delegate.
       emulatableBackend.runtime = runtimeDelegate.runtime;
       emulatableBackend.bin = runtimeDelegate.bin;
 
@@ -522,7 +522,6 @@ export class FunctionsEmulator implements EmulatorInstance {
       );
       return;
     }
-
     // Before loading any triggers we need to make sure there are no 'stale' workers
     // in the pool that would cause us to run old code.
     this.workerPools[emulatableBackend.codebase].refresh();

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -15,9 +15,6 @@ import { needProjectId } from "../../projectUtils";
 import { Emulators } from "../../emulator/types";
 import { SecretEnvVar } from "../../deploy/functions/backend";
 
-/**
- *
- */
 export async function buildOptions(options: any): Promise<any> {
   const extDevDir = localHelper.findExtensionYaml(process.cwd());
   options.extDevDir = extDevDir;

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -15,6 +15,9 @@ import { needProjectId } from "../../projectUtils";
 import { Emulators } from "../../emulator/types";
 import { SecretEnvVar } from "../../deploy/functions/backend";
 
+/**
+ *
+ */
 export async function buildOptions(options: any): Promise<any> {
   const extDevDir = localHelper.findExtensionYaml(process.cwd());
   options.extDevDir = extDevDir;
@@ -37,16 +40,19 @@ export async function buildOptions(options: any): Promise<any> {
     triggerHelper.functionResourceToEmulatedTriggerDefintion(r)
   );
   options.extDevTriggers = functionEmuTriggerDefs;
-  options.extDevNodeVersion = specHelper.getNodeVersion(functionResources);
+  options.extDevRuntime = specHelper.getRuntime(functionResources);
   return options;
 }
 
 // TODO: Better name? Also, should this be in extensionsEmulator instead?
+/**
+ *
+ */
 export async function getExtensionFunctionInfo(
   instance: planner.InstanceSpec,
   paramValues: Record<string, string>
 ): Promise<{
-  nodeMajorVersion: number;
+  runtime: string;
   extensionTriggers: ParsedTriggerDefinition[];
   nonSecretEnv: Record<string, string>;
   secretEnvVariables: SecretEnvVar[];
@@ -59,12 +65,12 @@ export async function getExtensionFunctionInfo(
       trigger.name = `ext-${instance.instanceId}-${trigger.name}`;
       return trigger;
     });
-  const nodeMajorVersion = specHelper.getNodeVersion(functionResources);
+  const runtime = specHelper.getRuntime(functionResources);
   const nonSecretEnv = getNonSecretEnv(spec.params, paramValues);
   const secretEnvVariables = getSecretEnvVars(spec.params, paramValues);
   return {
     extensionTriggers,
-    nodeMajorVersion,
+    runtime,
     nonSecretEnv,
     secretEnvVariables,
   };
@@ -117,6 +123,9 @@ export function getSecretEnvVars(
 }
 
 // Exported for testing
+/**
+ *
+ */
 export function getParams(options: any, extensionSpec: ExtensionSpec) {
   const projectId = needProjectId(options);
   const userParams = paramHelper.readEnvFile(options.testParams);

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -123,9 +123,6 @@ export function getSecretEnvVars(
 }
 
 // Exported for testing
-/**
- *
- */
 export function getParams(options: any, extensionSpec: ExtensionSpec) {
   const projectId = needProjectId(options);
   const userParams = paramHelper.readEnvFile(options.testParams);

--- a/src/extensions/emulator/optionsHelper.ts
+++ b/src/extensions/emulator/optionsHelper.ts
@@ -15,6 +15,9 @@ import { needProjectId } from "../../projectUtils";
 import { Emulators } from "../../emulator/types";
 import { SecretEnvVar } from "../../deploy/functions/backend";
 
+/**
+ * Build firebase options based on the extension configuration.
+ */
 export async function buildOptions(options: any): Promise<any> {
   const extDevDir = localHelper.findExtensionYaml(process.cwd());
   options.extDevDir = extDevDir;
@@ -41,9 +44,8 @@ export async function buildOptions(options: any): Promise<any> {
   return options;
 }
 
-// TODO: Better name? Also, should this be in extensionsEmulator instead?
 /**
- *
+ * TODO: Better name? Also, should this be in extensionsEmulator instead?
  */
 export async function getExtensionFunctionInfo(
   instance: planner.InstanceSpec,
@@ -119,7 +121,9 @@ export function getSecretEnvVars(
   return secretEnvVar;
 }
 
-// Exported for testing
+/**
+ * Exported for testing
+ */
 export function getParams(options: any, extensionSpec: ExtensionSpec) {
   const projectId = needProjectId(options);
   const userParams = paramHelper.readEnvFile(options.testParams);

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -79,9 +79,6 @@ export function readFileFromDirectory(
   });
 }
 
-/**
- *
- */
 export function getFunctionResourcesWithParamSubstitution(
   extensionSpec: ExtensionSpec,
   params: { [key: string]: string }
@@ -92,9 +89,6 @@ export function getFunctionResourcesWithParamSubstitution(
   return substituteParams<Resource[]>(rawResources, params);
 }
 
-/**
- *
- */
 export function getFunctionProperties(resources: Resource[]) {
   return resources.map((r) => r.properties);
 }

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -79,6 +79,9 @@ export function readFileFromDirectory(
   });
 }
 
+/**
+ * Substitue parameters of function resources in the extensions spec.
+ */
 export function getFunctionResourcesWithParamSubstitution(
   extensionSpec: ExtensionSpec,
   params: { [key: string]: string }
@@ -89,14 +92,18 @@ export function getFunctionResourcesWithParamSubstitution(
   return substituteParams<Resource[]>(rawResources, params);
 }
 
+/**
+ * Get properties associated with the function resource.
+ */
 export function getFunctionProperties(resources: Resource[]) {
   return resources.map((r) => r.properties);
 }
 
-const DEFAULT_RUNTIME = "nodejs14";
+export const DEFAULT_RUNTIME = "nodejs14";
 
 /**
- * Get runtime associated with the resources. If conflicting, arbitrarily pick one.
+ * Get runtime associated with the resources. If multiple runtimes exists, choose the latest runtime.
+ * e.g. prefer nodejs14 over nodejs12.
  */
 export function getRuntime(resources: Resource[]): string {
   if (resources.length === 0) {
@@ -109,7 +116,7 @@ export function getRuntime(resources: Resource[]): string {
     if (!runtime) {
       return DEFAULT_RUNTIME;
     }
-    if (!/(nodejs)?([0-9]+)/.test(runtime)) {
+    if (!/$(nodejs)?([0-9]+)/.test(runtime)) {
       invalidRuntimes.push(runtime);
       return DEFAULT_RUNTIME;
     }
@@ -122,5 +129,8 @@ export function getRuntime(resources: Resource[]): string {
       )}. \n Only Node runtimes are supported.`
     );
   }
-  return runtimes[0];
+  // Assumes that all runtimes target the nodejs.
+  // Rely on lexicographically order of nodejs runtime to pick the latest version.
+  // e.g. nodejs12 < nodejs14 < nodejs18 < nodejs20 ...
+  return runtimes.sort()[runtimes.length - 1];
 }

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -116,7 +116,7 @@ export function getRuntime(resources: Resource[]): string {
     if (!runtime) {
       return DEFAULT_RUNTIME;
     }
-    if (!/$(nodejs)?([0-9]+)/.test(runtime)) {
+    if (!/^(nodejs)?([0-9]+)/.test(runtime)) {
       invalidRuntimes.push(runtime);
       return DEFAULT_RUNTIME;
     }

--- a/src/extensions/emulator/specHelper.ts
+++ b/src/extensions/emulator/specHelper.ts
@@ -6,7 +6,6 @@ import { ExtensionSpec, Resource } from "../types";
 import { FirebaseError } from "../../error";
 import { substituteParams } from "../extensionsHelper";
 import { getResourceRuntime } from "../utils";
-import { parseRuntimeVersion } from "../../emulator/functionsEmulatorUtils";
 
 const SPEC_FILE = "extension.yaml";
 const POSTINSTALL_FILE = "POSTINSTALL.md";
@@ -80,6 +79,9 @@ export function readFileFromDirectory(
   });
 }
 
+/**
+ *
+ */
 export function getFunctionResourcesWithParamSubstitution(
   extensionSpec: ExtensionSpec,
   params: { [key: string]: string }
@@ -90,25 +92,35 @@ export function getFunctionResourcesWithParamSubstitution(
   return substituteParams<Resource[]>(rawResources, params);
 }
 
+/**
+ *
+ */
 export function getFunctionProperties(resources: Resource[]) {
   return resources.map((r) => r.properties);
 }
 
-export function getNodeVersion(resources: Resource[]): number {
-  const invalidRuntimes: string[] = [];
-  const versions = resources.map((r: Resource) => {
-    if (getResourceRuntime(r)) {
-      const runtimeName = getResourceRuntime(r) as string;
-      const runtime = parseRuntimeVersion(runtimeName);
-      if (!runtime) {
-        invalidRuntimes.push(runtimeName);
-      } else {
-        return runtime;
-      }
-    }
-    return 14;
-  });
+const DEFAULT_RUNTIME = "nodejs14";
 
+/**
+ * Get runtime associated with the resources. If conflicting, arbitrarily pick one.
+ */
+export function getRuntime(resources: Resource[]): string {
+  if (resources.length === 0) {
+    return DEFAULT_RUNTIME;
+  }
+
+  const invalidRuntimes: string[] = [];
+  const runtimes = resources.map((r: Resource) => {
+    const runtime = getResourceRuntime(r);
+    if (!runtime) {
+      return DEFAULT_RUNTIME;
+    }
+    if (!/(nodejs)?([0-9]+)/.test(runtime)) {
+      invalidRuntimes.push(runtime);
+      return DEFAULT_RUNTIME;
+    }
+    return runtime;
+  });
   if (invalidRuntimes.length) {
     throw new FirebaseError(
       `The following runtimes are not supported by the Emulator Suite: ${invalidRuntimes.join(
@@ -116,5 +128,5 @@ export function getNodeVersion(resources: Resource[]): number {
       )}. \n Only Node runtimes are supported.`
     );
   }
-  return Math.max(...versions);
+  return runtimes[0];
 }

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -30,11 +30,10 @@ export class FunctionsServer {
     const backends: EmulatableBackend[] = [];
     for (const cfg of config) {
       const functionsDir = path.join(options.config.projectDir, cfg.source);
-      const nodeMajorVersion = parseRuntimeVersion(cfg.runtime);
       backends.push({
         functionsDir,
         codebase: cfg.codebase,
-        nodeMajorVersion,
+        runtime: cfg.runtime,
         env: {},
         secretEnv: [],
       });

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -4,7 +4,6 @@ import {
   FunctionsEmulator,
   FunctionsEmulatorArgs,
 } from "../emulator/functionsEmulator";
-import { parseRuntimeVersion } from "../emulator/functionsEmulatorUtils";
 import { needProjectId } from "../projectUtils";
 import { getProjectDefaultAccount } from "../auth";
 import { Options } from "../options";

--- a/src/test/deploy/functions/runtimes/node/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/node/index.spec.ts
@@ -1,0 +1,74 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as path from "path";
+
+import * as node from "../../../../../deploy/functions/runtimes/node";
+import * as versioning from "../../../../../deploy/functions/runtimes/node/versioning";
+import * as utils from "../../../../../utils";
+import { FirebaseError } from "../../../../../error";
+
+const PROJECT_ID = "test-project";
+const PROJECT_DIR = "/some/path";
+const SOURCE_DIR = "/some/path/fns";
+
+describe("NodeDelegate", () => {
+  describe("getNodeBinary", () => {
+    let warnSpy: sinon.SinonSpy;
+    let successSpy: sinon.SinonSpy;
+    let hostVersionMock: sinon.SinonStub;
+    let localVersionMock: sinon.SinonStub;
+
+    beforeEach(() => {
+      warnSpy = sinon.spy(utils, "logLabeledWarning");
+      successSpy = sinon.spy(utils, "logLabeledSuccess");
+      hostVersionMock = sinon.stub(process, "versions");
+      localVersionMock = sinon.stub(versioning, "findModuleVersion");
+    });
+
+    afterEach(() => {
+      warnSpy.restore();
+      successSpy.restore();
+      hostVersionMock.restore();
+      localVersionMock.restore();
+    });
+
+    it("prefers locally cached node version if matched with requested version", () => {
+      localVersionMock.returns("12.0.0");
+      hostVersionMock.value({ node: "14.5.0" });
+      const requestedRuntime = "nodejs12";
+      const delegate = new node.Delegate(PROJECT_ID, PROJECT_DIR, SOURCE_DIR, requestedRuntime);
+      expect(delegate.getNodeBinary()).to.equal(path.join(SOURCE_DIR, "node_modules", "node"));
+      expect(successSpy).to.have.been.calledWith(
+        "functions",
+        sinon.match("node@12 from local cache.")
+      );
+      expect(warnSpy).to.not.have.been.called;
+    });
+
+    it("checks if requested and hosted runtime version matches", () => {
+      hostVersionMock.value({ node: "12.5.0" });
+      const requestedRuntime = "nodejs12";
+      const delegate = new node.Delegate(PROJECT_ID, PROJECT_DIR, SOURCE_DIR, requestedRuntime);
+      expect(delegate.getNodeBinary()).to.equal(process.execPath);
+      expect(successSpy).to.have.been.calledWith("functions", sinon.match("node@12 from host."));
+      expect(warnSpy).to.not.have.been.called;
+    });
+
+    it("warns users if hosted and requested runtime version differs", () => {
+      hostVersionMock.value({ node: "12.0.0" });
+      const requestedRuntime = "nodejs10";
+      const delegate = new node.Delegate(PROJECT_ID, PROJECT_DIR, SOURCE_DIR, requestedRuntime);
+
+      expect(delegate.getNodeBinary()).to.equal(process.execPath);
+      expect(successSpy).to.not.have.been.called;
+      expect(warnSpy).to.have.been.calledWith("functions", sinon.match("doesn't match"));
+    });
+
+    it("throws errors if requested runtime version is invalid", () => {
+      const invalidRuntime = "foobar";
+      const delegate = new node.Delegate(PROJECT_ID, PROJECT_DIR, SOURCE_DIR, invalidRuntime);
+
+      expect(() => delegate.getNodeBinary()).to.throw(FirebaseError);
+    });
+  });
+});

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -109,7 +109,7 @@ describe("Extensions Emulator", () => {
           // so test also runs on win machines
           // eslint-disable-next-line prettier/prettier
             functionsDir: join("src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions"),
-          nodeMajorVersion: 10,
+          runtime: "nodejs10",
           predefinedTriggers: [
             {
               entryPoint: "generateResizedImage",

--- a/src/test/emulators/extensionsEmulator.spec.ts
+++ b/src/test/emulators/extensionsEmulator.spec.ts
@@ -140,6 +140,8 @@ describe("Extensions Emulator", () => {
         });
 
         const result = await e.toEmulatableBackend(testCase.input);
+        // ignore result.bin, as it is platform dependent
+        delete result.bin;
         expect(result).to.deep.equal(testCase.expected);
       });
     }

--- a/src/test/extensions/emulator/specHelper.spec.ts
+++ b/src/test/extensions/emulator/specHelper.spec.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai";
+
+import * as specHelper from "../../../extensions/emulator/specHelper";
+import { Resource } from "../../../extensions/types";
+import { FirebaseError } from "../../../error";
+
+const testResource: Resource = {
+  name: "test-resource",
+  entryPoint: "functionName",
+  type: "firebaseextensions.v1beta.function",
+  properties: {
+    timeout: "3s",
+    location: "us-east1",
+    availableMemoryMb: 1024,
+  },
+};
+
+describe("getRuntime", () => {
+  it("gets runtime of resources", () => {
+    const r1 = {
+      ...testResource,
+      properties: {
+        runtime: "nodejs14",
+      },
+    };
+    const r2 = {
+      ...testResource,
+      properties: {
+        runtime: "nodejs14",
+      },
+    };
+    expect(specHelper.getRuntime([r1, r2])).to.equal("nodejs14");
+  });
+
+  it("chooses the latest runtime if many runtime exists", () => {
+    const r1 = {
+      ...testResource,
+      properties: {
+        runtime: "nodejs12",
+      },
+    };
+    const r2 = {
+      ...testResource,
+      properties: {
+        runtime: "nodejs14",
+      },
+    };
+    expect(specHelper.getRuntime([r1, r2])).to.equal("nodejs14");
+  });
+
+  it("returns default runtime if none specified", () => {
+    const r1 = {
+      ...testResource,
+      properties: {},
+    };
+    const r2 = {
+      ...testResource,
+      properties: {},
+    };
+    expect(specHelper.getRuntime([r1, r2])).to.equal(specHelper.DEFAULT_RUNTIME);
+  });
+
+  it("returns default runtime given no resources", () => {
+    expect(specHelper.getRuntime([])).to.equal(specHelper.DEFAULT_RUNTIME);
+  });
+
+  it("throws error given invalid runtime", () => {
+    const r1 = {
+      ...testResource,
+      properties: {
+        runtime: "dotnet6",
+      },
+    };
+    const r2 = {
+      ...testResource,
+      properties: {
+        runtime: "nodejs14",
+      },
+    };
+    expect(() => specHelper.getRuntime([r1, r2])).to.throw(FirebaseError);
+  });
+});


### PR DESCRIPTION
Today, Functions Emulator make strong assumption that all functions target node runtime and pass around references like `nodeBinary`, `nodeMajorVersion`, etc.

This PR refactors the logic to abstract away `node` into `bin` and `runtime`. The logic for choosing the appropriate `bin` for the function is lifted to `RuntimeDelegate`, same piece of code that holds together other `nodejs` runtime specific logic. 

The refactored required small changes to the extensions emulator - looping in @joehan to see if he has any objections.