### PR TITLE
Updated expectedSize and expectedChecksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixes an issue where downloading Firestore emulator fails due to incorrect expectedSize and expectedChecksum (#5734).
+- Fixes an issue where downloading Firestore emulator fails due to incorrect expectedSize and expectedChecksum. (#5734)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes an issue where downloading Firestore emulator fails due to incorrect expectedSize and expectedChecksum (#5734).

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -34,8 +34,8 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
   },
   firestore: {
     version: "1.17.2",
-    expectedSize: 64907894,
-    expectedChecksum: "bc56ccf2419be3242e7b53def0a51566",
+    expectedSize: 64723779,
+    expectedChecksum: "963b46bce1a2f8ca5dfc504ab7b2c901",
   },
   storage: {
     version: "1.1.3",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Proposed fix for #5734.

Looks like the cause is the incorrect expectedSize and expectedChecksum [here](https://github.com/firebase/firebase-tools/blob/0d2acc5f8e17c8baf0126d2daf419285fa45e731/src/emulator/downloadableEmulators.ts#L37). `expectedSize` is 64723779 and `expectedChecksum` is 963b46bce1a2f8ca5dfc504ab7b2c901.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

1. Deleting the `.cache/firebase/emulators/cloud-firestore-emulator-v1.17.2.jar`. 
2. Run `firebase emulators:start --project demo-proj --only firestore` to re-install the emulator.
3. Firestore emulator is downloaded as intended.

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
