### PR TITLE
corrects regex for domain matching authorized domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Enable [preferRest](https://firebase.google.com/docs/reference/admin/node/firebase-admin.firestore.firestoresettings.md#firestoresettingspreferrest) option by default for Firestore functions. (#6147)
 - Fixed a bug where re-deploying 2nd Gen Firestore function failed after updating secrets. (#6456)
+- Fixed a bug where similarly-named Hosting channels would cause issues when updating authorized domains. (#6356)

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -633,8 +633,8 @@ export async function getCleanDomains(project: string, site: string): Promise<st
       return acc;
     }, {});
 
-  // match any string that has ${site}--*
-  const siteMatch = new RegExp(`${site}--`, "i");
+  // match any string that starts with ${site}--*
+  const siteMatch = new RegExp(`^${site}--`, "i");
   // match any string that ends in firebaseapp.com
   const firebaseAppMatch = new RegExp(/firebaseapp.com$/);
   const domains = await getAuthDomains(project);

--- a/src/test/hosting/api.spec.ts
+++ b/src/test/hosting/api.spec.ts
@@ -711,6 +711,41 @@ describe("hosting", () => {
       expect(res).to.deep.equal(EXPECTED_DOMAINS_RESPONSE);
       expect(nock.isDone()).to.be.true;
     });
+
+    it("should not remove sites that are similarly named", async () => {
+      // mock listChannels response
+      nock(hostingApiOrigin)
+        .get(`/v1beta1/projects/${PROJECT_ID}/sites/${SITE}/channels`)
+        .query(() => true)
+        .reply(200, {
+          channels: [
+            { url: "https://my-site--ch1-4iyrl1uo.web.app" },
+            { url: "https://my-site--ch2-ygd8582v.web.app" },
+          ],
+        });
+      // mock getAuthDomains response
+      nock(identityOrigin)
+        .get(`/admin/v2/projects/${PROJECT_ID}/config`)
+        .reply(200, {
+          authorizedDomains: [
+            "localhost",
+            "randomurl.com",
+            "my-site--ch1-4iyrl1uo.web.app",
+            "my-site--expiredchannel-difhyc76.web.app",
+            "backendof-my-site--some-abcd1234.web.app",
+          ],
+        });
+
+      const res = await hostingApi.getCleanDomains(PROJECT_ID, SITE);
+
+      expect(res).to.deep.equal([
+        "localhost",
+        "randomurl.com",
+        "my-site--ch1-4iyrl1uo.web.app",
+        "backendof-my-site--some-abcd1234.web.app",
+      ]);
+      expect(nock.isDone()).to.be.true;
+    });
   });
 
   describe("getSiteDomains", () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #6356

There's a case where if two sites are deployed such as `my-site` and `foo-my-site` that the cleanup mechanism around auth domains will try to update the list for `my-site` but see a channel domain like `foo-my-site--channel-random8`, for the other site, and say "hey, that's not a channel for `my-site` any more, delete it!".

By making the check look for the _start_ of the domain to match the site name (and still end with the `--`, the delineator for a Hosting channel name, we eliminate that issue.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

I set up a pair of sites like above and tested on `master` and my branch, and it works correctly now!