### PR TITLE
Add python 3.12 to firebase functions runtimes.

### DIFF
--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -15,6 +15,7 @@ const RUNTIMES: string[] = [
   "nodejs20",
   "python310",
   "python311",
+  "python312",
 ];
 // Experimental runtimes are part of the Runtime type, but are in a
 // different list to help guard against some day accidentally iterating over
@@ -47,6 +48,7 @@ const MESSAGE_FRIENDLY_RUNTIMES: Record<Runtime | DeprecatedRuntime, string> = {
   nodejs20: "Node.js 20",
   python310: "Python 3.10",
   python311: "Python 3.11",
+  python312: "Python 3.12 (Preview)",
 };
 
 /**

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -13,7 +13,7 @@ import { DEFAULT_VENV_DIR, runWithVirtualEnv, virtualEnvCmd } from "../../../../
 import { FirebaseError } from "../../../../error";
 import { Build } from "../../build";
 
-export const LATEST_VERSION: runtimes.Runtime = "python311";
+export const LATEST_VERSION: runtimes.Runtime = "python312";
 
 /**
  * Create a runtime delegate for the Python runtime, if applicable.
@@ -47,12 +47,12 @@ export function getPythonBinary(runtime: runtimes.Runtime): string {
     // There is no easy way to get specific version of python executable in Windows.
     return "python.exe";
   }
-  if (runtime === "python310") {
-    return "python3.10";
-  } else if (runtime === "python311") {
-    return "python3.11";
-  }
-  return "python";
+  const binaryMap: Record<string, string> = {
+    python310: "python3.10",
+    python311: "python3.11",
+    python312: "python3.12",
+  };
+  return binaryMap[runtime] ?? "python";
 }
 
 export class Delegate implements runtimes.RuntimeDelegate {

--- a/src/test/deploy/functions/runtimes/python/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/python/index.spec.ts
@@ -28,7 +28,7 @@ describe("PythonDelegate", () => {
 
     it("returns generic python binary given non-recognized python runtime", () => {
       platformMock.value("darwin");
-      const requestedRuntime = "python312";
+      const requestedRuntime = "python318";
       const delegate = new python.Delegate(PROJECT_ID, SOURCE_DIR, requestedRuntime);
 
       expect(delegate.getPythonBinary()).to.equal("python");


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
Firebase functions now support the Python 3.12 runtime. This commit updates cli-tools to work for python 3.12 as well. This should also resolve https://github.com/firebase/firebase-tools/issues/5873 for users in a Python 3.12 environment.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

<!-- ### Scenarios Tested -->

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

<!-- ### Sample Commands -->

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
