### PR TITLE
Release firestore emulator v1.16.2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - The hosting emulator integration with web frameworks now has improved support for HMR and dev-tools. (#5582)
 - Fixes an issue where `init hosting:github` would hang if it could not access a repository's public key. (#5317)
+- Release Firestore Emulator v1.16.2 which captures an HTTP1 header fix and requests monitor fix. (#TODO)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -33,9 +33,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "311609538bd65666eb724ef47c2e6466",
   },
   firestore: {
-    version: "1.16.1",
-    expectedSize: 64213741,
-    expectedChecksum: "befa5f6cbe258e787bf0bbb4eb9da2c8",
+    version: "1.16.2",
+    expectedSize: 64601019,
+    expectedChecksum: "83f379a5b3d367503a860497fea3a936",
   },
   storage: {
     version: "1.1.3",


### PR DESCRIPTION
Release firestore emulator v1.16.2.