### PR TITLE
Send enabled experiments to the UI

### DIFF
--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -55,6 +55,9 @@ export class Constants {
 
   static DEFAULT_DATABASE_EMULATOR_NAMESPACE = "fake-server";
 
+  // Environment variable for a list of active CLI experiments
+  static FIREBASE_ENABLED_EXPERIMENTS = "FIREBASE_ENABLED_EXPERIMENTS";
+
   // Environment variable to override SDK/CLI to point at the Firestore emulator.
   static FIRESTORE_EMULATOR_HOST = "FIRESTORE_EMULATOR_HOST";
 

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -11,7 +11,6 @@ import { EmulatorRegistry } from "./registry";
 import { FunctionsEmulator } from "./functionsEmulator";
 import { ExpressBasedEmulator } from "./ExpressBasedEmulator";
 import { PortName } from "./portUtils";
-import { ALL_EXPERIMENTS, ExperimentName, isEnabled } from "../experiments";
 
 // We use the CLI version from package.json
 const pkg = require("../../package.json");
@@ -36,7 +35,6 @@ export class EmulatorHub extends ExpressBasedEmulator {
   static PATH_DISABLE_FUNCTIONS = "/functions/disableBackgroundTriggers";
   static PATH_ENABLE_FUNCTIONS = "/functions/enableBackgroundTriggers";
   static PATH_EMULATORS = "/emulators";
-  static PATH_ENABLED_EXPERIMENTS = "/enabled-experiments";
 
   /**
    * Given a project ID, find and read the Locator file for the emulator hub.

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -30,8 +30,6 @@ export interface EmulatorHubArgs {
 
 export type GetEmulatorsResponse = Record<string, EmulatorInfo>;
 
-export type GetEnabledExperimentsResponse = { experiments: Array<ExperimentName> };
-
 export class EmulatorHub extends ExpressBasedEmulator {
   static CLI_VERSION = pkg.version;
   static PATH_EXPORT = "/_admin/export";
@@ -98,18 +96,6 @@ export class EmulatorHub extends ExpressBasedEmulator {
           ...info,
         };
       }
-      res.json(body);
-    });
-
-    /**
-     * Send any experiments set by `firebase experiments:enable`
-     */
-    app.get(EmulatorHub.PATH_ENABLED_EXPERIMENTS, (req, res) => {
-      const body: GetEnabledExperimentsResponse = {
-        experiments: (Object.keys(ALL_EXPERIMENTS) as Array<ExperimentName>).filter(
-          (experimentName) => isEnabled(experimentName)
-        ),
-      };
       res.json(body);
     });
 

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -11,6 +11,7 @@ import { EmulatorRegistry } from "./registry";
 import { FunctionsEmulator } from "./functionsEmulator";
 import { ExpressBasedEmulator } from "./ExpressBasedEmulator";
 import { PortName } from "./portUtils";
+import { ALL_EXPERIMENTS, ExperimentName, isEnabled } from "../experiments";
 
 // We use the CLI version from package.json
 const pkg = require("../../package.json");
@@ -29,12 +30,15 @@ export interface EmulatorHubArgs {
 
 export type GetEmulatorsResponse = Record<string, EmulatorInfo>;
 
+export type GetEnabledExperimentsResponse = { experiments: Array<ExperimentName> };
+
 export class EmulatorHub extends ExpressBasedEmulator {
   static CLI_VERSION = pkg.version;
   static PATH_EXPORT = "/_admin/export";
   static PATH_DISABLE_FUNCTIONS = "/functions/disableBackgroundTriggers";
   static PATH_ENABLE_FUNCTIONS = "/functions/enableBackgroundTriggers";
   static PATH_EMULATORS = "/emulators";
+  static PATH_ENABLED_EXPERIMENTS = "/enabled-experiments";
 
   /**
    * Given a project ID, find and read the Locator file for the emulator hub.
@@ -94,6 +98,18 @@ export class EmulatorHub extends ExpressBasedEmulator {
           ...info,
         };
       }
+      res.json(body);
+    });
+
+    /**
+     * Send any experiments set by `firebase experiments:enable`
+     */
+    app.get(EmulatorHub.PATH_ENABLED_EXPERIMENTS, (req, res) => {
+      const body: GetEnabledExperimentsResponse = {
+        experiments: (Object.keys(ALL_EXPERIMENTS) as Array<ExperimentName>).filter(
+          (experimentName) => isEnabled(experimentName)
+        ),
+      };
       res.json(body);
     });
 

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -5,6 +5,7 @@ import { FirebaseError } from "../error";
 import { Constants } from "./constants";
 import { emulatorSession } from "../track";
 import { ExpressBasedEmulator } from "./ExpressBasedEmulator";
+import { ALL_EXPERIMENTS, ExperimentName, isEnabled } from "../experiments";
 
 export interface EmulatorUIOptions {
   listen: ListenSpec[];
@@ -34,6 +35,11 @@ export class EmulatorUI implements EmulatorInstance {
     if (session) {
       env[Constants.FIREBASE_GA_SESSION] = JSON.stringify(session);
     }
+
+    const enabledExperiments = (Object.keys(ALL_EXPERIMENTS) as Array<ExperimentName>).filter(
+      (experimentName) => isEnabled(experimentName)
+    );
+    env[Constants.FIREBASE_ENABLED_EXPERIMENTS] = JSON.stringify(enabledExperiments);
 
     return downloadableEmulators.start(Emulators.UI, { auto_download: autoDownload }, env);
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Allow experiments set with `firebase experiments:enable` to be accessed by the emulator UI. UI PR: https://github.com/firebase/firebase-tools-ui/pull/979

### Scenarios Tested

Ran the UI (https://github.com/firebase/firebase-tools-ui/pull/979) and saw the enabled experiments surfaced there