### PR TITLE
quote entire custom claims object and escape inner quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Releases Cloud Firestore emulator v1.16.1, which adds support for read_time in ListCollectionIds.
+- Fixes auth:export with csv format for users with custom claims

--- a/src/accountExporter.ts
+++ b/src/accountExporter.ts
@@ -84,7 +84,10 @@ function transUserToArray(user: any): any[] {
   arr[24] = user.lastLoginAt;
   arr[25] = user.phoneNumber;
   arr[26] = user.disabled;
-  arr[27] = user.customAttributes;
+  // quote entire custom claims object and escape inner quotes with quotes
+  arr[27] = user.customAttributes
+    ? `"${user.customAttributes.replace(/(?<!\\)"/g, '""')}"`
+    : user.customAttributes;
   return arr;
 }
 


### PR DESCRIPTION
### Description

fixes [3319](https://github.com/firebase/firebase-tools/issues/3319)

### Scenarios Tested

* Export of a user with a single custom claim
* Export of a user with multiple custom claims
* Export of a user with a custom claim that contains a "
* Export of a user with a custom claim that's value is not quota, e.g. `true` or 99`
* Export of a user with no custom claims
* Export of users with a mix of the above
