### PR TITLE
Wrap init and logout commands in named exported functions

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -12,6 +12,7 @@ import { prompt, promptOnce } from "../prompt";
 import { requireAuth } from "../requireAuth";
 import * as fsutils from "../fsutils";
 import * as utils from "../utils";
+import { Options } from "../options";
 
 const homeDir = os.homedir();
 
@@ -80,130 +81,137 @@ ${[...featureNames]
 export const command = new Command("init [feature]")
   .description(DESCRIPTION)
   .before(requireAuth)
-  .action((feature, options) => {
-    if (feature && !featureNames.includes(feature)) {
-      return utils.reject(
-        clc.bold(feature) +
-          " is not a supported feature; must be one of " +
-          featureNames.join(", ") +
-          "."
-      );
-    }
+  .action(initAction);
 
-    const cwd = options.cwd || process.cwd();
-
-    const warnings = [];
-    let warningText = "";
-    if (isOutside(homeDir, cwd)) {
-      warnings.push("You are currently outside your home directory");
-    }
-    if (cwd === homeDir) {
-      warnings.push("You are initializing your home directory as a Firebase project directory");
-    }
-
-    const existingConfig = Config.load(options, true);
-    if (existingConfig) {
-      warnings.push("You are initializing within an existing Firebase project directory");
-    }
-
-    const config =
-      existingConfig !== null ? existingConfig : new Config({}, { projectDir: cwd, cwd: cwd });
-
-    if (warnings.length) {
-      warningText =
-        "\nBefore we get started, keep in mind:\n\n  " +
-        clc.yellow(clc.bold("* ")) +
-        warnings.join("\n  " + clc.yellow(clc.bold("* "))) +
-        "\n";
-    }
-
-    logger.info(
-      clc.yellow(clc.bold(BANNER_TEXT)) +
-        "\nYou're about to initialize a Firebase project in this directory:\n\n  " +
-        clc.bold(config.projectDir) +
-        "\n" +
-        warningText
+/**
+ * Init command action
+ * @param feature Feature to init (e.g., hosting, functions)
+ * @param options Command options
+ */
+export function initAction(feature: string, options: Options): Promise<void> {
+  if (feature && !featureNames.includes(feature)) {
+    return utils.reject(
+      clc.bold(feature) +
+        " is not a supported feature; must be one of " +
+        featureNames.join(", ") +
+        "."
     );
+  }
 
-    const setup: Setup = {
-      config: config.src,
-      rcfile: config.readProjectFile(".firebaserc", {
-        json: true,
-        fallback: {},
-      }),
-    };
+  const cwd = options.cwd || process.cwd();
 
-    let next;
-    // HACK: Windows Node has issues with selectables as the first prompt, so we
-    // add an extra confirmation prompt that fixes the problem
-    if (process.platform === "win32") {
-      next = promptOnce({
-        type: "confirm",
-        message: "Are you ready to proceed?",
-      });
-    } else {
-      next = Promise.resolve(true);
-    }
+  const warnings = [];
+  let warningText = "";
+  if (isOutside(homeDir, cwd)) {
+    warnings.push("You are currently outside your home directory");
+  }
+  if (cwd === homeDir) {
+    warnings.push("You are initializing your home directory as a Firebase project directory");
+  }
 
-    return next
-      .then((proceed) => {
-        if (!proceed) {
-          return utils.reject("Aborted by user.", { exit: 1 });
-        }
+  const existingConfig = Config.load(options, true);
+  if (existingConfig) {
+    warnings.push("You are initializing within an existing Firebase project directory");
+  }
 
-        if (feature) {
-          setup.featureArg = true;
-          setup.features = [feature];
-          return undefined;
-        }
-        return prompt(setup, [
-          {
-            type: "checkbox",
-            name: "features",
-            message:
-              "Which Firebase features do you want to set up for this directory? " +
-              "Press Space to select features, then Enter to confirm your choices.",
-            choices: choices,
-          },
-        ]);
-      })
-      .then(() => {
-        if (!setup.features || setup.features?.length === 0) {
-          return utils.reject(
-            "Must select at least one feature. Use " +
-              clc.bold(clc.underline("SPACEBAR")) +
-              " to select features, or specify a feature by running " +
-              clc.bold("firebase init [feature_name]")
-          );
-        }
+  const config =
+    existingConfig !== null ? existingConfig : new Config({}, { projectDir: cwd, cwd: cwd });
 
-        // Always set up project
-        setup.features.unshift("project");
+  if (warnings.length) {
+    warningText =
+      "\nBefore we get started, keep in mind:\n\n  " +
+      clc.yellow(clc.bold("* ")) +
+      warnings.join("\n  " + clc.yellow(clc.bold("* "))) +
+      "\n";
+  }
 
-        // If there is more than one account, add an account choice phase
-        const allAccounts = getAllAccounts();
-        if (allAccounts.length > 1) {
-          setup.features.unshift("account");
-        }
+  logger.info(
+    clc.yellow(clc.bold(BANNER_TEXT)) +
+      "\nYou're about to initialize a Firebase project in this directory:\n\n  " +
+      clc.bold(config.projectDir) +
+      "\n" +
+      warningText
+  );
 
-        // "hosting:github" is a part of "hosting", so if both are selected, "hosting:github" is ignored.
-        if (setup.features.includes("hosting") && setup.features.includes("hosting:github")) {
-          setup.features = setup.features.filter((f) => f !== "hosting:github");
-        }
+  const setup: Setup = {
+    config: config.src,
+    rcfile: config.readProjectFile(".firebaserc", {
+      json: true,
+      fallback: {},
+    }),
+  };
 
-        return init(setup, config, options);
-      })
-      .then(() => {
-        logger.info();
-        utils.logBullet("Writing configuration info to " + clc.bold("firebase.json") + "...");
-        config.writeProjectFile("firebase.json", setup.config);
-        utils.logBullet("Writing project information to " + clc.bold(".firebaserc") + "...");
-        config.writeProjectFile(".firebaserc", setup.rcfile);
-        if (!fsutils.fileExistsSync(config.path(".gitignore"))) {
-          utils.logBullet("Writing gitignore file to " + clc.bold(".gitignore") + "...");
-          config.writeProjectFile(".gitignore", GITIGNORE_TEMPLATE);
-        }
-        logger.info();
-        utils.logSuccess("Firebase initialization complete!");
-      });
-  });
+  let next;
+  // HACK: Windows Node has issues with selectables as the first prompt, so we
+  // add an extra confirmation prompt that fixes the problem
+  if (process.platform === "win32") {
+    next = promptOnce({
+      type: "confirm",
+      message: "Are you ready to proceed?",
+    });
+  } else {
+    next = Promise.resolve(true);
+  }
+
+  return next
+    .then((proceed) => {
+      if (!proceed) {
+        return utils.reject("Aborted by user.", { exit: 1 });
+      }
+
+      if (feature) {
+        setup.featureArg = true;
+        setup.features = [feature];
+        return undefined;
+      }
+      return prompt(setup, [
+        {
+          type: "checkbox",
+          name: "features",
+          message:
+            "Which Firebase features do you want to set up for this directory? " +
+            "Press Space to select features, then Enter to confirm your choices.",
+          choices: choices,
+        },
+      ]);
+    })
+    .then(() => {
+      if (!setup.features || setup.features?.length === 0) {
+        return utils.reject(
+          "Must select at least one feature. Use " +
+            clc.bold(clc.underline("SPACEBAR")) +
+            " to select features, or specify a feature by running " +
+            clc.bold("firebase init [feature_name]")
+        );
+      }
+
+      // Always set up project
+      setup.features.unshift("project");
+
+      // If there is more than one account, add an account choice phase
+      const allAccounts = getAllAccounts();
+      if (allAccounts.length > 1) {
+        setup.features.unshift("account");
+      }
+
+      // "hosting:github" is a part of "hosting", so if both are selected, "hosting:github" is ignored.
+      if (setup.features.includes("hosting") && setup.features.includes("hosting:github")) {
+        setup.features = setup.features.filter((f) => f !== "hosting:github");
+      }
+
+      return init(setup, config, options);
+    })
+    .then(() => {
+      logger.info();
+      utils.logBullet("Writing configuration info to " + clc.bold("firebase.json") + "...");
+      config.writeProjectFile("firebase.json", setup.config);
+      utils.logBullet("Writing project information to " + clc.bold(".firebaserc") + "...");
+      config.writeProjectFile(".firebaserc", setup.rcfile);
+      if (!fsutils.fileExistsSync(config.path(".gitignore"))) {
+        utils.logBullet("Writing gitignore file to " + clc.bold(".gitignore") + "...");
+        config.writeProjectFile(".gitignore", GITIGNORE_TEMPLATE);
+      }
+      logger.info();
+      utils.logSuccess("Firebase initialization complete!");
+    });
+}

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -5,85 +5,90 @@ import * as clc from "colorette";
 import * as utils from "../utils";
 import * as auth from "../auth";
 import { promptOnce } from "../prompt";
+import { Options } from "../options";
 
 export const command = new Command("logout [email]")
   .description("log the CLI out of Firebase")
-  .action(async (email: string | undefined, options: any) => {
-    const globalToken = utils.getInheritedOption(options, "token");
-    utils.assertIsStringOrUndefined(globalToken);
+  .action(logoutAction);
+/**
+ *
+ * @param email Email of account to log out.
+ * @param options Command options.
+ */
+export async function logoutAction(email: string | undefined, options: Options): Promise<void> {
+  const globalToken = utils.getInheritedOption(options, "token");
+  utils.assertIsStringOrUndefined(globalToken);
 
-    const allAccounts = auth.getAllAccounts();
-    if (allAccounts.length === 0 && !globalToken) {
-      logger.info("No need to logout, not logged in");
-      return;
+  const allAccounts = auth.getAllAccounts();
+  if (allAccounts.length === 0 && !globalToken) {
+    logger.info("No need to logout, not logged in");
+    return;
+  }
+
+  const defaultAccount = auth.getGlobalDefaultAccount();
+  const additionalAccounts = auth.getAdditionalAccounts();
+
+  const accountsToLogOut = email ? allAccounts.filter((a) => a.user.email === email) : allAccounts;
+
+  if (email && accountsToLogOut.length === 0) {
+    utils.logWarning(`No account matches ${email}, can't log out.`);
+    return;
+  }
+
+  // If they are logging out of their primary account, choose one to
+  // replace it.
+  const logoutDefault = email === defaultAccount?.user.email;
+  let newDefaultAccount: auth.Account | undefined = undefined;
+  if (logoutDefault && additionalAccounts.length > 0) {
+    if (additionalAccounts.length === 1) {
+      newDefaultAccount = additionalAccounts[0];
+    } else {
+      const choices = additionalAccounts.map((a) => {
+        return {
+          name: a.user.email,
+          value: a,
+        };
+      });
+
+      newDefaultAccount = await promptOnce({
+        type: "list",
+        message:
+          "You are logging out of your default account, which account should become the new default?",
+        choices,
+      });
     }
+  }
 
-    const defaultAccount = auth.getGlobalDefaultAccount();
-    const additionalAccounts = auth.getAdditionalAccounts();
+  for (const account of accountsToLogOut) {
+    const token = account.tokens.refresh_token;
 
-    const accountsToLogOut = email
-      ? allAccounts.filter((a) => a.user.email === email)
-      : allAccounts;
-
-    if (email && accountsToLogOut.length === 0) {
-      utils.logWarning(`No account matches ${email}, can't log out.`);
-      return;
-    }
-
-    // If they are logging out of their primary account, choose one to
-    // replace it.
-    const logoutDefault = email === defaultAccount?.user.email;
-    let newDefaultAccount: auth.Account | undefined = undefined;
-    if (logoutDefault && additionalAccounts.length > 0) {
-      if (additionalAccounts.length === 1) {
-        newDefaultAccount = additionalAccounts[0];
-      } else {
-        const choices = additionalAccounts.map((a) => {
-          return {
-            name: a.user.email,
-            value: a,
-          };
-        });
-
-        newDefaultAccount = await promptOnce({
-          type: "list",
-          message:
-            "You are logging out of your default account, which account should become the new default?",
-          choices,
-        });
-      }
-    }
-
-    for (const account of accountsToLogOut) {
-      const token = account.tokens.refresh_token;
-
-      if (token) {
-        auth.setRefreshToken(token);
-        try {
-          await auth.logout(token);
-        } catch (e: any) {
-          utils.logWarning(
-            `Invalid refresh token for ${account.user.email}, did not need to deauthorize`
-          );
-        }
-
-        utils.logSuccess(`Logged out from ${clc.bold(account.user.email)}`);
-      }
-    }
-
-    if (globalToken) {
-      auth.setRefreshToken(globalToken);
+    if (token) {
+      auth.setRefreshToken(token);
       try {
-        await auth.logout(globalToken);
+        await auth.logout(token);
       } catch (e: any) {
-        utils.logWarning("Invalid refresh token, did not need to deauthorize");
+        utils.logWarning(
+          `Invalid refresh token for ${account.user.email}, did not need to deauthorize`
+        );
       }
 
-      utils.logSuccess(`Logged out from token "${clc.bold(globalToken)}"`);
+      utils.logSuccess(`Logged out from ${clc.bold(account.user.email)}`);
+    }
+  }
+
+  if (globalToken) {
+    auth.setRefreshToken(globalToken);
+    try {
+      await auth.logout(globalToken);
+    } catch (e: any) {
+      utils.logWarning("Invalid refresh token, did not need to deauthorize");
     }
 
-    if (newDefaultAccount) {
-      utils.logSuccess(`Setting default account to "${newDefaultAccount.user.email}"`);
-      auth.setGlobalDefaultAccount(newDefaultAccount);
-    }
-  });
+    utils.logSuccess(`Logged out from token "${clc.bold(globalToken)}"`);
+  }
+
+  if (newDefaultAccount) {
+    utils.logSuccess(`Setting default account to "${newDefaultAccount.user.email}"`);
+    auth.setGlobalDefaultAccount(newDefaultAccount);
+  }
+}

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -10,8 +10,9 @@ import { Options } from "../options";
 export const command = new Command("logout [email]")
   .description("log the CLI out of Firebase")
   .action(logoutAction);
+
 /**
- *
+ * Logout command action
  * @param email Email of account to log out.
  * @param options Command options.
  */


### PR DESCRIPTION
### Description

Convert inline command action functions for `init` and `logout` into named exported functions that can be imported by other files in this repo (such as the VS Code Extension).

### Scenarios Tested

Tested init and logout commands on a test project.
