### PR TITLE
Migrates functions metrics to GA4 

### DIFF
--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -2,6 +2,7 @@ import * as backend from "./backend";
 import * as gcfV2 from "../../gcp/cloudfunctionsv2";
 import * as projectConfig from "../../functions/projectConfig";
 import * as deployHelper from "./functionsDeployHelper";
+import { Runtime } from "./runtimes";
 
 // These types should probably be in a root deploy.ts, but we can only boil the ocean one bit at a time.
 interface CodebasePayload {
@@ -49,6 +50,19 @@ export interface Context {
     gcfV1: string[];
     gcfV2: string[];
   };
+
+  // Tracks metrics about codebase deployments to send to GA4
+  codebaseDeployEvents?: Record<string, CodebaseDeployEvent>;
+}
+
+export interface CodebaseDeployEvent {
+  params?: "env_only" | "with_secrets" | "none";
+  runtime?: Runtime;
+  runtime_notice?: string;
+  fn_deploy_num_successes: number;
+  fn_deploy_num_failures: number;
+  fn_deploy_num_canceled: number;
+  fn_deploy_num_skipped: number;
 }
 
 export interface FirebaseConfig {

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -6,12 +6,14 @@ import { FirebaseError } from "../../error";
 import { assertExhaustive, mapObject, nullsafeVisitor } from "../../functional";
 import { UserEnvsOpts, writeUserEnvs } from "../../functions/env";
 import { FirebaseConfig } from "./args";
+import { Runtime } from "./runtimes";
 
 /* The union of a customer-controlled deployment and potentially deploy-time defined parameters */
 export interface Build {
   requiredAPIs: RequiredApi[];
   endpoints: Record<string, Endpoint>;
   params: params.Param[];
+  runtime?: Runtime;
 }
 
 /**

--- a/src/deploy/functions/ensure.ts
+++ b/src/deploy/functions/ensure.ts
@@ -8,7 +8,6 @@ import { logLabeledBullet, logLabeledSuccess } from "../../utils";
 import { ensureServiceAgentRole } from "../../gcp/secretManager";
 import { getFirebaseProject } from "../../management/projects";
 import { assertExhaustive } from "../../functional";
-import { track } from "../../track";
 import * as backend from "./backend";
 
 const FAQ_URL = "https://firebase.google.com/support/faq#functions-runtime";
@@ -37,7 +36,6 @@ export async function defaultServiceAccount(e: backend.Endpoint): Promise<string
 }
 
 function nodeBillingError(projectId: string): FirebaseError {
-  void track("functions_runtime_notices", "nodejs10_billing_error");
   return new FirebaseError(
     `Cloud Functions deployment requires the pay-as-you-go (Blaze) billing plan. To upgrade your project, visit the following URL:
 
@@ -51,7 +49,6 @@ ${FAQ_URL}`,
 }
 
 function nodePermissionError(projectId: string): FirebaseError {
-  void track("functions_runtime_notices", "nodejs10_permission_error");
   return new FirebaseError(`Cloud Functions deployment requires the Cloud Build API to be enabled. The current credentials do not have permission to enable APIs for project ${clc.bold(
     projectId
   )}.

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -167,14 +167,11 @@ export async function prepare(
     if (wantBuild.params.length > 0) {
       if (wantBuild.params.every((p) => p.type !== "secret")) {
         context.codebaseDeployEvents[codebase].params = "env_only";
-        void track("functions_params_in_build", "env_only");
       } else {
         context.codebaseDeployEvents[codebase].params = "with_secrets";
-        void track("functions_params_in_build", "with_secrets");
       }
     } else {
       context.codebaseDeployEvents[codebase].params = "none";
-      void track("functions_params_in_build", "none");
     }
     context.codebaseDeployEvents[codebase].runtime = wantBuild.runtime;
   }
@@ -226,18 +223,6 @@ export async function prepare(
     validate.endpointsAreValid(wantBackend);
     inferBlockingDetails(wantBackend);
   }
-
-  const tag = hasUserConfig(runtimeConfig)
-    ? codebaseUsesEnvs.length > 0
-      ? "mixed"
-      : "runtime_config"
-    : codebaseUsesEnvs.length > 0
-    ? "dotenv"
-    : "none";
-  void track("functions_codebase_deploy_env_method", tag);
-
-  const codebaseCnt = Object.keys(payload.functions).length;
-  void track("functions_codebase_deploy_count", codebaseCnt >= 5 ? "5+" : codebaseCnt.toString());
 
   // ===Phase 5. Enable APIs required by the deploying backends.
   const wantBackend = backend.merge(...Object.values(wantBackends));

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -21,7 +21,6 @@ import { logLabeledBullet } from "../../utils";
 import { getFunctionsConfig, prepareFunctionsUpload } from "./prepareFunctionsUpload";
 import { promptForFailurePolicies, promptForMinInstances } from "./prompts";
 import { needProjectId, needProjectNumber } from "../../projectUtils";
-import { track } from "../../track";
 import { logger } from "../../logger";
 import { ensureTriggerRegions } from "./triggerRegionHelper";
 import { ensureServiceAgentRoles } from "./checkIam";
@@ -38,11 +37,6 @@ import { allEndpoints, Backend } from "./backend";
 import { assertExhaustive } from "../../functional";
 
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
-function hasUserConfig(config: Record<string, unknown>): boolean {
-  // "firebase" key is always going to exist in runtime config.
-  // If any other key exists, we can assume that user is using runtime config.
-  return Object.keys(config).length > 1;
-}
 
 /**
  * Prepare functions codebases for deploy.

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -76,7 +76,7 @@ export async function release(
 
   const summary = await fab.applyPlan(plan);
 
-  await reporter.logAndTrackDeployStats(summary);
+  await reporter.logAndTrackDeployStats(summary, context);
   reporter.printErrors(summary);
 
   // N.B. Fabricator::applyPlan updates the endpoints it deploys to include the

--- a/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
+++ b/src/deploy/functions/runtimes/node/parseRuntimeAndValidateSDK.ts
@@ -2,7 +2,6 @@ import * as path from "path";
 import * as clc from "colorette";
 
 import { FirebaseError } from "../../../../error";
-import { track } from "../../../../track";
 import * as runtimes from "../../runtimes";
 
 // have to require this because no @types/cjson available
@@ -80,7 +79,6 @@ export function getRuntimeChoice(sourceDir: string, runtimeFromConfig?: string):
       : UNSUPPORTED_NODE_VERSION_PACKAGE_JSON_MSG) + DEPRECATED_NODE_VERSION_INFO;
 
   if (!runtime || !ENGINE_RUNTIMES_NAMES.includes(runtime)) {
-    void track("functions_runtime_notices", "package_missing_runtime");
     throw new FirebaseError(errorMessage, { exit: 1 });
   }
 
@@ -88,7 +86,6 @@ export function getRuntimeChoice(sourceDir: string, runtimeFromConfig?: string):
   // it's in ENGINE_RUNTIME_NAMES and not in DEPRECATED_RUNTIMES. This is still a
   // good defense in depth and also lets us upcast the response to Runtime safely.
   if (runtimes.isDeprecatedRuntime(runtime) || !runtimes.isValidRuntime(runtime)) {
-    void track("functions_runtime_notices", `${runtime}_deploy_prohibited`);
     throw new FirebaseError(errorMessage, { exit: 1 });
   }
 

--- a/src/deploy/functions/runtimes/node/versioning.ts
+++ b/src/deploy/functions/runtimes/node/versioning.ts
@@ -6,7 +6,6 @@ import * as spawn from "cross-spawn";
 import * as semver from "semver";
 
 import { logger } from "../../../../logger";
-import { track } from "../../../../track";
 import * as utils from "../../../../utils";
 
 interface NpmShowResult {
@@ -113,7 +112,6 @@ export function getLatestSDKVersion(): string | undefined {
 export function checkFunctionsSDKVersion(currentVersion: string): void {
   try {
     if (semver.lt(currentVersion, MIN_SDK_VERSION)) {
-      void track("functions_runtime_notices", "functions_sdk_too_old");
       utils.logWarning(FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
     }
 

--- a/src/test/deploy/functions/release/reporter.spec.ts
+++ b/src/test/deploy/functions/release/reporter.spec.ts
@@ -119,12 +119,10 @@ describe("reporter", () => {
 
   describe("logAndTrackDeployStats", () => {
     let trackGA4Stub: sinon.SinonStub;
-    let trackStub: sinon.SinonStub;
     let debugStub: sinon.SinonStub;
 
     beforeEach(() => {
       trackGA4Stub = sinon.stub(track, "trackGA4");
-      trackStub = sinon.stub(track, "track");
       debugStub = sinon.stub(logger, "debug");
     });
 
@@ -226,87 +224,8 @@ describe("reporter", () => {
         fn_deploy_num_failures: 1,
       });
 
-      expect(trackStub).to.have.been.calledWith("functions_region_count", "1", 1);
-      expect(trackStub).to.have.been.calledWith("function_deploy_success", "v1.https", 2_000);
-      expect(trackStub).to.have.been.calledWith("function_deploy_failure", "v1.https", 1_000);
-      // Aborts aren't tracked because they would throw off timing metrics
-      expect(trackStub).to.not.have.been.calledWith("function_deploy_failure", "v1.https", 0);
-
-      expect(debugStub).to.have.been.calledWith("Total Function Deployment time: 2000");
-      expect(debugStub).to.have.been.calledWith("3 Functions Deployed");
-      expect(debugStub).to.have.been.calledWith("1 Functions Errored");
-      expect(debugStub).to.have.been.calledWith("1 Function Deployments Aborted");
-
       // The 0ms for an aborted function isn't counted.
       expect(debugStub).to.have.been.calledWith("Average Function Deployment time: 1500");
-    });
-
-    it("tracks v1 vs v2 codebases", async () => {
-      const v1 = { ...ENDPOINT };
-      const v2: backend.Endpoint = { ...ENDPOINT, platform: "gcfv2" };
-
-      const summary: reporter.Summary = {
-        totalTime: 1_000,
-        results: [
-          {
-            endpoint: v1,
-            durationMs: 1_000,
-          },
-          {
-            endpoint: v2,
-            durationMs: 1_000,
-          },
-        ],
-      };
-
-      await reporter.logAndTrackDeployStats(summary);
-      expect(trackStub).to.have.been.calledWith("functions_codebase_deploy", "v1+v2", 2);
-      trackStub.resetHistory();
-
-      summary.results = [{ endpoint: v1, durationMs: 1_000 }];
-      await reporter.logAndTrackDeployStats(summary);
-      expect(trackStub).to.have.been.calledWith("functions_codebase_deploy", "v1", 1);
-      trackStub.resetHistory();
-
-      summary.results = [{ endpoint: v2, durationMs: 1_000 }];
-      await reporter.logAndTrackDeployStats(summary);
-      expect(trackStub).to.have.been.calledWith("functions_codebase_deploy", "v2", 1);
-    });
-
-    it("tracks overall success/failure", async () => {
-      const success: reporter.DeployResult = {
-        endpoint: ENDPOINT,
-        durationMs: 1_000,
-      };
-      const failure: reporter.DeployResult = {
-        endpoint: ENDPOINT,
-        durationMs: 1_000,
-        error: new reporter.DeploymentError(ENDPOINT, "create", undefined),
-      };
-
-      const summary: reporter.Summary = {
-        totalTime: 1_000,
-        results: [success, failure],
-      };
-
-      await reporter.logAndTrackDeployStats(summary);
-      expect(trackStub).to.have.been.calledWith("functions_deploy_result", "partial_success", 1);
-      expect(trackStub).to.have.been.calledWith("functions_deploy_result", "partial_failure", 1);
-      expect(trackStub).to.have.been.calledWith(
-        "functions_deploy_result",
-        "partial_error_ratio",
-        0.5
-      );
-      trackStub.resetHistory();
-
-      summary.results = [success];
-      await reporter.logAndTrackDeployStats(summary);
-      expect(trackStub).to.have.been.calledWith("functions_deploy_result", "success", 1);
-      trackStub.resetHistory();
-
-      summary.results = [failure];
-      await reporter.logAndTrackDeployStats(summary);
-      expect(trackStub).to.have.been.calledWith("functions_deploy_result", "failure", 1);
     });
   });
 

--- a/src/track.ts
+++ b/src/track.ts
@@ -14,7 +14,10 @@ type cliEventNames =
   | "login"
   | "api_enabled"
   | "hosting_version"
-  | "extension_added_to_manifest";
+  | "extension_added_to_manifest"
+  | "function_deploy"
+  | "codebase_deploy"
+  | "function_deploy_group";
 type GA4Property = "cli" | "emulator";
 interface GA4Info {
   measurementId: string;


### PR DESCRIPTION
Follow-up to https://github.com/firebase/firebase-tools/pull/6016. This PR enables the CLI to send functions metrics data to our new GA4 property. For now, we are intentionally limiting the metrics we track in GA4 to the metrics we are tracking in UA today, but in the next few weeks we will follow up with an expanded set of metrics that will enhance our ability to assess the health of CF3 deployments.

To avoid duplicate reporting to UA and GA4, this PR also stops sending functions metrics to UA.