### PR TITLE
Handle deletion of objects in the storage emulator for the API v1

### DIFF
--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -160,23 +160,25 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     });
   });
 
-  gcloudStorageAPI.delete("/b/:bucketId/o/:objectId", async (req, res) => {
-    try {
-      await adminStorageLayer.deleteObject({
-        bucketId: req.params.bucketId,
-        decodedObjectId: req.params.objectId,
-      });
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return sendObjectNotFound(req, res);
+  gcloudStorageAPI.delete(
+    ["/b/:bucketId/o/:objectId", "/storage/v1/b/:bucketId/o/:objectId"],
+    async (req, res) => {
+      try {
+        await adminStorageLayer.deleteObject({
+          bucketId: req.params.bucketId,
+          decodedObjectId: req.params.objectId
+        });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return sendObjectNotFound(req, res);
+        }
+        if (err instanceof ForbiddenError) {
+          return res.sendStatus(403);
+        }
+        throw err;
       }
-      if (err instanceof ForbiddenError) {
-        return res.sendStatus(403);
-      }
-      throw err;
-    }
-    return res.sendStatus(204);
-  });
+      return res.sendStatus(204);
+    });
 
   gcloudStorageAPI.put("/upload/storage/v1/b/:bucketId/o", async (req, res) => {
     if (!req.query.upload_id) {


### PR DESCRIPTION
### Description

The Storage emulator supports the v1 for listing, getting, and creating the objects but not for deleting an object. It prevents the usage of a client library for GCP Cloud Storage (e.g. the one in [Go](https://github.com/googleapis/google-cloud-go/tree/main/storage)).

