### PR TITLE
Fix issue where a user is created when empty email and password is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Address additional cases where we were attempting to deploy a framework's development bundle (#5895)
+- Fixes issue where Authentication emulator creates a user if empty email and empty password is provided. (#5639)

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -198,13 +198,13 @@ async function signUp(
     }
   }
 
-  if (reqBody.email) {
+  if (typeof reqBody.email === "string") {
     assert(isValidEmailAddress(reqBody.email), "INVALID_EMAIL");
     const email = canonicalizeEmailAddress(reqBody.email);
     assert(!state.getUserByEmail(email), "EMAIL_EXISTS");
     updates.email = email;
   }
-  if (reqBody.password) {
+  if (typeof reqBody.password === "string") {
     assert(
       reqBody.password.length >= PASSWORD_MIN_LENGTH,
       `WEAK_PASSWORD : Password should be at least ${PASSWORD_MIN_LENGTH} characters`

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -40,7 +40,7 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
       });
   });
 
-  it("should throw error if blank email and password is provided", async () => {
+  it("should throw error if empty email and password is provided", async () => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
       .send({ email: "", password: "" })

--- a/src/test/emulators/auth/signUp.spec.ts
+++ b/src/test/emulators/auth/signUp.spec.ts
@@ -40,6 +40,17 @@ describeAuthEmulator("accounts:signUp", ({ authApi }) => {
       });
   });
 
+  it("should throw error if blank email and password is provided", async () => {
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")
+      .send({ email: "", password: "" })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("INVALID_EMAIL");
+      });
+  });
+
   it("should issue idToken and refreshToken on anon signUp", async () => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:signUp")


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Proposed fix for #5639.

Using code snippet below creates a user with empty identifier and empty provider (similar to anonymous sign in):
```
      const email = ""; 
      const password = ""; 
      await createUserWithEmailAndPassword(auth, email, password)
        .then((user) => {
          console.log("Registered and logged in:", user);
        })
        .catch((error) => {console.log(error)}
```

Cause of the issue seems to be cause by https://github.com/firebase/firebase-tools/blob/51d2fd574a2c5e81bf51acb0b89409182edb40e9/src/emulator/auth/operations.ts#L201 
When value of `reqBody.email` is "", `if (reqBody.email)` becomes false so we don't call `assert(isValidEmailAddress(reqBody.email), "INVALID_EMAIL");`.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

| Scenario                                 | Prod                                              | Emulator                                          | PR                                                |
|------------------------------------------|---------------------------------------------------|---------------------------------------------------|---------------------------------------------------|
| email="" password=""                     | Error (auth/invalid-email)                        | Creates a user with blank identifier and provider | Error (auth/invalid-email)                        |
| email="" password="123456"               | Error (auth/missing-email)                        | Error (auth/missing-email)                        | Error (auth/missing-email)                        |
| email="test@gmail.com" password=""       | Error (auth/missing-password)                     | Error (auth/missing-password)                     | Error (auth/missing-password)                     |
| email="test@gmail.com" password="123456" | Creates a user with identifier and email provider | Creates a user with identifier and email provider | Creates a user with identifier and email provider |

