### PR TITLE
Improve error message when `firebase init hosting:github` fails because of key limit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Improve error message raised when `firebase init hosting:github` fails due to max number of keys limit for a service account. (#6145)

--- a/src/gcp/iam.ts
+++ b/src/gcp/iam.ts
@@ -132,6 +132,19 @@ export async function deleteServiceAccount(projectId: string, accountEmail: stri
 }
 
 /**
+ * Lists every key for a given service account.
+ */
+export async function listServiceAccountKeys(
+  projectId: string,
+  serviceAccountName: string
+): Promise<ServiceAccountKey[]> {
+  const response = await apiClient.get<{ keys: ServiceAccountKey[] }>(
+    `/projects/${projectId}/serviceAccounts/${serviceAccountName}@${projectId}.iam.gserviceaccount.com/keys`
+  );
+  return response.body.keys;
+}
+
+/**
  * Given a name, returns corresponding Role, see
  * https://cloud.google.com/iam/reference/rest/v1/organizations.roles#Role
  * for more details.

--- a/src/init/features/hosting/github.ts
+++ b/src/init/features/hosting/github.ts
@@ -13,6 +13,7 @@ import {
   createServiceAccount,
   createServiceAccountKey,
   deleteServiceAccount,
+  listServiceAccountKeys,
 } from "../../../gcp/iam";
 import { addServiceAccountToRoles, firebaseRoles } from "../../../gcp/resourceManager";
 import { logger } from "../../../logger";
@@ -20,6 +21,7 @@ import { prompt } from "../../../prompt";
 import { logBullet, logLabeledBullet, logSuccess, logWarning, reject } from "../../../utils";
 import { githubApiOrigin, githubClientId } from "../../../api";
 import { Client } from "../../../apiv2";
+import { FirebaseError } from "../../../error";
 
 let GIT_DIR: string;
 let GITHUB_DIR: string;
@@ -547,6 +549,18 @@ async function createServiceAccountAndKeyWithRetry(
   } catch (e: any) {
     spinnerServiceAccount.stop();
     if (!e.message.includes("429")) {
+      const serviceAccountKeys = await listServiceAccountKeys(options.projectId, accountId);
+      if (serviceAccountKeys.length >= 10) {
+        throw new FirebaseError(
+          `You cannot add another key because the service account ${bold(
+            accountId
+          )} already contains the max number of keys: 10.`,
+          {
+            original: e,
+            exit: 1,
+          }
+        );
+      }
       throw e;
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

In #6145, creation of GitHub Actions fails because the service account reached the limit of 10 keys, which is the maximum amount a service account can have as per our [docs](https://cloud.google.com/iam/docs/keys-create-delete#creating)

Current behavior when running `firebase init hosting:github` and  the service account has 10 keys is raising this error message:
```
Error: HTTP Error: 400, Precondition check failed.
```

Checking `firebase-debug.log` shows this error from the request:
```
{
  "body": {
    "error": {
      "code": 400,
      "message": "Precondition check failed.",
      "status": "FAILED_PRECONDITION"
    }
  },
  "response": {
    "statusCode": 400
  }
}
```

Since the request does not provide much info. To verify if the issue is caused by the key limit, make a request to list the number of current keys registered to the service account then raise an error when it has reached the limit.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1. Run `firebase init hosting:github` to create the service account
2. Add keys manually or re-run `firebase init hosting:github` until service account has 10 keys
3. Run `firebase init hosting:github`
Output:
```
Error: You cannot add another key because the service account github-action-<id> already contains the max number of keys: 10.
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase init hosting:github`
