### PR TITLE
Fix auth emulator multi-tenant import/export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Increase Next.js config bundle timeout to 60 seconds (#6214)
+- Fixes issue where auth emulator multi-tenant mode exports/imports only users tied to the default tenant (#5623)

--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -172,7 +172,7 @@ export function registerHandlers(
     res.set("Content-Type", "text/html; charset=utf-8");
     const apiKey = req.query.apiKey as string | undefined;
     const providerId = req.query.providerId as string | undefined;
-    const tenantId = req.query.tenantId as string | undefined;
+    const tenantId = (req.query.tenantId || req.query.tid) as string | undefined;
     if (!apiKey || !providerId) {
       return res.status(400).json({
         authEmulator: {

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -102,32 +102,38 @@ export class AuthEmulator implements EmulatorInstance {
       );
     }
 
-    const accountsPath = path.join(authExportDir, "accounts.json");
-    const accountsStat = await stat(accountsPath);
-    if (accountsStat?.isFile()) {
-      logger.logLabeled("BULLET", "auth", `Importing accounts from ${accountsPath}`);
+    const accountFiles = fs
+      .readdirSync(authExportDir)
+      .filter((fileName) => fileName.includes("accounts"));
+    for (const accountFile of accountFiles) {
+      const accountsPath = path.join(authExportDir, accountFile);
+      const accountsStat = await stat(accountsPath);
+      const tenantId = accountFile.replace(/accounts(-|)|.json/gm, "");
+      if (accountsStat?.isFile()) {
+        logger.logLabeled("BULLET", "auth", `Importing accounts from ${accountsPath}`);
 
-      await importFromFile(
-        {
-          method: "POST",
-          host: utils.connectableHostname(host),
-          port,
-          path: `/identitytoolkit.googleapis.com/v1/projects/${projectId}/accounts:batchCreate`,
-          headers: {
-            Authorization: "Bearer owner",
-            "Content-Type": "application/json",
+        await importFromFile(
+          {
+            method: "POST",
+            host: utils.connectableHostname(host),
+            port,
+            path: `/identitytoolkit.googleapis.com/v1/projects/${projectId}/tenants/${tenantId}/accounts:batchCreate`,
+            headers: {
+              Authorization: "Bearer owner",
+              "Content-Type": "application/json",
+            },
           },
-        },
-        accountsPath,
-        // Ignore the error when there are no users. No action needed.
-        { ignoreErrors: ["MISSING_USER_ACCOUNT"] }
-      );
-    } else {
-      logger.logLabeled(
-        "WARN",
-        "auth",
-        `Skipped importing accounts because ${accountsPath} does not exist.`
-      );
+          accountsPath,
+          // Ignore the error when there are no users. No action needed.
+          { ignoreErrors: ["MISSING_USER_ACCOUNT"] }
+        );
+      } else {
+        logger.logLabeled(
+          "WARN",
+          "auth",
+          `Skipped importing accounts because ${accountsPath} does not exist.`
+        );
+      }
     }
   }
 }

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -557,11 +557,22 @@ function batchGet(
 ): Schemas["GoogleCloudIdentitytoolkitV1DownloadAccountResponse"] {
   assert(!state.disableAuth, "PROJECT_DISABLED");
   const maxResults = Math.min(Math.floor(ctx.params.query.maxResults) || 20, 1000);
+  const queryTenantId = ctx.params.query.tenantId;
+  let users: UserInfo[];
 
-  const users = state.queryUsers(
-    {},
-    { sortByField: "localId", order: "ASC", startToken: ctx.params.query.nextPageToken }
-  );
+  // Get the accounts from the tenant when tenantId is specified in the query.
+  if (queryTenantId && state instanceof AgentProjectState) {
+    const tenant = state.getTenantProject(queryTenantId);
+    users = tenant.queryUsers(
+      {},
+      { sortByField: "localId", order: "ASC", startToken: ctx.params.query.nextPageToken }
+    );
+  } else {
+    users = state.queryUsers(
+      {},
+      { sortByField: "localId", order: "ASC", startToken: ctx.params.query.nextPageToken }
+    );
+  }
   let newPageToken: string | undefined = undefined;
 
   // As a non-standard behavior, passing in maxResults=-1 will return all users.

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -8,6 +8,7 @@ import { IMPORT_EXPORT_EMULATORS, Emulators, ALL_EMULATORS } from "./types";
 import { EmulatorRegistry } from "./registry";
 import { FirebaseError } from "../error";
 import { EmulatorHub } from "./hub";
+import { Tenant } from "./auth/state";
 import { getDownloadDetails } from "./downloadableEmulators";
 import { DatabaseEmulator } from "./databaseEmulator";
 import * as rimraf from "rimraf";
@@ -228,10 +229,36 @@ export class HubExport {
       fs.mkdirSync(authExportPath);
     }
 
+    const tenantsRes = await EmulatorRegistry.client(Emulators.AUTH).get<{
+      tenants: Array<Tenant>;
+    }>(`/identitytoolkit.googleapis.com/v2/projects/${this.projectId}/tenants`, {
+      headers: { Authorization: "Bearer owner" },
+    });
+    const tenants = tenantsRes.body.tenants.map((instance: Tenant) => instance.tenantId);
+
+    // Export accounts from other tenants.
+    for (const tenantId of tenants) {
+      const accountsFile = path.join(authExportPath, `accounts-${tenantId}.json`);
+      logger.debug(
+        `Exporting auth users in Project ${this.projectId} ${tenantId} tenant to ${accountsFile}`
+      );
+      await fetchToFile(
+        {
+          host,
+          port,
+          path: `/identitytoolkit.googleapis.com/v1/projects/${this.projectId}/accounts:batchGet?maxResults=-1&tenantId=${tenantId}`,
+          headers: { Authorization: "Bearer owner" },
+        },
+        accountsFile
+      );
+    }
+
     // TODO: Shall we support exporting other projects too?
 
     const accountsFile = path.join(authExportPath, "accounts.json");
-    logger.debug(`Exporting auth users in Project ${this.projectId} to ${accountsFile}`);
+    logger.debug(
+      `Exporting auth users in Project ${this.projectId} default tenant to ${accountsFile}`
+    );
     await fetchToFile(
       {
         host,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fix multi-tenant auth emulator import/export.

#### ----- emulator export -----

Proposed fix is to export accounts into different `json` files. For example, a project that has the tenants **tenant-1** and **tenant-2** would generate:

1. account.json <- Contains accounts from **default tenant**
1. account-tenant-1.json <- Contains accounts from **tenant-1 tenant**
1. account-tenant-2.json <- Contains accounts from **tenant-2 tenant**

Process for emulator export

1. Get a list of tenants on the emulator using [projects.tenants.list](https://cloud.google.com/identity-platform/docs/reference/rest/v2/projects.tenants/list)

```js
const tenantsRes = await EmulatorRegistry.client(Emulators.AUTH).get<{
    tenants: Array<Tenant>;
}>(`/identitytoolkit.googleapis.com/v2/projects/${this.projectId}/tenants`, {
    headers: { Authorization: "Bearer owner" },
});
const tenants = tenantsRes.body.tenants.map((instance: Tenant) => instance.tenantId);
```

2. Loop through each tenant and create a file called `account-${tenantId}.json`

```js
for (const tenantId of tenants) {
  const accountsFile = path.join(authExportPath, `accounts-${tenantId}.json`);
  logger.debug(
    `Exporting auth users in Project ${this.projectId} ${tenantId} tenant to ${accountsFile}`
  );
  await fetchToFile(
    {
      host,
      port,
      path: `/identitytoolkit.googleapis.com/v1/projects/${this.projectId}/accounts:batchGet?maxResults=-1&tenantId=${tenantId}`,
      headers: { Authorization: "Bearer owner" },
    },
    accountsFile
  );
}
```

Outuput export would look like

```
$ tree .
└── <emulator_export_path>
    └── auth_export
        ├── account.json
        ├── accounts-second-tenant.json
        ├── accounts-third-tenant.json
        └── accounts-${tenantId}.json
```

#### ----- emulator import -----

Proposed fix is to import accounts from the different `json` files created from export.

Replace the endpoint being used from `/identitytoolkit.googleapis.com/v1/projects/${this.projectId}/accounts:batchCreate`[(projects.accounts.batchCreate)](https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects.accounts/batchCreate) to `/identitytoolkit.googleapis.com/v1/projects/${this.projectId}/tenants/${tenantId}/accounts:batchCreate`[(projects.tenants.accounts.batchCreate)](https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects.tenants.accounts/batchCreate). This will allow us to specify which tenant the account should belong to.

It looks like the the two APIs are almost the same.

1. [projects.accounts.batchCreate](https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects.accounts/batchCreate#request-body)
1. [projects.tenants.accounts.batchCreate](https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects.tenants.accounts/batchCreate#request-body)

Note: AFAICT when no tenantId is provided for the API [projects.tenants.accounts.accounts](https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects.tenants.accounts/batchCreate), it will use the default tenant.

1. Making a POST request to a blank tenantId path should add the account to the default tenant, and return a instance of [UploadAccountResponse](https://cloud.google.com/identity-platform/docs/reference/rest/v1/UploadAccountResponse)
   - URL(actual project) - `https://content-identitytoolkit.googleapis.com/v1/projects/<project_id>/tenants//accounts:batchCreate`
   - URL(emulator) - `https://content-identitytoolkit.googleapis.com/v1/projects/<project_id>/tenants//accounts:batchCreate`
   - JSON body -
   ```json
   {
     "kind": "identitytoolkit#DownloadAccountResponse",
     "users": [
       {
         "localId": "9GB64Wph3kXRkoSMZm3ZPWr01cPF",
         "createdAt": "1691019099015",
         "lastLoginAt": "1691019099016",
         "displayName": "Chicken Chicken",
         "providerUserInfo": [
           {
             "providerId": "google.com",
             "rawId": "2698285215994534916150568022884447626235",
             "displayName": "Chicken Chicken",
             "email": "chicken.chicken.931@example.com",
             "screenName": "chicken_chicken"
           }
         ],
         "validSince": "1691019147",
         "email": "chicken.chicken.931@example.com",
         "emailVerified": true,
         "disabled": false
       }
     ]
   }
   ```

Process for emulator import

1. Get a list of account `json` files in `<emulator_export_path>/auth_export`

```js
const accountFiles = fs
  .readdirSync(authExportDir)
  .filter((fileName) => fileName.includes("accounts"));
```

2. Loop though each account file name and pass it through `importFromFile`

```js
for (const accountFile of accountFiles) {
  const accountsPath = path.join(authExportDir, accountFile);
  const accountsStat = await stat(accountsPath);
  const tenantId = accountFile.replace(/accounts(-|)|.json/gm, "");
  if (accountsStat?.isFile()) {
    logger.logLabeled(
      "BULLET",
      "auth",
      `Importing accounts from ${accountsPath}`
    );

    await importFromFile(
      {
        method: "POST",
        host: utils.connectableHostname(host),
        port,
        path: `/identitytoolkit.googleapis.com/v1/projects/${projectId}/tenants/${tenantId}/accounts:batchCreate`,
        headers: {
          Authorization: "Bearer owner",
          "Content-Type": "application/json",
        },
      },
      accountsPath,
      // Ignore the error when there are no users. No action needed.
      { ignoreErrors: ["MISSING_USER_ACCOUNT"] }
    );
  } else {
    logger.logLabeled(
      "WARN",
      "auth",
      `Skipped importing accounts because ${accountsPath} does not exist.`
    );
  }
}
```

#### ----- auth emulator batchGet endpoint -----

Noticed that the batchGet endpoint was not working as intended when passing the path parameter `tenantId`. A GET request to `127.0.0.1:9099/identitytoolkit.googleapis.com/v1/projects/${projectId}/accounts:batchGet?tenantId=${tenantId}` will always return an object containing users from the default tenant.

Reference API: https://cloud.google.com/identity-platform/docs/reference/rest/v1/projects.accounts/batchGet

#### ----- auth emulator only shows default tenants users in the UI -----

As mentioned [here](https://github.com/firebase/firebase-tools/issues/5623#issuecomment-1577324485), "other tenants than the default using the Google Auth Provider are not being listed in the popup sign-in screen". Cause of this may be because the the link created is `localhost:9099/emulator/auth/handler?<query_string>&tid=<tenant_id>`, but the emulator is looking for `req.query.tenantId`. So the URL should be `localhost:9099/emulator/auth/handler?<query_string>&tenantId=<tenant_id>`. `tenantId` vs `tid`

Proposed solution is to get either `req.query.tenantId` or `req.query.tid`.

```js
const tenantId = (req.query.tenantId || req.query.tid) as string | undefined;
```

### Scenarios Tested

Using the sample web app in https://github.com/aalej/issues-5623.

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

`firebase emulators:start --export-on-exit=./users --import=./users --project demo-project`
<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
