### PR TITLE
fix: properly warn users not to use "=" character in pre or post deploy commands

### DIFF
--- a/src/deploy/lifecycleHooks.ts
+++ b/src/deploy/lifecycleHooks.ts
@@ -19,6 +19,13 @@ function runCommand(command: string, childOptions: childProcess.SpawnOptions) {
 
   return new Promise<void>((resolve, reject) => {
     logger.info("Running command: " + command);
+    if (command.includes("=")) {
+      utils.logWarning(
+        clc.yellow(clc.bold("Warning: ")) +
+          "Your command contains '=', it may result in the command not running." +
+          " Please consider removing it."
+      );
+    }
     if (translatedCommand === "") {
       return resolve();
     }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Warn users not to use the character "=" in their pre or post deploy scripts. Here is the result in the console:

```bash
Running command: npm --prefix "$RESOURCE_DIR" run build

> build
> tsc

Running command: echo e=1
⚠  Warning: Your command contains '=', it may result in the command not running. Please consider removing it.
✔  functions: Finished running predeploy script.
i  functions: preparing codebase default for deployment
``` 
How it looks in color:
<img width="769" alt="Screenshot 2023-11-09 at 15 00 49" src="https://github.com/firebase/firebase-tools/assets/16018629/084fd0d3-6d76-417a-9ec9-5faec85d88bc">

closes https://github.com/firebase/firebase-tools/issues/5339

### Scenarios Tested

The scripts in the firebase.json that triggered the warning:
```json
  "functions": [
    {
      "source": "functions",
      "codebase": "default",
      "ignore": [
        "node_modules",
        ".git",
        "firebase-debug.log",
        "firebase-debug.*.log"
      ],
      "predeploy": [
        "npm --prefix \"$RESOURCE_DIR\" run lint",
        "npm --prefix \"$RESOURCE_DIR\" run build",
        "echo e=1"
      ]
    }
  ],
``` 

### Sample Commands

```
firebase deploy
```
