### PR TITLE
Allow user to configure `database:import` chunk size and concurrency

### DIFF
--- a/src/database/import.ts
+++ b/src/database/import.ts
@@ -9,9 +9,6 @@ import { Client, ClientResponse } from "../apiv2";
 import { FirebaseError } from "../error";
 import * as pLimit from "p-limit";
 
-const MAX_CHUNK_SIZE = 1024 * 1024 * 10;
-const CONCURRENCY_LIMIT = 5;
-
 type JsonType = { [key: string]: JsonType } | string | number | boolean;
 
 type Data = {
@@ -31,15 +28,17 @@ type ChunkedData = {
  */
 export default class DatabaseImporter {
   private client: Client;
-  private limit = pLimit(CONCURRENCY_LIMIT);
+  private limit: pLimit.Limit;
 
   constructor(
     private dbUrl: URL,
     private inStream: stream.Readable,
     private dataPath: string,
-    private chunkSize = MAX_CHUNK_SIZE
+    private chunkSize: number,
+    concurrency: number
   ) {
     this.client = new Client({ urlPrefix: dbUrl.origin, auth: true });
+    this.limit = pLimit(concurrency);
   }
 
   /**

--- a/src/database/import.ts
+++ b/src/database/import.ts
@@ -34,7 +34,7 @@ export default class DatabaseImporter {
     private dbUrl: URL,
     private inStream: stream.Readable,
     private dataPath: string,
-    private chunkSize: number,
+    private chunkBytes: number,
     concurrency: number
   ) {
     this.client = new Client({ urlPrefix: dbUrl.origin, auth: true });
@@ -156,7 +156,7 @@ export default class DatabaseImporter {
         }
       }
 
-      if (hasChunkedChild || size >= this.chunkSize) {
+      if (hasChunkedChild || size >= this.chunkBytes) {
         return { chunks, size };
       } else {
         return { chunks: null, size };

--- a/src/test/database/import.spec.ts
+++ b/src/test/database/import.spec.ts
@@ -7,6 +7,8 @@ import DatabaseImporter from "../../database/import";
 import { FirebaseError } from "../../error";
 
 const dbUrl = new URL("https://test-db.firebaseio.com/foo");
+const chunkSize = 1024 * 1024 * 10;
+const concurrencyLimit = 5;
 
 describe("DatabaseImporter", () => {
   const DATA = { a: 100, b: [true, "bar", { f: { g: 0, h: 1 }, i: "baz" }] };
@@ -22,7 +24,9 @@ describe("DatabaseImporter", () => {
     const importer = new DatabaseImporter(
       dbUrl,
       utils.stringToStream(INVALID_JSON)!,
-      /* importPath= */ "/"
+      /* importPath= */ "/",
+      chunkSize,
+      concurrencyLimit
     );
 
     await expect(importer.execute()).to.be.rejectedWith(
@@ -37,7 +41,13 @@ describe("DatabaseImporter", () => {
     nock("https://test-db.firebaseio.com")
       .put("/foo/b.json", JSON.stringify([true, "bar", { f: { g: 0, h: 1 }, i: "baz" }]))
       .reply(200);
-    const importer = new DatabaseImporter(dbUrl, DATA_STREAM, /* importPath= */ "/");
+    const importer = new DatabaseImporter(
+      dbUrl,
+      DATA_STREAM,
+      /* importPath= */ "/",
+      chunkSize,
+      concurrencyLimit
+    );
 
     const responses = await importer.execute();
 
@@ -58,7 +68,8 @@ describe("DatabaseImporter", () => {
       dbUrl,
       DATA_STREAM,
       /* importPath= */ "/",
-      /* chunkSize= */ 20
+      /* chunkSize= */ 20,
+      concurrencyLimit
     );
 
     const responses = await importer.execute();
@@ -72,7 +83,13 @@ describe("DatabaseImporter", () => {
     nock("https://test-db.firebaseio.com")
       .put("/foo/b.json", JSON.stringify([true, "bar", { f: { g: 0, h: 1 }, i: "baz" }]))
       .reply(200);
-    const importer = new DatabaseImporter(dbUrl, DATA_STREAM, /* importPath= */ "/b");
+    const importer = new DatabaseImporter(
+      dbUrl,
+      DATA_STREAM,
+      /* importPath= */ "/b",
+      chunkSize,
+      concurrencyLimit
+    );
 
     const responses = await importer.execute();
 
@@ -82,7 +99,13 @@ describe("DatabaseImporter", () => {
 
   it("throws FirebaseError when data location is nonempty", async () => {
     nock("https://test-db.firebaseio.com").get("/foo.json?shallow=true").reply(200, { a: "foo" });
-    const importer = new DatabaseImporter(dbUrl, DATA_STREAM, /* importPath= */ "/");
+    const importer = new DatabaseImporter(
+      dbUrl,
+      DATA_STREAM,
+      /* importPath= */ "/",
+      chunkSize,
+      concurrencyLimit
+    );
 
     await expect(importer.execute()).to.be.rejectedWith(
       FirebaseError,


### PR DESCRIPTION
### Description
[b/278767412](http://b/278767412)
API proposal: [go/firebase-database-import](http://go/firebase-database-import)

### Sample Commands
```
firebase database:import / data.json --chunk-size 20 --concurrency 10
```