### PR TITLE
Cleaning up outdated warnings around --params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,0 @@
-- Fixes an issue where `ext:dev:init` would fail due to a missing CHANGELOG.md file (#5530).

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -11,7 +11,7 @@ import { track } from "../track";
 import * as env from "../functions/env";
 import { cloneDeep } from "../utils";
 
-const NONINTERACTIVE_WARNING =
+const NONINTERACTIVE_ERROR_MESSAGE =
   "As of firebase-tools@11, `ext:install`, `ext:update` and `ext:configure` are interactive only commands. " +
   "To deploy an extension noninteractively, use an extensions manifest and `firebase deploy --only extensions`.  " +
   "See https://firebase.google.com/docs/extensions/manifest for more details";
@@ -100,7 +100,7 @@ export async function getParams(args: {
 }): Promise<Record<string, ParamBindingOptions>> {
   let params: Record<string, ParamBindingOptions>;
   if (args.nonInteractive) {
-    throw new FirebaseError(NONINTERACTIVE_WARNING);
+    throw new FirebaseError(NONINTERACTIVE_ERROR_MESSAGE);
   } else {
     const firebaseProjectParams = await getFirebaseProjectParams(args.projectId);
     params = await askUserForParam.ask({
@@ -127,7 +127,7 @@ export async function getParamsForUpdate(args: {
 }): Promise<Record<string, ParamBindingOptions>> {
   let params: Record<string, ParamBindingOptions>;
   if (args.nonInteractive) {
-    throw new FirebaseError(NONINTERACTIVE_WARNING);
+    throw new FirebaseError(NONINTERACTIVE_ERROR_MESSAGE);
   } else {
     params = await promptForNewParams({
       spec: args.spec,

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -5,17 +5,16 @@ import * as fs from "fs-extra";
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
 import { ExtensionInstance, ExtensionSpec, Param } from "./types";
-import {
-  getFirebaseProjectParams,
-  populateDefaultParams,
-  substituteParams,
-  validateCommandLineParams,
-} from "./extensionsHelper";
+import { getFirebaseProjectParams, substituteParams } from "./extensionsHelper";
 import * as askUserForParam from "./askUserForParam";
 import { track } from "../track";
 import * as env from "../functions/env";
 import { cloneDeep } from "../utils";
-import { paramsFlagDeprecationWarning } from "./warnings";
+
+const NONINTERACTIVE_WARNING =
+  "As of firebase-tools@11, `ext:install`, `ext:update` and `ext:configure` are interactive only commands. " +
+  "To deploy an extension noninteractively, use an extensions manifest and `firebase deploy --only extensions`.  " +
+  "See https://firebase.google.com/docs/extensions/manifest for more details";
 
 /**
  * Interface for holding different param values for different environments/configs.
@@ -84,8 +83,7 @@ export function getParamsWithCurrentValuesAsDefaults(
 }
 
 /**
- * Gets params from the user, either by
- * reading the env file passed in the --params command line option
+ * Gets params from the user
  * or prompting the user for each param.
  * @param projectId the id of the project in use
  * @param paramSpecs a list of params, ie. extensionSpec.params
@@ -101,24 +99,8 @@ export async function getParams(args: {
   reconfiguring?: boolean;
 }): Promise<Record<string, ParamBindingOptions>> {
   let params: Record<string, ParamBindingOptions>;
-  if (args.nonInteractive && !args.paramsEnvPath) {
-    const paramsMessage = args.paramSpecs
-      .map((p) => {
-        return `\t${p.param}${p.required ? "" : " (Optional)"}`;
-      })
-      .join("\n");
-    throw new FirebaseError(
-      "In non-interactive mode but no `--params` flag found. " +
-        "To install this extension in non-interactive mode, set `--params` to a path to an .env file" +
-        " containing values for this extension's params:\n" +
-        paramsMessage
-    );
-  } else if (args.paramsEnvPath) {
-    paramsFlagDeprecationWarning();
-    params = getParamsFromFile({
-      paramSpecs: args.paramSpecs,
-      paramsEnvPath: args.paramsEnvPath,
-    });
+  if (args.nonInteractive) {
+    throw new FirebaseError(NONINTERACTIVE_WARNING);
   } else {
     const firebaseProjectParams = await getFirebaseProjectParams(args.projectId);
     params = await askUserForParam.ask({
@@ -144,23 +126,8 @@ export async function getParamsForUpdate(args: {
   instanceId: string;
 }): Promise<Record<string, ParamBindingOptions>> {
   let params: Record<string, ParamBindingOptions>;
-  if (args.nonInteractive && !args.paramsEnvPath) {
-    const paramsMessage = args.newSpec.params
-      .map((p) => {
-        return `\t${p.param}${p.required ? "" : " (Optional)"}`;
-      })
-      .join("\n");
-    throw new FirebaseError(
-      "In non-interactive mode but no `--params` flag found. " +
-        "To update this extension in non-interactive mode, set `--params` to a path to an .env file" +
-        " containing values for this extension's params:\n" +
-        paramsMessage
-    );
-  } else if (args.paramsEnvPath) {
-    params = getParamsFromFile({
-      paramSpecs: args.newSpec.params,
-      paramsEnvPath: args.paramsEnvPath,
-    });
+  if (args.nonInteractive) {
+    throw new FirebaseError(NONINTERACTIVE_WARNING);
   } else {
     params = await promptForNewParams({
       spec: args.spec,
@@ -232,25 +199,6 @@ export async function promptForNewParams(args: {
   }
 
   return newParamBindingOptions;
-}
-
-function getParamsFromFile(args: {
-  paramSpecs: Param[];
-  paramsEnvPath: string;
-}): Record<string, ParamBindingOptions> {
-  let envParams;
-  try {
-    envParams = readEnvFile(args.paramsEnvPath);
-    void track("Extension Env File", "Present");
-  } catch (err: any) {
-    void track("Extension Env File", "Invalid");
-    throw new FirebaseError(`Error reading env file: ${err.message}\n`, { original: err });
-  }
-  const params = populateDefaultParams(envParams, args.paramSpecs);
-  validateCommandLineParams(params, args.paramSpecs);
-  logger.info(`Using param values from ${args.paramsEnvPath}`);
-
-  return buildBindingOptionsWithBaseValue(params);
 }
 
 export function readEnvFile(envPath: string): Record<string, string> {

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -122,17 +122,6 @@ export async function displayWarningsForDeploy(instancesToCreate: InstanceSpec[]
   return experimental.length > 0 || eapExtensions.length > 0;
 }
 
-/**
- * paramsFlagDeprecationWarning displays a warning about the future depreaction of the --params flag.
- */
-export function paramsFlagDeprecationWarning() {
-  logger.warn(
-    "The --params flag is deprecated and will be removed in firebase-tools@11. " +
-      "Instead, use an extensions manifest and `firebase deploy --only extensions` to deploy extensions noninteractively. " +
-      "See https://firebase.google.com/docs/extensions/manifest for more details"
-  );
-}
-
 export function outOfBandChangesWarning(instanceIds: string[]) {
   logger.warn(
     "The following instances may have been changed in the Firebase console or by another machine since the last deploy from this machine.\n\t" +

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -3,11 +3,9 @@ import * as sinon from "sinon";
 import * as fs from "fs-extra";
 
 import { FirebaseError } from "../../error";
-import { logger } from "../../logger";
 import { ExtensionInstance, Param, ParamType } from "../../extensions/types";
 import * as extensionsHelper from "../../extensions/extensionsHelper";
 import * as paramHelper from "../../extensions/paramHelper";
-import * as env from "../../functions/env";
 import * as prompt from "../../prompt";
 import { cloneDeep } from "../../utils";
 

--- a/src/test/extensions/paramHelper.spec.ts
+++ b/src/test/extensions/paramHelper.spec.ts
@@ -114,153 +114,19 @@ describe("paramHelper", () => {
   });
 
   describe("getParams", () => {
-    let envStub: sinon.SinonStub;
     let promptStub: sinon.SinonStub;
-    let loggerSpy: sinon.SinonSpy;
 
     beforeEach(() => {
       sinon.stub(fs, "readFileSync").returns("");
-      envStub = sinon.stub(env, "parse");
       sinon.stub(extensionsHelper, "getFirebaseProjectParams").resolves({ PROJECT_ID });
       promptStub = sinon.stub(prompt, "promptOnce").resolves("user input");
-      loggerSpy = sinon.spy(logger, "warn");
     });
 
     afterEach(() => {
       sinon.restore();
     });
 
-    it("should read params from envFilePath if it is provided and is valid", async () => {
-      envStub.returns({
-        envs: {
-          A_PARAMETER: "aValue",
-          ANOTHER_PARAMETER: "value",
-        },
-        errors: [],
-      });
-
-      const params = await paramHelper.getParams({
-        projectId: PROJECT_ID,
-        paramSpecs: TEST_PARAMS,
-        nonInteractive: false,
-        paramsEnvPath: "./a/path/to/a/file.env",
-        instanceId: INSTANCE_ID,
-      });
-
-      expect(params).to.eql({
-        A_PARAMETER: { baseValue: "aValue" },
-        ANOTHER_PARAMETER: { baseValue: "value" },
-      });
-    });
-
-    it("should return the defaults for params that are not in envFilePath", async () => {
-      envStub.returns({
-        envs: {
-          A_PARAMETER: "aValue",
-        },
-        errors: [],
-      });
-
-      const params = await paramHelper.getParams({
-        projectId: PROJECT_ID,
-        paramSpecs: TEST_PARAMS,
-        nonInteractive: false,
-        paramsEnvPath: "./a/path/to/a/file.env",
-        instanceId: INSTANCE_ID,
-      });
-
-      expect(params).to.eql({
-        A_PARAMETER: { baseValue: "aValue" },
-        ANOTHER_PARAMETER: { baseValue: "default" },
-      });
-    });
-
-    it("should omit optional params that are not in envFilePath", async () => {
-      envStub.returns({
-        envs: {
-          A_PARAMETER: "aValue",
-        },
-        errors: [],
-      });
-
-      const params = await paramHelper.getParams({
-        projectId: PROJECT_ID,
-        paramSpecs: TEST_PARAMS_3,
-        nonInteractive: false,
-        paramsEnvPath: "./a/path/to/a/file.env",
-        instanceId: INSTANCE_ID,
-      });
-
-      expect(params).to.eql({
-        A_PARAMETER: { baseValue: "aValue" },
-      });
-    });
-
-    it("should throw if a required param without a default is not in envFilePath", async () => {
-      envStub.returns({
-        envs: {
-          ANOTHER_PARAMETER: "aValue",
-        },
-        errors: [],
-      });
-
-      await expect(
-        paramHelper.getParams({
-          projectId: PROJECT_ID,
-          paramSpecs: TEST_PARAMS,
-          nonInteractive: false,
-          paramsEnvPath: "./a/path/to/a/file.env",
-          instanceId: INSTANCE_ID,
-        })
-      ).to.be.rejectedWith(
-        FirebaseError,
-        "A_PARAMETER has not been set in the given params file and there is no default available. " +
-          "Please set this variable before installing again."
-      );
-    });
-
-    it("should warn about extra params provided in the env file", async () => {
-      envStub.returns({
-        envs: {
-          A_PARAMETER: "aValue",
-          ANOTHER_PARAMETER: "default",
-          A_THIRD_PARAMETER: "aValue",
-          A_FOURTH_PARAMETER: "default",
-        },
-        errors: [],
-      });
-      await paramHelper.getParams({
-        projectId: PROJECT_ID,
-        paramSpecs: TEST_PARAMS,
-        nonInteractive: false,
-        paramsEnvPath: "./a/path/to/a/file.env",
-        instanceId: INSTANCE_ID,
-      });
-
-      expect(loggerSpy).to.have.been.calledWith(
-        "Warning: The following params were specified in your env file but" +
-          " do not exist in the extension spec: A_THIRD_PARAMETER, A_FOURTH_PARAMETER."
-      );
-    });
-
-    it("should throw FirebaseError if an invalid envFilePath is provided", async () => {
-      envStub.returns({
-        envs: {},
-        errors: ["An error"],
-      });
-
-      await expect(
-        paramHelper.getParams({
-          projectId: PROJECT_ID,
-          paramSpecs: TEST_PARAMS,
-          nonInteractive: false,
-          paramsEnvPath: "./a/path/to/a/file.env",
-          instanceId: INSTANCE_ID,
-        })
-      ).to.be.rejectedWith(FirebaseError, "Error reading env file");
-    });
-
-    it("should prompt the user for params if no env file is provided", async () => {
+    it("should prompt the user for params", async () => {
       const params = await paramHelper.getParams({
         projectId: PROJECT_ID,
         paramSpecs: TEST_PARAMS,


### PR DESCRIPTION
### Description
As noted in #5591, we still have some confusing error messaging around the no longer supported --params flag. This cleans that up, and points users to the appropriate docs.


Fixes #5591