### PR TITLE
Hide confusing debug logs during functions deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed Astro web framework bug when loading configuration for version `2.9.7` and above. (#6213)
 - Increase Next.js config bundle timeout to 60 seconds (#6214)
+- Hides "shutdown requested via /\_\_/quitquitquit" log during functions deploy when `--debug` flag is not passed. (#6212)

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -208,7 +208,7 @@ export class Delegate {
           stdio: [/* stdin=*/ "ignore", /* stdout=*/ "pipe", /* stderr=*/ "pipe"],
         });
         childProcess.stdout?.on("data", (chunk: Buffer) => {
-          logger.info(chunk.toString("utf8"));
+          logger.debug(chunk.toString("utf8"));
         });
         childProcess.stderr?.on("data", (chunk: Buffer) => {
           logger.error(chunk.toString("utf8"));

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -151,7 +151,7 @@ export class Delegate implements runtimes.RuntimeDelegate {
     );
     const childProcess = runWithVirtualEnv(args, this.sourceDir, envWithAdminPort);
     childProcess.stdout?.on("data", (chunk: Buffer) => {
-      logger.info(chunk.toString("utf8"));
+      logger.debug(chunk.toString("utf8"));
     });
     childProcess.stderr?.on("data", (chunk: Buffer) => {
       logger.error(chunk.toString("utf8"));


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #6212 

The childProcess.stdout is being output in `logger.info` for Node runtime and Python runtime:
Node: https://github.com/firebase/firebase-tools/blob/05ed2aa58ee35c2979e875db71a035b68250f1c5/src/deploy/functions/runtimes/node/index.ts#L210-L212
Python: https://github.com/firebase/firebase-tools/blob/05ed2aa58ee35c2979e875db71a035b68250f1c5/src/deploy/functions/runtimes/python/index.ts#L153-L155

https://github.com/firebase/firebase-tools/blob/master/CONTRIBUTING.md#logging-and-terminal-formatting
- `logger.info` is displayed to the end user.
- `logger.debug` is only visible only in firebase-debug.log or when running with --debug.


### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1. Run `firebase init functions --project <project_id>`
2. Select Typescript
3. Uncomment the `helloWorld` functions in `src/index.ts` file
4. Run `firebase deploy --only functions`
```
✔  functions: Finished running predeploy script.
i  functions: preparing codebase default for deployment
i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
i  functions: ensuring required API cloudbuild.googleapis.com is enabled...
i  artifactregistry: ensuring required API artifactregistry.googleapis.com is enabled...
✔  artifactregistry: required API artifactregistry.googleapis.com is enabled
✔  functions: required API cloudfunctions.googleapis.com is enabled
✔  functions: required API cloudbuild.googleapis.com is enabled
i  functions: Loading and analyzing source code for codebase default to determine what to deploy
i  functions: preparing functions directory for uploading...
i  functions: packaged <PATH> (161.77 KB) for uploading
i  functions: ensuring required API run.googleapis.com is enabled...
i  functions: ensuring required API eventarc.googleapis.com is enabled...
i  functions: ensuring required API pubsub.googleapis.com is enabled...
i  functions: ensuring required API storage.googleapis.com is enabled...
✔  functions: required API eventarc.googleapis.com is enabled
✔  functions: required API pubsub.googleapis.com is enabled
✔  functions: required API storage.googleapis.com is enabled
✔  functions: required API run.googleapis.com is enabled
i  functions: generating the service identity for pubsub.googleapis.com...
i  functions: generating the service identity for eventarc.googleapis.com...
✔  functions: functions folder uploaded successfully
i  functions: creating Node.js 18 (2nd Gen) function helloWorld(us-central1)...
✔  functions[helloWorld(us-central1)] Successful create operation.
Function URL (helloWorld(us-central1)): <URL>
i  functions: cleaning up build files...

✔  Deploy complete!
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase deploy --only functions`