### PR TITLE
Handle permissions for pinTags and the Github Action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added more helpful error messages for the Firebase Hosting GitHub Action (#5749)

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -60,7 +60,7 @@ export const deploy = async function (
   if (targetNames.includes("hosting")) {
     const config = options.config.get("hosting");
     if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
-      experiments.assertEnabled("webframeworks", "deploy a web framework to hosting");
+      experiments.assertEnabled("webframeworks", "deploy a web framework from source");
       await prepareFrameworks(targetNames, context, options);
     }
   }

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -17,8 +17,6 @@ import * as RemoteConfigTarget from "./remoteconfig";
 import * as ExtensionsTarget from "./extensions";
 import { prepareFrameworks } from "../frameworks";
 import { HostingDeploy } from "./hosting/context";
-import { requirePermissions } from "../requirePermissions";
-import { TARGET_PERMISSIONS } from "../commands/deploy";
 
 const TARGETS = {
   hosting: HostingTarget,
@@ -63,17 +61,7 @@ export const deploy = async function (
     const config = options.config.get("hosting");
     if (Array.isArray(config) ? config.some((it) => it.source) : config.source) {
       experiments.assertEnabled("webframeworks", "deploy a web framework to hosting");
-      const usedToTargetFunctions = targetNames.includes("functions");
       await prepareFrameworks(targetNames, context, options);
-      const nowTargetsFunctions = targetNames.includes("functions");
-      if (nowTargetsFunctions && !usedToTargetFunctions) {
-        if (context.hostingChannel && !experiments.isEnabled("pintags")) {
-          throw new FirebaseError(
-            "Web frameworks with dynamic content do not yet support deploying to preview channels"
-          );
-        }
-        await requirePermissions(TARGET_PERMISSIONS["functions"]);
-      }
     }
   }
 

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -198,21 +198,24 @@ export function assertEnabled(name: ExperimentName, task: string): void {
         throw new FirebaseError(
           `Cannot ${task} because the experiment ${bold(name)} is not enabled. To enable add ${bold(
             name
-          )} to your ${bold("FIREBASE_CLI_EXPERIMENTS")} environment variable like so: ${italic(
-            `FIREBASE_CLI_EXPERIMENTS: ${process.env.FIREBASE_CLI_EXPERIMENTS},${name}`
-          )}`);
+          )} to your ${bold("FIREBASE_CLI_EXPERIMENTS")} environment variable like so: ${italic(`
+  FIREBASE_CLI_EXPERIMENTS: ${process.env.FIREBASE_CLI_EXPERIMENTS},${name}`)}`
+        );
       } else {
         throw new FirebaseError(
           `Cannot ${task} because the experiment ${bold(name)} is not enabled. To enable ${bold(
             name
-          )} add a ${bold("FIREBASE_CLI_EXPERIMENTS")} environment variable to your action's yml, like so: ${italic(`
+          )} add a ${bold(
+            "FIREBASE_CLI_EXPERIMENTS"
+          )} environment variable to your action's yml, like so: ${italic(`
 
   - uses: FirebaseExtended/action-hosting-deploy@v0
     with:
       ...
     env:
       FIREBASE_CLI_EXPERIMENTS: ${name}
-`)}`);
+`)}`
+        );
       }
     } else {
       throw new FirebaseError(

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -1,5 +1,6 @@
 import { bold, italic } from "colorette";
 import * as leven from "leven";
+import { basename } from "path";
 
 import { configstore } from "./configstore";
 import { FirebaseError } from "./error";
@@ -193,43 +194,26 @@ export function enableExperimentsFromCliEnvVariable(): void {
  */
 export function assertEnabled(name: ExperimentName, task: string): void {
   if (!isEnabled(name)) {
+    const prefix = `Cannot ${task} because the experiment ${bold(name)} is not enabled.`;
     if (isRunningInGithubAction()) {
-      if (process.env.FIREBASE_CLI_EXPERIMENTS) {
-        throw new FirebaseError(
-          `Cannot ${task} because the experiment ${bold(name)} is not enabled. To enable add ${bold(
-            name
-          )} to your ${bold(
-            "FIREBASE_CLI_EXPERIMENTS"
-          )} environment variable to your action's yml, like so: ${italic(`
+      const path = process.env.GITHUB_WORKFLOW_REF?.split("@")[0];
+      const filename = path ? `.github/workflows/${basename(path)}` : "your action's yml";
+      const newValue = [process.env.FIREBASE_CLI_EXPERIMENTS, name].filter((it) => !!it).join(",");
+      throw new FirebaseError(
+        `${prefix} To enable add a ${bold(
+          "FIREBASE_CLI_EXPERIMENTS"
+        )} environment variable to ${filename}, like so: ${italic(`
 
-  - uses: FirebaseExtended/action-hosting-deploy@v0
-    with:
-      ...
-    env:
-      FIREBASE_CLI_EXPERIMENTS: ${process.env.FIREBASE_CLI_EXPERIMENTS},${name}
+- uses: FirebaseExtended/action-hosting-deploy@v0
+  with:
+    ...
+  env:
+    FIREBASE_CLI_EXPERIMENTS: ${newValue}
 `)}`
-        );
-      } else {
-        throw new FirebaseError(
-          `Cannot ${task} because the experiment ${bold(name)} is not enabled. To enable ${bold(
-            name
-          )} add a ${bold(
-            "FIREBASE_CLI_EXPERIMENTS"
-          )} environment variable to your action's yml, like so: ${italic(`
-
-  - uses: FirebaseExtended/action-hosting-deploy@v0
-    with:
-      ...
-    env:
-      FIREBASE_CLI_EXPERIMENTS: ${name}
-`)}`
-        );
-      }
+      );
     } else {
       throw new FirebaseError(
-        `Cannot ${task} because the experiment ${bold(name)} is not enabled. To enable ${bold(
-          name
-        )} run ${bold(`firebase experiments:enable ${name}`)}`
+        `${prefix} To enable ${bold(name)} run ${bold(`firebase experiments:enable ${name}`)}`
       );
     }
   }

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -198,8 +198,16 @@ export function assertEnabled(name: ExperimentName, task: string): void {
         throw new FirebaseError(
           `Cannot ${task} because the experiment ${bold(name)} is not enabled. To enable add ${bold(
             name
-          )} to your ${bold("FIREBASE_CLI_EXPERIMENTS")} environment variable like so: ${italic(`
-  FIREBASE_CLI_EXPERIMENTS: ${process.env.FIREBASE_CLI_EXPERIMENTS},${name}`)}`
+          )} to your ${bold(
+            "FIREBASE_CLI_EXPERIMENTS"
+          )} environment variable to your action's yml, like so: ${italic(`
+
+  - uses: FirebaseExtended/action-hosting-deploy@v0
+    with:
+      ...
+    env:
+      FIREBASE_CLI_EXPERIMENTS: ${process.env.FIREBASE_CLI_EXPERIMENTS},${name}
+`)}`
         );
       } else {
         throw new FirebaseError(

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -24,7 +24,6 @@ import { formatHost } from "../emulator/functionsEmulatorShared";
 import { Constants } from "../emulator/constants";
 import { FirebaseError } from "../error";
 import { requireHostingSite } from "../requireHostingSite";
-import { HostingRewrites } from "../firebaseConfig";
 import * as experiments from "../experiments";
 import { ensureTargeted } from "../functions/ensureTargeted";
 import { implicitInit } from "../hosting/implicitInit";
@@ -479,16 +478,21 @@ export async function prepareFrameworks(
         process.env.__FIREBASE_DEFAULTS__ = JSON.stringify(firebaseDefaults);
       }
 
-      const rewrite: HostingRewrites = {
+      if (context.hostingChannel) {
+        experiments.assertEnabled(
+          "pintags",
+          "deploy an app that requires a backend to a preview channel"
+        );
+      }
+
+      config.rewrites.push({
         source: "**",
         function: {
           functionId,
+          region: ssrRegion,
+          pinTag: experiments.isEnabled("pintags"),
         },
-      };
-      if (experiments.isEnabled("pintags")) {
-        rewrite.function.pinTag = true;
-      }
-      config.rewrites.push(rewrite);
+      });
 
       const codebase = `firebase-frameworks-${site}`;
       const existingFunctionsConfig = options.config.get("functions")

--- a/src/gcp/resourceManager.ts
+++ b/src/gcp/resourceManager.ts
@@ -11,6 +11,7 @@ const apiClient = new Client({ urlPrefix: resourceManagerOrigin, apiVersion: API
 export const firebaseRoles = {
   apiKeysViewer: "roles/serviceusage.apiKeysViewer",
   authAdmin: "roles/firebaseauth.admin",
+  functionsDeveloper: "roles/cloudfunctions.developer",
   hostingAdmin: "roles/firebasehosting.admin",
   runViewer: "roles/run.viewer",
 };

--- a/src/hosting/config.ts
+++ b/src/hosting/config.ts
@@ -18,7 +18,6 @@ import { dirExistsSync } from "../fsutils";
 import { resolveProjectPath } from "../projectPath";
 import { HostingOptions } from "./options";
 import * as path from "node:path";
-import * as experiments from "../experiments";
 import { logger } from "../logger";
 
 // After validating a HostingMultiple and resolving targets, we will instead

--- a/src/hosting/config.ts
+++ b/src/hosting/config.ts
@@ -159,20 +159,17 @@ function validateOne(config: HostingMultiple[number], options: HostingOptions): 
   if (config.source && config.public) {
     throw new FirebaseError('Can only specify "source" or "public" in a Hosting config, not both');
   }
-  const root = experiments.isEnabled("webframeworks")
-    ? config.source || config.public
-    : config.public;
-  const orSource = experiments.isEnabled("webframeworks") ? ' or "source"' : "";
+  const root = config.source || config.public;
 
   if (!root && hasAnyStaticRewrites) {
     throw new FirebaseError(
-      `Must supply a "public"${orSource} directory when using "destination" rewrites.`
+      `Must supply a "public" or "source" directory when using "destination" rewrites.`
     );
   }
 
   if (!root && !hasAnyDynamicRewrites && !hasAnyRedirects) {
     throw new FirebaseError(
-      `Must supply a "public"${orSource} directory or at least one rewrite or redirect in each "hosting" config.`
+      `Must supply a "public" or "source" directory or at least one rewrite or redirect in each "hosting" config.`
     );
   }
 
@@ -199,7 +196,7 @@ function validateOne(config: HostingMultiple[number], options: HostingOptions): 
   if (config.i18n) {
     if (!root) {
       throw new FirebaseError(
-        `Must supply a "public"${orSource} directory when using "i18n" configuration.`
+        `Must supply a "public" or "source" directory when using "i18n" configuration.`
       );
     }
 

--- a/src/init/features/hosting/github.ts
+++ b/src/init/features/hosting/github.ts
@@ -571,7 +571,7 @@ async function createServiceAccountAndKey(
     await createServiceAccount(
       options.projectId,
       accountId,
-      `A service account with permission to deploy to Firebase Hosting for the GitHub repository ${repo}`,
+      `A service account with permission to deploy to Firebase Hosting and Cloud Functions for the GitHub repository ${repo}`,
       `GitHub Actions (${repo})`
     );
   } catch (e: any) {
@@ -595,6 +595,9 @@ async function createServiceAccountAndKey(
 
     // Required for projects that use Hosting rewrites to Cloud Run
     firebaseRoles.runViewer,
+
+    // Required for previewing backends (Web Frameworks and pinTags)
+    firebaseRoles.functionsDeveloper,
   ];
   await addServiceAccountToRoles(options.projectId, accountId, requiredRoles);
 

--- a/src/init/features/hosting/github.ts
+++ b/src/init/features/hosting/github.ts
@@ -636,3 +636,7 @@ async function encryptServiceAccountJSON(serviceAccountJSON: string, key: string
   // Base64 the encrypted secret
   return Buffer.from(encryptedBytes).toString("base64");
 }
+
+export function isRunningInGithubAction() {
+  return process.env.GITHUB_ACTION_REPOSITORY === HOSTING_GITHUB_ACTION_NAME.split("@")[0];
+}

--- a/src/test/hosting/config.spec.ts
+++ b/src/test/hosting/config.spec.ts
@@ -319,7 +319,7 @@ describe("config", () => {
     });
   });
 
-  const PUBLIC_DIR_ERROR_PREFIX = /Must supply a "public" directory/;
+  const PUBLIC_DIR_ERROR_PREFIX = /Must supply a "public" or "source" directory/;
   describe("validate", () => {
     const tests: Array<{
       desc: string;


### PR DESCRIPTION
Now that we have preview channel support for backends we need to:

* Add the Cloud Function permission for the Github Action
* Catch the missing permission if functions are being deployed & fire off an appropriate error
* Add instructions to enable experiments in Github Actions

Further the checking of the webframeworks experiment in the hosting validation routine was leading to an unhelpful error message: `Error: Must supply a "public" directory or at least one rewrite or redirect in each "hosting" config.` when the experiment is not enabled.

New error messages (on Github Actions):

```
Error: Cannot deploy a web framework from source because the experiment webframeworks is not enabled. To enable webframeworks add a FIREBASE_CLI_EXPERIMENTS environment variable to .github/workflows/my-workflow.yml, like so: 

  - uses: FirebaseExtended/action-hosting-deploy@v0
    with:
      ...
    env:
      FIREBASE_CLI_EXPERIMENTS: webframeworks
```

```
Error: Cannot deploy an app that requires a backend to a preview channel because the experiment pintags is not enabled. To enable add a FIREBASE_CLI_EXPERIMENTS environment variable to .github/workflows/my-workflow.yml, like so: 

- uses: FirebaseExtended/action-hosting-deploy@v0
  with:
    ...
  env:
    FIREBASE_CLI_EXPERIMENTS: webframeworks,pintags
```

```
Please reinstall the Github Action with `firebase init hosting:github` to grant this project the required permissions to deploy Cloud Functions.
```