### PR TITLE
Bump Firestore emulator up to 1.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Upgrade Firestore emulator to 1.17.4

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -33,9 +33,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "311609538bd65666eb724ef47c2e6466",
   },
   firestore: {
-    version: "1.17.3",
-    expectedSize: 64970588,
-    expectedChecksum: "75beb285dc404176b974fec9e3032712",
+    version: "1.17.4",
+    expectedSize: 64969580,
+    expectedChecksum: "9d580b58e55e57b0cdc3ca8888098d43",
   },
   storage: {
     version: "1.1.3",


### PR DESCRIPTION
Upgrade Firestore emulator to 1.17.4


This is is effectively a no-op update and the difference is just the newer version of the base CL.