### PR TITLE
Adding extensions to firebase init

### DIFF
--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -14,7 +14,6 @@ import * as refs from "../extensions/refs";
 import { displayWarningPrompts } from "../extensions/warnings";
 import * as paramHelper from "../extensions/paramHelper";
 import {
-  confirm,
   createSourceFromLocation,
   ensureExtensionsApiEnabled,
   logPrefix,
@@ -25,6 +24,7 @@ import {
   isLocalPath,
   canonicalizeRefInput,
 } from "../extensions/extensionsHelper";
+import { confirm } from "../prompt";
 import { getRandomString } from "../extensions/utils";
 import { requirePermissions } from "../requirePermissions";
 import * as utils from "../utils";

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -11,7 +11,6 @@ import {
   logPrefix,
   getSourceOrigin,
   SourceOrigin,
-  confirm,
   diagnoseAndFixProject,
   isLocalPath,
 } from "../extensions/extensionsHelper";
@@ -19,6 +18,7 @@ import * as paramHelper from "../extensions/paramHelper";
 import { inferUpdateSource } from "../extensions/updateHelper";
 import * as refs from "../extensions/refs";
 import { getProjectId } from "../projectUtils";
+import { confirm } from "../prompt";
 import { requirePermissions } from "../requirePermissions";
 import * as utils from "../utils";
 import * as experiments from "../experiments";

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -65,6 +65,11 @@ const choices = [
     name: "Remote Config: Configure a template file for Remote Config",
     checked: false,
   },
+  {
+    value: "extensions",
+    name: "Extensions: Set up an empty Extensions manifest",
+    checked: false,
+  },
 ];
 const featureNames = choices.map((choice) => choice.value);
 

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -36,7 +36,7 @@ import {
 import { Extension, ExtensionSource, ExtensionSpec, ExtensionVersion, Param } from "./types";
 import * as refs from "./refs";
 import { EXTENSIONS_SPEC_FILE, readFile, getLocalExtensionSpec } from "./localHelper";
-import { promptOnce } from "../prompt";
+import { confirm, promptOnce } from "../prompt";
 import { logger } from "../logger";
 import { envOverride } from "../utils";
 import { getLocalChangelog } from "./change-log";
@@ -1057,28 +1057,6 @@ export function getSourceOrigin(sourceOrVersion: string): SourceOrigin {
       sourceOrVersion
     )}'. Check to make sure the source is correct, and then please try again.`
   );
-}
-
-/**
- * Confirm if the user wants to continue
- */
-export async function confirm(args: {
-  nonInteractive?: boolean;
-  force?: boolean;
-  default?: boolean;
-}): Promise<boolean> {
-  if (!args.nonInteractive && !args.force) {
-    const message = `Do you wish to continue?`;
-    return await promptOnce({
-      type: "confirm",
-      message,
-      default: args.default,
-    });
-  } else if (args.nonInteractive && !args.force) {
-    throw new FirebaseError("Pass the --force flag to use this command in non-interactive mode");
-  } else {
-    return true;
-  }
 }
 
 export async function diagnoseAndFixProject(options: any): Promise<void> {

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -1,10 +1,12 @@
 import * as clc from "colorette";
 import * as path from "path";
+import * as fs from 'fs-extra';
+
 import * as refs from "./refs";
 import { Config } from "../config";
 import { getExtensionSpec, ManifestInstanceSpec } from "../deploy/extensions/planner";
 import { logger } from "../logger";
-import { promptOnce } from "../prompt";
+import { confirm, promptOnce } from "../prompt";
 import { readEnvFile } from "./paramHelper";
 import { FirebaseError } from "../error";
 import * as utils from "../utils";
@@ -58,6 +60,33 @@ export async function writeToManifest(
   writeExtensionsToFirebaseJson(specs, config);
   await writeEnvFiles(specs, config, options.force);
   await writeLocalSecrets(specs, config, options.force);
+}
+
+export async function writeEmptyManifest(
+  config: Config,
+  options: { nonInteractive: boolean; force: boolean },
+): Promise<void> {
+
+  if (!fs.existsSync(config.path("extensions"))) {
+    fs.mkdirSync(config.path("extensions"));
+  }
+  if (
+    config.has("extensions") &&
+    Object.keys(config.get("extensions")).length
+  ) {
+    const currentExtensions = Object.entries(config.get("extensions"))
+    .map((i) => `${i[0]}: ${i[1]}`)
+    .join("\n\t");
+    if (!await confirm({
+      message: `firebase.json already contains extensions:\n${currentExtensions}\nWould you like to overwrite them?`,
+      nonInteractive: options.nonInteractive,
+      force: options.force,
+      default: false,
+    })){
+      return
+    }
+  }
+  config.set("extensions", {});
 }
 
 /**
@@ -173,7 +202,7 @@ export function getInstanceRef(instanceId: string, config: Config): refs.Ref {
   return refs.parse(source);
 }
 
-function writeExtensionsToFirebaseJson(specs: ManifestInstanceSpec[], config: Config): void {
+export function writeExtensionsToFirebaseJson(specs: ManifestInstanceSpec[], config: Config): void {
   const extensions = config.get("extensions", {});
   for (const s of specs) {
     let target;

--- a/src/init/features/extensions/index.ts
+++ b/src/init/features/extensions/index.ts
@@ -1,0 +1,25 @@
+import * as clc from "colorette";
+
+import { logger } from "../../../logger";
+import { promptOnce } from "../../../prompt";
+import { requirePermissions } from "../../../requirePermissions";
+import { Options } from "../../../options";
+import { ensure } from "../../../ensureApiEnabled";
+import { Config } from "../../../config";
+import * as manifest from "../../../extensions/manifest";
+import { option } from "commander";
+
+/**
+ * Set up a new firebase project for extensions.
+ */
+export async function doSetup(setup: any, config: Config, options: Options): Promise<any> {
+  const projectId = setup?.rcfile?.projects?.default;
+  if (projectId) {
+    await requirePermissions({ ...options, project: projectId });
+    await Promise.all([
+      ensure(projectId, "firebaseextensions.googleapis.com", "unused", true),
+    ]);
+  }
+  return manifest.writeEmptyManifest(config, options);
+}
+

--- a/src/init/features/index.ts
+++ b/src/init/features/index.ts
@@ -5,6 +5,7 @@ export { doSetup as functions } from "./functions";
 export { doSetup as hosting } from "./hosting";
 export { doSetup as storage } from "./storage";
 export { doSetup as emulators } from "./emulators";
+export { doSetup as extensions } from "./extensions";
 // always runs, sets up .firebaserc
 export { doSetup as project } from "./project";
 export { doSetup as remoteconfig } from "./remoteconfig";

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -25,6 +25,7 @@ const featureFns = new Map<string, (setup: any, config: any, options?: any) => P
   ["hosting", features.hosting],
   ["storage", features.storage],
   ["emulators", features.emulators],
+  ["extensions", features.extensions],
   ["project", features.project], // always runs, sets up .firebaserc
   ["remoteconfig", features.remoteconfig],
   ["hosting:github", features.hostingGithub],

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -97,3 +97,26 @@ export async function promptOnce<A>(question: Question, options: Options = {}): 
   await prompt(options, [question]);
   return options[question.name];
 }
+
+/**
+ * Confirm if the user wants to continue
+ */
+export async function confirm(args: {
+  nonInteractive?: boolean;
+  force?: boolean;
+  default?: boolean;
+  message?: string
+}): Promise<boolean> {
+  if (!args.nonInteractive && !args.force) {
+    const message = args.message ?? `Do you wish to continue?`;
+    return await promptOnce({
+      type: "confirm",
+      message,
+      default: args.default,
+    });
+  } else if (args.nonInteractive && !args.force) {
+    throw new FirebaseError("Pass the --force flag to use this command in non-interactive mode");
+  } else {
+    return true;
+  }
+}


### PR DESCRIPTION
### Description
Adds `extensions` as an option to `firebase init`. If selected, this will set up an empty `extensions` section in `firebase.json` and create an empty `extensions` directory. If called from a directory that already has extensions set up, it will prompt users if they want to overwrite.

### Scenarios Tested
<img width="568" alt="Screenshot 2023-04-17 at 11 28 07 AM" src="https://user-images.githubusercontent.com/4635763/232580396-6c8caed9-1f6a-4eac-beaa-7fc922a7bfb3.png">
init a fresh directory
<img width="568" alt="Screenshot 2023-04-17 at 11 32 26 AM" src="https://user-images.githubusercontent.com/4635763/232580440-7c633338-7eb2-4ace-a6c3-8271f2b48c39.png">
init a directory that already has extensions:
<img width="562" alt="Screenshot 2023-04-17 at 11 34 21 AM" src="https://user-images.githubusercontent.com/4635763/232580621-edfd18b7-b2f0-46e4-823e-0858ab89103a.png">

