### PR TITLE
Randomize port used for function discovery to reduce race conditions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Refactor Functions Emulator. (#5422)
+- Fix race condition when discoerying functions. (#5444)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Refactor Functions Emulator. (#5422)
-- Fix race condition when discoerying functions. (#5444)
+- Fix race condition when discovering functions. (#5444)

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -9,7 +9,7 @@ import fetch from "node-fetch";
 import { FirebaseError } from "../../../../error";
 import { getRuntimeChoice } from "./parseRuntimeAndValidateSDK";
 import { logger } from "../../../../logger";
-import { logLabeledSuccess, logLabeledWarning } from "../../../../utils";
+import { logLabeledSuccess, logLabeledWarning, randomInt } from "../../../../utils";
 import * as backend from "../../backend";
 import * as build from "../../build";
 import * as discovery from "../discovery";
@@ -220,8 +220,8 @@ export class Delegate {
 
     let discovered = await discovery.detectFromYaml(this.sourceDir, this.projectId, this.runtime);
     if (!discovered) {
-      const getPort = promisify(portfinder.getPort) as () => Promise<number>;
-      const port = await getPort();
+      const basePort = 8000 + randomInt(0, 1000); // Add a jitter to reduce likelihood of race condition
+      const port = await portfinder.getPortPromise({ port: basePort });
       const kill = await this.serveAdmin(port.toString(), config, env);
       try {
         discovered = await discovery.detectFromPort(port, this.projectId, this.runtime);


### PR DESCRIPTION
When spinning up admin server for function discovery, we rely on `portfinder.getPort()` function to find an open port for the admin server to listen.

portfinder starts from a base port number (e.g. 9005), trying incrementally larger number until an open port is found. This mechanism can lead to race condition when multiple processes look for an open port from the same base port number.

This PR adds a small jitter to the base port number when calling `portfinder` to reduce likeliness of a race condition.

Fixes https://github.com/firebase/firebase-tools/issues/5418.