### PR TITLE
Fix bug where EVENTARC_CLOUD_EVENT_SOURCE environment variable was correctly set for some functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where EVENTARC_CLOUD_EVENT_SOURCE environment variable was correctly set for some functions. (#5597)

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -135,7 +135,7 @@ export async function prepare(
     }
 
     for (const endpoint of backend.allEndpoints(wantBackend)) {
-      endpoint.environmentVariables = wantBackend.environmentVariables || {};
+      endpoint.environmentVariables = { ...wantBackend.environmentVariables } || {};
       let resource: string;
       if (endpoint.platform === "gcfv1") {
         resource = `projects/${endpoint.project}/locations/${endpoint.region}/functions/${endpoint.id}`;


### PR DESCRIPTION
Object containing environment variable was mistakenly shared for all function.

This is usually okay as CF3 doesn't allow user to define per-function environment variable. However, Firebase-defined `EVENTARC_CLOUD_EVENT_SOURCE` env var is unique per function and due to this bug, all but one function has correct value for it.

Fixes https://github.com/firebase/firebase-tools/issues/5333.