### PR TITLE
Update Firestore emulator to v1.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
-- Removed nano precision in timestamp used in Firestore emulator (#5893); Fixed a bug where query behaves different from production.
+- Released Firestore emulator v1.18.2. 
+  - Removed nano precision in timestamp used in Firestore emulator (#5893)
+  - Fixed a bug where query behaves different from production.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,1 @@
-- Removed nano precision in timestamp used in Firestore emulator. (#5893)
-- Fixed a bug where query behaves different from production.
+- Removed nano precision in timestamp used in Firestore emulator (#5893); Fixed a bug where query behaves different from production.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
 - Fixed an issue where builds from https://firebase.tools could not run commands that spawn `npm`. (#6132)
 - Fixed an issue where `--non-interactive` and `--force` were not respected in some extension deploys. (#6321)
 - Fixed the regex in extensions changelog parser to lazy match the version prefix to allow matching higher versions (#6326)
+- Removed nano precision in timestamp used in Firestore emulator. (#5893)
+- Fixed a bug where query behaves different from production.
+

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -33,9 +33,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "2fd771101c0e1f7898c04c9204f2ce63",
   },
   firestore: {
-    version: "1.18.1",
-    expectedSize: 64866257,
-    expectedChecksum: "743211a3e33217fe71dc20aff1fa26a5",
+    version: "1.18.2",
+    expectedSize: 63929486,
+    expectedChecksum: "7b066cd684baf9bcd4a56a258be344a5",
   },
   storage: {
     version: "1.1.3",


### PR DESCRIPTION
- Removed nano precision in timestamp in events.
- Fixed a bug where query behaves different from production.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

- Removed nano precision in timestamp in events.
- Fixed a bug where query behaves different from production.

### Scenarios Tested

Unit tests.

### Sample Commands


