### PR TITLE
Ensure functionsEmulator respects logVerbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fix blocking functions in the emulator when using multiple codebases (#6504).
 - Add force flag call-out for bypassing prompts (#6506).
+- Fixed an issue where the functions emulator did not respect the `--log-verbosity` flag (#2859).

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -118,7 +118,7 @@ describe("FunctionsEmulator", function () {
       projectId: TEST_PROJECT_ID,
       projectDir: MODULE_ROOT,
       emulatableBackends: [TEST_BACKEND],
-      quiet: true,
+      verbosity: "QUIET",
       adminSdkConfig: {
         projectId: TEST_PROJECT_ID,
         databaseURL: `https://${TEST_PROJECT_ID}-default-rtdb.firebaseio.com`,

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -565,6 +565,7 @@ export async function startAll(
       host: functionsAddr.host,
       port: functionsAddr.port,
       debugPort: inspectFunctions,
+      verbosity: options.logVerbosity,
       projectAlias: options.projectAlias,
     });
     await startEmulator(functionsEmulator);

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -115,7 +115,7 @@ export interface FunctionsEmulatorArgs {
   account?: Account;
   port?: number;
   host?: string;
-  quiet?: boolean;
+  verbosity?: "SILENT" | "QUIET" | "INFO" | "DEBUG";
   disabledRuntimeFeatures?: FunctionsRuntimeFeatures;
   debugPort?: number;
   remoteEmulators?: Record<string, EmulatorInfo>;
@@ -215,7 +215,9 @@ export class FunctionsEmulator implements EmulatorInstance {
 
   constructor(private args: FunctionsEmulatorArgs) {
     // TODO: Would prefer not to have static state but here we are!
-    EmulatorLogger.setVerbosity(this.args.quiet ? Verbosity.QUIET : Verbosity.DEBUG);
+    EmulatorLogger.setVerbosity(
+      this.args.verbosity ? Verbosity[this.args.verbosity] : Verbosity["DEBUG"]
+    );
     // When debugging is enabled, the "timeout" feature needs to be disabled so that
     // functions don't timeout while a breakpoint is active.
     if (this.args.debugPort) {

--- a/src/functionsShellCommandAction.ts
+++ b/src/functionsShellCommandAction.ts
@@ -79,7 +79,7 @@ export const actionFunction = async (options: Options) => {
 
   return serveFunctions
     .start(options, {
-      quiet: true,
+      verbosity: "QUIET",
       remoteEmulators,
       debugPort,
     })


### PR DESCRIPTION
### Description
We recently added the `--log-verbosity` flag, but did not pipe its value through to the logger used by the functions emulator. Fixes #2859