### PR TITLE
Better logging when nonJSON errors are returned

### DIFF
--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -407,7 +407,7 @@ export class Client {
               } catch (err: unknown) {
                 // JSON-parse errors are useless. Log the response for better debugging.
                 // Force skipBody to false
-                this.logResponse(res, text, {...options, skipLog: {}});
+                this.logResponse(res, text, { ...options, skipLog: {} });
                 throw new FirebaseError(`Unable to parse JSON: ${err}`);
               }
             }

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -406,7 +406,8 @@ export class Client {
                 body = JSON.parse(text) as ResT;
               } catch (err: unknown) {
                 // JSON-parse errors are useless. Log the response for better debugging.
-                this.logResponse(res, text, options);
+                // Force skipBody to false
+                this.logResponse(res, text, {...options, skipLog: {}});
                 throw new FirebaseError(`Unable to parse JSON: ${err}`);
               }
             }


### PR DESCRIPTION
### Description
Better logging when non-JSON errors are returned on calls expecting JSON responses.

In some cases (usually related to auth or restricted regions), API calls are rejected by GFE and an HtML response is returned instead of the expected JSON (ie #6381). In these cases, let's force the full body to be printed in debug logs so that we can help users more easily.

