### PR TITLE
App Distribution: Add commands to manage groups 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+- Added `appdistribution:group:create` and
+  `appdistribution:group:delete`.
+- Added `--group-alias` option to `appdistribution:testers:add` and
+  `appdistribution:testers:remove`.

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -232,4 +232,32 @@ export class AppDistributionClient {
 
     utils.logSuccess(`Group deleted successfully`);
   }
+
+  async addTestersToGroup(groupName: string, emails: string[]): Promise<void> {
+    try {
+      await this.appDistroV2Client.request({
+        method: "POST",
+        path: `${groupName}:batchJoin`,
+        body: { emails: emails },
+      });
+    } catch (err: any) {
+      throw new FirebaseError(`Failed to add testers to group ${err}`);
+    }
+
+    utils.logSuccess(`Testers added to group successfully`);
+  }
+
+  async removeTestersFromGroup(groupName: string, emails: string[]): Promise<void> {
+    try {
+      await this.appDistroV2Client.request({
+        method: "POST",
+        path: `${groupName}:batchLeave`,
+        body: { emails: emails },
+      });
+    } catch (err: any) {
+      throw new FirebaseError(`Failed to remove testers from group ${err}`);
+    }
+
+    utils.logSuccess(`Testers removed from group successfully`);
+  }
 }

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -64,6 +64,14 @@ export interface BatchRemoveTestersResponse {
   emails: string[];
 }
 
+export interface Group {
+  name: string;
+  displayName: string;
+  testerCount?: number;
+  releaseCount?: number;
+  inviteLinkCount?: number;
+}
+
 /**
  * Makes RPCs to the App Distribution server backend.
  */
@@ -166,7 +174,7 @@ export class AppDistributionClient {
     utils.logSuccess("distributed to testers/groups successfully");
   }
 
-  async addTesters(projectName: string, emails: string[]) {
+  async addTesters(projectName: string, emails: string[]): Promise<void> {
     try {
       await this.appDistroV2Client.request({
         method: "POST",
@@ -195,5 +203,33 @@ export class AppDistributionClient {
       throw new FirebaseError(`Failed to remove testers ${err}`);
     }
     return apiResponse.body;
+  }
+
+  async createGroup(projectName: string, displayName: string, alias?: string): Promise<Group> {
+    let apiResponse;
+    try {
+      apiResponse = await this.appDistroV2Client.request<{ displayName: string }, Group>({
+        method: "POST",
+        path:
+          alias === undefined ? `${projectName}/groups` : `${projectName}/groups?groupId=${alias}`,
+        body: { displayName: displayName },
+      });
+    } catch (err: any) {
+      throw new FirebaseError(`Failed to create group ${err}`);
+    }
+    return apiResponse.body;
+  }
+
+  async deleteGroup(groupName: string): Promise<void> {
+    try {
+      await this.appDistroV2Client.request({
+        method: "DELETE",
+        path: groupName,
+      });
+    } catch (err: any) {
+      throw new FirebaseError(`Failed to delete group ${err}`);
+    }
+
+    utils.logSuccess(`Group deleted successfully`);
   }
 }

--- a/src/commands/appdistribution-group-create.ts
+++ b/src/commands/appdistribution-group-create.ts
@@ -13,5 +13,5 @@ export const command = new Command("appdistribution:group:create <displayName> [
     utils.logBullet(`Creating group in project`);
     const group = await appDistroClient.createGroup(projectName, displayName, alias);
     alias = group.name.split("/").pop();
-    utils.logSuccess(`Group '${group.displayName}' (${alias}) created successfully`);
+    utils.logSuccess(`Group '${group.displayName}' (alias: ${alias}) created successfully`);
   });

--- a/src/commands/appdistribution-group-create.ts
+++ b/src/commands/appdistribution-group-create.ts
@@ -1,0 +1,17 @@
+import { Command } from "../command";
+import * as utils from "../utils";
+import { requireAuth } from "../requireAuth";
+import { AppDistributionClient } from "../appdistribution/client";
+import { getProjectName } from "../appdistribution/options-parser-util";
+
+export const command = new Command("appdistribution:group:create <displayName> [alias]")
+  .description("create group in project")
+  .before(requireAuth)
+  .action(async (displayName: string, alias?: string, options?: any) => {
+    const projectName = await getProjectName(options);
+    const appDistroClient = new AppDistributionClient();
+    utils.logBullet(`Creating group in project`);
+    const group = await appDistroClient.createGroup(projectName, displayName, alias);
+    alias = group.name.split("/").pop()
+    utils.logSuccess(`Group '${group.displayName}' (${alias}) created successfully`);
+  });

--- a/src/commands/appdistribution-group-create.ts
+++ b/src/commands/appdistribution-group-create.ts
@@ -12,6 +12,6 @@ export const command = new Command("appdistribution:group:create <displayName> [
     const appDistroClient = new AppDistributionClient();
     utils.logBullet(`Creating group in project`);
     const group = await appDistroClient.createGroup(projectName, displayName, alias);
-    alias = group.name.split("/").pop()
+    alias = group.name.split("/").pop();
     utils.logSuccess(`Group '${group.displayName}' (${alias}) created successfully`);
   });

--- a/src/commands/appdistribution-group-delete.ts
+++ b/src/commands/appdistribution-group-delete.ts
@@ -3,8 +3,7 @@ import * as utils from "../utils";
 import { requireAuth } from "../requireAuth";
 import { FirebaseError } from "../error";
 import { AppDistributionClient } from "../appdistribution/client";
-import { getEmails, getProjectName } from "../appdistribution/options-parser-util";
-import { logger } from "../logger";
+import { getProjectName } from "../appdistribution/options-parser-util";
 
 export const command = new Command("appdistribution:group:delete <alias>")
   .description("delete group from a project")

--- a/src/commands/appdistribution-group-delete.ts
+++ b/src/commands/appdistribution-group-delete.ts
@@ -1,0 +1,22 @@
+import { Command } from "../command";
+import * as utils from "../utils";
+import { requireAuth } from "../requireAuth";
+import { FirebaseError } from "../error";
+import { AppDistributionClient } from "../appdistribution/client";
+import { getEmails, getProjectName } from "../appdistribution/options-parser-util";
+import { logger } from "../logger";
+
+export const command = new Command("appdistribution:group:delete <alias>")
+  .description("delete group from a project")
+  .before(requireAuth)
+  .action(async (alias: string, options: any) => {
+    const projectName = await getProjectName(options);
+    const appDistroClient = new AppDistributionClient();
+    try {
+      utils.logBullet(`Deleting group from project`);
+      await appDistroClient.deleteGroup(`${projectName}/groups/${alias}`);
+    } catch (err: any) {
+      throw new FirebaseError(`Failed to delete group ${err}`);
+    }
+    utils.logSuccess(`Group ${alias} has successfully been deleted`);
+  });

--- a/src/commands/appdistribution-testers-add.ts
+++ b/src/commands/appdistribution-testers-add.ts
@@ -5,8 +5,9 @@ import { AppDistributionClient } from "../appdistribution/client";
 import { getEmails, getProjectName } from "../appdistribution/options-parser-util";
 
 export const command = new Command("appdistribution:testers:add [emails...]")
-  .description("add testers to project")
+  .description("add testers to project (and possibly group)")
   .option("--file <file>", "a path to a file containing a list of tester emails to be added")
+  .option("--group-alias <group-alias>", "if specified, the testers are added to the group identified by this alias")
   .before(requireAuth)
   .action(async (emails: string[], options?: any) => {
     const projectName = await getProjectName(options);
@@ -14,4 +15,8 @@ export const command = new Command("appdistribution:testers:add [emails...]")
     const emailsToAdd = getEmails(emails, options.file);
     utils.logBullet(`Adding ${emailsToAdd.length} testers to project`);
     await appDistroClient.addTesters(projectName, emailsToAdd);
+    if (options.groupAlias) {
+      utils.logBullet(`Adding ${emailsToAdd.length} testers to group`);
+      await appDistroClient.addTestersToGroup(`${projectName}/groups/${options.groupAlias}`, emailsToAdd);
+    }
   });

--- a/src/commands/appdistribution-testers-add.ts
+++ b/src/commands/appdistribution-testers-add.ts
@@ -9,7 +9,7 @@ export const command = new Command("appdistribution:testers:add [emails...]")
   .option("--file <file>", "a path to a file containing a list of tester emails to be added")
   .option(
     "--group-alias <group-alias>",
-    "if specified, the testers are added to the group identified by this alias"
+    "if specified, the testers are also added to the group identified by this alias"
   )
   .before(requireAuth)
   .action(async (emails: string[], options?: any) => {

--- a/src/commands/appdistribution-testers-add.ts
+++ b/src/commands/appdistribution-testers-add.ts
@@ -7,7 +7,10 @@ import { getEmails, getProjectName } from "../appdistribution/options-parser-uti
 export const command = new Command("appdistribution:testers:add [emails...]")
   .description("add testers to project (and possibly group)")
   .option("--file <file>", "a path to a file containing a list of tester emails to be added")
-  .option("--group-alias <group-alias>", "if specified, the testers are added to the group identified by this alias")
+  .option(
+    "--group-alias <group-alias>",
+    "if specified, the testers are added to the group identified by this alias"
+  )
   .before(requireAuth)
   .action(async (emails: string[], options?: any) => {
     const projectName = await getProjectName(options);
@@ -17,6 +20,9 @@ export const command = new Command("appdistribution:testers:add [emails...]")
     await appDistroClient.addTesters(projectName, emailsToAdd);
     if (options.groupAlias) {
       utils.logBullet(`Adding ${emailsToAdd.length} testers to group`);
-      await appDistroClient.addTestersToGroup(`${projectName}/groups/${options.groupAlias}`, emailsToAdd);
+      await appDistroClient.addTestersToGroup(
+        `${projectName}/groups/${options.groupAlias}`,
+        emailsToAdd
+      );
     }
   });

--- a/src/commands/appdistribution-testers-remove.ts
+++ b/src/commands/appdistribution-testers-remove.ts
@@ -7,25 +7,31 @@ import { getEmails, getProjectName } from "../appdistribution/options-parser-uti
 import { logger } from "../logger";
 
 export const command = new Command("appdistribution:testers:remove [emails...]")
-  .description("remove testers from a project")
+  .description("remove testers from a project (or group)")
   .option("--file <file>", "a path to a file containing a list of tester emails to be removed")
+  .option("--group-alias <group-alias>", "if specified, the testers are only removed from the group identified by this alias, but not the project")
   .before(requireAuth)
   .action(async (emails: string[], options?: any) => {
     const projectName = await getProjectName(options);
     const appDistroClient = new AppDistributionClient();
     const emailsArr = getEmails(emails, options.file);
-    let deleteResponse;
-    try {
-      utils.logBullet(`Deleting ${emailsArr.length} testers from project`);
-      deleteResponse = await appDistroClient.removeTesters(projectName, emailsArr);
-    } catch (err: any) {
-      throw new FirebaseError(`Failed to remove testers ${err}`);
-    }
+    if (options.groupAlias) {
+      utils.logBullet(`Removing ${emailsArr.length} testers from group`);
+      await appDistroClient.removeTestersFromGroup(`${projectName}/groups/${options.groupAlias}`, emailsArr);
+    } else {
+      let deleteResponse;
+      try {
+        utils.logBullet(`Deleting ${emailsArr.length} testers from project`);
+        deleteResponse = await appDistroClient.removeTesters(projectName, emailsArr);
+      } catch (err: any) {
+        throw new FirebaseError(`Failed to remove testers ${err}`);
+      }
 
-    if (!deleteResponse.emails) {
-      utils.logSuccess(`Testers did not exist`);
-      return;
+      if (!deleteResponse.emails) {
+        utils.logSuccess(`Testers did not exist`);
+        return;
+      }
+      logger.debug(`Testers: ${deleteResponse.emails}, have been successfully deleted`);
+      utils.logSuccess(`${deleteResponse.emails.length} testers have successfully been deleted`);
     }
-    logger.debug(`Testers: ${deleteResponse.emails}, have been successfully deleted`);
-    utils.logSuccess(`${deleteResponse.emails.length} testers have successfully been deleted`);
   });

--- a/src/commands/appdistribution-testers-remove.ts
+++ b/src/commands/appdistribution-testers-remove.ts
@@ -9,7 +9,10 @@ import { logger } from "../logger";
 export const command = new Command("appdistribution:testers:remove [emails...]")
   .description("remove testers from a project (or group)")
   .option("--file <file>", "a path to a file containing a list of tester emails to be removed")
-  .option("--group-alias <group-alias>", "if specified, the testers are only removed from the group identified by this alias, but not the project")
+  .option(
+    "--group-alias <group-alias>",
+    "if specified, the testers are only removed from the group identified by this alias, but not the project"
+  )
   .before(requireAuth)
   .action(async (emails: string[], options?: any) => {
     const projectName = await getProjectName(options);
@@ -17,7 +20,10 @@ export const command = new Command("appdistribution:testers:remove [emails...]")
     const emailsArr = getEmails(emails, options.file);
     if (options.groupAlias) {
       utils.logBullet(`Removing ${emailsArr.length} testers from group`);
-      await appDistroClient.removeTestersFromGroup(`${projectName}/groups/${options.groupAlias}`, emailsArr);
+      await appDistroClient.removeTestersFromGroup(
+        `${projectName}/groups/${options.groupAlias}`,
+        emailsArr
+      );
     } else {
       let deleteResponse;
       try {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -25,6 +25,9 @@ export function load(client: any): any {
   client.appdistribution.testers = {};
   client.appdistribution.testers.add = loadCommand("appdistribution-testers-add");
   client.appdistribution.testers.delete = loadCommand("appdistribution-testers-remove");
+  client.appdistribution.group = {};
+  client.appdistribution.group.create = loadCommand("appdistribution-group-create");
+  client.appdistribution.group.delete = loadCommand("appdistribution-group-delete");
   client.apps = {};
   client.apps.create = loadCommand("apps-create");
   client.apps.list = loadCommand("apps-list");

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -243,16 +243,16 @@ describe.only("distribution", () => {
       nock(appDistributionOrigin)
         .delete(`/v1/${groupName}`)
         .reply(400, { error: { status: "FAILED_PRECONDITION" } });
-      await expect(
-        appDistributionClient.deleteGroup(groupName)
-      ).to.be.rejectedWith(FirebaseError, "Failed to delete group");
+      await expect(appDistributionClient.deleteGroup(groupName)).to.be.rejectedWith(
+        FirebaseError,
+        "Failed to delete group"
+      );
       expect(nock.isDone()).to.be.true;
     });
 
     it("should resolve when request succeeds", async () => {
       nock(appDistributionOrigin).delete(`/v1/${groupName}`).reply(200, {});
-      await expect(appDistributionClient.deleteGroup(groupName)).to.be
-        .eventually.fulfilled;
+      await expect(appDistributionClient.deleteGroup(groupName)).to.be.eventually.fulfilled;
       expect(nock.isDone()).to.be.true;
     });
   });
@@ -286,10 +286,9 @@ describe.only("distribution", () => {
       nock(appDistributionOrigin)
         .post(`/v1/${groupName}:batchLeave`)
         .reply(400, { error: { status: "FAILED_PRECONDITION" } });
-      await expect(appDistributionClient.removeTestersFromGroup(groupName, emails)).to.be.rejectedWith(
-        FirebaseError,
-        "Failed to remove testers from group"
-      );
+      await expect(
+        appDistributionClient.removeTestersFromGroup(groupName, emails)
+      ).to.be.rejectedWith(FirebaseError, "Failed to remove testers from group");
       expect(nock.isDone()).to.be.true;
     });
 

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -17,7 +17,7 @@ import { FirebaseError } from "../../error";
 
 tmp.setGracefulCleanup();
 
-describe.only("distribution", () => {
+describe("distribution", () => {
   const tempdir = tmp.dirSync();
   const projectName = "projects/123456789";
   const appName = `${projectName}/apps/1:123456789:ios:abc123def456`;

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -66,6 +66,7 @@ describe("distribution", () => {
 
   describe("deleteTesters", () => {
     const emails = ["a@foo.com", "b@foo.com"];
+    const mockResponse: BatchRemoveTestersResponse = { emails: emails };
 
     it("should throw error if delete fails", async () => {
       nock(appDistributionOrigin)
@@ -78,7 +79,6 @@ describe("distribution", () => {
       expect(nock.isDone()).to.be.true;
     });
 
-    const mockResponse: BatchRemoveTestersResponse = { emails: emails };
     it("should resolve when request succeeds", async () => {
       nock(appDistributionOrigin)
         .post(`/v1/${projectName}/testers:batchRemove`)
@@ -207,6 +207,8 @@ describe("distribution", () => {
   });
 
   describe("createGroup", () => {
+    const mockResponse: Group = { name: groupName, displayName: "My Group" };
+
     it("should throw error if request fails", async () => {
       nock(appDistributionOrigin)
         .post(`/v1/${projectName}/groups`)
@@ -218,7 +220,6 @@ describe("distribution", () => {
       expect(nock.isDone()).to.be.true;
     });
 
-    const mockResponse: Group = { name: groupName, displayName: "My Group" };
     it("should resolve when request succeeds", async () => {
       nock(appDistributionOrigin).post(`/v1/${projectName}/groups`).reply(200, mockResponse);
       await expect(


### PR DESCRIPTION
### Description

- Added `appdistribution:group:create` and `appdistribution:group:delete`.
- Added `--group-alias` option to `appdistribution:testers:add` and `appdistribution:testers:remove`.

### Sample Commands

```
$ firebase appdistribution:group:create "My Awesome Group" my-awesome-group
$ firebase appdistribution:testers:add --group-alias=my-awesome-group tester@one.tld tester@two.tld
$ firebase appdistribution:testers:remove --group-alias=my-awesome-group tester@one.tld tester@two.tld
$ firebase appdistribution:group:delete my-awesome-group
```