### PR TITLE
Fix bug where 2nd Gen firestore functions were mistakenly parsed as pubsub function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixed an issue with deploying multilevel grouped functions containing v2 functions. (#6419)
+- Fix bug where re-deploying 2nd Gen Firestore function fails after updating secrets. (#6456)

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -661,7 +661,10 @@ export function endpointFromFunction(gcfFunction: OutputCloudFunction): backend.
   } else if (gcfFunction.eventTrigger) {
     const eventFilters: Record<string, string> = {};
     const eventFilterPathPatterns: Record<string, string> = {};
-    if (gcfFunction.eventTrigger.pubsubTopic) {
+    if (
+      gcfFunction.eventTrigger.pubsubTopic &&
+      gcfFunction.eventTrigger.eventType === PUBSUB_PUBLISH_EVENT
+    ) {
       eventFilters.topic = gcfFunction.eventTrigger.pubsubTopic;
     } else {
       for (const eventFilter of gcfFunction.eventTrigger.eventFilters || []) {

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -475,6 +475,46 @@ describe("cloudfunctionsv2", () => {
           },
         })
       ).to.deep.equal(want);
+
+      // And again with a pattern match event trigger
+      want = {
+        ...want,
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.written",
+          eventFilters: {
+            database: "(default)",
+            namespace: "(default)",
+          },
+          eventFilterPathPatterns: {
+            document: "users/{userId}",
+          },
+          retry: false,
+        },
+      };
+      expect(
+        cloudfunctionsv2.endpointFromFunction({
+          ...HAVE_CLOUD_FUNCTION_V2,
+          eventTrigger: {
+            eventType: "google.cloud.firestore.document.v1.written",
+            eventFilters: [
+              {
+                attribute: "database",
+                value: "(default)",
+              },
+              {
+                attribute: "namespace",
+                value: "(default)",
+              },
+              {
+                attribute: "document",
+                value: "users/{userId}",
+                operator: "match-path-pattern",
+              },
+            ],
+            pubsubTopic: "eventarc-us-central1-abc", // firestore triggers use pubsub as transport
+          },
+        })
+      ).to.deep.equal(want);
     });
 
     it("should translate custom event triggers", () => {


### PR DESCRIPTION
Firestore trigger also includes pubsubTopic since they use pubsub as transport. This triggered a bug where 2nd Gen Firestore bugs were being parsed as pubsub function which manifests in bugs like https://github.com/firebase/firebase-tools/issues/6453.

Fixes https://github.com/firebase/firebase-tools/issues/6453