### PR TITLE
Fix npm packaging so that npm commands work

### DIFF
--- a/standalone/package-lock.json
+++ b/standalone/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "chalk": "^2.4.2",
-        "npm": "^9.8.0",
+        "npm": "^8.19.0",
         "shelljs": "^0.8.3",
         "shx": "^0.3.2",
         "user-home": "^2.0.0"
@@ -328,8 +328,7 @@
     "node_modules/chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "node_modules/cliui": {
       "version": "7.0.4",
@@ -955,23 +954,23 @@
       }
     },
     "node_modules/npm": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
-      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
+        "@npmcli/ci-detect",
         "@npmcli/config",
         "@npmcli/fs",
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
-        "@npmcli/promise-spawn",
         "@npmcli/run-script",
         "abbrev",
         "archy",
         "cacache",
         "chalk",
-        "ci-info",
+        "chownr",
         "cli-columns",
         "cli-table3",
         "columnify",
@@ -999,6 +998,8 @@
         "minimatch",
         "minipass",
         "minipass-pipeline",
+        "mkdirp",
+        "mkdirp-infer-owner",
         "ms",
         "node-gyp",
         "nopt",
@@ -1010,16 +1011,19 @@
         "npm-registry-fetch",
         "npm-user-validate",
         "npmlog",
+        "opener",
         "p-map",
         "pacote",
         "parse-conflict-json",
         "proc-log",
         "qrcode-terminal",
         "read",
+        "read-package-json",
+        "read-package-json-fast",
+        "readdir-scoped-modules",
+        "rimraf",
         "semver",
-        "sigstore",
         "ssri",
-        "supports-color",
         "tar",
         "text-table",
         "tiny-relative-date",
@@ -1030,80 +1034,85 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^6.3.0",
-        "@npmcli/config": "^6.2.1",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^4.0.1",
-        "@npmcli/promise-spawn": "^6.0.2",
-        "@npmcli/run-script": "^6.0.2",
-        "abbrev": "^2.0.0",
+        "@npmcli/arborist": "^5.6.3",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.2.1",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/run-script": "^4.2.1",
+        "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^17.1.3",
-        "chalk": "^5.3.0",
-        "ci-info": "^3.8.0",
+        "cacache": "^16.1.3",
+        "chalk": "^4.1.2",
+        "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.3",
+        "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
-        "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.2",
-        "glob": "^10.2.7",
-        "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^6.1.1",
-        "ini": "^4.1.1",
-        "init-package-json": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "graceful-fs": "^4.2.10",
+        "hosted-git-info": "^5.2.1",
+        "ini": "^3.0.1",
+        "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "libnpmaccess": "^7.0.2",
-        "libnpmdiff": "^5.0.19",
-        "libnpmexec": "^6.0.3",
-        "libnpmfund": "^4.0.19",
-        "libnpmhook": "^9.0.3",
-        "libnpmorg": "^5.0.4",
-        "libnpmpack": "^5.0.19",
-        "libnpmpublish": "^7.5.0",
-        "libnpmsearch": "^6.0.2",
-        "libnpmteam": "^5.0.3",
-        "libnpmversion": "^4.0.2",
-        "make-fetch-happen": "^11.1.1",
-        "minimatch": "^9.0.3",
-        "minipass": "^5.0.0",
+        "json-parse-even-better-errors": "^2.3.1",
+        "libnpmaccess": "^6.0.4",
+        "libnpmdiff": "^4.0.5",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
+        "libnpmhook": "^8.0.4",
+        "libnpmorg": "^4.0.4",
+        "libnpmpack": "^4.1.3",
+        "libnpmpublish": "^6.0.5",
+        "libnpmsearch": "^5.0.4",
+        "libnpmteam": "^4.0.4",
+        "libnpmversion": "^3.0.7",
+        "make-fetch-happen": "^10.2.0",
+        "minimatch": "^5.1.0",
+        "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.4.0",
-        "nopt": "^7.2.0",
-        "npm-audit-report": "^5.0.0",
-        "npm-install-checks": "^6.1.1",
-        "npm-package-arg": "^10.1.0",
-        "npm-pick-manifest": "^8.0.1",
-        "npm-profile": "^7.0.1",
-        "npm-registry-fetch": "^14.0.5",
-        "npm-user-validate": "^2.0.0",
-        "npmlog": "^7.0.1",
+        "node-gyp": "^9.1.0",
+        "nopt": "^6.0.0",
+        "npm-audit-report": "^3.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.1.0",
+        "npm-pick-manifest": "^7.0.2",
+        "npm-profile": "^6.2.0",
+        "npm-registry-fetch": "^13.3.1",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "^6.0.2",
+        "opener": "^1.5.2",
         "p-map": "^4.0.0",
-        "pacote": "^15.2.0",
-        "parse-conflict-json": "^3.0.1",
-        "proc-log": "^3.0.0",
+        "pacote": "^13.6.2",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.1.0",
-        "semver": "^7.5.4",
-        "sigstore": "^1.7.0",
-        "ssri": "^10.0.4",
-        "supports-color": "^9.4.0",
-        "tar": "^6.1.15",
+        "read": "~1.0.7",
+        "read-package-json": "^5.0.2",
+        "read-package-json-fast": "^2.0.3",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.1",
+        "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^5.0.0",
-        "which": "^3.0.1",
-        "write-file-atomic": "^5.0.1"
+        "treeverse": "^2.0.0",
+        "validate-npm-package-name": "^4.0.0",
+        "which": "^2.0.2",
+        "write-file-atomic": "^4.0.1"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
         "npx": "bin/npx-cli.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@colors/colors": {
@@ -1115,67 +1124,10 @@
         "node": ">=0.1.90"
       }
     },
-    "node_modules/npm/node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
-      "version": "9.2.2",
+    "node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.3",
       "inBundle": true,
       "license": "MIT"
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
@@ -1183,249 +1135,247 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "6.3.0",
+      "version": "5.6.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
-        "@npmcli/map-workspaces": "^3.0.2",
-        "@npmcli/metavuln-calculator": "^5.0.0",
-        "@npmcli/name-from-folder": "^2.0.0",
-        "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^4.0.0",
-        "@npmcli/query": "^3.0.0",
-        "@npmcli/run-script": "^6.0.0",
-        "bin-links": "^4.0.1",
-        "cacache": "^17.0.4",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/metavuln-calculator": "^3.0.1",
+        "@npmcli/move-file": "^2.0.0",
+        "@npmcli/name-from-folder": "^1.0.1",
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/query": "^1.2.0",
+        "@npmcli/run-script": "^4.1.3",
+        "bin-links": "^3.0.3",
+        "cacache": "^16.1.3",
         "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^6.1.1",
-        "json-parse-even-better-errors": "^3.0.0",
+        "hosted-git-info": "^5.2.1",
+        "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^9.0.0",
-        "nopt": "^7.0.0",
-        "npm-install-checks": "^6.0.0",
-        "npm-package-arg": "^10.1.0",
-        "npm-pick-manifest": "^8.0.1",
-        "npm-registry-fetch": "^14.0.3",
-        "npmlog": "^7.0.1",
-        "pacote": "^15.0.8",
-        "parse-conflict-json": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "minimatch": "^5.1.0",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^6.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.0.0",
+        "npm-pick-manifest": "^7.0.2",
+        "npm-registry-fetch": "^13.0.0",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.6.1",
+        "parse-conflict-json": "^2.0.1",
+        "proc-log": "^2.0.0",
         "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.2",
-        "read-package-json-fast": "^3.0.2",
+        "promise-call-limit": "^1.0.1",
+        "read-package-json-fast": "^2.0.2",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
         "semver": "^7.3.7",
-        "ssri": "^10.0.1",
-        "treeverse": "^3.0.0",
-        "walk-up-path": "^3.0.1"
+        "ssri": "^9.0.0",
+        "treeverse": "^2.0.0",
+        "walk-up-path": "^1.0.0"
       },
       "bin": {
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/ci-detect": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "6.2.1",
+      "version": "4.2.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/map-workspaces": "^3.0.2",
-        "ci-info": "^3.8.0",
-        "ini": "^4.1.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "read-package-json-fast": "^3.0.2",
+        "@npmcli/map-workspaces": "^2.0.2",
+        "ini": "^3.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "nopt": "^6.0.0",
+        "proc-log": "^2.0.0",
+        "read-package-json-fast": "^2.0.3",
         "semver": "^7.3.5",
-        "walk-up-path": "^3.0.1"
+        "walk-up-path": "^1.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "3.0.0",
+      "version": "2.0.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "ansi-styles": "^4.3.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "3.1.0",
+      "version": "2.1.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promisify": "^1.1.3",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "4.1.0",
+      "version": "3.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^6.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
         "lru-cache": "^7.4.4",
-        "npm-pick-manifest": "^8.0.0",
-        "proc-log": "^3.0.0",
+        "mkdirp": "^1.0.4",
+        "npm-pick-manifest": "^7.0.0",
+        "proc-log": "^2.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^3.0.0"
+        "which": "^2.0.2"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "2.0.2",
+      "version": "1.0.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^3.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "npm-bundled": "^1.1.1",
+        "npm-normalize-package-bin": "^1.0.1"
       },
       "bin": {
-        "installed-package-contents": "lib/index.js"
+        "installed-package-contents": "index.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">= 10"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/installed-package-contents/node_modules/npm-bundled": {
+      "version": "1.1.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.4",
+      "version": "2.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/name-from-folder": "^2.0.0",
-        "glob": "^10.2.2",
-        "minimatch": "^9.0.0",
-        "read-package-json-fast": "^3.0.0"
+        "@npmcli/name-from-folder": "^1.0.1",
+        "glob": "^8.0.1",
+        "minimatch": "^5.0.1",
+        "read-package-json-fast": "^2.0.3"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "5.0.1",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cacache": "^17.0.0",
-        "json-parse-even-better-errors": "^3.0.0",
-        "pacote": "^15.0.0",
+        "cacache": "^16.0.0",
+        "json-parse-even-better-errors": "^2.3.1",
+        "pacote": "^13.0.3",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "2.0.0",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "4.0.1",
+      "version": "2.0.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^4.1.0",
-        "glob": "^10.2.2",
-        "hosted-git-info": "^6.1.1",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^5.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.5.3"
+        "json-parse-even-better-errors": "^2.3.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "6.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "which": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/query": {
       "version": "3.0.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "infer-owner": "^1.0.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "6.0.2",
+    "node_modules/npm/node_modules/@npmcli/query": {
+      "version": "1.2.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/promise-spawn": "^6.0.0",
-        "node-gyp": "^9.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "which": "^3.0.0"
+        "npm-package-arg": "^9.1.0",
+        "postcss-selector-parser": "^6.0.10",
+        "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/npm/node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
+    "node_modules/npm/node_modules/@npmcli/run-script": {
+      "version": "4.2.1",
       "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "1.0.2",
-      "inBundle": true,
-      "license": "Apache-2.0",
+      "license": "ISC",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.1.0",
-        "tuf-js": "^1.1.7"
+        "@npmcli/node-gyp": "^2.0.0",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "node-gyp": "^9.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "which": "^2.0.2"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/@tootallnate/once": {
@@ -1436,44 +1386,10 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/@tufjs/canonical-json": {
-      "version": "1.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "1.0.4",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "1.0.0",
-        "minimatch": "^9.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "2.0.0",
+      "version": "1.1.1",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/abort-controller": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "6.0.2",
@@ -1487,12 +1403,12 @@
       }
     },
     "node_modules/npm/node_modules/agentkeepalive": {
-      "version": "4.3.0",
+      "version": "4.2.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.1.0",
-        "depd": "^2.0.0",
+        "depd": "^1.1.2",
         "humanize-ms": "^1.2.1"
       },
       "engines": {
@@ -1544,53 +1460,49 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "4.0.0",
+      "version": "3.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
-        "readable-stream": "^4.1.0"
+        "readable-stream": "^3.6.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/npm/node_modules/asap": {
+      "version": "2.0.6",
+      "inBundle": true,
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/base64-js": {
-      "version": "1.5.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.2",
+      "version": "3.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cmd-shim": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "read-cmd-shim": "^4.0.0",
-        "write-file-atomic": "^5.0.0"
+        "cmd-shim": "^5.0.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
+        "read-cmd-shim": "^3.0.0",
+        "rimraf": "^3.0.0",
+        "write-file-atomic": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/bin-links/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
@@ -1609,29 +1521,6 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/npm/node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/npm/node_modules/builtins": {
       "version": "5.0.1",
       "inBundle": true,
@@ -1641,33 +1530,43 @@
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "17.1.3",
+      "version": "16.1.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^3.1.0",
-        "fs-minipass": "^3.0.0",
-        "glob": "^10.2.2",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
         "lru-cache": "^7.7.1",
-        "minipass": "^5.0.0",
+        "minipass": "^3.1.6",
         "minipass-collect": "^1.0.2",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
         "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
         "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
+        "unique-filename": "^2.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "5.3.0",
+      "version": "4.1.2",
       "inBundle": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
       "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
@@ -1679,20 +1578,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/ci-info": {
-      "version": "3.8.0",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/sibiraj-s"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
@@ -1727,7 +1612,7 @@
       }
     },
     "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.3",
+      "version": "0.6.2",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -1749,11 +1634,14 @@
       }
     },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "6.0.1",
+      "version": "5.0.0",
       "inBundle": true,
       "license": "ISC",
+      "dependencies": {
+        "mkdirp-infer-owner": "^2.0.0"
+      },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/color-convert": {
@@ -1807,33 +1695,6 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
       "inBundle": true,
@@ -1866,15 +1727,20 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/debuglog": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.4",
+      "version": "1.0.3",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/delegates": {
@@ -1883,11 +1749,20 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/depd": {
-      "version": "2.0.0",
+      "version": "1.1.2",
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/npm/node_modules/dezalgo": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/npm/node_modules/diff": {
@@ -1897,11 +1772,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/npm/node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -1930,59 +1800,20 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/events": {
-      "version": "3.3.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/npm/node_modules/exponential-backoff": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/npm/node_modules/fastest-levenshtein": {
-      "version": "1.0.16",
+      "version": "1.0.12",
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.9.1"
-      }
-    },
-    "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/fs-minipass": {
-      "version": "3.0.2",
+      "version": "2.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^5.0.0"
+        "minipass": "^3.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">= 8"
       }
     },
     "node_modules/npm/node_modules/fs.realpath": {
@@ -1996,7 +1827,7 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "5.0.1",
+      "version": "4.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -2004,38 +1835,35 @@
         "color-support": "^1.1.3",
         "console-control-strings": "^1.1.0",
         "has-unicode": "^2.0.1",
-        "signal-exit": "^4.0.1",
+        "signal-exit": "^3.0.7",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.2.7",
+      "version": "8.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2",
-        "path-scurry": "^1.7.0"
-      },
-      "bin": {
-        "glob": "dist/cjs/src/bin.js"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.11",
+      "version": "4.2.10",
       "inBundle": true,
       "license": "ISC"
     },
@@ -2050,20 +1878,28 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/npm/node_modules/has-flag": {
+      "version": "4.0.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/npm/node_modules/has-unicode": {
       "version": "2.0.1",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "6.1.1",
+      "version": "5.2.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^7.5.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
@@ -2116,34 +1952,15 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.3",
+      "version": "5.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minimatch": "^9.0.0"
+        "minimatch": "^5.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/imurmurhash": {
@@ -2162,6 +1979,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/infer-owner": {
+      "version": "1.0.4",
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/inflight": {
       "version": "1.0.6",
       "inBundle": true,
@@ -2177,28 +1999,28 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "4.1.1",
+      "version": "3.0.1",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "5.0.0",
+      "version": "3.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^10.0.0",
-        "promzard": "^1.0.0",
-        "read": "^2.0.0",
-        "read-package-json": "^6.0.0",
+        "npm-package-arg": "^9.0.1",
+        "promzard": "^0.3.0",
+        "read": "^1.0.7",
+        "read-package-json": "^5.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^5.0.0"
+        "validate-npm-package-name": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/ip": {
@@ -2226,7 +2048,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.12.1",
+      "version": "2.10.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -2254,30 +2076,10 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/jackspeak": {
-      "version": "2.2.1",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.0",
+      "version": "2.3.1",
       "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
@@ -2296,174 +2098,174 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff": {
-      "version": "6.0.2",
+      "version": "5.1.1",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
-      "version": "5.5.0",
+      "version": "5.4.1",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "7.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-package-arg": "^10.1.0",
-        "npm-registry-fetch": "^14.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "5.0.19",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^6.3.0",
-        "@npmcli/disparity-colors": "^3.0.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
-        "binary-extensions": "^2.2.0",
-        "diff": "^5.1.0",
-        "minimatch": "^9.0.0",
-        "npm-package-arg": "^10.1.0",
-        "pacote": "^15.0.8",
-        "tar": "^6.1.13"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmexec": {
-      "version": "6.0.3",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^6.3.0",
-        "@npmcli/run-script": "^6.0.0",
-        "ci-info": "^3.7.1",
-        "npm-package-arg": "^10.1.0",
-        "npmlog": "^7.0.1",
-        "pacote": "^15.0.8",
-        "proc-log": "^3.0.0",
-        "read": "^2.0.0",
-        "read-package-json-fast": "^3.0.2",
-        "semver": "^7.3.7",
-        "walk-up-path": "^3.0.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmfund": {
-      "version": "4.0.19",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^6.3.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmhook": {
-      "version": "9.0.3",
+      "version": "6.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^14.0.3"
+        "minipass": "^3.1.1",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmdiff": {
+      "version": "4.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/disparity-colors": "^2.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "binary-extensions": "^2.2.0",
+        "diff": "^5.1.0",
+        "minimatch": "^5.0.1",
+        "npm-package-arg": "^9.0.1",
+        "pacote": "^13.6.1",
+        "tar": "^6.1.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmexec": {
+      "version": "4.0.14",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^5.6.3",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/fs": "^2.1.1",
+        "@npmcli/run-script": "^4.2.0",
+        "chalk": "^4.1.0",
+        "mkdirp-infer-owner": "^2.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npmlog": "^6.0.2",
+        "pacote": "^13.6.1",
+        "proc-log": "^2.0.0",
+        "read": "^1.0.7",
+        "read-package-json-fast": "^2.0.2",
+        "semver": "^7.3.7",
+        "walk-up-path": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmfund": {
+      "version": "3.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^5.6.3"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmhook": {
+      "version": "8.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmorg": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^13.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "4.1.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/run-script": "^4.1.3",
+        "npm-package-arg": "^9.0.1",
+        "pacote": "^13.6.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
+      "version": "6.0.5",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-package-data": "^4.0.0",
+        "npm-package-arg": "^9.0.1",
+        "npm-registry-fetch": "^13.0.0",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmsearch": {
       "version": "5.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^14.0.3"
+        "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "5.0.19",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^6.3.0",
-        "@npmcli/run-script": "^6.0.0",
-        "npm-package-arg": "^10.1.0",
-        "pacote": "^15.0.8"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "7.5.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ci-info": "^3.6.1",
-        "normalize-package-data": "^5.0.0",
-        "npm-package-arg": "^10.1.0",
-        "npm-registry-fetch": "^14.0.3",
-        "proc-log": "^3.0.0",
-        "semver": "^7.3.7",
-        "sigstore": "^1.4.0",
-        "ssri": "^10.0.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "6.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^14.0.3"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "5.0.3",
+      "version": "4.0.4",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^14.0.3"
+        "npm-registry-fetch": "^13.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "4.0.2",
+      "version": "3.0.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^4.0.1",
-        "@npmcli/run-script": "^6.0.0",
-        "json-parse-even-better-errors": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/run-script": "^4.1.3",
+        "json-parse-even-better-errors": "^2.3.1",
+        "proc-log": "^2.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "7.18.3",
+      "version": "7.13.2",
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -2471,48 +2273,49 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "11.1.1",
+      "version": "10.2.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "agentkeepalive": "^4.2.1",
-        "cacache": "^17.0.0",
-        "http-cache-semantics": "^4.1.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
         "is-lambda": "^1.0.1",
         "lru-cache": "^7.7.1",
-        "minipass": "^5.0.0",
-        "minipass-fetch": "^3.0.0",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.3",
         "promise-retry": "^2.0.1",
         "socks-proxy-agent": "^7.0.0",
-        "ssri": "^10.0.0"
+        "ssri": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "5.1.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "5.0.0",
+      "version": "3.3.4",
       "inBundle": true,
       "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -2528,28 +2331,17 @@
         "node": ">= 8"
       }
     },
-    "node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "3.0.3",
+      "version": "2.1.1",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "minipass": "^5.0.0",
+        "minipass": "^3.1.6",
         "minipass-sized": "^1.0.3",
         "minizlib": "^2.1.2"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
@@ -2566,17 +2358,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/minipass-json-stream": {
       "version": "1.0.1",
       "inBundle": true,
@@ -2584,17 +2365,6 @@
       "dependencies": {
         "jsonparse": "^1.3.1",
         "minipass": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
@@ -2608,34 +2378,12 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -2653,17 +2401,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
       "inBundle": true,
@@ -2675,18 +2412,28 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm/node_modules/mkdirp-infer-owner": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "infer-owner": "^1.0.4",
+        "mkdirp": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "1.0.0",
+      "version": "0.0.8",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/negotiator": {
       "version": "0.6.3",
@@ -2697,16 +2444,15 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "9.4.0",
+      "version": "9.1.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.0",
-        "exponential-backoff": "^3.1.1",
         "glob": "^7.1.4",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^11.0.3",
-        "nopt": "^6.0.0",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^5.0.0",
         "npmlog": "^6.0.0",
         "rimraf": "^3.0.2",
         "semver": "^7.3.5",
@@ -2717,24 +2463,7 @@
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^12.13 || ^14.13 || >=16"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
-      "version": "1.1.1",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/are-we-there-yet": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+        "node": "^12.22 || ^14.13 || >=16"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/brace-expansion": {
@@ -2744,24 +2473,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
-      "version": "4.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^3.0.7",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/glob": {
@@ -2795,6 +2506,20 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "1"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/npm/node_modules/nopt": {
       "version": "6.0.0",
       "inBundle": true,
       "license": "ISC",
@@ -2808,7 +2533,162 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
+    "node_modules/npm/node_modules/normalize-package-data": {
+      "version": "4.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-audit-report": {
+      "version": "3.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-bundled/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-install-checks": {
+      "version": "5.0.0",
+      "inBundle": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "semver": "^7.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "9.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^5.0.0",
+        "proc-log": "^2.0.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "5.1.3",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^8.0.1",
+        "ignore-walk": "^5.0.1",
+        "npm-bundled": "^2.0.0",
+        "npm-normalize-package-bin": "^2.0.0"
+      },
+      "bin": {
+        "npm-packlist": "bin/index.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "7.0.2",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^5.0.0",
+        "npm-normalize-package-bin": "^2.0.0",
+        "npm-package-arg": "^9.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch": {
+      "version": "13.3.1",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "make-fetch-happen": "^10.0.6",
+        "minipass": "^3.1.6",
+        "minipass-fetch": "^2.0.3",
+        "minipass-json-stream": "^1.0.1",
+        "minizlib": "^2.1.2",
+        "npm-package-arg": "^9.0.1",
+        "proc-log": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-user-validate": {
+      "version": "1.0.1",
+      "inBundle": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/npm/node_modules/npmlog": {
       "version": "6.0.2",
       "inBundle": true,
       "license": "ISC",
@@ -2822,200 +2702,20 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/npm/node_modules/node-gyp/node_modules/readable-stream": {
-      "version": "3.6.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/node-gyp/node_modules/which": {
-      "version": "2.0.2",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "node-which": "bin/node-which"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/nopt": {
-      "version": "7.2.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "abbrev": "^2.0.0"
-      },
-      "bin": {
-        "nopt": "bin/nopt.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "hosted-git-info": "^6.0.0",
-        "is-core-module": "^2.8.1",
-        "semver": "^7.3.5",
-        "validate-npm-package-license": "^3.0.4"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "5.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-bundled": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-normalize-package-bin": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "6.1.1",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "semver": "^7.1.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "3.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-package-arg": {
-      "version": "10.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "hosted-git-info": "^6.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "7.0.4",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ignore-walk": "^6.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "8.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^10.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "7.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^14.0.0",
-        "proc-log": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "14.0.5",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "make-fetch-happen": "^11.0.0",
-        "minipass": "^5.0.0",
-        "minipass-fetch": "^3.0.0",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.1.2",
-        "npm-package-arg": "^10.0.0",
-        "proc-log": "^3.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npmlog": {
-      "version": "7.0.1",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/once": {
       "version": "1.4.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/npm/node_modules/opener": {
+      "version": "1.5.2",
+      "inBundle": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/npm/node_modules/p-map": {
@@ -3033,47 +2733,50 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "15.2.0",
+      "version": "13.6.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^4.0.0",
-        "@npmcli/installed-package-contents": "^2.0.1",
-        "@npmcli/promise-spawn": "^6.0.1",
-        "@npmcli/run-script": "^6.0.0",
-        "cacache": "^17.0.0",
-        "fs-minipass": "^3.0.0",
-        "minipass": "^5.0.0",
-        "npm-package-arg": "^10.0.0",
-        "npm-packlist": "^7.0.0",
-        "npm-pick-manifest": "^8.0.0",
-        "npm-registry-fetch": "^14.0.0",
-        "proc-log": "^3.0.0",
+        "@npmcli/git": "^3.0.0",
+        "@npmcli/installed-package-contents": "^1.0.7",
+        "@npmcli/promise-spawn": "^3.0.0",
+        "@npmcli/run-script": "^4.1.0",
+        "cacache": "^16.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "infer-owner": "^1.0.4",
+        "minipass": "^3.1.6",
+        "mkdirp": "^1.0.4",
+        "npm-package-arg": "^9.0.0",
+        "npm-packlist": "^5.1.0",
+        "npm-pick-manifest": "^7.0.0",
+        "npm-registry-fetch": "^13.0.1",
+        "proc-log": "^2.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^6.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "sigstore": "^1.3.0",
-        "ssri": "^10.0.0",
+        "read-package-json": "^5.0.0",
+        "read-package-json-fast": "^2.0.3",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
         "pacote": "lib/bin.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "3.0.1",
+      "version": "2.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0",
-        "just-diff": "^6.0.0",
+        "json-parse-even-better-errors": "^2.3.1",
+        "just-diff": "^5.0.1",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/path-is-absolute": {
@@ -3084,39 +2787,8 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/path-key": {
-      "version": "3.1.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.9.2",
-      "inBundle": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^9.1.1",
-        "minipass": "^5.0.0 || ^6.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "9.1.1",
-      "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
-    },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.13",
+      "version": "6.0.10",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3128,19 +2800,11 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
-      "version": "3.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/process": {
-      "version": "0.11.10",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -3152,7 +2816,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.2",
+      "version": "1.0.1",
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -3177,14 +2841,11 @@
       }
     },
     "node_modules/npm/node_modules/promzard": {
-      "version": "1.0.0",
+      "version": "0.3.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "read": "1"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -3195,62 +2856,80 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "2.1.0",
+      "version": "1.0.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "mute-stream": "~1.0.0"
+        "mute-stream": "~0.0.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=0.8"
       }
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
-      "version": "4.0.0",
+      "version": "3.0.0",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "6.0.4",
+      "version": "5.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^10.2.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^5.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "glob": "^8.0.1",
+        "json-parse-even-better-errors": "^2.3.1",
+        "normalize-package-data": "^4.0.0",
+        "npm-normalize-package-bin": "^2.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "3.0.2",
+      "version": "2.0.3",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "json-parse-even-better-errors": "^2.3.0",
+        "npm-normalize-package-bin": "^1.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm/node_modules/read-package-json/node_modules/npm-normalize-package-bin": {
+      "version": "2.0.0",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "4.4.0",
+      "version": "3.6.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">= 6"
+      }
+    },
+    "node_modules/npm/node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "node_modules/npm/node_modules/retry": {
@@ -3340,7 +3019,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.3.7",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -3369,51 +3048,10 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/shebang-command": {
-      "version": "2.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "shebang-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/shebang-regex": {
-      "version": "3.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/signal-exit": {
-      "version": "4.0.2",
+      "version": "3.0.7",
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/npm/node_modules/sigstore": {
-      "version": "1.7.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.1.0",
-        "@sigstore/tuf": "^1.0.1",
-        "make-fetch-happen": "^11.0.1"
-      },
-      "bin": {
-        "sigstore": "bin/sigstore.js"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
@@ -3425,7 +3063,7 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.7.1",
+      "version": "2.7.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -3451,7 +3089,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
-      "version": "3.2.0",
+      "version": "3.1.1",
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3474,19 +3112,19 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.13",
+      "version": "3.0.11",
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/ssri": {
-      "version": "10.0.4",
+      "version": "9.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "minipass": "^5.0.0"
+        "minipass": "^3.1.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
@@ -3510,20 +3148,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
       "inBundle": true,
@@ -3535,65 +3159,31 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
-      "version": "6.0.1",
+    "node_modules/npm/node_modules/supports-color": {
+      "version": "7.2.0",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^5.0.1"
+        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/supports-color": {
-      "version": "9.4.0",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.15",
+      "version": "6.1.11",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
+        "minipass": "^3.0.0",
         "minizlib": "^2.1.1",
         "mkdirp": "^1.0.3",
         "yallist": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
-      "version": "2.1.0",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
-      "version": "3.3.6",
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">= 10"
       }
     },
     "node_modules/npm/node_modules/text-table": {
@@ -3607,46 +3197,33 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
-      "version": "3.0.0",
+      "version": "2.0.0",
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/tuf-js": {
-      "version": "1.1.7",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/models": "1.0.4",
-        "debug": "^4.3.4",
-        "make-fetch-happen": "^11.1.1"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-filename": {
-      "version": "3.0.0",
+      "version": "2.0.1",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^4.0.0"
+        "unique-slug": "^3.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/unique-slug": {
-      "version": "4.0.0",
+      "version": "3.0.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -3664,18 +3241,18 @@
       }
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
+      "version": "4.0.0",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "builtins": "^5.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
-      "version": "3.0.1",
+      "version": "1.0.0",
       "inBundle": true,
       "license": "ISC"
     },
@@ -3688,17 +3265,17 @@
       }
     },
     "node_modules/npm/node_modules/which": {
-      "version": "3.0.1",
+      "version": "2.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
       "bin": {
-        "node-which": "bin/which.js"
+        "node-which": "bin/node-which"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">= 8"
       }
     },
     "node_modules/npm/node_modules/wide-align": {
@@ -3709,111 +3286,21 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "node_modules/npm/node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.1",
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "5.1.2",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.1.0",
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/npm/node_modules/wrappy": {
       "version": "1.0.2",
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "5.0.1",
+      "version": "4.0.2",
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
-        "signal-exit": "^4.0.1"
+        "signal-exit": "^3.0.7"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -4890,8 +4377,7 @@
     "chownr": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "dev": true
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "cliui": {
       "version": "7.0.4",
@@ -5350,78 +4836,83 @@
       }
     },
     "npm": {
-      "version": "9.8.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-9.8.1.tgz",
-      "integrity": "sha512-AfDvThQzsIXhYgk9zhbk5R+lh811lKkLAeQMMhSypf1BM7zUafeIIBzMzespeuVEJ0+LvY36oRQYf7IKLzU3rw==",
+      "version": "8.19.4",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-8.19.4.tgz",
+      "integrity": "sha512-3HANl8i9DKnUA89P4KEgVNN28EjSeDCmvEqbzOAuxCFDzdBZzjUl99zgnGpOUumvW5lvJo2HKcjrsc+tfyv1Hw==",
       "requires": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^6.3.0",
-        "@npmcli/config": "^6.2.1",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^4.0.1",
-        "@npmcli/promise-spawn": "^6.0.2",
-        "@npmcli/run-script": "^6.0.2",
-        "abbrev": "^2.0.0",
+        "@npmcli/arborist": "^5.6.3",
+        "@npmcli/ci-detect": "^2.0.0",
+        "@npmcli/config": "^4.2.1",
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/map-workspaces": "^2.0.3",
+        "@npmcli/package-json": "^2.0.0",
+        "@npmcli/run-script": "^4.2.1",
+        "abbrev": "~1.1.1",
         "archy": "~1.0.0",
-        "cacache": "^17.1.3",
-        "chalk": "^5.3.0",
-        "ci-info": "^3.8.0",
+        "cacache": "^16.1.3",
+        "chalk": "^4.1.2",
+        "chownr": "^2.0.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.3",
+        "cli-table3": "^0.6.2",
         "columnify": "^1.6.0",
-        "fastest-levenshtein": "^1.0.16",
-        "fs-minipass": "^3.0.2",
-        "glob": "^10.2.7",
-        "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^6.1.1",
-        "ini": "^4.1.1",
-        "init-package-json": "^5.0.0",
+        "fastest-levenshtein": "^1.0.12",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "graceful-fs": "^4.2.10",
+        "hosted-git-info": "^5.2.1",
+        "ini": "^3.0.1",
+        "init-package-json": "^3.0.2",
         "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "libnpmaccess": "^7.0.2",
-        "libnpmdiff": "^5.0.19",
-        "libnpmexec": "^6.0.3",
-        "libnpmfund": "^4.0.19",
-        "libnpmhook": "^9.0.3",
-        "libnpmorg": "^5.0.4",
-        "libnpmpack": "^5.0.19",
-        "libnpmpublish": "^7.5.0",
-        "libnpmsearch": "^6.0.2",
-        "libnpmteam": "^5.0.3",
-        "libnpmversion": "^4.0.2",
-        "make-fetch-happen": "^11.1.1",
-        "minimatch": "^9.0.3",
-        "minipass": "^5.0.0",
+        "json-parse-even-better-errors": "^2.3.1",
+        "libnpmaccess": "^6.0.4",
+        "libnpmdiff": "^4.0.5",
+        "libnpmexec": "^4.0.14",
+        "libnpmfund": "^3.0.5",
+        "libnpmhook": "^8.0.4",
+        "libnpmorg": "^4.0.4",
+        "libnpmpack": "^4.1.3",
+        "libnpmpublish": "^6.0.5",
+        "libnpmsearch": "^5.0.4",
+        "libnpmteam": "^4.0.4",
+        "libnpmversion": "^3.0.7",
+        "make-fetch-happen": "^10.2.0",
+        "minimatch": "^5.1.0",
+        "minipass": "^3.1.6",
         "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "mkdirp-infer-owner": "^2.0.0",
         "ms": "^2.1.2",
-        "node-gyp": "^9.4.0",
-        "nopt": "^7.2.0",
-        "npm-audit-report": "^5.0.0",
-        "npm-install-checks": "^6.1.1",
-        "npm-package-arg": "^10.1.0",
-        "npm-pick-manifest": "^8.0.1",
-        "npm-profile": "^7.0.1",
-        "npm-registry-fetch": "^14.0.5",
-        "npm-user-validate": "^2.0.0",
-        "npmlog": "^7.0.1",
+        "node-gyp": "^9.1.0",
+        "nopt": "^6.0.0",
+        "npm-audit-report": "^3.0.0",
+        "npm-install-checks": "^5.0.0",
+        "npm-package-arg": "^9.1.0",
+        "npm-pick-manifest": "^7.0.2",
+        "npm-profile": "^6.2.0",
+        "npm-registry-fetch": "^13.3.1",
+        "npm-user-validate": "^1.0.1",
+        "npmlog": "^6.0.2",
+        "opener": "^1.5.2",
         "p-map": "^4.0.0",
-        "pacote": "^15.2.0",
-        "parse-conflict-json": "^3.0.1",
-        "proc-log": "^3.0.0",
+        "pacote": "^13.6.2",
+        "parse-conflict-json": "^2.0.2",
+        "proc-log": "^2.0.1",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.1.0",
-        "semver": "^7.5.4",
-        "sigstore": "^1.7.0",
-        "ssri": "^10.0.4",
-        "supports-color": "^9.4.0",
-        "tar": "^6.1.15",
+        "read": "~1.0.7",
+        "read-package-json": "^5.0.2",
+        "read-package-json-fast": "^2.0.3",
+        "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.7",
+        "ssri": "^9.0.1",
+        "tar": "^6.1.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
-        "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^5.0.0",
-        "which": "^3.0.1",
-        "write-file-atomic": "^5.0.1"
+        "treeverse": "^2.0.0",
+        "validate-npm-package-name": "^4.0.0",
+        "which": "^2.0.2",
+        "write-file-atomic": "^4.0.1"
       },
       "dependencies": {
         "@colors/colors": {
@@ -5429,246 +4920,199 @@
           "bundled": true,
           "optional": true
         },
-        "@isaacs/cliui": {
-          "version": "8.0.2",
-          "bundled": true,
-          "requires": {
-            "string-width": "^5.1.2",
-            "string-width-cjs": "npm:string-width@^4.2.0",
-            "strip-ansi": "^7.0.1",
-            "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-            "wrap-ansi": "^8.1.0",
-            "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "6.0.1",
-              "bundled": true
-            },
-            "emoji-regex": {
-              "version": "9.2.2",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "7.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^6.0.1"
-              }
-            }
-          }
+        "@gar/promisify": {
+          "version": "1.1.3",
+          "bundled": true
         },
         "@isaacs/string-locale-compare": {
           "version": "1.1.0",
           "bundled": true
         },
         "@npmcli/arborist": {
-          "version": "6.3.0",
+          "version": "5.6.3",
           "bundled": true,
           "requires": {
             "@isaacs/string-locale-compare": "^1.1.0",
-            "@npmcli/fs": "^3.1.0",
-            "@npmcli/installed-package-contents": "^2.0.2",
-            "@npmcli/map-workspaces": "^3.0.2",
-            "@npmcli/metavuln-calculator": "^5.0.0",
-            "@npmcli/name-from-folder": "^2.0.0",
-            "@npmcli/node-gyp": "^3.0.0",
-            "@npmcli/package-json": "^4.0.0",
-            "@npmcli/query": "^3.0.0",
-            "@npmcli/run-script": "^6.0.0",
-            "bin-links": "^4.0.1",
-            "cacache": "^17.0.4",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/map-workspaces": "^2.0.3",
+            "@npmcli/metavuln-calculator": "^3.0.1",
+            "@npmcli/move-file": "^2.0.0",
+            "@npmcli/name-from-folder": "^1.0.1",
+            "@npmcli/node-gyp": "^2.0.0",
+            "@npmcli/package-json": "^2.0.0",
+            "@npmcli/query": "^1.2.0",
+            "@npmcli/run-script": "^4.1.3",
+            "bin-links": "^3.0.3",
+            "cacache": "^16.1.3",
             "common-ancestor-path": "^1.0.1",
-            "hosted-git-info": "^6.1.1",
-            "json-parse-even-better-errors": "^3.0.0",
+            "hosted-git-info": "^5.2.1",
+            "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
-            "minimatch": "^9.0.0",
-            "nopt": "^7.0.0",
-            "npm-install-checks": "^6.0.0",
-            "npm-package-arg": "^10.1.0",
-            "npm-pick-manifest": "^8.0.1",
-            "npm-registry-fetch": "^14.0.3",
-            "npmlog": "^7.0.1",
-            "pacote": "^15.0.8",
-            "parse-conflict-json": "^3.0.0",
-            "proc-log": "^3.0.0",
+            "minimatch": "^5.1.0",
+            "mkdirp": "^1.0.4",
+            "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^6.0.0",
+            "npm-install-checks": "^5.0.0",
+            "npm-package-arg": "^9.0.0",
+            "npm-pick-manifest": "^7.0.2",
+            "npm-registry-fetch": "^13.0.0",
+            "npmlog": "^6.0.2",
+            "pacote": "^13.6.1",
+            "parse-conflict-json": "^2.0.1",
+            "proc-log": "^2.0.0",
             "promise-all-reject-late": "^1.0.0",
-            "promise-call-limit": "^1.0.2",
-            "read-package-json-fast": "^3.0.2",
+            "promise-call-limit": "^1.0.1",
+            "read-package-json-fast": "^2.0.2",
+            "readdir-scoped-modules": "^1.1.0",
+            "rimraf": "^3.0.2",
             "semver": "^7.3.7",
-            "ssri": "^10.0.1",
-            "treeverse": "^3.0.0",
-            "walk-up-path": "^3.0.1"
+            "ssri": "^9.0.0",
+            "treeverse": "^2.0.0",
+            "walk-up-path": "^1.0.0"
           }
         },
+        "@npmcli/ci-detect": {
+          "version": "2.0.0",
+          "bundled": true
+        },
         "@npmcli/config": {
-          "version": "6.2.1",
+          "version": "4.2.2",
           "bundled": true,
           "requires": {
-            "@npmcli/map-workspaces": "^3.0.2",
-            "ci-info": "^3.8.0",
-            "ini": "^4.1.0",
-            "nopt": "^7.0.0",
-            "proc-log": "^3.0.0",
-            "read-package-json-fast": "^3.0.2",
+            "@npmcli/map-workspaces": "^2.0.2",
+            "ini": "^3.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "nopt": "^6.0.0",
+            "proc-log": "^2.0.0",
+            "read-package-json-fast": "^2.0.3",
             "semver": "^7.3.5",
-            "walk-up-path": "^3.0.1"
+            "walk-up-path": "^1.0.0"
           }
         },
         "@npmcli/disparity-colors": {
-          "version": "3.0.0",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
             "ansi-styles": "^4.3.0"
           }
         },
         "@npmcli/fs": {
-          "version": "3.1.0",
+          "version": "2.1.2",
           "bundled": true,
           "requires": {
+            "@gar/promisify": "^1.1.3",
             "semver": "^7.3.5"
           }
         },
         "@npmcli/git": {
-          "version": "4.1.0",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "@npmcli/promise-spawn": "^6.0.0",
+            "@npmcli/promise-spawn": "^3.0.0",
             "lru-cache": "^7.4.4",
-            "npm-pick-manifest": "^8.0.0",
-            "proc-log": "^3.0.0",
+            "mkdirp": "^1.0.4",
+            "npm-pick-manifest": "^7.0.0",
+            "proc-log": "^2.0.0",
             "promise-inflight": "^1.0.1",
             "promise-retry": "^2.0.1",
             "semver": "^7.3.5",
-            "which": "^3.0.0"
+            "which": "^2.0.2"
           }
         },
         "@npmcli/installed-package-contents": {
-          "version": "2.0.2",
+          "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "npm-bundled": "^3.0.0",
-            "npm-normalize-package-bin": "^3.0.0"
+            "npm-bundled": "^1.1.1",
+            "npm-normalize-package-bin": "^1.0.1"
+          },
+          "dependencies": {
+            "npm-bundled": {
+              "version": "1.1.2",
+              "bundled": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            }
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "3.0.4",
+          "version": "2.0.4",
           "bundled": true,
           "requires": {
-            "@npmcli/name-from-folder": "^2.0.0",
-            "glob": "^10.2.2",
-            "minimatch": "^9.0.0",
-            "read-package-json-fast": "^3.0.0"
+            "@npmcli/name-from-folder": "^1.0.1",
+            "glob": "^8.0.1",
+            "minimatch": "^5.0.1",
+            "read-package-json-fast": "^2.0.3"
           }
         },
         "@npmcli/metavuln-calculator": {
-          "version": "5.0.1",
+          "version": "3.1.1",
           "bundled": true,
           "requires": {
-            "cacache": "^17.0.0",
-            "json-parse-even-better-errors": "^3.0.0",
-            "pacote": "^15.0.0",
+            "cacache": "^16.0.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "pacote": "^13.0.3",
             "semver": "^7.3.5"
           }
         },
+        "@npmcli/move-file": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "mkdirp": "^1.0.4",
+            "rimraf": "^3.0.2"
+          }
+        },
         "@npmcli/name-from-folder": {
-          "version": "2.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "@npmcli/node-gyp": {
-          "version": "3.0.0",
+          "version": "2.0.0",
           "bundled": true
         },
         "@npmcli/package-json": {
-          "version": "4.0.1",
+          "version": "2.0.0",
           "bundled": true,
           "requires": {
-            "@npmcli/git": "^4.1.0",
-            "glob": "^10.2.2",
-            "hosted-git-info": "^6.1.1",
-            "json-parse-even-better-errors": "^3.0.0",
-            "normalize-package-data": "^5.0.0",
-            "proc-log": "^3.0.0",
-            "semver": "^7.5.3"
+            "json-parse-even-better-errors": "^2.3.1"
           }
         },
         "@npmcli/promise-spawn": {
-          "version": "6.0.2",
-          "bundled": true,
-          "requires": {
-            "which": "^3.0.0"
-          }
-        },
-        "@npmcli/query": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "postcss-selector-parser": "^6.0.10"
+            "infer-owner": "^1.0.4"
+          }
+        },
+        "@npmcli/query": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "npm-package-arg": "^9.1.0",
+            "postcss-selector-parser": "^6.0.10",
+            "semver": "^7.3.7"
           }
         },
         "@npmcli/run-script": {
-          "version": "6.0.2",
+          "version": "4.2.1",
           "bundled": true,
           "requires": {
-            "@npmcli/node-gyp": "^3.0.0",
-            "@npmcli/promise-spawn": "^6.0.0",
+            "@npmcli/node-gyp": "^2.0.0",
+            "@npmcli/promise-spawn": "^3.0.0",
             "node-gyp": "^9.0.0",
-            "read-package-json-fast": "^3.0.0",
-            "which": "^3.0.0"
-          }
-        },
-        "@pkgjs/parseargs": {
-          "version": "0.11.0",
-          "bundled": true,
-          "optional": true
-        },
-        "@sigstore/protobuf-specs": {
-          "version": "0.1.0",
-          "bundled": true
-        },
-        "@sigstore/tuf": {
-          "version": "1.0.2",
-          "bundled": true,
-          "requires": {
-            "@sigstore/protobuf-specs": "^0.1.0",
-            "tuf-js": "^1.1.7"
+            "read-package-json-fast": "^2.0.3",
+            "which": "^2.0.2"
           }
         },
         "@tootallnate/once": {
           "version": "2.0.0",
           "bundled": true
         },
-        "@tufjs/canonical-json": {
-          "version": "1.0.0",
-          "bundled": true
-        },
-        "@tufjs/models": {
-          "version": "1.0.4",
-          "bundled": true,
-          "requires": {
-            "@tufjs/canonical-json": "1.0.0",
-            "minimatch": "^9.0.0"
-          }
-        },
         "abbrev": {
-          "version": "2.0.0",
+          "version": "1.1.1",
           "bundled": true
-        },
-        "abort-controller": {
-          "version": "3.0.0",
-          "bundled": true,
-          "requires": {
-            "event-target-shim": "^5.0.0"
-          }
         },
         "agent-base": {
           "version": "6.0.2",
@@ -5678,11 +5122,11 @@
           }
         },
         "agentkeepalive": {
-          "version": "4.3.0",
+          "version": "4.2.1",
           "bundled": true,
           "requires": {
             "debug": "^4.1.0",
-            "depd": "^2.0.0",
+            "depd": "^1.1.2",
             "humanize-ms": "^1.2.1"
           }
         },
@@ -5714,29 +5158,37 @@
           "bundled": true
         },
         "are-we-there-yet": {
-          "version": "4.0.0",
+          "version": "3.0.1",
           "bundled": true,
           "requires": {
             "delegates": "^1.0.0",
-            "readable-stream": "^4.1.0"
+            "readable-stream": "^3.6.0"
           }
+        },
+        "asap": {
+          "version": "2.0.6",
+          "bundled": true
         },
         "balanced-match": {
           "version": "1.0.2",
           "bundled": true
         },
-        "base64-js": {
-          "version": "1.5.1",
-          "bundled": true
-        },
         "bin-links": {
-          "version": "4.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "requires": {
-            "cmd-shim": "^6.0.0",
-            "npm-normalize-package-bin": "^3.0.0",
-            "read-cmd-shim": "^4.0.0",
-            "write-file-atomic": "^5.0.0"
+            "cmd-shim": "^5.0.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-normalize-package-bin": "^2.0.0",
+            "read-cmd-shim": "^3.0.0",
+            "rimraf": "^3.0.0",
+            "write-file-atomic": "^4.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true
+            }
           }
         },
         "binary-extensions": {
@@ -5750,14 +5202,6 @@
             "balanced-match": "^1.0.0"
           }
         },
-        "buffer": {
-          "version": "6.0.3",
-          "bundled": true,
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
         "builtins": {
           "version": "5.0.1",
           "bundled": true,
@@ -5766,33 +5210,39 @@
           }
         },
         "cacache": {
-          "version": "17.1.3",
+          "version": "16.1.3",
           "bundled": true,
           "requires": {
-            "@npmcli/fs": "^3.1.0",
-            "fs-minipass": "^3.0.0",
-            "glob": "^10.2.2",
+            "@npmcli/fs": "^2.1.0",
+            "@npmcli/move-file": "^2.0.0",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
+            "glob": "^8.0.1",
+            "infer-owner": "^1.0.4",
             "lru-cache": "^7.7.1",
-            "minipass": "^5.0.0",
+            "minipass": "^3.1.6",
             "minipass-collect": "^1.0.2",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
+            "mkdirp": "^1.0.4",
             "p-map": "^4.0.0",
-            "ssri": "^10.0.0",
+            "promise-inflight": "^1.0.1",
+            "rimraf": "^3.0.2",
+            "ssri": "^9.0.0",
             "tar": "^6.1.11",
-            "unique-filename": "^3.0.0"
+            "unique-filename": "^2.0.0"
           }
         },
         "chalk": {
-          "version": "5.3.0",
-          "bundled": true
+          "version": "4.1.2",
+          "bundled": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
         },
         "chownr": {
           "version": "2.0.0",
-          "bundled": true
-        },
-        "ci-info": {
-          "version": "3.8.0",
           "bundled": true
         },
         "cidr-regex": {
@@ -5815,7 +5265,7 @@
           }
         },
         "cli-table3": {
-          "version": "0.6.3",
+          "version": "0.6.2",
           "bundled": true,
           "requires": {
             "@colors/colors": "1.5.0",
@@ -5827,8 +5277,11 @@
           "bundled": true
         },
         "cmd-shim": {
-          "version": "6.0.1",
-          "bundled": true
+          "version": "5.0.0",
+          "bundled": true,
+          "requires": {
+            "mkdirp-infer-owner": "^2.0.0"
+          }
         },
         "color-convert": {
           "version": "2.0.1",
@@ -5865,24 +5318,6 @@
           "version": "1.1.0",
           "bundled": true
         },
-        "cross-spawn": {
-          "version": "7.0.3",
-          "bundled": true,
-          "requires": {
-            "path-key": "^3.1.0",
-            "shebang-command": "^2.0.0",
-            "which": "^2.0.1"
-          },
-          "dependencies": {
-            "which": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            }
-          }
-        },
         "cssesc": {
           "version": "3.0.0",
           "bundled": true
@@ -5900,8 +5335,12 @@
             }
           }
         },
+        "debuglog": {
+          "version": "1.0.1",
+          "bundled": true
+        },
         "defaults": {
-          "version": "1.0.4",
+          "version": "1.0.3",
           "bundled": true,
           "requires": {
             "clone": "^1.0.2"
@@ -5912,15 +5351,19 @@
           "bundled": true
         },
         "depd": {
-          "version": "2.0.0",
+          "version": "1.1.2",
           "bundled": true
+        },
+        "dezalgo": {
+          "version": "1.0.4",
+          "bundled": true,
+          "requires": {
+            "asap": "^2.0.0",
+            "wrappy": "1"
+          }
         },
         "diff": {
           "version": "5.1.0",
-          "bundled": true
-        },
-        "eastasianwidth": {
-          "version": "0.2.0",
           "bundled": true
         },
         "emoji-regex": {
@@ -5943,35 +5386,15 @@
           "version": "2.0.3",
           "bundled": true
         },
-        "event-target-shim": {
-          "version": "5.0.1",
-          "bundled": true
-        },
-        "events": {
-          "version": "3.3.0",
-          "bundled": true
-        },
-        "exponential-backoff": {
-          "version": "3.1.1",
-          "bundled": true
-        },
         "fastest-levenshtein": {
-          "version": "1.0.16",
+          "version": "1.0.12",
           "bundled": true
-        },
-        "foreground-child": {
-          "version": "3.1.1",
-          "bundled": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "signal-exit": "^4.0.1"
-          }
         },
         "fs-minipass": {
-          "version": "3.0.2",
+          "version": "2.1.0",
           "bundled": true,
           "requires": {
-            "minipass": "^5.0.0"
+            "minipass": "^3.0.0"
           }
         },
         "fs.realpath": {
@@ -5983,32 +5406,32 @@
           "bundled": true
         },
         "gauge": {
-          "version": "5.0.1",
+          "version": "4.0.4",
           "bundled": true,
           "requires": {
             "aproba": "^1.0.3 || ^2.0.0",
             "color-support": "^1.1.3",
             "console-control-strings": "^1.1.0",
             "has-unicode": "^2.0.1",
-            "signal-exit": "^4.0.1",
+            "signal-exit": "^3.0.7",
             "string-width": "^4.2.3",
             "strip-ansi": "^6.0.1",
             "wide-align": "^1.1.5"
           }
         },
         "glob": {
-          "version": "10.2.7",
+          "version": "8.0.3",
           "bundled": true,
           "requires": {
-            "foreground-child": "^3.1.0",
-            "jackspeak": "^2.0.3",
-            "minimatch": "^9.0.1",
-            "minipass": "^5.0.0 || ^6.0.2",
-            "path-scurry": "^1.7.0"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^5.0.1",
+            "once": "^1.3.0"
           }
         },
         "graceful-fs": {
-          "version": "4.2.11",
+          "version": "4.2.10",
           "bundled": true
         },
         "has": {
@@ -6018,12 +5441,16 @@
             "function-bind": "^1.1.1"
           }
         },
+        "has-flag": {
+          "version": "4.0.0",
+          "bundled": true
+        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
         "hosted-git-info": {
-          "version": "6.1.1",
+          "version": "5.2.1",
           "bundled": true,
           "requires": {
             "lru-cache": "^7.5.1"
@@ -6065,15 +5492,11 @@
             "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
-        "ieee754": {
-          "version": "1.2.1",
-          "bundled": true
-        },
         "ignore-walk": {
-          "version": "6.0.3",
+          "version": "5.0.1",
           "bundled": true,
           "requires": {
-            "minimatch": "^9.0.0"
+            "minimatch": "^5.0.1"
           }
         },
         "imurmurhash": {
@@ -6082,6 +5505,10 @@
         },
         "indent-string": {
           "version": "4.0.0",
+          "bundled": true
+        },
+        "infer-owner": {
+          "version": "1.0.4",
           "bundled": true
         },
         "inflight": {
@@ -6097,20 +5524,20 @@
           "bundled": true
         },
         "ini": {
-          "version": "4.1.1",
+          "version": "3.0.1",
           "bundled": true
         },
         "init-package-json": {
-          "version": "5.0.0",
+          "version": "3.0.2",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^10.0.0",
-            "promzard": "^1.0.0",
-            "read": "^2.0.0",
-            "read-package-json": "^6.0.0",
+            "npm-package-arg": "^9.0.1",
+            "promzard": "^0.3.0",
+            "read": "^1.0.7",
+            "read-package-json": "^5.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
-            "validate-npm-package-name": "^5.0.0"
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "ip": {
@@ -6129,7 +5556,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.12.1",
+          "version": "2.10.0",
           "bundled": true,
           "requires": {
             "has": "^1.0.3"
@@ -6147,16 +5574,8 @@
           "version": "2.0.0",
           "bundled": true
         },
-        "jackspeak": {
-          "version": "2.2.1",
-          "bundled": true,
-          "requires": {
-            "@isaacs/cliui": "^8.0.2",
-            "@pkgjs/parseargs": "^0.11.0"
-          }
-        },
         "json-parse-even-better-errors": {
-          "version": "3.0.0",
+          "version": "2.3.1",
           "bundled": true
         },
         "json-stringify-nice": {
@@ -6168,184 +5587,179 @@
           "bundled": true
         },
         "just-diff": {
-          "version": "6.0.2",
+          "version": "5.1.1",
           "bundled": true
         },
         "just-diff-apply": {
-          "version": "5.5.0",
+          "version": "5.4.1",
           "bundled": true
         },
         "libnpmaccess": {
-          "version": "7.0.2",
+          "version": "6.0.4",
           "bundled": true,
           "requires": {
-            "npm-package-arg": "^10.1.0",
-            "npm-registry-fetch": "^14.0.3"
+            "aproba": "^2.0.0",
+            "minipass": "^3.1.1",
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmdiff": {
-          "version": "5.0.19",
+          "version": "4.0.5",
           "bundled": true,
           "requires": {
-            "@npmcli/arborist": "^6.3.0",
-            "@npmcli/disparity-colors": "^3.0.0",
-            "@npmcli/installed-package-contents": "^2.0.2",
+            "@npmcli/disparity-colors": "^2.0.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
             "binary-extensions": "^2.2.0",
             "diff": "^5.1.0",
-            "minimatch": "^9.0.0",
-            "npm-package-arg": "^10.1.0",
-            "pacote": "^15.0.8",
-            "tar": "^6.1.13"
+            "minimatch": "^5.0.1",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.6.1",
+            "tar": "^6.1.0"
           }
         },
         "libnpmexec": {
-          "version": "6.0.3",
+          "version": "4.0.14",
           "bundled": true,
           "requires": {
-            "@npmcli/arborist": "^6.3.0",
-            "@npmcli/run-script": "^6.0.0",
-            "ci-info": "^3.7.1",
-            "npm-package-arg": "^10.1.0",
-            "npmlog": "^7.0.1",
-            "pacote": "^15.0.8",
-            "proc-log": "^3.0.0",
-            "read": "^2.0.0",
-            "read-package-json-fast": "^3.0.2",
+            "@npmcli/arborist": "^5.6.3",
+            "@npmcli/ci-detect": "^2.0.0",
+            "@npmcli/fs": "^2.1.1",
+            "@npmcli/run-script": "^4.2.0",
+            "chalk": "^4.1.0",
+            "mkdirp-infer-owner": "^2.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npmlog": "^6.0.2",
+            "pacote": "^13.6.1",
+            "proc-log": "^2.0.0",
+            "read": "^1.0.7",
+            "read-package-json-fast": "^2.0.2",
             "semver": "^7.3.7",
-            "walk-up-path": "^3.0.1"
+            "walk-up-path": "^1.0.0"
           }
         },
         "libnpmfund": {
-          "version": "4.0.19",
+          "version": "3.0.5",
           "bundled": true,
           "requires": {
-            "@npmcli/arborist": "^6.3.0"
+            "@npmcli/arborist": "^5.6.3"
           }
         },
         "libnpmhook": {
-          "version": "9.0.3",
+          "version": "8.0.4",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^14.0.3"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmorg": {
-          "version": "5.0.4",
+          "version": "4.0.4",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^14.0.3"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmpack": {
-          "version": "5.0.19",
+          "version": "4.1.3",
           "bundled": true,
           "requires": {
-            "@npmcli/arborist": "^6.3.0",
-            "@npmcli/run-script": "^6.0.0",
-            "npm-package-arg": "^10.1.0",
-            "pacote": "^15.0.8"
+            "@npmcli/run-script": "^4.1.3",
+            "npm-package-arg": "^9.0.1",
+            "pacote": "^13.6.1"
           }
         },
         "libnpmpublish": {
-          "version": "7.5.0",
+          "version": "6.0.5",
           "bundled": true,
           "requires": {
-            "ci-info": "^3.6.1",
-            "normalize-package-data": "^5.0.0",
-            "npm-package-arg": "^10.1.0",
-            "npm-registry-fetch": "^14.0.3",
-            "proc-log": "^3.0.0",
+            "normalize-package-data": "^4.0.0",
+            "npm-package-arg": "^9.0.1",
+            "npm-registry-fetch": "^13.0.0",
             "semver": "^7.3.7",
-            "sigstore": "^1.4.0",
-            "ssri": "^10.0.1"
+            "ssri": "^9.0.0"
           }
         },
         "libnpmsearch": {
-          "version": "6.0.2",
+          "version": "5.0.4",
           "bundled": true,
           "requires": {
-            "npm-registry-fetch": "^14.0.3"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmteam": {
-          "version": "5.0.3",
+          "version": "4.0.4",
           "bundled": true,
           "requires": {
             "aproba": "^2.0.0",
-            "npm-registry-fetch": "^14.0.3"
+            "npm-registry-fetch": "^13.0.0"
           }
         },
         "libnpmversion": {
-          "version": "4.0.2",
+          "version": "3.0.7",
           "bundled": true,
           "requires": {
-            "@npmcli/git": "^4.0.1",
-            "@npmcli/run-script": "^6.0.0",
-            "json-parse-even-better-errors": "^3.0.0",
-            "proc-log": "^3.0.0",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/run-script": "^4.1.3",
+            "json-parse-even-better-errors": "^2.3.1",
+            "proc-log": "^2.0.0",
             "semver": "^7.3.7"
           }
         },
         "lru-cache": {
-          "version": "7.18.3",
+          "version": "7.13.2",
           "bundled": true
         },
         "make-fetch-happen": {
-          "version": "11.1.1",
+          "version": "10.2.1",
           "bundled": true,
           "requires": {
             "agentkeepalive": "^4.2.1",
-            "cacache": "^17.0.0",
-            "http-cache-semantics": "^4.1.1",
+            "cacache": "^16.1.0",
+            "http-cache-semantics": "^4.1.0",
             "http-proxy-agent": "^5.0.0",
             "https-proxy-agent": "^5.0.0",
             "is-lambda": "^1.0.1",
             "lru-cache": "^7.7.1",
-            "minipass": "^5.0.0",
-            "minipass-fetch": "^3.0.0",
+            "minipass": "^3.1.6",
+            "minipass-collect": "^1.0.2",
+            "minipass-fetch": "^2.0.3",
             "minipass-flush": "^1.0.5",
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.3",
             "promise-retry": "^2.0.1",
             "socks-proxy-agent": "^7.0.0",
-            "ssri": "^10.0.0"
+            "ssri": "^9.0.0"
           }
         },
         "minimatch": {
-          "version": "9.0.3",
+          "version": "5.1.0",
           "bundled": true,
           "requires": {
             "brace-expansion": "^2.0.1"
           }
         },
         "minipass": {
-          "version": "5.0.0",
-          "bundled": true
+          "version": "3.3.4",
+          "bundled": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
         },
         "minipass-collect": {
           "version": "1.0.2",
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
           }
         },
         "minipass-fetch": {
-          "version": "3.0.3",
+          "version": "2.1.1",
           "bundled": true,
           "requires": {
             "encoding": "^0.1.13",
-            "minipass": "^5.0.0",
+            "minipass": "^3.1.6",
             "minipass-sized": "^1.0.3",
             "minizlib": "^2.1.2"
           }
@@ -6355,15 +5769,6 @@
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
           }
         },
         "minipass-json-stream": {
@@ -6372,15 +5777,6 @@
           "requires": {
             "jsonparse": "^1.3.1",
             "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
           }
         },
         "minipass-pipeline": {
@@ -6388,15 +5784,6 @@
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
           }
         },
         "minipass-sized": {
@@ -6404,15 +5791,6 @@
           "bundled": true,
           "requires": {
             "minipass": "^3.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
           }
         },
         "minizlib": {
@@ -6421,27 +5799,27 @@
           "requires": {
             "minipass": "^3.0.0",
             "yallist": "^4.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "3.3.6",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            }
           }
         },
         "mkdirp": {
           "version": "1.0.4",
           "bundled": true
         },
+        "mkdirp-infer-owner": {
+          "version": "2.0.0",
+          "bundled": true,
+          "requires": {
+            "chownr": "^2.0.0",
+            "infer-owner": "^1.0.4",
+            "mkdirp": "^1.0.3"
+          }
+        },
         "ms": {
           "version": "2.1.3",
           "bundled": true
         },
         "mute-stream": {
-          "version": "1.0.0",
+          "version": "0.0.8",
           "bundled": true
         },
         "negotiator": {
@@ -6449,15 +5827,14 @@
           "bundled": true
         },
         "node-gyp": {
-          "version": "9.4.0",
+          "version": "9.1.0",
           "bundled": true,
           "requires": {
             "env-paths": "^2.2.0",
-            "exponential-backoff": "^3.1.1",
             "glob": "^7.1.4",
             "graceful-fs": "^4.2.6",
-            "make-fetch-happen": "^11.0.3",
-            "nopt": "^6.0.0",
+            "make-fetch-happen": "^10.0.3",
+            "nopt": "^5.0.0",
             "npmlog": "^6.0.0",
             "rimraf": "^3.0.2",
             "semver": "^7.3.5",
@@ -6465,38 +5842,12 @@
             "which": "^2.0.2"
           },
           "dependencies": {
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "are-we-there-yet": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-              }
-            },
-            "gauge": {
-              "version": "4.0.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.3",
-                "console-control-strings": "^1.1.0",
-                "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.5"
               }
             },
             "glob": {
@@ -6519,142 +5870,136 @@
               }
             },
             "nopt": {
-              "version": "6.0.0",
+              "version": "5.0.0",
               "bundled": true,
               "requires": {
-                "abbrev": "^1.0.0"
-              }
-            },
-            "npmlog": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "are-we-there-yet": "^3.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^4.0.3",
-                "set-blocking": "^2.0.0"
-              }
-            },
-            "readable-stream": {
-              "version": "3.6.2",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "signal-exit": {
-              "version": "3.0.7",
-              "bundled": true
-            },
-            "which": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "isexe": "^2.0.0"
+                "abbrev": "1"
               }
             }
           }
         },
         "nopt": {
-          "version": "7.2.0",
+          "version": "6.0.0",
           "bundled": true,
           "requires": {
-            "abbrev": "^2.0.0"
+            "abbrev": "^1.0.0"
           }
         },
         "normalize-package-data": {
-          "version": "5.0.0",
+          "version": "4.0.1",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^6.0.0",
+            "hosted-git-info": "^5.0.0",
             "is-core-module": "^2.8.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4"
           }
         },
         "npm-audit-report": {
-          "version": "5.0.0",
-          "bundled": true
-        },
-        "npm-bundled": {
           "version": "3.0.0",
           "bundled": true,
           "requires": {
-            "npm-normalize-package-bin": "^3.0.0"
+            "chalk": "^4.0.0"
+          }
+        },
+        "npm-bundled": {
+          "version": "2.0.1",
+          "bundled": true,
+          "requires": {
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true
+            }
           }
         },
         "npm-install-checks": {
-          "version": "6.1.1",
+          "version": "5.0.0",
           "bundled": true,
           "requires": {
             "semver": "^7.1.1"
           }
         },
         "npm-normalize-package-bin": {
-          "version": "3.0.1",
+          "version": "1.0.1",
           "bundled": true
         },
         "npm-package-arg": {
-          "version": "10.1.0",
+          "version": "9.1.0",
           "bundled": true,
           "requires": {
-            "hosted-git-info": "^6.0.0",
-            "proc-log": "^3.0.0",
+            "hosted-git-info": "^5.0.0",
+            "proc-log": "^2.0.1",
             "semver": "^7.3.5",
-            "validate-npm-package-name": "^5.0.0"
+            "validate-npm-package-name": "^4.0.0"
           }
         },
         "npm-packlist": {
-          "version": "7.0.4",
+          "version": "5.1.3",
           "bundled": true,
           "requires": {
-            "ignore-walk": "^6.0.0"
+            "glob": "^8.0.1",
+            "ignore-walk": "^5.0.1",
+            "npm-bundled": "^2.0.0",
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true
+            }
           }
         },
         "npm-pick-manifest": {
-          "version": "8.0.1",
+          "version": "7.0.2",
           "bundled": true,
           "requires": {
-            "npm-install-checks": "^6.0.0",
-            "npm-normalize-package-bin": "^3.0.0",
-            "npm-package-arg": "^10.0.0",
+            "npm-install-checks": "^5.0.0",
+            "npm-normalize-package-bin": "^2.0.0",
+            "npm-package-arg": "^9.0.0",
             "semver": "^7.3.5"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true
+            }
           }
         },
         "npm-profile": {
-          "version": "7.0.1",
+          "version": "6.2.1",
           "bundled": true,
           "requires": {
-            "npm-registry-fetch": "^14.0.0",
-            "proc-log": "^3.0.0"
+            "npm-registry-fetch": "^13.0.1",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-registry-fetch": {
-          "version": "14.0.5",
+          "version": "13.3.1",
           "bundled": true,
           "requires": {
-            "make-fetch-happen": "^11.0.0",
-            "minipass": "^5.0.0",
-            "minipass-fetch": "^3.0.0",
+            "make-fetch-happen": "^10.0.6",
+            "minipass": "^3.1.6",
+            "minipass-fetch": "^2.0.3",
             "minipass-json-stream": "^1.0.1",
             "minizlib": "^2.1.2",
-            "npm-package-arg": "^10.0.0",
-            "proc-log": "^3.0.0"
+            "npm-package-arg": "^9.0.1",
+            "proc-log": "^2.0.0"
           }
         },
         "npm-user-validate": {
-          "version": "2.0.0",
+          "version": "1.0.1",
           "bundled": true
         },
         "npmlog": {
-          "version": "7.0.1",
+          "version": "6.0.2",
           "bundled": true,
           "requires": {
-            "are-we-there-yet": "^4.0.0",
+            "are-we-there-yet": "^3.0.0",
             "console-control-strings": "^1.1.0",
-            "gauge": "^5.0.0",
+            "gauge": "^4.0.3",
             "set-blocking": "^2.0.0"
           }
         },
@@ -6665,6 +6010,10 @@
             "wrappy": "1"
           }
         },
+        "opener": {
+          "version": "1.5.2",
+          "bundled": true
+        },
         "p-map": {
           "version": "4.0.0",
           "bundled": true,
@@ -6673,35 +6022,38 @@
           }
         },
         "pacote": {
-          "version": "15.2.0",
+          "version": "13.6.2",
           "bundled": true,
           "requires": {
-            "@npmcli/git": "^4.0.0",
-            "@npmcli/installed-package-contents": "^2.0.1",
-            "@npmcli/promise-spawn": "^6.0.1",
-            "@npmcli/run-script": "^6.0.0",
-            "cacache": "^17.0.0",
-            "fs-minipass": "^3.0.0",
-            "minipass": "^5.0.0",
-            "npm-package-arg": "^10.0.0",
-            "npm-packlist": "^7.0.0",
-            "npm-pick-manifest": "^8.0.0",
-            "npm-registry-fetch": "^14.0.0",
-            "proc-log": "^3.0.0",
+            "@npmcli/git": "^3.0.0",
+            "@npmcli/installed-package-contents": "^1.0.7",
+            "@npmcli/promise-spawn": "^3.0.0",
+            "@npmcli/run-script": "^4.1.0",
+            "cacache": "^16.0.0",
+            "chownr": "^2.0.0",
+            "fs-minipass": "^2.1.0",
+            "infer-owner": "^1.0.4",
+            "minipass": "^3.1.6",
+            "mkdirp": "^1.0.4",
+            "npm-package-arg": "^9.0.0",
+            "npm-packlist": "^5.1.0",
+            "npm-pick-manifest": "^7.0.0",
+            "npm-registry-fetch": "^13.0.1",
+            "proc-log": "^2.0.0",
             "promise-retry": "^2.0.1",
-            "read-package-json": "^6.0.0",
-            "read-package-json-fast": "^3.0.0",
-            "sigstore": "^1.3.0",
-            "ssri": "^10.0.0",
+            "read-package-json": "^5.0.0",
+            "read-package-json-fast": "^2.0.3",
+            "rimraf": "^3.0.2",
+            "ssri": "^9.0.0",
             "tar": "^6.1.11"
           }
         },
         "parse-conflict-json": {
-          "version": "3.0.1",
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
-            "json-parse-even-better-errors": "^3.0.0",
-            "just-diff": "^6.0.0",
+            "json-parse-even-better-errors": "^2.3.1",
+            "just-diff": "^5.0.1",
             "just-diff-apply": "^5.2.0"
           }
         },
@@ -6709,26 +6061,8 @@
           "version": "1.0.1",
           "bundled": true
         },
-        "path-key": {
-          "version": "3.1.1",
-          "bundled": true
-        },
-        "path-scurry": {
-          "version": "1.9.2",
-          "bundled": true,
-          "requires": {
-            "lru-cache": "^9.1.1",
-            "minipass": "^5.0.0 || ^6.0.2"
-          },
-          "dependencies": {
-            "lru-cache": {
-              "version": "9.1.1",
-              "bundled": true
-            }
-          }
-        },
         "postcss-selector-parser": {
-          "version": "6.0.13",
+          "version": "6.0.10",
           "bundled": true,
           "requires": {
             "cssesc": "^3.0.0",
@@ -6736,11 +6070,7 @@
           }
         },
         "proc-log": {
-          "version": "3.0.0",
-          "bundled": true
-        },
-        "process": {
-          "version": "0.11.10",
+          "version": "2.0.1",
           "bundled": true
         },
         "promise-all-reject-late": {
@@ -6748,7 +6078,7 @@
           "bundled": true
         },
         "promise-call-limit": {
-          "version": "1.0.2",
+          "version": "1.0.1",
           "bundled": true
         },
         "promise-inflight": {
@@ -6764,10 +6094,10 @@
           }
         },
         "promzard": {
-          "version": "1.0.0",
+          "version": "0.3.0",
           "bundled": true,
           "requires": {
-            "read": "^2.0.0"
+            "read": "1"
           }
         },
         "qrcode-terminal": {
@@ -6775,42 +6105,57 @@
           "bundled": true
         },
         "read": {
-          "version": "2.1.0",
+          "version": "1.0.7",
           "bundled": true,
           "requires": {
-            "mute-stream": "~1.0.0"
+            "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
-          "version": "4.0.0",
+          "version": "3.0.0",
           "bundled": true
         },
         "read-package-json": {
-          "version": "6.0.4",
+          "version": "5.0.2",
           "bundled": true,
           "requires": {
-            "glob": "^10.2.2",
-            "json-parse-even-better-errors": "^3.0.0",
-            "normalize-package-data": "^5.0.0",
-            "npm-normalize-package-bin": "^3.0.0"
+            "glob": "^8.0.1",
+            "json-parse-even-better-errors": "^2.3.1",
+            "normalize-package-data": "^4.0.0",
+            "npm-normalize-package-bin": "^2.0.0"
+          },
+          "dependencies": {
+            "npm-normalize-package-bin": {
+              "version": "2.0.0",
+              "bundled": true
+            }
           }
         },
         "read-package-json-fast": {
-          "version": "3.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "requires": {
-            "json-parse-even-better-errors": "^3.0.0",
-            "npm-normalize-package-bin": "^3.0.0"
+            "json-parse-even-better-errors": "^2.3.0",
+            "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "readable-stream": {
-          "version": "4.4.0",
+          "version": "3.6.0",
           "bundled": true,
           "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "readdir-scoped-modules": {
+          "version": "1.1.0",
+          "bundled": true,
+          "requires": {
+            "debuglog": "^1.0.1",
+            "dezalgo": "^1.0.0",
+            "graceful-fs": "^4.1.2",
+            "once": "^1.3.0"
           }
         },
         "retry": {
@@ -6863,7 +6208,7 @@
           "optional": true
         },
         "semver": {
-          "version": "7.5.4",
+          "version": "7.3.7",
           "bundled": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -6882,36 +6227,16 @@
           "version": "2.0.0",
           "bundled": true
         },
-        "shebang-command": {
-          "version": "2.0.0",
-          "bundled": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "bundled": true
-        },
         "signal-exit": {
-          "version": "4.0.2",
+          "version": "3.0.7",
           "bundled": true
-        },
-        "sigstore": {
-          "version": "1.7.0",
-          "bundled": true,
-          "requires": {
-            "@sigstore/protobuf-specs": "^0.1.0",
-            "@sigstore/tuf": "^1.0.1",
-            "make-fetch-happen": "^11.0.1"
-          }
         },
         "smart-buffer": {
           "version": "4.2.0",
           "bundled": true
         },
         "socks": {
-          "version": "2.7.1",
+          "version": "2.7.0",
           "bundled": true,
           "requires": {
             "ip": "^2.0.0",
@@ -6928,7 +6253,7 @@
           }
         },
         "spdx-correct": {
-          "version": "3.2.0",
+          "version": "3.1.1",
           "bundled": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -6948,14 +6273,14 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.13",
+          "version": "3.0.11",
           "bundled": true
         },
         "ssri": {
-          "version": "10.0.4",
+          "version": "9.0.1",
           "bundled": true,
           "requires": {
-            "minipass": "^5.0.0"
+            "minipass": "^3.1.1"
           }
         },
         "string_decoder": {
@@ -6974,15 +6299,6 @@
             "strip-ansi": "^6.0.1"
           }
         },
-        "string-width-cjs": {
-          "version": "npm:string-width@4.2.3",
-          "bundled": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
         "strip-ansi": {
           "version": "6.0.1",
           "bundled": true,
@@ -6990,45 +6306,23 @@
             "ansi-regex": "^5.0.1"
           }
         },
-        "strip-ansi-cjs": {
-          "version": "npm:strip-ansi@6.0.1",
+        "supports-color": {
+          "version": "7.2.0",
           "bundled": true,
           "requires": {
-            "ansi-regex": "^5.0.1"
+            "has-flag": "^4.0.0"
           }
         },
-        "supports-color": {
-          "version": "9.4.0",
-          "bundled": true
-        },
         "tar": {
-          "version": "6.1.15",
+          "version": "6.1.11",
           "bundled": true,
           "requires": {
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
-            "minipass": "^5.0.0",
+            "minipass": "^3.0.0",
             "minizlib": "^2.1.1",
             "mkdirp": "^1.0.3",
             "yallist": "^4.0.0"
-          },
-          "dependencies": {
-            "fs-minipass": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.0.0"
-              },
-              "dependencies": {
-                "minipass": {
-                  "version": "3.3.6",
-                  "bundled": true,
-                  "requires": {
-                    "yallist": "^4.0.0"
-                  }
-                }
-              }
-            }
           }
         },
         "text-table": {
@@ -7040,27 +6334,18 @@
           "bundled": true
         },
         "treeverse": {
-          "version": "3.0.0",
+          "version": "2.0.0",
           "bundled": true
         },
-        "tuf-js": {
-          "version": "1.1.7",
-          "bundled": true,
-          "requires": {
-            "@tufjs/models": "1.0.4",
-            "debug": "^4.3.4",
-            "make-fetch-happen": "^11.1.1"
-          }
-        },
         "unique-filename": {
-          "version": "3.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "requires": {
-            "unique-slug": "^4.0.0"
+            "unique-slug": "^3.0.0"
           }
         },
         "unique-slug": {
-          "version": "4.0.0",
+          "version": "3.0.0",
           "bundled": true,
           "requires": {
             "imurmurhash": "^0.1.4"
@@ -7079,14 +6364,14 @@
           }
         },
         "validate-npm-package-name": {
-          "version": "5.0.0",
+          "version": "4.0.0",
           "bundled": true,
           "requires": {
             "builtins": "^5.0.0"
           }
         },
         "walk-up-path": {
-          "version": "3.0.1",
+          "version": "1.0.0",
           "bundled": true
         },
         "wcwidth": {
@@ -7097,7 +6382,7 @@
           }
         },
         "which": {
-          "version": "3.0.1",
+          "version": "2.0.2",
           "bundled": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -7110,64 +6395,16 @@
             "string-width": "^1.0.2 || 2 || 3 || 4"
           }
         },
-        "wrap-ansi": {
-          "version": "8.1.0",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^6.1.0",
-            "string-width": "^5.0.1",
-            "strip-ansi": "^7.0.1"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "6.0.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "6.2.1",
-              "bundled": true
-            },
-            "emoji-regex": {
-              "version": "9.2.2",
-              "bundled": true
-            },
-            "string-width": {
-              "version": "5.1.2",
-              "bundled": true,
-              "requires": {
-                "eastasianwidth": "^0.2.0",
-                "emoji-regex": "^9.2.2",
-                "strip-ansi": "^7.0.1"
-              }
-            },
-            "strip-ansi": {
-              "version": "7.1.0",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^6.0.1"
-              }
-            }
-          }
-        },
-        "wrap-ansi-cjs": {
-          "version": "npm:wrap-ansi@7.0.0",
-          "bundled": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
         "wrappy": {
           "version": "1.0.2",
           "bundled": true
         },
         "write-file-atomic": {
-          "version": "5.0.1",
+          "version": "4.0.2",
           "bundled": true,
           "requires": {
             "imurmurhash": "^0.1.4",
-            "signal-exit": "^4.0.1"
+            "signal-exit": "^3.0.7"
           }
         },
         "yallist": {

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -19,7 +19,8 @@
   },
   "pkg": {
     "scripts": [
-      "node_modules/npm/src/**/*.js"
+      "node_modules/npm/lib/*.js",
+      "node_modules/npm/lib/**/*.js"
     ],
     "assets": [
       "node_modules/.bin/**",


### PR DESCRIPTION
### Description

Fix `npm` packaging for standalone `firebase` (firepit) version. Although #6300 somewhat fixed #6132, all npm subcommands are still broken in `12.5.4`. This PR updates the `pkg` configuration to include the correct js files for these npm commands.

This may affect function deploys and other parts of `firebase-tools` that depend on `npm`, though I haven't tested this.

### Scenarios Tested

## Before
Running `firebase is:npm version` yields:
```
npm ERR! code MODULE_NOT_FOUND
npm ERR! Cannot find module './commands/version.js'
npm ERR! Require stack:
npm ERR! - /snapshot/firepit/node_modules/npm/lib/npm.js
npm ERR! - /snapshot/firepit/node_modules/npm/lib/cli.js
npm ERR! - /snapshot/firepit/node_modules/npm/bin/npm-cli.js
npm ERR! 1) If you want to compile the package/file into executable, please pay attention to compilation warnings and specify a literal in 'require' call. 2) If you don't want to compile the package/file into executable and want to 'require' it from filesystem (likely plugin), specify an absolute path in 'require' call using process.cwd() or process.execPath.
```

## After
Running `firebase is:npm version` yields:
```
firebase-tools-macos is:npm version
{
  cloud_build: '1.0.0',
  npm: '8.19.4',
  node: '18.5.0',
  v8: '10.2.154.4-node.8',
  uv: '1.43.0',
  zlib: '1.2.11',
  brotli: '1.0.9',
  ares: '1.18.1',
  modules: '108',
  nghttp2: '1.47.0',
  napi: '8',
  llhttp: '6.0.7',
  openssl: '3.0.5+quic',
  cldr: '41.0',
  icu: '71.1',
  tz: '2022a',
  unicode: '14.0',
  ngtcp2: '0.1.0-DEV',
  nghttp3: '0.1.0-DEV',
  pkg: '5.8.1'
}
```
