### PR TITLE
Remove call to Cloud Run API and set CPU & concurrency in GCF API instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Remove call to Cloud Run API and set CPU & concurrency in GCF API instead. (#5605)
 - Fix function deploy retry after quota exceeded bug and increase backoff. (#5601)
 - Fix bug where EVENTARC_CLOUD_EVENT_SOURCE environment variable was correctly set for some functions. (#5597)

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -394,26 +394,6 @@ export class Fabricator {
         .run(() => run.setInvokerCreate(endpoint.project, serviceName, invoker))
         .catch(rethrowAs(endpoint, "set invoker"));
     }
-
-    const mem = endpoint.availableMemoryMb || backend.DEFAULT_MEMORY;
-
-    // "CustomCPU" here means "not the CPU that GCF gives us". GCF automatically
-    // sets the CPU for a Run service based on the RAM settings. The value GCF
-    // uses is memoryToGen1Cpu.
-    const hasCustomCPU = endpoint.cpu !== backend.memoryToGen1Cpu(mem);
-    // I don't love editing an input in this function, but the code gets ugly
-    // otherwise. It's nice to not resolve concurrency in the prepare stage
-    // because it helps us know whether we should call setRunTraits on update.
-    if (!endpoint.concurrency) {
-      endpoint.concurrency =
-        (endpoint.cpu as number) >= backend.MIN_CPU_FOR_CONCURRENCY
-          ? backend.DEFAULT_CONCURRENCY
-          : 1;
-    }
-    const hasConcurrency = endpoint.concurrency !== 1;
-    if (hasCustomCPU || hasConcurrency) {
-      await this.setRunTraits(serviceName, endpoint);
-    }
   }
 
   async updateV1Function(endpoint: backend.Endpoint, scraper: SourceTokenScraper): Promise<void> {
@@ -503,26 +483,6 @@ export class Fabricator {
       await this.executor
         .run(() => run.setInvokerUpdate(endpoint.project, serviceName, invoker!))
         .catch(rethrowAs(endpoint, "set invoker"));
-    }
-
-    // Ideally we'd avoid a read of the Cloud Run service. We need to read if we
-    // believe a setting (CPU or concurrency) has changed because the user
-    // changed their mind or if GCF has stamped over the user's choice (we're
-    // using custom VM shapes).
-    const hasCustomCPU =
-      endpoint.cpu !==
-      backend.memoryToGen1Cpu(endpoint.availableMemoryMb || backend.DEFAULT_MEMORY);
-    const explicitConcurrency = endpoint.concurrency !== undefined;
-    if (hasCustomCPU || explicitConcurrency) {
-      // GCF may have stamped over the CPU to be <1 which would reset concurrency.
-      // We may have to reapply defaults.
-      if (endpoint.concurrency === undefined) {
-        endpoint.concurrency =
-          (endpoint.cpu as number) < backend.MIN_CPU_FOR_CONCURRENCY
-            ? 1
-            : backend.DEFAULT_CONCURRENCY;
-      }
-      await this.setRunTraits(serviceName, endpoint);
     }
   }
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -480,14 +480,7 @@ export function functionFromEndpoint(
     "concurrency"
   );
   proto.convertIfPresent(gcfFunction.serviceConfig, endpoint, "availableCpu", "cpu", (cpu) => {
-    if (cpu === "gcf_gen1") {
-      return String(backend.memoryToGen1Cpu(mem));
-    } else if (typeof cpu === "number") {
-      return String(cpu);
-    } else {
-      // If the user explicitly specified "null", set a default CPU number here
-      return String(backend.memoryToGen2Cpu(mem));
-    }
+    return String(cpu);
   });
 
   if (endpoint.vpc) {

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -473,6 +473,8 @@ export function functionFromEndpoint(
   gcfFunction.serviceConfig.availableMemory = mem > 1024 ? `${mem / 1024}Gi` : `${mem}Mi`;
   proto.renameIfPresent(gcfFunction.serviceConfig, endpoint, "minInstanceCount", "minInstances");
   proto.renameIfPresent(gcfFunction.serviceConfig, endpoint, "maxInstanceCount", "maxInstances");
+  // N.B. only convert CPU and concurrency fields for 2nd gen functions, once we
+  // eventually use the v2 API to configure both 1st and 2nd gen functions)
   proto.renameIfPresent(
     gcfFunction.serviceConfig,
     endpoint,

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -631,64 +631,6 @@ describe("Fabricator", () => {
       );
     });
 
-    it("sets run traits by default for large functions", async () => {
-      gcfv2.createFunction.resolves({ name: "op", done: false });
-      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
-      run.setInvokerCreate.resolves();
-      const ep = endpoint(
-        { httpsTrigger: {} },
-        { platform: "gcfv2", availableMemoryMb: 256, cpu: 1 }
-      );
-
-      await fab.createV2Function(ep);
-      expect(setRunTraits).to.have.been.calledWith("service", ep);
-    });
-
-    it("sets run traits for functions with concurrency", async () => {
-      gcfv2.createFunction.resolves({ name: "op", done: false });
-      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
-      run.setInvokerCreate.resolves();
-      const ep = endpoint(
-        { httpsTrigger: {} },
-        { platform: "gcfv2", availableMemoryMb: 2048, cpu: 1, concurrency: 80 }
-      );
-
-      await fab.createV2Function(ep);
-      expect(setRunTraits).to.have.been.calledWith("service", ep);
-    });
-
-    it("does not set concurrency by default for small functions", async () => {
-      gcfv2.createFunction.resolves({ name: "op", done: false });
-      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
-      run.setInvokerCreate.resolves();
-      const ep = endpoint(
-        { httpsTrigger: {} },
-        {
-          platform: "gcfv2",
-          availableMemoryMb: 256,
-          cpu: backend.memoryToGen1Cpu(256),
-          concurrency: 1,
-        }
-      );
-
-      await fab.createV2Function(ep);
-      expect(run.setInvokerCreate).to.have.been.calledWith(ep.project, "service", ["public"]);
-      expect(setRunTraits).to.not.have.been.called;
-    });
-
-    it("sets explicit concurrency", async () => {
-      gcfv2.createFunction.resolves({ name: "op", done: false });
-      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
-      run.setInvokerCreate.resolves();
-      const ep = endpoint(
-        { httpsTrigger: {} },
-        { platform: "gcfv2", availableMemoryMb: 2048, cpu: 1, concurrency: 2 }
-      );
-
-      await fab.createV2Function(ep);
-      expect(setRunTraits).to.have.been.calledWith("service", ep);
-    });
-
     describe("httpsTrigger", () => {
       it("sets invoker to public by default", async () => {
         gcfv2.createFunction.resolves({ name: "op", done: false });
@@ -900,27 +842,6 @@ describe("Fabricator", () => {
 
       await fab.updateV2Function(ep);
       expect(run.setInvokerUpdate).to.not.have.been.called;
-    });
-
-    it("Reapplies customer VM preferences after GCF overwrite", async () => {
-      setRunTraits.resolves();
-      gcfv2.updateFunction.resolves({ name: "op", done: false });
-      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
-      run.setInvokerUpdate.resolves();
-      const ep = endpoint(
-        { httpsTrigger: {} },
-        {
-          platform: "gcfv2",
-          availableMemoryMb: 256,
-          cpu: 1,
-        }
-      );
-
-      await fab.updateV2Function(ep);
-      expect(setRunTraits).to.have.been.calledWithMatch("service", {
-        cpu: 1,
-        concurrency: backend.DEFAULT_CONCURRENCY,
-      });
     });
   });
 

--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -845,6 +845,28 @@ describe("Fabricator", () => {
     });
   });
 
+  describe("upsertScheduleV1", () => {
+    const ep = endpoint({
+      scheduleTrigger: {
+        schedule: "every 5 minutes",
+      },
+    }) as backend.Endpoint & backend.ScheduleTriggered;
+
+    it("upserts schedules", async () => {
+      scheduler.createOrReplaceJob.resolves();
+      await fab.upsertScheduleV1(ep);
+      expect(scheduler.createOrReplaceJob).to.have.been.called;
+    });
+
+    it("wraps errors", async () => {
+      scheduler.createOrReplaceJob.rejects(new Error("Fail"));
+      await expect(fab.upsertScheduleV1(ep)).to.eventually.be.rejectedWith(
+        reporter.DeploymentError,
+        "upsert schedule"
+      );
+    });
+  });
+
   describe("upsertScheduleV2", () => {
     const ep = {
       ...endpoint({

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -347,6 +347,33 @@ describe("cloudfunctionsv2", () => {
       ).to.deep.equal(complexGcfFunction);
     });
 
+    it("should correctly convert CPU and concurrency values", () => {
+      const endpoint: backend.Endpoint = {
+        ...ENDPOINT,
+        platform: "gcfv2",
+        httpsTrigger: {},
+        concurrency: 40,
+        cpu: 2,
+      };
+      const gcfFunction: Omit<cloudfunctionsv2.CloudFunction, cloudfunctionsv2.OutputOnlyFields> = {
+        ...CLOUD_FUNCTION_V2,
+        serviceConfig: {
+          ...CLOUD_FUNCTION_V2.serviceConfig,
+          maxInstanceRequestConcurrency: 40,
+          availableCpu: "2",
+        },
+      };
+      expect(
+        cloudfunctionsv2.functionFromEndpoint(endpoint, CLOUD_FUNCTION_V2_SOURCE)
+      ).to.deep.equal(gcfFunction);
+
+      endpoint.cpu = "gcf_gen1";
+      gcfFunction.serviceConfig.availableCpu = "0.1666";
+      expect(
+        cloudfunctionsv2.functionFromEndpoint(endpoint, CLOUD_FUNCTION_V2_SOURCE)
+      ).to.deep.equal(gcfFunction);
+    });
+
     it("should export codebase as label", () => {
       expect(
         cloudfunctionsv2.functionFromEndpoint(

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -366,12 +366,6 @@ describe("cloudfunctionsv2", () => {
       expect(
         cloudfunctionsv2.functionFromEndpoint(endpoint, CLOUD_FUNCTION_V2_SOURCE)
       ).to.deep.equal(gcfFunction);
-
-      endpoint.cpu = "gcf_gen1";
-      gcfFunction.serviceConfig.availableCpu = "0.1666";
-      expect(
-        cloudfunctionsv2.functionFromEndpoint(endpoint, CLOUD_FUNCTION_V2_SOURCE)
-      ).to.deep.equal(gcfFunction);
     });
 
     it("should export codebase as label", () => {


### PR DESCRIPTION
The GCF API was recently updated to expose the concurrency and CPU fields for the Cloud Run service underlying 2nd gen Cloud Functions. Setting concurrency and CPU used to require a separate request to the Cloud Run API, which meant an extra API call per 2nd gen function deploy (for functions with non-default concurrency and CPU values). This PR eliminates the extra API call to the Cloud Run service and sets the concurrency and CPU values in the GCF API in the same API request as creating or updating the function. 

Deploying functions via the GCF API consumes the user's project quota for the Cloud Run API; reducing the number of Cloud Run API calls should lead to less quota-related failures on large function deployments.