### PR TITLE
Run lifecycle hooks for specific codebases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Run lifecycle hooks for specific codebases. (#6011)

--- a/src/deploy/lifecycleHooks.ts
+++ b/src/deploy/lifecycleHooks.ts
@@ -127,7 +127,6 @@ function getReleventConfigs(target: string, options: Options) {
 
   let onlyTargets = options.only.split(",");
   if (onlyTargets.includes(target)) {
-    // If the target matches entirely then all instances should be included.
     return targetConfigs;
   }
 
@@ -140,6 +139,9 @@ function getReleventConfigs(target: string, options: Options) {
     });
 
   return targetConfigs.filter((config: any) => {
+    if (target === "functions") {
+      return onlyTargets.includes(config.codebase);
+    }
     return !config.target || onlyTargets.includes(config.target);
   });
 }


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-tools/issues/6002. Further investigation has surfaced another issue where deploying individual functions specified by the `--only` flag will not run any predeploy hooks, but will table this issue for another fix.