### PR TITLE
Changed unzipper library to adm-zip for unzipping emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Fix bug where Custom Event channels weren't automatically crated on function deploys (#5700)
 - Lift GCF 2nd gen naming restrictions (#5690)
 - Fixes a bug where `ext:install` and `ext:configure` would error on extensions with no params.
+- Fixes an issue where emulators are unable to start due to corrupt unzipped emulator files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 - Fix bug where Custom Event channels weren't automatically crated on function deploys (#5700)
 - Lift GCF 2nd gen naming restrictions (#5690)
 - Fixes a bug where `ext:install` and `ext:configure` would error on extensions with no params.
-- Fixes an issue where emulators are unable to start due to corrupt unzipped emulator files.
+- Fixes an issue where emulators are unable to start due to corrupt unzipped emulator files (#5724).

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,9 @@
       "license": "MIT",
       "dependencies": {
         "@google-cloud/pubsub": "^3.0.1",
+        "@types/adm-zip": "^0.5.0",
         "abort-controller": "^3.0.0",
+        "adm-zip": "^0.5.10",
         "ajv": "^6.12.6",
         "archiver": "^5.0.0",
         "async-lock": "1.3.2",
@@ -3399,6 +3401,14 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "node_modules/@types/adm-zip": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+      "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/archiver": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
@@ -4566,6 +4576,14 @@
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==",
+      "engines": {
+        "node": ">=6.0"
       }
     },
     "node_modules/agent-base": {
@@ -21728,6 +21746,14 @@
       "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
+    "@types/adm-zip": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+      "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/archiver": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@types/archiver/-/archiver-5.1.0.tgz",
@@ -22752,6 +22778,11 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
+    },
+    "adm-zip": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.10.tgz",
+      "integrity": "sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ=="
     },
     "agent-base": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,9 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "^3.0.1",
+    "@types/adm-zip": "^0.5.0",
     "abort-controller": "^3.0.0",
+    "adm-zip": "^0.5.10",
     "ajv": "^6.12.6",
     "archiver": "^5.0.0",
     "async-lock": "1.3.2",

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -2,7 +2,7 @@ import * as crypto from "crypto";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as tmp from "tmp";
-import * as admZip from "adm-zip";
+import * as AdmZip from "adm-zip";
 
 import { EmulatorLogger } from "./emulatorLogger";
 import { EmulatorDownloadDetails, DownloadableEmulators } from "./types";
@@ -81,7 +81,7 @@ export async function downloadExtensionVersion(
 function unzip(zipPath: string, unzipDir: string): Promise<void> {
   return new Promise((resolve, reject) => {
     try {
-      const zip = new admZip(zipPath);
+      const zip = new AdmZip(zipPath);
       zip.extractAllTo(unzipDir);
       resolve();
     } catch (err) {

--- a/src/emulator/download.ts
+++ b/src/emulator/download.ts
@@ -2,7 +2,7 @@ import * as crypto from "crypto";
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as tmp from "tmp";
-import * as unzipper from "unzipper";
+import * as admZip from "adm-zip";
 
 import { EmulatorLogger } from "./emulatorLogger";
 import { EmulatorDownloadDetails, DownloadableEmulators } from "./types";
@@ -80,10 +80,13 @@ export async function downloadExtensionVersion(
 
 function unzip(zipPath: string, unzipDir: string): Promise<void> {
   return new Promise((resolve, reject) => {
-    fs.createReadStream(zipPath)
-      .pipe(unzipper.Extract({ path: unzipDir })) // eslint-disable-line new-cap
-      .on("error", reject)
-      .on("close", resolve);
+    try {
+      const zip = new admZip(zipPath);
+      zip.extractAllTo(unzipDir);
+      resolve();
+    } catch (err) {
+      reject();
+    }
   });
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Changed `unzipper` library to `adm-zip` library since the `unzipper` library creates corrupt files and is also unmaintained.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

Platform:  macOS
Node Versions: v18.12.1, v18.16.0, v19.8.0, v19.18.1

1 Switch node versions since issue starts from Node v18.16.0 and above
2. Delete `pubsub-emulator-0.7.1` and `ui-v1.11.5` from `.cache/firebase/emulators`
3. Run `firebase emulators:start --project demo-proj --only auth,firestore,pubsub` to download Emulator UI and PubSub emulator.
4. Emulators starts without any issues

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
