### PR TITLE
Adding new console links to ext:dev:register and ext:dev:upload

### DIFF
--- a/src/commands/ext-dev-register.ts
+++ b/src/commands/ext-dev-register.ts
@@ -34,7 +34,7 @@ export const command = new Command("ext:dev:register")
       message: msg,
       default: projectId,
     });
-    let profile: PublisherProfile
+    let profile: PublisherProfile;
     try {
       profile = await registerPublisherProfile(projectId, publisherId);
     } catch (err: any) {
@@ -57,13 +57,14 @@ export const command = new Command("ext:dev:register")
         )}: ${err.message}`
       );
     }
-   utils.logLabeledSuccess(
+    utils.logLabeledSuccess(
       logPrefix,
       `Publisher ID '${clc.bold(publisherId)}' has been registered to project ${clc.bold(
         projectId
-      )}. View and edit your profile at ${
-        utils.consoleUrl(projectId, `/publisher/${publisherId}/dashboard`)
-      }`
+      )}. View and edit your profile at ${utils.consoleUrl(
+        projectId,
+        `/publisher/${publisherId}/dashboard`
+      )}`
     );
     return profile;
   });

--- a/src/commands/ext-dev-register.ts
+++ b/src/commands/ext-dev-register.ts
@@ -61,10 +61,7 @@ export const command = new Command("ext:dev:register")
       logPrefix,
       `Publisher ID '${clc.bold(publisherId)}' has been registered to project ${clc.bold(
         projectId
-      )}. View and edit your profile at ${utils.consoleUrl(
-        projectId,
-        `/publisher`
-      )}`
+      )}. View and edit your profile at ${utils.consoleUrl(projectId, `/publisher`)}`
     );
     return profile;
   });

--- a/src/commands/ext-dev-register.ts
+++ b/src/commands/ext-dev-register.ts
@@ -10,6 +10,7 @@ import { acceptLatestPublisherTOS } from "../extensions/tos";
 import { requirePermissions } from "../requirePermissions";
 import { FirebaseError } from "../error";
 import * as utils from "../utils";
+import { PublisherProfile } from "../extensions/types";
 
 /**
  * Register a publisher ID; run this before publishing any extensions.
@@ -33,8 +34,9 @@ export const command = new Command("ext:dev:register")
       message: msg,
       default: projectId,
     });
+    let profile: PublisherProfile
     try {
-      await registerPublisherProfile(projectId, publisherId);
+      profile = await registerPublisherProfile(projectId, publisherId);
     } catch (err: any) {
       if (err.status === 409) {
         const error =
@@ -55,10 +57,13 @@ export const command = new Command("ext:dev:register")
         )}: ${err.message}`
       );
     }
-    return utils.logLabeledSuccess(
+   utils.logLabeledSuccess(
       logPrefix,
       `Publisher ID '${clc.bold(publisherId)}' has been registered to project ${clc.bold(
         projectId
-      )}`
+      )}. View and edit your profile at ${
+        utils.consoleUrl(projectId, `/publisher/${publisherId}/dashboard`)
+      }`
     );
+    return profile;
   });

--- a/src/commands/ext-dev-register.ts
+++ b/src/commands/ext-dev-register.ts
@@ -63,7 +63,7 @@ export const command = new Command("ext:dev:register")
         projectId
       )}. View and edit your profile at ${utils.consoleUrl(
         projectId,
-        `/publisher/${publisherId}/dashboard`
+        `/publisher`
       )}`
     );
     return profile;

--- a/src/commands/ext-dev-upload.ts
+++ b/src/commands/ext-dev-upload.ts
@@ -103,8 +103,16 @@ export async function uploadExtensionAction(
   }
   if (res) {
     utils.logLabeledBullet(logPrefix, marked(`[Install Link](${consoleInstallLink(res.ref)})`));
-    const version = res.ref.split("@")[1]
-    utils.logLabeledBullet(logPrefix, marked(`[View in Console](${utils.consoleUrl(projectNumber, `/publisher/extensions/${extensionId}/v/${version}`)})`));
+    const version = res.ref.split("@")[1];
+    utils.logLabeledBullet(
+      logPrefix,
+      marked(
+        `[View in Console](${utils.consoleUrl(
+          projectNumber,
+          `/publisher/extensions/${extensionId}/v/${version}`
+        )})`
+      )
+    );
   }
   return res;
 }

--- a/src/commands/ext-dev-upload.ts
+++ b/src/commands/ext-dev-upload.ts
@@ -103,6 +103,8 @@ export async function uploadExtensionAction(
   }
   if (res) {
     utils.logLabeledBullet(logPrefix, marked(`[Install Link](${consoleInstallLink(res.ref)})`));
+    const version = res.ref.split("@")[1]
+    utils.logLabeledBullet(logPrefix, marked(`[View in Console](${utils.consoleUrl(projectNumber, `/publisher/extensions/${extensionId}/v/${version}`)})`));
   }
   return res;
 }


### PR DESCRIPTION
### Description
Add links to publisher profile after ext:dev:register, and to the extension details page after ext:dev:upload/publish.
