### PR TITLE
Generate ESM-compatible web framework SSR function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Allow configuration of the Cloud Function generated for full-stack web frameworks (#5504)
 - Improve error message during deploy when given invalid hosting rewrite rule (#5533)
+- Generate ESM-compatible SSR function for web frameworks (#5540)

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -572,15 +572,28 @@ ${firebaseDefaults ? `__FIREBASE_DEFAULTS__=${JSON.stringify(firebaseDefaults)}\
       if (bootstrapScript) await writeFile(join(functionsDist, "bootstrap.js"), bootstrapScript);
 
       // TODO move to templates
-      await writeFile(
-        join(functionsDist, "server.js"),
-        `const { onRequest } = require('firebase-functions/v2/https');
-const server = import('firebase-frameworks');
-exports.${functionId} = onRequest(${JSON.stringify(
-          frameworksBackend || {}
-        )}, (req, res) => server.then(it => it.handle(req, res)));
-`
-      );
+
+      if (packageJson.type === "module") {
+        await writeFile(
+          join(functionsDist, "server.js"),
+          `import { onRequest } from 'firebase-functions/v2/https';
+  const server = import('firebase-frameworks');
+  export const ${functionId} = onRequest(${JSON.stringify(
+            frameworksBackend || {}
+          )}, (req, res) => server.then(it => it.handle(req, res)));
+  `
+        );
+      } else {
+        await writeFile(
+          join(functionsDist, "server.js"),
+          `const { onRequest } = require('firebase-functions/v2/https');
+  const server = import('firebase-frameworks');
+  exports.${functionId} = onRequest(${JSON.stringify(
+            frameworksBackend || {}
+          )}, (req, res) => server.then(it => it.handle(req, res)));
+  `
+        );
+      }
     } else {
       // No function, treat as an SPA
       // TODO(jamesdaniels) be smarter about this, leave it to the framework?


### PR DESCRIPTION
### Description
Web frameworks like SvelteKit and Astro are ESM-first and break with the current generated SSR function that uses `require` and `exports`.

Will unblock #5527 and #5525.

Code adapted from #5248.

### Scenarios Tested
Tested with the WIP Astro and SvelteKit branches.