### PR TITLE
Improve error message when given invalid hosting configuration.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Allow configuration of the Cloud Function generated for full-stack web frameworks (#5504)
+- Improve error message during deploy when given invalid hosting rewrite rule (#5533)

--- a/src/deploy/hosting/convertConfig.ts
+++ b/src/deploy/hosting/convertConfig.ts
@@ -247,7 +247,14 @@ export async function convertConfig(
 
     // This line makes sure this function breaks if there is ever added a new
     // kind of rewrite and we haven't yet handled it.
-    assertExhaustive(rewrite);
+    try {
+      assertExhaustive(rewrite);
+    } catch (e: any) {
+      throw new FirebaseError(
+        "Invalid hosting rewrite config in firebase.json. " +
+          "A rewrite config must specify 'destination', 'function', 'dynamicLinks', or 'run'"
+      );
+    }
   });
 
   if (config.rewrites) {

--- a/src/deploy/hosting/release.ts
+++ b/src/deploy/hosting/release.ts
@@ -29,9 +29,19 @@ export async function release(
       }
       utils.logLabeledBullet(`hosting[${deploy.config.site}]`, "finalizing version...");
 
+      let convertedConfig;
+      try {
+        convertedConfig = await convertConfig(context, functionsPayload, deploy);
+      } catch (e: any) {
+        throw new FirebaseError(
+          "Failed to process hosting config. Ensure that your hosting config in firebase.json is valid.",
+          { original: e }
+        );
+      }
+
       const update: Partial<api.Version> = {
         status: "FINALIZED",
-        config: await convertConfig(context, functionsPayload, deploy),
+        config: convertedConfig,
       };
 
       const versionId = utils.last(deploy.version.split("/"));

--- a/src/deploy/hosting/release.ts
+++ b/src/deploy/hosting/release.ts
@@ -29,16 +29,6 @@ export async function release(
       }
       utils.logLabeledBullet(`hosting[${deploy.config.site}]`, "finalizing version...");
 
-      let convertedConfig;
-      try {
-        convertedConfig = await convertConfig(context, functionsPayload, deploy);
-      } catch (e: any) {
-        throw new FirebaseError(
-          "Failed to process hosting config. Ensure that your hosting config in firebase.json is valid.",
-          { original: e }
-        );
-      }
-
       const update: Partial<api.Version> = {
         status: "FINALIZED",
         config: await convertConfig(context, functionsPayload, deploy),

--- a/src/deploy/hosting/release.ts
+++ b/src/deploy/hosting/release.ts
@@ -41,7 +41,7 @@ export async function release(
 
       const update: Partial<api.Version> = {
         status: "FINALIZED",
-        config: convertedConfig,
+        config: await convertConfig(context, functionsPayload, deploy),
       };
 
       const versionId = utils.last(deploy.version.split("/"));

--- a/src/functional.ts
+++ b/src/functional.ts
@@ -88,7 +88,7 @@ export const zipIn =
 /** Used with type guards to guarantee that all cases have been covered. */
 export function assertExhaustive(val: never): never {
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-  throw new Error(`Never has a value (${val}). This should be impossible`);
+  throw new Error(`Never has a value (${val}).`);
 }
 
 /**


### PR DESCRIPTION
Given invalid hosting configuration, Firebase CLI fails in an unhelpful way.

e.g. 
```
{
  "hosting": {
    "public": "public",
    "rewrites": [
      {
        // missing "destination", "function", or "run"
        "source": "**"
      }
    ]
  }
}
```

**Before**:
```
$ firebase deploy --only hosting
...
Error: An unexpected error has occurred.

$ firebase deploy --only hosting --debug
...
Error: Never has a value ([object Object]). This should be impossible
```

**After**
```
$ firebase deploy --only hosting
...
Error: Invalid hosting rewrite config in firebase.json. A rewrite config must specify 'destination', 'function', 'dynamicLinks', or 'run'
```

Fixes https://groups.google.com/a/google.com/g/firebase-discuss/c/VoQ0XkNnZFs