### PR TITLE
Next.js/glob fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed `glob` usage in Next.js utility function to detect images in `app` directory (#6166)

--- a/scripts/webframeworks-deploy-tests/nextjs/app/app/image/page.tsx
+++ b/scripts/webframeworks-deploy-tests/nextjs/app/app/image/page.tsx
@@ -1,0 +1,10 @@
+import Image from 'next/image'
+
+export default function PageWithImage() {
+  return <Image 
+      src="https://www.google.com/logos/doodles/2015/googles-new-logo-5078286822539264.3-hp2x.gif"
+      alt=""
+      width={300} 
+      height={300}
+    />;
+}

--- a/scripts/webframeworks-deploy-tests/nextjs/next.config.js
+++ b/scripts/webframeworks-deploy-tests/nextjs/next.config.js
@@ -10,6 +10,9 @@ const nextConfig = {
     locales: ['en', 'fr'],
     defaultLocale: 'en',
   },
+  images: {
+    domains: ['google.com'],
+  },
   rewrites: () => [{
     source: '/about',
     destination: '/',

--- a/scripts/webframeworks-deploy-tests/tests.ts
+++ b/scripts/webframeworks-deploy-tests/tests.ts
@@ -305,6 +305,7 @@ describe("webframeworks", function (this) {
                 `/${NEXT_BASE_PATH}/_next/static/${buildId}/_buildManifest.js`,
                 `/${NEXT_BASE_PATH}/_next/static/${buildId}/_ssgManifest.js`,
                 `/${NEXT_BASE_PATH}/app/api/static`,
+                `/${NEXT_BASE_PATH}/app/image.html`,
                 `/${NEXT_BASE_PATH}/app/ssg.html`,
               ]),
           `/${I18N_BASE}/${locale}/${NEXT_BASE_PATH}/pages/fallback/1.html`,

--- a/scripts/webframeworks-deploy-tests/tests.ts
+++ b/scripts/webframeworks-deploy-tests/tests.ts
@@ -233,6 +233,12 @@ describe("webframeworks", function (this) {
         expect(apiDynamicResponse.headers.get("cache-control")).to.eql("private");
         expect(await apiDynamicResponse.json()).to.eql([1, 2, 3]);
       });
+
+      it("should have working image", async () => {
+        const response = await fetch(`${NEXTJS_HOST}/app/image`);
+        expect(response.ok).to.be.true;
+        expect(await response.text()).to.include("<body><img");
+      });
     });
 
     describe("pages directory", () => {

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -249,7 +249,7 @@ export async function isUsingNextImageInAppDirectory(
     join(projectDir, nextDir, "server", "**", "*client-reference-manifest.js")
   );
 
-  for await (const filepath of files) {
+  for (const filepath of files) {
     const fileContents = await readFile(filepath);
 
     // Return true when the first file containing the next/image component is found

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -2,7 +2,7 @@ import { existsSync } from "fs";
 import { pathExists } from "fs-extra";
 import { basename, extname, join, posix } from "path";
 import { readFile } from "fs/promises";
-import { Glob } from "glob";
+import * as glob from "glob";
 import type { PagesManifest } from "next/dist/build/webpack/plugins/pages-manifest-plugin";
 import { coerce } from "semver";
 
@@ -245,9 +245,14 @@ export async function isUsingNextImageInAppDirectory(
   projectDir: string,
   nextDir: string
 ): Promise<boolean> {
-  const { found: files } = new Glob(
-    join(projectDir, nextDir, "server", "**", "*client-reference-manifest.js")
-  );
+  const files = await new Promise<string[]>((resolve) => {
+    glob(
+      join(projectDir, nextDir, "server", "**", "*client-reference-manifest.js"),
+      (err, matches) => {
+        resolve(matches);
+      }
+    );
+  });
 
   for await (const filepath of files) {
     const fileContents = await readFile(filepath);

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -2,7 +2,7 @@ import { existsSync } from "fs";
 import { pathExists } from "fs-extra";
 import { basename, extname, join, posix } from "path";
 import { readFile } from "fs/promises";
-import * as glob from "glob";
+import { sync as globSync } from "glob";
 import type { PagesManifest } from "next/dist/build/webpack/plugins/pages-manifest-plugin";
 import { coerce } from "semver";
 
@@ -245,14 +245,9 @@ export async function isUsingNextImageInAppDirectory(
   projectDir: string,
   nextDir: string
 ): Promise<boolean> {
-  const files = await new Promise<string[]>((resolve) => {
-    glob(
-      join(projectDir, nextDir, "server", "**", "*client-reference-manifest.js"),
-      (err, matches) => {
-        resolve(matches);
-      }
-    );
-  });
+  const files = globSync(
+    join(projectDir, nextDir, "server", "**", "*client-reference-manifest.js")
+  );
 
   for await (const filepath of files) {
     const fileContents = await readFile(filepath);

--- a/src/test/frameworks/next/utils.spec.ts
+++ b/src/test/frameworks/next/utils.spec.ts
@@ -282,8 +282,8 @@ describe("Next.js utils", () => {
 
       it("should return true when using next/image in the app directory", async () => {
         sandbox
-          .stub(glob, "Glob")
-          .returns({ found: ["/path-to-app/.next/server/app/page_client-reference-manifest.js"] });
+          .stub(glob, "sync")
+          .returns(["/path-to-app/.next/server/app/page_client-reference-manifest.js"]);
         sandbox.stub(fsPromises, "readFile").resolves(pageClientReferenceManifestWithImage);
 
         expect(await isUsingNextImageInAppDirectory("", "")).to.be.true;
@@ -292,13 +292,13 @@ describe("Next.js utils", () => {
       it("should return false when not using next/image in the app directory", async () => {
         sandbox.stub(fsPromises, "readFile").resolves(pageClientReferenceManifestWithoutImage);
         const globStub = sandbox
-          .stub(glob, "Glob")
-          .returns({ found: ["/path-to-app/.next/server/app/page_client-reference-manifest.js"] });
+          .stub(glob, "sync")
+          .returns(["/path-to-app/.next/server/app/page_client-reference-manifest.js"]);
 
         expect(await isUsingNextImageInAppDirectory("", "")).to.be.false;
 
         globStub.restore();
-        sandbox.stub(glob, "Glob").returns({ found: [] });
+        sandbox.stub(glob, "sync").returns([]);
 
         expect(await isUsingNextImageInAppDirectory("", "")).to.be.false;
       });
@@ -312,15 +312,15 @@ describe("Next.js utils", () => {
       it("should return true when using next/image in the app directory", async () => {
         sandbox.stub(fsPromises, "readFile").resolves(clientReferenceManifestWithImage);
         sandbox
-          .stub(glob, "Glob")
-          .returns({ found: ["/path-to-app/.next/server/client-reference-manifest.js"] });
+          .stub(glob, "sync")
+          .returns(["/path-to-app/.next/server/client-reference-manifest.js"]);
 
         expect(await isUsingNextImageInAppDirectory("", "")).to.be.true;
       });
 
       it("should return false when not using next/image in the app directory", async () => {
         sandbox.stub(fsPromises, "readFile").resolves(clientReferenceManifestWithoutImage);
-        sandbox.stub(glob, "Glob").returns({ found: [] });
+        sandbox.stub(glob, "sync").returns([]);
 
         expect(await isUsingNextImageInAppDirectory("", "")).to.be.false;
       });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #6163

The usage of `Glob` caused problems in the CLI build. This PR replaces `Glob` with `sync`. 

In other parts of the frameworks code `glob` is being used as `import * as glob from "glob"`: https://github.com/firebase/firebase-tools/blob/29747a824caa5589a4e04851a4ca0fa92491f03e/src/frameworks/index.ts#L8

 but I could not find a way to stub it with Sinon for the unit tests, that's why `Glob` was used.

@joehan can you help confirming `sync` won't cause problems? Maybe because the CLI `glob` version is old? The CLI uses `7.1.2` but the latest is `10.3.3`.


<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

`deploy`

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
