### PR TITLE
Support non-ASCII file names in `appdistribution:distribute`

### DIFF
--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -92,7 +92,7 @@ export class AppDistributionClient {
       method: "POST",
       path: `/upload/v1/${appName}/releases:upload`,
       headers: {
-        "X-Goog-Upload-File-Name": distribution.getFileName(),
+        "X-Goog-Upload-File-Name": encodeURIComponent(distribution.getFileName()),
         "X-Goog-Upload-Protocol": "raw",
         "Content-Type": "application/octet-stream",
       },


### PR DESCRIPTION
### Description

Adds support for non-ASCII characters in app binary file names that are sent over the wire using the `X-Goog-Upload-File-Name` HTTP header.

Leverages `encodeURIComponent` to encode the file name.
