### PR TITLE
Correctly handle optional fields in EventArc emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes an issue in the EventArc emualtor where events missing optional fields would cause crashes. (#5803)

--- a/src/emulator/eventarcEmulatorUtils.ts
+++ b/src/emulator/eventarcEmulatorUtils.ts
@@ -36,11 +36,11 @@ export function cloudEventFromProtoToJson(ce: any): CloudEvent<any> {
 }
 
 function getOptionalAttribute(ce: any, attr: string, type: string): string | undefined {
-  return ce["attributes"][attr][type];
+  return ce?.["attributes"]?.[attr]?.[type];
 }
 
 function getRequiredAttribute(ce: any, attr: string, type: string): string {
-  const val = ce["attributes"][attr][type];
+  const val = ce?.["attributes"]?.[attr]?.[type];
   if (val === undefined) {
     throw new FirebaseError("CloudEvent must contain " + attr + " attribute");
   }

--- a/src/test/emulators/eventarcEmulatorUtils.spec.ts
+++ b/src/test/emulators/eventarcEmulatorUtils.spec.ts
@@ -122,5 +122,40 @@ describe("eventarcEmulatorUtils", () => {
       expect(got.datacontenttype).to.deep.eq("text/plain");
       expect(got.data).to.eq("hello world");
     });
+
+    it("allows optional attribute to not be set", () => {
+      expect(
+        cloudEventFromProtoToJson({
+          "@type": "type.googleapis.com/io.cloudevents.v1.CloudEvent",
+          attributes: {
+            customattr: {
+              ceString: "custom value",
+            },
+            datacontenttype: {
+              ceString: "application/json",
+            },
+            time: {
+              ceTimestamp: "2022-03-16T20:20:42.212Z",
+            },
+          },
+          id: "user-provided-id",
+          source: "/my/functions",
+          specVersion: "1.0",
+          textData: '{"hello":"world"}',
+          type: "some.custom.event",
+        })
+      ).to.deep.eq({
+        type: "some.custom.event",
+        specversion: "1.0",
+        datacontenttype: "application/json",
+        id: "user-provided-id",
+        data: {
+          hello: "world",
+        },
+        source: "/my/functions",
+        time: "2022-03-16T20:20:42.212Z",
+        customattr: "custom value",
+      });
+    });
   });
 });

--- a/src/test/emulators/eventarcEmulatorUtils.spec.ts
+++ b/src/test/emulators/eventarcEmulatorUtils.spec.ts
@@ -138,6 +138,7 @@ describe("eventarcEmulatorUtils", () => {
               ceTimestamp: "2022-03-16T20:20:42.212Z",
             },
           },
+          subject: undefined,
           id: "user-provided-id",
           source: "/my/functions",
           specVersion: "1.0",

--- a/src/test/emulators/eventarcEmulatorUtils.spec.ts
+++ b/src/test/emulators/eventarcEmulatorUtils.spec.ts
@@ -138,7 +138,6 @@ describe("eventarcEmulatorUtils", () => {
               ceTimestamp: "2022-03-16T20:20:42.212Z",
             },
           },
-          subject: undefined,
           id: "user-provided-id",
           source: "/my/functions",
           specVersion: "1.0",
@@ -150,6 +149,7 @@ describe("eventarcEmulatorUtils", () => {
         specversion: "1.0",
         datacontenttype: "application/json",
         id: "user-provided-id",
+        subject: undefined,
         data: {
           hello: "world",
         },


### PR DESCRIPTION
Description
Previously, if you omitted an optional field in the EventaArc emulator, it would throw a NPE. This change improves that handling, and also ensures that missing required fields throw a friendlier error. Fixes #5803