### PR TITLE
Add support for nodejs20 (in preview)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes an issue in the EventArc emualtor where events missing optional fields would cause crashes. (#5803)
 - Fixes an issue running `firebase emulators:start` and `firebase deploy` when Python Cloud Functions directory path has spaces. (#5830)
+- Add support for nodejs20 for Cloud Functions for Firebase

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fixes an issue running `firebase emulators:start` when Python Cloud Functions directory path has spaces. (#5854)
-- Add support for nodejs20 for Cloud Functions for Firebase
+- Add support for nodejs20 for Cloud Functions for Firebase. (#5837)

--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -617,7 +617,8 @@
                                 "nodejs12",
                                 "nodejs14",
                                 "nodejs16",
-                                "nodejs18"
+                                "nodejs18",
+                                "nodejs20"
                             ],
                             "type": "string"
                         },
@@ -672,7 +673,8 @@
                                     "nodejs12",
                                     "nodejs14",
                                     "nodejs16",
-                                    "nodejs18"
+                                    "nodejs18",
+                                    "nodejs20"
                                 ],
                                 "type": "string"
                             },

--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -12,6 +12,7 @@ const RUNTIMES: string[] = [
   "nodejs14",
   "nodejs16",
   "nodejs18",
+  "nodejs20",
   "python310",
   "python311",
 ];
@@ -43,6 +44,7 @@ const MESSAGE_FRIENDLY_RUNTIMES: Record<Runtime | DeprecatedRuntime, string> = {
   nodejs14: "Node.js 14",
   nodejs16: "Node.js 16",
   nodejs18: "Node.js 18",
+  nodejs20: "Node.js 20",
   python310: "Python 3.10",
   python311: "Python 3.11",
 };

--- a/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
+++ b/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
@@ -17,6 +17,7 @@ const ENGINE_RUNTIMES: Record<number, runtimes.Runtime | runtimes.DeprecatedRunt
   14: "nodejs14",
   16: "nodejs16",
   18: "nodejs18",
+  20: "nodejs20",
 };
 
 const ENGINE_RUNTIMES_NAMES = Object.values(ENGINE_RUNTIMES);

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -10,7 +10,7 @@ import type { HttpsOptions } from "firebase-functions/v2/https";
 import { IngressSetting, MemoryOption, VpcEgressSetting } from "firebase-functions/v2/options";
 
 // should be sourced from - https://github.com/firebase/firebase-tools/blob/master/src/deploy/functions/runtimes/index.ts#L15
-type CloudFunctionRuntimes = "nodejs10" | "nodejs12" | "nodejs14" | "nodejs16" | "nodejs18";
+type CloudFunctionRuntimes = "nodejs10" | "nodejs12" | "nodejs14" | "nodejs16" | "nodejs18" | "nodejs20";
 
 export type Deployable = {
   predeploy?: string | string[];

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -10,7 +10,13 @@ import type { HttpsOptions } from "firebase-functions/v2/https";
 import { IngressSetting, MemoryOption, VpcEgressSetting } from "firebase-functions/v2/options";
 
 // should be sourced from - https://github.com/firebase/firebase-tools/blob/master/src/deploy/functions/runtimes/index.ts#L15
-type CloudFunctionRuntimes = "nodejs10" | "nodejs12" | "nodejs14" | "nodejs16" | "nodejs18" | "nodejs20";
+type CloudFunctionRuntimes =
+  | "nodejs10"
+  | "nodejs12"
+  | "nodejs14"
+  | "nodejs16"
+  | "nodejs18"
+  | "nodejs20";
 
 export type Deployable = {
   predeploy?: string | string[];


### PR DESCRIPTION
To resolve the following error when trying to deploy with Node 20:

`Error: package.json in functions directory has an engines field which is unsupported. Valid choices are: {"node": 10|12|14|16|18}`

This is a mirror of https://github.com/firebase/firebase-tools/pull/5319 but changed for `nodejs20`, which [is now available as a Functions runtime in preview](https://cloud.google.com/functions/docs/concepts/nodejs-runtime). I simply copied the changes in that PR. If a Firebaser finds these changes to be correct then of course feel free to merge, otherwise I would greatly appreciate it if someone else added support swiftly so that we may deploy with this runtime. Thanks!

