### PR TITLE
Ignore Firestore emulator host on functions deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Ignore Firestore emulator host on functions deploy. (#6442)
 - Added support for enabling, disabling, and displaying Point In Time Recovery enablement state on Firestore databases (#6388)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-- Ignore Firestore emulator host on functions deploy. (#6442)
+- Ignore `FIRESTORE_EMULATOR_HOST` environment variable on functions deploy. (#6442)
 - Added support for enabling, disabling, and displaying Point In Time Recovery enablement state on Firestore databases (#6388)

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -1,11 +1,11 @@
-import { firestoreOriginOrEmulator } from "../api";
+import { firestoreOrigin } from "../api";
 import { Client } from "../apiv2";
 import { logger } from "../logger";
 
 const apiClient = new Client({
   auth: true,
   apiVersion: "v1",
-  urlPrefix: firestoreOriginOrEmulator,
+  urlPrefix: firestoreOrigin,
 });
 
 interface Database {


### PR DESCRIPTION
Some users were running into an error at functions deploy time due to their `FIRESTORE_EMULATOR_HOST` environment variable being set. The deploy logic should not be reading the emulator host environment variable; this PR fixes the issue by only checking the Firestore origin host URL on deploys.

Fixes https://github.com/firebase/firebase-tools/issues/6364.