### PR TITLE
Explicitly check for channel existence before creating it

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -316,7 +316,7 @@ export class Fabricator {
       await this.executor
         .run(async () => {
           try {
-            if (await eventarc.getChannel(channel) !== undefined) {
+            if ((await eventarc.getChannel(channel)) !== undefined) {
               return;
             }
             const op: { name: string } = await eventarc.createChannel({ name: channel });

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -316,6 +316,9 @@ export class Fabricator {
       await this.executor
         .run(async () => {
           try {
+            if (await eventarc.getChannel(channel) !== undefined) {
+              return;
+            }
             const op: { name: string } = await eventarc.createChannel({ name: channel });
             return await poller.pollOperation<eventarc.Channel>({
               ...eventarcPollerOptions,

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -316,6 +316,10 @@ export class Fabricator {
       await this.executor
         .run(async () => {
           try {
+            // eventarc.createChannel doesn't always return 409 when channel already exists.
+            // Ex. when channel exists and has active triggers the API will return 400 (bad
+            // request) with message saying something about active triggers. So instead of
+            // relying on 409 response we explicitly check for channel existense.
             if ((await eventarc.getChannel(channel)) !== undefined) {
               return;
             }

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -490,7 +490,7 @@ describe("Fabricator", () => {
     });
 
     it("handles already existing eventarc channels", async () => {
-      eventarc.getChannel.resolves({name: "channel"})
+      eventarc.getChannel.resolves({ name: "channel" });
       gcfv2.createFunction.resolves({ name: "op", done: false });
       poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
 
@@ -513,7 +513,7 @@ describe("Fabricator", () => {
       expect(gcfv2.createFunction).to.have.been.called;
     });
 
-    it("handles already existing eventarc channels", async () => {
+    it("handles already existing eventarc channels (createChannel return 409)", async () => {
       eventarc.getChannel.resolves(undefined);
       eventarc.createChannel.callsFake(({ name }) => {
         expect(name).to.equal("channel");


### PR DESCRIPTION
calling createChannel on an existing channel with existing triggers can result in 400 error
