### PR TITLE
Enable preferRest by default for functions

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -181,7 +181,7 @@ export const serviceUsageOrigin = utils.envOverride(
 );
 export const frameworksOrigin = utils.envOverride(
   "FRAMEWORKS_URL",
-  "https://placeholder.googleapis.com"
+  "https://autopush-firestack.sandbox.googleapis.com"
 );
 export const githubOrigin = utils.envOverride("GITHUB_URL", "https://github.com");
 export const githubApiOrigin = utils.envOverride("GITHUB_API_URL", "https://api.github.com");

--- a/src/api.ts
+++ b/src/api.ts
@@ -181,7 +181,7 @@ export const serviceUsageOrigin = utils.envOverride(
 );
 export const frameworksOrigin = utils.envOverride(
   "FRAMEWORKS_URL",
-  "https://autopush-firestack.sandbox.googleapis.com"
+  "https://placeholder.googleapis.com"
 );
 export const githubOrigin = utils.envOverride("GITHUB_URL", "https://github.com");
 export const githubApiOrigin = utils.envOverride("GITHUB_API_URL", "https://api.github.com");

--- a/src/api.ts
+++ b/src/api.ts
@@ -181,7 +181,7 @@ export const serviceUsageOrigin = utils.envOverride(
 );
 export const frameworksOrigin = utils.envOverride(
   "FRAMEWORKS_URL",
-  `${process.env.FRAMEWORKS_URL}`
+  "https://placeholder.googleapis.com"
 );
 export const githubOrigin = utils.envOverride("GITHUB_URL", "https://github.com");
 export const githubApiOrigin = utils.envOverride("GITHUB_API_URL", "https://api.github.com");

--- a/src/api.ts
+++ b/src/api.ts
@@ -181,7 +181,7 @@ export const serviceUsageOrigin = utils.envOverride(
 );
 export const frameworksOrigin = utils.envOverride(
   "FRAMEWORKS_URL",
-  "https://placeholder.googleapis.com"
+  `${process.env.FRAMEWORKS_URL}`
 );
 export const githubOrigin = utils.envOverride("GITHUB_URL", "https://github.com");
 export const githubApiOrigin = utils.envOverride("GITHUB_API_URL", "https://api.github.com");

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -410,5 +410,6 @@ export function loadFirebaseEnvs(
   return {
     FIREBASE_CONFIG: JSON.stringify(firebaseConfig),
     GCLOUD_PROJECT: projectId,
+    FIRESTORE_PREFER_REST: "true",
   };
 }

--- a/src/gcp/frameworks.ts
+++ b/src/gcp/frameworks.ts
@@ -1,7 +1,7 @@
 import { Client } from "../apiv2";
 import { frameworksOrigin } from "../api";
 
-export const API_VERSION = "v2";
+export const API_VERSION = "v1alpha";
 
 const client = new Client({
   urlPrefix: frameworksOrigin,
@@ -27,7 +27,7 @@ export interface Stack {
   uri: string;
 }
 
-export type StackOutputOnlyFields = "createTime" | "updateTime" | "uri";
+export type StackOutputOnlyFields = "createTime" | "updateTime" | "uri" | "codebase";
 
 export interface Build {
   name: string;

--- a/src/gcp/frameworks.ts
+++ b/src/gcp/frameworks.ts
@@ -27,7 +27,7 @@ export interface Stack {
   uri: string;
 }
 
-export type StackOutputOnlyFields = "createTime" | "updateTime" | "uri";
+export type StackOutputOnlyFields = "createTime" | "updateTime" | "uri" | "codebase";
 
 export interface Build {
   name: string;

--- a/src/gcp/frameworks.ts
+++ b/src/gcp/frameworks.ts
@@ -100,6 +100,20 @@ export async function createStack(
 }
 
 /**
+ * Gets stack details.
+ */
+export async function getStack(
+  projectId: string,
+  location: string,
+  stackId: string
+): Promise<Stack> {
+  const name = `projects/${projectId}/locations/${location}/stacks/${stackId}`;
+  const res = await client.get<Stack>(name);
+
+  return res.body;
+}
+
+/**
  * Creates a new Build in a given project and location.
  */
 export async function createBuild(

--- a/src/gcp/frameworks.ts
+++ b/src/gcp/frameworks.ts
@@ -27,7 +27,7 @@ export interface Stack {
   uri: string;
 }
 
-export type StackOutputOnlyFields = "createTime" | "updateTime" | "uri" | "codebase";
+export type StackOutputOnlyFields = "createTime" | "updateTime" | "uri";
 
 export interface Build {
   name: string;

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -76,7 +76,8 @@ export async function doSetup(setup: any): Promise<void> {
       setup.frameworks.region,
       setup.frameworks.serviceName
     );
-    toStack(cloudBuildConnRepo, setup.frameworks.serviceName);
+    const stackDetails = toStack(cloudBuildConnRepo, setup.frameworks.serviceName);
+    await createStack(projectId, setup.frameworks.region, stackDetails);
   }
 }
 
@@ -86,7 +87,6 @@ function toStack(
 ): Omit<Stack, StackOutputOnlyFields> {
   return {
     name: stackId,
-    codebase: { repository: cloudBuildConnRepo.name, rootDirectory: "/" },
     labels: {},
   };
 }

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -92,7 +92,7 @@ function toStack(
 }
 
 /**
- * Creates Stack object.
+ * Creates Stack object from long running operations.
  */
 export async function createStack(
   projectId: string,

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -110,7 +110,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
       }
     } else {
       throw new FirebaseError(
-        `Unable to fetch or create stack. Try using different initialization details: ${err}`
+        `Failed to get or create a stack using the given initialization details: ${err}`
       );
     }
   }

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -110,7 +110,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
       }
     } else {
       throw new FirebaseError(
-        `Unable to fetch or create stack, try using different initialization details: ${err}`
+        `Unable to fetch or create stack. Try using different initialization details: ${err}`
       );
     }
   }

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -80,10 +80,6 @@ function toStack(
 ): Omit<Stack, StackOutputOnlyFields> {
   return {
     name: stackId,
-    codebase: {
-      repository: cloudBuildConnRepo.name,
-      rootDirectory: ".",
-    },
     labels: {},
   };
 }

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -80,6 +80,10 @@ function toStack(
 ): Omit<Stack, StackOutputOnlyFields> {
   return {
     name: stackId,
+    codebase: {
+      repository: cloudBuildConnRepo.name,
+      rootDirectory: ".",
+    },
     labels: {},
   };
 }

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -94,7 +94,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
     return await getExistingStack(projectId, setup, location);
   } catch (err: unknown) {
     if ((err as FirebaseError).status === 404) {
-      logger.info("Create new stack.");
+      logger.info("Creating new stack.");
       if (deployMethod === "github") {
         const cloudBuildConnRepo = await repo.linkGitHubRepository(
           projectId,
@@ -121,14 +121,14 @@ async function getExistingStack(projectId: string, setup: any, location: string)
     await promptOnce(
       {
         name: "existingStack",
-        type: "input",
-        default: "yes",
+        type: "confirm",
+        default: true,
         message:
           "A stack already exists for the given serviceName, do you want to use existing stack? (yes/no)",
       },
       setup.frameworks
     );
-    if (setup.frameworks.existingStack === "y" || setup.frameworks.existingStack === "yes") {
+    if (setup.frameworks.existingStack) {
       logger.info("Using the existing stack.");
       return stack;
     }

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -110,7 +110,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
       }
     } else {
       throw new FirebaseError(
-        `Unable to fetch or create stack try using different initialization details: ${err}`
+        `Unable to fetch or create stack, try using different initialization details: ${err}`
       );
     }
   }

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -94,7 +94,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
     return await getExistingStack(projectId, setup, location);
   } catch (err: unknown) {
     if ((err as FirebaseError).status === 404) {
-      logger.info("Create new stack");
+      logger.info("Create new stack.");
       if (deployMethod === "github") {
         const cloudBuildConnRepo = await repo.linkGitHubRepository(
           projectId,
@@ -117,6 +117,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
 async function getExistingStack(projectId: string, setup: any, location: string): Promise<Stack> {
   let stack = await gcp.getStack(projectId, location, setup.frameworks.serviceName);
   while (stack) {
+    setup.frameworks.serviceName = undefined;
     await promptOnce(
       {
         name: "existingStack",
@@ -128,6 +129,7 @@ async function getExistingStack(projectId: string, setup: any, location: string)
       setup.frameworks
     );
     if (setup.frameworks.existingStack === "y" || setup.frameworks.existingStack === "yes") {
+      logger.info("Using the existing stack.");
       return stack;
     }
     await promptOnce(
@@ -140,7 +142,6 @@ async function getExistingStack(projectId: string, setup: any, location: string)
       setup.frameworks
     );
     stack = await gcp.getStack(projectId, location, setup.frameworks.serviceName);
-    setup.frameworks.serviceName = undefined;
     setup.frameworks.existingStack = undefined;
   }
 

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -109,7 +109,9 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
         return await createStack(projectId, location, stackDetails);
       }
     } else {
-      throw new FirebaseError(`Unable to fetch or create stack: ${err}`);
+      throw new FirebaseError(
+        `Unable to fetch or create stack try using different initialization details: ${err}`
+      );
     }
   }
 

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -78,7 +78,7 @@ export async function doSetup(setup: any): Promise<void> {
       setup.frameworks.serviceName
     );
     const stackDetails = toStack(cloudBuildConnRepo, setup.frameworks.serviceName);
-    await createStack(projectId, setup.frameworks.region, stackDetails);
+    await getOrCreateStack(projectId, setup.frameworks.region, stackDetails);
   }
 }
 
@@ -90,24 +90,6 @@ function toStack(
     name: stackId,
     labels: {},
   };
-}
-
-/**
- * Creates Stack object from long running operations.
- */
-export async function createStack(
-  projectId: string,
-  location: string,
-  stackInput: Omit<Stack, StackOutputOnlyFields>
-): Promise<Stack> {
-  const op = await gcp.createStack(projectId, location, stackInput);
-  const stack = await poller.pollOperation<Stack>({
-    ...frameworksPollerOptions,
-    pollerName: `create-${projectId}-${location}-${stackInput.name}`,
-    operationResourceName: op.name,
-  });
-
-  return stack;
 }
 
 /**

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -95,7 +95,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
   const location: string = setup.frameworks.region;
   const deployMethod: string = setup.frameworks.deployMethod;
   try {
-    return await getStack(projectId, setup, location);
+    return await getExistingStack(projectId, setup, location);
   } catch (err: unknown) {
     if ((err as FirebaseError).status === 404) {
       logger.info("Create new stack");
@@ -118,7 +118,7 @@ export async function getOrCreateStack(projectId: string, setup: any): Promise<S
   return undefined;
 }
 
-async function getStack(projectId: string, setup: any, location: string): Promise<Stack> {
+async function getExistingStack(projectId: string, setup: any, location: string): Promise<Stack> {
   let stack = await gcp.getStack(projectId, location, setup.frameworks.serviceName);
   while (stack) {
     await promptOnce(

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -64,7 +64,7 @@ describe("operationsConverter", () => {
       updateTime: "1",
     };
 
-    it("checks create stack operation", async () => {
+    it("should createStack", async () => {
       createStackStub.resolves(op);
       pollOperationStub.resolves(completeStack);
 

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -53,7 +53,7 @@ describe("operationsConverter", () => {
       frameworks: {
         region: location,
         serviceName: stackId,
-        existingStack: "yes",
+        existingStack: true,
         deployMethod: "github",
       },
     };

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 
 import * as gcp from "../../../gcp/frameworks";
 import * as poller from "../../../operation-poller";
-import { getOrCreateStack } from "../../../init/features/frameworks/index";
+import { createStack } from "../../../init/features/frameworks/index";
 
 describe("operationsConverter", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
@@ -54,7 +54,7 @@ describe("operationsConverter", () => {
       createStackStub.resolves(op);
       pollOperationStub.resolves(completeStack);
 
-      await getOrCreateStack(projectId, location, stackInput);
+      await createStack(projectId, location, stackInput);
       expect(createStackStub).to.be.calledWith(projectId, location, stackInput);
     });
   });

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -53,7 +53,7 @@ describe("operationsConverter", () => {
       frameworks: {
         region: location,
         serviceName: stackId,
-        useExistingStack: "yes",
+        existingStack: "yes",
         deployMethod: "github",
       },
     };

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -64,7 +64,7 @@ describe("operationsConverter", () => {
       updateTime: "1",
     };
 
-    it("checks is correct arguments are sent & creates a stack", async () => {
+    it("checks create stack operation", async () => {
       createStackStub.resolves(op);
       pollOperationStub.resolves(completeStack);
 

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -81,7 +81,7 @@ describe("operationsConverter", () => {
       expect(createStackStub).to.be.calledWith(projectId, location, stackInput);
     });
 
-    it("should return an existing stack if useExistingStack is 'yes'", async () => {
+    it("should return a stack, if user wants use the exiting stack", async () => {
       getStackStub.resolves(completeStack);
       const result = await getOrCreateStack("projectId", setup);
 
@@ -89,7 +89,7 @@ describe("operationsConverter", () => {
       expect(getStackStub.calledOnceWithExactly(projectId, location, stackId)).to.be.true;
     });
 
-    it("should create new stack if stack doesn't exist", async () => {
+    it("should create a new stack, if stack doesn't exist", async () => {
       const newStackId = "newStackId";
       const newPath = `projects/${projectId}/locations/${location}/stacks/${newStackId}`;
       setup.frameworks.serviceName = newStackId;

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 
 import * as gcp from "../../../gcp/frameworks";
 import * as poller from "../../../operation-poller";
-import { createStack } from "../../../init/features/frameworks/index";
+import { getOrCreateStack } from "../../../init/features/frameworks/index";
 
 describe("operationsConverter", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
@@ -54,7 +54,7 @@ describe("operationsConverter", () => {
       createStackStub.resolves(op);
       pollOperationStub.resolves(completeStack);
 
-      await createStack(projectId, location, stackInput);
+      await getOrCreateStack(projectId, location, stackInput);
       expect(createStackStub).to.be.calledWith(projectId, location, stackInput);
     });
   });

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -36,6 +36,10 @@ describe("operationsConverter", () => {
     const stackId = "stackId";
     const stackInput = {
       name: stackId,
+      codebase: {
+        repository: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
+        rootDirectory: ".",
+      },
       labels: {},
     };
     const op = {
@@ -44,6 +48,10 @@ describe("operationsConverter", () => {
     };
     const completeStack = {
       name: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
+      codebase: {
+        repository: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
+        rootDirectory: ".",
+      },
       labels: {},
       createTime: "0",
       updateTime: "1",
@@ -83,12 +91,14 @@ describe("operationsConverter", () => {
 
     it("should create new stack if stack doesn't exist", async () => {
       const newStackId = "newStackId";
-      const newStackIdPath = `projects/${projectId}/locations/${location}/stacks/${newStackId}`;
+      const newPath = `projects/${projectId}/locations/${location}/stacks/${newStackId}`;
       setup.frameworks.serviceName = newStackId;
       stackInput.name = newStackId;
-      op.name = newStackIdPath;
-      completeStack.name = newStackIdPath;
-      cloudBuildConnRepo.name = newStackIdPath;
+      stackInput.codebase.repository = newPath;
+      op.name = newPath;
+      completeStack.name = newPath;
+      completeStack.codebase.repository = newPath;
+      cloudBuildConnRepo.name = newPath;
 
       getStackStub.throws(new FirebaseError("error", { status: 404 }));
       linkGitHubRepositoryStub.resolves(cloudBuildConnRepo);

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -75,6 +75,7 @@ describe("operationsConverter", () => {
 
     it("should return a stack, if user wants use the exiting stack", async () => {
       getStackStub.resolves(completeStack);
+
       const result = await getOrCreateStack("projectId", setup);
 
       expect(result).to.deep.equal(completeStack);
@@ -89,11 +90,11 @@ describe("operationsConverter", () => {
       op.name = newPath;
       completeStack.name = newPath;
       cloudBuildConnRepo.name = newPath;
-
       getStackStub.throws(new FirebaseError("error", { status: 404 }));
       linkGitHubRepositoryStub.resolves(cloudBuildConnRepo);
       createStackStub.resolves(op);
       pollOperationStub.resolves(completeStack);
+
       const result = await getOrCreateStack(projectId, setup);
 
       expect(result).to.deep.equal(completeStack);

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -2,20 +2,28 @@ import * as sinon from "sinon";
 import { expect } from "chai";
 
 import * as gcp from "../../../gcp/frameworks";
+import * as repo from "../../../init/features/frameworks/repo";
 import * as poller from "../../../operation-poller";
-import { createStack } from "../../../init/features/frameworks/index";
+import { createStack, getOrCreateStack } from "../../../init/features/frameworks/index";
+import { FirebaseError } from "../../../error";
 
 describe("operationsConverter", () => {
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
 
   let pollOperationStub: sinon.SinonStub;
   let createStackStub: sinon.SinonStub;
+  let getStackStub: sinon.SinonStub;
+  let linkGitHubRepositoryStub: sinon.SinonStub;
 
   beforeEach(() => {
     pollOperationStub = sandbox
       .stub(poller, "pollOperation")
       .throws("Unexpected pollOperation call");
     createStackStub = sandbox.stub(gcp, "createStack").throws("Unexpected createStack call");
+    getStackStub = sandbox.stub(gcp, "getStack").throws("Unexpected getStack call");
+    linkGitHubRepositoryStub = sandbox
+      .stub(repo, "linkGitHubRepository")
+      .throws("Unexpected getStack call");
   });
 
   afterEach(() => {
@@ -28,10 +36,6 @@ describe("operationsConverter", () => {
     const stackId = "stackId";
     const stackInput = {
       name: stackId,
-      codebase: {
-        repository: `projects/${projectId}/locations/${location}/connections/${stackId}`,
-        rootDirectory: "/",
-      },
       labels: {},
     };
     const op = {
@@ -40,10 +44,6 @@ describe("operationsConverter", () => {
     };
     const completeStack = {
       name: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
-      codebase: {
-        repository: `projects/${projectId}/locations/${location}/connections/${stackId}`,
-        rootDirectory: "/",
-      },
       labels: {},
       createTime: "0",
       updateTime: "1",
@@ -55,6 +55,63 @@ describe("operationsConverter", () => {
       pollOperationStub.resolves(completeStack);
 
       await createStack(projectId, location, stackInput);
+
+      expect(createStackStub).to.be.calledWith(projectId, location, stackInput);
+    });
+
+    it("should return an existing stack if useExistingStack is 'yes'", async () => {
+      const setup = {
+        frameworks: {
+          region: location,
+          serviceName: stackId,
+          useExistingStack: "yes",
+        },
+      };
+      getStackStub.resolves(completeStack);
+
+      const result = await getOrCreateStack("projectId", setup);
+      expect(result).to.deep.equal(completeStack);
+      expect(getStackStub.calledOnceWithExactly(projectId, location, stackId)).to.be.true;
+    });
+
+    it("should create new stack if stack doesn't exist", async () => {
+      const stackId = "newStackId";
+      const setup = {
+        frameworks: {
+          region: location,
+          serviceName: "newStackId",
+          useExistingStack: "yes",
+          deployMethod: "github",
+        },
+      };
+      const op = {
+        name: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
+        done: true,
+      };
+      const completeStack = {
+        name: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
+        labels: {},
+        createTime: "0",
+        updateTime: "1",
+        uri: "https://placeholder.com",
+      };
+      const cloudBuildConnRepo = {
+        name: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
+        remoteUri: "remoteUri",
+        createTime: "0",
+        updateTime: "1",
+      };
+      const stackInput = {
+        name: stackId,
+        labels: {},
+      };
+
+      getStackStub.throws(new FirebaseError("error", { status: 404 }));
+      linkGitHubRepositoryStub.resolves(cloudBuildConnRepo);
+      createStackStub.resolves(op);
+      pollOperationStub.resolves(completeStack);
+      const result = await getOrCreateStack("projectId", setup);
+      expect(result).to.deep.equal(completeStack);
       expect(createStackStub).to.be.calledWith(projectId, location, stackInput);
     });
   });

--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -36,10 +36,6 @@ describe("operationsConverter", () => {
     const stackId = "stackId";
     const stackInput = {
       name: stackId,
-      codebase: {
-        repository: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
-        rootDirectory: ".",
-      },
       labels: {},
     };
     const op = {
@@ -48,10 +44,6 @@ describe("operationsConverter", () => {
     };
     const completeStack = {
       name: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
-      codebase: {
-        repository: `projects/${projectId}/locations/${location}/stacks/${stackId}`,
-        rootDirectory: ".",
-      },
       labels: {},
       createTime: "0",
       updateTime: "1",
@@ -94,10 +86,8 @@ describe("operationsConverter", () => {
       const newPath = `projects/${projectId}/locations/${location}/stacks/${newStackId}`;
       setup.frameworks.serviceName = newStackId;
       stackInput.name = newStackId;
-      stackInput.codebase.repository = newPath;
       op.name = newPath;
       completeStack.name = newPath;
-      completeStack.codebase.repository = newPath;
       cloudBuildConnRepo.name = newPath;
 
       getStackStub.throws(new FirebaseError("error", { status: 404 }));


### PR DESCRIPTION
The Firestore team has added the option to use HTTP/1.1 REST transport instead of gRPC. Using REST significantly reduces cold start times by eliminating the need to load gRPC libraries with the Firestore client. With https://github.com/googleapis/nodejs-firestore/pull/1848, functions developers can now enable the `preferRest` option for the Firestore SDK by setting an environment variable `FIRESTORE_PREFER_REST` in the GCF runtime environment. This PR enables `preferRest` by default for all functions. Note: methods that require gRPC will still cause the Firestore client to load dependent gRPC libraries.