### PR TITLE
Fix requireAuthWrapper logic and service account email detection

### DIFF
--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-vscode",
-  "version": "0.0.23-alpha.3",
+  "version": "0.0.23-alpha.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-vscode",
-      "version": "0.0.23-alpha.3",
+      "version": "0.0.23-alpha.4",
       "dependencies": {
         "@vscode/codicons": "0.0.30",
         "@vscode/webview-ui-toolkit": "^1.2.1",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "firebase-vscode",
   "publisher": "firebase",
   "description": "VSCode Extension for Firebase",
-  "version": "0.0.23-alpha.3",
+  "version": "0.0.23-alpha.4",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
- requireAuthWrapper should have returned true when the service account was found and it got left out, causing it to return false and prevent deployment and other CLI operations
- getCredentials() doesn't currently work to get the workspace service account in Monospace as the metadata server is not set up to return credentials. Use a provided environment variable instead.