### PR TITLE
Adding app dev TOS acceptance, and cleaning up out of date warnings

### DIFF
--- a/src/commands/ext-configure.ts
+++ b/src/commands/ext-configure.ts
@@ -23,6 +23,7 @@ import { Options } from "../options";
 import { partition } from "../functional";
 import { buildBindingOptionsWithBaseValue } from "../extensions/paramHelper";
 import * as askUserForEventsConfig from "../extensions/askUserForEventsConfig";
+import { displayDeveloperTOSWarning } from "../extensions/tos";
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -113,7 +114,6 @@ export const command = new Command("ext:configure <extensionInstanceId>")
       ...buildBindingOptionsWithBaseValue(oldParamValues),
       ...mutableParamsBindingOptions,
     };
-
     await manifest.writeToManifest(
       [
         {
@@ -130,7 +130,7 @@ export const command = new Command("ext:configure <extensionInstanceId>")
         force: true, // Skip asking for permission again
       }
     );
-    manifest.showPostDeprecationNotice();
+    displayDeveloperTOSWarning();
     return;
   });
 

--- a/src/commands/ext-install.ts
+++ b/src/commands/ext-install.ts
@@ -12,7 +12,6 @@ import * as extensionsApi from "../extensions/extensionsApi";
 import { ExtensionVersion, ExtensionSource } from "../extensions/types";
 import * as refs from "../extensions/refs";
 import * as secretsUtils from "../extensions/secretsUtils";
-import { displayWarningPrompts } from "../extensions/warnings";
 import * as paramHelper from "../extensions/paramHelper";
 import {
   createSourceFromLocation,
@@ -32,6 +31,7 @@ import { track } from "../track";
 import { confirm } from "../prompt";
 import { Options } from "../options";
 import * as manifest from "../extensions/manifest";
+import { displayDeveloperTOSWarning } from "../extensions/tos";
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -163,7 +163,6 @@ async function infoExtensionVersion(args: {
 }): Promise<void> {
   const ref = refs.parse(args.extensionName);
   await displayExtInfo(args.extensionName, ref.publisherId, args.extensionVersion.spec, true);
-  await displayWarningPrompts(ref.publisherId, args.extensionVersion);
 }
 
 interface InstallExtensionOptions {
@@ -239,5 +238,5 @@ async function installToManifest(options: InstallExtensionOptions): Promise<void
     config,
     { nonInteractive, force: force ?? false }
   );
-  manifest.showPostDeprecationNotice();
+  displayDeveloperTOSWarning();
 }

--- a/src/commands/ext-uninstall.ts
+++ b/src/commands/ext-uninstall.ts
@@ -34,5 +34,4 @@ export const command = new Command("ext:uninstall <extensionInstanceId>")
     }
     const config = manifest.loadConfig(options);
     manifest.removeFromManifest(instanceId, config);
-    manifest.showPostDeprecationNotice();
   });

--- a/src/commands/ext-update.ts
+++ b/src/commands/ext-update.ts
@@ -25,6 +25,7 @@ import { confirm } from "../prompt";
 import * as manifest from "../extensions/manifest";
 import { Options } from "../options";
 import * as askUserForEventsConfig from "../extensions/askUserForEventsConfig";
+import { displayDeveloperTOSWarning } from "../extensions/tos";
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -84,7 +85,6 @@ export const command = new Command("ext:update <extensionInstanceId> [updateSour
       );
       return;
     }
-
     utils.logLabeledBullet(
       logPrefix,
       `Updating ${clc.bold(instanceId)} from version ${clc.bold(
@@ -151,6 +151,6 @@ export const command = new Command("ext:update <extensionInstanceId> [updateSour
         force: true, // Skip asking for permission again
       }
     );
-    manifest.showPostDeprecationNotice();
+    displayDeveloperTOSWarning();
     return;
   });

--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -14,6 +14,7 @@ import { checkSpecForSecrets } from "./secrets";
 import { displayWarningsForDeploy, outOfBandChangesWarning } from "../../extensions/warnings";
 import { detectEtagChanges } from "../../extensions/etags";
 import { checkSpecForV2Functions, ensureNecessaryV2ApisAndRoles } from "./v2FunctionHelper";
+import { acceptLatestAppDeveloperTOS } from "../../extensions/tos";
 
 export async function prepare(context: Context, options: Options, payload: Payload) {
   const projectId = needProjectId(options);
@@ -35,15 +36,8 @@ export async function prepare(context: Context, options: Options, payload: Paylo
   const etagsChanged = detectEtagChanges(options.rc, projectId, context.have);
   if (etagsChanged.length) {
     outOfBandChangesWarning(etagsChanged);
-    if (!options.force && options.nonInteractive) {
-      throw new FirebaseError(
-        "Pass the --force flag to overwrite out of band changes in non-interactive mode"
-      );
-    } else if (
-      !options.force &&
-      !options.nonInteractive &&
-      !(await prompt.promptOnce({
-        type: "confirm",
+    if (
+      !(await prompt.confirm({
         message: `Do you wish to continue deploying these extension instances?`,
         default: false,
       }))
@@ -70,15 +64,8 @@ export async function prepare(context: Context, options: Options, payload: Paylo
   payload.instancesToDelete = context.have.filter((i) => !context.want?.some(matchesInstanceId(i)));
 
   if (await displayWarningsForDeploy(payload.instancesToCreate)) {
-    if (!options.force && options.nonInteractive) {
-      throw new FirebaseError(
-        "Pass the --force flag to acknowledge these terms in non-interactive mode"
-      );
-    } else if (
-      !options.force &&
-      !options.nonInteractive &&
-      !(await prompt.promptOnce({
-        type: "confirm",
+    if (
+      !(await prompt.confirm({
         message: `Do you wish to continue deploying these extension instances?`,
         default: true,
       }))
@@ -103,13 +90,8 @@ export async function prepare(context: Context, options: Options, payload: Paylo
   }
   if (payload.instancesToDelete.length) {
     logger.info(deploymentSummary.deletesSummary(payload.instancesToDelete));
-    if (!options.force && options.nonInteractive) {
-      throw new FirebaseError("Pass the --force flag to use this command in non-interactive mode");
-    } else if (
-      !options.force &&
-      !options.nonInteractive &&
-      !(await prompt.promptOnce({
-        type: "confirm",
+    if (
+      !(await prompt.confirm({
         message: `Would you like to delete ${payload.instancesToDelete
           .map((i) => i.instanceId)
           .join(", ")}?`,
@@ -123,6 +105,11 @@ export async function prepare(context: Context, options: Options, payload: Paylo
   }
 
   await requirePermissions(options, permissionsNeeded);
+  await acceptLatestAppDeveloperTOS(
+    options,
+    projectId,
+    context.want.map((i) => i.instanceId)
+  );
 }
 const matchesInstanceId = (dep: planner.InstanceSpec) => (test: planner.InstanceSpec) => {
   return dep.instanceId === test.instanceId;

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -10,7 +10,7 @@ import { confirm, promptOnce } from "../prompt";
 import { readEnvFile } from "./paramHelper";
 import { FirebaseError } from "../error";
 import * as utils from "../utils";
-import { isLocalPath, logPrefix } from "./extensionsHelper";
+import { isLocalPath } from "./extensionsHelper";
 import { ParamType } from "./types";
 
 export const ENV_DIRECTORY = "extensions";
@@ -289,19 +289,4 @@ function readParamsFile(projectDir: string, fileName: string): Record<string, st
   const paramPath = path.join(projectDir, ENV_DIRECTORY, fileName);
   const params = readEnvFile(paramPath);
   return params;
-}
-
-/**
- * Show post deprecation notice about --local flag taking over current default bahaviors.
- */
-export function showPostDeprecationNotice() {
-  utils.logLabeledBullet(
-    logPrefix,
-    "The behavior of ext:install, ext:update, ext:configure, and ext:uninstall has changed in firebase-tools@11.0.0. " +
-      "Instead of deploying extensions directly, " +
-      "changes to extension instances will be written to firebase.json and ./extensions/*.env. " +
-      `Then ${clc.bold(
-        "firebase deploy (--only extensions)"
-      )} will deploy the changes to your Firebase project. See https://firebase.google.com/docs/extensions/manifest for more details.`
-  );
 }

--- a/src/extensions/resolveSource.ts
+++ b/src/extensions/resolveSource.ts
@@ -1,4 +1,3 @@
-import { logger } from "../logger";
 import { Client } from "../apiv2";
 import { firebaseExtensionsRegistryOrigin } from "../api";
 
@@ -36,26 +35,4 @@ export async function getExtensionRegistry(
     return filteredExtensions;
   }
   return extensions;
-}
-
-/**
- * Fetches a list all publishers that appear in the v1 registry.
- */
-export async function getTrustedPublishers(): Promise<string[]> {
-  let registry: { [key: string]: RegistryEntry };
-  try {
-    registry = await getExtensionRegistry();
-  } catch (err: any) {
-    logger.debug(
-      "Couldn't get extensions registry, assuming no trusted publishers except Firebase."
-    );
-    return ["firebase"];
-  }
-  const publisherIds = new Set<string>();
-
-  // eslint-disable-next-line guard-for-in
-  for (const entry in registry) {
-    publisherIds.add(registry[entry].publisher);
-  }
-  return Array.from(publisherIds);
 }

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -117,6 +117,6 @@ export function displayDeveloperTOSWarning(): void {
   const tosLink = extensionsTosUrl("appdev");
   utils.logLabeledBullet(
     logPrefix,
-    `By installing an extension instance onto a Firebase project, you accept the Firebase Extensions Developer Terms of Service: ${tosLink}`,
+    `By installing an extension instance onto a Firebase project, you accept the Firebase Extensions Developer Terms of Service: ${tosLink}`
   );
 }

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -98,11 +98,11 @@ export async function acceptLatestAppDeveloperTOS(
   displayDeveloperTOSWarning();
   const currentAcceptance = await getAppDeveloperTOSStatus(projectId);
   if (currentAcceptance.lastAcceptedVersion) {
-    logger.debug(`Developer Terms of Service aready accepted on project ${projectId}.`);
+    logger.debug(`User Terms of Service aready accepted on project ${projectId}.`);
   } else if (
     !(await confirm({
       ...options,
-      message: "Do you accept the Firebase Extensions Developer Terms of Service?",
+      message: "Do you accept the Firebase Extensions User Terms of Service?",
     }))
   ) {
     throw new FirebaseError("You must accept the terms of service to continue.");
@@ -114,9 +114,9 @@ export async function acceptLatestAppDeveloperTOS(
 }
 
 export function displayDeveloperTOSWarning(): void {
-  const tosLink = extensionsTosUrl("appdev");
+  const tosLink = extensionsTosUrl("user");
   utils.logLabeledBullet(
     logPrefix,
-    `By installing an extension instance onto a Firebase project, you accept the Firebase Extensions Developer Terms of Service: ${tosLink}`
+    `By installing an extension instance onto a Firebase project, you accept the Firebase Extensions User Terms of Service: ${tosLink}`
   );
 }

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -27,6 +27,12 @@ export interface Extension {
   repoUri?: string;
 }
 
+export interface Listing {
+  state: ListingState;
+}
+
+export type ListingState = "STATE_UPSPECIFIED" | "UNLISTED" | "PENDING" | "APPROVED" | "REJECTED";
+
 export interface ExtensionVersion {
   name: string;
   ref: string;
@@ -34,10 +40,12 @@ export interface ExtensionVersion {
   spec: ExtensionSpec;
   hash: string;
   sourceDownloadUri: string;
+  buildSourceUri?: string;
   releaseNotes?: string;
   createTime?: string;
   deprecationMessage?: string;
   extensionRoot?: string;
+  listing?: Listing;
 }
 
 export interface PublisherProfile {

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -1,57 +1,19 @@
-import { marked } from "marked";
 import * as clc from "colorette";
+import * as TerminalRenderer from "marked-terminal";
+import { marked } from "marked";
+marked.setOptions({
+  renderer: new TerminalRenderer(),
+});
 
-import { ExtensionVersion } from "./types";
-import { printSourceDownloadLink } from "./displayExtensionInfo";
 import { logPrefix } from "./extensionsHelper";
-import { getTrustedPublishers } from "./resolveSource";
 import { humanReadable } from "../deploy/extensions/deploymentSummary";
-import { InstanceSpec, getExtension } from "../deploy/extensions/planner";
-import * as utils from "../utils";
+import { InstanceSpec, getExtensionVersion } from "../deploy/extensions/planner";
 import { logger } from "../logger";
-
-interface displayEAPWarningParameters {
-  publisherId: string;
-  sourceDownloadUri: string;
-  githubLink?: string;
-}
-
-function displayEAPWarning({
-  publisherId,
-  sourceDownloadUri,
-  githubLink,
-}: displayEAPWarningParameters): void {
-  const publisherNameLink = githubLink ? `[${publisherId}](${githubLink})` : publisherId;
-  const warningMsg = `This extension is in preview and is built by a developer in the [Extensions Publisher Early Access Program](http://bit.ly/firex-provider). Its functionality might change in backward-incompatible ways. Since this extension isn't built by Firebase, reach out to ${publisherNameLink} with questions about this extension.`;
-  const legalMsg =
-    "\n\nIt is provided “AS IS”, without any warranty, express or implied, from Google. Google disclaims all liability for any damages, direct or indirect, resulting from the use of the extension, and its functionality might change in backward - incompatible ways.";
-  utils.logLabeledBullet(logPrefix, marked(warningMsg + legalMsg));
-  printSourceDownloadLink(sourceDownloadUri);
-}
-
-/**
- * Show warning if extension is experimental or developed by 3P.
- */
-export async function displayWarningPrompts(
-  publisherId: string,
-  extensionVersion: ExtensionVersion
-): Promise<void> {
-  const trustedPublishers = await getTrustedPublishers();
-  if (!trustedPublishers.includes(publisherId)) {
-    displayEAPWarning({
-      publisherId,
-      sourceDownloadUri: extensionVersion.sourceDownloadUri,
-      githubLink: extensionVersion.spec.sourceUrl,
-    });
-  } else {
-    // Otherwise, this is an official extension and requires no warning prompts.
-    return;
-  }
-}
+import * as utils from "../utils";
 
 const toListEntry = (i: InstanceSpec) => {
   const idAndRef = humanReadable(i);
-  const sourceCodeLink = `\n\t[Source Code](${i.extensionVersion?.sourceDownloadUri})`;
+  const sourceCodeLink = `\n\t[Source Code](${i.extensionVersion?.buildSourceUri ?? i.extensionVersion?.sourceDownloadUri})`;
   const githubLink = i.extensionVersion?.spec?.sourceUrl
     ? `\n\t[Publisher Contact](${i.extensionVersion?.spec.sourceUrl})`
     : "";
@@ -64,29 +26,25 @@ const toListEntry = (i: InstanceSpec) => {
  * @param instancesToCreate A list of instances that will be created in this deploy
  */
 export async function displayWarningsForDeploy(instancesToCreate: InstanceSpec[]) {
-  const trustedPublishers = await getTrustedPublishers();
-  const publishedExtensionInstances = instancesToCreate.filter((i) => i.ref);
-  for (const i of publishedExtensionInstances) {
-    await getExtension(i);
+  const uploadedExtensionInstances = instancesToCreate.filter((i) => i.ref);
+  for (const i of uploadedExtensionInstances) {
+    await getExtensionVersion(i);
   }
+  const unpublishedExtensions = uploadedExtensionInstances.filter((i) => i.extensionVersion?.listing?.state != "APPROVED");
 
-  const eapExtensions = publishedExtensionInstances.filter(
-    (i) => !trustedPublishers.includes(i.ref?.publisherId ?? "")
-  );
-
-  if (eapExtensions.length) {
-    const humanReadableList = eapExtensions.map(toListEntry).join("\n");
+  if (unpublishedExtensions.length) {
+    const humanReadableList = unpublishedExtensions.map(toListEntry).join("\n");
     utils.logLabeledBullet(
       logPrefix,
       marked(
-        `These extensions are in preview and are built by a developer in the Extensions Publisher Early Access Program (http://bit.ly/firex-provider). Their functionality might change in backwards-incompatible ways. Since these extensions aren't built by Firebase, reach out to their publisher with questions about them.` +
-          ` They are provided “AS IS”, without any warranty, express or implied, from Google.` +
-          ` Google disclaims all liability for any damages, direct or indirect, resulting from the use of these extensions\n${humanReadableList}`,
+        `The following extension versions have not been published to the Firebase Extensions Hub:\n${
+          humanReadableList
+        }\nUnpublished extensions may carry a higher risk of containing malicious or low quality code. It is provided “AS IS”, without any warranty, express or implied, from Google. Google disclaims all liability for any damages, direct or indirect, resulting from the use of the extension, and its functionality might change in backwards-incompatible ways.`,
         { gfm: false }
       )
     );
   }
-  return eapExtensions.length > 0;
+  return unpublishedExtensions.length > 0;
 }
 
 export function outOfBandChangesWarning(instanceIds: string[]) {

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -13,7 +13,9 @@ import * as utils from "../utils";
 
 const toListEntry = (i: InstanceSpec) => {
   const idAndRef = humanReadable(i);
-  const sourceCodeLink = `\n\t[Source Code](${i.extensionVersion?.buildSourceUri ?? i.extensionVersion?.sourceDownloadUri})`;
+  const sourceCodeLink = `\n\t[Source Code](${
+    i.extensionVersion?.buildSourceUri ?? i.extensionVersion?.sourceDownloadUri
+  })`;
   const githubLink = i.extensionVersion?.spec?.sourceUrl
     ? `\n\t[Publisher Contact](${i.extensionVersion?.spec.sourceUrl})`
     : "";
@@ -30,16 +32,16 @@ export async function displayWarningsForDeploy(instancesToCreate: InstanceSpec[]
   for (const i of uploadedExtensionInstances) {
     await getExtensionVersion(i);
   }
-  const unpublishedExtensions = uploadedExtensionInstances.filter((i) => i.extensionVersion?.listing?.state != "APPROVED");
+  const unpublishedExtensions = uploadedExtensionInstances.filter(
+    (i) => i.extensionVersion?.listing?.state !== "APPROVED"
+  );
 
   if (unpublishedExtensions.length) {
     const humanReadableList = unpublishedExtensions.map(toListEntry).join("\n");
     utils.logLabeledBullet(
       logPrefix,
       marked(
-        `The following extension versions have not been published to the Firebase Extensions Hub:\n${
-          humanReadableList
-        }\nUnpublished extensions may carry a higher risk of containing malicious or low quality code. It is provided “AS IS”, without any warranty, express or implied, from Google. Google disclaims all liability for any damages, direct or indirect, resulting from the use of the extension, and its functionality might change in backwards-incompatible ways.`,
+        `The following extension versions have not been published to the Firebase Extensions Hub:\n${humanReadableList}\nUnpublished extensions may carry a higher risk of containing malicious or low quality code. It is provided “AS IS”, without any warranty, express or implied, from Google. Google disclaims all liability for any damages, direct or indirect, resulting from the use of the extension, and its functionality might change in backwards-incompatible ways.`,
         { gfm: false }
       )
     );

--- a/src/test/extensions/tos.spec.ts
+++ b/src/test/extensions/tos.spec.ts
@@ -87,28 +87,56 @@ describe("tos", () => {
           nonInteractive: true,
           force: true,
         },
-        testProjectId
+        testProjectId,
+        ["my-instance"]
       );
 
-      expect(appDevTos).to.deep.equal(t);
+      expect(appDevTos).to.deep.equal([t]);
       expect(nock.isDone()).to.be.true;
     });
-  });
 
-  it("should return the latest app dev TOS if it has already been accepted", async () => {
-    const t = testTOS("appdevtos", "1.1.0", "1.1.0");
-    nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
+    it("should not prompt for the latest app dev TOS if it has already been accepted", async () => {
+      const t = testTOS("appdevtos", "1.1.0", "1.1.0");
+      nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
+      nock(api.extensionsTOSOrigin)
+        .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+        .reply(200, t);
 
-    const appDevTos = await tos.acceptLatestAppDeveloperTOS(
-      {
-        nonInteractive: true,
-        force: true,
-      },
-      testProjectId
-    );
+      const appDevTos = await tos.acceptLatestAppDeveloperTOS(
+        {
+          nonInteractive: true,
+          force: true,
+        },
+        testProjectId,
+        ["my-instance"]
+      );
 
-    expect(appDevTos).to.deep.equal(t);
-    expect(nock.isDone()).to.be.true;
+      expect(appDevTos).to.deep.equal([t]);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should accept the TOS once per instance", async () => {
+      const t = testTOS("appdevtos", "1.1.0", "1.1.0");
+      nock(api.extensionsTOSOrigin).get(`/v1/projects/${testProjectId}/appdevtos`).reply(200, t);
+      nock(api.extensionsTOSOrigin)
+        .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+        .reply(200, t);
+      nock(api.extensionsTOSOrigin)
+      .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+      .reply(200, t);
+
+      const appDevTos = await tos.acceptLatestAppDeveloperTOS(
+        {
+          nonInteractive: true,
+          force: true,
+        },
+        testProjectId,
+        ["my-instance", "my-other-instance"]
+      );
+
+      expect(appDevTos).to.deep.equal([t, t]);
+      expect(nock.isDone()).to.be.true;
+    });
   });
 
   describe("acceptLatestPublisherTOS", () => {

--- a/src/test/extensions/tos.spec.ts
+++ b/src/test/extensions/tos.spec.ts
@@ -122,8 +122,8 @@ describe("tos", () => {
         .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
         .reply(200, t);
       nock(api.extensionsTOSOrigin)
-      .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
-      .reply(200, t);
+        .post(`/v1/projects/${testProjectId}/appdevtos:accept`)
+        .reply(200, t);
 
       const appDevTos = await tos.acceptLatestAppDeveloperTOS(
         {

--- a/src/test/extensions/warnings.spec.ts
+++ b/src/test/extensions/warnings.spec.ts
@@ -10,7 +10,7 @@ import {
   Visibility,
 } from "../../extensions/types";
 import { DeploymentInstanceSpec } from "../../deploy/extensions/planner";
-import { logger } from "../../logger";
+import * as utils from "../../utils";
 
 const testExtensionVersion = (listingState: ListingState): ExtensionVersion => {
   return {
@@ -66,7 +66,7 @@ describe("displayWarningsForDeploy", () => {
   let loggerStub: sinon.SinonStub;
 
   beforeEach(() => {
-    loggerStub = sinon.stub(logger, "warn");
+    loggerStub = sinon.stub(utils, "logLabeledBullet");
   });
 
   afterEach(() => {
@@ -95,7 +95,8 @@ describe("displayWarningsForDeploy", () => {
 
     expect(warned).to.be.true;
     expect(loggerStub).to.have.been.calledWithMatch(
-      "have not been published to the Firebase Extensions Hub"
+      "extensions",
+      "have not been published to the Firebase Extensions Hub",
     );
   });
 });

--- a/src/test/extensions/warnings.spec.ts
+++ b/src/test/extensions/warnings.spec.ts
@@ -96,7 +96,7 @@ describe("displayWarningsForDeploy", () => {
     expect(warned).to.be.true;
     expect(loggerStub).to.have.been.calledWithMatch(
       "extensions",
-      "have not been published to the Firebase Extensions Hub",
+      "have not been published to the Firebase Extensions Hub"
     );
   });
 });

--- a/src/test/extensions/warnings.spec.ts
+++ b/src/test/extensions/warnings.spec.ts
@@ -1,38 +1,43 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 
-import * as resolveSource from "../../extensions/resolveSource";
-import * as utils from "../../utils";
 import * as warnings from "../../extensions/warnings";
 import {
   Extension,
   ExtensionVersion,
+  ListingState,
   RegistryLaunchStage,
   Visibility,
 } from "../../extensions/types";
 import { DeploymentInstanceSpec } from "../../deploy/extensions/planner";
+import { logger } from "../../logger";
 
-const testExtensionVersion: ExtensionVersion = {
-  name: "test",
-  ref: "test/test@0.1.0",
-  state: "PUBLISHED",
-  hash: "abc123",
-  sourceDownloadUri: "https://download.com/source",
-  spec: {
+const testExtensionVersion = (listingState: ListingState): ExtensionVersion => {
+  return {
     name: "test",
-    version: "0.1.0",
-    resources: [],
-    params: [],
-    systemParams: [],
-    sourceUrl: "github.com/test/meout",
-  },
+    ref: "test/test@0.1.0",
+    state: "PUBLISHED",
+    hash: "abc123",
+    sourceDownloadUri: "https://download.com/source",
+    spec: {
+      name: "test",
+      version: "0.1.0",
+      resources: [],
+      params: [],
+      systemParams: [],
+      sourceUrl: "github.com/test/meout",
+    },
+    listing: {
+      state: listingState,
+    },
+  };
 };
 
-const testExtension = (publisherId: string, launchStage: RegistryLaunchStage): Extension => {
+const testExtension = (publisherId: string): Extension => {
   return {
     name: "test",
     ref: `${publisherId}/test`,
-    registryLaunchStage: launchStage,
+    registryLaunchStage: RegistryLaunchStage.BETA,
     createTime: "101",
     visibility: Visibility.PUBLIC,
   };
@@ -41,7 +46,7 @@ const testExtension = (publisherId: string, launchStage: RegistryLaunchStage): E
 const testInstanceSpec = (
   publisherId: string,
   instanceId: string,
-  launchStage: RegistryLaunchStage
+  listingState: ListingState
 ): DeploymentInstanceSpec => {
   return {
     instanceId,
@@ -52,79 +57,45 @@ const testInstanceSpec = (
     },
     params: {},
     systemParams: {},
-    extensionVersion: testExtensionVersion,
-    extension: testExtension(publisherId, launchStage),
+    extensionVersion: testExtensionVersion(listingState),
+    extension: testExtension(publisherId),
   };
 };
 
-describe("displayWarningPrompts", () => {
-  let getTrustedPublisherStub: sinon.SinonStub;
-  let logLabeledStub: sinon.SinonStub;
-
-  beforeEach(() => {
-    getTrustedPublisherStub = sinon.stub(resolveSource, "getTrustedPublishers");
-    getTrustedPublisherStub.returns(["firebase"]);
-    logLabeledStub = sinon.stub(utils, "logLabeledBullet");
-  });
-
-  afterEach(() => {
-    getTrustedPublisherStub.restore();
-    logLabeledStub.restore();
-  });
-
-  it("should not warn if from trusted publisher", async () => {
-    const publisherId = "firebase";
-
-    await warnings.displayWarningPrompts(publisherId, testExtensionVersion);
-
-    expect(logLabeledStub).to.not.have.been.called;
-  });
-
-  it("should warn if the publisher is not on the approved publisher list", async () => {
-    const publisherId = "pubby-mcpublisher";
-
-    await warnings.displayWarningPrompts(publisherId, testExtensionVersion);
-
-    expect(logLabeledStub).to.have.been.calledWithMatch("extensions", "Early Access Program");
-  });
-});
-
 describe("displayWarningsForDeploy", () => {
-  let getTrustedPublisherStub: sinon.SinonStub;
-  let logLabeledStub: sinon.SinonStub;
+  let loggerStub: sinon.SinonStub;
 
   beforeEach(() => {
-    getTrustedPublisherStub = sinon.stub(resolveSource, "getTrustedPublishers");
-    getTrustedPublisherStub.returns(["firebase"]);
-    logLabeledStub = sinon.stub(utils, "logLabeledBullet");
+    loggerStub = sinon.stub(logger, "warn");
   });
 
   afterEach(() => {
-    getTrustedPublisherStub.restore();
-    logLabeledStub.restore();
+    loggerStub.restore();
   });
 
-  it("should not warn or prompt if from trusted publisher", async () => {
+  it("should not warn if published", async () => {
     const toCreate = [
-      testInstanceSpec("firebase", "ext-id-1", RegistryLaunchStage.GA),
-      testInstanceSpec("firebase", "ext-id-2", RegistryLaunchStage.GA),
+      testInstanceSpec("firebase", "ext-id-1", "APPROVED"),
+      testInstanceSpec("firebase", "ext-id-2", "APPROVED"),
     ];
 
     const warned = await warnings.displayWarningsForDeploy(toCreate);
 
     expect(warned).to.be.false;
-    expect(logLabeledStub).to.not.have.been.called;
+    expect(loggerStub).to.not.have.been.called;
   });
 
-  it("should prompt if the publisher is not on the approved publisher list", async () => {
+  it("should not warn if not published", async () => {
     const toCreate = [
-      testInstanceSpec("pubby-mcpublisher", "ext-id-1", RegistryLaunchStage.GA),
-      testInstanceSpec("pubby-mcpublisher", "ext-id-2", RegistryLaunchStage.GA),
+      testInstanceSpec("pubby-mcpublisher", "ext-id-1", "PENDING"),
+      testInstanceSpec("pubby-mcpublisher", "ext-id-2", "REJECTED"),
     ];
 
     const warned = await warnings.displayWarningsForDeploy(toCreate);
 
     expect(warned).to.be.true;
-    expect(logLabeledStub).to.have.been.calledWithMatch("extensions", "Early Access Program");
+    expect(loggerStub).to.have.been.calledWithMatch(
+      "have not been published to the Firebase Extensions Hub"
+    );
   });
 });


### PR DESCRIPTION
### Description
- Adds TOS messages to ext:install/update/configure
<img width="1352" alt="Screenshot 2023-04-27 at 3 46 35 PM" src="https://user-images.githubusercontent.com/4635763/235010484-2107f300-c520-4d49-a75b-9953e0a63093.png">

- Adds TOS acceptance to deploy, one per instances in the deployment. User will be prompted iff the project has never accepted the app developer TOS before.

<img width="1437" alt="Screenshot 2023-04-27 at 3 51 09 PM" src="https://user-images.githubusercontent.com/4635763/235010548-18f61b86-969e-4e71-9f8b-22e965ac6c71.png">

- Adds a warning about unapproved extensions being higher risk
<img width="1440" alt="Screenshot 2023-04-27 at 4 12 00 PM" src="https://user-images.githubusercontent.com/4635763/235010583-fcd84327-d589-4159-9606-460b99559ee4.png">

- Removes EAP warning, since it's no longer relevant
- Removes notice about v11 breaking changes, since this will go in v12


Still need to clean this up a bit and figure out why listing is not being returned by getExtensionVersion
