### PR TITLE
Patch fix for issues caused by adding type check in #5906

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug where `functions:secrets:set` didn't remove stale versions of a secret. (#6080)
+- Fixes issue caused by adding type checks in #5906.

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -206,7 +206,7 @@ async function signUp(
     assert(!state.getUserByEmail(email), "EMAIL_EXISTS");
     updates.email = email;
   }
-  if (typeof reqBody.password === "string") {
+  if (reqBody.password) {
     assert(
       reqBody.password.length >= PASSWORD_MIN_LENGTH,
       `WEAK_PASSWORD : Password should be at least ${PASSWORD_MIN_LENGTH} characters`

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -198,7 +198,9 @@ async function signUp(
     }
   }
 
-  if (typeof reqBody.email === "string") {
+  // Assert a valid email address when we expect the email to have a value.
+  // Prevents empty email and password string to be treated as anonymous sign in.
+  if (reqBody.email || (reqBody.email === "" && provider)) {
     assert(isValidEmailAddress(reqBody.email), "INVALID_EMAIL");
     const email = canonicalizeEmailAddress(reqBody.email);
     assert(!state.getUserByEmail(email), "EMAIL_EXISTS");


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

Copied from #5987 

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
 
Type checking `reqBody.email` and `reqBody.password` introduced in #5906 caused some issues with the Auth Emulator UI.

Request made by the emulator UI ofter contain a blank values by default. Creating a user via the Emulator UI using phone number will provide a blank email and password string. This will result in the request received by the Auth Emulator to look like:
```
reqBody: {
  customAttributes: '',
  displayName: '',
  photoUrl: '',
  email: '',
  password: '',
  phoneNumber: '+1230104124',
  ....
} 
```

Adding type checking of `reqBody.email` and `reqBody.password` causes the emulator to always assert a valid email address value. Proposed solution is to remove type check for both `reqBody.email` and `reqBody.password`. 

To keep the solution in #5906, add a condition to specifically check if `reqBody.email` is an empty string and a provider is defined `(reqBody.email === "" && provider)`.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

| Scenario                                 | Prod                                              | Emulator                                          | PR                                                |
|------------------------------------------|---------------------------------------------------|---------------------------------------------------|---------------------------------------------------|
| email="" password=""                     | Error (auth/invalid-email)                        | Creates a user with blank identifier and provider | Error (auth/invalid-email)                        |
| email="" password="123456"               | Error (auth/missing-email)                        | Error (auth/missing-email)                        | Error (auth/missing-email)                        |
| email="test@gmail.com" password="123456" | Creates a user with identifier and email provider | Creates a user with identifier and email provider | Creates a user with identifier and email provider |

Emulator UI
1. Tested creating a user using only a phone number
2. Tested toggling the verified email toggle in the Auth Emulator UI
