### PR TITLE
Fix incorrect warnings when emulating extensions with httpsTriggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Increased extension instance create poll timeout to 1h to match backend (#5969).
 - Refactored `ext:install` to use the latest extension metadata. (#5997)
+- Fixed issue where missing trigger warnings would be wrongly displayed when emulating extensions with HTTPS triggers.

--- a/src/extensions/emulator/triggerHelper.ts
+++ b/src/extensions/emulator/triggerHelper.ts
@@ -77,7 +77,8 @@ export function functionResourceToEmulatedTriggerDefintion(
     proto.convertIfPresent(etd, properties, "timeoutSeconds", "timeout", proto.secondsFromDuration);
     proto.convertIfPresent(etd, properties, "regions", "location", (str: string) => [str]);
     proto.copyIfPresent(etd, properties, "availableMemoryMb");
-    if (properties.httpsTrigger) {
+    if (properties.httpsTrigger !== undefined) {
+      // Need to explcitly check undefined since {} is falsey
       etd.httpsTrigger = properties.httpsTrigger;
     }
     if (properties.eventTrigger) {


### PR DESCRIPTION
### Description
Previously, these 'missing trigger' warnings were firing for all httpsTriggers, because `{}` is falsey. By explicitly comparing to undefined, we avoid this.