### PR TITLE
Fix bundle next.config.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Improve performance and reliability when deploying multiple 2nd gen functions using single builds. (#6275)
+- Fix bundle next.config.js (#6287)

--- a/src/frameworks/next/constants.ts
+++ b/src/frameworks/next/constants.ts
@@ -18,3 +18,5 @@ export const PAGES_MANIFEST: typeof PAGES_MANIFEST_TYPE = "pages-manifest.json";
 export const PRERENDER_MANIFEST: typeof PRERENDER_MANIFEST_TYPE = "prerender-manifest.json";
 export const ROUTES_MANIFEST: typeof ROUTES_MANIFEST_TYPE = "routes-manifest.json";
 export const APP_PATHS_MANIFEST: typeof APP_PATHS_MANIFEST_TYPE = "app-paths-manifest.json";
+
+export const ESBUILD_VERSION = "^0.19.2";

--- a/src/frameworks/next/constants.ts
+++ b/src/frameworks/next/constants.ts
@@ -19,4 +19,4 @@ export const PRERENDER_MANIFEST: typeof PRERENDER_MANIFEST_TYPE = "prerender-man
 export const ROUTES_MANIFEST: typeof ROUTES_MANIFEST_TYPE = "routes-manifest.json";
 export const APP_PATHS_MANIFEST: typeof APP_PATHS_MANIFEST_TYPE = "app-paths-manifest.json";
 
-export const ESBUILD_VERSION = "^0.19.2";
+export const ESBUILD_VERSION = "0.19.2";

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -64,6 +64,7 @@ import {
   ROUTES_MANIFEST,
   APP_PATH_ROUTES_MANIFEST,
   APP_PATHS_MANIFEST,
+  ESBUILD_VERSION,
 } from "./constants";
 import { getAllSiteDomains } from "../../hosting/api";
 import { logger } from "../../logger";
@@ -517,10 +518,14 @@ export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: st
           `--outdir=${destDir}`,
           "--log-level=error"
         );
-      const bundle = spawnSync("npx", ["--yes", "esbuild", "next.config.js", ...esbuildArgs], {
-        cwd: sourceDir,
-        timeout: BUNDLE_NEXT_CONFIG_TIMEOUT,
-      });
+      const bundle = spawnSync(
+        "npx",
+        ["--yes", `esbuild@${ESBUILD_VERSION}`, "next.config.js", ...esbuildArgs],
+        {
+          cwd: sourceDir,
+          timeout: BUNDLE_NEXT_CONFIG_TIMEOUT,
+        }
+      );
       if (bundle.status !== 0) {
         throw new FirebaseError(bundle.stderr.toString());
       }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

`npx esbuild` was always trying to get the local `esbuild` dependency with my local npm version(`8.19.2`), so the CLI was failing to bundle `next.config.js`. Adding the `esbuild` version to the `npx` command forces `esbuild` to be retrieved from the registry.

`esbuild`'s latest version `0.19.2` was used instead of `latest` to avoid issues with possible broken releases.

Possibly helps fixing #6193 depending on the npm version used.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
