### PR TITLE
b/390633880 fix --only in firestore deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-- Fix bug where `functions:secrets:set` didn't remove stale versions of a secret. (#6080)
-- Fix bug where `firebase deploy --only firestore:named-db` didn't update rules. (#6129)
+- Fixed bug where `functions:secrets:set` didn't remove stale versions of a secret. (#6080)
+- Fixed bug where `firebase deploy --only firestore:named-db` didn't update rules. (#6129)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
 - Fixed bug where `functions:secrets:set` didn't remove stale versions of a secret. (#6080)
 - Fixed bug where `firebase deploy --only firestore:named-db` didn't update rules. (#6129)
-<<<<<<< HEAD
 - Fixed issue where Flutter Web is not detected as a web framework. (#6085)
-=======
-- Fixed issue where Flutter Web is not detected as a web framework. (#6085)
->>>>>>> 0582db03 (prettier)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug where `functions:secrets:set` didn't remove stale versions of a secret. (#6080)
+- Fix bug where `firebase deploy --only firestore:named-db` didn't update rules. (#6129)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
 - Fixed bug where `functions:secrets:set` didn't remove stale versions of a secret. (#6080)
 - Fixed bug where `firebase deploy --only firestore:named-db` didn't update rules. (#6129)
+<<<<<<< HEAD
 - Fixed issue where Flutter Web is not detected as a web framework. (#6085)
+=======
+- Fixed issue where Flutter Web is not detected as a web framework. (#6085)
+>>>>>>> 0582db03 (prettier)

--- a/src/deploy/firestore/prepare.ts
+++ b/src/deploy/firestore/prepare.ts
@@ -72,12 +72,12 @@ function prepareIndexes(
 export default async function (context: any, options: any): Promise<void> {
   if (options.only) {
     const targets = options.only.split(",");
-    const onlyIndexes = targets.indexOf("firestore:indexes") >= 0;
-    const onlyRules = targets.indexOf("firestore:rules") >= 0;
+    const excludeRules = targets.indexOf("firestore:indexes") >= 0;
+    const excludeIndexes = targets.indexOf("firestore:rules") >= 0;
     const onlyFirestore = targets.indexOf("firestore") >= 0;
 
-    context.firestoreIndexes = onlyIndexes || onlyFirestore;
-    context.firestoreRules = onlyRules || onlyFirestore;
+    context.firestoreIndexes = !excludeIndexes || onlyFirestore;
+    context.firestoreRules = !excludeRules || onlyFirestore;
   } else {
     context.firestoreIndexes = true;
     context.firestoreRules = true;

--- a/src/firestore/fsConfig.ts
+++ b/src/firestore/fsConfig.ts
@@ -67,6 +67,14 @@ export function getFirestoreConfig(projectId: string, options: Options): ParsedF
     }
   }
 
+  // If user specifies firestore:rules or firestore:indexes make sure we don't throw an error if this doesn't match a database name
+  if (onlyDatabases.has("rules")) {
+    onlyDatabases.delete("rules");
+  }
+  if (onlyDatabases.has("indexes")) {
+    onlyDatabases.delete("indexes");
+  }
+
   if (!allDatabases && onlyDatabases.size !== 0) {
     throw new FirebaseError(
       `Could not find configurations in firebase.json for the following database targets: ${[

--- a/src/firestore/fsConfig.ts
+++ b/src/firestore/fsConfig.ts
@@ -58,8 +58,9 @@ export function getFirestoreConfig(projectId: string, options: Options): ParsedF
         onlyDatabases.delete(target);
       }
     } else if (database) {
-      if (allDatabases) {
+      if (allDatabases || onlyDatabases.has(database)) {
         results.push(c as ParsedFirestoreConfig);
+        onlyDatabases.delete(database);
       }
     } else {
       throw new FirebaseError('Must supply either "target" or "databaseId" in firestore config');


### PR DESCRIPTION
b/390633880 

#### Edge case:

issue arises if user tries to deploy with a command such as

```
firebase deploy --only firestore:named
```

instead of:

```
firebase deploy --only firestore:named,firestore:rules
firebase deploy --only firestore:named,firestore:indexes
```

this change makes us match with the public documentation for more granularity in our deploy

#### Testing

create default and named database in firestore:

create firebase ruleset for each database and configure in firebase.json

test commands:

`firebase deploy --only firestore:(default)`
- updates rules and indexes for only default db

`firebase deploy --only firestore:named`
- updates rules and indexes for only named db

`firebase deploy --only firestore:rules`
- updates only rules

`firebase deploy --only firestore:indexes`
- updates only indexe

`firebase deploy --only firestore:rules,firestore:(default)`
- updates only rules for default db

`firebase deploy --only firestore,firestore:rules,firestore:(default)`
- updates both rules and indexes for (default) db and possibly a rules db if it exists
