### PR TITLE
Continue publishing even if tweet fails to send

### DIFF
--- a/scripts/tweet.js
+++ b/scripts/tweet.js
@@ -45,8 +45,7 @@ client.post(
   { status: `v${version} of @Firebase CLI is available. Release notes: ${getUrl(version)}` },
   (err) => {
     if (err) {
-      console.error(err);
-      process.exit(1);
+      console.error(`Failed to make a tweet for firebase-tools@${version}: ${err}`);
     }
   }
 );


### PR DESCRIPTION
### Description
Still continue publishing, even if the tweet fails to send, to ensure that Firepit artifacts are created. This is a simple mitigation for the issues we ran into while releasing 11.27.0 - I'll dig into _why_ the tweet failed yesterday, but I want to get back to a working publish script ASAP.
