### PR TITLE
Add condition to change value of port when options.port is specified.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Allow configuration of the Cloud Function generated for full-stack web frameworks (#5504)
+- Fixes bug where passing `--port` flag in `functions:shell` does not set which port to emulate functions (#5521)

--- a/src/functionsShellCommandAction.ts
+++ b/src/functionsShellCommandAction.ts
@@ -49,6 +49,10 @@ export const actionFunction = async (options: Options) => {
   // If the port was not set by the --port flag or determined from 'firebase.json', just scan
   // up from 5000
   let port = 5000;
+  if (typeof options.port === "number") {
+    port = options.port;
+  }
+
   const functionsInfo = remoteEmulators[Emulators.FUNCTIONS];
   if (functionsInfo) {
     utils.logLabeledWarning(


### PR DESCRIPTION
### Description

Fixes #5521.

The port value is set to `5000` [here](https://github.com/firebase/firebase-tools/blob/master/src/functionsShellCommandAction.ts#L51), but is never changed anywhere else even if the `options.port` value is specified.

### Steps to reproduce issue:

1. firebase init > functions > any existing project > typescript
2. Enable helloWorld in index.ts
3. Run `cd functions`
4. Run `npm run build`
5. Run `firebase functions:shell --port 5005`

Output for firebase-tools versions

firebase-tools v11.23.1, v11.18.0, and v11.14.2
```
http function initialized (http://127.0.0.1:5000/<project_id>/us-central1/helloWorld)
```

firebase-tools v11.14.1
```
http function initialized (http://localhost:5005/<project_id>/us-central1/helloWorld)
```

### Scenarios Tested

Checking the value of `options.port` to be valid, then if the value is a number, change the value of `port` to the value of `options.port`. This should now use the passed `--port` flag value.

1. firebase init > functions > any existing project > typescript
2. Enable helloWorld in index.ts
3. Run `cd functions`
4. Run `npm run build`
5. Run `firebase functions:shell --port 5005`
```
http function initialized (http://127.0.0.1:5005/<project_id>/us-central1/helloWorld).
```


### Sample Commands

```
firebase functions:shell --port <port>
```
