### PR TITLE
Correctly set FUNCTION_TARGET for grouped functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,1 @@
-- Improve performance and reliability when deploying multiple 2nd gen functions using single builds. (#6376)
-- Fixed an issue where `emulators:export` did not check if the target folder is empty. (#6313)
-- Fixed an issue where retry could not be set for event triggered functions. (#6391)
-- Fixed "Could not find the next executable" on Next.js deployments (#6372)
-- Fixed issues caused by breaking changes in Next >=v13.5.0. (#6382)
+- Fixed an issue with deploying function groups containing v2 functions. (#6408)

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -331,7 +331,7 @@ export async function createFunction(cloudFunction: InputCloudFunction): Promise
 
   cloudFunction.serviceConfig.environmentVariables = {
     ...cloudFunction.serviceConfig.environmentVariables,
-    FUNCTION_TARGET: functionId,
+    FUNCTION_TARGET: functionId.replace("-", "."),
   };
 
   try {
@@ -439,7 +439,7 @@ export async function updateFunction(cloudFunction: InputCloudFunction): Promise
 
   cloudFunction.serviceConfig.environmentVariables = {
     ...cloudFunction.serviceConfig.environmentVariables,
-    FUNCTION_TARGET: functionId,
+    FUNCTION_TARGET: functionId.replace("-", "."),
   };
 
   try {


### PR DESCRIPTION

### Description
Fixed an issue where we were setting the wrong FUNCTION_TARGET for grouped functions. Fixes #6408

### Scenarios Tested

I was able to repro the original issue & confirmed that the fix worked, using this following steps: 

Steps to reproduce the issue:
1. Run `firebase init functions --project <project_id>`
2. Select “Typescript”
3. Copy the code snippet provided by author to `index.ts` file:
```ts
import { onRequest } from 'firebase-functions/v2/https'

export const Hello = {
  world: onRequest((req, res) => {
    res.send('Hello World')
  })
}
```
4. Run `firebase deploy --only functions`
