### PR TITLE
Export on exit typing

### DIFF
--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -193,7 +193,6 @@ export function parseInspectionPort(options: any): number {
 export function setExportOnExitOptions(options: {
   exportOnExit: boolean | string;
   import?: string;
-  [x: string | number | symbol]: unknown;
 }): void {
   if (options.exportOnExit || typeof options.exportOnExit === "string") {
     // note that options.exportOnExit may be a bool when used as a flag without a [dir] argument:

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -190,7 +190,11 @@ export function parseInspectionPort(options: any): number {
  * export data the first time they start developing on a clean project.
  * @param options
  */
-export function setExportOnExitOptions(options: any) {
+export function setExportOnExitOptions(options: {
+  exportOnExit: boolean | string;
+  import?: string;
+  [x: string | number | symbol]: unknown;
+}): void {
   if (options.exportOnExit || typeof options.exportOnExit === "string") {
     // note that options.exportOnExit may be a bool when used as a flag without a [dir] argument:
     // --import ./data --export-on-exit


### PR DESCRIPTION
Export on exit typing. An example of incrementally adding typing to the common `options:any` paradigm.

See a similar example here:
https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgCoHcD2AhTmA2yA3gFDLJwBcyARnvhHCANxm3V0GMskC+JoSLEQoA8iAi4CxNlU4MmrfjACuIBGGCYQyABYR8+TAAoADnChwAttXGT6ASmS2JUwqXIJtAZy4A6IwBzYwAic0sbEOQAamQAKQBlUQA5P28wKFBA4BgATzMLawcHVnJw6z84ZABeZHh8bwhS5C8QXwYAzGCQq0wAExzgCD7KKNjElLSMrJz88qti5qgIMBUoHXmlElb05DAsN2oMHHoa4ioMlQgAGnZ6xt5WHf8g0OXV9eHRmPik1PTMiBsnljPpDJhkMZ9icCMUSkA