### PR TITLE
First crack at using defaultBucket endpoint instead of GAE

### DIFF
--- a/src/deploy/storage/prepare.ts
+++ b/src/deploy/storage/prepare.ts
@@ -34,7 +34,7 @@ export default async function (context: any, options: Options): Promise<void> {
   const rulesDeploy = new RulesDeploy(options, RulesetServiceType.FIREBASE_STORAGE);
   const rulesConfigsToDeploy: any[] = [];
 
-  if (!Array.isArray(rulesConfig)) {
+  if (!Array.isArray(rulesConfig) && options.project) {
     const defaultBucket = await gcp.storage.getDefaultBucket(options.project);
     rulesConfig = [Object.assign(rulesConfig, { bucket: defaultBucket })];
   }


### PR DESCRIPTION
### Description
Took a crack at using defaultBucket endpoint instead of App engine. Unfortunately, this fails with the following error on projects without a bucket:

 "[ORIGINAL ERROR] generic::permission_denied: com.google.apps.framework.request.CanonicalCodeException: User is missing the following permissions: storage.buckets.get.\ncom.google.apps.framework.request.StatusException: <eye3 title='PERMISSION_DENIED'/> generic::PERMISSION_DENIED: User is missing the following permissions: storage.buckets.get. Code: PERMISSION_DENIED"