### PR TITLE
Update CHANGELOG.md to include #6453

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Enable [preferRest](https://firebase.google.com/docs/reference/admin/node/firebase-admin.firestore.firestoresettings.md#firestoresettingspreferrest) option by default for Firestore functions. (#6147)
-- Fixed an issue with deploying multilevel grouped functions containing v2 functions. (#6419)
+- Fix bug where re-deploying 2nd Gen Firestore function fails after updating secrets. (#6456)


### PR DESCRIPTION
It looks like we added the a different changelog message.

"Fixed an issue with deploying multilevel grouped functions containing v2 functions. (#6419)"  was released in [v12.6.2](https://github.com/firebase/firebase-tools/releases/tag/v12.6.2)