### PR TITLE
Ensure spec.params and spec.systemParams are not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Fixes an issue where Secret Manager secrets were tagged incorrectly (#5704).
 - Fix bug where Custom Event channels weren't automatically crated on function deploys (#5700)
 - Lift GCF 2nd gen naming restrictions (#5690)
+- Fixes a bug where `ext:install` and `ext:configure` would error on extensions with no params.

--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -75,9 +75,8 @@ export const command = new Command("ext:configure <extensionInstanceId>")
       instanceId,
       projectDir: config.projectDir,
     });
-
     const [immutableParams, tbdParams] = partition(
-      spec.params.concat(spec.systemParams ?? []),
+      (spec.params ?? []).concat(spec.systemParams ?? []),
       (param) => param.immutable ?? false
     );
     infoImmutableParams(immutableParams, oldParamValues);

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -211,7 +211,7 @@ async function installToManifest(options: InstallExtensionOptions): Promise<void
 
   const paramBindingOptions = await paramHelper.getParams({
     projectId,
-    paramSpecs: spec.params.concat(spec.systemParams ?? []),
+    paramSpecs: (spec.params ?? []).concat(spec.systemParams ?? []),
     nonInteractive,
     paramsEnvPath,
     instanceId,


### PR DESCRIPTION
### Description
Due to the conversion to and from proto wire format, required repeated fields of extensionSpec would be undefined instead of empty. This caused some unexpected behavior, including erroring out when trying to ext:install or ext:configure an extension that has no params.

This change ensures that spec.param and spec.systemParams will be [] instead of undefined, and adds some defensive checking in other places to prevent similar issues.

