### PR TITLE
Add support for new links added to the release object (release links)

### DIFF
--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -46,6 +46,9 @@ export interface Release {
   displayVersion: string;
   buildVersion: string;
   createTime: Date;
+  firebaseConsoleUri: string;
+  testingUri: string;
+  binaryDownloadUri: string;
 }
 
 export interface ReleaseNotes {

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -129,6 +129,11 @@ export const command = new Command("appdistribution:distribute <release-binary-f
             `uploaded release ${release.displayVersion} (${release.buildVersion}) successfully!`
           );
       }
+      utils.logSuccess(`View this release in the Firebase console: ${release.firebaseConsoleUri}`);
+      utils.logSuccess(`Share this release with testers who have access: ${release.testingUri}`);
+      utils.logSuccess(
+        `Download the release binary (link expires in 1 hour): ${release.binaryDownloadUri}`
+      );
       releaseName = uploadResponse.release.name;
     } catch (err: any) {
       if (err.status === 404) {


### PR DESCRIPTION

Printing links that will be added to the Release Object. There are three links.

Firebase Console link for devs to link to a specific release in the console
Testing Link for devs to send to testers to test a specific release
Binary Link to download the binary associated with that release