### PR TITLE
nuxt 3: fix bundled deps build errors

### DIFF
--- a/src/frameworks/nuxt/index.ts
+++ b/src/frameworks/nuxt/index.ts
@@ -71,22 +71,17 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
   const outputPackageJsonBuffer = await readFile(
     join(sourceDir, ".output", "server", "package.json")
   );
-
   const outputPackageJson = JSON.parse(outputPackageJsonBuffer.toString());
-
-  // FIXME: load lodash conditionally
-  // packageJson.dependencies["lodash"] = "latest";
-  outputPackageJson.dependencies = outputPackageJson.bundledDependencies.reduce(
-    (a: any, v: any) => ({
-      ...a,
-      [v]: "latest",
-    }),
+  // TODO: is using "latest" version the best option?
+  const bundledDependencies = outputPackageJson.bundledDependencies.reduce(
+    (deps: Record<string, string>, value: string) => ({ ...deps, [value]: "latest" }),
     {}
   );
 
   outputPackageJson.dependencies = {
     ...outputPackageJson.dependencies,
     ...packageJson.dependencies,
+    ...bundledDependencies,
   };
 
   await copy(join(sourceDir, ".output", "server"), destDir);

--- a/src/frameworks/nuxt/index.ts
+++ b/src/frameworks/nuxt/index.ts
@@ -72,6 +72,7 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
     join(sourceDir, ".output", "server", "package.json")
   );
 
+  // FIXME: load lodash conditionally
   packageJson.dependencies["lodash"] = "latest";
 
   const outputPackageJson = JSON.parse(outputPackageJsonBuffer.toString());

--- a/src/frameworks/nuxt/index.ts
+++ b/src/frameworks/nuxt/index.ts
@@ -72,10 +72,18 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
     join(sourceDir, ".output", "server", "package.json")
   );
 
-  // FIXME: load lodash conditionally
-  packageJson.dependencies["lodash"] = "latest";
-
   const outputPackageJson = JSON.parse(outputPackageJsonBuffer.toString());
+
+  // FIXME: load lodash conditionally
+  // packageJson.dependencies["lodash"] = "latest";
+  outputPackageJson.dependencies = outputPackageJson.bundledDependencies.reduce(
+    (a: any, v: any) => ({
+      ...a,
+      [v]: "latest",
+    }),
+    {}
+  );
+
   await copy(join(sourceDir, ".output", "server"), destDir);
   return { packageJson: { ...packageJson, ...outputPackageJson }, frameworksEntry: "nuxt3" };
 }

--- a/src/frameworks/nuxt/index.ts
+++ b/src/frameworks/nuxt/index.ts
@@ -84,6 +84,11 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
     {}
   );
 
+  outputPackageJson.dependencies = {
+    ...outputPackageJson.dependencies,
+    ...packageJson.dependencies,
+  };
+
   await copy(join(sourceDir, ".output", "server"), destDir);
   return { packageJson: { ...packageJson, ...outputPackageJson }, frameworksEntry: "nuxt3" };
 }

--- a/src/frameworks/nuxt/index.ts
+++ b/src/frameworks/nuxt/index.ts
@@ -71,6 +71,9 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
   const outputPackageJsonBuffer = await readFile(
     join(sourceDir, ".output", "server", "package.json")
   );
+
+  packageJson.dependencies["lodash"] = "latest";
+
   const outputPackageJson = JSON.parse(outputPackageJsonBuffer.toString());
   await copy(join(sourceDir, ".output", "server"), destDir);
   return { packageJson: { ...packageJson, ...outputPackageJson }, frameworksEntry: "nuxt3" };


### PR DESCRIPTION
Bug was discovered while testing with [a Nuxt 3 project](https://github.com/vercel/nuxt3-kitchen-sink) that uses `@nuxt/content`. It would generate the following error while building:
```
functions: Failed to load function definition from source: FirebaseError: Failed to load function definition from source: Failed to generate manifest from function source: 

Error: Cannot find module '/Users/austincrim/github.com/firebase/nuxt3-kitchen-sink/.firebase/fb-tools-dev/functions/node_modules/lodash/lodash.js'. Please verify that the package.json has a valid "main" entry
```

Nitro (part of the Nuxt 3 build process), traces dependencies used by Nuxt and its plugins and adds them to the outputted `package.json` `bundledDependencies` key. I don't understand the whole process but converting the `bundledDependencies` into `dependencies` fixes all issues.

**TODO per conversation with James**: investigate using `npm pack`. See express integration.