### PR TITLE
Updating changelog with releaseLinks changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added links to new releases. These links help you manage binaries and ensure that testers and other developers have the right release. (#5438)


### PR DESCRIPTION
I did not update the changelog last time with the release that went out on 1/19/2023 adding the changes to the changelog for the next release