### PR TITLE
fix: don't assume nextjs app root is workspace root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix framework detection limitation for NextJs applications that aren't co-located with their package.json (monorepo)

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -83,11 +83,11 @@ function getReactVersion(cwd: string): string | undefined {
 }
 
 /**
- * Returns whether this codebase is a Next.js backend.
+ * Returns whether this project is a Next.js app.
  */
 export async function discover(dir: string) {
-  if (!(await pathExists(join(dir, "package.json")))) return;
-  if (!(await pathExists("next.config.js")) && !getNextVersion(dir)) return;
+  if (!(await pathExists(join(dir, "next.config.js")))) return;
+  if (!getNextVersion(dir)) return;
 
   return { mayWantBackend: true, publicDirectory: join(dir, PUBLIC_DIR) };
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Configuring a NextJs app in `firebase.json` that doesn't have its own `package.json` results in firebase failing to detect the framework:

```json
// firebase.json
...
"hosting": {
    "source": "./path/to/next-js-app-project-without-package-json"
}
...
```
This assumption is often not true in a monorepo.

This fix removes that assumption, which shouldn't be an issue because the remaining checks should still be able to reliably determine the framework.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
