### PR TITLE
Replace user of `source` command with with `.` when invoking venv for python functions.

### DIFF
--- a/src/functions/python.ts
+++ b/src/functions/python.ts
@@ -16,7 +16,7 @@ export function virtualEnvCmd(cwd: string, venvDir: string): { command: string; 
     process.platform === "win32" ? ["Scripts", "activate.bat"] : ["bin", "activate"];
   const venvActivate = path.join(cwd, venvDir, ...activateScriptPath);
   return {
-    command: process.platform === "win32" ? venvActivate : "source",
+    command: process.platform === "win32" ? venvActivate : ".",
     args: [process.platform === "win32" ? "" : venvActivate],
   };
 }


### PR DESCRIPTION
Per https://stackoverflow.com/questions/13702425/source-command-not-found-in-sh-shell, `.` is more widely supportedthan `source`. For example, `bin/sh` packaged in Ubuntu does not have `source` but supports `.`.

Credits for @RafaelZasas to discovering the issue on Ubuntu.

Fixes https://github.com/firebase/firebase-tools/issues/5636