### PR TITLE
Roll back standalone to npm@8.x.x, remove redundant configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where builds from https://firebase.tools could not run commands that spawn `npm`. (#6132)

--- a/standalone/firepit.js
+++ b/standalone/firepit.js
@@ -184,7 +184,6 @@ let runtimeBinsPath = path.join(homePath, ".cache", "firebase", "runtime");
 const npmArgs = [
   `--script-shell=${runtimeBinsPath}/shell${isWindows ? ".bat" : ""}`,
   `--globalconfig=${path.join(runtimeBinsPath, "npmrc")}`,
-  `--userconfig=${path.join(runtimeBinsPath, "npmrc")}`,
   `--scripts-prepend-node-path=auto`
 ];
 

--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -616,8 +616,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -697,8 +696,7 @@
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "node_modules/interpret": {
       "version": "1.4.0",
@@ -809,7 +807,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -879,8 +876,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/multistream": {
       "version": "4.1.0",
@@ -959,15 +955,17 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.0.tgz",
-      "integrity": "sha512-AXeiBAdfM5K2jvBwA7EGLKeYyt0VnhmJRnlq4k2+M0Ao9v7yKJBqF8xFPzQL8kAybzwlfpTPCZwM4uTIszb3xA==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/config",
+        "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
+        "@npmcli/promise-spawn",
         "@npmcli/run-script",
         "abbrev",
         "archy",
@@ -1034,13 +1032,15 @@
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^6.3.0",
         "@npmcli/config": "^6.2.1",
+        "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
         "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
         "cacache": "^17.1.3",
-        "chalk": "^5.2.0",
+        "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
@@ -1056,7 +1056,7 @@
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
         "libnpmdiff": "^5.0.19",
-        "libnpmexec": "^6.0.2",
+        "libnpmexec": "^6.0.3",
         "libnpmfund": "^4.0.19",
         "libnpmhook": "^9.0.3",
         "libnpmorg": "^5.0.4",
@@ -1066,7 +1066,7 @@
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
         "make-fetch-happen": "^11.1.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -1086,10 +1086,10 @@
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
-        "semver": "^7.5.2",
+        "semver": "^7.5.4",
         "sigstore": "^1.7.0",
         "ssri": "^10.0.4",
-        "supports-color": "^9.3.1",
+        "supports-color": "^9.4.0",
         "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
@@ -1346,16 +1346,17 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "4.0.0",
+      "version": "4.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/git": "^4.1.0",
         "glob": "^10.2.2",
+        "hosted-git-info": "^6.1.1",
         "json-parse-even-better-errors": "^3.0.0",
         "normalize-package-data": "^5.0.0",
-        "npm-normalize-package-bin": "^3.0.1",
-        "proc-log": "^3.0.0"
+        "proc-log": "^3.0.0",
+        "semver": "^7.5.3"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -1579,7 +1580,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -1662,7 +1663,7 @@
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "5.2.0",
+      "version": "5.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -2336,7 +2337,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2495,7 +2496,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.1",
+      "version": "9.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3339,7 +3340,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.5.2",
+      "version": "7.5.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3547,7 +3548,7 @@
       }
     },
     "node_modules/npm/node_modules/supports-color": {
-      "version": "9.3.1",
+      "version": "9.4.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4274,7 +4275,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -4635,8 +4635,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -5120,8 +5119,7 @@
     "graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "has": {
       "version": "1.0.3",
@@ -5175,8 +5173,7 @@
     "ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "interpret": {
       "version": "1.4.0",
@@ -5255,7 +5252,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -5304,8 +5300,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "multistream": {
       "version": "4.1.0",
@@ -5355,20 +5350,22 @@
       }
     },
     "npm": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.0.tgz",
-      "integrity": "sha512-AXeiBAdfM5K2jvBwA7EGLKeYyt0VnhmJRnlq4k2+M0Ao9v7yKJBqF8xFPzQL8kAybzwlfpTPCZwM4uTIszb3xA==",
+      "version": "9.8.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
+      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/arborist": "^6.3.0",
         "@npmcli/config": "^6.2.1",
+        "@npmcli/fs": "^3.1.0",
         "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^4.0.0",
+        "@npmcli/package-json": "^4.0.1",
+        "@npmcli/promise-spawn": "^6.0.2",
         "@npmcli/run-script": "^6.0.2",
         "abbrev": "^2.0.0",
         "archy": "~1.0.0",
         "cacache": "^17.1.3",
-        "chalk": "^5.2.0",
+        "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
         "cli-columns": "^4.0.0",
         "cli-table3": "^0.6.3",
@@ -5384,7 +5381,7 @@
         "json-parse-even-better-errors": "^3.0.0",
         "libnpmaccess": "^7.0.2",
         "libnpmdiff": "^5.0.19",
-        "libnpmexec": "^6.0.2",
+        "libnpmexec": "^6.0.3",
         "libnpmfund": "^4.0.19",
         "libnpmhook": "^9.0.3",
         "libnpmorg": "^5.0.4",
@@ -5394,7 +5391,7 @@
         "libnpmteam": "^5.0.3",
         "libnpmversion": "^4.0.2",
         "make-fetch-happen": "^11.1.1",
-        "minimatch": "^9.0.0",
+        "minimatch": "^9.0.3",
         "minipass": "^5.0.0",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -5414,10 +5411,10 @@
         "proc-log": "^3.0.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^2.1.0",
-        "semver": "^7.5.2",
+        "semver": "^7.5.4",
         "sigstore": "^1.7.0",
         "ssri": "^10.0.4",
-        "supports-color": "^9.3.1",
+        "supports-color": "^9.4.0",
         "tar": "^6.1.15",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
@@ -5592,15 +5589,16 @@
           "bundled": true
         },
         "@npmcli/package-json": {
-          "version": "4.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
             "@npmcli/git": "^4.1.0",
             "glob": "^10.2.2",
+            "hosted-git-info": "^6.1.1",
             "json-parse-even-better-errors": "^3.0.0",
             "normalize-package-data": "^5.0.0",
-            "npm-normalize-package-bin": "^3.0.1",
-            "proc-log": "^3.0.0"
+            "proc-log": "^3.0.0",
+            "semver": "^7.5.3"
           }
         },
         "@npmcli/promise-spawn": {
@@ -5732,7 +5730,7 @@
           "bundled": true
         },
         "bin-links": {
-          "version": "4.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "cmd-shim": "^6.0.0",
@@ -5786,7 +5784,7 @@
           }
         },
         "chalk": {
-          "version": "5.2.0",
+          "version": "5.3.0",
           "bundled": true
         },
         "chownr": {
@@ -6201,7 +6199,7 @@
           }
         },
         "libnpmexec": {
-          "version": "6.0.2",
+          "version": "6.0.3",
           "bundled": true,
           "requires": {
             "@npmcli/arborist": "^6.3.0",
@@ -6316,7 +6314,7 @@
           }
         },
         "minimatch": {
-          "version": "9.0.1",
+          "version": "9.0.3",
           "bundled": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -6865,7 +6863,7 @@
           "optional": true
         },
         "semver": {
-          "version": "7.5.2",
+          "version": "7.5.4",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -7000,7 +6998,7 @@
           }
         },
         "supports-color": {
-          "version": "9.3.1",
+          "version": "9.4.0",
           "bundled": true
         },
         "tar": {
@@ -7499,7 +7497,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -7758,8 +7755,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "dependencies": {
     "chalk": "^2.4.2",
-    "npm": "^9.8.0",
+    "npm": "^8.19.0",
     "shelljs": "^0.8.3",
     "shx": "^0.3.2",
     "user-home": "^2.0.0"


### PR DESCRIPTION
### Description
It seems like upgrading npm to 9.x.x broke our Firepit scripts in a few subtle ways: namely: 
- pkg (the tool we use to make a standalone binary) does not properly support ESM (https://github.com/vercel/pkg/issues/1291), which means that some dependencies don't get bundled in as expected.
- Sometime between 6.x.x and 9.x.x, npm made it an error to try to load the same config file 2x (https://github.com/npm/cli/blob/f916d333c16b4f0433d8a304e856b73ed4f949cd/workspaces/config/lib/index.js#L565). Firepit was trying to default userconfig and globalconfig to the same file, which was always redundant and is now broken.

In the future, I'd like to try to roll forward npm to 9.x.x again - however, I think it may end up a larger project that expected. Based on https://github.com/vercel/pkg/issues/1291, we'll likely either need to do some bundling of deps to beforehand or find a different solution than pkg. 

Hopefuly fixes #6132.

### Scenarios Tested
Ran `node ./pipeline.js --package="/Users/joehanley/Workspace/firebase-tools"` to locally generate Firepit artifacts, and verified that: 
- they built without warnings about not being able to generate bytecode for our deps.
- `/private/var/folders/cs/2ft4wd910wncc4mg3zh8t4g800l9wf/T/firepit_artifacts/firebase-tools-instant-macos is:npm` did not error out with a `double-loading config` error.
