### PR TITLE
Inject `FIREBASE_CONFIG` environment variable for scripts executed via emulators:exec command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Allow configuration of the Cloud Function generated for full-stack web frameworks (#5504)
 - Improve error message during deploy when given invalid hosting rewrite rule (#5533)
 - Generate ESM-compatible SSR function for web frameworks (#5540)
+- Fix bug emulators:exec script didn't populate FIREBASE_CONFIG environment variable (#5544)

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -71,9 +71,6 @@ const DEFAULT_CONFIG = new Config(
   {}
 );
 
-/**
- *
- */
 export function printNoticeIfEmulated(
   options: any,
   emulator: Emulators.DATABASE | Emulators.FIRESTORE
@@ -97,9 +94,6 @@ export function printNoticeIfEmulated(
   }
 }
 
-/**
- *
- */
 export function warnEmulatorNotSupported(
   options: any,
   emulator: Emulators.DATABASE | Emulators.FIRESTORE
@@ -137,9 +131,6 @@ export function warnEmulatorNotSupported(
   }
 }
 
-/**
- *
- */
 export async function beforeEmulatorCommand(options: any): Promise<any> {
   const optionsWithDefaultConfig = {
     ...options,
@@ -175,9 +166,6 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
   }
 }
 
-/**
- *
- */
 export function parseInspectionPort(options: any): number {
   let port = options.inspectFunctions;
   if (port === true) {


### PR DESCRIPTION
As discussed in https://github.com/firebase/firebase-tools/issues/5536#issuecomment-1435432041, we learned that old versions of Firebase Functions SDK always made `process.env.FIREBASE_CONFIG` available to the underlying script that imported the Firebase Functions SDK.

While making `process.env.FIREBASE_CONFIG` available wasn't intentional, we'll consider this a case of [Hyrum's Law](https://www.hyrumslaw.com/) and will try our best to fix the regression by making `process.env.FIREBASE_CONFIG` environment variable available if not set in the parent process.

Fixes https://github.com/firebase/firebase-tools/issues/5536