### PR TITLE
Fix two issues with Firestore database updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed 2 bugs (unintended database mode changes and disabling of PITR or delete-protection) when updating Firestore databases (#6478)

--- a/src/commands/firestore-databases-update.ts
+++ b/src/commands/firestore-databases-update.ts
@@ -26,13 +26,12 @@ export const command = new Command("firestore:databases:update <database>")
   .action(async (database: string, options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
 
-    if (!options.type && !options.deleteProtection && !options.pointInTimeRecovery) {
+    if (!options.deleteProtection && !options.pointInTimeRecovery) {
       logger.error(
         "Missing properties to update. See firebase firestore:databases:update --help for more info."
       );
       return;
     }
-    const type: types.DatabaseType = types.DatabaseType.FIRESTORE_NATIVE;
     if (
       options.deleteProtection &&
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.ENABLED &&
@@ -43,10 +42,12 @@ export const command = new Command("firestore:databases:update <database>")
       );
       return;
     }
-    const deleteProtectionState: types.DatabaseDeleteProtectionState =
-      options.deleteProtection === types.DatabaseDeleteProtectionStateOption.ENABLED
-        ? types.DatabaseDeleteProtectionState.ENABLED
-        : types.DatabaseDeleteProtectionState.DISABLED;
+    let deleteProtectionState: types.DatabaseDeleteProtectionState | undefined;
+    if (options.deleteProtection === types.DatabaseDeleteProtectionStateOption.ENABLED) {
+      deleteProtectionState = types.DatabaseDeleteProtectionState.ENABLED;
+    } else if (options.deleteProtection === types.DatabaseDeleteProtectionStateOption.DISABLED) {
+      deleteProtectionState = types.DatabaseDeleteProtectionState.DISABLED;
+    }
 
     if (
       options.pointInTimeRecovery &&
@@ -58,15 +59,16 @@ export const command = new Command("firestore:databases:update <database>")
       );
       return;
     }
-    const pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement =
-      options.pointInTimeRecovery === types.PointInTimeRecoveryEnablementOption.ENABLED
-        ? types.PointInTimeRecoveryEnablement.ENABLED
-        : types.PointInTimeRecoveryEnablement.DISABLED;
+    let pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement | undefined;
+    if (options.pointInTimeRecovery === types.PointInTimeRecoveryEnablementOption.ENABLED) {
+      pointInTimeRecoveryEnablement = types.PointInTimeRecoveryEnablement.ENABLED;
+    } else if (options.pointInTimeRecovery === types.PointInTimeRecoveryEnablementOption.DISABLED) {
+      pointInTimeRecoveryEnablement = types.PointInTimeRecoveryEnablement.DISABLED;
+    }
 
     const databaseResp: types.DatabaseResp = await api.updateDatabase(
       options.project,
       database,
-      type,
       deleteProtectionState,
       pointInTimeRecoveryEnablement
     );

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -754,20 +754,17 @@ export class FirestoreApi {
    * Update a named Firestore Database
    * @param project the Firebase project id.
    * @param databaseId the name of the Firestore Database
-   * @param type FIRESTORE_NATIVE or DATASTORE_MODE
    * @param deleteProtectionState DELETE_PROTECTION_ENABLED or DELETE_PROTECTION_DISABLED
    * @param pointInTimeRecoveryEnablement POINT_IN_TIME_RECOVERY_ENABLED or POINT_IN_TIME_RECOVERY_DISABLED
    */
   async updateDatabase(
     project: string,
     databaseId: string,
-    type?: types.DatabaseType,
     deleteProtectionState?: types.DatabaseDeleteProtectionState,
     pointInTimeRecoveryEnablement?: types.PointInTimeRecoveryEnablement
   ): Promise<types.DatabaseResp> {
     const url = `/projects/${project}/databases/${databaseId}`;
     const payload: types.DatabaseReq = {
-      type,
       deleteProtectionState,
       pointInTimeRecoveryEnablement,
     };


### PR DESCRIPTION
### Description

* Performing an update on a Datastore mode database could silently change it to Firestore Native
* Enabling PITR (--point-in-time-recovery=ENABLED) while not specifying --disaster-recovery=ENABLED would silently disable disaster recovery, and vice-versa

 The former issue was due to always sending FIRESTORE_NATIVE as the database type, when we
 actually didn't need to send it at all. The latter issue was due to command-line option
 parsing that assumed not specifying an option was equivalent to sending an explicit DISABLE.

### Scenarios Tested

* [x] Datastore mode db has data - no complaints about updating type at same time as delete protection
* [x] Datastore mode db has data - no complaints about updating type at same time as pitr
* [x] Datastore mode no data - mode is not silently changed to Firestore Native
* [x] Firestore Native mode - delete protection and PITR enabled, --point-in-time-recovery=DISABLED updates PITR but not delete protection
* [x] Firestore Native mode - delete protection and PITR enabled, --delete-protection=DISABLED updates delete protection but not PITR
* [x] Firestore Native mode - delete proetection and PITR enabled, --point-in-time-recovery=DISABLED --delete-protection=DISABLED updates both
* [x] Firestore Native mode - delete protection and PITR disabled, --point-in-time-recovery=ENABLED updates PITR but not delete protection
* [x] Firestore Native mode - delete protection and PITR disabled, --delete-protection=ENABLED updates delete protection but not PITR
* [x] Firestore Native mode - delete protection enabled and PITR disabled, --point-in-time-recovery=ENABLED updates PITR but not delete protection
* [x] Firestore Native mode - delete protection disabled and PITR enabled, --delete-protection=ENABLED updates delete protection but not PITR
* [x] Firestore Native mode - delete protection enabled and PITR disabled, --delete-protection=DISABLED and --point-in-time-recovery=ENABLED updates both
* [x] Firestore Native mode - delete protection disabled and PITR enabled, --delete-protection=ENABLED and --point-in-time-recovery=DISABLED updates both
* [x] Firestore Native mode - delete protection enabled and PITR disabled, --delete-protection=ENABLED and --point-in-time-recovery=DISABLED has no effect
* [x] Firestore Native mode - delete protection disabled and PITR enabled, --delete-protection=DISABLED and --point-in-time-recovery=ENABLED has no effect

Closes #6451 