### PR TITLE
Fix issue where Flutter Web is not detected as a web framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug where `functions:secrets:set` didn't remove stale versions of a secret. (#6080)
+- Fix issue where Flutter Web is not detected as a web framework. (#6085)

--- a/src/frameworks/frameworks.ts
+++ b/src/frameworks/frameworks.ts
@@ -10,6 +10,7 @@ import * as svelte from "./svelte";
 import * as svelekit from "./sveltekit";
 import * as react from "./react";
 import * as vite from "./vite";
+import * as flutter from "./flutter";
 
 import { Framework } from "./interfaces";
 
@@ -26,4 +27,5 @@ export const WebFrameworks: Record<string, Framework> = {
   svelekit,
   react,
   vite,
+  flutter,
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #6085 

From Firebase Tools v12.4.0, Flutter Web is no longer automatically detected when webframeworks experiments is enabled.

In #6000, we changed the way we discover the web framework being used to use the exports listed in [src/frameworks/frameworks.ts](https://github.com/firebase/firebase-tools/blob/master/src/frameworks/frameworks.ts). Currently, `flutter` is not included in the exports.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

In an existing Flutter project
1. Run `firebase init hosting --project <project_id>`
```
=== Hosting Setup
? Detected an existing Flutter Web codebase in the current directory, should we use this? (Y/n) 
```
In a new project
1. Run `firebase init hosting --project <project_id>`
```
=== Hosting Setup
? Do you want to use a web framework? (experimental) Yes
? What folder would you like to use for your web application's root directory? hosting
Could not determine the web framework in use.
? Please choose the framework: 
  Lit 
  Next.js 
  Preact 
❯ Svelte 
  React 
  Vite 
  Flutter Web 
```

Deploying a Flutter Web app
1. Run `firebase deploy`
```
Compiling lib/main.dart for the Web...                           1,118ms

=== Deploying to '<project_id>'...

i  deploying hosting
Using Google Analytics in DEBUG mode. Emulators (+ UI) events will be shown in GA Debug View only.
i  hosting[<project_id>]: beginning deploy...
i  hosting[<project_id>]: found 25 files in .firebase/<project_id>/hosting
✔  hosting[<project_id>]: file upload complete
i  hosting[<project_id>]: finalizing version...
✔  hosting[<project_id>]: version finalized
i  hosting[<project_id>]: releasing new version...
✔  hosting[<project_id>]: release complete

✔  Deploy complete!
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase init hosting --project <project_id>`