### PR TITLE
Add option to initialize python functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Refactor the way timeouts are enforced by the Functions Emulator (#5464)

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -1037,4 +1037,33 @@ describe("FunctionsEmulator", function () {
       expect(triggerDefinitions[0].timeoutSeconds).to.equal(26);
     });
   });
+
+  it("should enforce timeout", async () => {
+    await useFunction(
+      emu,
+      "timeoutFn",
+      () => {
+        return {
+          timeoutFn: require("firebase-functions")
+            .runWith({ timeoutSeconds: 1 })
+            .https.onRequest((req: express.Request, res: express.Response): Promise<void> => {
+              return new Promise((resolve) => {
+                setTimeout(() => {
+                  res.sendStatus(200);
+                  resolve();
+                }, 5_000);
+              });
+            }),
+        };
+      },
+      ["us-central1"],
+      {
+        timeoutSeconds: 1,
+      }
+    );
+
+    await supertest(emu.createHubServer())
+      .get("/fake-project-id/us-central1/timeoutFn")
+      .expect(500);
+  });
 });

--- a/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
+++ b/scripts/emulator-tests/functionsEmulatorRuntime.spec.ts
@@ -730,40 +730,6 @@ describe("FunctionsEmulator-Runtime", function () {
         expect(runtime.sysMsg["runtime-error"]?.length).to.eq(1);
       });
     });
-
-    describe("Timeout", () => {
-      it("enforces configured timeout", async () => {
-        const timeoutEnvs = {
-          FUNCTIONS_EMULATOR_TIMEOUT_SECONDS: "1",
-          FUNCTIONS_EMULATOR_DISABLE_TIMEOUT: "false",
-        };
-        runtime = await startRuntime(
-          "functionId",
-          "http",
-          () => {
-            return {
-              functionId: require("firebase-functions").https.onRequest(
-                (req: any, resp: any): Promise<void> => {
-                  return new Promise((resolve) => {
-                    setTimeout(() => {
-                      resp.sendStatus(200);
-                      resolve();
-                    }, 5_000);
-                  });
-                }
-              ),
-            };
-          },
-          timeoutEnvs
-        );
-        try {
-          await sendReq(runtime);
-        } catch (e: any) {
-          // Carry on
-        }
-        expect(runtime.sysMsg["runtime-error"]?.length).to.eq(1);
-      });
-    });
   });
 
   describe("Debug", () => {

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -13,7 +13,7 @@ import { runWithVirtualEnv } from "../../../../functions/python";
 import { FirebaseError } from "../../../../error";
 import { Build } from "../../build";
 
-const LATEST_VERSION: runtimes.Runtime = "python310";
+export const LATEST_VERSION: runtimes.Runtime = "python310";
 
 /**
  * Create a runtime delegate for the Python runtime, if applicable.
@@ -35,6 +35,24 @@ export async function tryCreateDelegate(
     throw new FirebaseError(`Runtime ${runtime} is not a valid Python runtime`);
   }
   return Promise.resolve(new Delegate(context.projectId, context.sourceDir, runtime));
+}
+
+/**
+ * Get corresponding python binary name for a given runtime.
+ *
+ * By default, returns "python"
+ */
+export function getPythonBinary(runtime: runtimes.Runtime): string {
+  if (process.platform === "win32") {
+    // There is no easy way to get specific version of python executable in Windows.
+    return "python.exe";
+  }
+  if (runtime === "python310") {
+    return "python3.10";
+  } else if (runtime === "python311") {
+    return "python3.11";
+  }
+  return "python";
 }
 
 export class Delegate implements runtimes.RuntimeDelegate {
@@ -82,16 +100,7 @@ export class Delegate implements runtimes.RuntimeDelegate {
   }
 
   getPythonBinary(): string {
-    if (process.platform === "win32") {
-      // There is no easy way to get specific version of python executable in Windows.
-      return "python.exe";
-    }
-    if (this.runtime === "python310") {
-      return "python3.10";
-    } else if (this.runtime === "python311") {
-      return "python3.11";
-    }
-    return "python";
+    return getPythonBinary(this.runtime);
   }
 
   validate(): Promise<void> {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1108,12 +1108,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     envs.K_REVISION = "1";
     envs.PORT = "80";
 
-    // TODO(danielylee): Later, we want timeout to be enforce by the data plane. For now, we rely on the runtime to
-    // enforce timeout.
-    if (trigger?.timeoutSeconds) {
-      envs.FUNCTIONS_EMULATOR_TIMEOUT_SECONDS = trigger.timeoutSeconds.toString();
-    }
-
     if (trigger) {
       const target = trigger.entryPoint;
       envs.FUNCTION_TARGET = target;
@@ -1357,7 +1351,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     };
 
     const pool = this.workerPools[backend.codebase];
-    const worker = pool.addWorker(trigger?.id, runtime, extensionLogInfo);
+    const worker = pool.addWorker(trigger, runtime, extensionLogInfo);
     await worker.waitForSocketReady();
     return worker;
   }

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -3,12 +3,11 @@ import * as uuid from "uuid";
 
 import { FunctionsRuntimeInstance } from "./functionsEmulator";
 import { EmulatorLog, Emulators, FunctionsExecutionMode } from "./types";
-import { FunctionsRuntimeBundle } from "./functionsEmulatorShared";
+import { EmulatedTriggerDefinition, FunctionsRuntimeBundle } from "./functionsEmulatorShared";
 import { EventEmitter } from "events";
 import { EmulatorLogger, ExtensionLogInfo } from "./emulatorLogger";
 import { FirebaseError } from "../error";
 import { Serializable } from "child_process";
-import { IncomingMessage } from "http";
 
 type LogListener = (el: EmulatorLog) => any;
 
@@ -32,17 +31,22 @@ export enum RuntimeWorkerState {
 
 export class RuntimeWorker {
   readonly id: string;
-  readonly key: string;
-  readonly runtime: FunctionsRuntimeInstance;
+  readonly triggerKey: string;
 
   stateEvents: EventEmitter = new EventEmitter();
 
   private logListeners: Array<LogListener> = [];
+  private logger: EmulatorLogger;
   private _state: RuntimeWorkerState = RuntimeWorkerState.CREATED;
 
-  constructor(key: string, runtime: FunctionsRuntimeInstance) {
+  constructor(
+    triggerId: string | undefined,
+    readonly runtime: FunctionsRuntimeInstance,
+    readonly extensionLogInfo: ExtensionLogInfo,
+    readonly timeoutSeconds?: number
+  ) {
     this.id = uuid.v4();
-    this.key = key;
+    this.triggerKey = triggerId || "~free~";
     this.runtime = runtime;
 
     const childProc = this.runtime.process;
@@ -64,8 +68,15 @@ export class RuntimeWorker {
       });
     }
 
+    this.logger = triggerId
+      ? EmulatorLogger.forFunction(triggerId, extensionLogInfo)
+      : EmulatorLogger.forEmulator(Emulators.FUNCTIONS);
+    this.onLogs((log: EmulatorLog) => {
+      this.logger.handleRuntimeLog(log);
+    }, true /* listen forever */);
+
     childProc.on("exit", () => {
-      this.log("exited");
+      this.logDebug("exited");
       this.state = RuntimeWorkerState.FINISHED;
     });
   }
@@ -107,33 +118,57 @@ export class RuntimeWorker {
   }
 
   request(req: http.RequestOptions, resp: http.ServerResponse, body?: unknown): Promise<void> {
+    if (this.triggerKey !== "~free~") {
+      this.logInfo(`Beginning execution of "${this.triggerKey}"`);
+    }
+    const startHrTime = process.hrtime();
+
     this.state = RuntimeWorkerState.BUSY;
     const onFinish = (): void => {
+      if (this.triggerKey !== "~free~") {
+        const elapsedHrTime = process.hrtime(startHrTime);
+        this.logInfo(
+          `Finished "${this.triggerKey}" in ${
+            elapsedHrTime[0] * 1000 + elapsedHrTime[1] / 1000000
+          }ms`
+        );
+      }
+
       if (this.state === RuntimeWorkerState.BUSY) {
         this.state = RuntimeWorkerState.IDLE;
       } else if (this.state === RuntimeWorkerState.FINISHING) {
-        this.log(`IDLE --> FINISHING`);
+        this.logDebug(`IDLE --> FINISHING`);
         this.runtime.process.kill();
       }
     };
     return new Promise((resolve) => {
-      const proxy = http.request(
-        {
-          ...this.runtime.conn.httpReqOpts(),
-          method: req.method,
-          path: req.path,
-          headers: req.headers,
-        },
-        (_resp: IncomingMessage) => {
-          resp.writeHead(_resp.statusCode || 200, _resp.headers);
-          const piped = _resp.pipe(resp);
-          piped.on("finish", () => {
-            onFinish();
-            resolve();
-          });
-        }
-      );
+      const reqOpts = {
+        ...this.runtime.conn.httpReqOpts(),
+        method: req.method,
+        path: req.path,
+        headers: req.headers,
+      };
+      if (this.timeoutSeconds) {
+        reqOpts.timeout = this.timeoutSeconds * 1000;
+      }
+      const proxy = http.request(reqOpts, (_resp: http.IncomingMessage) => {
+        resp.writeHead(_resp.statusCode || 200, _resp.headers);
+        const piped = _resp.pipe(resp);
+        piped.on("finish", () => {
+          onFinish();
+          resolve();
+        });
+      });
+      proxy.on("timeout", () => {
+        this.logger.log(
+          "ERROR",
+          `Your function timed out after ~${this.timeoutSeconds}s. To configure this timeout, see
+      https://firebase.google.com/docs/functions/manage-functions#set_timeout_and_memory_allocation.`
+        );
+        proxy.destroy();
+      });
       proxy.on("error", (err) => {
+        this.logger.log("ERROR", `Request to function failed: ${err}`);
         resp.writeHead(500);
         resp.write(JSON.stringify(err));
         resp.end();
@@ -164,7 +199,7 @@ export class RuntimeWorker {
       this.runtime.events.removeAllListeners();
     }
 
-    this.log(state);
+    this.logDebug(state);
     this._state = state;
     this.stateEvents.emit(this._state);
   }
@@ -220,11 +255,12 @@ export class RuntimeWorker {
     }
   }
 
-  private log(msg: string): void {
-    EmulatorLogger.forEmulator(Emulators.FUNCTIONS).log(
-      "DEBUG",
-      `[worker-${this.key}-${this.id}]: ${msg}`
-    );
+  private logDebug(msg: string): void {
+    this.logger.log("DEBUG", `[worker-${this.triggerKey}-${this.id}]: ${msg}`);
+  }
+
+  private logInfo(msg: string): void {
+    this.logger.logLabeled("BULLET", "functions", msg);
   }
 }
 
@@ -233,7 +269,7 @@ export class RuntimeWorkerPool {
 
   constructor(private mode: FunctionsExecutionMode = FunctionsExecutionMode.AUTO) {}
 
-  getKey(triggerId: string | undefined) {
+  getKey(triggerId: string | undefined): string {
     if (this.mode === FunctionsExecutionMode.SEQUENTIAL) {
       return "~shared~";
     } else {
@@ -247,15 +283,15 @@ export class RuntimeWorkerPool {
    * each BUSY worker we move it to the FINISHING state so that it will
    * kill itself after it's done with its current task.
    */
-  refresh() {
+  refresh(): void {
     for (const arr of this.workers.values()) {
       arr.forEach((w) => {
         if (w.state === RuntimeWorkerState.IDLE) {
-          this.log(`Shutting down IDLE worker (${w.key})`);
+          this.log(`Shutting down IDLE worker (${w.triggerKey})`);
           w.state = RuntimeWorkerState.FINISHING;
           w.runtime.process.kill();
         } else if (w.state === RuntimeWorkerState.BUSY) {
-          this.log(`Marking BUSY worker to finish (${w.key})`);
+          this.log(`Marking BUSY worker to finish (${w.triggerKey})`);
           w.state = RuntimeWorkerState.FINISHING;
         }
       });
@@ -265,7 +301,7 @@ export class RuntimeWorkerPool {
   /**
    * Immediately kill all workers.
    */
-  exit() {
+  exit(): void {
     for (const arr of this.workers.values()) {
       arr.forEach((w) => {
         if (w.state === RuntimeWorkerState.IDLE) {
@@ -340,25 +376,27 @@ export class RuntimeWorkerPool {
    * `worker.readyForWork()` or `worker.waitForSocketReady()`.
    */
   addWorker(
-    triggerId: string | undefined,
+    trigger: EmulatedTriggerDefinition | undefined,
     runtime: FunctionsRuntimeInstance,
-    extensionLogInfo?: ExtensionLogInfo
+    extensionLogInfo: ExtensionLogInfo
   ): RuntimeWorker {
-    const worker = new RuntimeWorker(this.getKey(triggerId), runtime);
-    this.log(`addWorker(${worker.key})`);
+    this.log(`addWorker(${this.getKey(trigger?.id)})`);
+    // Disable worker timeout if:
+    //   (1) This is a diagnostic call without trigger id OR
+    //   (2) If in SEQUENTIAL execution mode
+    const disableTimeout = !trigger?.id || this.mode === FunctionsExecutionMode.SEQUENTIAL;
+    const worker = new RuntimeWorker(
+      trigger?.id,
+      runtime,
+      extensionLogInfo,
+      disableTimeout ? undefined : trigger?.timeoutSeconds
+    );
 
-    const keyWorkers = this.getTriggerWorkers(triggerId);
+    const keyWorkers = this.getTriggerWorkers(trigger?.id);
     keyWorkers.push(worker);
-    this.setTriggerWorkers(triggerId, keyWorkers);
+    this.setTriggerWorkers(trigger?.id, keyWorkers);
 
-    const logger = triggerId
-      ? EmulatorLogger.forFunction(triggerId, extensionLogInfo)
-      : EmulatorLogger.forEmulator(Emulators.FUNCTIONS);
-    worker.onLogs((log: EmulatorLog) => {
-      logger.handleRuntimeLog(log);
-    }, true /* listen forever */);
-
-    this.log(`Adding worker with key ${worker.key}, total=${keyWorkers.length}`);
+    this.log(`Adding worker with key ${worker.triggerKey}, total=${keyWorkers.length}`);
     return worker;
   }
 

--- a/src/functions/python.ts
+++ b/src/functions/python.ts
@@ -12,6 +12,7 @@ export function runWithVirtualEnv(
   commandAndArgs: string[],
   cwd: string,
   envs: Record<string, string>,
+  spawnOpts: cp.SpawnOptions = {},
   venvDir = DEFAULT_VENV_DIR
 ): cp.ChildProcess {
   const activateScriptPath =
@@ -25,6 +26,7 @@ export function runWithVirtualEnv(
     shell: true,
     cwd,
     stdio: [/* stdin= */ "pipe", /* stdout= */ "pipe", /* stderr= */ "pipe", "pipe"],
+    ...spawnOpts,
     // Linting disabled since internal types expect NODE_ENV which does not apply to Python runtimes.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     env: envs as any,

--- a/src/init/features/functions/index.ts
+++ b/src/init/features/functions/index.ts
@@ -13,6 +13,7 @@ import {
   assertUnique,
 } from "../../../functions/projectConfig";
 import { FirebaseError } from "../../../error";
+import { isEnabled } from "../../../experiments";
 
 const MAX_ATTEMPTS = 5;
 
@@ -167,6 +168,12 @@ async function languageSetup(setup: any, config: Config): Promise<any> {
       value: "typescript",
     },
   ];
+  if (isEnabled("pythonfunctions")) {
+    choices.push({
+      name: "Python",
+      value: "python",
+    });
+  }
   const language = await promptOnce({
     type: "list",
     message: "What language would you like to use to write Cloud Functions?",

--- a/src/init/features/functions/python.ts
+++ b/src/init/features/functions/python.ts
@@ -1,0 +1,71 @@
+import * as fs from "fs";
+import * as spawn from "cross-spawn";
+import * as path from "path";
+
+import { Config } from "../../../config";
+import { getPythonBinary, LATEST_VERSION } from "../../../deploy/functions/runtimes/python";
+import { runWithVirtualEnv } from "../../../functions/python";
+import { promptOnce } from "../../../prompt";
+
+const TEMPLATE_ROOT = path.resolve(__dirname, "../../../../templates/init/functions/python");
+const MAIN_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "main.py"), "utf8");
+const REQUIREMENTS_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "requirements.txt"), "utf8");
+const GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
+
+/**
+ * Create a Python Firebase Functions project.
+ */
+export async function setup(setup: any, config: Config): Promise<void> {
+  await config.askWriteProjectFile(
+    `${setup.functions.source}/requirements.txt`,
+    REQUIREMENTS_TEMPLATE
+  );
+  await config.askWriteProjectFile(`${setup.functions.source}/.gitignore`, GITIGNORE_TEMPLATE);
+  await config.askWriteProjectFile(`${setup.functions.source}/main.py`, MAIN_TEMPLATE);
+
+  // Write the latest supported runtime version to the config.
+  config.set("functions.runtime", LATEST_VERSION);
+  // Add python specific ignores to config.
+  config.set("functions.ignore", ["venv", "__pycache__"]);
+
+  // Setup VENV.
+  const venvProcess = spawn(getPythonBinary(LATEST_VERSION), ["-m", "venv", "venv"], {
+    shell: true,
+    cwd: config.path(setup.functions.source),
+    stdio: [/* stdin= */ "pipe", /* stdout= */ "pipe", /* stderr= */ "pipe", "pipe"],
+  });
+  await new Promise((resolve, reject) => {
+    venvProcess.on("exit", resolve);
+    venvProcess.on("error", reject);
+  });
+
+  const install = await promptOnce({
+    name: "install",
+    type: "confirm",
+    message: "Do you want to install dependencies now?",
+    default: true,
+  });
+  if (install) {
+    // Update pip to support dependencies like pyyaml.
+    const upgradeProcess = runWithVirtualEnv(
+      ["pip3", "install", "--upgrade", "pip"],
+      config.path(setup.functions.source),
+      {},
+      { stdio: ["inherit", "inherit", "inherit"] }
+    );
+    await new Promise((resolve, reject) => {
+      upgradeProcess.on("exit", resolve);
+      upgradeProcess.on("error", reject);
+    });
+    const installProcess = runWithVirtualEnv(
+      [getPythonBinary(LATEST_VERSION), "-m", "pip", "install", "-r", "requirements.txt"],
+      config.path(setup.functions.source),
+      {},
+      { stdio: ["inherit", "inherit", "inherit"] }
+    );
+    await new Promise((resolve, reject) => {
+      installProcess.on("exit", resolve);
+      installProcess.on("error", reject);
+    });
+  }
+}

--- a/templates/init/functions/python/main.py
+++ b/templates/init/functions/python/main.py
@@ -1,0 +1,13 @@
+# Welcome to Cloud Functions for Firebase for Python!
+# To get started, simply uncomment the below code or create your own.
+# Deploy with `firebase deploy`
+
+from firebase_functions import https
+from firebase_admin import initialize_app
+
+# initialize_app()
+#
+#
+# @https.on_request()
+# def on_request_example(req: https.Request) -> https.Response:
+#     return https.Response("Hello world!")

--- a/templates/init/functions/python/requirements.txt
+++ b/templates/init/functions/python/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/firebase/firebase-functions-python.git@main#egg=firebase-functions


### PR DESCRIPTION
Add Python as an option for `firebase init functions`.

The python choice is guarded behind the `pythonfunctions` experiment. You can enable the experiment with `firebase experiments:enable pythonfunctions`.

This PR is a fork of https://github.com/firebase/firebase-tools/pull/4653. With this PR, https://github.com/firebase/firebase-tools/pull/4653 is now obsolete.