### PR TITLE
fix: Pass statusCode to fix retry in cloud function deploy

### DIFF
--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -166,6 +166,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
   throw new FirebaseError(`Failed to ${type} function ${funcName}`, {
     original: err,
     context: { function: funcName },
+    status: err?.context?.response?.statusCode,
   });
 }
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -263,6 +263,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
   throw new FirebaseError(`Failed to ${type} function ${funcName}`, {
     original: err,
     context: { function: funcName },
+    status: err?.context?.response?.statusCode
   });
 }
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -263,7 +263,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
   throw new FirebaseError(`Failed to ${type} function ${funcName}`, {
     original: err,
     context: { function: funcName },
-    status: err?.context?.response?.statusCode
+    status: err?.context?.response?.statusCode,
   });
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Pass statusCode to fix retry handling in function deploy.

Fix #5474

#### Details

In FirebaseError, the `status` field will be 500 when don't pass `status`. 
https://github.com/firebase/firebase-tools/blob/master/src/error.ts#L32

Then, this executor doesn't rethrow here.
It causes that retry handling doesn't works.
https://github.com/firebase/firebase-tools/blob/master/src/deploy/functions/release/executor.ts#L33-L35

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->


