### PR TITLE
Switch functions emulator https body limit to 32mb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed bug where `functions:secrets:\*` family of commands did not work when Firebase CLI is authenticated via GOOGLE_APPLICATION_CREDENTIALS (#6190)
 - Fixed bug where some extension instance updates would default to the wrong location.
+- Increased HTTPS body size limit to 32mb to match production. (#6201)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Fixed bug where `functions:secrets:\*` family of commands did not work when Firebase CLI is authenticated via GOOGLE_APPLICATION_CREDENTIALS (#6190)
 - Fixed bug where some extension instance updates would default to the wrong location.
-- Increased HTTPS body size limit to 32mb to match production. (#6201)
+- Increased functions emulator HTTPS body size limit to 32mb to match production. (#6201)

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -11,7 +11,6 @@ import * as _ from "lodash";
 import { EmulatorLog } from "./types";
 import { Constants } from "./constants";
 import {
-  EmulatedTriggerMap,
   findModuleRoot,
   FunctionsRuntimeBundle,
   HttpConstants,
@@ -862,7 +861,7 @@ function logDebug(msg: string, data?: any): void {
   new EmulatorLog("DEBUG", "runtime-status", `[${process.pid}] ${msg}`, data).log();
 }
 
-async function initializeRuntime(): Promise<EmulatedTriggerMap | undefined> {
+async function initializeRuntime(): Promise<void> {
   FUNCTION_DEBUG_MODE = process.env.FUNCTION_DEBUG_MODE || "";
 
   if (!FUNCTION_DEBUG_MODE) {
@@ -979,32 +978,33 @@ async function main(): Promise<void> {
     ).log();
     await flushAndExit(1);
   }
-
   const app = express();
   app.enable("trust proxy");
+  // TODO: This should be 10mb for v1 functions, 32mb for v2, but there is not an easy way to check platform from here.
+  const bodyParserLimit = "32mb";
   app.use(
     bodyParser.json({
-      limit: "10mb",
+      limit: bodyParserLimit,
       verify: rawBodySaver,
     })
   );
   app.use(
     bodyParser.text({
-      limit: "10mb",
+      limit: bodyParserLimit,
       verify: rawBodySaver,
     })
   );
   app.use(
     bodyParser.urlencoded({
       extended: true,
-      limit: "10mb",
+      limit: bodyParserLimit,
       verify: rawBodySaver,
     })
   );
   app.use(
     bodyParser.raw({
       type: "*/*",
-      limit: "10mb",
+      limit: bodyParserLimit,
       verify: rawBodySaver,
     })
   );


### PR DESCRIPTION
### Description
Switch HTTPS body size limit to 32mb, as per https://firebase.google.com/docs/functions/quotas#resource_limits. Fixes #6201.

Ideally, we'd check whether we're emulating a v1 or v2 function and set this accordingly. I spent some time trying to implement a check for this, but the info is not easily available within functionsEmualtorRuntime.
