### PR TITLE
Fix Issue #6382 Firebase not working for NextJs >=v13.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed an issue where `emulators:export` did not check if the target folder is empty. (#6313)
-- Fix "Could not find the next executable" on Next.js deployments (#6372)
+- Fixed "Could not find the next executable" on Next.js deployments (#6372)
+- Fixed issues caused by breaking changes in Next >=v13.5.0. (#6382)

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -594,7 +594,7 @@ async function getConfig(
     if (gte(version, "12.0.0")) {
       const { default: loadConfig } = relativeRequire(dir, "next/dist/server/config");
       const { PHASE_PRODUCTION_BUILD } = relativeRequire(dir, "next/constants");
-      config = await loadConfig(PHASE_PRODUCTION_BUILD, dir, null);
+      config = await loadConfig(PHASE_PRODUCTION_BUILD, dir);
     } else {
       try {
         config = await import(pathToFileURL(join(dir, "next.config.js")).toString());


### PR DESCRIPTION
Copy of #6383 on a branch + a changelog.

Fixes https://github.com/firebase/firebase-tools/issues/6382

Due to braking changes on the signature of loadConfig (https://github.com/vercel/next.js/blob/d96e0258de2caf34e9322d0d32ab5748533c4465/packages/next/src/server/config.ts#L784) Firebase does not deploy correctly.

