### PR TITLE
Ensure Extensions TOS api is enabled before calling it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Address additional cases where we were attempting to deploy a framework's development bundle (#5895)
+- Fixes an issue where the Firebase Extensions Terms of Service API was not enabled in some cases where it is needed. (#5855)

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -5,6 +5,7 @@ import { confirm } from "../prompt";
 import { FirebaseError } from "../error";
 import { logPrefix } from "./extensionsHelper";
 import * as utils from "../utils";
+import { ensure } from "../ensureApiEnabled";
 
 const VERSION = "v1";
 const extensionsTosUrl = (tos: string) => `https://firebase.google.com/terms/extensions/${tos}`;
@@ -72,6 +73,7 @@ export async function acceptLatestPublisherTOS(
     );
     return currentAcceptance;
   } else {
+    await ensure(projectId, extensionsTOSOrigin, "extensions", true);
     // Display link to TOS, prompt for acceptance
     const tosLink = extensionsTosUrl("publisher");
     logger.info(
@@ -107,6 +109,7 @@ export async function acceptLatestAppDeveloperTOS(
   ) {
     throw new FirebaseError("You must accept the terms of service to continue.");
   }
+  await ensure(projectId, extensionsTOSOrigin, "extensions", true);
   const tosPromises = instanceIds.map((instanceId) => {
     return acceptAppDeveloperTOS(projectId, currentAcceptance.latestTosVersion, instanceId);
   });

--- a/src/test/extensions/tos.spec.ts
+++ b/src/test/extensions/tos.spec.ts
@@ -1,15 +1,22 @@
 import { expect } from "chai";
 import * as nock from "nock";
+import * as sinon from "sinon";
 
 import * as api from "../../api";
+import * as ensure from "../../ensureApiEnabled";
 import * as tos from "../../extensions/tos";
 
 describe("tos", () => {
+  const testProjectId = "test-proj";
+  let ensureApiEnabedStub: sinon.SinonStub;
+  beforeEach(() => {
+    ensureApiEnabedStub = sinon.stub(ensure, "ensure");
+  });
   afterEach(() => {
     nock.cleanAll();
+    ensureApiEnabedStub.restore();
   });
 
-  const testProjectId = "test-proj";
   describe("getAppDeveloperTOSStatus", () => {
     it("should get app developer TOS", async () => {
       const t = testTOS("appdevtos", "1.0.0");


### PR DESCRIPTION
### Description
Ensure that the TOS api is enabled before we call it. Fixes #5855
