### PR TITLE
fix/typescript-function-template: Corrected out-of-the-box ESLint setup

### DIFF
--- a/templates/init/functions/typescript/_eslintrc
+++ b/templates/init/functions/typescript/_eslintrc
@@ -16,6 +16,7 @@ module.exports = {
   parserOptions: {
     project: ["tsconfig.json", "tsconfig.dev.json"],
     sourceType: "module",
+    tsconfigRootDir: __dirname,
   },
   ignorePatterns: [
     "/lib/**/*", // Ignore built files.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Previously the project structure created by `firebase init` command causes an eslint error when opened on vscode, saying: 
```
Parsing error: Cannot read file '/home/vaju/Desktop/firebase/tsconfig.json'
```
![Screenshot from 2023-07-27 01-09-02](https://github.com/firebase/firebase-tools/assets/12165822/afc80403-ef51-4fc3-ac25-2a0a2634ee8b)

This commit fixes it with correct eslint config.

The vscode eslint extension must me looking for the tsconfig at the root. But the tsconfig is located at `./functions` directory. Adding `tsconfigRootDir: __dirname` fixes it.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
