### PR TITLE
Fix frameworks deploy to preview channel

### DIFF
--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -12,6 +12,7 @@ import * as utils from "../../utils";
 import { HostingSource, RunRewrite } from "../../firebaseConfig";
 import * as backend from "../functions/backend";
 import { ensureTargeted } from "../../functions/ensureTargeted";
+import { normalizeAndValidate } from "../../functions/projectConfig";
 
 function handlePublicDirectoryFlag(options: HostingOptions & Options): void {
   // Allow the public directory to be overridden by the --public flag
@@ -75,8 +76,20 @@ export async function addPinnedFunctionsToOnlyString(
       if (endpoint) {
         options.only = ensureTargeted(options.only, endpoint.codebase || "default", endpoint.id);
       } else {
-        // This endpoint is just being added in this push. We don't know what codebase it is.
-        options.only = ensureTargeted(options.only, r.function.functionId);
+        const functionsConfig = normalizeAndValidate(options.config.src.functions);
+        const codebasesFromConfig = [
+          ...new Set(Object.values(functionsConfig).map((c) => c.codebase)),
+        ];
+        if (codebasesFromConfig.length > 0) {
+          options.only = ensureTargeted(
+            options.only,
+            codebasesFromConfig[0],
+            r.function.functionId
+          );
+        } else {
+          // This endpoint is just being added in this push. We don't know what codebase it is.
+          options.only = ensureTargeted(options.only, r.function.functionId);
+        }
       }
       addedFunctionsPerSite.push(r.function.functionId);
     }

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -105,6 +105,14 @@ function memoizeBuild(
 }
 
 /**
+ * Use a function to ensure the same codebase name is used here and
+ * during hosting deploy.
+ */
+export function generateSSRCodebaseId(site: string) {
+  return `firebase-frameworks-${site}`;
+}
+
+/**
  *
  */
 export async function prepareFrameworks(
@@ -330,7 +338,7 @@ export async function prepareFrameworks(
         );
       }
 
-      const codebase = `firebase-frameworks-${site}`;
+      const codebase = generateSSRCodebaseId(site);
       const existingFunctionsConfig = options.config.get("functions")
         ? [].concat(options.config.get("functions"))
         : [];


### PR DESCRIPTION
There is a bug when doing a web frameworks deploy that requires a function deploy, when the target is a preview channel and the function has not previously been deployed to the live channel.

The error is: `Error deploying to hosting: No function matches given --only filters. Aborting deployment.`

This happens because in this case (function has not been deployed, and the codebase is not default), a codebase needs to be supplied to `only`.

We can solve the problem for web frameworks by detecting the use of web frameworks and providing the codebase name using the same deterministic function that web frameworks uses to generate the codebase name in the first place. If it is not web frameworks and the function has not been deployed before, it will fall back to using the default codebase which should be correct in most cases.