### PR TITLE
Added a check to see if export target folder is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
   - Removed nano precision in timestamp used in Firestore emulator (#5893)
   - Fixed a bug where query behaves differently from production.
 - Fixed an issue where very long command outputs would be cut off. (#3286)
+- Fixed an issue where `emulators:export` does not check if the target folder is empty. (#6313)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -961,7 +961,8 @@ export async function exportEmulatorData(exportPath: string, options: any, initi
 
   // Check if there is already an export there and prompt the user about deleting it
   const existingMetadata = HubExport.readMetadata(exportAbsPath);
-  if (existingMetadata && !(options.force || options.exportOnExit)) {
+  const isExportDirEmpty = fs.readdirSync(exportAbsPath).length === 0;
+  if ((existingMetadata || !isExportDirEmpty) && !(options.force || options.exportOnExit)) {
     if (options.noninteractive) {
       throw new FirebaseError(
         "Export already exists in the target directory, re-run with --force to overwrite.",
@@ -971,7 +972,7 @@ export async function exportEmulatorData(exportPath: string, options: any, initi
 
     const prompt = await promptOnce({
       type: "confirm",
-      message: `The directory ${exportAbsPath} already contains export data. Exporting again to the same directory will overwrite all data. Do you want to continue?`,
+      message: `The directory ${exportAbsPath} is not empty. Existing files in this directory will be overwritten. Do you want to continue?`,
       default: false,
     });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #6313 

Running `firebase emulators:export .` will delete everything in the current directory

Steps to reproduce:
1. Run `firebase init firestore --project <project_id>`
   - Setup emulator
2. Run `firebase emulators:start`
3. In a new terminal, under the same directory, run `firebase emulators:export .`
   - Entire directory is deleted

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1. Run `firebase init firestore --project <project_id>`
   - Setup emulator
2. Run `firebase emulators:start`
3. In a new terminal, under the same directory, run `firebase emulators:export .`
4. Receive prompt:
```
The directory /Users/<path>/test is not empty. Existing files in this directory will be overwritten. Do you
 want to continue? (y/N)
```
5. Test passing `--force` flag to override checks
   - Entire directory is deleted


### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase emulators:export`
