### PR TITLE
adds 404 check when fetching repo public key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - The hosting emulator integration with web frameworks now has improved support for HMR and dev-tools. (#5582)
+- Fixes an issue where `init hosting:github` would hang if it could not access a repository's public key. (#5317)

--- a/src/init/features/hosting/github.ts
+++ b/src/init/features/hosting/github.ts
@@ -418,7 +418,7 @@ async function promptForRepo(
           key = body.key;
           keyId = body.key_id;
         } catch (e: any) {
-          if (e.status === 403) {
+          if ([403, 404].includes(e.status)) {
             logger.info();
             logger.info();
             logWarning(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Does what it says on the box. In addition to catching 403 errors, now we'll catch 404 errors and also prompt that we may not have access to the repository.

Fixes #5317 

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

I don't have a repo that doesn't prevent me access, but `hosting:github` does continue to work for me.