### PR TITLE
Correctly set FUNCTION_TARGET for multilevel grouped functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue with deploying multilevel grouped functions containing v2 functions. (#6419)

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -331,7 +331,7 @@ export async function createFunction(cloudFunction: InputCloudFunction): Promise
 
   cloudFunction.serviceConfig.environmentVariables = {
     ...cloudFunction.serviceConfig.environmentVariables,
-    FUNCTION_TARGET: functionId.replace("-", "."),
+    FUNCTION_TARGET: functionId.replaceAll("-", "."),
   };
 
   try {
@@ -439,7 +439,7 @@ export async function updateFunction(cloudFunction: InputCloudFunction): Promise
 
   cloudFunction.serviceConfig.environmentVariables = {
     ...cloudFunction.serviceConfig.environmentVariables,
-    FUNCTION_TARGET: functionId.replace("-", "."),
+    FUNCTION_TARGET: functionId.replaceAll("-", "."),
   };
 
   try {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixed an issue where the `FUNCTION_TARGET` is incorrectly set for multilevel grouped functions. #6419 

In #6410, we added `.replace("-", ".")` to correctly set the `FUNCTION_TARGET`, but this only replaces the first instance of "-". If initial `functionId` is `codebase-trigger-trigger2`, this would result in `codebase.trigger-trigger2`

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1. Run `firebase init functions --project <project_id>`
2. Select “Typescript”
3. Copy the code snippet bellow to `index.ts` file:
```ts
import {onRequest} from "firebase-functions/v2/https";
import {onRequest as onRequestV1} from "firebase-functions/v1/https";
import {onDocumentWritten} from "firebase-functions/v2/firestore";
import {firestore} from "firebase-functions/v1";

const httpFuncv1 = onRequestV1((req, res) => {
  res.send("Hello World");
});

const httpFuncv2 = onRequest((req, res) => {
  res.send("Hello World");
});

const trigger1 = firestore.document("pets/{id}").onWrite((change, context) => {
  console.log(`pets: ${JSON.stringify(change)}`);
});

const trigger2 = onDocumentWritten("users/{id}", (event) => {
  console.log(`users: ${JSON.stringify(event)}`);
});

export const codebase = {
  httpFunc: {
    httpFuncv1,
    httpFuncv2,
  },
  trigger: {
    trigger1,
    trigger2,
  },
};

```
4. Run `firebase deploy --only functions`
