### PR TITLE
Remove proxy-agent stub

### DIFF
--- a/firebase-vscode/webpack.common.js
+++ b/firebase-vscode/webpack.common.js
@@ -33,7 +33,6 @@ const extensionConfig = {
     extensions: [".ts", ".js"],
     alias: {
       // provides alternate implementation for node module and source files
-      "proxy-agent": path.resolve(__dirname, 'src/stubs/empty-class.js'),
       "marked-terminal": path.resolve(__dirname, 'src/stubs/empty-class.js'),
       // "ora": path.resolve(__dirname, 'src/stubs/empty-function.js'),
       "commander": path.resolve(__dirname, 'src/stubs/empty-class.js'),


### PR DESCRIPTION
Proxy-agent stub no longer works after https://github.com/firebase/firebase-tools/pull/6160

This change actually seems to be good as the reason I stubbed proxy-agent in the first place was that it was dependent on vm2, which had some hardcoded paths that didn't play well with webpack bundling. It seems like the updated version no longer has that problem and no longer requires a stub.