### PR TITLE
Bump firestore emulator version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes a bug preventing local extension instances from being updated to uploaded versions.
+- Releases firestore emulator version 1.17.3

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -33,9 +33,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "311609538bd65666eb724ef47c2e6466",
   },
   firestore: {
-    version: "1.17.2",
-    expectedSize: 64907894,
-    expectedChecksum: "bc56ccf2419be3242e7b53def0a51566",
+    version: "1.17.3",
+    expectedSize: 64970588,
+    expectedChecksum: "75beb285dc404176b974fec9e3032712",
   },
   storage: {
     version: "1.1.3",


### PR DESCRIPTION
Releases version `1.17.3` of firestore