### PR TITLE
Refactored ext:dev:upload with new features in mind.

### DIFF
--- a/src/commands/ext-dev-list.ts
+++ b/src/commands/ext-dev-list.ts
@@ -6,7 +6,7 @@ import { FirebaseError } from "../error";
 import { last, logLabeledBullet } from "../utils";
 import { listExtensions } from "../extensions/publisherApi";
 import { logger } from "../logger";
-import { logPrefix } from "../extensions/extensionsHelper";
+import { logPrefix, unpackExtensionState } from "../extensions/extensionsHelper";
 import { requireAuth } from "../requireAuth";
 
 /**
@@ -40,31 +40,9 @@ export const command = new Command("ext:dev:list <publisherId>")
     });
     const sorted = extensions.sort((a, b) => a.ref.localeCompare(b.ref));
     sorted.forEach((extension) => {
-      let state: string;
-      switch (extension.state) {
-        case "PUBLISHED":
-          // Unpacking legacy "published" terminology.
-          if (extension.latestApprovedVersion) {
-            state = clc.bold(clc.green("Published"));
-          } else if (extension.latestVersion) {
-            state = clc.green("Uploaded");
-          } else {
-            state = "Prerelease";
-          }
-          break;
-        case "DEPRECATED":
-          state = clc.red("Deprecated");
-          break;
-        case "SUSPENDED":
-          state = clc.bold(clc.red("Suspended"));
-          break;
-        default:
-          state = "-";
-          break;
-      }
       table.push([
         last(extension.ref.split("/")),
-        state,
+        unpackExtensionState(extension),
         extension.latestVersion ?? "-",
         extension.latestApprovedVersion ?? "-",
       ]);

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -95,7 +95,7 @@ export const resourceTypeToNiceName: Record<string, string> = {
 };
 export type ReleaseStage = "alpha" | "beta" | "rc" | "stable";
 const repoRegex = new RegExp(`^https:\/\/github\.com\/[^\/]+\/[^\/]+$`);
-const stageOptions = ["alpha", "beta", "rc", "stable"];
+const stageOptions = ["rc", "alpha", "beta", "stable"];
 
 /**
  * Turns database URLs (e.g. https://my-db.firebaseio.com) into database instance names
@@ -248,6 +248,13 @@ export function validateSpec(spec: any) {
   }
   if (!spec.version) {
     errors.push("extension.yaml is missing required field: version");
+  } else if (!semver.valid(spec.version)) {
+    errors.push(`version ${spec.version} in extension.yaml is not a valid semver`);
+  } else {
+    const version = semver.parse(spec.version)!;
+    if (version.prerelease.length > 0 || version.build.length > 0) {
+      errors.push("version field in extension.yaml does not support pre-release annotations");
+    }
   }
   if (!spec.license) {
     errors.push("extension.yaml is missing required field: license");
@@ -388,7 +395,7 @@ export async function promptForValidRepoURI(): Promise<string> {
   while (!repoIsValid) {
     extensionRoot = await promptOnce({
       type: "input",
-      message: "Enter the GitHub repo URI where this Extension's source code is located:",
+      message: "Enter the GitHub repo URI where this extension's source code is located:",
     });
     if (!repoRegex.test(extensionRoot)) {
       logger.info("Repo URI must follow this format: https://github.com/<user>/<repo>");
@@ -397,6 +404,92 @@ export async function promptForValidRepoURI(): Promise<string> {
     }
   }
   return extensionRoot;
+}
+
+/**
+ * Prompts for a valid extension root.
+ *
+ * @param defaultRoot the default extension root
+ */
+export async function promptForValidExtensionRoot(defaultRoot: string): Promise<string> {
+  let rootIsValid = false;
+  let extensionRoot = "";
+  while (!rootIsValid) {
+    extensionRoot = await promptOnce({
+      type: "input",
+      message:
+        "Enter this extension's root directory in the repo (defaults to previous root if set):",
+      default: defaultRoot,
+    });
+    // TODO: Change this to a real check.
+    if (false) {
+      logger.info(`${extensionRoot} is not a valid directory path.`);
+    } else {
+      rootIsValid = true;
+    }
+  }
+  return extensionRoot;
+}
+
+/**
+ * Prompts for the extension version's release stage.
+ *
+ * @param versionByStage map from stage to the next version to upload
+ * @param autoReview whether the stable version will be automatically sent for review on upload
+ * @param allowStable whether to allow stable versions
+ * @param hasVersions whether there have been any pre-release versions uploaded already
+ */
+async function promptForReleaseStage(args: {
+  versionByStage: Map<string, string>;
+  autoReview: boolean;
+  allowStable: boolean;
+  hasVersions: boolean;
+  nonInteractive: boolean;
+  force: boolean;
+}): Promise<ReleaseStage> {
+  const defaultStage = "rc";
+  let stage: ReleaseStage;
+  const choices = [
+    { name: `Release candidate (${args.versionByStage.get("rc")})`, value: "rc" },
+    { name: `Alpha (${args.versionByStage.get("alpha")})`, value: "alpha" },
+    { name: `Beta (${args.versionByStage.get("beta")})`, value: "beta" },
+  ];
+  if (args.allowStable) {
+    const stableChoice = {
+      name: `Stable (${args.versionByStage.get("stable")}${
+        args.autoReview ? ", automatically sent for review" : ""
+      })`,
+      value: "stable",
+    };
+    choices.push(stableChoice);
+  }
+  stage = await promptOnce({
+    type: "list",
+    message: "Choose the release stage:",
+    choices: choices,
+    default: defaultStage,
+  });
+  if (stage === "stable" && !args.hasVersions) {
+    logger.info(
+      `${clc.bold(
+        clc.yellow("Warning:")
+      )} It's highly recommended to first upload a pre-release version before choosing stable.`
+    );
+    const confirmed = await confirm({
+      nonInteractive: args.nonInteractive,
+      force: args.force,
+      default: false,
+    });
+    if (!confirmed) {
+      stage = await promptOnce({
+        type: "list",
+        message: "Choose the release stage:",
+        choices: choices,
+        default: defaultStage,
+      });
+    }
+  }
+  return stage;
 }
 
 export async function ensureExtensionsApiEnabled(options: any): Promise<void> {
@@ -479,32 +572,57 @@ export async function incrementPrereleaseVersion(
 }
 
 /**
- * Validates the Extension spec.
+ * Gets a list of the next version to upload by release stage.
  *
- * @param publisherId the ID of the Publisher
- * @param extensionId the ID of the Extension
- * @param rootDirectory the directory with the Extension's source
- * @param latestVersion the latest version of the Extension (if any)
- * @param stage the release stage
- *
+ * @param extensionRef the ref of the extension
+ * @param version the new version of the extension
  */
-async function validateExtensionSpec(args: {
-  publisherId: string;
-  extensionId: string;
-  rootDirectory: string;
-  latestVersion?: string;
-  stage: ReleaseStage;
-}): Promise<{ extensionSpec: ExtensionSpec; notes: string }> {
-  const extensionRef = `${args.publisherId}/${args.extensionId}`;
-  const extensionSpec = await getLocalExtensionSpec(args.rootDirectory);
-  if (extensionSpec.name !== args.extensionId) {
+async function getNextVersionByStage(
+  extensionRef: string,
+  newVersion: string
+): Promise<{ versionByStage: Map<string, string>; hasVersions: boolean }> {
+  const versionByStage = new Map(
+    ["rc", "alpha", "beta"].map((stage) => [
+      stage,
+      semver.inc(`${newVersion}-${stage}`, "prerelease", undefined, stage)!,
+    ])
+  );
+  let extensionVersions: ExtensionVersion[] = [];
+  try {
+    extensionVersions = await listExtensionVersions(extensionRef, `id="${newVersion}"`, true);
+    for (const extensionVersion of extensionVersions) {
+      const version = semver.parse(extensionVersion.spec.version)!;
+      // Extensions only support semvers of format: <major>.<minor>.<patch>-<stage>.<count>
+      const stage = String(version.prerelease[0]).split(".")[0];
+      if (versionByStage.has(stage) && semver.gte(version, versionByStage.get(stage)!)) {
+        versionByStage.set(stage, semver.inc(version, "prerelease", undefined, stage)!);
+      }
+    }
+  } catch (e) {
+    // Fallthrough.
+  }
+  versionByStage.set("stable", newVersion);
+  return { versionByStage, hasVersions: extensionVersions.length > 0 };
+}
+
+/**
+ * Validates the extension spec.
+ *
+ * @param rootDirectory the directory with the extension source
+ * @param extensionRef the ref of the extension
+ */
+async function validateExtensionSpec(
+  rootDirectory: string,
+  extensionId: string
+): Promise<ExtensionSpec> {
+  const extensionSpec = await getLocalExtensionSpec(rootDirectory);
+  if (extensionSpec.name !== extensionId) {
     throw new FirebaseError(
       `Extension ID '${clc.bold(
-        args.extensionId
+        extensionId
       )}' does not match the name in extension.yaml '${clc.bold(extensionSpec.name)}'.`
     );
   }
-
   // Substitute deepcopied spec with autopopulated params, and make sure that it passes basic extension.yaml validation.
   const subbedSpec = JSON.parse(JSON.stringify(extensionSpec));
   subbedSpec.params = substituteParams<Param[]>(
@@ -512,18 +630,20 @@ async function validateExtensionSpec(args: {
     AUTOPOULATED_PARAM_PLACEHOLDERS
   );
   validateSpec(subbedSpec);
+  return extensionSpec;
+}
 
-  // Increment the pre-release annotation if it is not a stable version.
-  extensionSpec.version = await incrementPrereleaseVersion(
-    extensionRef,
-    extensionSpec.version,
-    args.stage
-  );
-
+/**
+ * Validates the release notes.
+ *
+ * @param rootDirectory the directory with the extension source
+ * @param newVersion the new extension version
+ */
+function validateReleaseNotes(rootDirectory: string, newVersion: string, required: boolean) {
   let notes: string;
   try {
-    const changes = getLocalChangelog(args.rootDirectory);
-    notes = changes[extensionSpec.version];
+    const changes = getLocalChangelog(rootDirectory);
+    notes = changes[newVersion];
   } catch (err: any) {
     throw new FirebaseError(
       "No CHANGELOG.md file found. " +
@@ -534,156 +654,133 @@ async function validateExtensionSpec(args: {
     );
   }
   // Notes are required for all stable versions after the initial release.
-  if (!notes && !semver.prerelease(extensionSpec.version) && args.latestVersion) {
+  if (!notes && !semver.prerelease(newVersion) && required) {
     throw new FirebaseError(
-      `No entry for version ${extensionSpec.version} found in CHANGELOG.md. ` +
+      `No entry for version ${newVersion} found in CHANGELOG.md. ` +
         "Please add one so users know what has changed in this version. " +
         marked(
           "See https://firebase.google.com/docs/extensions/alpha/create-user-docs#writing-changelog for more details."
         )
     );
   }
+  return notes;
+}
 
-  if (args.latestVersion) {
-    if (semver.lt(extensionSpec.version, args.latestVersion)) {
+/**
+ * Validates the extension version.
+ *
+ * @param newVersion the new extension version
+ * @param latestVersion the latest extension version
+ * @param extensionRef the ref of the extension
+ */
+function validateVersion(
+  newVersion: string,
+  latestVersion: string | undefined,
+  extensionRef: string
+) {
+  if (latestVersion) {
+    if (semver.lt(newVersion, latestVersion)) {
       throw new FirebaseError(
         `The version you are trying to publish (${clc.bold(
-          extensionSpec.version
+          newVersion
         )}) is lower than the current version (${clc.bold(
-          args.latestVersion
+          latestVersion
         )}) for the extension '${clc.bold(
           extensionRef
-        )}'. Please make sure this version is greater than the current version (${clc.bold(
-          args.latestVersion
-        )}) inside of extension.yaml.\n`,
+        )}'. Make sure this version is greater than the current version (${clc.bold(
+          latestVersion
+        )}) inside of extension.yaml and try again.\n`,
         { exit: 104 }
       );
-    } else if (semver.eq(extensionSpec.version, args.latestVersion)) {
+    } else if (semver.eq(newVersion, latestVersion)) {
       throw new FirebaseError(
-        `The version you are trying to publish (${clc.bold(
-          extensionSpec.version
-        )}) already exists for Extension '${clc.bold(
+        `The version you are trying to upload (${clc.bold(
+          newVersion
+        )}) already exists for extension '${clc.bold(
           extensionRef
-        )}'. Please increment the version inside of extension.yaml.\n`,
+        )}'. Increment the version inside of extension.yaml and try again.\n`,
         { exit: 103 }
       );
     }
   }
+}
 
-  return { extensionSpec, notes };
+/** Unpacks extension state into a more specific string. */
+export function unpackExtensionState(extension: Extension) {
+  switch (extension.state) {
+    case "PUBLISHED":
+      // Unpacking legacy "published" terminology.
+      if (extension.latestApprovedVersion) {
+        return clc.bold(clc.green("Published"));
+      } else if (extension.latestVersion) {
+        return clc.green("Uploaded");
+      } else {
+        return "Prerelease";
+      }
+    case "DEPRECATED":
+      return clc.red("Deprecated");
+    case "SUSPENDED":
+      return clc.bold(clc.red("Suspended"));
+    default:
+      return "-";
+  }
 }
 
 /**
- * Uploads an extension version from a GitHub repo.
+ * Fetches the extension and its latest version and displays all metadata.
  *
- * @param publisherId the ID of the Publisher this Extension will be published under
- * @param extensionId the ID of the Extension to be published
- * @param repoUri the URI of the repo where this Extension's source exists
- * @param sourceRef the commit hash, branch, or tag name in the repo to publish from
- * @param extensionRoot the root directory that contains this Extension's source
- * @param stage the release stage to publish
- * @param nonInteractive whether to display prompts
- * @param force whether to force confirmations
+ * @param extensionRef the ref of the extension
  */
-export async function uploadExtensionVersionFromGitHubSource(args: {
-  publisherId: string;
-  extensionId: string;
-  repoUri?: string;
-  sourceRef?: string;
-  extensionRoot?: string;
-  stage?: ReleaseStage;
-  nonInteractive: boolean;
-  force: boolean;
-}): Promise<ExtensionVersion | undefined> {
-  const extensionRef = `${args.publisherId}/${args.extensionId}`;
-
-  // Check if Extension already exists.
+async function displayExtensionHeader(extensionRef: string): Promise<{
+  extension?: Extension;
+  latestVersion?: ExtensionVersion;
+}> {
   let extension: Extension | undefined;
+  let latestVersion: ExtensionVersion | undefined;
   try {
     extension = await getExtension(extensionRef);
-  } catch (err: any) {
-    // Silently fail and continue the publish flow if Extension not found.
-  }
-
-  // Prompt for repo URI and validate that it hasn't changed if previously set.
-  if (args.repoUri && !repoRegex.test(args.repoUri)) {
-    throw new FirebaseError("Repo URI must follow this format: https://github.com/<user>/<repo>");
-  }
-  let repoUri = args.repoUri || extension?.repoUri;
-  if (!repoUri) {
-    if (!args.nonInteractive) {
-      repoUri = await promptForValidRepoURI();
-    } else {
-      throw new FirebaseError("Repo URI is required but not currently set.");
+    try {
+      latestVersion = await getExtensionVersion(`${extensionRef}@latest`);
+    } catch (err: any) {
+      // Silently fail and continue if extension has no latest version.
     }
-  }
-  if (extension?.repoUri) {
+    const source = extension.repoUri
+      ? `${new URL(
+          latestVersion?.extensionRoot ?? "",
+          extension.repoUri
+        )} (use --repo and --root to modify)`
+      : "-";
+    logger.info("");
+    logger.info(`${clc.bold("Extension:")} ${extension.ref}`);
+    logger.info(`${clc.bold("State:")} ${unpackExtensionState(extension)}`);
+    logger.info(`${clc.bold("Latest Version:")} ${extension.latestVersion ?? "-"}`);
     logger.info(
-      `Extension ${clc.bold(extensionRef)} is uploaded from ${clc.bold(
-        extension?.repoUri
-      )}. Use --repo to change this repo.`
+      `${clc.bold("Version in Extensions Hub:")} ${extension.latestApprovedVersion ?? "-"}`
     );
+    logger.info(`${clc.bold("Source in GitHub:")} ${source}`);
+    logger.info("");
+  } catch (err: any) {
+    logger.info("");
+    logger.info(`${clc.bold("Extension:")} ${extensionRef}`);
+    logger.info(`${clc.bold("State:")} ${clc.bold(clc.blue("New"))}`);
+    logger.info("");
+    // Silently fail and continue if extension does not exist.
   }
+  return { extension, latestVersion };
+}
 
-  let extensionRoot = args.extensionRoot;
-  let defaultRoot = "/";
-  if (!extensionRoot) {
-    // Try to get the cached root only if the root hasn't already been passed in.
-    if (extension) {
-      try {
-        const extensionVersionRef = `${extensionRef}@${extension.latestVersion}`;
-
-        const extensionVersion = await getExtensionVersion(extensionVersionRef);
-        if (extensionVersion.extensionRoot) {
-          defaultRoot = extensionVersion.extensionRoot;
-        }
-      } catch (err: any) {
-        // Not a critical error so continue with default root.
-      }
-    }
-    extensionRoot = defaultRoot;
-    if (!args.nonInteractive) {
-      extensionRoot = await promptOnce({
-        type: "input",
-        message:
-          "Enter this Extension's root directory in the repo (defaults to previous root if set):",
-        default: defaultRoot,
-      });
-    }
-  }
-
-  // Prompt for source ref and default to HEAD.
-  let sourceRef = args.sourceRef;
-  const defaultSourceRef = "HEAD";
-  if (!sourceRef) {
-    if (!args.nonInteractive) {
-      sourceRef = await promptOnce({
-        type: "input",
-        message: "Enter the commit hash, branch, or tag name to build from in the repo:",
-        default: defaultSourceRef,
-      });
-    } else {
-      sourceRef = defaultSourceRef;
-    }
-  }
-
-  // Prompt for release stage.
-  let stage = args.stage;
-  const defaultStage = "rc";
-  if (!stage) {
-    if (!args.nonInteractive) {
-      stage = await promptOnce({
-        type: "list",
-        message: "Choose the release stage (pre-release annotations will be auto-incremented):",
-        choices: stageOptions,
-        default: defaultStage,
-      });
-    } else {
-      stage = defaultStage;
-    }
-  }
-
-  // Fetch and validate extension from remote repo.
+/**
+ * Fetches the extension source from GitHub.
+ *
+ * @param repoUri the public GitHub repo URI that contains the extension source
+ * @param sourceRef the commit hash, branch, or tag to build from the repo
+ * @param extensionRoot the root directory that contains this extension
+ */
+async function fetchExtensionSource(
+  repoUri: string,
+  sourceRef: string,
+  extensionRoot: string
+): Promise<string> {
   const sourceUri = repoUri + path.join("/tree", sourceRef, extensionRoot);
   logger.info(`Validating source code at ${clc.bold(sourceUri)}...`);
   const archiveUri = `${repoUri}/archive/${sourceRef}.zip`;
@@ -710,15 +807,118 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
       )}. Please verify the root and try again.`
     );
   }
-  const { extensionSpec, notes } = await validateExtensionSpec({
-    publisherId: args.publisherId,
-    extensionId: args.extensionId,
-    rootDirectory: rootDirectory,
-    latestVersion: extension?.latestVersion,
-    stage: stage!,
-  });
+  return rootDirectory;
+}
 
-  displayReleaseNotes(extensionRef, extensionSpec.version, notes, sourceUri);
+/**
+ * Uploads an extension version from a GitHub repo.
+ *
+ * @param publisherId the ID of the Publisher this Extension will be published under
+ * @param extensionId the ID of the Extension to be published
+ * @param repoUri the URI of the repo where this Extension's source exists
+ * @param sourceRef the commit hash, branch, or tag name in the repo to publish from
+ * @param extensionRoot the root directory that contains this Extension's source
+ * @param stage the release stage to publish
+ * @param nonInteractive whether to display prompts
+ * @param force whether to force confirmations
+ */
+export async function uploadExtensionVersionFromGitHubSource(args: {
+  publisherId: string;
+  extensionId: string;
+  repoUri?: string;
+  sourceRef?: string;
+  extensionRoot?: string;
+  stage?: ReleaseStage;
+  nonInteractive: boolean;
+  force: boolean;
+}): Promise<ExtensionVersion | undefined> {
+  const extensionRef = `${args.publisherId}/${args.extensionId}`;
+  const { extension, latestVersion } = await displayExtensionHeader(extensionRef);
+
+  if (args.stage && !stageOptions.includes(args.stage)) {
+    throw new FirebaseError(`--stage flag only supports the following values: ${stageOptions}`);
+  }
+
+  // Prompt for repo URI.
+  if (args.repoUri && !repoRegex.test(args.repoUri)) {
+    throw new FirebaseError("Repo URI must follow this format: https://github.com/<user>/<repo>");
+  }
+  let repoUri = args.repoUri || extension?.repoUri;
+  if (!repoUri) {
+    if (!args.nonInteractive) {
+      repoUri = await promptForValidRepoURI();
+    } else {
+      throw new FirebaseError("Repo URI is required but not currently set.");
+    }
+  }
+
+  // TODO: Normalize the extension root.
+  let extensionRoot = args.extensionRoot || latestVersion?.extensionRoot;
+  if (!extensionRoot) {
+    const defaultRoot = "/";
+    if (!args.nonInteractive) {
+      extensionRoot = await promptOnce({
+        type: "input",
+        message:
+          "Enter this extension's root directory in the repo (defaults to previous root if set):",
+        default: defaultRoot,
+      });
+    } else {
+      extensionRoot = defaultRoot;
+    }
+  }
+
+  // Prompt for source ref and default to HEAD.
+  let sourceRef = args.sourceRef;
+  const defaultSourceRef = "HEAD";
+  if (!sourceRef) {
+    if (!args.nonInteractive) {
+      sourceRef = await promptOnce({
+        type: "input",
+        message: "Enter the commit hash, branch, or tag name to build from in the repo:",
+        default: defaultSourceRef,
+      });
+    } else {
+      sourceRef = defaultSourceRef;
+    }
+  }
+
+  const rootDirectory = await fetchExtensionSource(repoUri, sourceRef, extensionRoot);
+  const extensionSpec = await validateExtensionSpec(rootDirectory, args.extensionId);
+  validateVersion(extensionSpec.version, extension?.latestVersion, extensionRef);
+  const { versionByStage, hasVersions } = await getNextVersionByStage(
+    extensionRef,
+    extensionSpec.version
+  );
+  const autoReview =
+    !!extension?.latestApprovedVersion ||
+    ["PENDING", "APPROVED", "REJECTED"].includes(latestVersion?.listing?.state ?? "");
+
+  // Prompt for release stage.
+  let stage = args.stage;
+  if (!stage) {
+    if (!args.nonInteractive) {
+      stage = await promptForReleaseStage({
+        versionByStage,
+        autoReview,
+        allowStable: true,
+        hasVersions,
+        nonInteractive: args.nonInteractive,
+        force: args.force,
+      });
+    } else {
+      stage = "rc";
+    }
+  }
+
+  const newVersion = versionByStage.get(stage)!;
+  const releaseNotes = validateReleaseNotes(
+    rootDirectory,
+    extensionSpec.version,
+    !!extension?.latestVersion
+  );
+  const sourceUri = repoUri + path.join("/tree", sourceRef, extensionRoot);
+  displayReleaseNotes({ extensionRef, newVersion, releaseNotes, sourceUri, autoReview });
   const confirmed = await confirm({
     nonInteractive: args.nonInteractive,
     force: args.force,
@@ -729,8 +929,8 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
   }
 
   // Upload the extension version.
-  const extensionVersionRef = `${extensionRef}@${extensionSpec.version}`;
-  const uploadSpinner = ora(` Uploading ${clc.bold(extensionVersionRef)}`);
+  const extensionVersionRef = `${extensionRef}@${newVersion}`;
+  const uploadSpinner = ora(`Uploading ${clc.bold(extensionVersionRef)}...`);
   let res;
   try {
     uploadSpinner.start();
@@ -740,7 +940,7 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
       repoUri,
       sourceRef: sourceRef,
     });
-    uploadSpinner.succeed(` Successfully uploaded ${clc.bold(extensionRef)}`);
+    uploadSpinner.succeed(`Successfully uploaded ${clc.bold(extensionRef)}`);
   } catch (err: any) {
     uploadSpinner.fail();
     if (err.status === 404) {
@@ -769,23 +969,44 @@ export async function uploadExtensionVersionFromLocalSource(args: {
   nonInteractive: boolean;
   force: boolean;
 }): Promise<ExtensionVersion | undefined> {
-  let extension;
-  try {
-    extension = await getExtension(`${args.publisherId}/${args.extensionId}`);
-  } catch (err: any) {
-    // Silently fail and continue the publish flow if extension not found.
+  const extensionRef = `${args.publisherId}/${args.extensionId}`;
+  const { extension, latestVersion } = await displayExtensionHeader(extensionRef);
+
+  const localStageOptions = ["rc", "alpha", "beta"];
+  if (args.stage && !localStageOptions.includes(args.stage)) {
+    throw new FirebaseError(
+      `--stage flag only supports the following values when used with --local: ${localStageOptions}`
+    );
   }
 
-  const { extensionSpec, notes } = await validateExtensionSpec({
-    publisherId: args.publisherId,
-    extensionId: args.extensionId,
-    rootDirectory: args.rootDirectory,
-    latestVersion: extension?.latestVersion,
-    stage: args.stage,
-  });
+  const extensionSpec = await validateExtensionSpec(args.rootDirectory, args.extensionId);
+  validateVersion(extensionSpec.version, extension?.latestVersion, extensionRef);
+  const { versionByStage } = await getNextVersionByStage(extensionRef, extensionSpec.version);
 
-  const extensionRef = `${args.publisherId}/${args.extensionId}`;
-  displayReleaseNotes(extensionRef, extensionSpec.version, notes);
+  // Prompt for release stage.
+  let stage = args.stage;
+  if (!stage) {
+    if (!args.nonInteractive) {
+      stage = await promptForReleaseStage({
+        versionByStage,
+        autoReview: false,
+        allowStable: true,
+        hasVersions: false,
+        nonInteractive: args.nonInteractive,
+        force: args.force,
+      });
+    } else {
+      stage = "rc";
+    }
+  }
+
+  const newVersion = versionByStage.get(stage)!;
+  const releaseNotes = validateReleaseNotes(
+    args.rootDirectory,
+    extensionSpec.version,
+    !!extension?.latestVersion
+  );
+  displayReleaseNotes({ extensionRef, newVersion, releaseNotes, autoReview: false });
   const confirmed = await confirm({
     nonInteractive: args.nonInteractive,
     force: args.force,
@@ -795,10 +1016,10 @@ export async function uploadExtensionVersionFromLocalSource(args: {
     return;
   }
 
-  const extensionVersionRef = `${extensionRef}@${extensionSpec.version}`;
+  const extensionVersionRef = `${extensionRef}@${newVersion}`;
   let packageUri: string;
   let objectPath = "";
-  const uploadSpinner = ora(" Archiving and uploading extension source code");
+  const uploadSpinner = ora(" Archiving and uploading extension source code...");
   try {
     uploadSpinner.start();
     objectPath = await archiveAndUploadSource(args.rootDirectory, EXTENSIONS_BUCKET_NAME);
@@ -810,7 +1031,7 @@ export async function uploadExtensionVersionFromLocalSource(args: {
       original: err,
     });
   }
-  const publishSpinner = ora(` Uploading ${clc.bold(extensionVersionRef)}`);
+  const publishSpinner = ora(` Uploading ${clc.bold(extensionVersionRef)}...`);
   let res;
   try {
     publishSpinner.start();
@@ -824,7 +1045,7 @@ export async function uploadExtensionVersionFromLocalSource(args: {
     throw err;
   }
   await deleteUploadedSource(objectPath);
-  return res;
+  return;
 }
 
 function getMissingPublisherError(publisherId: string): FirebaseError {
@@ -904,33 +1125,35 @@ export function getPublisherProjectFromName(publisherName: string): number {
 }
 
 /**
- * Displays the release notes and confirmation message for an Extension about to be published.
+ * Displays the release notes and confirmation message for the extension to be uploaded.
  *
- * @param extensionRef the ref of the Extension being published
- * @param versionId the version ID of the Extension being published
- * @param releaseNotes the release notes for the version being published (if any)
- * @param sourceUri the repo URI + root from which the Extension will be published
- * @param sourceRef the source ref in the repo from which the Extension will be published
+ * @param extensionRef the ref of the extension
+ * @param newVersion the new version of the extension
+ * @param releaseNotes the release notes for the version being uploaded (if any)
+ * @param sourceUri the source URI from which the extension will be uploaded
  */
-export function displayReleaseNotes(
-  extensionRef: string,
-  versionId: string,
-  releaseNotes?: string,
-  sourceUri?: string
-): void {
-  const source = sourceUri || "local source";
-  const releaseNotesMessage = releaseNotes
-    ? `${clc.bold("Release notes:")}\n${marked(releaseNotes)}`
-    : "";
+export function displayReleaseNotes(args: {
+  extensionRef: string;
+  newVersion: string;
+  autoReview: boolean;
+  releaseNotes?: string;
+  sourceUri?: string;
+}): void {
+  const source = args.sourceUri || "local source";
+  const releaseNotesMessage = args.releaseNotes
+    ? `${clc.bold("Release notes:")}\n${marked(args.releaseNotes)}`
+    : "\n";
   const metadataMessage =
-    `${clc.bold("Extension:")} ${extensionRef}\n` +
-    `${clc.bold("Version:")} ${clc.bold(clc.green(versionId))}\n` +
+    `${clc.bold("Extension:")} ${args.extensionRef}\n` +
+    `${clc.bold("Version:")} ${clc.bold(clc.green(args.newVersion))} ${
+      args.autoReview ? "(automatically sent for review)" : ""
+    }\n` +
     `${clc.bold("Source:")} ${source}\n`;
   const message =
     `\nYou are about to upload a new version to Firebase's registry of extensions.\n\n` +
     metadataMessage +
     releaseNotesMessage +
-    `\nOnce an Extension version is uploaded, it cannot be changed. If you wish to make changes after uploading, you will need to upload a new version.\n`;
+    `Once an extension version is uploaded, it cannot be changed. If you wish to make changes after uploading, you will need to upload a new version.\n`;
   logger.info(message);
 }
 

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -253,7 +253,7 @@ export function validateSpec(spec: any) {
   } else {
     const version = semver.parse(spec.version)!;
     if (version.prerelease.length > 0 || version.build.length > 0) {
-      errors.push("version field in extension.yaml does not support pre-release annotations");
+      errors.push("version field in extension.yaml does not support pre-release annotations; instead, set a pre-release stage using the --stage flag");
     }
   }
   if (!spec.license) {
@@ -544,7 +544,7 @@ async function getNextVersionByStage(
   try {
     extensionVersions = await listExtensionVersions(extensionRef, `id="${newVersion}"`, true);
   } catch (err: any) {
-    // Silently fail if there are no extension versions exist.
+    // Silently fail if no extension versions exist.
   }
   // Maps stage to default next version (e.g. "rc" => "1.0.0-rc.0").
   const versionByStage = new Map(

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -538,7 +538,7 @@ async function archiveAndUploadSource(extPath: string, bucketName: string): Prom
  * @param extensionRef the ref of the extension
  * @param version the new version of the extension
  */
-async function getNextVersionByStage(
+export async function getNextVersionByStage(
   extensionRef: string,
   newVersion: string
 ): Promise<{ versionByStage: Map<string, string>; hasVersions: boolean }> {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -791,7 +791,7 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
   } catch (err: any) {
     // Silently fail and continue if extension is new or has no latest version set.
   }
-  displayExtensionHeader(extensionRef);
+  displayExtensionHeader(extensionRef, extension, latestVersion?.extensionRoot);
 
   if (args.stage && !stageOptions.includes(args.stage)) {
     throw new FirebaseError(`--stage flag only supports the following values: ${stageOptions}`);
@@ -934,7 +934,7 @@ export async function uploadExtensionVersionFromLocalSource(args: {
   } catch (err: any) {
     // Silently fail and continue if extension is new or has no latest version set.
   }
-  displayExtensionHeader(extensionRef);
+  displayExtensionHeader(extensionRef, extension, latestVersion?.extensionRoot);
 
   const localStageOptions = ["rc", "alpha", "beta"];
   if (args.stage && !localStageOptions.includes(args.stage)) {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -796,7 +796,7 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
   displayExtensionHeader(extensionRef, extension, latestVersion?.extensionRoot);
 
   if (args.stage && !stageOptions.includes(args.stage)) {
-    throw new FirebaseError(`--stage flag only supports the following values: ${stageOptions}`);
+    throw new FirebaseError(`--stage flag only supports the following values: ${stageOptions.join(", ")}`);
   }
 
   // Prompt for repo URI.
@@ -937,7 +937,7 @@ export async function uploadExtensionVersionFromLocalSource(args: {
   const localStageOptions = ["rc", "alpha", "beta"];
   if (args.stage && !localStageOptions.includes(args.stage)) {
     throw new FirebaseError(
-      `--stage flag only supports the following values when used with --local: ${localStageOptions}`
+      `--stage flag only supports the following values when used with --local: ${localStageOptions.join(", ")}`
     );
   }
 

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -981,11 +981,11 @@ export async function uploadExtensionVersionFromLocalSource(args: {
   const extensionVersionRef = `${extensionRef}@${newVersion}`;
   let packageUri: string;
   let objectPath = "";
-  const uploadSpinner = ora(" Archiving and uploading extension source code...");
+  const uploadSpinner = ora("Archiving and uploading extension source code...");
   try {
     uploadSpinner.start();
     objectPath = await archiveAndUploadSource(args.rootDirectory, EXTENSIONS_BUCKET_NAME);
-    uploadSpinner.succeed(" Uploaded extension source code");
+    uploadSpinner.succeed("Uploaded extension source code");
     packageUri = storageOrigin + objectPath + "?alt=media";
   } catch (err: any) {
     uploadSpinner.fail();
@@ -993,12 +993,12 @@ export async function uploadExtensionVersionFromLocalSource(args: {
       original: err,
     });
   }
-  const publishSpinner = ora(` Uploading ${clc.bold(extensionVersionRef)}...`);
+  const publishSpinner = ora(`Uploading ${clc.bold(extensionVersionRef)}...`);
   let res;
   try {
     publishSpinner.start();
     res = await createExtensionVersionFromLocalSource({ extensionVersionRef, packageUri });
-    publishSpinner.succeed(` Successfully uploaded ${clc.bold(extensionVersionRef)}`);
+    publishSpinner.succeed(`Successfully uploaded ${clc.bold(extensionVersionRef)}`);
   } catch (err: any) {
     publishSpinner.fail();
     if (err.status === 404) {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -545,6 +545,7 @@ async function getNextVersionByStage(
   } catch (err: any) {
     // Silently fail if there are no extension versions exist.
   }
+  // Maps stage to default next version (e.g. "rc" => "1.0.0-rc.0").
   const versionByStage = new Map(
     ["rc", "alpha", "beta"].map((stage) => [
       stage,
@@ -555,9 +556,9 @@ async function getNextVersionByStage(
     .map((extensionVersion) => semver.parse(extensionVersion.spec.version)!)
     .filter((version) => !!version.prerelease)
     .forEach((version) => {
-      // Extensions only support semvers of format: <major>.<minor>.<patch>-<stage>.<count>
+      // Extensions only support a single prerelease annotation.
       const prerelease = semver.prerelease(version)![0];
-      // Parse out stage from <stage>.<count>
+      // Parse out stage from prerelease (e.g. "rc" from "rc.0").
       const stage = prerelease.split(".")[0];
       if (versionByStage.has(stage) && semver.gte(version, versionByStage.get(stage)!)) {
         versionByStage.set(stage, semver.inc(version, "prerelease", undefined, stage)!);

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -696,10 +696,12 @@ function displayExtensionHeader(
   extensionRoot?: string
 ) {
   if (extension) {
-    // TODO: Fix this logic.
-    const source = extension.repoUri
-      ? `${new URL(extensionRoot ?? "", extension.repoUri)} (use --repo and --root to modify)`
-      : "Local source";
+    let source = "Local source";
+    if (extension.repoUri) {
+      const uri = new URL(extension.repoUri!);
+      uri.pathname = path.join(uri.pathname, extensionRoot ?? "");
+      source = `${uri.toString()} (use --repo and --root to modify)`;
+    }
     logger.info(
       `\n${clc.bold("Extension:")} ${extension.ref}\n` +
         `${clc.bold("State:")} ${unpackExtensionState(extension)}\n` +

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -796,7 +796,9 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
   displayExtensionHeader(extensionRef, extension, latestVersion?.extensionRoot);
 
   if (args.stage && !stageOptions.includes(args.stage)) {
-    throw new FirebaseError(`--stage flag only supports the following values: ${stageOptions.join(", ")}`);
+    throw new FirebaseError(
+      `--stage only supports the following values: ${stageOptions.join(", ")}`
+    );
   }
 
   // Prompt for repo URI.
@@ -937,7 +939,9 @@ export async function uploadExtensionVersionFromLocalSource(args: {
   const localStageOptions = ["rc", "alpha", "beta"];
   if (args.stage && !localStageOptions.includes(args.stage)) {
     throw new FirebaseError(
-      `--stage flag only supports the following values when used with --local: ${localStageOptions.join(", ")}`
+      `--stage only supports the following values when used with --local: ${localStageOptions.join(
+        ", "
+      )}`
     );
   }
 

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -557,7 +557,7 @@ async function getNextVersionByStage(
   );
   for (const extensionVersion of extensionVersions) {
     const version = semver.parse(extensionVersion.spec.version)!;
-    if (!version.prerelease) {
+    if (!version.prerelease || version.prerelease.length === 0) {
       continue;
     }
     // Extensions only support a single prerelease annotation.

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -6,6 +6,7 @@ import * as fs from "fs-extra";
 import fetch from "node-fetch";
 import * as path from "path";
 import { marked } from "marked";
+import normalize from "normalize-path";
 
 import { createUnzipTransform } from "./../unzip";
 const TerminalRenderer = require("marked-terminal");
@@ -693,30 +694,28 @@ export function unpackExtensionState(extension: Extension) {
 function displayExtensionHeader(
   extensionRef: string,
   extension?: Extension,
-  latestVersion?: ExtensionVersion
+  extensionRoot?: string
 ) {
   if (extension) {
     // TODO: Fix this logic.
     const source = extension.repoUri
       ? `${new URL(
-          latestVersion?.extensionRoot ?? "",
+          extensionRoot ?? "",
           extension.repoUri
         )} (use --repo and --root to modify)`
       : "Local source";
-    logger.info("");
-    logger.info(`${clc.bold("Extension:")} ${extension.ref}`);
-    logger.info(`${clc.bold("State:")} ${unpackExtensionState(extension)}`);
-    logger.info(`${clc.bold("Latest Version:")} ${extension.latestVersion ?? "-"}`);
     logger.info(
-      `${clc.bold("Version in Extensions Hub:")} ${extension.latestApprovedVersion ?? "-"}`
+      `\n${clc.bold("Extension:")} ${extension.ref}\n` +
+        `${clc.bold("State:")} ${unpackExtensionState(extension)}\n` +
+        `${clc.bold("Latest Version:")} ${extension.latestVersion ?? "-"}\n` +
+        `${clc.bold("Version in Extensions Hub:")} ${extension.latestApprovedVersion ?? "-"}\n` +
+        `${clc.bold("Source in GitHub:")} ${source}\n`
     );
-    logger.info(`${clc.bold("Source in GitHub:")} ${source}`);
-    logger.info("");
   } else {
-    logger.info("");
-    logger.info(`${clc.bold("Extension:")} ${extensionRef}`);
-    logger.info(`${clc.bold("State:")} ${clc.bold(clc.blue("New"))}`);
-    logger.info("");
+    logger.info(
+      `\n${clc.bold("Extension:")} ${extensionRef}\n` +
+        `${clc.bold("State:")} ${clc.bold(clc.blue("New"))}\n`
+    );
   }
 }
 

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -253,7 +253,9 @@ export function validateSpec(spec: any) {
   } else {
     const version = semver.parse(spec.version)!;
     if (version.prerelease.length > 0 || version.build.length > 0) {
-      errors.push("version field in extension.yaml does not support pre-release annotations; instead, set a pre-release stage using the --stage flag");
+      errors.push(
+        "version field in extension.yaml does not support pre-release annotations; instead, set a pre-release stage using the --stage flag"
+      );
     }
   }
   if (!spec.license) {

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -6,7 +6,6 @@ import * as fs from "fs-extra";
 import fetch from "node-fetch";
 import * as path from "path";
 import { marked } from "marked";
-import normalize from "normalize-path";
 
 import { createUnzipTransform } from "./../unzip";
 const TerminalRenderer = require("marked-terminal");
@@ -699,10 +698,7 @@ function displayExtensionHeader(
   if (extension) {
     // TODO: Fix this logic.
     const source = extension.repoUri
-      ? `${new URL(
-          extensionRoot ?? "",
-          extension.repoUri
-        )} (use --repo and --root to modify)`
+      ? `${new URL(extensionRoot ?? "", extension.repoUri)} (use --repo and --root to modify)`
       : "Local source";
     logger.info(
       `\n${clc.bold("Extension:")} ${extension.ref}\n` +

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -845,9 +845,9 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
   );
   const autoReview =
     !!extension?.latestApprovedVersion ||
-    latestVersion?.listing?.state == "PENDING" ||
-    latestVersion?.listing?.state == "APPROVED" ||
-    latestVersion?.listing?.state == "REJECTED";
+    latestVersion?.listing?.state === "PENDING" ||
+    latestVersion?.listing?.state === "APPROVED" ||
+    latestVersion?.listing?.state === "REJECTED";
 
   // Prompt for release stage.
   let stage = args.stage;

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -557,7 +557,7 @@ async function getNextVersionByStage(
   );
   for (const extensionVersion of extensionVersions) {
     const version = semver.parse(extensionVersion.spec.version)!;
-    if (!version.prerelease || version.prerelease.length === 0) {
+    if (!version.prerelease.length) {
       continue;
     }
     // Extensions only support a single prerelease annotation.

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -952,7 +952,7 @@ export async function uploadExtensionVersionFromLocalSource(args: {
       stage = await promptForReleaseStage({
         versionByStage,
         autoReview: false,
-        allowStable: true,
+        allowStable: false,
         hasVersions: false,
         nonInteractive: args.nonInteractive,
         force: args.force,

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -690,7 +690,11 @@ export function unpackExtensionState(extension: Extension) {
  *
  * @param extensionRef the ref of the extension
  */
-function displayExtensionHeader(extensionRef: string, extension?: Extension, latestVersion?: ExtensionVersion) {
+function displayExtensionHeader(
+  extensionRef: string,
+  extension?: Extension,
+  latestVersion?: ExtensionVersion
+) {
   if (extension) {
     // TODO: Fix this logic.
     const source = extension.repoUri

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -669,11 +669,7 @@ function validateReleaseNotes(rootDirectory: string, newVersion: string, require
  * @param newVersion the new extension version
  * @param latestVersion the latest extension version
  */
-function validateVersion(
-  extensionRef: string,
-  newVersion: string,
-  latestVersion?: string,
-) {
+function validateVersion(extensionRef: string, newVersion: string, latestVersion?: string) {
   if (latestVersion) {
     if (semver.lt(newVersion, latestVersion)) {
       throw new FirebaseError(
@@ -908,7 +904,13 @@ export async function uploadExtensionVersionFromGitHubSource(args: {
     !!extension?.latestVersion
   );
   const sourceUri = repoUri + path.join("/tree", sourceRef, extensionRoot);
-  displayReleaseNotes({ extensionRef, newVersion, releaseNotes, sourceUri, autoReview });
+  displayReleaseNotes({
+    extensionRef,
+    newVersion,
+    releaseNotes,
+    sourceUri,
+    autoReview: stage === "stable" && autoReview,
+  });
   const confirmed = await confirm({
     nonInteractive: args.nonInteractive,
     force: args.force,
@@ -970,7 +972,7 @@ export async function uploadExtensionVersionFromLocalSource(args: {
   }
 
   const extensionSpec = await validateExtensionSpec(args.rootDirectory, args.extensionId);
-  validateVersion( extensionRef, extensionSpec.version, extension?.latestVersion);
+  validateVersion(extensionRef, extensionSpec.version, extension?.latestVersion);
   const { versionByStage } = await getNextVersionByStage(extensionRef, extensionSpec.version);
 
   // Prompt for release stage.
@@ -1129,7 +1131,7 @@ export function displayReleaseNotes(args: {
   releaseNotes?: string;
   sourceUri?: string;
 }): void {
-  const source = args.sourceUri || "local source";
+  const source = args.sourceUri || "Local source";
   const releaseNotesMessage = args.releaseNotes
     ? `${clc.bold("Release notes:")}\n${marked(args.releaseNotes)}`
     : "\n";
@@ -1143,7 +1145,7 @@ export function displayReleaseNotes(args: {
     `\nYou are about to upload a new version to Firebase's registry of extensions.\n\n` +
     metadataMessage +
     releaseNotesMessage +
-    `Once an extension version is uploaded, it cannot be changed. If you wish to make changes after uploading, you will need to upload a new version.\n`;
+    `Once an extension version is uploaded, it becomes installable by other users and cannot be changed. If you wish to make changes after uploading, you will need to upload a new version.\n`;
   logger.info(message);
 }
 

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -467,46 +467,6 @@ describe("extensionsHelper", () => {
     });
   });
 
-  describe("incrementPrereleaseVersion", () => {
-    let listExtensionVersionsStub: sinon.SinonStub;
-
-    beforeEach(() => {
-      listExtensionVersionsStub = sinon.stub(publisherApi, "listExtensionVersions");
-      listExtensionVersionsStub.returns(Promise.resolve([TEST_EXT_VERSION_1, TEST_EXT_VERSION_2]));
-    });
-
-    afterEach(() => {
-      listExtensionVersionsStub.restore();
-    });
-
-    it("should increment rc version", async () => {
-      const newVersion = await extensionsHelper.incrementPrereleaseVersion(
-        "test-pub/ext-one",
-        "0.0.1",
-        "rc"
-      );
-      expect(newVersion).to.eql("0.0.1-rc.2");
-    });
-
-    it("should be first beta version", async () => {
-      const newVersion = await extensionsHelper.incrementPrereleaseVersion(
-        "test-pub/ext-one",
-        "0.0.1",
-        "beta"
-      );
-      expect(newVersion).to.eql("0.0.1-beta.0");
-    });
-
-    it("should not increment version", async () => {
-      const newVersion = await extensionsHelper.incrementPrereleaseVersion(
-        "test-pub/ext-one",
-        "0.0.1",
-        "stable"
-      );
-      expect(newVersion).to.eql("0.0.1");
-    });
-  });
-
   describe("validateSpec", () => {
     it("should not error on a valid spec", () => {
       const testSpec: ExtensionSpec = {

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -9,44 +9,11 @@ import * as functionsConfig from "../../functionsConfig";
 import { storage } from "../../gcp";
 import * as archiveDirectory from "../../archiveDirectory";
 import * as prompt from "../../prompt";
-import {
-  ExtensionSource,
-  ExtensionSpec,
-  ExtensionVersion,
-  Param,
-  ParamType,
-} from "../../extensions/types";
+import { ExtensionSource, ExtensionSpec, Param, ParamType } from "../../extensions/types";
 import { Readable } from "stream";
 import { ArchiveResult } from "../../archiveDirectory";
 import { canonicalizeRefInput } from "../../extensions/extensionsHelper";
 import * as planner from "../../deploy/extensions/planner";
-
-const EXT_SPEC_1: ExtensionSpec = {
-  name: "cool-things",
-  version: "0.0.1-rc.0",
-  resources: [
-    {
-      name: "cool-resource",
-      type: "firebaseextensions.v1beta.function",
-    },
-  ],
-  sourceUrl: "www.google.com/cool-things-here",
-  params: [],
-  systemParams: [],
-};
-const EXT_SPEC_2: ExtensionSpec = {
-  name: "cool-things",
-  version: "0.0.1-rc.1",
-  resources: [
-    {
-      name: "cool-resource",
-      type: "firebaseextensions.v1beta.function",
-    },
-  ],
-  sourceUrl: "www.google.com/cool-things-here",
-  params: [],
-  systemParams: [],
-};
 
 describe("extensionsHelper", () => {
   describe("substituteParams", () => {

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -4,7 +4,6 @@ import * as sinon from "sinon";
 import { FirebaseError } from "../../error";
 import * as extensionsApi from "../../extensions/extensionsApi";
 import * as extensionsHelper from "../../extensions/extensionsHelper";
-import * as publisherApi from "../../extensions/publisherApi";
 import * as getProjectNumber from "../../getProjectNumber";
 import * as functionsConfig from "../../functionsConfig";
 import { storage } from "../../gcp";
@@ -47,24 +46,6 @@ const EXT_SPEC_2: ExtensionSpec = {
   sourceUrl: "www.google.com/cool-things-here",
   params: [],
   systemParams: [],
-};
-const TEST_EXT_VERSION_1: ExtensionVersion = {
-  name: "publishers/test-pub/extensions/ext-one/versions/0.0.1-rc.0",
-  ref: "test-pub/ext-one@0.0.1-rc.0",
-  spec: EXT_SPEC_1,
-  state: "PUBLISHED",
-  hash: "12345",
-  createTime: "2020-06-30T00:21:06.722782Z",
-  sourceDownloadUri: "",
-};
-const TEST_EXT_VERSION_2: ExtensionVersion = {
-  name: "publishers/test-pub/extensions/ext-one/versions/0.0.1-rc.1",
-  ref: "test-pub/ext-one@0.0.1-rc.1",
-  spec: EXT_SPEC_2,
-  state: "PUBLISHED",
-  hash: "23456",
-  createTime: "2020-06-30T00:21:06.722782Z",
-  sourceDownloadUri: "",
 };
 
 describe("extensionsHelper", () => {

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -951,15 +951,15 @@ describe("extensionsHelper", () => {
   });
 
   describe("unpackExtensionState", () => {
-    it("should return correct state", () => {
-      const testExtension: Extension = {
-        name: "publishers/publisher-id/extensions/extension-id",
-        ref: "publisher-id/extension-id",
-        visibility: Visibility.PUBLIC,
-        registryLaunchStage: RegistryLaunchStage.BETA,
-        createTime: "",
-        state: "PUBLISHED",
-      };
+    const testExtension: Extension = {
+      name: "publishers/publisher-id/extensions/extension-id",
+      ref: "publisher-id/extension-id",
+      visibility: Visibility.PUBLIC,
+      registryLaunchStage: RegistryLaunchStage.BETA,
+      createTime: "",
+      state: "PUBLISHED",
+    };
+    it("should return correct published state", () => {
       expect(
         extensionsHelper.unpackExtensionState({
           ...testExtension,
@@ -968,6 +968,8 @@ describe("extensionsHelper", () => {
           latestApprovedVersion: "1.0.0",
         })
       ).to.eql(clc.bold(clc.green("Published")));
+    });
+    it("should return correct uploaded state", () => {
       expect(
         extensionsHelper.unpackExtensionState({
           ...testExtension,
@@ -975,12 +977,16 @@ describe("extensionsHelper", () => {
           latestVersion: "1.0.0",
         })
       ).to.eql(clc.green("Uploaded"));
+    });
+    it("should return correct deprecated state", () => {
       expect(
         extensionsHelper.unpackExtensionState({
           ...testExtension,
           state: "DEPRECATED",
         })
       ).to.eql(clc.red("Deprecated"));
+    });
+    it("should return correct suspended state", () => {
       expect(
         extensionsHelper.unpackExtensionState({
           ...testExtension,
@@ -988,6 +994,8 @@ describe("extensionsHelper", () => {
           latestVersion: "1.0.0",
         })
       ).to.eql(clc.bold(clc.red("Suspended")));
+    });
+    it("should return correct prerelease state", () => {
       expect(
         extensionsHelper.unpackExtensionState({
           ...testExtension,

--- a/src/test/extensions/extensionsHelper.spec.ts
+++ b/src/test/extensions/extensionsHelper.spec.ts
@@ -1,3 +1,4 @@
+import * as clc from "colorette";
 import { expect } from "chai";
 import * as sinon from "sinon";
 
@@ -10,7 +11,15 @@ import * as functionsConfig from "../../functionsConfig";
 import { storage } from "../../gcp";
 import * as archiveDirectory from "../../archiveDirectory";
 import * as prompt from "../../prompt";
-import { ExtensionSource, ExtensionSpec, Param, ParamType } from "../../extensions/types";
+import {
+  ExtensionSource,
+  ExtensionSpec,
+  Param,
+  ParamType,
+  Extension,
+  Visibility,
+  RegistryLaunchStage,
+} from "../../extensions/types";
 import { Readable } from "stream";
 import { ArchiveResult } from "../../archiveDirectory";
 import { canonicalizeRefInput } from "../../extensions/extensionsHelper";
@@ -938,6 +947,53 @@ describe("extensionsHelper", () => {
       );
       expect(Array.from(versionByStage.entries())).to.eql(Array.from(expected.entries()));
       expect(hasVersions).to.eql(true);
+    });
+  });
+
+  describe("unpackExtensionState", () => {
+    it("should return correct state", () => {
+      const testExtension: Extension = {
+        name: "publishers/publisher-id/extensions/extension-id",
+        ref: "publisher-id/extension-id",
+        visibility: Visibility.PUBLIC,
+        registryLaunchStage: RegistryLaunchStage.BETA,
+        createTime: "",
+        state: "PUBLISHED",
+      };
+      expect(
+        extensionsHelper.unpackExtensionState({
+          ...testExtension,
+          state: "PUBLISHED",
+          latestVersion: "1.0.0",
+          latestApprovedVersion: "1.0.0",
+        })
+      ).to.eql(clc.bold(clc.green("Published")));
+      expect(
+        extensionsHelper.unpackExtensionState({
+          ...testExtension,
+          state: "PUBLISHED",
+          latestVersion: "1.0.0",
+        })
+      ).to.eql(clc.green("Uploaded"));
+      expect(
+        extensionsHelper.unpackExtensionState({
+          ...testExtension,
+          state: "DEPRECATED",
+        })
+      ).to.eql(clc.red("Deprecated"));
+      expect(
+        extensionsHelper.unpackExtensionState({
+          ...testExtension,
+          state: "SUSPENDED",
+          latestVersion: "1.0.0",
+        })
+      ).to.eql(clc.bold(clc.red("Suspended")));
+      expect(
+        extensionsHelper.unpackExtensionState({
+          ...testExtension,
+          state: "PUBLISHED",
+        })
+      ).to.eql("Prerelease");
     });
   });
 


### PR DESCRIPTION
This PR consists of a few things:

- Refactoring of the ext:dev:upload code into smaller functions that are called by both the local and GitHub upload paths.
- Adding quality of life features and information like extension metadata, next version by stage, warnings for not uploading pre-release versions first, callouts that stable versions will be submitted for review, etc.
- Adding restrictions on upload from local to pre-release only.

<img width="913" alt="Screenshot 2023-05-08 at 9 08 41 AM" src="https://user-images.githubusercontent.com/8932584/236880633-c73eb74a-27c6-4259-a0d6-1807d6dd9bb1.png">
<img width="913" alt="Screenshot 2023-05-08 at 9 08 56 AM" src="https://user-images.githubusercontent.com/8932584/236880647-851f3f02-9d88-471f-b746-bacee80770f6.png">
<img width="913" alt="Screenshot 2023-05-08 at 9 13 50 AM" src="https://user-images.githubusercontent.com/8932584/236880668-712f32ff-4f01-42d5-88d1-23cb573f7ebf.png">
<img width="913" alt="Screenshot 2023-05-08 at 9 15 24 AM" src="https://user-images.githubusercontent.com/8932584/236880685-0f49592c-54c7-4f82-8ea1-6bc979814cd0.png">
<img width="913" alt="Screenshot 2023-05-08 at 9 55 56 AM" src="https://user-images.githubusercontent.com/8932584/236885164-6e2b3a20-040a-48dc-8e48-634590f207ed.png">
