### PR TITLE
Web frameworks simpleProxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- The hosting emulator integration with web frameworks now has improved support for HMR and dev-tools. (#5582)

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -14,8 +14,7 @@ import {
   SupportLevel,
 } from "..";
 import { promptOnce } from "../../prompt";
-import { proxyRequestHandler } from "../../hosting/proxy";
-import { warnIfCustomBuildScript } from "../utils";
+import { simpleProxy, warnIfCustomBuildScript } from "../utils";
 
 export const name = "Angular";
 export const support = SupportLevel.Experimental;
@@ -106,7 +105,7 @@ export async function getDevModeHandle(dir: string) {
       process.stderr.write(data);
     });
   });
-  return proxyRequestHandler(await host, "Angular Live Development Server", { forceCascade: true });
+  return simpleProxy(await host);
 }
 
 export async function ɵcodegenPublicDirectory(sourceDir: string, destDir: string) {

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -19,7 +19,6 @@ import { streamObject } from "stream-json/streamers/StreamObject";
 
 import {
   BuildResult,
-  createServerResponseProxy,
   findDependency,
   FrameworkType,
   NODE_VERSION,
@@ -40,7 +39,7 @@ import {
   allDependencyNames,
 } from "./utils";
 import type { Manifest, NpmLsDepdendency } from "./interfaces";
-import { readJSON } from "../utils";
+import { readJSON, simpleProxy } from "../utils";
 import { warnIfCustomBuildScript } from "../utils";
 import type { EmulatorInfo } from "../../emulator/types";
 import { usesAppDirRouter, usesNextImage, hasUnoptimizedImage } from "./utils";
@@ -444,11 +443,10 @@ export async function getDevModeHandle(dir: string, hostingEmulatorInfo?: Emulat
   const handler = nextApp.getRequestHandler();
   await nextApp.prepare();
 
-  return (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+  return simpleProxy(async (req: IncomingMessage, res: ServerResponse) => {
     const parsedUrl = parse(req.url!, true);
-    const proxy = createServerResponseProxy(req, res, next);
-    handler(req, proxy, parsedUrl);
-  };
+    await handler(req, res, parsedUrl);
+  });
 }
 
 async function getConfig(dir: string): Promise<NextConfig & { distDir: string }> {

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -4,9 +4,8 @@ import { existsSync } from "fs";
 import { copy, pathExists } from "fs-extra";
 import { join } from "path";
 import { findDependency, FrameworkType, relativeRequire, SupportLevel } from "..";
-import { proxyRequestHandler } from "../../hosting/proxy";
 import { promptOnce } from "../../prompt";
-import { warnIfCustomBuildScript } from "../utils";
+import { simpleProxy, warnIfCustomBuildScript } from "../utils";
 
 export const name = "Vite";
 export const support = SupportLevel.Experimental;
@@ -92,7 +91,7 @@ export async function getDevModeHandle(dir: string) {
       process.stderr.write(data);
     });
   });
-  return proxyRequestHandler(await host, "Vite Development Server", { forceCascade: true });
+  return simpleProxy(await host);
 }
 
 async function getConfig(root: string) {


### PR DESCRIPTION
Go with a simpler proxy implementation for fast dev-mode and web frameworks. This should better support HMR, dev-tools, and non-standard URLs like those used by Vue.