### PR TITLE
Improves cleanup process when reloading emulated functions in debug mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Update error message when function deploy fails due to quota. (#5867)
 - Fixes RTDB emulator 127.0.0.1 namespace resolution bug. (#5863)
 - Improves RTDB emulator to GCF emulator network reliability. (#5863)
+- Improves cleanup process when reloading emulated functions in debug mode. (#5878)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -561,7 +561,12 @@ export class FunctionsEmulator implements EmulatorInstance {
     }
     // Before loading any triggers we need to make sure there are no 'stale' workers
     // in the pool that would cause us to run old code.
-    this.workerPools[emulatableBackend.codebase].refresh();
+    if (this.debugMode) {
+      // Kill the workerPool. This should clean up all inspectors connected to the debug port.
+      this.workerPools[emulatableBackend.codebase].exit();
+    } else {
+      this.workerPools[emulatableBackend.codebase].refresh();
+    }
     // reset blocking functions config for reloads
     this.blockingFunctionsConfig = {};
 


### PR DESCRIPTION
Instead of spawning a new process that exposes the debugger endpoint, the Functions Emulator will attempt to explicitly kill the existing process before loading the function with the updated source code.

Possible fix for https://github.com/firebase/firebase-tools/issues/5508, https://github.com/firebase/firebase-tools/issues/5653