### PR TITLE
Fix tag pinning for run servcies and functions with different svc ids

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -357,6 +357,7 @@ export class Fabricator {
 
     endpoint.uri = resultFunction.serviceConfig?.uri;
     const serviceName = resultFunction.serviceConfig?.service;
+    endpoint.runServiceId = utils.last(serviceName?.split("/"));
     if (!serviceName) {
       logger.debug("Result function unexpectedly didn't have a service name.");
       utils.logLabeledWarning(
@@ -473,6 +474,7 @@ export class Fabricator {
 
     endpoint.uri = resultFunction.serviceConfig?.uri;
     const serviceName = resultFunction.serviceConfig?.service;
+    endpoint.runServiceId = utils.last(serviceName?.split("/"));
     if (!serviceName) {
       logger.debug("Result function unexpectedly didn't have a service name.");
       utils.logLabeledWarning(

--- a/src/deploy/hosting/convertConfig.ts
+++ b/src/deploy/hosting/convertConfig.ts
@@ -235,12 +235,13 @@ export async function convertConfig(
       const apiRewrite: api.Rewrite = {
         ...target,
         run: {
-          region: "us-central1",
-          ...rewrite.run,
+          serviceId: rewrite.run.serviceId,
+          region: rewrite.run.region || "us-central1",
         },
       };
-      if (apiRewrite.run.tag) {
+      if (rewrite.run.pinTag) {
         experiments.assertEnabled("pintags", "pin to a run service revision");
+        apiRewrite.run.tag = runTags.TODO_TAG_NAME;
       }
       return apiRewrite;
     }

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -9,6 +9,7 @@ import * as api from "../../../hosting/api";
 import { FirebaseError } from "../../../error";
 import { Payload } from "../../../deploy/functions/args";
 import * as runTags from "../../../hosting/runTags";
+import * as experiments from "../../../experiments";
 
 const FUNCTION_ID = "functionId";
 const SERVICE_ID = "function-id";
@@ -46,6 +47,16 @@ function endpoint(opts?: Partial<backend.Endpoint>): backend.Endpoint {
 
 describe("convertConfig", () => {
   let setRewriteTagsStub: sinon.SinonStub;
+
+  let wasPinTagsEnabled: boolean;
+  before(() => {
+    wasPinTagsEnabled = experiments.isEnabled("pintags");
+    experiments.setEnabled("pintags", true);
+  });
+
+  after(() => {
+    experiments.setEnabled("pintags", wasPinTagsEnabled);
+  });
 
   beforeEach(() => {
     setRewriteTagsStub = sinon.stub(runTags, "setRewriteTags");

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -8,6 +8,7 @@ import { HostingSingle } from "../../../firebaseConfig";
 import * as api from "../../../hosting/api";
 import { FirebaseError } from "../../../error";
 import { Payload } from "../../../deploy/functions/args";
+import * as runTags from "../../../hosting/runTags";
 
 const FUNCTION_ID = "functionId";
 const SERVICE_ID = "function-id";
@@ -44,6 +45,17 @@ function endpoint(opts?: Partial<backend.Endpoint>): backend.Endpoint {
 }
 
 describe("convertConfig", () => {
+  let setRewriteTagsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    setRewriteTagsStub = sinon.stub(runTags, "setRewriteTags");
+    setRewriteTagsStub.resolves();
+  });
+
+  afterEach(() => {
+    setRewriteTagsStub.restore();
+  });
+
   const tests: Array<{
     name: string;
     input: HostingSingle;
@@ -406,6 +418,41 @@ describe("convertConfig", () => {
       name: "returns i18n as it is set",
       input: { i18n: { root: "bar" } },
       want: { i18n: { root: "bar" } },
+    },
+    // Tag pinning.
+    {
+      name: "rewrites v2 functions tags",
+      input: { rewrites: [{ glob: "**", function: { functionId: FUNCTION_ID, pinTag: true } }] },
+      want: {
+        rewrites: [
+          {
+            glob: "**",
+            run: { serviceId: SERVICE_ID, region: REGION, tag: runTags.TODO_TAG_NAME },
+          },
+        ],
+      },
+      existingBackend: backend.of({
+        id: FUNCTION_ID,
+        project: PROJECT_ID,
+        entryPoint: FUNCTION_ID,
+        runtime: "nodejs16",
+        region: REGION,
+        platform: "gcfv2",
+        httpsTrigger: {},
+        runServiceId: SERVICE_ID,
+      }),
+    },
+    {
+      name: "rewrites run tags",
+      input: { rewrites: [{ glob: "**", run: { serviceId: SERVICE_ID, pinTag: true } }] },
+      want: {
+        rewrites: [
+          {
+            glob: "**",
+            run: { serviceId: SERVICE_ID, region: "us-central1", tag: runTags.TODO_TAG_NAME },
+          },
+        ],
+      },
     },
   ];
 


### PR DESCRIPTION
Fixes two bugs that @jamesdaniels found:

1. We were not setting pin tags for Run services correctly (I could have sworn this was working so I'm confused...)
2. We weren't updating function.runServiceId on create which caused the pin tag to target the wrong service ID