### PR TITLE
Switch publisher methods to extensonspublisher API

### DIFF
--- a/src/extensions/extensionsApi.ts
+++ b/src/extensions/extensionsApi.ts
@@ -533,7 +533,7 @@ export async function getPublisherProfile(
   projectId: string,
   publisherId?: string
 ): Promise<PublisherProfile> {
-  const res = await extensionsApiClient.get(`/projects/${projectId}/publisherProfile`, {
+  const res = await extensionsPublisherApiClient.get(`/projects/${projectId}/publisherProfile`, {
     queryParams:
       publisherId === undefined
         ? undefined
@@ -552,10 +552,16 @@ export async function registerPublisherProfile(
   projectId: string,
   publisherId: string
 ): Promise<PublisherProfile> {
-  const res = await extensionsApiClient.post<{ publisherId: string }, PublisherProfile>(
-    `/projects/${projectId}/publisherProfile:register`,
+  const res = await extensionsPublisherApiClient.patch<Partial<PublisherProfile>, PublisherProfile>(
+    `/projects/${projectId}/publisherProfile`,
     {
       publisherId,
+      displayName: publisherId,
+    },
+    {
+      queryParams: {
+        updateMask: "publisher_id,display_name",
+      },
     }
   );
   return res.body;
@@ -571,12 +577,12 @@ export async function deprecateExtensionVersion(
 ): Promise<ExtensionVersion> {
   const ref = refs.parse(extensionRef);
   try {
-    const res = await extensionsApiClient.post<{ deprecationMessage: string }, ExtensionVersion>(
-      `/${refs.toExtensionVersionName(ref)}:deprecate`,
-      {
-        deprecationMessage,
-      }
-    );
+    const res = await extensionsPublisherApiClient.post<
+      { deprecationMessage: string },
+      ExtensionVersion
+    >(`/${refs.toExtensionVersionName(ref)}:deprecate`, {
+      deprecationMessage,
+    });
     return res.body;
   } catch (err: any) {
     if (err.status === 403) {
@@ -606,7 +612,7 @@ export async function deprecateExtensionVersion(
 export async function undeprecateExtensionVersion(extensionRef: string): Promise<ExtensionVersion> {
   const ref = refs.parse(extensionRef);
   try {
-    const res = await extensionsApiClient.post<void, ExtensionVersion>(
+    const res = await extensionsPublisherApiClient.post<void, ExtensionVersion>(
       `/${refs.toExtensionVersionName(ref)}:undeprecate`
     );
     return res.body;

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -52,6 +52,9 @@ export interface PublisherProfile {
   name: string;
   publisherId: string;
   registerTime: string;
+  displayName: string;
+  websiteUri?: string;
+  iconUri?: string;
 }
 
 export interface ExtensionInstance {

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -1102,7 +1102,7 @@ describe("getPublisherProfile", () => {
     registerTime: "2020-06-30T00:21:06.722782Z",
   };
   it("should make a GET call to the correct endpoint", async () => {
-    nock(api.extensionsOrigin)
+    nock(api.extensionsPublisherOrigin)
       .get(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile`)
       .query(true)
       .reply(200, PUBLISHER_PROFILE);
@@ -1113,7 +1113,7 @@ describe("getPublisherProfile", () => {
   });
 
   it("should throw a FirebaseError if the endpoint returns an error response", async () => {
-    nock(api.extensionsOrigin)
+    nock(api.extensionsPublisherOrigin)
       .get(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile`)
       .query(true)
       .reply(404);
@@ -1134,8 +1134,8 @@ describe("registerPublisherProfile", () => {
     registerTime: "2020-06-30T00:21:06.722782Z",
   };
   it("should make a POST call to the correct endpoint", async () => {
-    nock(api.extensionsOrigin)
-      .post(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile:register`)
+    nock(api.extensionsPublisherOrigin)
+      .patch(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile?updateMask=publisher_id%2Cdisplay_name`)
       .reply(200, PUBLISHER_PROFILE);
 
     const res = await extensionsApi.registerPublisherProfile(PROJECT_ID, PUBLISHER_ID);
@@ -1144,8 +1144,8 @@ describe("registerPublisherProfile", () => {
   });
 
   it("should throw a FirebaseError if the endpoint returns an error response", async () => {
-    nock(api.extensionsOrigin)
-      .post(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile:register`)
+    nock(api.extensionsPublisherOrigin)
+      .patch(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile?updateMask=publisher_id%2Cdisplay_name`)
       .reply(404);
     await expect(
       extensionsApi.registerPublisherProfile(PROJECT_ID, PUBLISHER_ID)
@@ -1161,7 +1161,7 @@ describe("deprecateExtensionVersion", () => {
 
   it("should make a POST call to the correct endpoint", async () => {
     const { publisherId, extensionId, version } = refs.parse(TEST_EXT_VERSION_4.ref);
-    nock(api.extensionsOrigin)
+    nock(api.extensionsPublisherOrigin)
       .persist()
       .post(
         `/${VERSION}/publishers/${publisherId}/extensions/${extensionId}/versions/${version}:deprecate`
@@ -1178,7 +1178,7 @@ describe("deprecateExtensionVersion", () => {
 
   it("should throw a FirebaseError if the endpoint returns an error response", async () => {
     const { publisherId, extensionId, version } = refs.parse(TEST_EXT_VERSION_4.ref);
-    nock(api.extensionsOrigin)
+    nock(api.extensionsPublisherOrigin)
       .persist()
       .post(
         `/${VERSION}/publishers/${publisherId}/extensions/${extensionId}/versions/${version}:deprecate`
@@ -1198,7 +1198,7 @@ describe("undeprecateExtensionVersion", () => {
 
   it("should make a POST call to the correct endpoint", async () => {
     const { publisherId, extensionId, version } = refs.parse(TEST_EXT_VERSION_3.ref);
-    nock(api.extensionsOrigin)
+    nock(api.extensionsPublisherOrigin)
       .persist()
       .post(
         `/${VERSION}/publishers/${publisherId}/extensions/${extensionId}/versions/${version}:undeprecate`
@@ -1212,7 +1212,7 @@ describe("undeprecateExtensionVersion", () => {
 
   it("should throw a FirebaseError if the endpoint returns an error response", async () => {
     const { publisherId, extensionId, version } = refs.parse(TEST_EXT_VERSION_3.ref);
-    nock(api.extensionsOrigin)
+    nock(api.extensionsPublisherOrigin)
       .persist()
       .post(
         `/${VERSION}/publishers/${publisherId}/extensions/${extensionId}/versions/${version}:undeprecate`

--- a/src/test/extensions/extensionsApi.spec.ts
+++ b/src/test/extensions/extensionsApi.spec.ts
@@ -1135,7 +1135,9 @@ describe("registerPublisherProfile", () => {
   };
   it("should make a POST call to the correct endpoint", async () => {
     nock(api.extensionsPublisherOrigin)
-      .patch(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile?updateMask=publisher_id%2Cdisplay_name`)
+      .patch(
+        `/${VERSION}/projects/${PROJECT_ID}/publisherProfile?updateMask=publisher_id%2Cdisplay_name`
+      )
       .reply(200, PUBLISHER_PROFILE);
 
     const res = await extensionsApi.registerPublisherProfile(PROJECT_ID, PUBLISHER_ID);
@@ -1145,7 +1147,9 @@ describe("registerPublisherProfile", () => {
 
   it("should throw a FirebaseError if the endpoint returns an error response", async () => {
     nock(api.extensionsPublisherOrigin)
-      .patch(`/${VERSION}/projects/${PROJECT_ID}/publisherProfile?updateMask=publisher_id%2Cdisplay_name`)
+      .patch(
+        `/${VERSION}/projects/${PROJECT_ID}/publisherProfile?updateMask=publisher_id%2Cdisplay_name`
+      )
       .reply(404);
     await expect(
       extensionsApi.registerPublisherProfile(PROJECT_ID, PUBLISHER_ID)


### PR DESCRIPTION
### Description
Switch more publisher methods to the extensionspublisher API.

### Scenarios Tested
ext:dev:register
<img width="1006" alt="Screenshot 2023-04-30 at 9 46 18 PM" src="https://user-images.githubusercontent.com/4635763/235410141-e6ce9e52-85f3-413c-b2fd-de9442823525.png">
ext:dev:deprecate, undeprecate
<img width="936" alt="Screenshot 2023-04-30 at 9 50 51 PM" src="https://user-images.githubusercontent.com/4635763/235410162-ddb2a910-a3a1-4dbc-a5ed-4ffe684abb50.png">
