### PR TITLE
Use fake adminsdkconfig for demo- projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@
 - Adds function emulator support for v2 firestore triggers (#5685)
 - Improvements for developers using Next 13's app directory (#5691)
 - Resolve timeouts when bundling Next.js applications for Cloud Functions (#5691)
-- Fixes bug where the functions emulator would attempt to call to prod for 'demo-' projects (#5218)
+- Fixes bug where the functions emulator would attempt to call to prod for 'demo-' projects (#5170)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Upgrade Firestore emulator to 1.17.4
 - Web Frameworks will no longer try to deploy unsupported versions of NodeJS to Cloud Functions (#5733)
 - Adding experimental support for deploying Flutter Web applications to Firebase Hosting (#5332)
-- Adds function emulator support for v2 firestore triggers (#5685).
+- Adds function emulator support for v2 firestore triggers (#5685)
 - Improvements for developers using Next 13's app directory (#5691)
 - Resolve timeouts when bundling Next.js applications for Cloud Functions (#5691)
+- Fixes bug where the functions emulator would attempt to call to prod for 'demo-' projects (#5218)

--- a/src/emulator/adminSdkConfig.ts
+++ b/src/emulator/adminSdkConfig.ts
@@ -58,7 +58,16 @@ async function getProjectAdminSdkConfig(projectId: string): Promise<AdminSdkConf
     apiVersion: "v1beta1",
     urlPrefix: firebaseApiOrigin,
   });
-
+  if (projectId.startsWith("demo-")) {
+    logger.debug(
+      `Detected demo- project: ${projectId}. Using default adminSdkConfig instead of calling firebase API.`
+    );
+    return {
+      projectId,
+      databaseURL: `${projectId}-default-rtdb.firebaseio.com`,
+      storageBucket: `${projectId}.appspot.com`,
+    };
+  }
   try {
     const res = await apiClient.get<AdminSdkConfig>(`projects/${projectId}/adminSdkConfig`);
     return res.body;


### PR DESCRIPTION
### Description
Don't try to call prod apis for demo- projects, as they cannot be real projects. Instead, use reasonable defaults for adminSdkConfig. Fixes #5170