### PR TITLE
Require auth for functions:secrets family of commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where functions:secrets:* family of commands did not work when Firebase CLI is authenticated via GOOGLE_APPLICATION_CREDENTIALS (#6190)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fix bug where functions:secrets:* family of commands did not work when Firebase CLI is authenticated via GOOGLE_APPLICATION_CREDENTIALS (#6190)
+- Fix bug where functions:secrets:\* family of commands did not work when Firebase CLI is authenticated via GOOGLE_APPLICATION_CREDENTIALS (#6190)

--- a/src/commands/functions-secrets-access.ts
+++ b/src/commands/functions-secrets-access.ts
@@ -3,12 +3,14 @@ import { logger } from "../logger";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
 import { accessSecretVersion } from "../gcp/secretManager";
+import { requireAuth } from "../requireAuth";
 import * as secrets from "../functions/secrets";
 
 export const command = new Command("functions:secrets:access <KEY>[@version]")
   .description(
     "Access secret value given secret and its version. Defaults to accessing the latest version."
   )
+  .before(requireAuth)
   .before(secrets.ensureApi)
   .action(async (key: string, options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/functions-secrets-destroy.ts
+++ b/src/commands/functions-secrets-destroy.ts
@@ -10,6 +10,7 @@ import {
 } from "../gcp/secretManager";
 import { promptOnce } from "../prompt";
 import { logBullet, logWarning } from "../utils";
+import { requireAuth } from "../requireAuth";
 import * as secrets from "../functions/secrets";
 import * as backend from "../deploy/functions/backend";
 import * as args from "../deploy/functions/args";
@@ -17,6 +18,7 @@ import * as args from "../deploy/functions/args";
 export const command = new Command("functions:secrets:destroy <KEY>[@version]")
   .description("Destroy a secret. Defaults to destroying the latest version.")
   .withForce("Destroys a secret without confirmation.")
+  .before(requireAuth)
   .before(secrets.ensureApi)
   .action(async (key: string, options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/functions-secrets-get.ts
+++ b/src/commands/functions-secrets-get.ts
@@ -1,5 +1,6 @@
 const Table = require("cli-table");
 
+import { requireAuth } from "../requireAuth";
 import { Command } from "../command";
 import { logger } from "../logger";
 import { Options } from "../options";
@@ -10,6 +11,7 @@ import * as secrets from "../functions/secrets";
 
 export const command = new Command("functions:secrets:get <KEY>")
   .description("Get metadata for secret and its versions")
+  .before(requireAuth)
   .before(secrets.ensureApi)
   .before(requirePermissions, ["secretmanager.secrets.get"])
   .action(async (key: string, options: Options) => {

--- a/src/commands/functions-secrets-prune.ts
+++ b/src/commands/functions-secrets-prune.ts
@@ -1,18 +1,21 @@
 import * as args from "../deploy/functions/args";
 import * as backend from "../deploy/functions/backend";
+import * as secrets from "../functions/secrets";
+
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId, needProjectNumber } from "../projectUtils";
-import * as secrets from "../functions/secrets";
 import { requirePermissions } from "../requirePermissions";
 import { isFirebaseManaged } from "../deploymentTool";
 import { logBullet, logSuccess } from "../utils";
 import { promptOnce } from "../prompt";
 import { destroySecretVersion } from "../gcp/secretManager";
+import { requireAuth } from "../requireAuth";
 
 export const command = new Command("functions:secrets:prune")
   .withForce("Destroys unused secrets without prompt")
   .description("Destroys unused secrets")
+  .before(requireAuth)
   .before(secrets.ensureApi)
   .before(requirePermissions, [
     "cloudfunctions.functions.list",

--- a/src/commands/functions-secrets-set.ts
+++ b/src/commands/functions-secrets-set.ts
@@ -17,6 +17,7 @@ import {
   toSecretVersionResourceName,
 } from "../gcp/secretManager";
 import { check } from "../ensureApiEnabled";
+import { requireAuth } from "../requireAuth";
 import * as secrets from "../functions/secrets";
 import * as backend from "../deploy/functions/backend";
 import * as args from "../deploy/functions/args";
@@ -24,6 +25,7 @@ import * as args from "../deploy/functions/args";
 export const command = new Command("functions:secrets:set <KEY>")
   .description("Create or update a secret for use in Cloud Functions for Firebase.")
   .withForce("Automatically updates functions to use the new secret.")
+  .before(requireAuth)
   .before(secrets.ensureApi)
   .before(requirePermissions, [
     "secretmanager.secrets.create",

--- a/src/functions/secrets.ts
+++ b/src/functions/secrets.ts
@@ -78,7 +78,7 @@ function toUpperSnakeCase(key: string): string {
  */
 export function ensureApi(options: any): Promise<void> {
   const projectId = needProjectId(options);
-  return ensureApiEnabled.ensure(projectId, "secretmanager.googleapis.com", "runtimeconfig", true);
+  return ensureApiEnabled.ensure(projectId, "secretmanager.googleapis.com", "secretmanager", true);
 }
 
 /**


### PR DESCRIPTION
Need requireAuth call to properly setup credentials when developer is relying on  GOOGLE_APPLICATION_CREDENTIALS.

Fixes https://github.com/firebase/firebase-tools/issues/6186