### PR TITLE
Use a safer exit when terminating CLI commands

### DIFF
--- a/src/command.ts
+++ b/src/command.ts
@@ -217,7 +217,12 @@ export class Command {
               ])
             );
           }
-          process.exit();
+          process.exitCode = 0;
+          var timeout = setTimeout(function (cmd: any) {
+            track(cmd, "terminated_with_open_handlers");
+            process.exit(0);
+          }, 2000, this.name);
+          timeout.unref(); 
         })
         .catch(async (err) => {
           if (getInheritedOption(options, "json")) {

--- a/src/command.ts
+++ b/src/command.ts
@@ -66,7 +66,6 @@ export class Command {
    *
    * @example
    *   command.option("-d, --debug", "turn on debugging", false)
-   *
    * @param args the commander-style option definition.
    * @return the command, for chaining.
    */
@@ -80,7 +79,7 @@ export class Command {
    * Sets up --force flag for the command.
    *
    * @param message overrides the description for --force for this command
-   * @returns the command, for chaining
+   * @return the command, for chaining
    */
   withForce(message?: string): Command {
     this.options.push(["-f, --force", message || "automatically accept all interactive prompts"]);
@@ -218,11 +217,15 @@ export class Command {
             );
           }
           process.exitCode = 0;
-          var timeout = setTimeout(function (cmd: any) {
-            track(cmd, "terminated_with_open_handlers");
-            process.exit(0);
-          }, 2000, this.name);
-          timeout.unref(); 
+          const timeout = setTimeout(
+            (cmd: any) => {
+              track(cmd, "terminated_with_open_handlers");
+              process.exit(0);
+            },
+            2000,
+            this.name
+          );
+          timeout.unref();
         })
         .catch(async (err) => {
           if (getInheritedOption(options, "json")) {


### PR DESCRIPTION
This is a shot at addressing https://github.com/firebase/firebase-tools/issues/5618, which is in brief caused by the fact that process.exit() does not guarantee that stdout/stderr are fully flushed before exiting on all platforms. 

Setting process.exitCode causes an exit (https://nodejs.org/api/process.html#process_process_exit_code), but outstanding call handlers that have not been cleaned up will cause the process to hang. Since I have no way of proving that firebase-tools does not contain any leaky handlers, I propose setting a hard timeout after which we fall back on process.exit(), while using metrics to track whether this is actually happening.