### PR TITLE
GetStorageDefaultBucket through Storage API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Enable [preferRest](https://firebase.google.com/docs/reference/admin/node/firebase-admin.firestore.firestoresettings.md#firestoresettingspreferrest) option by default for Firestore functions. (#6147)
 - Fixed a bug where re-deploying 2nd Gen Firestore function failed after updating secrets. (#6456)
-- Use GetDefaultBucket endpoint to fetch Storage Default Bucket. (#6467)
+- Switched Storage deployment to use GetDefaultBucket endpoint to fetch default Storage bucket. (#6467)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Enable [preferRest](https://firebase.google.com/docs/reference/admin/node/firebase-admin.firestore.firestoresettings.md#firestoresettingspreferrest) option by default for Firestore functions. (#6147)
 - Fixed a bug where re-deploying 2nd Gen Firestore function failed after updating secrets. (#6456)
+- Use GetDefaultBucket endpoint to fetch Storage Default Bucket. (#6467)

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -150,17 +150,17 @@ interface StorageServiceAccountResponse {
 export async function getDefaultBucket(projectId: string): Promise<string> {
   await ensure(projectId, "firebasestorage.googleapis.com", "storage", false);
   try {
-      const localAPIClient = new Client({ urlPrefix: firebaseStorageOrigin, apiVersion: "v1alpha" });
-      const response = await localAPIClient.get<GetDefaultBucketResponse>(
-        `/projects/${projectId}/defaultBucket`
+    const localAPIClient = new Client({ urlPrefix: firebaseStorageOrigin, apiVersion: "v1alpha" });
+    const response = await localAPIClient.get<GetDefaultBucketResponse>(
+      `/projects/${projectId}/defaultBucket`
+    );
+    if (!response.body?.bucket.name) {
+      logger.debug("Default storage bucket is undefined.");
+      throw new FirebaseError(
+        "Your project is being set up. Please wait a minute before deploying again."
       );
-      if (!response.body?.bucket.name) {
-        logger.debug("Default storage bucket is undefined.");
-        throw new FirebaseError(
-          "Your project is being set up. Please wait a minute before deploying again."
-        );
-      }
-      return response.body.bucket.name.split("/").pop()!;
+    }
+    return response.body.bucket.name.split("/").pop()!;
   } catch (err: any) {
     logger.info(
       "\n\nThere was an issue deploying your functions. Verify that your project has a Google App Engine instance setup at https://console.cloud.google.com/appengine and try again. If this issue persists, please contact support."


### PR DESCRIPTION
GetStorageDefaultBucket through Storage API.

This change is breaking as it introduces a new permission, it rolls in changes from https://github.com/firebase/firebase-tools/commit/77b3690ff3cd8f283782ab58513b71243080027e and https://github.com/firebase/firebase-tools/commit/6ff08fc7101f995b5a695c72f169a7d19c80c23c into one PR.

Fixes #6467