### PR TITLE
Allow enabling and disabling PITR on Firestore databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added support for enabling, disabling, and displaying Point In Time Recovery enablement state on Firestore databases (#6388)

--- a/src/commands/firestore-databases-create.ts
+++ b/src/commands/firestore-databases-create.ts
@@ -18,6 +18,10 @@ export const command = new Command("firestore:databases:create <database>")
     "--delete-protection <deleteProtectionState>",
     "Whether or not to prevent deletion of database, for example 'ENABLED' or 'DISABLED'. Default is 'DISABLED'"
   )
+  .option(
+    "--point-in-time-recovery <enablement>",
+    "Whether to enable the PITR feature on this database, for example 'ENABLED' or 'DISABLED'. Default is 'DISABLED'"
+  )
   .before(requirePermissions, ["datastore.databases.create"])
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (database: string, options: FirestoreOptions) => {
@@ -45,12 +49,28 @@ export const command = new Command("firestore:databases:create <database>")
         ? types.DatabaseDeleteProtectionState.ENABLED
         : types.DatabaseDeleteProtectionState.DISABLED;
 
+    if (
+      options.pointInTimeRecovery &&
+      options.pointInTimeRecovery !== types.PointInTimeRecoveryEnablementOption.ENABLED &&
+      options.pointInTimeRecovery !== types.PointInTimeRecoveryEnablementOption.DISABLED
+    ) {
+      logger.error(
+        "Invalid value for flag --point-in-time-recovery. See firebase firestore:databases:create --help for more info."
+      );
+      return;
+    }
+    const pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement =
+      options.pointInTimeRecovery === types.PointInTimeRecoveryEnablementOption.ENABLED
+        ? types.PointInTimeRecoveryEnablement.ENABLED
+        : types.PointInTimeRecoveryEnablement.DISABLED;
+
     const databaseResp: types.DatabaseResp = await api.createDatabase(
       options.project,
       database,
       options.location,
       type,
-      deleteProtectionState
+      deleteProtectionState,
+      pointInTimeRecoveryEnablement
     );
 
     if (options.json) {

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -105,10 +105,21 @@ export enum DatabaseDeleteProtectionState {
   DISABLED = "DELETE_PROTECTION_DISABLED",
 }
 
+export enum PointInTimeRecoveryEnablementOption {
+  ENABLED = "ENABLED",
+  DISABLED = "DISABLED",
+}
+
+export enum PointInTimeRecoveryEnablement {
+  ENABLED = "POINT_IN_TIME_RECOVERY_ENABLED",
+  DISABLED = "POINT_IN_TIME_RECOVERY_DISABLED",
+}
+
 export interface DatabaseReq {
   locationId?: string;
   type?: DatabaseType;
   deleteProtectionState?: DatabaseDeleteProtectionState;
+  pointInTimeRecoveryEnablement?: PointInTimeRecoveryEnablement;
 }
 
 export interface DatabaseResp {
@@ -122,5 +133,8 @@ export interface DatabaseResp {
   appEngineIntegrationMode: string;
   keyPrefix: string;
   deleteProtectionState: DatabaseDeleteProtectionState;
+  pointInTimeRecoveryEnablement: PointInTimeRecoveryEnablement;
   etag: string;
+  versionRetentionPeriod: string;
+  earliestVersionTime: string;
 }

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -321,7 +321,10 @@ export class FirestoreApi {
       ["Last Update Time", clc.yellow(database.updateTime)],
       ["Type", clc.yellow(database.type)],
       ["Location", clc.yellow(database.locationId)],
-      ["Delete Protection State", clc.yellow(database.deleteProtectionState)]
+      ["Delete Protection State", clc.yellow(database.deleteProtectionState)],
+      ["Point In Time Recovery", clc.yellow(database.pointInTimeRecoveryEnablement)],
+      ["Earliest Version Time", clc.yellow(database.earliestVersionTime)],
+      ["Version Retention Period", clc.yellow(database.versionRetentionPeriod)]
     );
     logger.info(table.toString());
   }
@@ -716,19 +719,22 @@ export class FirestoreApi {
    * @param locationId the id of the region the database will be created in
    * @param type FIRESTORE_NATIVE or DATASTORE_MODE
    * @param deleteProtectionState DELETE_PROTECTION_ENABLED or DELETE_PROTECTION_DISABLED
+   * @param pointInTimeRecoveryEnablement POINT_IN_TIME_RECOVERY_ENABLED or POINT_IN_TIME_RECOVERY_DISABLED
    */
   async createDatabase(
     project: string,
     databaseId: string,
     locationId: string,
     type: types.DatabaseType,
-    deleteProtectionState: types.DatabaseDeleteProtectionState
+    deleteProtectionState: types.DatabaseDeleteProtectionState,
+    pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement
   ): Promise<types.DatabaseResp> {
     const url = `/projects/${project}/databases`;
     const payload: types.DatabaseReq = {
       type,
       locationId,
       deleteProtectionState,
+      pointInTimeRecoveryEnablement,
     };
     const options = { queryParams: { databaseId: databaseId } };
     const res = await this.apiClient.post<types.DatabaseReq, { response?: types.DatabaseResp }>(
@@ -750,17 +756,20 @@ export class FirestoreApi {
    * @param databaseId the name of the Firestore Database
    * @param type FIRESTORE_NATIVE or DATASTORE_MODE
    * @param deleteProtectionState DELETE_PROTECTION_ENABLED or DELETE_PROTECTION_DISABLED
+   * @param pointInTimeRecoveryEnablement POINT_IN_TIME_RECOVERY_ENABLED or POINT_IN_TIME_RECOVERY_DISABLED
    */
   async updateDatabase(
     project: string,
     databaseId: string,
     type?: types.DatabaseType,
-    deleteProtectionState?: types.DatabaseDeleteProtectionState
+    deleteProtectionState?: types.DatabaseDeleteProtectionState,
+    pointInTimeRecoveryEnablement?: types.PointInTimeRecoveryEnablement
   ): Promise<types.DatabaseResp> {
     const url = `/projects/${project}/databases/${databaseId}`;
     const payload: types.DatabaseReq = {
       type,
       deleteProtectionState,
+      pointInTimeRecoveryEnablement,
     };
     const res = await this.apiClient.patch<types.DatabaseReq, { response?: types.DatabaseResp }>(
       url,

--- a/src/firestore/options.ts
+++ b/src/firestore/options.ts
@@ -16,4 +16,5 @@ export interface FirestoreOptions extends Options {
   location?: string;
   type?: types.DatabaseType;
   deleteProtection?: types.DatabaseDeleteProtectionStateOption;
+  pointInTimeRecoveryEnablement?: types.PointInTimeRecoveryEnablementOption;
 }


### PR DESCRIPTION
### Description

This lets the Firebase CLI view and manipulate the Point In Time Recovery (PITR) settings for Firestore databases.

Create and Update now both take a `--point-in-time-recovery` option, with `ENABLED` and `DISABLED` as valid choices, defaulting to disabled.

Get displays PITR settings as well.

### Scenarios Tested

* [x] Creating a new database with no options, PITR defaults to disabled
* [x] Creating a new database with PITR enabled
* [x] Creating a new database with PITR disabled
* [x] Fail to create a database because --point-in-time-recovery is misspelled
* [x] Fail to create a database because ENABLED/DISABLED is misspelled
* [x] Fail to create a database because PITR is enabled and billing is not
* [x] Updating a database without specifying PITR, it does not change
* [x] Updating a database with PITR enabled
* [x] Updating a database with PITR disabled
* [x] Fail to update a database because --point-in-time-recovery is misspelled
* [x] Fail to update a database because ENABLED/DISABLED is misspelled
* [x] Fail to update a database because no options to update were given
* [x] Fail to update a database because PITR will be enabled and billing is not
* [x] Get a database, it shows PITR enabled/disabled as appropriate


### Sample Commands

* `firebase firestore:databases:create 'db-to-create'` - as before, PITR defaults to disabled
* `firebase firestore:databases:create --point-in-time-recovery ENABLED 'db-to-create'`
* `firebase firestore:databases:create --point-in-time-recovery DISABLED 'db-to-create'`
* `firebase firestore:databases:update '(default)' --point-in-time-recovery ENABLED`
* `firebase firestore:databases:update '(default)' --point-in-time-recovery DISABLED`
