### PR TITLE
Updated  `--force` description for deploy command

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -45,9 +45,7 @@ export const TARGET_PERMISSIONS: Record<(typeof VALID_DEPLOY_TARGETS)[number], s
 
 export const command = new Command("deploy")
   .description("deploy code and assets to your Firebase project")
-  .withForce(
-    "delete Cloud Functions missing from the current working directory without confirmation"
-  )
+  .withForce()
   .option("-p, --public <path>", "override the Hosting public directory specified in firebase.json")
   .option("-m, --message <message>", "an optional message describing this deploy")
   .option(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Feedback from #6485 

Updated the `--force` description to use the default description for `--force`. Current description is that `--force` is that it's used to automatically delete Cloud Functions missing from the current working directory without confirmation

```
Options:
  -f, --force              delete Cloud Functions missing from the current working directory without confirmation
```

Looks like it's used to
- automatically deploy functions with a failure policy https://github.com/firebase/firebase-tools/blob/ca4349d91047811f68ac615e94db249d5be1a9ee/src/deploy/functions/prompts.ts#L51
- automatically deploy functions that increase the minimum bill https://github.com/firebase/firebase-tools/blob/ca4349d91047811f68ac615e94db249d5be1a9ee/src/deploy/functions/prompts.ts#L135
- automatically delete Cloud Functions missing from the current working directory without confirmation https://github.com/firebase/firebase-tools/blob/ca4349d91047811f68ac615e94db249d5be1a9ee/src/deploy/functions/prompts.ts#L82

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Running `firebase deploy --help`
```
Usage: firebase deploy [options]

deploy code and assets to your Firebase project

Options:
  -f, --force              automatically accept all interactive prompts
```
