### PR TITLE
Block deploys to preview channels if would break prod

### DIFF
--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -108,7 +108,6 @@ export async function unsafePins(
   }
 
   if (!Object.keys(targetTaggedRewrites).length) {
-    console.error("No targets with tags");
     return [];
   }
 

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -75,7 +75,11 @@ function rewriteTarget(source: HostingSource): string {
 }
 
 /**
- *
+ * Returns a list of rewrite targets that would break in prod if deployed.
+ * People use tag pinning so that they can deploy to preview channels without
+ * modifying production. This assumption is violated if the live channel isn't
+ * actually pinned. This method returns "unsafe" pins, where we're deploying to
+ * a non-live channel with a rewrite that is pinned but haven't yet pinned live.
  */
 export async function unsafePins(
   context: Context,

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -8,7 +8,7 @@ import { HostingOptions } from "../../hosting/options";
 import { assertExhaustive, zipIn } from "../../functional";
 import { track } from "../../track";
 import * as utils from "../../utils";
-import { HostingRewrites, HostingSource, RunRewrite } from "../../firebaseConfig";
+import { HostingSource } from "../../firebaseConfig";
 import * as backend from "../functions/backend";
 
 /**

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -5,8 +5,11 @@ import * as deploymentTool from "../../deploymentTool";
 import { Context } from "./context";
 import { Options } from "../../options";
 import { HostingOptions } from "../../hosting/options";
-import { zipIn } from "../../functional";
+import { assertExhaustive, zipIn } from "../../functional";
 import { track } from "../../track";
+import * as utils from "../../utils";
+import { HostingRewrites, HostingSource, RunRewrite } from "../../firebaseConfig";
+import * as backend from "../functions/backend";
 
 /**
  *  Prepare creates versions for each Hosting site to be deployed.
@@ -34,6 +37,12 @@ export async function prepare(context: Context, options: HostingOptions & Option
       if (config.webFramework) {
         labels["firebase-web-framework"] = config.webFramework;
       }
+      const unsafe = await unsafePins(context, config);
+      if (unsafe.length) {
+        const msg = `Cannot deploy site ${config.site} to channel ${context.hostingChannel} because it would modify one or more rewrites in "live" that are not pinned, breaking production. Please pin "live" before pinning other channels.`;
+        utils.logLabeledError("Hosting", msg);
+        throw new Error(msg);
+      }
       const version: Omit<api.Version, api.VERSION_OUTPUT_FIELDS> = {
         status: "CREATED",
         labels,
@@ -51,4 +60,71 @@ export async function prepare(context: Context, options: HostingOptions & Option
   for (const [config, version] of configs.map(zipIn(versions))) {
     context.hosting.deploys.push({ config, version });
   }
+}
+
+function rewriteTarget(source: HostingSource): string {
+  if ("glob" in source) {
+    return source.glob;
+  } else if ("source" in source) {
+    return source.source;
+  } else if ("regex" in source) {
+    return source.regex;
+  } else {
+    assertExhaustive(source);
+  }
+}
+
+/**
+ *
+ */
+export async function unsafePins(
+  context: Context,
+  config: config.HostingResolved
+): Promise<string[]> {
+  // Overwriting prod won't break prod
+  if ((context.hostingChannel || "live") === "live") {
+    return [];
+  }
+
+  const targetTaggedRewrites: Record<string, string> = {};
+  for (const rewrite of config.rewrites || []) {
+    const target = rewriteTarget(rewrite);
+    if ("run" in rewrite && rewrite.run.pinTag) {
+      targetTaggedRewrites[target] = `${rewrite.run.region || "us-central1"}/${
+        rewrite.run.serviceId
+      }`;
+    }
+    if ("function" in rewrite && typeof rewrite.function === "object" && rewrite.function.pinTag) {
+      const region = rewrite.function.region || "us-central1";
+      const endpoint = (await backend.existingBackend(context)).endpoints[region][
+        rewrite.function.functionId
+      ];
+      // This function is new. It can't be pinned elsewhere
+      if (!endpoint) {
+        continue;
+      }
+      targetTaggedRewrites[target] = `${region}/${endpoint.runServiceId || endpoint.id}`;
+    }
+  }
+
+  if (!Object.keys(targetTaggedRewrites).length) {
+    console.error("No targets with tags");
+    return [];
+  }
+
+  const channelConfig = await api.getChannel(context.projectId, config.site, "live");
+  const existingUntaggedRewrites: Record<string, string> = {};
+  for (const rewrite of channelConfig?.release?.version?.config?.rewrites || []) {
+    if ("run" in rewrite && !rewrite.run.tag) {
+      existingUntaggedRewrites[
+        rewriteTarget(rewrite)
+      ] = `${rewrite.run.region}/${rewrite.run.serviceId}`;
+    }
+  }
+
+  // There is only a problem if we're targeting the same exact run service but
+  // live isn't tagged.
+  return Object.keys(targetTaggedRewrites).filter(
+    (target) => targetTaggedRewrites[target] === existingUntaggedRewrites[target]
+  );
 }

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -67,11 +67,6 @@ export const deploy = async function (
       await prepareFrameworks(targetNames, context, options);
       const nowTargetsFunctions = targetNames.includes("functions");
       if (nowTargetsFunctions && !usedToTargetFunctions) {
-        if (context.hostingChannel && !experiments.isEnabled("pintags")) {
-          throw new FirebaseError(
-            "Web frameworks with dynamic content do not yet support deploying to preview channels"
-          );
-        }
         await requirePermissions(TARGET_PERMISSIONS["functions"]);
       }
     }

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -67,6 +67,11 @@ export const deploy = async function (
       await prepareFrameworks(targetNames, context, options);
       const nowTargetsFunctions = targetNames.includes("functions");
       if (nowTargetsFunctions && !usedToTargetFunctions) {
+        if (context.hostingChannel && !experiments.isEnabled("pintags")) {
+          throw new FirebaseError(
+            "Web frameworks with dynamic content do not yet support deploying to preview channels"
+          );
+        }
         await requirePermissions(TARGET_PERMISSIONS["functions"]);
       }
     }


### PR DESCRIPTION
Thanks to @jamesdaniels clever idea, we are able to dramatically cut scope by erroring if deploying to a preview would break prod rather than simply trying to modify prod while deploying to a preview.

This is an alternative approach to #5717 that is intended to be more surgical.