### PR TITLE
VSCode Plugin: Better error handling for init and deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,0 @@
-- Disables KeepAlive timeout when debugger is attached to the functions emulator. (#6069)
-- Fixed an issue where `database:list` would have inaccurate results. (#6063)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Disables KeepAlive timeout when debugger is attached to the functions emulator. (#6069)
+- Fixed an issue where `database:list` would have inaccurate results. (#6063)

--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,9 +1,25 @@
 # Change Log
 
-All notable changes to the "firebase-vscode" extension will be documented in this file.
+## 0.0.23 (July 13, 2023)
 
-Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+- Same as alpha.5, marked as stable.
 
-## [Unreleased]
+## 0.0.23-alpha.5 (July 12, 2023)
 
-- Initial release
+- More fixes for service account detection logic.
+- Better output and error handling for init and deploy steps.
+
+## 0.0.23-alpha.4 (July 11, 2023)
+
+- Fix for service account bugs
+
+## 0.0.23-alpha.3 (July 7, 2023)
+
+- UX updates
+  - Get last deploy date
+  - Write to and show info level logs in output channel when deploying
+  - Enable user to view service account email
+
+## 0.0.23-alpha.2 (July 6 2023)
+
+- Service account internal fixes plus fix for deploying Next.js twice in a row

--- a/firebase-vscode/common/messaging/protocol.ts
+++ b/firebase-vscode/common/messaging/protocol.ts
@@ -97,6 +97,7 @@ export interface ExtensionToWebviewParamsMap {
    * and it has been written to firebase.json.
    */
   notifyHostingInitDone: {
+    success: boolean,
     projectId: string,
     folderPath?: string
     framework?: string

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-vscode",
-  "version": "0.0.23-alpha.4",
+  "version": "0.0.23",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-vscode",
-      "version": "0.0.23-alpha.4",
+      "version": "0.0.23",
       "dependencies": {
         "@vscode/codicons": "0.0.30",
         "@vscode/webview-ui-toolkit": "^1.2.1",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -22,12 +22,12 @@
       "properties": {
         "firebase.debug": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Enable writing debug-level messages to the file provided in firebase.debugLogPath (requires restart)"
         },
         "firebase.debugLogPath": {
           "type": "string",
-          "default": "/tmp/firebase-plugin.log",
+          "default": "",
           "description": "If firebase.debug is true, appends debug-level messages to the provided file (requires restart)"
         },
         "firebase.npmPath": {
@@ -133,8 +133,5 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-merge": "^5.8.0"
-  },
-  "extensionDependencies": [
-    "google.monospace"
-  ]
+  }
 }

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "firebase-vscode",
   "publisher": "firebase",
   "description": "VSCode Extension for Firebase",
-  "version": "0.0.23-alpha.4",
+  "version": "0.0.23",
   "engines": {
     "vscode": "^1.69.0"
   },
@@ -22,12 +22,12 @@
       "properties": {
         "firebase.debug": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Enable writing debug-level messages to the file provided in firebase.debugLogPath (requires restart)"
         },
         "firebase.debugLogPath": {
           "type": "string",
-          "default": "",
+          "default": "/tmp/firebase-plugin.log",
           "description": "If firebase.debug is true, appends debug-level messages to the provided file (requires restart)"
         },
         "firebase.npmPath": {
@@ -133,5 +133,8 @@
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-merge": "^5.8.0"
-  }
+  },
+  "extensionDependencies": [
+    "google.monospace"
+  ]
 }

--- a/firebase-vscode/src/cli.ts
+++ b/firebase-vscode/src/cli.ts
@@ -33,10 +33,16 @@ import { setAccessToken } from "../../src/apiv2";
 async function getServiceAccount() {
   let email = null;
   try {
-    // Do not send options to make sure no oauth user/token is sent
+    // Make sure no user/token is sent
     // to requireAuth which would prevent autoAuth() from being reached.
-    // We do need to send isVSCE true to prevent project selection popup
-    email = (await requireAuth({ isVSCE: true })) || null;
+    // We do need to send isVSCE to prevent project selection popup
+    const optionsMinusUser = await getCommandOptions(undefined, {
+      ...currentOptions
+    });
+    delete optionsMinusUser.user;
+    delete optionsMinusUser.tokens;
+    delete optionsMinusUser.token;
+    email = (await requireAuth(optionsMinusUser)) || null;
   } catch (e) {
     let errorMessage = e.message;
     if (e.original?.message) {

--- a/firebase-vscode/webviews/components/DeployPanel.tsx
+++ b/firebase-vscode/webviews/components/DeployPanel.tsx
@@ -10,7 +10,7 @@ import { Label } from "./ui/Text";
 import { broker } from "../globals/html-broker";
 import styles from "../sidebar.entry.scss";
 import { PanelSection } from "./ui/PanelSection";
-import { HostingState } from "../webview-types";
+import { DeployState as DeployState } from "../webview-types";
 import { ChannelWithId } from "../messaging/types";
 import { ExternalLink } from "./ui/ExternalLink";
 import { SplitButton } from "./ui/SplitButton";
@@ -24,14 +24,14 @@ interface DeployInfo {
 }
 
 export function DeployPanel({
-  hostingState,
-  setHostingState,
+  deployState,
+  setDeployState,
   projectId,
   channels,
   framework,
 }: {
-  hostingState: HostingState;
-  setHostingState: (hostingState: HostingState) => void;
+  deployState: DeployState;
+  setDeployState: (deployState: DeployState) => void;
   projectId: string;
   channels: ChannelWithId[];
   framework: string;
@@ -41,15 +41,15 @@ export function DeployPanel({
   const [deployedInfo, setDeployedInfo] = useState<DeployInfo>(null);
 
   useEffect(() => {
-    if (hostingState === "success" || hostingState === "failure") {
+    if (deployState === "success" || deployState === "failure") {
       setDeployedInfo({
         date: new Date().toLocaleString(),
         channelId: deployTarget === "new" ? newPreviewChannel : deployTarget,
-        succeeded: hostingState === "success",
+        succeeded: deployState === "success",
       });
       setNewPreviewChannel("");
     }
-  }, [hostingState]);
+  }, [deployState]);
 
   useEffect(() => {
     broker.on("notifyPreviewChannelResponse", ({ id }: { id: string }) => {
@@ -117,7 +117,7 @@ export function DeployPanel({
     <SplitButton
       appearance="primary"
       onClick={() => {
-        setHostingState("deploying");
+        setDeployState("deploying");
         broker.send("hostingDeploy", {
           target: deployTarget === "new" ? newPreviewChannel : deployTarget,
         });
@@ -166,7 +166,7 @@ export function DeployPanel({
         <>
           {DeploySplitButton}
           <Spacer size="xsmall" />
-          {hostingState !== "deploying" && (
+          {deployState !== "deploying" && (
             <>
               <Spacer size="xsmall" />
               <div>
@@ -182,7 +182,7 @@ export function DeployPanel({
               </div>
             </>
           )}
-          {hostingState === "deploying" && (
+          {deployState === "deploying" && (
             <>
               <Spacer size="medium" />
               <div className={styles.integrationStatus}>

--- a/firebase-vscode/webviews/components/InitPanel.tsx
+++ b/firebase-vscode/webviews/components/InitPanel.tsx
@@ -7,14 +7,18 @@ import { TEXT } from "../globals/ux-text";
 import { PanelSection } from "./ui/PanelSection";
 import { Spacer } from "./ui/Spacer";
 import styles from "../sidebar.entry.scss";
+import { HostingInitState } from "../webview-types";
 
 export function InitFirebasePanel({
   onHostingInit,
+  hostingInitState,
+  setHostingInitState
 }: {
   onHostingInit: Function;
+  hostingInitState: HostingInitState;
+  setHostingInitState: (state: HostingInitState) => void;
 }) {
-  const [ initInProgress, setInitInProgress ] = useState<boolean>(false);
-  if (initInProgress) {
+  if (hostingInitState === 'pending') {
     return (
       <PanelSection isLast>
         <Spacer size="medium" />
@@ -35,7 +39,7 @@ export function InitFirebasePanel({
       <VSCodeButton
         onClick={() => {
           onHostingInit();
-          setInitInProgress(true);
+          setHostingInitState('pending');
         }}
       >
         {TEXT.INIT_HOSTING_BUTTON}

--- a/firebase-vscode/webviews/webview-types.ts
+++ b/firebase-vscode/webviews/webview-types.ts
@@ -1,2 +1,2 @@
-export type HostingState = null | "success" | "failure" | "deploying";
-export type HostingInitState = "not-started" | "pending" | "done";
+export type DeployState = null | "success" | "failure" | "deploying";
+export type HostingInitState = null | "success" | "failure" | "pending";

--- a/firebase-vscode/webviews/webview-types.ts
+++ b/firebase-vscode/webviews/webview-types.ts
@@ -1,2 +1,2 @@
-
 export type HostingState = null | "success" | "failure" | "deploying";
+export type HostingInitState = "not-started" | "pending" | "done";


### PR DESCRIPTION
- Bug: ensure `isVSCE:true` option is always passed to `requireAuth` or else it may trigger the project selection dialog in `autoAuth()`: https://github.com/firebase/firebase-tools/blob/0586de758065a783b35e452b41d787c1f7b96c6e/src/requireAuth.ts#L55 Send all options and remove those specific ones to make sure we're not omitting anything requireAuth/autoAuth need.
- Make sure init and deploy auth check failures send a prominent message to the user - should be an error log and popup
- Show Firebase output window when starting init (same as already exists when starting deploy)
- Rename "hostingState" to "deployState" to be more clear and distinguish from "hostingInitState"