### PR TITLE
Update builder image to npm 9.5

### DIFF
--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -8,5 +8,5 @@ RUN apt-get update && \
 RUN curl -fsSL --output hub.tgz https://github.com/github/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz
 RUN tar --strip-components=2 -C /usr/bin -xf hub.tgz hub-linux-amd64-2.14.2/bin/hub
 
-# Upgrade npm to 8.
-RUN npm install --global npm@8.7
+# Upgrade npm to 9.
+RUN npm install --global npm@9.5

--- a/scripts/build/Dockerfile
+++ b/scripts/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 # Install dependencies
 RUN apt-get update && \


### PR DESCRIPTION
### Description
Update the builder image to use npm 9.5. The firepit builder was already updated, so no changes needed there AFAICT.
