### PR TITLE
Add support for latest-approved version, and default to it instead of latest.

### DIFF
--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -219,7 +219,7 @@ export async function resolveVersion(ref: refs.Ref): Promise<string> {
   if (!ref.version || ref.version === "latest-approved") {
     if (!extension.latestApprovedVersion) {
       throw new FirebaseError(
-        `${extensionRef} has not been published to https://extensions.dev. To install it, you must specify the version you want to install.`
+        `${extensionRef} has not been published to Extensions Hub (https://extensions.dev). To install it, you must specify the version you want to install.`
       );
     }
     return extension.latestApprovedVersion;

--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -227,7 +227,7 @@ export async function resolveVersion(ref: refs.Ref): Promise<string> {
   if (ref.version === "latest") {
     if (!extension.latestVersion) {
       throw new FirebaseError(
-        `${extensionRef} has no stables versions (or all have been deprecated). If you wish to install a prerelease version, you must specify the version you want to install.`
+        `${extensionRef} has no stable non-deprecated versions. If you wish to install a prerelease version, you must specify the version you want to install.`
       );
     }
     return extension.latestVersion;

--- a/src/deploy/extensions/planner.ts
+++ b/src/deploy/extensions/planner.ts
@@ -215,16 +215,27 @@ export async function want(args: {
  */
 export async function resolveVersion(ref: refs.Ref): Promise<string> {
   const extensionRef = refs.toExtensionRef(ref);
+  const extension = await extensionsApi.getExtension(extensionRef);
+  if (!ref.version || ref.version === "latest-approved") {
+    if (!extension.latestApprovedVersion) {
+      throw new FirebaseError(
+        `${extensionRef} has not been published to https://extensions.dev. To install it, you must specify the version you want to install.`
+      );
+    }
+    return extension.latestApprovedVersion;
+  }
+  if (ref.version === "latest") {
+    if (!extension.latestVersion) {
+      throw new FirebaseError(
+        `${extensionRef} has no stables versions (or all have been deprecated). If you wish to install a prerelease version, you must specify the version you want to install.`
+      );
+    }
+    return extension.latestVersion;
+  }
+
   const versions = await extensionsApi.listExtensionVersions(extensionRef, undefined, true);
   if (versions.length === 0) {
     throw new FirebaseError(`No versions found for ${extensionRef}`);
-  }
-  if (!ref.version || ref.version === "latest") {
-    return versions
-      .filter((ev) => ev.spec.version !== undefined)
-      .map((ev) => ev.spec.version)
-      .sort(semver.compare)
-      .pop()!;
   }
   const maxSatisfying = semver.maxSatisfying(
     versions.map((ev) => ev.spec.version),

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -1064,17 +1064,18 @@ export async function diagnoseAndFixProject(options: any): Promise<void> {
 /**
  * Canonicalize a user-inputted ref string.
  * 1. Infer firebase publisher if not provided
- * 2. Infer "latest" as the version if not provided
+ * 2. Infer "latest-approved" as the version if not provided
  */
 export async function canonicalizeRefInput(refInput: string): Promise<string> {
   let inferredRef = refInput;
+  // TODO: Stop defaulting to 'firebase' publisher ID if none provided.
   // Infer 'firebase' if publisher ID not provided.
   if (refInput.split("/").length < 2) {
     inferredRef = `firebase/${inferredRef}`;
   }
   // Infer 'latest' if no version provided.
   if (refInput.split("@").length < 2) {
-    inferredRef = `${inferredRef}@latest`;
+    inferredRef = `${inferredRef}@latest-approved`;
   }
   // Get the correct version for a given extension reference from the Registry API.
   const ref = refs.parse(inferredRef);

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -1073,7 +1073,7 @@ export async function canonicalizeRefInput(refInput: string): Promise<string> {
   if (refInput.split("/").length < 2) {
     inferredRef = `firebase/${inferredRef}`;
   }
-  // Infer 'latest' if no version provided.
+  // Infer 'latest-approved' if no version provided.
   if (refInput.split("@").length < 2) {
     inferredRef = `${inferredRef}@latest-approved`;
   }

--- a/src/extensions/refs.ts
+++ b/src/extensions/refs.ts
@@ -28,7 +28,7 @@ export function parse(refOrName: string): Ref {
     ret.version &&
     !semver.valid(ret.version) &&
     !semver.validRange(ret.version) &&
-    ret.version !== "latest"
+    !["latest", "latest-approved"].includes(ret.version)
   ) {
     throw new FirebaseError(
       `Extension reference ${ret} contains an invalid version ${ret.version}.`

--- a/src/extensions/types.ts
+++ b/src/extensions/types.ts
@@ -20,8 +20,8 @@ export interface Extension {
   name: string;
   ref: string;
   state: ExtensionState;
-  visibility: Visibility;
-  registryLaunchStage: RegistryLaunchStage;
+  visibility?: Visibility;
+  registryLaunchStage?: RegistryLaunchStage;
   createTime: string;
   latestApprovedVersion?: string;
   latestVersion?: string;


### PR DESCRIPTION
### Description
Default to latest-approved instead of latest.

### Scenarios Tested
Tested deploying with 'latest-approved' in the manifest, fetched the correct version:
<img width="617" alt="Screenshot 2023-05-08 at 3 54 59 PM" src="https://user-images.githubusercontent.com/4635763/236954785-db07a77f-a278-467b-b9a5-7359f77cb75c.png">
Tested ext:install with no version, defauted to latest-approved
<img width="732" alt="Screenshot 2023-05-08 at 3 56 11 PM" src="https://user-images.githubusercontent.com/4635763/236954943-cbf6606e-4155-4d53-874e-f2a32e75caa4.png">
Tested with explicit 'latest-approved; works:
<img width="828" alt="Screenshot 2023-05-08 at 3 56 50 PM" src="https://user-images.githubusercontent.com/4635763/236954978-40962539-263c-4dd4-8b97-21583812c6e0.png">


