### PR TITLE
Disambiguate logging for framework discovery

### DIFF
--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -228,14 +228,13 @@ export function getNpmRoot(cwd: string) {
 }
 
 export function getNodeModuleBin(name: string, cwd: string) {
-  const cantFindExecutable = new FirebaseError(`Could not find the ${name} executable.`);
   const npmRoot = getNpmRoot(cwd);
   if (!npmRoot) {
-    throw cantFindExecutable;
+    throw new FirebaseError(`Error finding ${name} executable: failed to spawn 'npm'`);;
   }
   const path = join(npmRoot, ".bin", name);
   if (!fileExistsSync(path)) {
-    throw cantFindExecutable;
+    throw new FirebaseError(`Could not find the ${name} executable.`);;
   }
   return path;
 }

--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -230,11 +230,11 @@ export function getNpmRoot(cwd: string) {
 export function getNodeModuleBin(name: string, cwd: string) {
   const npmRoot = getNpmRoot(cwd);
   if (!npmRoot) {
-    throw new FirebaseError(`Error finding ${name} executable: failed to spawn 'npm'`);;
+    throw new FirebaseError(`Error finding ${name} executable: failed to spawn 'npm'`);
   }
   const path = join(npmRoot, ".bin", name);
   if (!fileExistsSync(path)) {
-    throw new FirebaseError(`Could not find the ${name} executable.`);;
+    throw new FirebaseError(`Could not find the ${name} executable.`);
   }
   return path;
 }


### PR DESCRIPTION
### Description
Minor improvement to logs to help debug issues like #6187 and #6173. My suspicion right now is that these issues represent a bunch of different cases where either npm is not available on the system (ie Firepit) or where dependencies have unusual paths in `node_modules`. I'm hoping these logs help us fix at least some of those cases.

cc @alexastrum who knows much more about this frameworks
