### PR TITLE
Use a more reasonable test dependency for extensions emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 - Increased functions emulator HTTPS body size limit to 32mb to match production. (#6201)
 - Fixed Astro web framework bug when loading configuration for version `2.9.7` and above. (#6213)
-- Increase Next.js config bundle timeout to 60 seconds. (#6214)
-- Hides "shutdown requested via /\_\_/quitquitquit" log during functions deploy when `--debug` flag is not passed. (#6212)
+- Increased Next.js config bundle timeout to 60 seconds. (#6214)
+- Hid "shutdown requested via /\_\_/quitquitquit" log during functions deploy when `--debug` flag is not passed. (#6212)

--- a/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package.json
+++ b/src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package.json
@@ -3,6 +3,6 @@
     "vresion": "0.1.18",
     "description": "Package file for testing only",
     "dependencies": {
-        "firebase-tools": "file:../../../../../../.."
+        "firebase-functions": "4.4.1"
     }
 }


### PR DESCRIPTION

### Description
Switching dependency for extensions emulator tes
This test just needs any dependency to verify that we successfully `npm i` when emulating extensions. Previously, this relative dependency was messing with results from internal vulnerability scans - regardless, `firebase-functions` is a much more common dependency to test with.

