### PR TITLE
Firestore deploy works with multiple databases b/267549787

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -430,6 +430,9 @@
                 {
                     "additionalProperties": false,
                     "properties": {
+                        "database": {
+                            "type": "string"
+                        },
                         "indexes": {
                             "type": "string"
                         },
@@ -471,57 +474,10 @@
                             {
                                 "additionalProperties": false,
                                 "properties": {
+                                    "database": {
+                                        "type": "string"
+                                    },
                                     "indexes": {
-                                        "type": "string"
-                                    },
-                                    "instance": {
-                                        "type": "string"
-                                    },
-                                    "postdeploy": {
-                                        "anyOf": [
-                                            {
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array"
-                                            },
-                                            {
-                                                "type": "string"
-                                            }
-                                        ]
-                                    },
-                                    "predeploy": {
-                                        "anyOf": [
-                                            {
-                                                "items": {
-                                                    "type": "string"
-                                                },
-                                                "type": "array"
-                                            },
-                                            {
-                                                "type": "string"
-                                            }
-                                        ]
-                                    },
-                                    "rules": {
-                                        "type": "string"
-                                    },
-                                    "target": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "instance"
-                                ],
-                                "type": "object"
-                            },
-                            {
-                                "additionalProperties": false,
-                                "properties": {
-                                    "indexes": {
-                                        "type": "string"
-                                    },
-                                    "instance": {
                                         "type": "string"
                                     },
                                     "postdeploy": {
@@ -559,6 +515,53 @@
                                 },
                                 "required": [
                                     "target"
+                                ],
+                                "type": "object"
+                            },
+                            {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "database": {
+                                        "type": "string"
+                                    },
+                                    "indexes": {
+                                        "type": "string"
+                                    },
+                                    "postdeploy": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    "predeploy": {
+                                        "anyOf": [
+                                            {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            },
+                                            {
+                                                "type": "string"
+                                            }
+                                        ]
+                                    },
+                                    "rules": {
+                                        "type": "string"
+                                    },
+                                    "target": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "database"
                                 ],
                                 "type": "object"
                             }

--- a/src/deploy/firestore/prepare.ts
+++ b/src/deploy/firestore/prepare.ts
@@ -37,7 +37,7 @@ function prepareIndexes(
   indexesFileName: string
 ): void {
   const indexesPath = options.config.path(indexesFileName);
-  const parsedSrc = loadCJSON(indexesPath);
+  const indexesSrc = loadCJSON(indexesPath);
 
   utils.logBullet(
     `${clc.bold(clc.cyan("firestore:"))} reading indexes from ${clc.bold(indexesFileName)}...`
@@ -46,7 +46,7 @@ function prepareIndexes(
   context.firestore.indexes.push({
     databaseId,
     indexesFileName,
-    parsedSrc,
+    indexesSrc,
   });
 }
 
@@ -85,10 +85,10 @@ export default async function (context: any, options: any): Promise<void> {
 
   firestoreConfigs.forEach((firestoreConfig: fsConfig.ParsedFirestoreConfig) => {
     if (firestoreConfig.indexes) {
-      prepareIndexes(context, options, firestoreConfig.databaseId, firestoreConfig.indexes);
+      prepareIndexes(context, options, firestoreConfig.database, firestoreConfig.indexes);
     }
     if (firestoreConfig.rules) {
-      prepareRules(context, rulesDeploy, firestoreConfig.databaseId, firestoreConfig.rules);
+      prepareRules(context, rulesDeploy, firestoreConfig.database, firestoreConfig.rules);
     }
   });
 

--- a/src/deploy/firestore/prepare.ts
+++ b/src/deploy/firestore/prepare.ts
@@ -12,12 +12,12 @@ import * as fsConfig from "../../firestore/fsConfig";
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-async function prepareRules(
+function prepareRules(
   context: any,
   rulesDeploy: RulesDeploy,
   databaseId: string,
   rulesFile: string
-): Promise<void> {
+): void {
   rulesDeploy.addFile(rulesFile);
   context.firestore.rules.push({
     databaseId,

--- a/src/deploy/firestore/prepare.ts
+++ b/src/deploy/firestore/prepare.ts
@@ -12,21 +12,30 @@ import * as fsConfig from "../../firestore/fsConfig";
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-async function prepareRules(context: any, options: Options, rulesDeploy: RulesDeploy, databaseId: string, rulesFile: string): Promise<void> {
-    rulesDeploy.addFile(rulesFile);
-    context.firestore.rules.push({
-      databaseId,
-      rulesFile,
-    });
-  }
+async function prepareRules(
+  context: any,
+  rulesDeploy: RulesDeploy,
+  databaseId: string,
+  rulesFile: string
+): Promise<void> {
+  rulesDeploy.addFile(rulesFile);
+  context.firestore.rules.push({
+    databaseId,
+    rulesFile,
+  });
 }
+
 /**
  * Prepares Firestore Indexes deploys.
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-function prepareIndexes(context: any, options: Options, databaseId: string, indexesFileName: string): void {
-
+function prepareIndexes(
+  context: any,
+  options: Options,
+  databaseId: string,
+  indexesFileName: string
+): void {
   const indexesPath = options.config.path(indexesFileName);
   const parsedSrc = loadCJSON(indexesPath);
 
@@ -60,23 +69,26 @@ export default async function (context: any, options: any): Promise<void> {
     context.firestoreRules = true;
   }
 
-  const firestoreConfigs : fsConfig.ParsedFirestoreConfig[] = fsConfig.getFirestoreConfig(context.projectId, options);
+  const firestoreConfigs: fsConfig.ParsedFirestoreConfig[] = fsConfig.getFirestoreConfig(
+    context.projectId,
+    options
+  );
   if (!firestoreConfigs || firestoreConfigs.length === 0) {
     return;
   }
 
   context.firestore = context.firestore || {};
-  context.firestore.indexes = []
-  context.firestore.rules = []
-  const rulesDeploy : RulesDeploy = new RulesDeploy(options, RulesetServiceType.CLOUD_FIRESTORE);
+  context.firestore.indexes = [];
+  context.firestore.rules = [];
+  const rulesDeploy: RulesDeploy = new RulesDeploy(options, RulesetServiceType.CLOUD_FIRESTORE);
   _.set(context, "firestore.rulesDeploy", rulesDeploy);
 
   firestoreConfigs.forEach((firestoreConfig: fsConfig.ParsedFirestoreConfig) => {
     if (firestoreConfig.indexes) {
-      prepareIndexes(context, options, firestoreConfig.databaseId, firestoreConfig.indexes)
+      prepareIndexes(context, options, firestoreConfig.databaseId, firestoreConfig.indexes);
     }
     if (firestoreConfig.rules) {
-      prepareRules(context, options, rulesDeploy, firestoreConfig.databaseId, firestoreConfig.rules)
+      prepareRules(context, rulesDeploy, firestoreConfig.databaseId, firestoreConfig.rules);
     }
   });
 

--- a/src/deploy/firestore/release.ts
+++ b/src/deploy/firestore/release.ts
@@ -1,29 +1,36 @@
 import * as _ from "lodash";
 
 import { RulesDeploy, RulesetServiceType } from "../../rulesDeploy";
+import { logger } from "../../logger";
 import { Options } from "../../options";
-import { FirebaseError } from "../../error";
 
 /**
  * Releases Firestore rules.
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-export default async function (context: any, options: Options): Promise<void> {
+export default async function (context: any, options: Options): Promise<any> {
   const rulesDeploy: RulesDeploy = _.get(context, "firestore.rulesDeploy");
   if (!context.firestoreRules || !rulesDeploy) {
-    return;
+    return Promise.resolve();
   }
 
-  // todo victorvim
-  const rulesFile =
-    options.config.src.firestore &&
-    "rules" in options.config.src.firestore &&
-    options.config.src.firestore?.rules;
-  if (!rulesFile) {
-    throw new FirebaseError(
-      `Invalid firestore config: ${JSON.stringify(options.config.src.firestore)}`
-    );
-  }
-  await rulesDeploy.release(rulesFile, RulesetServiceType.CLOUD_FIRESTORE);
+  const rulesContext = _.get(context, "firestore.rules");
+  return Promise.all(
+    rulesContext.map((ruleContext: any) => {
+      const databaseId = ruleContext.databaseId;
+      const rulesFile = ruleContext.rulesFile;
+      if (!rulesFile) {
+        logger.error(
+          `Invalid firestore config for ${databaseId} database: ${JSON.stringify(
+            options.config.src.firestore
+          )}`
+        );
+        return Promise.resolve();
+      }
+      return Promise.resolve(
+        rulesDeploy.release(rulesFile, RulesetServiceType.CLOUD_FIRESTORE, databaseId)
+      );
+    })
+  );
 }

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -30,6 +30,7 @@ type DatabaseMultiple = ({
   Deployable)[];
 
 type FirestoreSingle = {
+  databaseId?: string;
   rules?: string;
   indexes?: string;
 } & Deployable;
@@ -38,7 +39,7 @@ type FirestoreMultiple = ({
   rules?: string;
   indexes?: string;
 } & RequireAtLeastOne<{
-  instance: string;
+  databaseId: string;
   target: string;
 }> &
   Deployable)[];

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -30,7 +30,7 @@ type DatabaseMultiple = ({
   Deployable)[];
 
 type FirestoreSingle = {
-  databaseId?: string;
+  database?: string;
   rules?: string;
   indexes?: string;
 } & Deployable;
@@ -39,7 +39,7 @@ type FirestoreMultiple = ({
   rules?: string;
   indexes?: string;
 } & RequireAtLeastOne<{
-  databaseId: string;
+  database: string;
   target: string;
 }> &
   Deployable)[];

--- a/src/firestore/fsConfig.ts
+++ b/src/firestore/fsConfig.ts
@@ -3,7 +3,7 @@ import { logger } from "../logger";
 import { Options } from "../options";
 
 export interface ParsedFirestoreConfig {
-  databaseId: string;
+  database: string;
   rules?: string;
   indexes?: string;
 }
@@ -35,8 +35,8 @@ export function getFirestoreConfig(projectId: string, options: Options): ParsedF
   if (!Array.isArray(fsConfig)) {
     if (fsConfig) {
       // databaseId is (default) if none provided
-      const databaseId = fsConfig.databaseId || `(default)`;
-      return [{ rules: fsConfig.rules, indexes: fsConfig.indexes, databaseId }];
+      const databaseId = fsConfig.database || `(default)`;
+      return [{ rules: fsConfig.rules, indexes: fsConfig.indexes, database: databaseId }];
     } else {
       logger.debug("Possibly invalid database config: ", JSON.stringify(fsConfig));
       return [];
@@ -45,19 +45,19 @@ export function getFirestoreConfig(projectId: string, options: Options): ParsedF
 
   const results: ParsedFirestoreConfig[] = [];
   for (const c of fsConfig) {
-    const { databaseId, target } = c;
+    const { database, target } = c;
     if (target) {
       if (allDatabases || onlyDatabases.has(target)) {
         // Make sure the target exists (this will throw otherwise)
         rc.requireTarget(projectId, "firestore", target);
         // Get a list of firestore instances the target maps to
         const databases = rc.target(projectId, "firestore", target);
-        for (const databaseId of databases) {
-          results.push({ databaseId, rules: c.rules, indexes: c.indexes });
+        for (const database of databases) {
+          results.push({ database, rules: c.rules, indexes: c.indexes });
         }
         onlyDatabases.delete(target);
       }
-    } else if (databaseId) {
+    } else if (database) {
       if (allDatabases) {
         results.push(c as ParsedFirestoreConfig);
       }

--- a/src/firestore/indexes.ts
+++ b/src/firestore/indexes.ts
@@ -172,7 +172,7 @@ export class FirestoreIndexes {
    * List all indexes that exist on a given project.
    * @param project the Firebase project id.
    */
-  async listIndexes(project: string, databaseId: string = "(default"): Promise<API.Index[]> {
+  async listIndexes(project: string, databaseId: string = "(default)"): Promise<API.Index[]> {
     const url = `/projects/${project}/databases/${databaseId}/collectionGroups/-/indexes`;
     const res = await this.apiClient.get<{ indexes?: API.Index[] }>(url);
     const indexes = res.body.indexes;

--- a/src/rulesDeploy.ts
+++ b/src/rulesDeploy.ts
@@ -254,9 +254,7 @@ export class RulesDeploy {
     await gcp.rules.updateOrCreateRelease(
       this.options.project,
       this.rulesetNames[filename],
-      resourceName === RulesetServiceType.FIREBASE_STORAGE
-        ? `${resourceName}/${subResourceName}`
-        : resourceName
+      subResourceName ? `${resourceName}/${subResourceName}` : resourceName
     );
     utils.logLabeledSuccess(
       RulesetType[this.type],


### PR DESCRIPTION
b/267549787

### Manual testing instructions:
- checkout branch (see go/firebase-cli-contributor for detailed setup guide)
- `npm link`
in a separate directory:
- create gcp project (using gcloud, api, or ui)
- create firebase project or using firebase tools
- add project to multiple databases allowlist go/firestore-enable-multiple-databases
- `firebase init` with firestore enabled in a separate directory
- create default database (using gcloud, api, or ui)
- create a named database (using api)
- configure rules for both databases in separate files (sample https://github.com/firebase/quickstart-js/blob/master/firestore/firestore.indexes.json)
- configure indexes for both in separate files (sample https://firebase.google.com/docs/firestore/security/get-started#deny-all)
- configure firebase.json to contain:
```  "firestore": [
    {
      "database": "(default)",
      "rules": "firestore.rules",
      "indexes": "firestore.indexes.json"
    },
    {
      "database": "named",
      "rules": "named.rules",
      "indexes": "named.indexes.json"
    }
  ]
```
- run `firebase deploy --only firestore`
- check composite indexes are updated using gcloud:
`gcloud firestore indexes composite list --database named`
`gcloud firestore indexes composite list --database \(default\)`
- check rules are updated for default by checking ui
- check rules are updated for named db by trying to write a document to named database using api
- modify rules/indexes slightly and deploy again, verify the changes are picked up


