### PR TITLE
Fix blocking functions in the emulator when using multiple codebases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix blocking functions in the emulator when using multiple codebases (#6504).

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -566,8 +566,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     } else {
       this.workerPools[emulatableBackend.codebase].refresh();
     }
-    // reset blocking functions config for reloads
-    this.blockingFunctionsConfig = {};
 
     // When force is true we set up all triggers, otherwise we only set up
     // triggers which have a unique function name
@@ -1436,6 +1434,8 @@ export class FunctionsEmulator implements EmulatorInstance {
 
   async reloadTriggers() {
     this.triggerGeneration++;
+    // reset blocking functions config for reloads
+    this.blockingFunctionsConfig = {};
     for (const backend of this.args.emulatableBackends) {
       await this.loadTriggers(backend);
     }


### PR DESCRIPTION
Fixes #6494

Moves `blockingFunctionsConfig` reset out of `loadTriggers()` and into `reloadTriggers()`.  This is because `loadTriggers()` is called once for each codebase/EmulatableBackend will reset the previously discovered functions.