### PR TITLE
Ensure the publisher API when its being used

### DIFF
--- a/src/commands/ext-dev-deprecate.ts
+++ b/src/commands/ext-dev-deprecate.ts
@@ -5,7 +5,7 @@ import * as refs from "../extensions/refs";
 import * as utils from "../utils";
 import { Command } from "../command";
 import { confirm } from "../prompt";
-import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
+import { ensureExtensionsPublisherApiEnabled, logPrefix } from "../extensions/extensionsHelper";
 import { deprecateExtensionVersion, listExtensionVersions } from "../extensions/extensionsApi";
 import { parseVersionPredicate } from "../extensions/versionHelper";
 import { requireAuth } from "../requireAuth";
@@ -27,7 +27,7 @@ export const command = new Command("ext:dev:deprecate <extensionRef> [versionPre
     "override deprecation message for existing deprecated extension versions that match"
   )
   .before(requireAuth)
-  .before(ensureExtensionsApiEnabled)
+  .before(ensureExtensionsPublisherApiEnabled)
   .action(
     async (extensionRef: string, versionPredicate: string, options: ExtDevDeprecateOptions) => {
       const ref = refs.parse(extensionRef);

--- a/src/commands/ext-dev-publish.ts
+++ b/src/commands/ext-dev-publish.ts
@@ -5,6 +5,7 @@ import { Command } from "../command";
 import { requireAuth } from "../requireAuth";
 import { uploadExtensionAction, UploadExtensionOptions } from "./ext-dev-upload";
 import { logLabeledWarning } from "../utils";
+import { ensureExtensionsPublisherApiEnabled } from "../extensions/extensionsHelper";
 
 marked.setOptions({
   renderer: new TerminalRenderer(),
@@ -29,6 +30,7 @@ export const command = new Command("ext:dev:publish <extensionRef>")
       "be greater than previous versions."
   )
   .before(requireAuth)
+  .before(ensureExtensionsPublisherApiEnabled)
   .action(async (extensionRef: string, options: UploadExtensionOptions) => {
     logLabeledWarning(
       "Extensions",

--- a/src/commands/ext-dev-register.ts
+++ b/src/commands/ext-dev-register.ts
@@ -5,7 +5,11 @@ import { Command } from "../command";
 import { registerPublisherProfile } from "../extensions/extensionsApi";
 import { needProjectId } from "../projectUtils";
 import { promptOnce } from "../prompt";
-import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
+import {
+  ensureExtensionsApiEnabled,
+  ensureExtensionsPublisherApiEnabled,
+  logPrefix,
+} from "../extensions/extensionsHelper";
 import { acceptLatestPublisherTOS } from "../extensions/tos";
 import { requirePermissions } from "../requirePermissions";
 import { FirebaseError } from "../error";
@@ -19,6 +23,7 @@ export const command = new Command("ext:dev:register")
   .description("register a publisher ID; run this before publishing your first extension.")
   // temporary until registry-specific permissions are available
   .before(requirePermissions, ["firebaseextensions.sources.create"])
+  .before(ensureExtensionsPublisherApiEnabled)
   .before(ensureExtensionsApiEnabled)
   .action(async (options: any) => {
     const projectId = needProjectId(options);

--- a/src/commands/ext-dev-undeprecate.ts
+++ b/src/commands/ext-dev-undeprecate.ts
@@ -5,7 +5,7 @@ import * as refs from "../extensions/refs";
 import * as utils from "../utils";
 import { Command } from "../command";
 import { promptOnce } from "../prompt";
-import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
+import { ensureExtensionsPublisherApiEnabled, logPrefix } from "../extensions/extensionsHelper";
 import { undeprecateExtensionVersion, listExtensionVersions } from "../extensions/extensionsApi";
 import { parseVersionPredicate } from "../extensions/versionHelper";
 import { requireAuth } from "../requireAuth";
@@ -17,7 +17,7 @@ import { FirebaseError } from "../error";
 export const command = new Command("ext:dev:undeprecate <extensionRef> <versionPredicate>")
   .description("undeprecate extension versions that match the version predicate")
   .before(requireAuth)
-  .before(ensureExtensionsApiEnabled)
+  .before(ensureExtensionsPublisherApiEnabled)
   .action(async (extensionRef: string, versionPredicate: string, options: any) => {
     const { publisherId, extensionId, version } = refs.parse(extensionRef);
     if (version) {

--- a/src/commands/ext-dev-upload.ts
+++ b/src/commands/ext-dev-upload.ts
@@ -8,6 +8,7 @@ import {
   logPrefix,
   uploadExtensionVersionFromLocalSource,
   uploadExtensionVersionFromGitHubSource,
+  ensureExtensionsPublisherApiEnabled,
 } from "../extensions/extensionsHelper";
 import * as refs from "../extensions/refs";
 import { findExtensionYaml } from "../extensions/localHelper";
@@ -45,6 +46,7 @@ export const command = new Command("ext:dev:upload <extensionRef>")
       "be greater than previous versions."
   )
   .before(requireAuth)
+  .before(ensureExtensionsPublisherApiEnabled)
   .action(uploadExtensionAction);
 
 export interface UploadExtensionOptions extends Options {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -413,6 +413,19 @@ export async function ensureExtensionsApiEnabled(options: any): Promise<void> {
   );
 }
 
+export async function ensureExtensionsPublisherApiEnabled(options: any): Promise<void> {
+  const projectId = getProjectId(options);
+  if (!projectId) {
+    return;
+  }
+  return await ensure(
+    projectId,
+    "firebaseextensionspublisher.googleapis.com",
+    "extensions",
+    options.markdown
+  );
+}
+
 /**
  * Zips and uploads a local extension to a bucket.
  * @param extPath a local path to archive and upload


### PR DESCRIPTION
### Description
Ensure that firebaseextensionspublisher API is enabled for commands where it is used. For :register, we ensure both because we need the firebaseextensions P4SA to create a lien on the project.