### PR TITLE
Fix bug where eagerly initializing UA failed function deployment that imported firebase-tools as a library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fix bug where functions shell failed to invoke event triggered functions in debug mode. (#5609)
 - Fixed bug with the web frameworks proxy that could see unexpected 404 errors while emulating. (#5525)
 - Added experimental support for SvelteKit codebases. (#5525)
+- Fix bug where eagerly initializing UA failed function deployment that imported firebase-tools as a library. (#5666)


### PR DESCRIPTION
Instead, we lazily initialize the UA agent to prevent CF3 deploy from failing when building function source that uses firebase-tools as a library.

Not sure why this suddenly became a problem in nodejs18 - my guess is that the builder image for nodejs18 runtime have stricter permission on filesystem directories that configstore needs.

Fixes https://github.com/firebase/firebase-tools/issues/5631.