### PR TITLE
Support lifecycle hooks for function codebases

### DIFF
--- a/src/deploy/lifecycleHooks.ts
+++ b/src/deploy/lifecycleHooks.ts
@@ -139,8 +139,19 @@ function getReleventConfigs(target: string, options: Options) {
       return individualOnly.replace(`${target}:`, "");
     });
 
-  return targetConfigs.filter((config: any) => {
+  // If config specifies a target, only include it if it's in the only list
+  targetConfigs = targetConfigs.filter((config) => {
     return !config.target || onlyTargets.includes(config.target);
+  });
+  // If config specifies a codebase, only include it if it's in the only list
+  targetConfigs = targetConfigs.filter((config) => {
+    if (!config.codebase) return true;
+
+    return onlyTargets.some(
+      (individualOnly) =>
+        individualOnly.indexOf(":") === -1 ||
+        config.codebase === individualOnly.split(":")[0]
+    );
   });
 }
 


### PR DESCRIPTION
Sample command:

`firebase deploy --only functions:metrics:report,functions:metrics:process`

Previous behavior:
Run lifecycle hooks of all codebases in the project

New behavior:
Run lifecycle hooks of relevant codebases only (`metrics` in the case of the sample command)