### PR TITLE
Switch ext:dev:init to default billingRequire to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Address additional cases where we were attempting to deploy a framework's development bundle (#5895)
+- Switch `ext:dev:init` to default 'billingRequired' to true in `extension.yaml`

--- a/templates/extensions/extension.yaml
+++ b/templates/extensions/extension.yaml
@@ -19,7 +19,7 @@ sourceUrl: https://github.com/firebase/firebase-tools/tree/master/templates/exte
 
 # Specify whether a paid-tier billing plan is required to use your extension.
 # Learn more in the docs: https://firebase.google.com/docs/extensions/reference/extension-yaml#billing-required-field
-billingRequired: false
+billingRequired: true
 
 # In an `apis` field, list any Google APIs (like Cloud Translation, BigQuery, etc.)
 # required for your extension to operate.


### PR DESCRIPTION
### Description
Switch `ext:dev:init` to default billingRequire to true.  Since Cloud Functions  require billing now, this should almost always be true.