### PR TITLE
Don't prompt for OOB change confirmation in noninteractive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Fixed an issue where builds from https://firebase.tools could not run commands that spawn `npm`. (#6132)
-- Fixed an issue where `--noninteractive` and `--force` were not respected in some extension deploys. (#6321)
+- Fixed an issue where `--non-interactive` and `--force` were not respected in some extension deploys. (#6321)
 - Fixed the regex in extensions changelog parser to lazy match the version prefix to allow matching higher versions (#6326)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed an issue where builds from https://firebase.tools could not run commands that spawn `npm`. (#6132)
+- Fixed an issue where `--noninteractive` and `--force` were not respected in some extension deploys. (#6321)
 - Fixed the regex in extensions changelog parser to lazy match the version prefix to allow matching higher versions (#6326)

--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -41,6 +41,8 @@ export async function prepare(context: Context, options: Options, payload: Paylo
       !(await prompt.confirm({
         message: `Do you wish to continue deploying these extension instances?`,
         default: false,
+        nonInteractive: options.nonInteractive,
+        force: options.force,
       }))
     ) {
       throw new FirebaseError("Deployment cancelled");
@@ -69,6 +71,8 @@ export async function prepare(context: Context, options: Options, payload: Paylo
       !(await prompt.confirm({
         message: `Do you wish to continue deploying these extension instances?`,
         default: true,
+        nonInteractive: options.nonInteractive,
+        force: options.force,
       }))
     ) {
       throw new FirebaseError("Deployment cancelled");
@@ -97,6 +101,8 @@ export async function prepare(context: Context, options: Options, payload: Paylo
           .map((i) => i.instanceId)
           .join(", ")}?`,
         default: false,
+        nonInteractive: options.nonInteractive,
+        force: options.force,
       }))
     ) {
       payload.instancesToDelete = [];


### PR DESCRIPTION
### Description
Pass `--noninteractive` and `--force` to prompts for out of band changes to extensions instances. Fixes #6321 
### Scenarios Tested
See https://github.com/aalej/issues-6321 - this no longer hangs in noninteractive mode.