### PR TITLE
Cleanup to frameworks env and more

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -45,6 +45,7 @@
         "minimatch": "^3.0.4",
         "morgan": "^1.10.0",
         "node-fetch": "^2.6.7",
+        "npm-run-path": "^5.1.0",
         "open": "^6.3.0",
         "ora": "^5.4.1",
         "p-limit": "^3.0.1",
@@ -11384,6 +11385,31 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npmlog": {
@@ -24582,6 +24608,21 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
+    },
+    "npm-run-path": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+      "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+      "requires": {
+        "path-key": "^4.0.0"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+          "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="
+        }
+      }
     },
     "npmlog": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -130,6 +130,7 @@
     "minimatch": "^3.0.4",
     "morgan": "^1.10.0",
     "node-fetch": "^2.6.7",
+    "npm-run-path": "^5.1.0",
     "open": "^6.3.0",
     "ora": "^5.4.1",
     "p-limit": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prepare": "npm run clean && npm run build:publish",
     "test": "npm run lint:quiet && npm run test:compile && npm run mocha",
     "test:client-integration": "bash ./scripts/client-integration-tests/run.sh",
-    "test:compile": "tsc --project tsconfig.compile.json",
+    "test:compile": "tsc --project tsconfig.compile.json && npm run copyfiles",
     "test:emulator": "bash ./scripts/emulator-tests/run.sh",
     "test:extensions-deploy": "bash ./scripts/extensions-deploy-tests/run.sh",
     "test:extensions-emulator": "bash ./scripts/extensions-emulator-tests/run.sh",

--- a/scripts/emulator-tests/run.sh
+++ b/scripts/emulator-tests/run.sh
@@ -5,6 +5,7 @@ set -ex
 rm -rf dev
 # Run a special build for these tests and the source code.
 tsc --build scripts/emulator-tests/tsconfig.dev.json
+cp src/dynamicImport.js dev/dynamicImport.js
 # Setup a cleanup process to run before exit.
 function cleanup() {
   # Remove the built artifacts.

--- a/scripts/emulator-tests/run.sh
+++ b/scripts/emulator-tests/run.sh
@@ -5,7 +5,6 @@ set -ex
 rm -rf dev
 # Run a special build for these tests and the source code.
 tsc --build scripts/emulator-tests/tsconfig.dev.json
-cp src/dynamicImport.js dev/dynamicImport.js
 # Setup a cleanup process to run before exit.
 function cleanup() {
   # Remove the built artifacts.
@@ -14,6 +13,7 @@ function cleanup() {
 trap cleanup EXIT
 # Need to copy `package.json` to the directory so it can be referenced in code.
 cp package.json dev/package.json
+cp src/dynamicImport.js dev/src/dynamicImport.js
 
 # Install deps required to run test triggers.
 (cd scripts/emulator-tests/functions && npm ci)

--- a/src/deploy/functions/runtimes/node/triggerParser.js
+++ b/src/deploy/functions/runtimes/node/triggerParser.js
@@ -4,18 +4,10 @@
 
 var url = require("url");
 var extractTriggers = require("./extractTriggers");
+var { dynamicImport } = require("../../../../utils");
 var EXIT = function () {
   process.exit(0);
 };
-
-/**
- * Dynamically load import function to prevent TypeScript from
- * transpiling into a require.
- *
- * See https://github.com/microsoft/TypeScript/issues/43329.
- */
-// eslint-disable-next-line @typescript-eslint/no-implied-eval
-const dynamicImport = new Function("modulePath", "return import(modulePath)");
 
 async function loadModule(packageDir) {
   try {

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -6,6 +6,7 @@ import * as path from "path";
 import * as admin from "firebase-admin";
 import * as bodyParser from "body-parser";
 import { pathToFileURL, URL } from "url";
+import { dynamicImport } from "../utils";
 import * as _ from "lodash";
 
 import { EmulatorLog } from "./types";
@@ -30,15 +31,6 @@ let FUNCTION_SIGNATURE: string;
 let FUNCTION_DEBUG_MODE: string;
 
 let developerPkgJSON: PackageJSON | undefined;
-
-/**
- * Dynamically load import function to prevent TypeScript from
- * transpiling into a require.
- *
- * See https://github.com/microsoft/TypeScript/issues/43329.
- */
-// eslint-disable-next-line @typescript-eslint/no-implied-eval
-const dynamicImport = new Function("modulePath", "return import(modulePath)");
 
 function noOp(): false {
   return false;

--- a/src/frameworks/express/index.ts
+++ b/src/frameworks/express/index.ts
@@ -3,10 +3,7 @@ import { copy, pathExists } from "fs-extra";
 import { mkdir, readFile } from "fs/promises";
 import { join } from "path";
 import { BuildResult, FrameworkType, SupportLevel } from "..";
-
-// Use "true &&"" to keep typescript from compiling this file and rewriting
-// the import statement into a require
-const { dynamicImport } = require(true && "../../dynamicImport");
+import { dynamicImport } from "../../utils";
 
 export const name = "Express.js";
 export const support = SupportLevel.Experimental;

--- a/src/frameworks/sveltekit/index.ts
+++ b/src/frameworks/sveltekit/index.ts
@@ -4,8 +4,7 @@ import { FrameworkType, SupportLevel } from "..";
 import { viteDiscoverWithNpmDependency, build as viteBuild } from "../vite";
 import { SvelteKitConfig } from "./interfaces";
 import { fileExistsSync } from "../../fsutils";
-
-const { dynamicImport } = require(true && "../../dynamicImport");
+import { dynamicImport } from "../../utils";
 
 export const name = "SvelteKit";
 export const support = SupportLevel.Experimental;

--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -4,6 +4,7 @@ import { join } from "path";
 import { readFile } from "fs/promises";
 import { IncomingMessage, request as httpRequest, ServerResponse, Agent } from "http";
 import { logger } from "../logger";
+import { dynamicImport } from "../utils";
 
 /**
  * Whether the given string starts with http:// or https://
@@ -90,4 +91,9 @@ export function simpleProxy(hostOrRequestHandler: string | RequestHandler) {
       await hostOrRequestHandler(originalReq, originalRes);
     }
   };
+}
+
+export async function getNodeEnv(cwd: string): Promise<NodeJS.ProcessEnv> {
+  const { npmRunPathEnv } = await dynamicImport<typeof import("npm-run-path")>("npm-run-path");
+  return { ...process.env, ...npmRunPathEnv({ cwd }) };
 }

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -3,9 +3,9 @@ import { spawn } from "cross-spawn";
 import { existsSync } from "fs";
 import { copy, pathExists } from "fs-extra";
 import { join } from "path";
-import { findDependency, FrameworkType, getNodeModuleBin, relativeRequire, SupportLevel } from "..";
+import { findDependency, FrameworkType, relativeRequire, SupportLevel } from "..";
 import { promptOnce } from "../../prompt";
-import { simpleProxy, warnIfCustomBuildScript } from "../utils";
+import { getNodeEnv, simpleProxy, warnIfCustomBuildScript } from "../utils";
 
 export const name = "Vite";
 export const support = SupportLevel.Experimental;
@@ -75,12 +75,15 @@ export async function ɵcodegenPublicDirectory(root: string, dest: string) {
   await copy(viteDistPath, dest);
 }
 
-export async function getDevModeHandle(dir: string) {
+export async function getDevModeHandle(cwd: string) {
+  const env = await getNodeEnv(cwd);
   const host = new Promise<string>((resolve) => {
     // Can't use scheduleTarget since that—like prerender—is failing on an ESM bug
     // will just grep for the hostname
-    const cli = getNodeModuleBin("vite", dir);
-    const serve = spawn(cli, [], { cwd: dir });
+    const serve = spawn("vite", [], {
+      cwd,
+      env,
+    });
     serve.stdout.on("data", (data: any) => {
       process.stdout.write(data);
       const match = data.toString().match(/(http:\/\/.+:\d+)/);

--- a/src/test/frameworks/utils.spec.ts
+++ b/src/test/frameworks/utils.spec.ts
@@ -1,30 +1,10 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as fs from "fs";
-import { resolve, join } from "path";
 
 import { warnIfCustomBuildScript, isUrl } from "../../frameworks/utils";
-import { getNodeModuleBin } from "../../frameworks";
 
 describe("Frameworks utils", () => {
-  describe("getNodeModuleBin", () => {
-    it("should return expected tsc path", () => {
-      expect(getNodeModuleBin("tsc", __dirname)).to.equal(
-        resolve(join(__dirname, "..", "..", "..", "node_modules", ".bin", "tsc"))
-      );
-    });
-    it("should throw when npm root not found", () => {
-      expect(() => {
-        getNodeModuleBin("tsc", "/");
-      }).to.throw("Could not find the tsc executable.");
-    });
-    it("should throw when executable not found", () => {
-      expect(() => {
-        getNodeModuleBin("xxxxx", __dirname);
-      }).to.throw("Could not find the xxxxx executable.");
-    });
-  });
-
   describe("isUrl", () => {
     it("should identify http URL", () => {
       expect(isUrl("http://firebase.google.com")).to.be.true;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,20 @@ export function consoleUrl(project: string, path: string): string {
   return `${api.consoleOrigin}/project/${project}${path}`;
 }
 
+// Use "true &&"" to keep typescript from compiling this file and rewriting
+// the import statement into a require
+const dynamicImportModule: {
+  dynamicImport: <T = any>(module: string) => Promise<T>;
+} = require(true && "./dynamicImport");
+
+/**
+ * Dynamically load import function to prevent TypeScript from
+ * transpiling into a require.
+ *
+ * See https://github.com/microsoft/TypeScript/issues/43329.
+ */
+export const { dynamicImport } = dynamicImportModule;
+
 /**
  * Trace up the ancestry of objects that have a `parent` key, finding the
  * first instance of the provided key.


### PR DESCRIPTION
* NPM bin detection was taking a while, use `npm-run-path` for a different take on paths
* Rename a couple arguments for better use as rest params
* Reexport dynamicImport in utils and reuse in a few places
* Add NPM command timeouts
* Handle no output on findDependency 
* Copy dynamicImport on test