### PR TITLE
Use firebase API to check for default bucket instead of AppEngine API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where Storage rules could not be deployed to projects without a billing plan. (#5955)

--- a/src/api.ts
+++ b/src/api.ts
@@ -37,10 +37,6 @@ export const appDistributionOrigin = utils.envOverride(
   "FIREBASE_APP_DISTRIBUTION_URL",
   "https://firebaseappdistribution.googleapis.com"
 );
-export const appengineOrigin = utils.envOverride(
-  "FIREBASE_APPENGINE_URL",
-  "https://appengine.googleapis.com"
-);
 export const authOrigin = utils.envOverride("FIREBASE_AUTH_URL", "https://accounts.google.com");
 export const consoleOrigin = utils.envOverride(
   "FIREBASE_CONSOLE_URL",

--- a/src/deploy/storage/prepare.ts
+++ b/src/deploy/storage/prepare.ts
@@ -34,7 +34,7 @@ export default async function (context: any, options: Options): Promise<void> {
   const rulesDeploy = new RulesDeploy(options, RulesetServiceType.FIREBASE_STORAGE);
   const rulesConfigsToDeploy: any[] = [];
 
-  if (!Array.isArray(rulesConfig)) {
+  if (!Array.isArray(rulesConfig) && options.project) {
     const defaultBucket = await gcp.storage.getDefaultBucket(options.project);
     rulesConfig = [Object.assign(rulesConfig, { bucket: defaultBucket })];
   }


### PR DESCRIPTION
### Description
Switch from the App Engine API to the Firebase API for checking default bucket. Fixes #5955 

### Scenarios Tested
Not yet tested.

