### PR TITLE
Fix flaky convertConfig test

### DIFF
--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -488,6 +488,18 @@ describe("convertConfig", () => {
   }
 
   describe("rewrites errors", () => {
+    let existingBackendStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      existingBackendStub = sinon
+        .stub(backend, "existingBackend")
+        .rejects(new FirebaseError("Some permissions 403 error (that should be caught)", { status: 403 }));
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it("should throw when rewrite points to function in the wrong region", async () => {
       await expect(
         convertConfig(
@@ -519,8 +531,7 @@ describe("convertConfig", () => {
           }
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
-    }).timeout(10000);
-
+    });
     it("should throw when rewrite points to function being deleted", async () => {
       await expect(
         convertConfig(
@@ -560,7 +571,7 @@ describe("convertConfig", () => {
           }
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
-    }).timeout(10000);
+    });
   });
 
   describe("with permissions issues", () => {

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -519,7 +519,7 @@ describe("convertConfig", () => {
           }
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
-    });
+    }).timeout(2000);
 
     it("should throw when rewrite points to function being deleted", async () => {
       await expect(
@@ -561,7 +561,7 @@ describe("convertConfig", () => {
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
     });
-  });
+  }).timeout(2000);
 
   describe("with permissions issues", () => {
     let existingBackendStub: sinon.SinonStub;

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -519,7 +519,7 @@ describe("convertConfig", () => {
           }
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
-    }).timeout(2000);
+    }).timeout(5000);
 
     it("should throw when rewrite points to function being deleted", async () => {
       await expect(
@@ -560,8 +560,8 @@ describe("convertConfig", () => {
           }
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
-    });
-  }).timeout(2000);
+    }).timeout(5000);
+  });
 
   describe("with permissions issues", () => {
     let existingBackendStub: sinon.SinonStub;

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -519,7 +519,7 @@ describe("convertConfig", () => {
           }
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
-    }).timeout(5000);
+    }).timeout(10000);
 
     it("should throw when rewrite points to function being deleted", async () => {
       await expect(
@@ -560,7 +560,7 @@ describe("convertConfig", () => {
           }
         )
       ).to.eventually.be.rejectedWith(FirebaseError);
-    }).timeout(5000);
+    }).timeout(10000);
   });
 
   describe("with permissions issues", () => {

--- a/src/test/deploy/hosting/convertConfig.spec.ts
+++ b/src/test/deploy/hosting/convertConfig.spec.ts
@@ -493,11 +493,13 @@ describe("convertConfig", () => {
     beforeEach(() => {
       existingBackendStub = sinon
         .stub(backend, "existingBackend")
-        .rejects(new FirebaseError("Some permissions 403 error (that should be caught)", { status: 403 }));
+        .rejects(
+          new FirebaseError("Some permissions 403 error (that should be caught)", { status: 403 })
+        );
     });
 
     afterEach(() => {
-      sinon.restore();
+      existingBackendStub.restore();
     });
 
     it("should throw when rewrite points to function in the wrong region", async () => {


### PR DESCRIPTION
### Description
Fix the flaky convertConfig tests (ie: https://github.com/firebase/firebase-tools/actions/runs/5270146691/jobs/9529263015?pr=5978) 
The code under test here calls `backend.existingBackend()` (which makes remote calls), and catches 403 errors. This unit test was not stubbing it, so it would make the real call, handle the errors and continue. However, this caused it to frequently timeout.