### PR TITLE
[Fix] spawnSync from cross-spawn

### DIFF
--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -3,7 +3,7 @@ import type { ReadOptions } from "fs-extra";
 import { extname, join, relative } from "path";
 import { readFile } from "fs/promises";
 import { IncomingMessage, request as httpRequest, ServerResponse, Agent } from "http";
-import { spawnSync } from "child_process";
+import { sync as spawnSync } from "cross-spawn";
 import * as clc from "colorette";
 
 import { logger } from "../logger";


### PR DESCRIPTION
### Description

Use of package cross-pawn instead of child-process for cross-platform compatibility

### Scenarios Tested

on Windows, child_process.spawnSync does not always find the npm command and therefore the getNPMRoot function returns null.

Indeed spawnSync returned the error "spawnSync npm ENOENT"

