### PR TITLE
Revert "Hide confusing debug logs during functions deploy"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
 - Increased functions emulator HTTPS body size limit to 32mb to match production. (#6201)
 - Fixed Astro web framework bug when loading configuration for version `2.9.7` and above. (#6213)
 - Increase Next.js config bundle timeout to 60 seconds. (#6214)
-- Hides "shutdown requested via /\_\_/quitquitquit" log during functions deploy when `--debug` flag is not passed. (#6212)

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -208,7 +208,7 @@ export class Delegate {
           stdio: [/* stdin=*/ "ignore", /* stdout=*/ "pipe", /* stderr=*/ "pipe"],
         });
         childProcess.stdout?.on("data", (chunk: Buffer) => {
-          logger.debug(chunk.toString("utf8"));
+          logger.info(chunk.toString("utf8"));
         });
         childProcess.stderr?.on("data", (chunk: Buffer) => {
           logger.error(chunk.toString("utf8"));

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -151,7 +151,7 @@ export class Delegate implements runtimes.RuntimeDelegate {
     );
     const childProcess = runWithVirtualEnv(args, this.sourceDir, envWithAdminPort);
     childProcess.stdout?.on("data", (chunk: Buffer) => {
-      logger.debug(chunk.toString("utf8"));
+      logger.info(chunk.toString("utf8"));
     });
     childProcess.stderr?.on("data", (chunk: Buffer) => {
       logger.error(chunk.toString("utf8"));


### PR DESCRIPTION
Reverts firebase/firebase-tools#6220 - will make changes in firebase-functions instead to clean up these logs. We want to keep these logs at info level to make it easier to debug real issues.