### PR TITLE
Revert "Enable preferRest option by default for Firestore functions"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Revert enabling preferRest by default to avoid performance degradations for some users (#6520).
 - Fix blocking functions in the emulator when using multiple codebases (#6504).
 - Add force flag call-out for bypassing prompts (#6506).

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -410,6 +410,5 @@ export function loadFirebaseEnvs(
   return {
     FIREBASE_CONFIG: JSON.stringify(firebaseConfig),
     GCLOUD_PROJECT: projectId,
-    FIRESTORE_PREFER_REST: "true",
   };
 }


### PR DESCRIPTION
Some users were reporting that the preferRest feature was actually resulting in a degradation of Firestore client performance in functions environments. This PR rolls back the default enabling of `preferRest: true` to give us the opportunity to investigate and potentially reintroduce it in a future major bump in the firebase functions SDK.

Reported issue: https://github.com/googleapis/nodejs-firestore/issues/1943