### PR TITLE
Use correct bucket name field when reading DefaultBucket for storage

### DIFF
--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -133,6 +133,14 @@ interface ListBucketsResponse {
   ];
 }
 
+interface GetDefaultBucketResponse {
+  name: string;
+  location: string;
+  bucket: {
+    name: string;
+  };
+}
+
 /** Response type for obtaining the storage service agent */
 interface StorageServiceAccountResponse {
   email_address: string;
@@ -143,19 +151,19 @@ export async function getDefaultBucket(projectId: string): Promise<string> {
   await ensure(projectId, "firebasestorage.googleapis.com", "storage", false);
   try {
     const localAPIClient = new Client({ urlPrefix: firebaseStorageOrigin, apiVersion: "v1alpha" });
-    const response = await localAPIClient.get<{ name: string }>(
+    const response = await localAPIClient.get<GetDefaultBucketResponse>(
       `/projects/${projectId}/defaultBucket`
     );
-    if (!response.body?.name) {
+    if (!response.body?.bucket.name) {
       logger.debug("Default storage bucket is undefined.");
       throw new FirebaseError(
         "Your project is being set up. Please wait a minute before deploying again."
       );
     }
-    return response.body.name;
+    return response.body.bucket.name.split("/").pop()!;
   } catch (err: any) {
     logger.info(
-      "\n\nThere was an issue deploying your Storage rules. Verify that your project has a Google App Engine instance setup at https://console.cloud.google.com/appengine and try again. If this issue persists, please contact support."
+      "\n\nThere was an issue deploying your functions. Verify that your project has a Google App Engine instance setup at https://console.cloud.google.com/appengine and try again. If this issue persists, please contact support."
     );
     throw err;
   }


### PR DESCRIPTION
### Description

Use correct bucket name field when reading in DefaultBucket proto.

Here is the Default Bucket proto format: https://firebase.google.com/docs/reference/rest/storage/rest/v1alpha/projects.defaultBucket#DefaultBucket

This will return a string with a format "projects/X/buckets/X", which we then need to strip to the last part of the path which is just the bucket name to match the API behavior that already existed.

