### PR TITLE
Use `checkout@v3` for Firebase Hosting Preview GitHub Workflow

### DIFF
--- a/src/init/features/hosting/github.ts
+++ b/src/init/features/hosting/github.ts
@@ -30,7 +30,7 @@ let YML_FULL_PATH_MERGE: string;
 const YML_PULL_REQUEST_FILENAME = "firebase-hosting-pull-request.yml";
 const YML_MERGE_FILENAME = "firebase-hosting-merge.yml";
 
-const CHECKOUT_GITHUB_ACTION_NAME = "actions/checkout@v2";
+const CHECKOUT_GITHUB_ACTION_NAME = "actions/checkout@v3";
 const HOSTING_GITHUB_ACTION_NAME = "FirebaseExtended/action-hosting-deploy@v0";
 
 const githubApiClient = new Client({ urlPrefix: githubApiOrigin, auth: false });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

The `firebase init hosting:github` command creates a `.yaml` file for GitHub Actions. However, this workflow uses the `actions/checkout@v2` action which uses the deprecated Node 12 version:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Node 12 will be removed in Summer 2023 (in a few months).

This PR updates the code so that `checkout@v3` is used.

Fixes #5599
Closes #5302 (duplicated - I opened a PR as well because I signed the CLA)

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

