### PR TITLE
Cleaning up init templates for functions and extensions

### DIFF
--- a/src/commands/ext-dev-init.ts
+++ b/src/commands/ext-dev-init.ts
@@ -68,7 +68,7 @@ export const command = new Command("ext:dev:init")
         }
       }
 
-      await npmDependencies.askInstallDependencies({}, config);
+      await npmDependencies.askInstallDependencies({ source: "functions" }, config);
 
       const welcome = fs.readFileSync(path.join(TEMPLATE_ROOT, lang, "WELCOME.md"), "utf8");
       return logger.info("\n" + marked(welcome));

--- a/templates/extensions/CHANGELOG.md
+++ b/templates/extensions/CHANGELOG.md
@@ -1,1 +1,2 @@
-- Added support for publishing pre-release Extension versions. (#4804)
+## Version 0.0.1
+- Initial Version

--- a/templates/extensions/extension.yaml
+++ b/templates/extensions/extension.yaml
@@ -40,7 +40,7 @@ resources:
       location: ${LOCATION}
       # httpsTrigger is used for an HTTP triggered function.
       httpsTrigger: {}
-      runtime: "nodejs12"
+      runtime: "nodejs16"
 
 # In the `params` field, set up your extension's user-configured parameters.
 # Learn more in the docs: https://firebase.google.com/docs/extensions/alpha/ref-extension-yaml#params-field

--- a/templates/extensions/javascript/index.js
+++ b/templates/extensions/javascript/index.js
@@ -1,22 +1,22 @@
 /*
- * This template contains a HTTP function that responds with a greeting when called
- *
- * Always use the FUNCTIONS HANDLER NAMESPACE
- * when writing Cloud Functions for extensions.
- * Learn more about the handler namespace in the docs
+ * This template contains a HTTP function that
+ * responds with a greeting when called
  *
  * Reference PARAMETERS in your functions code with:
  * `process.env.<parameter-name>`
- * Learn more about parameters in the docs
+ * Learn more about building extensions in the docs:
+ * https://firebase.google.com/docs/extensions/alpha/overview
  */
 
-const functions = require('firebase-functions');
+const functions = require("firebase-functions");
 
 exports.greetTheWorld = functions.https.onRequest((req, res) => {
-  // Here we reference a user-provided parameter (its value is provided by the user during installation)
+  // Here we reference a user-provided parameter
+  // (its value is provided by the user during installation)
   const consumerProvidedGreeting = process.env.GREETING;
 
-  // And here we reference an auto-populated parameter (its value is provided by Firebase after installation)
+  // And here we reference an auto-populated parameter
+  // (its value is provided by Firebase after installation)
   const instanceId = process.env.EXT_INSTANCE_ID;
 
   const greeting = `${consumerProvidedGreeting} World from ${instanceId}`;

--- a/templates/extensions/javascript/index.js
+++ b/templates/extensions/javascript/index.js
@@ -12,7 +12,7 @@
 
 const functions = require('firebase-functions');
 
-exports.greetTheWorld = functions.handler.https.onRequest((req, res) => {
+exports.greetTheWorld = functions.https.onRequest((req, res) => {
   // Here we reference a user-provided parameter (its value is provided by the user during installation)
   const consumerProvidedGreeting = process.env.GREETING;
 

--- a/templates/extensions/javascript/package.lint.json
+++ b/templates/extensions/javascript/package.lint.json
@@ -3,8 +3,8 @@
   "description": "Greet the world",
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^10.2.0",
-    "firebase-functions": "^3.21.0"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
     "eslint": "^8.15.1",

--- a/templates/extensions/javascript/package.lint.json
+++ b/templates/extensions/javascript/package.lint.json
@@ -8,7 +8,9 @@
   },
   "devDependencies": {
     "eslint": "^8.15.1",
-    "eslint-plugin-promise": "^6.0.0"
+    "eslint-plugin-promise": "^6.0.0",
+    "eslint-config-google": "^0.14.0",
+    "eslint-plugin-import": "^2.25.4"
   },
   "scripts": {
     "lint": "./node_modules/.bin/eslint --max-warnings=0 .."

--- a/templates/extensions/javascript/package.nolint.json
+++ b/templates/extensions/javascript/package.nolint.json
@@ -3,8 +3,8 @@
   "description": "Greet the world",
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^10.2.0",
-    "firebase-functions": "^3.21.0"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "private": true
 }

--- a/templates/extensions/typescript/index.ts
+++ b/templates/extensions/typescript/index.ts
@@ -12,7 +12,7 @@
 
 import * as functions from 'firebase-functions';
 
-exports.greetTheWorld = functions.handler.https.onRequest((req, res) => {
+exports.greetTheWorld = functions.https.onRequest((req: functions.Request, res: functions.Response) => {
   // Here we reference a user-provided parameter (its value is provided by the user during installation)
   const consumerProvidedGreeting = process.env.GREETING;
 

--- a/templates/extensions/typescript/index.ts
+++ b/templates/extensions/typescript/index.ts
@@ -1,25 +1,26 @@
 /*
- * This template contains a HTTP function that responds with a greeting when called
- *
- * Always use the FUNCTIONS HANDLER NAMESPACE
- * when writing Cloud Functions for extensions.
- * Learn more about the handler namespace in the docs
+ * This template contains a HTTP function that responds
+ * with a greeting when called
  *
  * Reference PARAMETERS in your functions code with:
  * `process.env.<parameter-name>`
- * Learn more about parameters in the docs
+ * Learn more about building extensions in the docs:
+ * https://firebase.google.com/docs/extensions/alpha/overview
  */
 
-import * as functions from 'firebase-functions';
+import * as functions from "firebase-functions";
 
-exports.greetTheWorld = functions.https.onRequest((req: functions.Request, res: functions.Response) => {
-  // Here we reference a user-provided parameter (its value is provided by the user during installation)
-  const consumerProvidedGreeting = process.env.GREETING;
+exports.greetTheWorld = functions.https.onRequest(
+  (req: functions.Request, res: functions.Response) => {
+    // Here we reference a user-provided parameter
+    // (its value is provided by the user during installation)
+    const consumerProvidedGreeting = process.env.GREETING;
 
-  // And here we reference an auto-populated parameter (its value is provided by Firebase after installation)
-  const instanceId = process.env.EXT_INSTANCE_ID;
+    // And here we reference an auto-populated parameter
+    // (its value is provided by Firebase after installation)
+    const instanceId = process.env.EXT_INSTANCE_ID;
 
-  const greeting = `${consumerProvidedGreeting} World from ${instanceId}`;
+    const greeting = `${consumerProvidedGreeting} World from ${instanceId}`;
 
-  res.send(greeting);
-});
+    res.send(greeting);
+  });

--- a/templates/extensions/typescript/package.lint.json
+++ b/templates/extensions/typescript/package.lint.json
@@ -7,13 +7,13 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^10.2.0",
-    "firebase-functions": "^3.21.0"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
     "eslint": "^8.15.1",
     "eslint-plugin-import": "^2.26.0",
-    "typescript": "^4.6.4"
+    "typescript": "^4.9.0"
   },
   "private": true
 }

--- a/templates/extensions/typescript/package.lint.json
+++ b/templates/extensions/typescript/package.lint.json
@@ -11,8 +11,11 @@
     "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.12.0",
+    "@typescript-eslint/parser": "^5.12.0",
     "eslint": "^8.15.1",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-config-google": "^0.14.0",
     "typescript": "^4.9.0"
   },
   "private": true

--- a/templates/extensions/typescript/package.nolint.json
+++ b/templates/extensions/typescript/package.nolint.json
@@ -6,11 +6,11 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^9.8.0",
-    "firebase-functions": "^3.14.1"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
-    "typescript": "^3.8.0"
+    "typescript": "^4.9.0"
   },
   "private": true
 }

--- a/templates/init/functions/javascript/_eslintrc
+++ b/templates/init/functions/javascript/_eslintrc
@@ -1,5 +1,4 @@
 module.exports = {
-  root: true,
   env: {
     es6: true,
     node: true,
@@ -9,6 +8,18 @@ module.exports = {
     "google",
   ],
   rules: {
-    quotes: ["error", "double"],
+    "no-restricted-globals": ["error", "name", "length"],
+    "prefer-arrow-callback": "error",
+    "quotes": ["error", "double", {"allowTemplateLiterals": true}],
   },
+  overrides: [
+    {
+      files: ["*.spec.*"],
+      env: {
+        mocha: true,
+      },
+      rules: {},
+    },
+  ],
+  globals: {},
 };

--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -14,13 +14,13 @@
   },
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^10.0.2",
-    "firebase-functions": "^3.18.0"
+    "firebase-admin": "^111.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
-    "eslint": "^8.9.0",
+    "eslint": "^8.15.0",
     "eslint-config-google": "^0.14.0",
-    "firebase-functions-test": "^0.2.0"
+    "firebase-functions-test": "^3.0.0"
   },
   "private": true
 }

--- a/templates/init/functions/javascript/package.nolint.json
+++ b/templates/init/functions/javascript/package.nolint.json
@@ -13,11 +13,11 @@
   },
   "main": "index.js",
   "dependencies": {
-    "firebase-admin": "^10.0.2",
-    "firebase-functions": "^3.18.0"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
-    "firebase-functions-test": "^0.2.0"
+    "firebase-functions-test": "^3.0.0"
   },
   "private": true
 }

--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -27,5 +27,6 @@ module.exports = {
   rules: {
     "quotes": ["error", "double"],
     "import/no-unresolved": 0,
+    "indent": ["error", 2]
   },
 };

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -15,8 +15,8 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^10.0.2",
-    "firebase-functions": "^3.18.0"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",
@@ -24,8 +24,8 @@
     "eslint": "^8.9.0",
     "eslint-config-google": "^0.14.0",
     "eslint-plugin-import": "^2.25.4",
-    "firebase-functions-test": "^0.2.0",
-    "typescript": "^4.5.4"
+    "firebase-functions-test": "^3.0.0",
+    "typescript": "^4.9.0"
   },
   "private": true
 }

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -14,11 +14,12 @@
   },
   "main": "lib/index.js",
   "dependencies": {
-    "firebase-admin": "^10.2.0",
-    "firebase-functions": "^3.21.0"
+    "firebase-admin": "^11.5.0",
+    "firebase-functions": "^4.2.0"
   },
   "devDependencies": {
-    "typescript": "^4.6.4"
+    "typescript": "^4.9.0",
+    "firebase-functions-test": "^3.0.0"
   },
   "private": true
 }


### PR DESCRIPTION
### Description
Fixing up some problems with the init templates for functions and extensions. Specifically:
Extensions:
- Fixed an issue where ext:dev:init would try to npm install the root folder instead of the functions folder, and fail.
- Moved from nodejs12 to nodejs16
- Upgraded to latest versions of firebase-admin, firebase-functions, and typescript
- Moved off of the (deprecated) handler namespace
- Improved instructional comments in index.js/ts
- Reworked linters so that they actually pass after a fresh init
- Removed a random changelog entry for firebase-tools from the extension changelog template.

Functions:
- Upgraded to latest versions of firebase-admin, firebase-functions, firebase-functions-test and typescript
- Reworked linters so that they actually pass after a fresh init

### Scenarios Tested
I tested out all 4 combinations for extensions (linter/no linter, js/ts), and verified that they all:
- firebase init successfully
- npm install successfully
- npm run lint passes (only if enabled)
- npm run build passes (only ts)
- can be published as is after a fresh init
- can be installed after publishing.

