### PR TITLE
Fix Python Functions error when path has spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes an issue in the EventArc emualtor where events missing optional fields would cause crashes. (#5803)
+- Fixes an issue running `firebase emulators:start` and `firebase deploy` when Python Cloud Functions directory path has spaces. (#5830)

--- a/src/functions/python.ts
+++ b/src/functions/python.ts
@@ -14,7 +14,7 @@ export const DEFAULT_VENV_DIR = "venv";
 export function virtualEnvCmd(cwd: string, venvDir: string): { command: string; args: string[] } {
   const activateScriptPath =
     process.platform === "win32" ? ["Scripts", "activate.bat"] : ["bin", "activate"];
-  const venvActivate = path.join(cwd, venvDir, ...activateScriptPath);
+  const venvActivate = `"${path.join(cwd, venvDir, ...activateScriptPath)}"`;
   return {
     command: process.platform === "win32" ? venvActivate : ".",
     args: [process.platform === "win32" ? "" : venvActivate],


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Proposed fix for #5830 

Issue seems to be caused by [spawn](https://github.com/firebase/firebase-tools/blob/f8f19dc060e6daf060b87d38fd2a38d24bab8210/src/functions/python.ts#L38) raising an error when path provided has spaces. Might be related to https://github.com/nodejs/node/issues/38490. 

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Similar to steps provided in #5830 

1. Run `mkdir 'i like spaces'`
2. Run `cd i\ like\ spaces` or `cd 'i like spaces'`
3. Run `firebase init functions --project <project_id>`
    1. Select `Python`
    2. Do you want to install dependencies now? Yes
4. Run `cd functions`
5. Run `firebase emulators:start`
    1. Emulators start with no issues
7. Uncomment code in `main.py` to deploy
8. Run `firebase deploy --only functions`
    1. Functions deployed with no issues

### Sample Commands

`firebase emulators:start` && `firebase deploy --only functions`
<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
