### PR TITLE
Fix bug where Custom Event channels weren't automatically crated on function deploys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Relaxed repo URI validation in ext:dev:publish (#5698).
+- Fix bug where Custom Event channels weren't automatically crated on function deploys (#5700)

--- a/src/gcp/eventarc.ts
+++ b/src/gcp/eventarc.ts
@@ -53,7 +53,7 @@ const client = new Client({
  * Gets a Channel.
  */
 export async function getChannel(name: string): Promise<Channel | undefined> {
-  const res = await client.get<Channel>(name);
+  const res = await client.get<Channel>(name, { resolveOnHTTPError: true });
   if (res.status === 404) {
     return undefined;
   }


### PR DESCRIPTION
Deploying Eventarc Custom Event Function deploy fails for projects that doesn't have `"projects/cf3-tq-sample/locations/us-central1/channels/firebase"` channel.

Fixes bug introduced in https://github.com/firebase/firebase-tools/pull/5443.
