### PR TITLE
moves permissions check to be earlier and conditional. 

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -18,7 +18,7 @@ export const VALID_DEPLOY_TARGETS = [
   "remoteconfig",
   "extensions",
 ];
-export const TARGET_PERMISSIONS: Record<string, string[]> = {
+export const TARGET_PERMISSIONS: Record<(typeof VALID_DEPLOY_TARGETS)[number], string[]> = {
   database: ["firebasedatabase.instances.update"],
   hosting: ["firebasehosting.sites.update"],
   functions: [

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -36,9 +36,6 @@ import { generateServiceIdentity } from "../../gcp/serviceusage";
 import { applyBackendHashToBackends } from "./cache/applyHash";
 import { allEndpoints, Backend } from "./backend";
 import { assertExhaustive } from "../../functional";
-import { isRunningInGithubAction } from "../../init/features/hosting/github";
-import { firebaseRoles } from "../../gcp/resourceManager";
-import { requirePermissions } from "../../requirePermissions";
 
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
 function hasUserConfig(config: Record<string, unknown>): boolean {
@@ -57,15 +54,6 @@ export async function prepare(
 ): Promise<void> {
   const projectId = needProjectId(options);
   const projectNumber = await needProjectNumber(options);
-
-  // Fail early if we're running in our Github Action and don't have permission
-  if (isRunningInGithubAction()) {
-    await requirePermissions(options, [firebaseRoles.functionsDeveloper]).catch(() => {
-      throw new FirebaseError(
-        "Please reinstall the Github Action with `firebase init hosting:github` to grant this project the required permissions to deploy Cloud Functions."
-      );
-    });
-  }
 
   context.config = normalizeAndValidate(options.config.src.functions);
   context.filters = getEndpointFilters(options); // Parse --only filters for functions.

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -24,7 +24,11 @@ function handlePublicDirectoryFlag(options: HostingOptions & Options): void {
 }
 
 /**
- *
+ * Return whether any hosting config tags any functions.
+ * This is used to know whether a deploy needs to add functions to the targets,
+ * ask for permissions explicitly (they may not have been asked for in the
+ * normal boilerplate), and the only string might need to be updated with
+ * addPinnedFunctionsToOnlyString.
  */
 export function hasPinnedFunctions(options: HostingOptions & Options): boolean {
   handlePublicDirectoryFlag(options);

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -25,7 +25,6 @@ import { Constants } from "../emulator/constants";
 import { FirebaseError } from "../error";
 import { requireHostingSite } from "../requireHostingSite";
 import * as experiments from "../experiments";
-import { ensureTargeted } from "../functions/ensureTargeted";
 import { implicitInit } from "../hosting/implicitInit";
 import { fileExistsSync } from "../fsutils";
 import { logWarning } from "../utils";
@@ -247,6 +246,9 @@ function scanDependencyTree(searchingFor: string, dependencies = {}): any {
   return;
 }
 
+/**
+ *
+ */
 export function getNodeModuleBin(name: string, cwd: string) {
   const cantFindExecutable = new FirebaseError(`Could not find the ${name} executable.`);
   const npmRoot = spawnSync("npm", ["root"], { cwd }).stdout?.toString().trim();
@@ -508,13 +510,6 @@ export async function prepareFrameworks(
           codebase,
         },
       ]);
-
-      if (!targetNames.includes("functions")) {
-        targetNames.unshift("functions");
-      }
-      if (options.only) {
-        options.only = ensureTargeted(options.only, codebase);
-      }
 
       // if exists, delete everything but the node_modules directory and package-lock.json
       // this should speed up repeated NPM installs

--- a/src/functions/ensureTargeted.ts
+++ b/src/functions/ensureTargeted.ts
@@ -4,22 +4,42 @@
  * with a web framework, or that a traditional hosting site includes its pinned
  * functions
  * @param only original only string
- * @param id function ID
- * @param codebase function codebase
+ * @param codebaseOrFunction codebase or function ID
  * @return new only string
  */
-export function ensureTargeted(only: string, codebase: string, id?: string): string {
+export function ensureTargeted(only: string, codebaseOrFunction: string): string;
+
+/**
+ * Ensures than an only string is modified so that it will enclude a function
+ * in its target. This is useful for making sure that an SSR function is included
+ * with a web framework, or that a traditional hosting site includes its pinned
+ * functions
+ * @param only original only string
+ * @param codebase codebase id
+ * @param functionId function id
+ * @return new only string
+ */
+export function ensureTargeted(only: string, codebase: string, functionId: string): string;
+
+/**
+ * Implementation of ensureTargeted.
+ */
+export function ensureTargeted(
+  only: string,
+  codebaseOrFunction: string,
+  functionId?: string
+): string {
   const parts = only.split(",");
   if (parts.includes("functions")) {
     return only;
   }
 
-  let newTarget = `functions:${codebase}`;
+  let newTarget = `functions:${codebaseOrFunction}`;
   if (parts.includes(newTarget)) {
     return only;
   }
-  if (id) {
-    newTarget = `${newTarget}:${id}`;
+  if (functionId) {
+    newTarget = `${newTarget}:${functionId}`;
     if (parts.includes(newTarget)) {
       return only;
     }

--- a/src/test/deploy/hosting/prepare.spec.ts
+++ b/src/test/deploy/hosting/prepare.spec.ts
@@ -10,7 +10,8 @@ import * as tracking from "../../../track";
 import * as deploymentTool from "../../../deploymentTool";
 import * as config from "../../../hosting/config";
 import {
-  addTaggedFunctionsToOnlyString,
+  addPinnedFunctionsToOnlyString,
+  hasPinnedFunctions,
   prepare,
   unsafePins,
 } from "../../../deploy/hosting/prepare";
@@ -246,7 +247,18 @@ describe("hosting prepare", () => {
     });
   });
 
-  describe("addTaggedFunctionsToOnlyString", () => {
+  describe("hasPinnedFunctions", () => {
+    it("detects function tags", () => {
+      expect(hasPinnedFunctions(options)).to.be.true;
+    });
+
+    it("detects a lack of function tags", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      delete (options as any).config.src.hosting?.rewrites?.[0]?.function?.pinTag;
+      expect(hasPinnedFunctions(options)).to.be.false;
+    });
+  });
+  describe("addPinnedFunctionsToOnlyString", () => {
     it("adds functions to deploy targets w/ codebases", async () => {
       backendStub.existingBackend.resolves({
         endpoints: {
@@ -262,7 +274,7 @@ describe("hosting prepare", () => {
         environmentVariables: {},
       });
 
-      await expect(addTaggedFunctionsToOnlyString({} as any, options)).to.eventually.be.true;
+      await expect(addPinnedFunctionsToOnlyString({} as any, options)).to.eventually.be.true;
       expect(options.only).to.equal("hosting,functions:backend:function");
     });
 
@@ -280,7 +292,7 @@ describe("hosting prepare", () => {
         environmentVariables: {},
       });
 
-      await expect(addTaggedFunctionsToOnlyString({} as any, options)).to.eventually.be.true;
+      await expect(addPinnedFunctionsToOnlyString({} as any, options)).to.eventually.be.true;
       expect(options.only).to.equal("hosting,functions:default:function");
     });
 
@@ -288,7 +300,7 @@ describe("hosting prepare", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       delete (siteConfig as any).rewrites[0].function.pinTag;
 
-      await expect(addTaggedFunctionsToOnlyString({} as any, options)).to.eventually.be.false;
+      await expect(addPinnedFunctionsToOnlyString({} as any, options)).to.eventually.be.false;
       expect(options.only).to.equal("hosting");
       expect(backendStub.existingBackend).to.not.have.been.called;
     });


### PR DESCRIPTION
1. Move the code for checking for GCF permissions to deploy/index where we can only do the check if functions is added by pintags
2. Make the functions permission check based on a set of permissions (and the same list by commands/deploy) rather than a fixed role name
3. Add fallback support in addTaggedFunctionsToOnlyString so that the function can limp along when backend.existingBackend fails because we haven't checked for functions permissions yet.