### PR TITLE
fix(templates/init/functions/typescript/_eslintrc): integrated lint vscode

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -16,6 +16,7 @@ module.exports = {
   parserOptions: {
     project: ["tsconfig.json", "tsconfig.dev.json"],
     sourceType: "module",
+    tsconfigRootDir: __dirname,
   },
   ignorePatterns: [
     "/lib/**/*", // Ignore built files.


### PR DESCRIPTION
  # fixes to correctly integrate eslint with the vscode extension.

### Description

Fixing a bug where, upon initiating the repository with typescript and eslint, ESLint is not properly recognized by VSCode.

### Bugs

Parsing error: Cannot read file '/home/gd/work/dev/firebase-eslint-vscode/tsconfig.json'.eslint

and 

```json
{
  "editor.codeActionsOnSave": {
    "source.fixAll.eslint": true
  }
}
```
Not working.



### Images
![image](https://github.com/firebase/firebase-tools/assets/52186091/16557155-34eb-4f3a-b79d-e6685244d255)

![image](https://github.com/firebase/firebase-tools/assets/52186091/9ac39347-ce94-4dd3-9033-00e6a91902d3)


