### PR TITLE
deploying --only hosting also deploys tagged functions

### DIFF
--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -10,11 +10,9 @@ import { track } from "../../track";
 import * as utils from "../../utils";
 import { HostingSource } from "../../firebaseConfig";
 import * as backend from "../functions/backend";
+import { ensureTargeted } from "../../functions/ensureTargeted";
 
-/**
- *  Prepare creates versions for each Hosting site to be deployed.
- */
-export async function prepare(context: Context, options: HostingOptions & Options): Promise<void> {
+function handlePublicDirectoryFlag(options: HostingOptions & Options): void {
   // Allow the public directory to be overridden by the --public flag
   if (options.public) {
     if (Array.isArray(options.config.get("hosting"))) {
@@ -23,6 +21,41 @@ export async function prepare(context: Context, options: HostingOptions & Option
 
     options.config.set("hosting.public", options.public);
   }
+}
+
+/**
+ * If there is a rewrite to a tagged function, add it to the deploy target.
+ */
+export async function addTaggedFunctionsToOnlyString(
+  context: Context,
+  options: HostingOptions & Options
+): Promise<boolean> {
+  // This must be called before modifying hosting config because we turn it from
+  // a scalar to an array now
+  handlePublicDirectoryFlag(options);
+
+  let addedFunctions = false;
+  for (const c of config.hostingConfig(options)) {
+    for (const r of c.rewrites || []) {
+      if (!("function" in r) || typeof r.function !== "object" || !r.function.pinTag) {
+        continue;
+      }
+
+      const existing = await backend.existingBackend(context);
+      const endpoint =
+        existing.endpoints[r.function.region || "us-central1"][r.function.functionId];
+      options.only = ensureTargeted(options.only, endpoint.codebase || "default", endpoint.id);
+      addedFunctions = true;
+    }
+  }
+  return addedFunctions;
+}
+
+/**
+ *  Prepare creates versions for each Hosting site to be deployed.
+ */
+export async function prepare(context: Context, options: HostingOptions & Options): Promise<void> {
+  handlePublicDirectoryFlag(options);
 
   const configs = config.hostingConfig(options);
   if (configs.length === 0) {

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -30,6 +30,10 @@ export async function addTaggedFunctionsToOnlyString(
   context: Context,
   options: HostingOptions & Options
 ): Promise<boolean> {
+  if (!options.only) {
+    return false;
+  }
+
   // This must be called before modifying hosting config because we turn it from
   // a scalar to an array now
   handlePublicDirectoryFlag(options);

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -78,11 +78,7 @@ export const deploy = async function (
     }
   }
 
-  if (
-    targetNames.includes("hosting") &&
-    !targetNames.includes("functions") &&
-    experiments.isEnabled("pintags")
-  ) {
+  if (targetNames.includes("hosting") && experiments.isEnabled("pintags")) {
     if (await addTaggedFunctionsToOnlyString(context, options)) {
       targetNames.unshift("functions");
     }

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -17,8 +17,6 @@ import * as RemoteConfigTarget from "./remoteconfig";
 import * as ExtensionsTarget from "./extensions";
 import { prepareFrameworks } from "../frameworks";
 import { HostingDeploy } from "./hosting/context";
-import { requirePermissions } from "../requirePermissions";
-import { TARGET_PERMISSIONS } from "../commands/deploy";
 import { addTaggedFunctionsToOnlyString } from "./hosting/prepare";
 
 const TARGETS = {

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -19,6 +19,7 @@ import { prepareFrameworks } from "../frameworks";
 import { HostingDeploy } from "./hosting/context";
 import { requirePermissions } from "../requirePermissions";
 import { TARGET_PERMISSIONS } from "../commands/deploy";
+import { addTaggedFunctionsToOnlyString } from "./hosting/prepare";
 
 const TARGETS = {
   hosting: HostingTarget,
@@ -74,6 +75,16 @@ export const deploy = async function (
         }
         await requirePermissions(TARGET_PERMISSIONS["functions"]);
       }
+    }
+  }
+
+  if (
+    targetNames.includes("hosting") &&
+    !targetNames.includes("functions") &&
+    experiments.isEnabled("pintags")
+  ) {
+    if (await addTaggedFunctionsToOnlyString(context, options)) {
+      targetNames.unshift("functions");
     }
   }
 

--- a/src/test/deploy/hosting/prepare.spec.ts
+++ b/src/test/deploy/hosting/prepare.spec.ts
@@ -9,13 +9,18 @@ import * as hostingApi from "../../../hosting/api";
 import * as tracking from "../../../track";
 import * as deploymentTool from "../../../deploymentTool";
 import * as config from "../../../hosting/config";
-import { prepare, unsafePins } from "../../../deploy/hosting/prepare";
+import {
+  addTaggedFunctionsToOnlyString,
+  prepare,
+  unsafePins,
+} from "../../../deploy/hosting/prepare";
 import { cloneDeep } from "../../../utils";
 import * as backend from "../../../deploy/functions/backend";
 
 describe("hosting prepare", () => {
   let hostingStub: sinon.SinonStubbedInstance<typeof hostingApi>;
   let trackingStub: sinon.SinonStubbedInstance<typeof tracking>;
+  let backendStub: sinon.SinonStubbedInstance<typeof backend>;
   let siteConfig: config.HostingResolved;
   let firebaseJson: FirebaseConfig;
   let options: HostingOptions & Options;
@@ -23,12 +28,22 @@ describe("hosting prepare", () => {
   beforeEach(() => {
     hostingStub = sinon.stub(hostingApi);
     trackingStub = sinon.stub(tracking);
+    backendStub = sinon.stub(backend);
 
     // We're intentionally using pointer references so that editing site
     // edits the results of hostingConfig() and changes firebase.json
     siteConfig = {
       site: "site",
       public: ".",
+      rewrites: [
+        {
+          glob: "**",
+          function: {
+            functionId: "function",
+            pinTag: true,
+          },
+        },
+      ],
     };
     firebaseJson = {
       hosting: siteConfig,
@@ -36,7 +51,7 @@ describe("hosting prepare", () => {
     options = {
       cwd: ".",
       configPath: ".",
-      only: "",
+      only: "hosting",
       except: "",
       filteredTargets: ["HOSTING"],
       force: false,
@@ -153,10 +168,7 @@ describe("hosting prepare", () => {
       ],
     };
 
-    let backendStub: sinon.SinonStubbedInstance<typeof backend>;
-
     beforeEach(() => {
-      backendStub = sinon.stub(backend);
       backendStub.existingBackend.resolves({
         endpoints: {
           "us-central1": {
@@ -231,6 +243,54 @@ describe("hosting prepare", () => {
       await expect(
         unsafePins({ projectId: "project", hostingChannel: "test" }, configWithFuncPin)
       ).to.eventually.deep.equal(["**"]);
+    });
+  });
+
+  describe("addTaggedFunctionsToOnlyString", () => {
+    it("adds functions to deploy targets w/ codebases", async () => {
+      backendStub.existingBackend.resolves({
+        endpoints: {
+          "us-central1": {
+            function: {
+              id: "function",
+              runServiceId: "service",
+              codebase: "backend",
+            } as unknown as backend.Endpoint,
+          },
+        },
+        requiredAPIs: [],
+        environmentVariables: {},
+      });
+
+      await expect(addTaggedFunctionsToOnlyString({} as any, options)).to.eventually.be.true;
+      expect(options.only).to.equal("hosting,functions:backend:function");
+    });
+
+    it("adds functions to deploy targets w/o codebases", async () => {
+      backendStub.existingBackend.resolves({
+        endpoints: {
+          "us-central1": {
+            function: {
+              id: "function",
+              runServiceId: "service",
+            } as unknown as backend.Endpoint,
+          },
+        },
+        requiredAPIs: [],
+        environmentVariables: {},
+      });
+
+      await expect(addTaggedFunctionsToOnlyString({} as any, options)).to.eventually.be.true;
+      expect(options.only).to.equal("hosting,functions:default:function");
+    });
+
+    it("doesn't add untagged functions", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      delete (siteConfig as any).rewrites[0].function.pinTag;
+
+      await expect(addTaggedFunctionsToOnlyString({} as any, options)).to.eventually.be.false;
+      expect(options.only).to.equal("hosting");
+      expect(backendStub.existingBackend).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
DO NOT MERGE UNTIL API COUNCIL GIVES THE LGTM IN THE DISCUSSION THREAD

Surgical implementation to add any functions specifically tagged to the deploy targets even when --only hosting is specified.

Tested manually in addition to using unit tests