### PR TITLE
Make Extensions TOS calls best effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where extension instances could not be deployed when authenticated as a service account (#6060).

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -274,6 +274,7 @@ export class Client {
       token = await this.getAccessToken();
     }
     reqOptions.headers.set("Authorization", `Bearer ${token}`);
+    console.log(reqOptions.headers.get("Authorization"));
     return reqOptions;
   }
 
@@ -282,11 +283,7 @@ export class Client {
     if (accessToken) {
       return accessToken;
     }
-    // TODO: remove the as any once auth.js is migrated to auth.ts
-    interface AccessToken {
-      access_token: string;
-    }
-    const data = (await auth.getAccessToken(refreshToken, [])) as AccessToken;
+    const data = await auth.getAccessToken(refreshToken, []);
     return data.access_token;
   }
 

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -274,7 +274,6 @@ export class Client {
       token = await this.getAccessToken();
     }
     reqOptions.headers.set("Authorization", `Bearer ${token}`);
-    console.log(reqOptions.headers.get("Authorization"));
     return reqOptions;
   }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -702,8 +702,8 @@ async function refreshTokens(
   }
 }
 
-export async function getAccessToken(refreshToken: string, authScopes: string[]) {
-  if (haveValidTokens(refreshToken, authScopes)) {
+export async function getAccessToken(refreshToken: string, authScopes: string[]): Promise<Tokens> {
+  if (haveValidTokens(refreshToken, authScopes) && lastAccessToken) {
     return lastAccessToken;
   }
 

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -110,16 +110,17 @@ export async function acceptLatestAppDeveloperTOS(
     if (currentAcceptance.lastAcceptedVersion) {
       logger.debug(`User Terms of Service aready accepted on project ${projectId}.`);
     } else if (
-      await confirm({
+      !(await confirm({
         ...options,
         message: "Do you accept the Firebase Extensions User Terms of Service?",
-      })
+      }))
     ) {
-      const tosPromises = instanceIds.map((instanceId) => {
-        return acceptAppDeveloperTOS(projectId, currentAcceptance.latestTosVersion, instanceId);
-      });
-      return Promise.all(tosPromises);
+      throw new FirebaseError("You must accept the terms of service to continue.");
     }
+    const tosPromises = instanceIds.map((instanceId) => {
+      return acceptAppDeveloperTOS(projectId, currentAcceptance.latestTosVersion, instanceId);
+    });
+    return Promise.all(tosPromises);
   } catch (err: any) {
     // This is a best effort check. When authenticated via a service account instead of OAuth, we cannot
     // make calls to a private API. The extensions backend will also check TOS acceptance at instance CRUD time.
@@ -128,7 +129,6 @@ export async function acceptLatestAppDeveloperTOS(
     );
     return [];
   }
-  throw new FirebaseError("You must accept the terms of service to continue.");
 }
 
 export function displayDeveloperTOSWarning(): void {

--- a/src/extensions/tos.ts
+++ b/src/extensions/tos.ts
@@ -63,30 +63,39 @@ export async function acceptPublisherTOS(
 export async function acceptLatestPublisherTOS(
   options: { force?: boolean; nonInteractive?: boolean },
   projectId: string
-): Promise<PublisherTOS> {
-  logger.debug(`Checking if latest publisher TOS has been accepted by ${projectId}...`);
-  const currentAcceptance = await getPublisherTOSStatus(projectId);
-  if (currentAcceptance.lastAcceptedVersion) {
-    logger.debug(
-      `Already accepted version ${currentAcceptance.lastAcceptedVersion} of Extensions publisher TOS.`
-    );
-    return currentAcceptance;
-  } else {
-    // Display link to TOS, prompt for acceptance
-    const tosLink = extensionsTosUrl("publisher");
-    logger.info(
-      `To continue, you must accept the Firebase Extensions Publisher Terms of Service: ${tosLink}`
-    );
-    if (
-      await confirm({
-        ...options,
-        message: "Do you accept the Firebase Extensions Publisher Terms of Service?",
-      })
-    ) {
-      return acceptPublisherTOS(projectId, currentAcceptance.latestTosVersion);
+): Promise<PublisherTOS | undefined> {
+  try {
+    logger.debug(`Checking if latest publisher TOS has been accepted by ${projectId}...`);
+    const currentAcceptance = await getPublisherTOSStatus(projectId);
+    if (currentAcceptance.lastAcceptedVersion) {
+      logger.debug(
+        `Already accepted version ${currentAcceptance.lastAcceptedVersion} of Extensions publisher TOS.`
+      );
+      return currentAcceptance;
+    } else {
+      // Display link to TOS, prompt for acceptance
+      const tosLink = extensionsTosUrl("publisher");
+      logger.info(
+        `To continue, you must accept the Firebase Extensions Publisher Terms of Service: ${tosLink}`
+      );
+      if (
+        await confirm({
+          ...options,
+          message: "Do you accept the Firebase Extensions Publisher Terms of Service?",
+        })
+      ) {
+        return acceptPublisherTOS(projectId, currentAcceptance.latestTosVersion);
+      }
     }
-    throw new FirebaseError("You must accept the terms of service to continue.");
+  } catch (err: any) {
+    // This is a best effort check. When authenticated via a service account instead of OAuth, we cannot
+    // make calls to a private API. The extensions backend will also check TOS acceptance at instance CRUD time.
+    logger.debug(
+      `Error when checking Publisher TOS for ${projectId}. This is expected if authenticated via a service account: ${err}`
+    );
+    return;
   }
+  throw new FirebaseError("You must accept the terms of service to continue.");
 }
 
 export async function acceptLatestAppDeveloperTOS(
@@ -94,23 +103,32 @@ export async function acceptLatestAppDeveloperTOS(
   projectId: string,
   instanceIds: string[]
 ): Promise<AppDevTOS[]> {
-  logger.debug(`Checking if latest AppDeveloper TOS has been accepted by ${projectId}...`);
-  displayDeveloperTOSWarning();
-  const currentAcceptance = await getAppDeveloperTOSStatus(projectId);
-  if (currentAcceptance.lastAcceptedVersion) {
-    logger.debug(`User Terms of Service aready accepted on project ${projectId}.`);
-  } else if (
-    !(await confirm({
-      ...options,
-      message: "Do you accept the Firebase Extensions User Terms of Service?",
-    }))
-  ) {
-    throw new FirebaseError("You must accept the terms of service to continue.");
+  try {
+    logger.debug(`Checking if latest AppDeveloper TOS has been accepted by ${projectId}...`);
+    displayDeveloperTOSWarning();
+    const currentAcceptance = await getAppDeveloperTOSStatus(projectId);
+    if (currentAcceptance.lastAcceptedVersion) {
+      logger.debug(`User Terms of Service aready accepted on project ${projectId}.`);
+    } else if (
+      await confirm({
+        ...options,
+        message: "Do you accept the Firebase Extensions User Terms of Service?",
+      })
+    ) {
+      const tosPromises = instanceIds.map((instanceId) => {
+        return acceptAppDeveloperTOS(projectId, currentAcceptance.latestTosVersion, instanceId);
+      });
+      return Promise.all(tosPromises);
+    }
+  } catch (err: any) {
+    // This is a best effort check. When authenticated via a service account instead of OAuth, we cannot
+    // make calls to a private API. The extensions backend will also check TOS acceptance at instance CRUD time.
+    logger.debug(
+      `Error when checking App Developer TOS for ${projectId}. This is expected if authenticated via a service account: ${err}`
+    );
+    return [];
   }
-  const tosPromises = instanceIds.map((instanceId) => {
-    return acceptAppDeveloperTOS(projectId, currentAcceptance.latestTosVersion, instanceId);
-  });
-  return Promise.all(tosPromises);
+  throw new FirebaseError("You must accept the terms of service to continue.");
 }
 
 export function displayDeveloperTOSWarning(): void {


### PR DESCRIPTION
### Description
Make calls to check and accept the Extensions TOS best effort. We have backend checks for these in place, so this should be safe.

When users who are authenticated via a service account (ie CI/CD pipelines) try to deploy extensions, calls to the private TOS API end up being done on the service accounts project instead of the CLI's OAuth project. This fails, because this API cannot be enabled on external projects.

Fixes #6060.

### Scenarios Tested
Tested that I can successfully deploy as a service account (and verified that the call was attempted & failed via the debug logs).
Tested that I can successfully deploy as a normal login'd user, and that the TOS check still succeeds and records acceptance.