### PR TITLE
Revert "Fix issue with mixed v1 and v2 functions deployments"

### DIFF
--- a/src/test/deploy/functions/release/fabricator.spec.ts
+++ b/src/test/deploy/functions/release/fabricator.spec.ts
@@ -1216,11 +1216,7 @@ describe("Fabricator", () => {
       const createV1Function = sinon.stub(fab, "createV1Function");
       createV1Function.resolves();
 
-      await fab.createEndpoint(
-        ep,
-        new scraper.SourceTokenScraper(),
-        new scraper.SourceTokenScraper()
-      );
+      await fab.createEndpoint(ep, new scraper.SourceTokenScraper());
       expect(createV1Function).is.calledOnce;
       expect(setTrigger).is.calledOnce;
       expect(setTrigger).is.calledAfter(createV1Function);
@@ -1233,11 +1229,7 @@ describe("Fabricator", () => {
       const createV2Function = sinon.stub(fab, "createV2Function");
       createV2Function.resolves();
 
-      await fab.createEndpoint(
-        ep,
-        new scraper.SourceTokenScraper(),
-        new scraper.SourceTokenScraper()
-      );
+      await fab.createEndpoint(ep, new scraper.SourceTokenScraper());
       expect(createV2Function).is.calledOnce;
       expect(setTrigger).is.calledOnce;
       expect(setTrigger).is.calledAfter(createV2Function);
@@ -1249,9 +1241,10 @@ describe("Fabricator", () => {
       const createV1Function = sinon.stub(fab, "createV1Function");
       createV1Function.rejects(new reporter.DeploymentError(ep, "set invoker", undefined));
 
-      await expect(
-        fab.createEndpoint(ep, new scraper.SourceTokenScraper(), new scraper.SourceTokenScraper())
-      ).to.be.rejectedWith(reporter.DeploymentError, "set invoker");
+      await expect(fab.createEndpoint(ep, new scraper.SourceTokenScraper())).to.be.rejectedWith(
+        reporter.DeploymentError,
+        "set invoker"
+      );
       expect(createV1Function).is.calledOnce;
       expect(setTrigger).is.not.called;
     });
@@ -1265,11 +1258,7 @@ describe("Fabricator", () => {
       const updateV1Function = sinon.stub(fab, "updateV1Function");
       updateV1Function.resolves();
 
-      await fab.updateEndpoint(
-        { endpoint: ep },
-        new scraper.SourceTokenScraper(),
-        new scraper.SourceTokenScraper()
-      );
+      await fab.updateEndpoint({ endpoint: ep }, new scraper.SourceTokenScraper());
       expect(updateV1Function).is.calledOnce;
       expect(setTrigger).is.calledOnce;
       expect(setTrigger).is.calledAfter(updateV1Function);
@@ -1282,11 +1271,7 @@ describe("Fabricator", () => {
       const updateV2Function = sinon.stub(fab, "updateV2Function");
       updateV2Function.resolves();
 
-      await fab.updateEndpoint(
-        { endpoint: ep },
-        new scraper.SourceTokenScraper(),
-        new scraper.SourceTokenScraper()
-      );
+      await fab.updateEndpoint({ endpoint: ep }, new scraper.SourceTokenScraper());
       expect(updateV2Function).is.calledOnce;
       expect(setTrigger).is.calledOnce;
       expect(setTrigger).is.calledAfter(updateV2Function);
@@ -1299,11 +1284,7 @@ describe("Fabricator", () => {
       updateV1Function.rejects(new reporter.DeploymentError(ep, "set invoker", undefined));
 
       await expect(
-        fab.updateEndpoint(
-          { endpoint: ep },
-          new scraper.SourceTokenScraper(),
-          new scraper.SourceTokenScraper()
-        )
+        fab.updateEndpoint({ endpoint: ep }, new scraper.SourceTokenScraper())
       ).to.be.rejectedWith(reporter.DeploymentError, "set invoker");
       expect(updateV1Function).is.calledOnce;
       expect(setTrigger).is.not.called;
@@ -1332,11 +1313,7 @@ describe("Fabricator", () => {
       const createV2Function = sinon.stub(fab, "createV2Function");
       createV2Function.resolves();
 
-      await fab.updateEndpoint(
-        update,
-        new scraper.SourceTokenScraper(),
-        new scraper.SourceTokenScraper()
-      );
+      await fab.updateEndpoint(update, new scraper.SourceTokenScraper());
 
       expect(deleteTrigger).to.have.been.called;
       expect(deleteV1Function).to.have.been.calledImmediatelyAfter(deleteTrigger);


### PR DESCRIPTION
Reverts firebase/firebase-tools#6293. Customers are continuing to report problems with functions at runtime deployed with the single build changes so we are reverting them until we can investigate the issue further.