### PR TITLE
Add TOS acceptance calls to ext:dev:upload and :register

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -124,6 +124,14 @@ export const extensionsOrigin = utils.envOverride(
   "FIREBASE_EXT_URL",
   "https://firebaseextensions.googleapis.com"
 );
+export const extensionsPublisherOrigin = utils.envOverride(
+  "FIREBASE_EXT_PUBLISHER_URL",
+  "https://firebaseextensionspublisher.googleapis.com"
+);
+export const extensionsTOSOrigin = utils.envOverride(
+  "FIREBASE_EXT_TOS_URL",
+  "https://firebaseextensionstos-pa.googleapis.com"
+);
 export const realtimeOrigin = utils.envOverride("FIREBASE_REALTIME_URL", "https://firebaseio.com");
 export const rtdbManagementOrigin = utils.envOverride(
   "FIREBASE_RTDB_MANAGEMENT_URL",

--- a/src/commands/ext-dev-register.ts
+++ b/src/commands/ext-dev-register.ts
@@ -6,7 +6,7 @@ import { registerPublisherProfile } from "../extensions/extensionsApi";
 import { needProjectId } from "../projectUtils";
 import { promptOnce } from "../prompt";
 import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
-import { promptForPublisherTOS } from "../extensions/askUserForConsent";
+import { acceptLatestPublisherTOS } from "../extensions/tos";
 import { requirePermissions } from "../requirePermissions";
 import { FirebaseError } from "../error";
 import * as utils from "../utils";
@@ -20,8 +20,8 @@ export const command = new Command("ext:dev:register")
   .before(requirePermissions, ["firebaseextensions.sources.create"])
   .before(ensureExtensionsApiEnabled)
   .action(async (options: any) => {
-    await promptForPublisherTOS();
     const projectId = needProjectId(options);
+    await acceptLatestPublisherTOS(options, projectId);
     const msg =
       "What would you like to register as your publisher ID? " +
       "This value identifies you in Firebase's registry of extensions as the author of your extensions. " +

--- a/src/commands/ext-dev-upload.ts
+++ b/src/commands/ext-dev-upload.ts
@@ -4,6 +4,7 @@ import * as TerminalRenderer from "marked-terminal";
 
 import { Command } from "../command";
 import {
+  ReleaseStage,
   logPrefix,
   publishExtensionVersionFromLocalSource,
   publishExtensionVersionFromRemoteRepo,
@@ -14,7 +15,11 @@ import { consoleInstallLink } from "../extensions/publishHelpers";
 import { ExtensionVersion } from "../extensions/types";
 import { requireAuth } from "../requireAuth";
 import { FirebaseError } from "../error";
+import { acceptLatestPublisherTOS } from "../extensions/tos";
 import * as utils from "../utils";
+import { Options } from "../options";
+import { getPublisherProfile } from "../extensions/extensionsApi";
+import { getPublisherProjectFromName } from "../extensions/extensionsHelper";
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -44,9 +49,15 @@ export const command = new Command("ext:dev:upload <extensionRef>")
   .before(requireAuth)
   .action(uploadExtensionAction);
 
+interface UploadExtensionOptions extends Options {
+  repo?: string;
+  ref?: string;
+  root?: string;
+  stage?: string;
+}
 export async function uploadExtensionAction(
   extensionRef: string,
-  options: any
+  options: UploadExtensionOptions
 ): Promise<ExtensionVersion | undefined> {
   const { publisherId, extensionId, version } = refs.parse(extensionRef);
   if (version) {
@@ -63,6 +74,12 @@ export async function uploadExtensionAction(
       )}'. Please use the format '${clc.bold("<publisherId>/<extensionId>")}'.`
     );
   }
+
+  // Get the project number and check the publisher TOS
+  const profile = await getPublisherProfile("-", publisherId);
+  const projectNumber = `${getPublisherProjectFromName(profile.name)}`;
+  await acceptLatestPublisherTOS(options, projectNumber);
+
   let res;
   // TODO: Default to this path instead of local source in a major version.
   if (options.repo || options.root || options.ref) {
@@ -74,7 +91,7 @@ export async function uploadExtensionAction(
       extensionRoot: options.root,
       nonInteractive: options.nonInteractive,
       force: options.force,
-      stage: options.stage,
+      stage: options.stage as ReleaseStage,
     });
   } else {
     const extensionYamlDirectory = findExtensionYaml(process.cwd());
@@ -84,7 +101,7 @@ export async function uploadExtensionAction(
       rootDirectory: extensionYamlDirectory,
       nonInteractive: options.nonInteractive,
       force: options.force,
-      stage: options.stage ?? "stable",
+      stage: (options.stage ?? "stable") as ReleaseStage,
     });
   }
   if (res) {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -725,7 +725,7 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
       extensionVersionRef,
       extensionRoot,
       repoUri,
-      sourceRef: args.sourceRef,
+      sourceRef: sourceRef,
     });
     uploadSpinner.succeed(` Successfully uploaded ${clc.bold(extensionRef)}`);
   } catch (err: any) {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -575,10 +575,10 @@ async function validateExtensionSpec(args: {
 export async function publishExtensionVersionFromRemoteRepo(args: {
   publisherId: string;
   extensionId: string;
-  repoUri: string;
-  sourceRef: string;
-  extensionRoot: string;
-  stage: ReleaseStage;
+  repoUri?: string;
+  sourceRef?: string;
+  extensionRoot?: string;
+  stage?: ReleaseStage;
   nonInteractive: boolean;
   force: boolean;
 }): Promise<ExtensionVersion | undefined> {
@@ -700,7 +700,7 @@ export async function publishExtensionVersionFromRemoteRepo(args: {
     extensionId: args.extensionId,
     rootDirectory: rootDirectory,
     latestVersion: extension?.latestVersion,
-    stage: stage,
+    stage: stage!,
   });
 
   const sourceUri = path.join(repoUri, "tree", sourceRef, extensionRoot);

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -1,0 +1,116 @@
+import { Client } from "../apiv2";
+import { extensionsTOSOrigin } from "../api";
+import { logger } from "../logger";
+import { confirm } from "../prompt";
+import { FirebaseError } from "../error";
+
+const VERSION = "v1";
+const extensionsTosUrl = (tos: string) => `https://firebase.google.com/terms/extensions/${tos}`;
+
+export interface TOS {
+  name: string;
+  lastAcceptedVersion: string;
+  lastAcceptedTime: string;
+  latestTosVersion: string;
+}
+export type PublisherTOS = TOS;
+export type AppDevTOS = TOS;
+
+const apiClient = new Client({ urlPrefix: extensionsTOSOrigin, apiVersion: VERSION });
+
+export async function getAppDeveloperTOSStatus(projectId: string): Promise<AppDevTOS> {
+  const res = await apiClient.get<AppDevTOS>(`/projects/${projectId}/appdevtos`);
+  return res.body;
+}
+
+export async function acceptAppDeveloperTOS(
+  projectId: string,
+  tosVersion: string,
+  instanceId: string = ""
+): Promise<AppDevTOS> {
+  const res = await apiClient.post<
+    { name: string; instanceId: string; version: string },
+    AppDevTOS
+  >(`/projects/${projectId}/appdevtos:accept`, {
+    name: `project/${projectId}/appdevtos`,
+    instanceId,
+    version: tosVersion,
+  });
+  return res.body;
+}
+
+export async function getPublisherTOSStatus(projectId: string): Promise<PublisherTOS> {
+  const res = await apiClient.get<PublisherTOS>(`/projects/${projectId}/publishertos`);
+  return res.body;
+}
+
+export async function acceptPublisherTOS(
+  projectId: string,
+  tosVersion: string
+): Promise<PublisherTOS> {
+  const res = await apiClient.post<{ name: string; version: string }, PublisherTOS>(
+    `/projects/${projectId}/publishertos:accept`,
+    {
+      name: `project/${projectId}/publishertos`,
+      version: tosVersion,
+    }
+  );
+  return res.body;
+}
+
+export async function acceptLatestPublisherTOS(
+  options: { force?: boolean; nonInteractive?: boolean },
+  projectId: string
+): Promise<PublisherTOS> {
+  logger.debug(`Checking if latest publisher TOS has been accepted by ${projectId}...`);
+  const currentAcceptance = await getPublisherTOSStatus(projectId);
+  if (currentAcceptance.lastAcceptedVersion === currentAcceptance.latestTosVersion) {
+    logger.debug(
+      `Latest version of publisher TOS is ${currentAcceptance.lastAcceptedVersion}, already accepted.`
+    );
+    return currentAcceptance;
+  } else {
+    // Display link to TOS, prompt for acceptance
+    const tosLink = extensionsTosUrl("publisher");
+    logger.info(`To continue, you must accept the [Extensions publisher terms of service](${tosLink})`);
+    if (
+      await confirm({
+        ...options,
+        message: "Do you accept the Extensions publisher terms of service?",
+      })
+    ) {
+      return acceptPublisherTOS(projectId, currentAcceptance.latestTosVersion);
+    }
+    throw new FirebaseError("Command terminated becuase publisher TOS was not accepted");
+  }
+}
+
+export async function acceptLatestAppDeveloperTOS(
+  options: { force?: boolean; nonInteractive?: boolean },
+  projectId: string,
+  instanceId: string = ""
+): Promise<AppDevTOS> {
+  logger.debug(
+    `Checking if latest AppDeveloper TOS has been accepted by ${projectId}/${instanceId}...`
+  );
+  const currentAcceptance = await getAppDeveloperTOSStatus(projectId);
+  if (currentAcceptance.lastAcceptedVersion === currentAcceptance.latestTosVersion) {
+    logger.debug(
+      `Latest version of app developer TOS is ${currentAcceptance.lastAcceptedVersion}, already accepted.`
+    );
+    return currentAcceptance;
+  } else {
+    // Display link to TOS, prompt for acceptance
+    const tosLink = extensionsTosUrl("appdev");
+    logger.info(`To continue, you must accept the [Extensions app developer terms of service](${tosLink})`);
+    if (
+      await confirm({
+        ...options,
+        message: "Do you accept the Extensions app developer terms of service?",
+      })
+    ) {
+      return acceptAppDeveloperTOS(projectId, instanceId, currentAcceptance.latestTosVersion);
+    }
+    throw new FirebaseError("Command terminated becuase app developer TOS was not accepted");
+  }
+}

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -64,7 +64,7 @@ export async function acceptLatestPublisherTOS(
 ): Promise<PublisherTOS> {
   logger.debug(`Checking if latest publisher TOS has been accepted by ${projectId}...`);
   const currentAcceptance = await getPublisherTOSStatus(projectId);
-  if (!!currentAcceptance.lastAcceptedVersion ) {
+  if (currentAcceptance.lastAcceptedVersion) {
     logger.debug(
       `Already accepted version ${currentAcceptance.lastAcceptedVersion} of Extensions publisher TOS.`
     );

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -83,7 +83,7 @@ export async function acceptLatestPublisherTOS(
     ) {
       return acceptPublisherTOS(projectId, currentAcceptance.latestTosVersion);
     }
-    throw new FirebaseError("Command terminated becuase publisher TOS was not accepted");
+    throw new FirebaseError("You must accept the terms of service to continue.");
   }
 }
 
@@ -115,6 +115,6 @@ export async function acceptLatestAppDeveloperTOS(
     ) {
       return acceptAppDeveloperTOS(projectId, instanceId, currentAcceptance.latestTosVersion);
     }
-    throw new FirebaseError("Command terminated becuase app developer TOS was not accepted");
+    throw new FirebaseError("You must accept the terms of service to continue.");
   }
 }

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -9,8 +9,8 @@ const extensionsTosUrl = (tos: string) => `https://firebase.google.com/terms/ext
 
 export interface TOS {
   name: string;
-  lastAcceptedVersion: string;
-  lastAcceptedTime: string;
+  lastAcceptedVersion?: string;
+  lastAcceptedTime?: string;
   latestTosVersion: string;
 }
 export type PublisherTOS = TOS;
@@ -64,9 +64,9 @@ export async function acceptLatestPublisherTOS(
 ): Promise<PublisherTOS> {
   logger.debug(`Checking if latest publisher TOS has been accepted by ${projectId}...`);
   const currentAcceptance = await getPublisherTOSStatus(projectId);
-  if (currentAcceptance.lastAcceptedVersion === currentAcceptance.latestTosVersion) {
+  if (!!currentAcceptance.lastAcceptedVersion ) {
     logger.debug(
-      `Latest version of publisher TOS is ${currentAcceptance.lastAcceptedVersion}, already accepted.`
+      `Already accepted version ${currentAcceptance.lastAcceptedVersion} of Extensions publisher TOS.`
     );
     return currentAcceptance;
   } else {

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -72,7 +72,9 @@ export async function acceptLatestPublisherTOS(
   } else {
     // Display link to TOS, prompt for acceptance
     const tosLink = extensionsTosUrl("publisher");
-    logger.info(`To continue, you must accept the [Extensions publisher terms of service](${tosLink})`);
+    logger.info(
+      `To continue, you must accept the [Extensions publisher terms of service](${tosLink})`
+    );
     if (
       await confirm({
         ...options,
@@ -102,7 +104,9 @@ export async function acceptLatestAppDeveloperTOS(
   } else {
     // Display link to TOS, prompt for acceptance
     const tosLink = extensionsTosUrl("appdev");
-    logger.info(`To continue, you must accept the [Extensions app developer terms of service](${tosLink})`);
+    logger.info(
+      `To continue, you must accept the [Extensions app developer terms of service](${tosLink})`
+    );
     if (
       await confirm({
         ...options,

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -73,7 +73,7 @@ export async function acceptLatestPublisherTOS(
     // Display link to TOS, prompt for acceptance
     const tosLink = extensionsTosUrl("publisher");
     logger.info(
-      `To continue, you must accept the [Extensions publisher terms of service](${tosLink})`
+      `To continue, you must accept the Extensions publisher terms of service: ${tosLink}`
     );
     if (
       await confirm({

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -9,13 +9,8 @@ const extensionsTosUrl = (tos: string) => `https://firebase.google.com/terms/ext
 
 export interface TOS {
   name: string;
-<<<<<<< HEAD
   lastAcceptedVersion?: string;
   lastAcceptedTime?: string;
-=======
-  lastAcceptedVersion: string;
-  lastAcceptedTime: string;
->>>>>>> public/next
   latestTosVersion: string;
 }
 export type PublisherTOS = TOS;

--- a/src/test/extensions/tos.spec.ts
+++ b/src/test/extensions/tos.spec.ts
@@ -77,14 +77,15 @@ describe("tos", () => {
   describe("acceptLatestAppDeveloperTOS", () => {
     it("should prompt to accept the latest app dev TOS if it has not been accepted", async () => {
       const t = testTOS("appdevtos", "1.0.0");
-      nock(api.extensionsTOSOrigin)
-        .get(`/v1/projects/${testProjectId}/appdevtos`)
-        .reply(200, t);
+      nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
 
-      const appDevTos = await tos.acceptLatestAppDeveloperTOS({
-        nonInteractive: true,
-        force: true,
-      }, testProjectId);
+      const appDevTos = await tos.acceptLatestAppDeveloperTOS(
+        {
+          nonInteractive: true,
+          force: true,
+        },
+        testProjectId
+      );
 
       expect(appDevTos).to.deep.equal(t);
       expect(nock.isDone()).to.be.true;
@@ -93,17 +94,18 @@ describe("tos", () => {
 
   it("should return the latest app dev TOS if it has already been accepted", async () => {
     const t = testTOS("appdevtos", "1.1.0");
-    nock(api.extensionsTOSOrigin)
-      .get(`/v1/projects/${testProjectId}/appdevtos`)
-      .reply(200, t);
+    nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
     nock(api.extensionsTOSOrigin)
       .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
       .reply(200, t);
 
-    const appDevTos = await tos.acceptLatestAppDeveloperTOS({
-      nonInteractive: true,
-      force: true,
-    }, testProjectId);
+    const appDevTos = await tos.acceptLatestAppDeveloperTOS(
+      {
+        nonInteractive: true,
+        force: true,
+      },
+      testProjectId
+    );
 
     expect(appDevTos).to.deep.equal(t);
     expect(nock.isDone()).to.be.true;
@@ -112,14 +114,15 @@ describe("tos", () => {
   describe("acceptLatestPublisherTOS", () => {
     it("should prompt to accept the latest publisher TOS if it has not been accepted", async () => {
       const t = testTOS("publishertos", "1.0.0");
-      nock(api.extensionsTOSOrigin)
-        .get(`/v1/projects/${testProjectId}/publishertos`)
-        .reply(200, t);
+      nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/publishertos`).reply(200, t);
 
-      const publisherTos = await tos.acceptLatestPublisherTOS({
-        nonInteractive: true,
-        force: true,
-      }, testProjectId);
+      const publisherTos = await tos.acceptLatestPublisherTOS(
+        {
+          nonInteractive: true,
+          force: true,
+        },
+        testProjectId
+      );
 
       expect(publisherTos).to.deep.equal(t);
       expect(nock.isDone()).to.be.true;
@@ -128,17 +131,18 @@ describe("tos", () => {
 
   it("should return the latest publisher TOS is it has already been accepted", async () => {
     const t = testTOS("publishertos", "1.1.0");
-    nock(api.extensionsTOSOrigin)
-      .get(`/v1/projects/${testProjectId}/publishertos`)
-      .reply(200, t);
+    nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/publishertos`).reply(200, t);
     nock(api.extensionsTOSOrigin)
       .post(`/v1/projects/${testProjectId}/publishertos:accept`)
       .reply(200, t);
 
-    const publisherTos = await tos.acceptLatestPublisherTOS({
-      nonInteractive: true,
-      force: true,
-    }, testProjectId);
+    const publisherTos = await tos.acceptLatestPublisherTOS(
+      {
+        nonInteractive: true,
+        force: true,
+      },
+      testProjectId
+    );
 
     expect(publisherTos).to.deep.equal(t);
     expect(nock.isDone()).to.be.true;

--- a/src/test/extensions/tos.spec.ts
+++ b/src/test/extensions/tos.spec.ts
@@ -78,6 +78,9 @@ describe("tos", () => {
     it("should prompt to accept the latest app dev TOS if it has not been accepted", async () => {
       const t = testTOS("appdevtos", "1.0.0");
       nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
+      nock(api.extensionsTOSOrigin)
+        .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+        .reply(200, t);
 
       const appDevTos = await tos.acceptLatestAppDeveloperTOS(
         {
@@ -93,11 +96,8 @@ describe("tos", () => {
   });
 
   it("should return the latest app dev TOS if it has already been accepted", async () => {
-    const t = testTOS("appdevtos", "1.1.0");
+    const t = testTOS("appdevtos", "1.1.0", "1.1.0");
     nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
-    nock(api.extensionsTOSOrigin)
-      .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
-      .reply(200, t);
 
     const appDevTos = await tos.acceptLatestAppDeveloperTOS(
       {
@@ -115,6 +115,9 @@ describe("tos", () => {
     it("should prompt to accept the latest publisher TOS if it has not been accepted", async () => {
       const t = testTOS("publishertos", "1.0.0");
       nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/publishertos`).reply(200, t);
+      nock(api.extensionsTOSOrigin)
+        .post(`/v1/projects/${testProjectId}/publishertos:accept`)
+        .reply(200, t);
 
       const publisherTos = await tos.acceptLatestPublisherTOS(
         {
@@ -130,11 +133,8 @@ describe("tos", () => {
   });
 
   it("should return the latest publisher TOS is it has already been accepted", async () => {
-    const t = testTOS("publishertos", "1.1.0");
+    const t = testTOS("publishertos", "1.1.0", "1.1.0");
     nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/publishertos`).reply(200, t);
-    nock(api.extensionsTOSOrigin)
-      .post(`/v1/projects/${testProjectId}/publishertos:accept`)
-      .reply(200, t);
 
     const publisherTos = await tos.acceptLatestPublisherTOS(
       {
@@ -149,11 +149,14 @@ describe("tos", () => {
   });
 });
 
-function testTOS(tosName: string, latestVersion: string): tos.TOS {
-  return {
+function testTOS(tosName: string, latestVersion: string, lastAcceptedVersion?: string): tos.TOS {
+  const t: tos.TOS = {
     name: `projects/test-project/${tosName}`,
-    lastAcceptedVersion: "1.0.0",
     lastAcceptedTime: "11111",
     latestTosVersion: latestVersion,
   };
+  if (lastAcceptedVersion) {
+    t.lastAcceptedVersion = lastAcceptedVersion;
+  }
+  return t;
 }

--- a/src/test/extensions/tos.spec.ts
+++ b/src/test/extensions/tos.spec.ts
@@ -1,0 +1,155 @@
+import { expect } from "chai";
+import * as nock from "nock";
+
+import * as api from "../../api";
+import * as tos from "../../extensions/tos";
+
+describe("tos", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  const testProjectId = "test-proj";
+  describe("getAppDeveloperTOSStatus", () => {
+    it("should get app developer TOS", async () => {
+      const t = testTOS("appdevtos", "1.0.0");
+      nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
+
+      const appDevTos = await tos.getAppDeveloperTOSStatus(testProjectId);
+
+      expect(appDevTos).to.deep.equal(t);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("getPublisherTOS", () => {
+    it("should get publisher TOS", async () => {
+      const t = testTOS("publishertos", "1.0.0");
+      nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/publishertos`).reply(200, t);
+
+      const pubTos = await tos.getPublisherTOSStatus(testProjectId);
+
+      expect(pubTos).to.deep.equal(t);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("acceptAppDeveloperTOS", () => {
+    it("should accept app dev TOS with no instance", async () => {
+      const t = testTOS("appdevtos", "1.0.0");
+      nock(api.extensionsTOSOrigin)
+        .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+        .reply(200, t);
+
+      const appDevTos = await tos.acceptAppDeveloperTOS(testProjectId, "1.0.0");
+
+      expect(appDevTos).to.deep.equal(t);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should accept app dev TOS with an instance", async () => {
+      const t = testTOS("appdevtos", "1.0.0");
+      nock(api.extensionsTOSOrigin)
+        .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+        .reply(200, t);
+
+      const appDevTos = await tos.acceptAppDeveloperTOS(testProjectId, "instanceId", "1.0.0");
+
+      expect(appDevTos).to.deep.equal(t);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("acceptPublisherTOS", () => {
+    it("should accept publisher TOS", async () => {
+      const t = testTOS("publishertos", "1.0.0");
+      nock(api.extensionsTOSOrigin)
+        .post(`/v1/projects/${testProjectId}/publishertos:accept`)
+        .reply(200, t);
+
+      const pubTos = await tos.acceptPublisherTOS(testProjectId, "1.0.0");
+
+      expect(pubTos).to.deep.equal(t);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("acceptLatestAppDeveloperTOS", () => {
+    it("should prompt to accept the latest app dev TOS if it has not been accepted", async () => {
+      const t = testTOS("appdevtos", "1.0.0");
+      nock(api.extensionsTOSOrigin)
+        .get(`/v1/projects/${testProjectId}/appdevtos`)
+        .reply(200, t);
+
+      const appDevTos = await tos.acceptLatestAppDeveloperTOS({
+        nonInteractive: true,
+        force: true,
+      }, testProjectId);
+
+      expect(appDevTos).to.deep.equal(t);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  it("should return the latest app dev TOS if it has already been accepted", async () => {
+    const t = testTOS("appdevtos", "1.1.0");
+    nock(api.extensionsTOSOrigin)
+      .get(`/v1/projects/${testProjectId}/appdevtos`)
+      .reply(200, t);
+    nock(api.extensionsTOSOrigin)
+      .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+      .reply(200, t);
+
+    const appDevTos = await tos.acceptLatestAppDeveloperTOS({
+      nonInteractive: true,
+      force: true,
+    }, testProjectId);
+
+    expect(appDevTos).to.deep.equal(t);
+    expect(nock.isDone()).to.be.true;
+  });
+
+  describe("acceptLatestPublisherTOS", () => {
+    it("should prompt to accept the latest publisher TOS if it has not been accepted", async () => {
+      const t = testTOS("publishertos", "1.0.0");
+      nock(api.extensionsTOSOrigin)
+        .get(`/v1/projects/${testProjectId}/publishertos`)
+        .reply(200, t);
+
+      const publisherTos = await tos.acceptLatestPublisherTOS({
+        nonInteractive: true,
+        force: true,
+      }, testProjectId);
+
+      expect(publisherTos).to.deep.equal(t);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  it("should return the latest publisher TOS is it has already been accepted", async () => {
+    const t = testTOS("publishertos", "1.1.0");
+    nock(api.extensionsTOSOrigin)
+      .get(`/v1/projects/${testProjectId}/publishertos`)
+      .reply(200, t);
+    nock(api.extensionsTOSOrigin)
+      .post(`/v1/projects/${testProjectId}/publishertos:accept`)
+      .reply(200, t);
+
+    const publisherTos = await tos.acceptLatestPublisherTOS({
+      nonInteractive: true,
+      force: true,
+    }, testProjectId);
+
+    expect(publisherTos).to.deep.equal(t);
+    expect(nock.isDone()).to.be.true;
+  });
+});
+
+function testTOS(tosName: string, latestVersion: string): tos.TOS {
+  return {
+    name: `projects/test-project/${tosName}`,
+    lastAcceptedVersion: "1.0.0",
+    lastAcceptedTime: "11111",
+    latestTosVersion: latestVersion,
+  };
+}


### PR DESCRIPTION
### Description
Adds calls to accept publisher TOS before ext:dev:upload and ext:dev:register.

 Also modifies the behavior of acceptLatestPublisherTos to only display the message once, if no version of the publisher TOS has been accepted yet.

### Scenarios Tested
Decline TOS, command exits
<img width="920" alt="Screenshot 2023-04-24 at 2 00 22 PM" src="https://user-images.githubusercontent.com/4635763/234124638-a3220c62-7a7a-4d6e-86b3-d32bdd1497db.png">
Accept TOS the first time, command continues. Next time, no prompt because that version of the TOS is already accepted. (ignore the other, unrelated error)
<img width="1440" alt="Screenshot 2023-04-24 at 2 01 18 PM" src="https://user-images.githubusercontent.com/4635763/234124801-5506323d-9989-4707-9463-59c61ea875db.png">

