### PR TITLE
Revert "Fix output buffer pipe issue"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
 - Released Firestore emulator v1.18.2.
   - Removed nano precision in timestamp used in Firestore emulator (#5893)
   - Fixed a bug where query behaves differently from production.
-- Fixed an issue where very long command outputs would be cut off. (#3286)

--- a/src/command.ts
+++ b/src/command.ts
@@ -125,7 +125,7 @@ export class Command {
   }
 
   /**
-   * Registers the command with the client. This is used to initially set up
+   * Registers the command with the client. This is used to inisially set up
    * all the commands and wraps their functionality with analytics and error
    * handling.
    * @param client the client object (from src/index.js).
@@ -190,7 +190,7 @@ export class Command {
       runner(...args)
         .then(async (result) => {
           if (getInheritedOption(options, "json")) {
-            process.stdout.write(
+            console.log(
               JSON.stringify(
                 {
                   status: "success",
@@ -222,6 +222,7 @@ export class Command {
               ])
             );
           }
+          process.exit();
         })
         .catch(async (err) => {
           if (getInheritedOption(options, "json")) {


### PR DESCRIPTION
Reverts firebase/firebase-tools#5310 - I missed that this also removed process.exit(), which breaks the emulator suite in a number of ways (and is why the triggers-end-to-end integration test is currently failing)