### PR TITLE
Fix table in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,15 +148,10 @@ are unavailable to Pull Requests coming from forks of the repository.
 | path            | description                                               |
 | --------------- | --------------------------------------------------------- |
 | `src`           | Contains shared/support code for the commands             |
-| `src/bin`       | Contains the runnable script. You shouldn't need to touch |
-:                 : this content.                                             :
-| `src/commands`  | Contains code for the commands, organized by              |
-:                 : one-file-per-command with dashes.                         :
-| `src/templates` | Contains static files needed for various reasons          |
-:                 : (inittemplates, login success HTML, etc.)                 :
-| `src/test`      | Contains tests. Mirrors the top-level directory structure |
-:                 : (i.e., `src/test/commands` contains command tests and     :
-:                 : `src/test/gcp` contains `gcp` tests)                      :
+| `src/bin`       | Contains the runnable script. You shouldn't need to touch this content. |
+| `src/commands`  | Contains code for the commands, organized by one-file-per-command with dashes. |
+| `src/templates` | Contains static files needed for various reasons (inittemplates, login success HTML, etc.) |
+| `src/test`      | Contains tests. Mirrors the top-level directory structure (i.e., `src/test/commands` contains command tests and `src/test/gcp` contains `gcp` tests) |
 
 ## Building CLI commands
 


### PR DESCRIPTION
### Description

Multi-line table syntax is not supported in GitHub Markdown.