### PR TITLE
fix `npm root` issues during Next.js build

### DIFF
--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -24,7 +24,7 @@ import { BUILD_TARGET_PURPOSE, RequestHandler } from "./interfaces";
 // the import statement into a require
 const { dynamicImport } = require(true && "../dynamicImport");
 
-const NPM_ROOT_TIMEOUT_MILLIES = 2_000;
+const NPM_ROOT_TIMEOUT_MILLIES = 5_000;
 
 /**
  * Whether the given string starts with http:// or https://

--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -25,6 +25,7 @@ import { BUILD_TARGET_PURPOSE, RequestHandler } from "./interfaces";
 const { dynamicImport } = require(true && "../dynamicImport");
 
 const NPM_ROOT_TIMEOUT_MILLIES = 5_000;
+const NPM_ROOT_MEMO = new Map<string, string>();
 
 /**
  * Whether the given string starts with http:// or https://
@@ -222,9 +223,19 @@ function scanDependencyTree(searchingFor: string, dependencies = {}): any {
 }
 
 export function getNpmRoot(cwd: string) {
-  return spawnSync("npm", ["root"], { cwd, timeout: NPM_ROOT_TIMEOUT_MILLIES })
+  let npmRoot = NPM_ROOT_MEMO.get(cwd);
+  if (npmRoot) return npmRoot;
+
+  npmRoot = spawnSync("npm", ["root"], {
+    cwd,
+    timeout: NPM_ROOT_TIMEOUT_MILLIES,
+  })
     .stdout?.toString()
     .trim();
+
+  NPM_ROOT_MEMO.set(cwd, npmRoot);
+
+  return npmRoot;
 }
 
 export function getNodeModuleBin(name: string, cwd: string) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Should fix #6173.

Depending on the user computer, `npm root` can take more than 2 seconds. This PR increases the timeout to 5 seconds and memoize the returned value for subsequent calls. This also reduces the build time on `deploy` as `npm root` runs multiple times during a single build.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

I was only able to reproduce #6173 on my Windows laptop as the CPU is way slower.

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

`firebase deploy`

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
