### PR TITLE
Incremental hosting deployments

### DIFF
--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -101,6 +101,7 @@ export type HostingBase = {
   redirects?: HostingRedirects[];
   rewrites?: HostingRewrites[];
   headers?: HostingHeaders[];
+  patch?: boolean;
   i18n?: {
     root: string;
   };

--- a/src/hosting/config.ts
+++ b/src/hosting/config.ts
@@ -39,15 +39,23 @@ function matchingConfigs(
   const matches: HostingMultiple = [];
   const [hasSite, hasTarget] = partition(configs, (c) => "site" in c);
   for (const target of targets) {
-    const siteMatch = hasSite.find((c) => c.site === target);
-    const targetMatch = hasTarget.find((c) => c.target === target);
+    let patch = false;
+    let parsedTarget = target;
+    if (target.endsWith(".patch")) {
+      parsedTarget = target.slice(0, target.lastIndexOf(".patch"));
+      patch = true;
+    }
+    const siteMatch = hasSite.find((c) => c.site === parsedTarget);
+    const targetMatch = hasTarget.find((c) => c.target === parsedTarget);
     if (siteMatch) {
+      siteMatch.patch = patch;
       matches.push(siteMatch);
     } else if (targetMatch) {
+      targetMatch.patch = patch;
       matches.push(targetMatch);
     } else if (assertMatches) {
       throw new FirebaseError(
-        `Hosting site or target ${bold(target)} not detected in firebase.json`
+        `Hosting site or target ${bold(parsedTarget)} not detected in firebase.json`
       );
     }
   }


### PR DESCRIPTION
### Description

We use firebase extensively, and deploying a hotfix it's a hassle. We host multiple js bundles built by webpack with code-splitting enabled. As per [webpack guidelines](https://webpack.js.org/guides/caching/#output-filenames), we include the file content hash in the filename to ensure proper cache invalidation.
When we want to deploy a hotfix, it means that all users that have not loaded the bundles affected by said hotfix will need to reload their browser tab since some of the bundle file names will change, as requests to the old bundles will fail with a 404, since the old files are not part of the latest deployment.

The community created multiple posts and code samples highlighting the need for incremental hosting deployments.
References:
1. https://koptional.com/article/why-we%E2%80%99re-moving-away-from-firebase
> Firebase Hosting doesn't expose granular file control; you can either deploy an entire application or nothing at all. Perhaps niche, but we've run into limitations with static page generation and debugging CDN issues.
2. https://stackoverflow.com/questions/30677351/upload-single-file-to-firebase-hosting-via-cli-or-other-without-deleting-existin
3. https://gist.github.com/puf/e00c34dd82b35c56e91adbc3a9b1c412
4. https://github.com/firebase/firebase-tools/tree/master/scripts/examples/hosting/update-single-file

We propose fixing this by adding a flag to the hosting deploy command to use the `cloneVersion` API method instead of creating a new hosting version for every deployment.

### Scenarios Tested

An additional cli argument/flag should be provided when a user wants to do an incremental hosting deployment.

### Sample Commands

As of right now, the command looks like `firebase deploy --only hosting:TARGET.patch`.

We don't consider this cli command to be final, and we need some guidance here, as we did not find any suitable flag or pattern to use. The biggest issue with the current pattern is potential conflicts with project hosting target names (i.e., someone might use ".patch" in the name of the hosting target)

### Notes

Some tests are failing, and we decided not to update them until we settle on a cli command/flag to use.