### PR TITLE
Default to open rules when emulating demo- projects without matching targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes a bug where the Storage emulator would not fall back to open rules for 'demo-' projects if `firebase.json` contained multiple storage targets (#5170)

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -62,7 +62,7 @@ export function getStorageRulesConfig(
         storageLogger.logLabeled(
           "BULLET",
           "storage",
-          `Detected demo project ID "${projectId}", using a default (open) rules configuration.`
+          `Detected demo project ID "${projectId}", using a default (open) rules configuration. Storage targets in firebase.json will be ignored.`
         );
         return defaultStorageRules();
       }

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -70,10 +70,9 @@ export function getStorageRulesConfig(
       rc.requireTarget(projectId, "storage", targetConfig.target);
     }
     results.push(
-      ...rc.target(projectId,"storage", targetConfig.target).map(
-        (resource: string) => {
-          return { resource, rules: getSourceFile(targetConfig.rules, options) };
-        })
+      ...rc.target(projectId, "storage", targetConfig.target).map((resource: string) => {
+        return { resource, rules: getSourceFile(targetConfig.rules, options) };
+      })
     );
   }
   return results;

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -23,16 +23,15 @@ export function getStorageRulesConfig(
   options: Options
 ): SourceFile | RulesConfig[] {
   const storageConfig = options.config.data.storage;
+  const storageLogger = EmulatorLogger.forEmulator(Emulators.STORAGE);
   if (!storageConfig) {
     if (Constants.isDemoProject(projectId)) {
-      const storageLogger = EmulatorLogger.forEmulator(Emulators.STORAGE);
       storageLogger.logLabeled(
         "BULLET",
         "storage",
         `Detected demo project ID "${projectId}", using a default (open) rules configuration.`
       );
-      const path = __dirname + "/../../../../templates/emulators/default_storage.rules";
-      return { name: path, content: readFile(path) };
+      return defaultStorageRules();
     }
     throw new FirebaseError(
       "Cannot start the Storage emulator without rules file specified in firebase.json: run 'firebase init' and set up your Storage configuration"
@@ -49,7 +48,6 @@ export function getStorageRulesConfig(
 
     return getSourceFile(storageConfig.rules, options);
   }
-
   // Multiple targets
   const results: RulesConfig[] = [];
   const { rc } = options;
@@ -57,10 +55,31 @@ export function getStorageRulesConfig(
     if (!targetConfig.target) {
       throw new FirebaseError("Must supply 'target' in Storage configuration");
     }
-    rc.requireTarget(projectId, "storage", targetConfig.target);
-    rc.target(projectId, "storage", targetConfig.target).forEach((resource: string) => {
-      results.push({ resource, rules: getSourceFile(targetConfig.rules, options) });
-    });
+    const targets = rc.target(projectId, "storage", targetConfig.target);
+    if (targets.length === 0) {
+      // Fall back to open if this is a demo project
+      if (Constants.isDemoProject(projectId)) {
+        storageLogger.logLabeled(
+          "BULLET",
+          "storage",
+          `Detected demo project ID "${projectId}", using a default (open) rules configuration.`
+        );
+        return defaultStorageRules();
+      }
+      // Otherwise, requireTarget will error out
+      rc.requireTarget(projectId, "storage", targetConfig.target);
+    }
+    results.push(
+      ...rc.target(projectId,"storage", targetConfig.target).map(
+        (resource: string) => {
+          return { resource, rules: getSourceFile(targetConfig.rules, options) };
+        })
+    );
   }
   return results;
+}
+
+function defaultStorageRules(): SourceFile {
+  const path = __dirname + "/../../../../templates/emulators/default_storage.rules";
+  return { name: path, content: readFile(path) };
 }


### PR DESCRIPTION
Change the Storage emulator to fall back to default open rules for 'demo-' projects if storage config refers to targets that are not defined for the project in  `.firebaserc`.
Fixes #5170