### PR TITLE
Angular v17 support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Enable [preferRest](https://firebase.google.com/docs/reference/admin/node/firebase-admin.firestore.firestoresettings.md#firestoresettingspreferrest) option by default for Firestore functions. (#6147)
 - Fixed a bug where re-deploying 2nd Gen Firestore function failed after updating secrets. (#6456)
+- Added the ability to deploy Angular apps using the new application-builder. (#6480)

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -36,18 +36,12 @@ export const docsUrl = "https://firebase.google.com/docs/hosting/frameworks/angu
 
 const DEFAULT_BUILD_SCRIPT = ["ng build"];
 
-/**
- *
- */
 export async function discover(dir: string): Promise<Discovery | undefined> {
   if (!(await pathExists(join(dir, "package.json")))) return;
   if (!(await pathExists(join(dir, "angular.json")))) return;
   return { mayWantBackend: true, publicDirectory: join(dir, "src", "assets") };
 }
 
-/**
- *
- */
 export async function init(setup: any, config: any) {
   execSync(
     `npx --yes -p @angular/cli@latest ng new ${setup.projectId} --directory ${setup.hosting.source} --skip-git`,
@@ -70,9 +64,6 @@ export async function init(setup: any, config: any) {
   }
 }
 
-/**
- *
- */
 export async function build(dir: string, configuration: string): Promise<BuildResult> {
   const {
     targets,
@@ -106,9 +97,6 @@ export async function build(dir: string, configuration: string): Promise<BuildRe
   return { wantsBackend, i18n, rewrites, baseUrl };
 }
 
-/**
- *
- */
 export async function getDevModeHandle(dir: string, configuration: string) {
   const { targetStringFromTarget } = relativeRequire(dir, "@angular-devkit/architect");
   const { serveTarget } = await getContext(dir, configuration);
@@ -133,9 +121,6 @@ export async function getDevModeHandle(dir: string, configuration: string) {
   return simpleProxy(await host);
 }
 
-/**
- *
- */
 export async function ɵcodegenPublicDirectory(
   sourceDir: string,
   destDir: string,
@@ -161,9 +146,6 @@ export async function ɵcodegenPublicDirectory(
   }
 }
 
-/**
- *
- */
 export async function getValidBuildTargets(purpose: BUILD_TARGET_PURPOSE, dir: string) {
   const validTargetNames = new Set(["development", "production"]);
   try {
@@ -182,18 +164,12 @@ export async function getValidBuildTargets(purpose: BUILD_TARGET_PURPOSE, dir: s
   return [...validTargetNames, ...allTargets];
 }
 
-/**
- *
- */
 export async function shouldUseDevModeHandle(targetOrConfiguration: string, dir: string) {
   const { serveTarget } = await getContext(dir, targetOrConfiguration);
   if (!serveTarget) return false;
   return serveTarget.configuration !== "production";
 }
 
-/**
- *
- */
 export async function ɵcodegenFunctionsDirectory(
   sourceDir: string,
   destDir: string,

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -149,11 +149,11 @@ export async function ɵcodegenPublicDirectory(
 export async function getValidBuildTargets(purpose: BUILD_TARGET_PURPOSE, dir: string) {
   const validTargetNames = new Set(["development", "production"]);
   try {
-    const { workspaceProject, buildTarget, browserTarget, serverTarget, serveTarget } =
+    const { workspaceProject, buildTarget, browserTarget, prerenderTarget, serveTarget } =
       await getContext(dir);
     const { target } = ((purpose === "emulate" && serveTarget) ||
       buildTarget ||
-      serverTarget ||
+      prerenderTarget ||
       browserTarget)!;
     const workspaceTarget = workspaceProject.targets.get(target)!;
     Object.keys(workspaceTarget.configurations || {}).forEach((it) => validTargetNames.add(it));

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -50,18 +50,6 @@ export async function init(setup: any, config: any) {
       cwd: config.projectDir,
     }
   );
-  const useAngularUniversal = await promptOnce({
-    name: "useAngularUniversal",
-    type: "confirm",
-    default: false,
-    message: `Would you like to setup Angular Universal?`,
-  });
-  if (useAngularUniversal) {
-    execSync("ng add @nguniversal/express-engine --skip-confirmation", {
-      stdio: "inherit",
-      cwd: join(config.projectDir, setup.hosting.source),
-    });
-  }
 }
 
 export async function build(dir: string, configuration: string): Promise<BuildResult> {

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -67,7 +67,6 @@ export async function init(setup: any, config: any) {
 export async function build(dir: string, configuration: string): Promise<BuildResult> {
   const {
     targets,
-    buildTarget,
     serveOptimizedImages,
     locales,
     baseHref: baseUrl,
@@ -95,7 +94,6 @@ export async function build(dir: string, configuration: string): Promise<BuildRe
         },
       ];
   const i18n = !!locales;
-  console.log({ buildTarget, wantsBackend, ssr, i18n, rewrites, baseUrl });
   return { wantsBackend, i18n, rewrites, baseUrl };
 }
 

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -11,7 +11,6 @@ import {
   SupportLevel,
   BUILD_TARGET_PURPOSE,
 } from "../interfaces";
-import { promptOnce } from "../../prompt";
 import {
   simpleProxy,
   relativeRequire,
@@ -42,7 +41,7 @@ export async function discover(dir: string): Promise<Discovery | undefined> {
   return { mayWantBackend: true, publicDirectory: join(dir, "src", "assets") };
 }
 
-export async function init(setup: any, config: any) {
+export function init(setup: any, config: any) {
   execSync(
     `npx --yes -p @angular/cli@latest ng new ${setup.projectId} --directory ${setup.hosting.source} --skip-git`,
     {
@@ -50,6 +49,7 @@ export async function init(setup: any, config: any) {
       cwd: config.projectDir,
     }
   );
+  return Promise.resolve();
 }
 
 export async function build(dir: string, configuration: string): Promise<BuildResult> {

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -36,12 +36,18 @@ export const docsUrl = "https://firebase.google.com/docs/hosting/frameworks/angu
 
 const DEFAULT_BUILD_SCRIPT = ["ng build"];
 
+/**
+ *
+ */
 export async function discover(dir: string): Promise<Discovery | undefined> {
   if (!(await pathExists(join(dir, "package.json")))) return;
   if (!(await pathExists(join(dir, "angular.json")))) return;
   return { mayWantBackend: true, publicDirectory: join(dir, "src", "assets") };
 }
 
+/**
+ *
+ */
 export async function init(setup: any, config: any) {
   execSync(
     `npx --yes -p @angular/cli@latest ng new ${setup.projectId} --directory ${setup.hosting.source} --skip-git`,
@@ -64,6 +70,9 @@ export async function init(setup: any, config: any) {
   }
 }
 
+/**
+ *
+ */
 export async function build(dir: string, configuration: string): Promise<BuildResult> {
   const {
     targets,
@@ -97,6 +106,9 @@ export async function build(dir: string, configuration: string): Promise<BuildRe
   return { wantsBackend, i18n, rewrites, baseUrl };
 }
 
+/**
+ *
+ */
 export async function getDevModeHandle(dir: string, configuration: string) {
   const { targetStringFromTarget } = relativeRequire(dir, "@angular-devkit/architect");
   const { serveTarget } = await getContext(dir, configuration);
@@ -121,6 +133,9 @@ export async function getDevModeHandle(dir: string, configuration: string) {
   return simpleProxy(await host);
 }
 
+/**
+ *
+ */
 export async function ɵcodegenPublicDirectory(
   sourceDir: string,
   destDir: string,
@@ -146,11 +161,18 @@ export async function ɵcodegenPublicDirectory(
   }
 }
 
+/**
+ *
+ */
 export async function getValidBuildTargets(purpose: BUILD_TARGET_PURPOSE, dir: string) {
   const validTargetNames = new Set(["development", "production"]);
   try {
-    const { workspaceProject, buildTarget, browserTarget, serverTarget, serveTarget } = await getContext(dir);
-    const { target } = ((purpose === "emulate" && serveTarget) || buildTarget || serverTarget || browserTarget)!;
+    const { workspaceProject, buildTarget, browserTarget, serverTarget, serveTarget } =
+      await getContext(dir);
+    const { target } = ((purpose === "emulate" && serveTarget) ||
+      buildTarget ||
+      serverTarget ||
+      browserTarget)!;
     const workspaceTarget = workspaceProject.targets.get(target)!;
     Object.keys(workspaceTarget.configurations || {}).forEach((it) => validTargetNames.add(it));
   } catch (e) {
@@ -160,12 +182,18 @@ export async function getValidBuildTargets(purpose: BUILD_TARGET_PURPOSE, dir: s
   return [...validTargetNames, ...allTargets];
 }
 
+/**
+ *
+ */
 export async function shouldUseDevModeHandle(targetOrConfiguration: string, dir: string) {
   const { serveTarget } = await getContext(dir, targetOrConfiguration);
   if (!serveTarget) return false;
   return serveTarget.configuration !== "production";
 }
 
+/**
+ *
+ */
 export async function ɵcodegenFunctionsDirectory(
   sourceDir: string,
   destDir: string,
@@ -221,8 +249,7 @@ export async function ɵcodegenFunctionsDirectory(
   let bootstrapScript: string;
   if (browserLocales) {
     const locales = serverLocales?.filter((it) => browserLocales.includes(it));
-    bootstrapScript = `
-const localizedApps = new Map();
+    bootstrapScript = `const localizedApps = new Map();
 const ffi18n = import("firebase-frameworks/i18n");
 exports.handle = function(req,res) {
   ffi18n.then(({ getPreferredLocale }) => {
@@ -234,7 +261,11 @@ exports.handle = function(req,res) {
     if (localizedApps.has(locale)) {
       localizedApps.get(locale)(req,res);
     } else {
-      ${serverEntry?.endsWith(".mjs") ? `import(\`./${serverOutputPath}/\${locale}/${serverEntry}\`)` : `Promise.resolve(require(\`./${serverOutputPath}/\${locale}/${serverEntry}\`))`}.then(server => {
+      ${
+        serverEntry?.endsWith(".mjs")
+          ? `import(\`./${serverOutputPath}/\${locale}/${serverEntry}\`)`
+          : `Promise.resolve(require(\`./${serverOutputPath}/\${locale}/${serverEntry}\`))`
+      }.then(server => {
         const app = server.app(locale);
         localizedApps.set(locale, app);
         app(req,res);
@@ -243,7 +274,11 @@ exports.handle = function(req,res) {
   });
 };\n`;
   } else if (serverOutputPath) {
-    bootstrapScript = `const app = ${serverEntry?.endsWith(".mjs") ? `import(\`./${serverOutputPath}/${serverEntry}\`)` : `Promise.resolve(require('./${serverOutputPath}/${serverEntry}'))`}.then(server => server.app());
+    bootstrapScript = `const app = ${
+      serverEntry?.endsWith(".mjs")
+        ? `import(\`./${serverOutputPath}/${serverEntry}\`)`
+        : `Promise.resolve(require('./${serverOutputPath}/${serverEntry}'))`
+    }.then(server => server.app());
 exports.handle = (req,res) => app.then(it => it(req,res));\n`;
   } else {
     bootstrapScript = `exports.handle = (res, req) => req.sendStatus(404);\n`;

--- a/src/frameworks/angular/utils.ts
+++ b/src/frameworks/angular/utils.ts
@@ -386,7 +386,7 @@ export async function getServerConfig(sourceDir: string, configuration: string) 
       "It's required that your source locale to be one of the localize options"
     );
   }
-  const serverEntry = buildTarget ? "main.server.mjs" : serverTarget && "main.js";
+  const serverEntry = buildTarget ? "server.mjs" : serverTarget && "main.js";
   const externalDependencies: string[] = (buildOrServerTargetOptions.externalDependencies as any) || [];
   const bundleDependencies = buildOrServerTargetOptions.bundleDependencies ?? true;
   const { locales: browserLocales } = await localesForTarget(

--- a/src/frameworks/angular/utils.ts
+++ b/src/frameworks/angular/utils.ts
@@ -88,9 +88,6 @@ function getValidBuilders(purpose: BUILD_TARGET_PURPOSE): string[] {
   ];
 }
 
-/**
- *
- */
 export async function getAllTargets(purpose: BUILD_TARGET_PURPOSE, dir: string) {
   const validBuilders = getValidBuilders(purpose);
   const { NodeJsAsyncHost } = relativeRequire(dir, "@angular-devkit/core/node");
@@ -117,9 +114,6 @@ export async function getAllTargets(purpose: BUILD_TARGET_PURPOSE, dir: string) 
 }
 
 // TODO(jamesdaniels) memoize, dry up
-/**
- *
- */
 export async function getContext(dir: string, targetOrConfiguration?: string) {
   const { NodeJsAsyncHost } = relativeRequire(dir, "@angular-devkit/core/node");
   const { workspaces } = relativeRequire(dir, "@angular-devkit/core");
@@ -298,13 +292,13 @@ export async function getContext(dir: string, targetOrConfiguration?: string) {
   if (!buildOrBrowserTarget) {
     throw new FirebaseError(`No build target on ${project}`);
   }
-  const buildOrBrowserTargetOptions = await architectHost.getOptionsForTarget(buildOrBrowserTarget);
-  if (!buildOrBrowserTargetOptions) {
+  const browserTargetOptions = await architectHost.getOptionsForTarget(buildOrBrowserTarget);
+  if (!browserTargetOptions) {
     const targetString = targetStringFromTarget(buildOrBrowserTarget);
     throw new FirebaseError(`Couldn't find options for ${targetString}.`);
   }
 
-  const baseHref = buildOrBrowserTarget.baseHref || "/";
+  const baseHref = browserTargetOptions.baseHref || "/";
   if (typeof baseHref !== "string") {
     const targetString = targetStringFromTarget(buildOrBrowserTarget);
     throw new FirebaseError(`baseHref on ${targetString} was not a string`);
@@ -329,9 +323,6 @@ export async function getContext(dir: string, targetOrConfiguration?: string) {
   };
 }
 
-/**
- *
- */
 export async function getBrowserConfig(sourceDir: string, configuration: string) {
   const { architectHost, browserTarget, buildTarget, baseHref, workspaceProject } =
     await getContext(sourceDir, configuration);
@@ -351,9 +342,6 @@ export async function getBrowserConfig(sourceDir: string, configuration: string)
   return { locales, baseHref, outputPath, defaultLocale };
 }
 
-/**
- *
- */
 export async function getServerConfig(sourceDir: string, configuration: string) {
   const {
     architectHost,
@@ -370,12 +358,9 @@ export async function getServerConfig(sourceDir: string, configuration: string) 
   if (!buildOrBrowserTarget) {
     throw new AssertionError({ message: "expected build or browser target to be defined" });
   }
-  const buildOrBrowserTargetOptions = await architectHost.getOptionsForTarget(buildOrBrowserTarget);
-  assertIsString(buildOrBrowserTargetOptions?.outputPath);
-  const browserOutputPath = join(
-    buildOrBrowserTargetOptions.outputPath,
-    buildTarget ? "browser" : ""
-  );
+  const browserTargetOptions = await architectHost.getOptionsForTarget(buildOrBrowserTarget);
+  assertIsString(browserTargetOptions?.outputPath);
+  const browserOutputPath = join(browserTargetOptions.outputPath, buildTarget ? "browser" : "");
   const packageJson = JSON.parse(await host.readFile(join(sourceDir, "package.json")));
   if (!ssr) {
     return {
@@ -401,18 +386,17 @@ export async function getServerConfig(sourceDir: string, configuration: string) 
     buildOrServerTarget,
     workspaceProject
   );
-  const buildOrServerTargetOptions = await architectHost.getOptionsForTarget(buildOrServerTarget);
-  assertIsString(buildOrServerTargetOptions?.outputPath);
-  const serverOutputPath = join(buildOrServerTargetOptions.outputPath, buildTarget ? "server" : "");
+  const serverTargetOptions = await architectHost.getOptionsForTarget(buildOrServerTarget);
+  assertIsString(serverTargetOptions?.outputPath);
+  const serverOutputPath = join(serverTargetOptions.outputPath, buildTarget ? "server" : "");
   if (serverLocales && !defaultLocale) {
     throw new FirebaseError(
       "It's required that your source locale to be one of the localize options"
     );
   }
   const serverEntry = buildTarget ? "server.mjs" : serverTarget && "main.js";
-  const externalDependencies: string[] =
-    (buildOrServerTargetOptions.externalDependencies as any) || [];
-  const bundleDependencies = buildOrServerTargetOptions.bundleDependencies ?? true;
+  const externalDependencies: string[] = (serverTargetOptions.externalDependencies as any) || [];
+  const bundleDependencies = serverTargetOptions.bundleDependencies ?? true;
   const { locales: browserLocales } = await localesForTarget(
     sourceDir,
     architectHost,
@@ -434,9 +418,6 @@ export async function getServerConfig(sourceDir: string, configuration: string) 
   };
 }
 
-/**
- *
- */
 export async function getBuildConfig(sourceDir: string, configuration: string) {
   const { targetStringFromTarget } = relativeRequire(sourceDir, "@angular-devkit/architect");
   const {

--- a/src/frameworks/angular/utils.ts
+++ b/src/frameworks/angular/utils.ts
@@ -305,7 +305,7 @@ export async function getContext(dir: string, targetOrConfiguration?: string) {
   }
 
   const buildTargetOptions = buildTarget && (await architectHost.getOptionsForTarget(buildTarget));
-  const ssr = !!buildTargetOptions?.ssr || !!serverTarget;
+  const ssr = buildTarget ? !!buildTargetOptions?.ssr : !!serverTarget;
 
   return {
     architect,

--- a/src/frameworks/angular/utils.ts
+++ b/src/frameworks/angular/utils.ts
@@ -67,9 +67,9 @@ async function localesForTarget(
 const enum ExpectedBuilder {
   APPLICATION = "@angular-devkit/build-angular:application",
   BROWSER_ESBUILD = "@angular-devkit/build-angular:browser-esbuild",
-  BROWSER_WEBPACK = "@angular-devkit/build-angular:browser",
   DEPLOY = "@angular/fire:deploy",
   DEV_SERVER = "@angular-devkit/build-angular:dev-server",
+  LEGACY_BROWSER = "@angular-devkit/build-angular:browser",
   LEGACY_PRERENDER = "@nguniversal/builders:prerender",
   LEGACY_SERVER = "@angular-devkit/build-angular:server",
   LEGACY_SSR_DEV_SERVER = "@nguniversal/builders:ssr-dev-server",
@@ -84,8 +84,8 @@ function getValidBuilders(purpose: BUILD_TARGET_PURPOSE): string[] {
   return [
     ExpectedBuilder.APPLICATION,
     ExpectedBuilder.BROWSER_ESBUILD,
-    ExpectedBuilder.BROWSER_WEBPACK,
     ExpectedBuilder.DEPLOY,
+    ExpectedBuilder.LEGACY_BROWSER,
     ExpectedBuilder.LEGACY_PRERENDER,
     ...(purpose === "deploy" ? [] : DEV_SERVER_TARGETS),
   ];
@@ -188,7 +188,7 @@ export async function getContext(dir: string, targetOrConfiguration?: string) {
         buildTarget = overrideTarget;
         break;
       case ExpectedBuilder.BROWSER_ESBUILD:
-      case ExpectedBuilder.BROWSER_WEBPACK:
+      case ExpectedBuilder.LEGACY_BROWSER:
         browserTarget = overrideTarget;
         break;
       case ExpectedBuilder.LEGACY_PRERENDER:
@@ -284,7 +284,7 @@ export async function getContext(dir: string, targetOrConfiguration?: string) {
         configuration: configuration || defaultConfiguration,
       };
       if (
-        builder === ExpectedBuilder.BROWSER_WEBPACK ||
+        builder === ExpectedBuilder.LEGACY_BROWSER ||
         builder === ExpectedBuilder.BROWSER_ESBUILD
       ) {
         browserTarget = target;
@@ -340,7 +340,7 @@ export async function getContext(dir: string, targetOrConfiguration?: string) {
       if (target === deployTarget && builder === ExpectedBuilder.DEPLOY) continue;
       if (target === buildTarget && builder === ExpectedBuilder.APPLICATION) continue;
       if (target === browserTarget && builder === ExpectedBuilder.BROWSER_ESBUILD) continue;
-      if (target === browserTarget && builder === ExpectedBuilder.BROWSER_WEBPACK) continue;
+      if (target === browserTarget && builder === ExpectedBuilder.LEGACY_BROWSER) continue;
       if (target === prerenderTarget && builder === ExpectedBuilder.LEGACY_PRERENDER) continue;
       if (target === serverTarget && builder === ExpectedBuilder.LEGACY_SERVER) continue;
       if (target === serveTarget && builder === ExpectedBuilder.LEGACY_SSR_DEV_SERVER) continue;

--- a/src/frameworks/angular/utils.ts
+++ b/src/frameworks/angular/utils.ts
@@ -434,7 +434,6 @@ export async function getBuildConfig(sourceDir: string, configuration: string) {
   return {
     targets,
     baseHref,
-    buildTarget,
     locales,
     serveOptimizedImages,
     ssr,

--- a/src/frameworks/docs/angular.md
+++ b/src/frameworks/docs/angular.md
@@ -8,7 +8,7 @@ page_type: guide
 
 <link rel="stylesheet" type="text/css" href="/styles/docs.css" />
 
-# Integrate Angular Universal
+# Integrate Angular
 
 With the Firebase framework-aware {{cli}}, you can deploy your Angular application
 to Firebase and serve dynamic content to your users.

--- a/src/frameworks/docs/angular.md
+++ b/src/frameworks/docs/angular.md
@@ -49,7 +49,7 @@ firebase deploy
 
 ## Pre-render dynamic content
 
-To prerender dynamic content in Angular, you need to set up Angular Universal.
+To prerender dynamic content in Angular, you need to set up Angular SSR.
 
 ```shell
 ng add @angular/ssr

--- a/src/frameworks/docs/angular.md
+++ b/src/frameworks/docs/angular.md
@@ -50,41 +50,13 @@ firebase deploy
 ## Pre-render dynamic content
 
 To prerender dynamic content in Angular, you need to set up Angular Universal.
-The {{firebase_cli}} expects Express Engine:
 
 ```shell
-ng add @nguniversal/express-engine
+ng add @angular/ssr
 ```
 
-See the [Angular Universal guide](https://angular.io/guide/universal)
+See the [Angular Prerendering (SSG) guide](https://angular.dev/guide/prerendering)
 for more information.
-
-### Add prerender URLs
-
-By default, only the root directory will be prerendered. You can add additional
-routes by locating the prerender step in `angular.json` and adding more routes:
-
-```json
-{
-  "prerender": {
-    "builder": "@nguniversal/builders:prerender",
-    "options": {
-      "routes": ["/", "ANOTHER_ROUTE", "AND_ANOTHER"]
-    },
-    "configurations": {
-      /* ... */
-    },
-    "defaultConfiguration": "production"
-  }
-}
-```
-
-Firebase also respects `guessRoutes` or a `routes.txt` file in the hosting root,
-if you need to customize further. See [Angular’s prerendering
-guide](https://angular.io/guide/prerendering) for more information on those
-options.
-
-### Optional: add a server module
 
 #### Deploy
 
@@ -94,21 +66,21 @@ to {{hosting}} and {{cloud_functions_full}}.
 
 #### Custom deploy
 
-The {{firebase_cli}} assumes that you have server, build, and prerender steps in
-your schematics with a production configuration.
+The {{firebase_cli}} assumes that you have a single application defined in your
+`angular.json` with a production build configuration.
 
-If you want to tailor the {{cli}}'s assumptions, configure `ng deploy` and edit the
-configuration in `angular.json`. For example, you could disable SSR and serve
-pre-rendered content exclusively by removing `serverTarget`:
+If need to tailor the {{cli}}'s assumptions, you can either use the
+`FIREBASE_FRAMEWORKS_BUILD_TARGET` environment variable or add
+[AngularFire](https://github.com/angular/angularfire#readme) and modify your
+`angular.json`:
 
 ```json
 {
   "deploy": {
     "builder": "@angular/fire:deploy",
     "options": {
-      "browserTarget": "app:build:production",
-      "serverTarget": "app:server:production",
-      "prerenderTarget": "app:prerender:production"
+      "version": 2,
+      "buildTarget": "OVERRIDE_YOUR_BUILD_TARGET"
     }
   }
 }
@@ -120,7 +92,8 @@ When including Firebase JS SDK methods in both server and client bundles, guard
 against runtime errors by checking `isSupported()` before using the product.
 Not all products are [supported in all environments](/docs/web/environments-js-sdk#other_environments).
 
-Tip: consider using AngularFire, which does this for you automatically.
+Tip: consider using [AngularFire](https://github.com/angular/angularfire#readme),
+which does this for you automatically.
 
 ### Optional: integrate with the Firebase Admin SDK
 

--- a/src/frameworks/docs/frameworks-overview.md
+++ b/src/frameworks/docs/frameworks-overview.md
@@ -54,7 +54,7 @@ live site:
 
 See the detailed guide for your preferred framework:
 
-* [Angular Universal](/docs/hosting/frameworks/angular)
+* [Angular](/docs/hosting/frameworks/angular)
 * [Next.js] (/docs/hosting/frameworks/nextjs)
 * [Flutter Web] (/docs/hosting/frameworks/flutter)
 * [Frameworks with Express.js](/docs/hosting/frameworks/express)


### PR DESCRIPTION
Adding support for [Angular's new build system](https://angular.dev/tools/cli/esbuild) based off esbuild and vite. This promises to dramatically simplify the integration, we'll work to depreciate the old builders once this is well adopted.

* Updated the documentation to reflect Angular v17
* Renamed the existing builders to LEGACY_* so it's clearer the code we can deprecate later
* For application builder:
  * SSR is an option, we don't have to infer it from another target
  * There is always a "browser" sub-folder, making outDir handling easier
  * Building the browser, server, and pre-rendering are all in a single command! wohoo!
  * Server target is an MJS now, switching the function template to use import
* For the es-build builder:
  * While it's not a legacy builder, we have to treat it the same in terms of path (no "browser" folder)
* Cleaned up some of the mess in getContext & adding more guardrails. It should be much clearer now the precedence assuming build targets:
  1. ng-deploy
  2. prerender
  3. build / server