### PR TITLE
Allow flask entry file as an init  config option

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -38,6 +38,15 @@
                     "description": "Determines whether Firebase AppCheck is enforced. Defaults to false.",
                     "type": "boolean"
                 },
+                "flask": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "entryFile": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
                 "ingressSettings": {
                     "description": "Ingress settings which control where this function can be called from.",
                     "enum": [
@@ -120,6 +129,9 @@
                     "type": "string"
                 }
             },
+            "required": [
+                "flask"
+            ],
             "type": "object"
         },
         "Record<string,string>": {

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -110,6 +110,10 @@ interface FrameworksBackendOptions extends HttpsOptions {
   region?: string;
   // Invoker can only be public
   invoker?: "public";
+  // To allow dynamic entry file for Flask apps
+  flask: {
+    entryFile?: string;
+  };
 }
 
 export type HostingBase = {

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -10,6 +10,8 @@ import {
   FrameworkType,
   SupportLevel,
   BUILD_TARGET_PURPOSE,
+  CodegenFunctionsDirectoryOptions,
+  CodegenPublicDirectoryOptions,
 } from "../interfaces";
 import { promptOnce } from "../../prompt";
 import {
@@ -123,9 +125,13 @@ export async function getDevModeHandle(dir: string, configuration: string) {
 
 export async function ɵcodegenPublicDirectory(
   sourceDir: string,
-  destDir: string,
-  configuration: string
+  options?: CodegenPublicDirectoryOptions
 ) {
+  const { dest: destDir, target: configuration } = options || {};
+  if (!destDir || !configuration) {
+    throw new FirebaseError("Missing required options for Angular ɵcodegenPublicDirectory");
+  }
+
   const { outputPath, baseHref, defaultLocale, locales } = await getBrowserConfig(
     sourceDir,
     configuration
@@ -168,9 +174,13 @@ export async function shouldUseDevModeHandle(targetOrConfiguration: string, dir:
 
 export async function ɵcodegenFunctionsDirectory(
   sourceDir: string,
-  destDir: string,
-  configuration: string
+  options?: CodegenFunctionsDirectoryOptions
 ) {
+  const { dest: destDir, configuration } = options || {};
+  if (!destDir || !configuration) {
+    throw new FirebaseError("Missing required options for Angular ɵcodegenFunctionsDirectory");
+  }
+
   const {
     packageJson,
     serverOutputPath,

--- a/src/frameworks/astro/index.ts
+++ b/src/frameworks/astro/index.ts
@@ -1,15 +1,16 @@
 import { sync as spawnSync, spawn } from "cross-spawn";
 import { copy, existsSync } from "fs-extra";
 import { join } from "path";
-import { BuildResult, Discovery, FrameworkType, SupportLevel } from "../interfaces";
-import { FirebaseError } from "../../error";
 import {
-  readJSON,
-  simpleProxy,
-  warnIfCustomBuildScript,
-  findNPMDependency,
-  getNodeModuleBin,
-} from "../utils";
+  BuildResult,
+  CodegenFunctionsDirectoryOptions,
+  CodegenPublicDirectoryOptions,
+  Discovery,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
+import { FirebaseError } from "../../error";
+import { readJSON, simpleProxy, warnIfCustomBuildScript, getNodeModuleBin } from "../utils";
 import { getAstroVersion, getBootstrapScript, getConfig } from "./utils";
 
 export const name = "Astro";
@@ -43,14 +44,25 @@ export async function build(cwd: string): Promise<BuildResult> {
   return { wantsBackend };
 }
 
-export async function ɵcodegenPublicDirectory(root: string, dest: string) {
+export async function ɵcodegenPublicDirectory(
+  root: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new FirebaseError("Missing destDir in options");
+
   const { outDir, output } = await getConfig(root);
   // output: "server" in astro.config builds "client" and "server" folders, otherwise assets are in top-level outDir
   const assetPath = join(root, outDir, output !== "static" ? "client" : "");
   await copy(assetPath, dest);
 }
 
-export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: string) {
+export async function ɵcodegenFunctionsDirectory(
+  sourceDir: string,
+  options?: CodegenFunctionsDirectoryOptions
+) {
+  const { dest: destDir } = options || {};
+  if (!destDir) throw new FirebaseError("Missing destDir in options");
   const { outDir } = await getConfig(sourceDir);
   const packageJson = await readJSON(join(sourceDir, "package.json"));
   await copy(join(sourceDir, outDir, "server"), join(destDir));

--- a/src/frameworks/django/index.ts
+++ b/src/frameworks/django/index.ts
@@ -1,7 +1,13 @@
 import { copy, mkdirp, pathExists } from "fs-extra";
 import { mkdir, readFile, readdir, writeFile } from "fs/promises";
 import { join } from "path";
-import { BuildResult, FrameworkType, SupportLevel } from "../interfaces";
+import {
+  BuildResult,
+  CodegenFunctionsDirectoryOptions,
+  CodegenPublicDirectoryOptions,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
 import { dirExistsSync } from "../../fsutils";
 import { findPythonCLI, getVenvDir, hasPipDependency, spawnPython } from "../utils";
 import { sync as spawnSync } from "cross-spawn";
@@ -35,7 +41,13 @@ export async function init(setup: any, config: any) {
   );
 }
 
-export async function ɵcodegenPublicDirectory(root: string, dest: string) {
+export async function ɵcodegenPublicDirectory(
+  root: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new Error("Missing dest in options");
+
   const output = await spawnPython(
     "python",
     [
@@ -58,7 +70,13 @@ export async function ɵcodegenPublicDirectory(root: string, dest: string) {
   }
 }
 
-export async function ɵcodegenFunctionsDirectory(root: string, dest: string) {
+export async function ɵcodegenFunctionsDirectory(
+  root: string,
+  options?: CodegenFunctionsDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new Error("Missing dest in options");
+
   await mkdir(dest, { recursive: true });
   const wsgiApplication = await spawnPython(
     "python",

--- a/src/frameworks/docs/flask.md
+++ b/src/frameworks/docs/flask.md
@@ -21,9 +21,9 @@ to Firebase and serve dynamic content to your users.
 
 <<_includes/_initialize-firebase.md>>
 
+1.  Answer yes to "Do you want to use a web framework? (experimental)"
 1. Choose your hosting source directory; this could be an existing Flask app.
-1. Choose "Dynamic web hosting with web framework."
-1. Choose Flask.
+1. If prompted, choose Flask.
 
 ### Initialize an existing project
 
@@ -37,6 +37,16 @@ than a `public` option. For example:
   }
 }
 ```
+
+#### Troubleshooting initialization
+
+If you experience any issues while initializing your application, here are some tips on using our tools with your Flask project:
+
+1. You have your app entry point in a "main.py" file in the hosting root folder.
+1. You have created and activated a virtual environment
+`python -m venv venv && . venv/bin/activate`.
+1. You have run `pip install -t requirements.txt` at least once and are able 
+to start a standalone Flask server.
 
 ## Serve fully dynamic content
 

--- a/src/frameworks/express/index.ts
+++ b/src/frameworks/express/index.ts
@@ -2,7 +2,13 @@ import { execSync } from "child_process";
 import { copy, pathExists } from "fs-extra";
 import { mkdir, readFile } from "fs/promises";
 import { join } from "path";
-import { BuildResult, FrameworkType, SupportLevel } from "../interfaces";
+import {
+  BuildResult,
+  CodegenFunctionsDirectoryOptions,
+  CodegenPublicDirectoryOptions,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
 
 // Use "true &&"" to keep typescript from compiling this file and rewriting
 // the import statement into a require
@@ -34,7 +40,13 @@ export async function build(cwd: string): Promise<BuildResult> {
   return { wantsBackend };
 }
 
-export async function ɵcodegenPublicDirectory(root: string, dest: string) {
+export async function ɵcodegenPublicDirectory(
+  root: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new Error("Missing destDir in options");
+
   const { serveDir } = await getConfig(root);
   await copy(serveDir!, dest);
 }
@@ -93,7 +105,13 @@ async function getBootstrapScript(
   return undefined;
 }
 
-export async function ɵcodegenFunctionsDirectory(root: string, dest: string) {
+export async function ɵcodegenFunctionsDirectory(
+  root: string,
+  options?: CodegenFunctionsDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new Error("Missing dest in options");
+
   const bootstrapScript = await getBootstrapScript(root);
   if (!bootstrapScript) throw new Error("Cloud not find bootstrapScript");
   await mkdir(dest, { recursive: true });

--- a/src/frameworks/flask/discover.py
+++ b/src/frameworks/flask/discover.py
@@ -3,9 +3,14 @@ import importlib.util
 import inspect
 import sys
 import os
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--entry_file', dest='entry_file', default='main.py', type=str, help='The entry file of the Flask application.')
+args = parser.parse_args()
 
 sys.path.insert(0, os.getcwd())
-spec = importlib.util.spec_from_file_location("main", "main.py")
+spec = importlib.util.spec_from_file_location("main", args.entry_file)
 if spec is not None and spec.loader is not None:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)

--- a/src/frameworks/flask/index.ts
+++ b/src/frameworks/flask/index.ts
@@ -118,8 +118,6 @@ async function getDiscoveryResults(
   cwd: string,
   flaskConfig?: NonNullable<HostingBase["frameworksBackend"]>["flask"]
 ) {
-  console.log("flaskConfig", flaskConfig);
-
   let entryFile = flaskConfig?.entryFile;
   if (!entryFile) {
     entryFile = await promptOnce({

--- a/src/frameworks/flutter/index.ts
+++ b/src/frameworks/flutter/index.ts
@@ -4,7 +4,13 @@ import { join } from "path";
 import { load as loadYaml } from "js-yaml";
 import { readFile } from "fs/promises";
 
-import { BuildResult, Discovery, FrameworkType, SupportLevel } from "../interfaces";
+import {
+  BuildResult,
+  CodegenPublicDirectoryOptions,
+  Discovery,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
 import { FirebaseError } from "../../error";
 import { assertFlutterCliExists } from "./utils";
 import { DART_RESERVED_WORDS, FALLBACK_PROJECT_NAME } from "./constants";
@@ -57,6 +63,12 @@ export function build(cwd: string): Promise<BuildResult> {
   return Promise.resolve({ wantsBackend: false });
 }
 
-export async function ɵcodegenPublicDirectory(sourceDir: string, destDir: string) {
+export async function ɵcodegenPublicDirectory(
+  sourceDir: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest: destDir } = options || {};
+  if (!destDir) throw new FirebaseError("Missing destDir in options");
+
   await copy(join(sourceDir, "build", "web"), destDir);
 }

--- a/src/frameworks/interfaces.ts
+++ b/src/frameworks/interfaces.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, ServerResponse } from "http";
 import { EmulatorInfo } from "../emulator/types";
-import { HostingHeaders, HostingRedirects, HostingRewrites } from "../firebaseConfig";
+import { HostingBase, HostingHeaders, HostingRedirects, HostingRewrites } from "../firebaseConfig";
 import { HostingOptions } from "../hosting/options";
 import { Options } from "../options";
 
@@ -23,6 +23,7 @@ export const enum SupportLevel {
 export interface Discovery {
   mayWantBackend: boolean;
   publicDirectory: string;
+  entryFile?: string;
 }
 
 export interface BuildResult {
@@ -66,8 +67,13 @@ interface PythonFramework {
   rewriteSource?: string;
 }
 
+export type DiscoverOptions = {
+  plugin?: string;
+  npmDependency?: string;
+  flaskConfig?: NonNullable<HostingBase["frameworksBackend"]>["flask"];
+};
 export interface Framework {
-  discover: (dir: string) => Promise<Discovery | undefined>;
+  discover: (dir: string, options?: DiscoverOptions) => Promise<Discovery | undefined>;
   type: FrameworkType;
   name: string;
   build: (dir: string, target: string) => Promise<BuildResult | void>;
@@ -79,23 +85,31 @@ export interface Framework {
     target: string,
     hostingEmulatorInfo?: EmulatorInfo
   ) => Promise<RequestHandler>;
-  ɵcodegenPublicDirectory: (
-    dir: string,
-    dest: string,
-    target: string,
-    context: {
-      project: string;
-      site: string;
-    }
-  ) => Promise<void>;
+  ɵcodegenPublicDirectory: (dir: string, options?: CodegenPublicDirectoryOptions) => Promise<void>;
   ɵcodegenFunctionsDirectory?: (
     dir: string,
-    dest: string,
-    target: string
+    options?: CodegenFunctionsDirectoryOptions
   ) => Promise<NodeJSFramework | PythonFramework>;
   getValidBuildTargets?: (purpose: BUILD_TARGET_PURPOSE, dir: string) => Promise<string[]>;
   shouldUseDevModeHandle?: (target: string, dir: string) => Promise<boolean>;
 }
+
+export type CodegenFunctionsDirectoryOptions = {
+  dest?: string;
+  target?: string;
+  configuration?: string;
+  frameworksBackend?: HostingBase["frameworksBackend"];
+};
+
+export type CodegenPublicDirectoryOptions = {
+  dest?: string;
+  target?: string;
+  context?: {
+    project: string;
+    site: string;
+  };
+  frameworksBackend?: HostingBase["frameworksBackend"];
+};
 
 export type BUILD_TARGET_PURPOSE = "deploy" | "test" | "emulate";
 

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -30,7 +30,13 @@ import {
   validateLocales,
   getNodeModuleBin,
 } from "../utils";
-import { BuildResult, FrameworkType, SupportLevel } from "../interfaces";
+import {
+  BuildResult,
+  CodegenFunctionsDirectoryOptions,
+  CodegenPublicDirectoryOptions,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
 
 import {
   cleanEscapedChars,
@@ -320,10 +326,11 @@ export async function init(setup: any, config: any) {
  */
 export async function ɵcodegenPublicDirectory(
   sourceDir: string,
-  destDir: string,
-  _: string,
-  context: { site: string; project: string }
+  options?: CodegenPublicDirectoryOptions
 ) {
+  const { dest: destDir, context } = options || {};
+  if (!destDir || !context) throw new Error("Missing destDir or context in options");
+
   const { distDir, i18n, basePath } = await getConfig(sourceDir);
 
   let matchingI18nDomain: DomainLocale | undefined = undefined;
@@ -476,7 +483,13 @@ export async function ɵcodegenPublicDirectory(
 /**
  * Create a directory for SSR content.
  */
-export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: string) {
+export async function ɵcodegenFunctionsDirectory(
+  sourceDir: string,
+  options?: CodegenFunctionsDirectoryOptions
+) {
+  const { dest: destDir } = options || {};
+  if (!destDir) throw new Error("Missing dest in options");
+
   const { distDir } = await getConfig(sourceDir);
   const packageJson = await readJSON(join(sourceDir, "package.json"));
   // Bundle their next.config.js with esbuild via NPX, pinned version was having troubles on m1

--- a/src/frameworks/nuxt/index.ts
+++ b/src/frameworks/nuxt/index.ts
@@ -3,7 +3,7 @@ import { readFile } from "fs/promises";
 import { join, posix } from "path";
 import { lt } from "semver";
 import { spawn, sync as spawnSync } from "cross-spawn";
-import { FrameworkType, SupportLevel } from "../interfaces";
+import { CodegenPublicDirectoryOptions, FrameworkType, SupportLevel } from "../interfaces";
 import { simpleProxy, warnIfCustomBuildScript, getNodeModuleBin, relativeRequire } from "../utils";
 import { getNuxtVersion } from "./utils";
 
@@ -64,7 +64,13 @@ export async function build(cwd: string) {
   return { wantsBackend, rewrites, baseUrl };
 }
 
-export async function ɵcodegenPublicDirectory(root: string, dest: string) {
+export async function ɵcodegenPublicDirectory(
+  root: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new FirebaseError("Missing destDir in options");
+
   const {
     app: { baseURL },
   } = await getConfig(root);

--- a/src/frameworks/nuxt2/index.ts
+++ b/src/frameworks/nuxt2/index.ts
@@ -3,7 +3,12 @@ import { readFile } from "fs/promises";
 import { basename, join, relative } from "path";
 import { gte } from "semver";
 
-import { SupportLevel, FrameworkType } from "../interfaces";
+import {
+  SupportLevel,
+  FrameworkType,
+  CodegenFunctionsDirectoryOptions,
+  CodegenPublicDirectoryOptions,
+} from "../interfaces";
 import { getNodeModuleBin, relativeRequire } from "../utils";
 import { getNuxtVersion } from "../nuxt/utils";
 import { simpleProxy } from "../utils";
@@ -67,22 +72,34 @@ export async function build(rootDir: string) {
  * @param rootDir
  * @param dest
  */
-export async function ɵcodegenPublicDirectory(rootDir: string, dest: string) {
+export async function ɵcodegenPublicDirectory(
+  rootDir: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new Error("Missing dest in options");
+
   const {
-    app: { options },
+    app: { options: nuxtOptions },
   } = await getAndLoadNuxt({ rootDir, for: "build" });
-  await copy(options.generate.dir, dest);
+  await copy(nuxtOptions.generate.dir, dest);
 }
 
-export async function ɵcodegenFunctionsDirectory(rootDir: string, destDir: string) {
+export async function ɵcodegenFunctionsDirectory(
+  rootDir: string,
+  options?: CodegenFunctionsDirectoryOptions
+) {
+  const { dest: destDir } = options || {};
+  if (!destDir) throw new Error("Missing destDir in options");
+
   const packageJsonBuffer = await readFile(join(rootDir, "package.json"));
   const packageJson = JSON.parse(packageJsonBuffer.toString());
 
   // Get the nuxt config into an object so we can check the `target` and `ssr` properties.
   const {
-    app: { options },
+    app: { options: nuxtOptions },
   } = await getAndLoadNuxt({ rootDir, for: "build" });
-  const { buildDir, _nuxtConfigFile: configFilePath } = options;
+  const { buildDir, _nuxtConfigFile: configFilePath } = nuxtOptions;
 
   // When starting the Nuxt 2 server, we need to copy the `.nuxt` to the destination directory (`functions`)
   // with the same folder name (.firebase/<project-name>/functions/.nuxt).

--- a/src/frameworks/sveltekit/index.ts
+++ b/src/frameworks/sveltekit/index.ts
@@ -1,6 +1,11 @@
 import { copy, pathExists, readFile } from "fs-extra";
 import { join } from "path";
-import { FrameworkType, SupportLevel } from "../interfaces";
+import {
+  CodegenFunctionsDirectoryOptions,
+  CodegenPublicDirectoryOptions,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
 import { viteDiscoverWithNpmDependency, build as viteBuild } from "../vite";
 import { SvelteKitConfig } from "./interfaces";
 import { fileExistsSync } from "../../fsutils";
@@ -20,7 +25,13 @@ export async function build(root: string) {
   return { wantsBackend };
 }
 
-export async function ɵcodegenPublicDirectory(root: string, dest: string) {
+export async function ɵcodegenPublicDirectory(
+  root: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new Error("Missing dest in options");
+
   const config = await getConfig(root);
   const output = join(root, config.kit.outDir, "output");
   await copy(join(output, "client"), dest);
@@ -31,7 +42,13 @@ export async function ɵcodegenPublicDirectory(root: string, dest: string) {
   }
 }
 
-export async function ɵcodegenFunctionsDirectory(sourceDir: string, destDir: string) {
+export async function ɵcodegenFunctionsDirectory(
+  sourceDir: string,
+  options?: CodegenFunctionsDirectoryOptions
+) {
+  const { dest: destDir } = options || {};
+  if (!destDir) throw new Error("Missing destDir in options");
+
   const packageJsonBuffer = await readFile(join(sourceDir, "package.json"));
   const packageJson = JSON.parse(packageJsonBuffer.toString());
   packageJson.dependencies ||= {};

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -3,7 +3,12 @@ import { spawn } from "cross-spawn";
 import { existsSync } from "fs";
 import { copy, pathExists } from "fs-extra";
 import { join } from "path";
-import { FrameworkType, SupportLevel } from "../interfaces";
+import {
+  CodegenPublicDirectoryOptions,
+  DiscoverOptions,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
 import { promptOnce } from "../../prompt";
 import {
   simpleProxy,
@@ -40,12 +45,15 @@ export async function init(setup: any, config: any, baseTemplate: string = "vani
 }
 
 export const viteDiscoverWithNpmDependency = (dep: string) => async (dir: string) =>
-  await discover(dir, undefined, dep);
+  await discover(dir, { npmDependency: dep });
 
 export const vitePluginDiscover = (plugin: string) => async (dir: string) =>
-  await discover(dir, plugin);
+  await discover(dir, { plugin });
 
-export async function discover(dir: string, plugin?: string, npmDependency?: string) {
+export async function discover(dir: string, options?: DiscoverOptions) {
+  const { plugin, npmDependency } = options || {};
+  if (!plugin && !npmDependency) throw new Error("Missing plugin or npmDependency");
+
   if (!existsSync(join(dir, "package.json"))) return;
   // If we're not searching for a vite plugin, depth has to be zero
   const additionalDep =
@@ -78,7 +86,13 @@ export async function build(root: string) {
   return { rewrites: [{ source: "**", destination: "/index.html" }] };
 }
 
-export async function ɵcodegenPublicDirectory(root: string, dest: string) {
+export async function ɵcodegenPublicDirectory(
+  root: string,
+  options?: CodegenPublicDirectoryOptions
+) {
+  const { dest } = options || {};
+  if (!dest) throw new Error("Missing destDir in options");
+
   const viteConfig = await getConfig(root);
   const viteDistPath = join(root, viteConfig.build.outDir);
   await copy(viteDistPath, dest);

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -52,7 +52,6 @@ export const vitePluginDiscover = (plugin: string) => async (dir: string) =>
 
 export async function discover(dir: string, options?: DiscoverOptions) {
   const { plugin, npmDependency } = options || {};
-  if (!plugin && !npmDependency) throw new Error("Missing plugin or npmDependency");
 
   if (!existsSync(join(dir, "package.json"))) return;
   // If we're not searching for a vite plugin, depth has to be zero

--- a/src/init/features/hosting/index.ts
+++ b/src/init/features/hosting/index.ts
@@ -125,24 +125,6 @@ export async function doSetup(setup: any, config: any): Promise<void> {
       if (discoveredFramework) {
         rimraf(setup.hosting.source);
       }
-      //  else if (setup.hosting.whichFramework === WebFrameworks.flask.name) {
-      //   await promptOnce(
-      //     {
-      //       name: "entryFile",
-      //       type: "input",
-      //       message:
-      //         "What file in the project root do you want to use as the entry point to your Flask application?",
-      //       default: "main.py",
-      //     },
-      //     setup.hosting
-      //   );
-
-      //   discoveredFramework = await discover(
-      //     join(config.projectDir, setup.hosting.source),
-      //     config.frameworksBackend
-      //   );
-      //   setup.hosting.webFramework = discoveredFramework.framework;
-      // }
 
       await WebFrameworks[setup.hosting.whichFramework].init!(setup, config);
     }
@@ -167,9 +149,12 @@ export async function doSetup(setup: any, config: any): Promise<void> {
       },
     };
 
-    if (discoveredFramework?.framework.toLowerCase() === WebFrameworks.flask.name.toLowerCase()) {
+    if (
+      discoveredFramework?.framework.toLowerCase() === WebFrameworks.flask.name.toLowerCase() ||
+      setup.hosting.whichFramework.toLowerCase() === WebFrameworks.flask.name.toLowerCase()
+    ) {
       setup.config.hosting.frameworksBackend.flask = {
-        entryFile: discoveredFramework.entryFile || "main.py",
+        entryFile: discoveredFramework?.entryFile || "main.py",
       };
     }
   } else {

--- a/src/test/frameworks/astro/index.spec.ts
+++ b/src/test/frameworks/astro/index.spec.ts
@@ -117,7 +117,7 @@ describe("Astro", () => {
 
       const copy = sandbox.stub(fsExtra, "copy");
 
-      await ɵcodegenPublicDirectory(root, dist);
+      await ɵcodegenPublicDirectory(root, { dest: dist });
       expect(copy.getCalls().map((it) => it.args)).to.deep.equal([[join(root, outDir), dist]]);
     });
 
@@ -142,7 +142,7 @@ describe("Astro", () => {
 
       const copy = sandbox.stub(fsExtra, "copy");
 
-      await ɵcodegenPublicDirectory(root, dist);
+      await ɵcodegenPublicDirectory(root, { dest: dist });
       expect(copy.getCalls().map((it) => it.args)).to.deep.equal([
         [join(root, outDir, "client"), dist],
       ]);
@@ -186,7 +186,7 @@ describe("Astro", () => {
 
       const copy = sandbox.stub(fsExtra, "copy");
       const bootstrapScript = astroUtils.getBootstrapScript();
-      expect(await ɵcodegenFunctionsDirectory(root, dist)).to.deep.equal({
+      expect(await ɵcodegenFunctionsDirectory(root, { dest: dist })).to.deep.equal({
         packageJson,
         bootstrapScript,
       });

--- a/src/test/frameworks/flutter/index.spec.ts
+++ b/src/test/frameworks/flutter/index.spec.ts
@@ -73,7 +73,7 @@ describe("Flutter", () => {
       const root = Math.random().toString(36).split(".")[1];
       const dist = Math.random().toString(36).split(".")[1];
       const copy = sandbox.stub(fsExtra, "copy");
-      await ɵcodegenPublicDirectory(root, dist);
+      await ɵcodegenPublicDirectory(root, { dest: dist });
       expect(copy.getCalls().map((it) => it.args)).to.deep.equal([
         [join(root, "build", "web"), dist],
       ]);


### PR DESCRIPTION


<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

- Detect flask app and ask for the entry file name
- Save the entry file  in firebase.json under `frameworksBackend.flask`
- Update firebase config schema

### Scenarios Tested
- Init with an existing Flask app with entry file = app.py.
- Init with an existing Flask app with entry file = main.py.
- Init with a blank project.
- Start emulators
- Deploy app

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
