### PR TITLE
Revert "Use default bucket api"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixed an issue cuasing errors due to incorrectly formatted Storage bucket data during functions deployments. (#6416)
+- Fixed an issue causing errors due to incorrectly formatted Storage bucket data during functions deployments. (#6416)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue cuasing errors due to incorrectly formatted Storage bucket data during functions deployments. (#6416)

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -1,11 +1,11 @@
 import { Readable } from "stream";
 import * as path from "path";
 
-import { firebaseStorageOrigin, storageOrigin } from "../api";
+import { storageOrigin } from "../api";
 import { Client } from "../apiv2";
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
-import { ensure } from "../ensureApiEnabled";
+import { getFirebaseProject } from "../management/projects";
 
 /** Bucket Interface */
 interface BucketResponse {
@@ -140,22 +140,18 @@ interface StorageServiceAccountResponse {
 }
 
 export async function getDefaultBucket(projectId: string): Promise<string> {
-  await ensure(projectId, "firebasestorage.googleapis.com", "storage", false);
   try {
-    const localAPIClient = new Client({ urlPrefix: firebaseStorageOrigin, apiVersion: "v1alpha" });
-    const response = await localAPIClient.get<{ name: string }>(
-      `/projects/${projectId}/defaultBucket`
-    );
-    if (!response.body?.name) {
+    const metadata = await getFirebaseProject(projectId);
+    if (!metadata.resources?.storageBucket) {
       logger.debug("Default storage bucket is undefined.");
       throw new FirebaseError(
         "Your project is being set up. Please wait a minute before deploying again."
       );
     }
-    return response.body.name;
+    return metadata.resources.storageBucket;
   } catch (err: any) {
     logger.info(
-      "\n\nThere was an issue deploying your Storage rules. Verify that your project has a Google App Engine instance setup at https://console.cloud.google.com/appengine and try again. If this issue persists, please contact support."
+      "\n\nThere was an issue deploying your functions. Verify that your project has a Google App Engine instance setup at https://console.cloud.google.com/appengine and try again. If this issue persists, please contact support."
     );
     throw err;
   }


### PR DESCRIPTION
Reverts firebase/firebase-tools#6406 - fixes #6416.

Turns out this API returns buckets in a different format than the old one.