### PR TITLE
Add only to channel deploys to pull in pinned functions

### DIFF
--- a/src/commands/hosting-channel-deploy.ts
+++ b/src/commands/hosting-channel-deploy.ts
@@ -86,6 +86,12 @@ export const command = new Command("hosting:channel:deploy [channelId]")
           .split(",")
           .map((o: string) => `hosting:${o}`)
           .join(",");
+      } else {
+        // N.B. The hosting deploy code uses the only string to add all (and only)
+        // functions that are pinned to the only string. If we didn't set the
+        // only string here and only used the hosting deploy targets, we'd only
+        // be able to deploy *all* functions.
+        options.only = "hosting";
       }
 
       const sites: ChannelInfo[] = hostingConfig(options).map((config) => {


### PR DESCRIPTION
The code to pull in pinned functions relies on modifying `options.only`. Previous attempts might try to not update "only" but this would cause _all_ functions to be deployed, not just pinned ones. We _need_ an only, and it needs to also include "hosting" or the hosting deploys would break. To fix this, we always have an only value in hosting channel deploys.