### PR TITLE
Improve error message when function deployment fails due to quota issues

### DIFF
--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -125,6 +125,16 @@ export function getEndpointFilters(options: { only?: string }): EndpointFilter[]
 }
 
 /**
+ * Get human friendly name for the given function platform
+ */
+export function getHumanFriendlyPlatformName(platform: backend.Endpoint["platform"]): string {
+  if (platform === "gcfv1") {
+    return "1st Gen";
+  }
+  return "2nd Gen";
+}
+
+/**
  * Generate label for a function.
  */
 export function getFunctionLabel(fn: backend.TargetIds & { codebase?: string }): string {

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -26,6 +26,7 @@ import * as utils from "../../../utils";
 import * as services from "../services";
 import { AUTH_BLOCKING_EVENTS } from "../../../functions/events/v1";
 import { getDefaultComputeServiceAgent } from "../checkIam";
+import { getHumanFriendlyPlatformName } from "../functionsDeployHelper";
 
 // TODO: Tune this for better performance.
 const gcfV1PollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
@@ -680,8 +681,12 @@ export class Fabricator {
 
   logOpStart(op: string, endpoint: backend.Endpoint): void {
     const runtime = getHumanFriendlyRuntimeName(endpoint.runtime);
+    const platform = getHumanFriendlyPlatformName(endpoint.platform);
     const label = helper.getFunctionLabel(endpoint);
-    utils.logLabeledBullet("functions", `${op} ${runtime} function ${clc.bold(label)}...`);
+    utils.logLabeledBullet(
+      "functions",
+      `${op} ${runtime} (${platform}) function ${clc.bold(label)}...`
+    );
   }
 
   logOpSuccess(op: string, endpoint: backend.Endpoint): void {

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -1,5 +1,3 @@
-import * as clc from "colorette";
-
 import { Client, ClientVerbOptions } from "../apiv2";
 import { FirebaseError } from "../error";
 import { functionsV2Origin } from "../api";
@@ -21,6 +19,9 @@ import {
 import { RequireKeys } from "../metaprogramming";
 
 export const API_VERSION = "v2";
+
+// Defined by Cloud Run: https://cloud.google.com/run/docs/configuring/max-instances#setting
+const DEFAULT_MAX_INSTANCE_COUNT = 100;
 
 const client = new Client({
   urlPrefix: functionsV2Origin,
@@ -234,51 +235,52 @@ export function mebibytes(memory: string): number {
 
 /**
  * Logs an error from a failed function deployment.
- * @param funcName Name of the function that was unsuccessfully deployed.
+ * @param func The function that was unsuccessfully deployed.
  * @param type Type of deployment - create, update, or delete.
  * @param err The error returned from the operation.
  */
-function functionsOpLogReject(funcName: string, type: string, err: any): void {
-  utils.logWarning(clc.bold(clc.yellow("functions:")) + ` ${err?.message}`);
-  if (err?.context?.response?.statusCode === 429) {
+function functionsOpLogReject(func: InputCloudFunction, type: string, err: any): void {
+  if (err?.message?.includes("maxScale may not exceed")) {
+    const maxInstances = func.serviceConfig.maxInstanceCount || DEFAULT_MAX_INSTANCE_COUNT;
     utils.logLabeledWarning(
       "functions",
-      `Got "Quota Exceeded" error while trying to ${type} ${funcName}. Waiting to retry...`
-    );
-  } else if (
-    err?.message?.includes(
-      "If you recently started to use Eventarc, it may take a few minutes before all necessary permissions are propagated to the Service Agent"
-    )
-  ) {
-    utils.logLabeledWarning(
-      "functions",
-      `Since this is your first time using functions v2, we need a little bit longer to finish setting everything up, please retry the deployment in a few minutes.`
-    );
-  } else if (err?.message?.includes("maxScale may not exceed")) {
-    const errMsg = err.message;
-    utils.logLabeledWarning(
-      "functions",
-      "You can adjust the max instances value in your function option:"
+      `Your current project quotas don't allow for the current max instances setting of ${maxInstances}. ` +
+        "Either reduce this function's maxInstances, or request a quota increase on the underlying Cloud Run service " +
+        "at https://cloud.google.com/run/quotas."
     );
     utils.logLabeledWarning(
       "functions",
-      "(Node.js) functions.v2.options.setGlobalOptions({maxInstances: 10})"
-    );
-    utils.logLabeledWarning(
-      "functions",
-      "(Python) firebase_functions.options.set_global_options(max_instances=10)"
+      "You can adjust the max instances value in your function's runtime options:\n" +
+        "\t(Node.js) setGlobalOptions({maxInstances: 10})\n" +
+        "\t(Python) firebase_functions.options.set_global_options(max_instances=10)"
     );
   } else {
+    utils.logLabeledWarning("functions", `${err?.message}`);
+    if (err?.context?.response?.statusCode === 429) {
+      utils.logLabeledWarning(
+        "functions",
+        `Got "Quota Exceeded" error while trying to ${type} ${func.name}. Waiting to retry...`
+      );
+    } else if (
+      err?.message?.includes(
+        "If you recently started to use Eventarc, it may take a few minutes before all necessary permissions are propagated to the Service Agent"
+      )
+    ) {
+      utils.logLabeledWarning(
+        "functions",
+        `Since this is your first time using functions v2, we need a little bit longer to finish setting everything up, please retry the deployment in a few minutes.`
+      );
+    }
     utils.logLabeledWarning(
       "functions",
 
-      ` failed to ${type} function ${funcName}`
+      ` failed to ${type} function ${func.name}`
     );
   }
-  throw new FirebaseError(`Failed to ${type} function ${funcName}`, {
+  throw new FirebaseError(`Failed to ${type} function ${func.name}`, {
     original: err,
     status: err?.context?.response?.statusCode,
-    context: { function: funcName },
+    context: { function: func.name },
   });
 }
 
@@ -325,7 +327,7 @@ export async function createFunction(cloudFunction: InputCloudFunction): Promise
     );
     return res.body;
   } catch (err: any) {
-    throw functionsOpLogReject(cloudFunction.name, "create", err);
+    throw functionsOpLogReject(cloudFunction, "create", err);
   }
 }
 
@@ -428,7 +430,7 @@ export async function updateFunction(cloudFunction: InputCloudFunction): Promise
     );
     return res.body;
   } catch (err: any) {
-    throw functionsOpLogReject(cloudFunction.name, "update", err);
+    throw functionsOpLogReject(cloudFunction, "update", err);
   }
 }
 
@@ -441,7 +443,7 @@ export async function deleteFunction(cloudFunction: string): Promise<Operation> 
     const res = await client.delete<Operation>(cloudFunction);
     return res.body;
   } catch (err: any) {
-    throw functionsOpLogReject(cloudFunction, "update", err);
+    throw functionsOpLogReject({ name: cloudFunction } as InputCloudFunction, "update", err);
   }
 }
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -241,24 +241,38 @@ export function mebibytes(memory: string): number {
 function functionsOpLogReject(funcName: string, type: string, err: any): void {
   utils.logWarning(clc.bold(clc.yellow("functions:")) + ` ${err?.message}`);
   if (err?.context?.response?.statusCode === 429) {
-    utils.logWarning(
-      `${clc.bold(
-        clc.yellow("functions:")
-      )} got "Quota Exceeded" error while trying to ${type} ${funcName}. Waiting to retry...`
+    utils.logLabeledWarning(
+      "functions",
+      `Got "Quota Exceeded" error while trying to ${type} ${funcName}. Waiting to retry...`
     );
   } else if (
-    err?.message.includes(
+    err?.message?.includes(
       "If you recently started to use Eventarc, it may take a few minutes before all necessary permissions are propagated to the Service Agent"
     )
   ) {
-    utils.logWarning(
-      `${clc.bold(
-        clc.yellow("functions:")
-      )} since this is your first time using functions v2, we need a little bit longer to finish setting everything up, please retry the deployment in a few minutes.`
+    utils.logLabeledWarning(
+      "functions",
+      `Since this is your first time using functions v2, we need a little bit longer to finish setting everything up, please retry the deployment in a few minutes.`
+    );
+  } else if (err?.message?.includes("maxScale may not exceed")) {
+    const errMsg = err.message;
+    utils.logLabeledWarning(
+      "functions",
+      "You can adjust the max instances value in your function option:"
+    );
+    utils.logLabeledWarning(
+      "functions",
+      "(Node.js) functions.v2.options.setGlobalOptions({maxInstances: 10})"
+    );
+    utils.logLabeledWarning(
+      "functions",
+      "(Python) firebase_functions.options.set_global_options(max_instances=10)"
     );
   } else {
-    utils.logWarning(
-      clc.bold(clc.yellow("functions:")) + " failed to " + type + " function " + funcName
+    utils.logLabeledWarning(
+      "functions",
+
+      ` failed to ${type} function ${funcName}`
     );
   }
   throw new FirebaseError(`Failed to ${type} function ${funcName}`, {


### PR DESCRIPTION
When function deployment fails due to insufficient quota on Cloud Run, the error message is difficult to understand:

```
i  functions: creating Node.js 18 function helloWorld(us-east4)...
⚠  functions: HTTP Error: 400, Could not create Cloud Run service helloworld. spec.template.spec.containers.resources.limits.cpu: Invalid value specified for cpu. For the specified value, maxScale may not exceed 10.
Consider running your workload in a region with greater capacity, decreasing your requested cpu-per-instance, or requesting an increase in quota for this region if you are seeing sustained usage near this limit, see https://cloud.google.com/run/quotas. Your project may gain access to further scaling by adding billing information to your account.
```

Updated error message, which we hope is clearer and actionable:

```
i  functions: creating Node.js 18 (2nd Gen) function helloWorld(us-east4)...
⚠  functions: Your current project quotas don't allow for the current max instances setting of 100. Either reduce this function's maxInstances, or request a quota increase on the underlying Cloud Run service at https://cloud.google.com/run/quotas.
⚠  functions: You can adjust the max instances value in your function's runtime options:
	setGlobalOptions({maxInstances: 10})
```