### PR TITLE
Fix issue with Python Functions when path has spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-Fixes an issue running `firebase emulators:start` when Python Cloud Functions directory path has spaces. (#5854)
+- Fixes an issue running `firebase emulators:start` when Python Cloud Functions directory path has spaces. (#5854)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Fixes an issue running `firebase emulators:start` when Python Cloud Functions directory path has spaces. (#5854)

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -144,7 +144,7 @@ export class Delegate implements runtimes.RuntimeDelegate {
       ...envs,
       ADMIN_PORT: port.toString(),
     };
-    const args = [this.bin, path.join(modulesDir, "private", "serving.py")];
+    const args = [this.bin, `"${path.join(modulesDir, "private", "serving.py")}"`];
     const stdout: string[] = [];
     const stderr: string[] = [];
     logger.debug(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Proposed fix for #5854.

Related to  #5830. Issue seems to be similar as the error message shows the incomplete path when path has spaces.  e.g. if path is `/Users/<user>/Desktop/project directory/function`, error message will shows path `/Users/<user>/Desktop/project`.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1. Create a directory with a space 
2. Run `firebase init functions` and run through the setup for Python functions.
3. Run `firebase init emulators` and setup the functions emulator
4. Run `firebase emulators:start`


### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase emulators:start`