### PR TITLE
Improve error message raised when `--import` flag directory does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Address additional cases where we were attempting to deploy a framework's development bundle (#5895)
-- Improve error message raised when `--import` flag directory does not exist. (#5895)
+- Improve error message raised when `--import` flag directory does not exist. (#5851)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Address additional cases where we were attempting to deploy a framework's development bundle (#5895)
+- Improve error message raised when `--import` flag directory does not exist. (#5895)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -186,6 +186,11 @@ export function shouldStart(options: Options, name: Emulators): boolean {
 }
 
 function findExportMetadata(importPath: string): ExportMetadata | undefined {
+  const pathExists = fs.existsSync(importPath);
+  if (!pathExists) {
+    throw new FirebaseError(`Directory "${importPath}" does not exist.`);
+  }
+
   const pathIsDirectory = fs.lstatSync(importPath).isDirectory();
   if (!pathIsDirectory) {
     return;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #5851.

Based on logs provided in #5851, error is being raised when `lstatSync()` is provided a path that does not exist. Proposed solution is to check if the file exists, then raise an error if it does not. 

Error message with `--debug` flag:
```
[2023-05-16T23:20:43.308Z] Error: ENOENT: no such file or directory, lstat '/home/gudmundur/projects/remembflutter/.seed'
    at Object.lstatSync (node:fs:1529:3)
    at Object.lstatSync (pkg/prelude/bootstrap.js:1503:33)
    at findExportMetadata (/home/gudmundur/.cache/firebase/tools/lib/node_modules/firebase-tools/lib/emulator/controller.js:119:32)
    at Object.startAll (/home/gudmundur/.cache/firebase/tools/lib/node_modules/firebase-tools/lib/emulator/controller.js:269:31)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /home/gudmundur/.cache/firebase/tools/lib/node_modules/firebase-tools/lib/commands/emulators-start.js:32:43
```

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1 - Directory does not exist
Running `firebase emulators:start --import=./directory`  result in:
```
Error: Directory "<path>/directory" does not exist.
```

2 - Directory does not exist and path has spaces
Running `firebase emulators:start --import="./directory path"`  result in:
```
Error: Directory "<path>/directory path" does not exist.
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase emulators:start --import=<path>`
