### PR TITLE
Increase Next.js config bundle timeout to 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Increase Next.js config bundle timeout to 60 seconds (#6214)

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -76,6 +76,7 @@ export const support = SupportLevel.Preview;
 export const type = FrameworkType.MetaFramework;
 export const docsUrl = "https://firebase.google.com/docs/hosting/frameworks/nextjs";
 
+const BUNDLE_NEXT_CONFIG_TIMEOUT = 60_000;
 const DEFAULT_NUMBER_OF_REASONS_TO_LIST = 5;
 
 function getReactVersion(cwd: string): string | undefined {
@@ -471,8 +472,6 @@ export async function ɵcodegenPublicDirectory(
     })
   );
 }
-
-const BUNDLE_NEXT_CONFIG_TIMEOUT = 10_000;
 
 /**
  * Create a directory for SSR content.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

After discussing the issue #6193 with @alexastrum, we decided to increase the Next.js config bundle timeout to 60 seconds. 

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
