### PR TITLE
Fix function deploy retry after quota exceeded bug and increase backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Fix function deploy retry after quota exceeded bug and increase backoff. (#5601)
 - Fix bug where EVENTARC_CLOUD_EVENT_SOURCE environment variable was correctly set for some functions. (#5597)

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -298,6 +298,7 @@ export class Fabricator {
             }
             throw new FirebaseError("Unexpected error creating Pub/Sub topic", {
               original: err as Error,
+              status: err.status,
             });
           }
         })
@@ -336,6 +337,7 @@ export class Fabricator {
             }
             throw new FirebaseError("Unexpected error creating Eventarc channel", {
               original: err as Error,
+              status: err.status,
             });
           }
         })

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -59,16 +59,16 @@ export async function release(
     }
   }
 
-  const functionExecutor: executor.QueueExecutor = new executor.QueueExecutor({
+  const throttlerOptions = {
     retries: 30,
     backoff: 20000,
     concurrency: 40,
-    maxBackoff: 40000,
-  });
+    maxBackoff: 100000,
+  };
 
   const fab = new fabricator.Fabricator({
-    functionExecutor,
-    executor: new executor.QueueExecutor({}),
+    functionExecutor: new executor.QueueExecutor(throttlerOptions),
+    executor: new executor.QueueExecutor(throttlerOptions),
     sources: context.sources,
     appEngineLocation: getAppEngineLocation(context.firebaseConfig),
     projectNumber: options.projectNumber || (await getProjectNumber(context.projectId)),

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -165,6 +165,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
   }
   throw new FirebaseError(`Failed to ${type} function ${funcName}`, {
     original: err,
+    status: err?.context?.response?.statusCode,
     context: { function: funcName },
   });
 }
@@ -244,6 +245,7 @@ export async function setIamPolicy(options: IamOptions): Promise<void> {
   } catch (err: any) {
     throw new FirebaseError(`Failed to set the IAM Policy on the function ${options.name}`, {
       original: err,
+      status: err?.context?.response?.statusCode,
     });
   }
 }

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -262,6 +262,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
   }
   throw new FirebaseError(`Failed to ${type} function ${funcName}`, {
     original: err,
+    status: err?.context?.response?.statusCode,
     context: { function: funcName },
   });
 }

--- a/src/gcp/run.ts
+++ b/src/gcp/run.ts
@@ -153,6 +153,7 @@ export async function getService(name: string): Promise<Service> {
   } catch (err: any) {
     throw new FirebaseError(`Failed to fetch Run service ${name}`, {
       original: err,
+      status: err?.context?.response?.statusCode,
     });
   }
 }
@@ -220,6 +221,7 @@ export async function replaceService(name: string, service: Service): Promise<Se
   } catch (err: any) {
     throw new FirebaseError(`Failed to replace Run service ${name}`, {
       original: err,
+      status: err?.context?.response?.statusCode,
     });
   }
 }
@@ -249,6 +251,7 @@ export async function setIamPolicy(
   } catch (err: any) {
     throw new FirebaseError(`Failed to set the IAM Policy on the Service ${name}`, {
       original: err,
+      status: err?.context?.response?.statusCode,
     });
   }
 }


### PR DESCRIPTION
On particularly large function deployments (<60 functions), the CLI easily hits the GCF API quota. Some customers were expecting the CLI to retry deployments that had been bounced by the quota, but did not see the retry actually occur.

Turns out that retries were not actually occurring because deploys that failed due to the Quota Exceeded error were throwing errors that were being wrapped in another error with the wrong status code. This PR surfaces the original, correct status code so that the QueueExecutor handler will detect that a deploy failed and retry after a backoff.

The PR also increases the maxBackoff on the throttler settings to give more opportunities to retry deploys.

Fixes #5474.