### PR TITLE
replace obsolete npm bin command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix an issue where Secret Manager secrets were tagged incorrectly (#5704).
+- Fixed an issue with Vite and Angular integrations using a obsolete NPM command (#5710)

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -234,10 +234,8 @@ function scanDependencyTree(searchingFor: string, dependencies = {}): any {
 
 export function getNodeModuleBin(name: string, cwd: string) {
   const cantFindExecutable = new FirebaseError(`Could not find the ${name} executable.`);
-  const npmBin = spawnSync("npm", ["bin"], { cwd }).stdout?.toString().trim();
-  if (!npmBin) {
-    throw cantFindExecutable;
-  }
+  const npmRoot = (_a = (0, cross_spawn_1.sync)("npm", ["root"], { cwd }).stdout) === null || _a === void 0 ? void 0 : _a.toString().trim();
+  const npmBin = (0, path_1.join)(npmRoot, ".bin")
   const path = join(npmBin, name);
   if (!fileExistsSync(path)) {
     throw cantFindExecutable;

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -235,8 +235,10 @@ function scanDependencyTree(searchingFor: string, dependencies = {}): any {
 export function getNodeModuleBin(name: string, cwd: string) {
   const cantFindExecutable = new FirebaseError(`Could not find the ${name} executable.`);
   const npmRoot = spawnSync("npm", ["root"], { cwd }).stdout?.toString().trim();
-  const npmBin = join (npmRoot, ".bin")
-  const path = join(npmBin, name);
+  if (!npmRoot) {
+    throw cantFindExecutable;
+  }
+  const path = join(npmRoot, ".bin", name);
   if (!fileExistsSync(path)) {
     throw cantFindExecutable;
   }

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -234,8 +234,8 @@ function scanDependencyTree(searchingFor: string, dependencies = {}): any {
 
 export function getNodeModuleBin(name: string, cwd: string) {
   const cantFindExecutable = new FirebaseError(`Could not find the ${name} executable.`);
-  const npmRoot = (_a = (0, cross_spawn_1.sync)("npm", ["root"], { cwd }).stdout) === null || _a === void 0 ? void 0 : _a.toString().trim();
-  const npmBin = (0, path_1.join)(npmRoot, ".bin")
+  const npmRoot = spawnSync("npm", ["root"], { cwd }).stdout?.toString().trim();
+  const npmBin = join (npmRoot, ".bin")
   const path = join(npmBin, name);
   if (!fileExistsSync(path)) {
     throw cantFindExecutable;


### PR DESCRIPTION
npm bin command was removed in npm version 9.

https://github.blog/changelog/2022-10-24-npm-v9-0-0-released/

The proposed solution is to get the root and join the .bin folder.
