### PR TITLE
Rename function name in python template

### DIFF
--- a/templates/init/functions/python/main.py
+++ b/templates/init/functions/python/main.py
@@ -9,5 +9,5 @@ from firebase_admin import initialize_app
 #
 #
 # @https_fn.on_request()
-# def on_request_example(req: https_fn.Request) -> https_fn.Response:
+# def onrequestexample(req: https_fn.Request) -> https_fn.Response:
 #     return https_fn.Response("Hello world!")


### PR DESCRIPTION
### Description

2nd gen function names cannot contain capital letters or underscores. The change is not very pythonic but I do not see other solutions at the moment. Maybe someone can point me to the right repo / channels to request 2nd gen function names with underscores or to some documentation why they are not available.
