### PR TITLE
Pass `NODE_OPTIONS` when spawning `firebase-functions`

### DIFF
--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -166,6 +166,7 @@ export class Delegate {
       HOME: process.env.HOME,
       PATH: process.env.PATH,
       NODE_ENV: process.env.NODE_ENV,
+      NODE_OPTIONS: process.env.NODE_OPTIONS,
       // Web Frameworks fails without this environment variable
       __FIREBASE_FRAMEWORKS_ENTRY__: process.env.__FIREBASE_FRAMEWORKS_ENTRY__,
     };


### PR DESCRIPTION
With this change, it's possible to pass a loader to Node.js via the `NODE_OPTIONS` environment variable to enable support for TypeScript in the Cloud Functions emulator during development. For example:
```sh
NODE_OPTIONS='--loader=@esbuild-kit/esm-loader' firebase emulators:start
```

It doesn't affect the deployed Cloud Functions which still need to be transpiled.

Closes https://github.com/firebase/firebase-tools/issues/6112.