### PR TITLE
Allow $schema property in firebase.json

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -129,8 +129,8 @@
     },
     "properties": {
         "$schema": {
-            "type": "string",
-            "format": "uri"
+            "format": "uri",
+            "type": "string"
         },
         "database": {
             "anyOf": [

--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -128,6 +128,10 @@
         }
     },
     "properties": {
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
         "database": {
             "anyOf": [
                 {

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -234,6 +234,10 @@ export type EmulatorsConfig = {
 export type ExtensionsConfig = Record<string, string>;
 
 export type FirebaseConfig = {
+  /**
+   * @TJS-format uri
+   */
+  $schema?: string;
   database?: DatabaseConfig;
   firestore?: FirestoreConfig;
   functions?: FunctionsConfig;


### PR DESCRIPTION
### Description

Adds a top level `$schema` property to allow referencing the schema file. Related #3528 

![Screenshot from 2023-06-28 15-40-39](https://github.com/firebase/firebase-tools/assets/489705/0e861529-504f-4e5e-af32-f8d51b4ba8fb)
