### PR TITLE
fix issues where project ID was missing in Hosting setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where initializing Hosting fails when selecting a project. (#6527)

--- a/src/getDefaultHostingSite.ts
+++ b/src/getDefaultHostingSite.ts
@@ -14,7 +14,7 @@ export const errNoDefaultSite = new FirebaseError(
  * @param options The command-line options object
  * @return The hosting site ID
  */
-export async function getDefaultHostingSite(options: any): Promise<string> {
+export async function getDefaultHostingSite(options: { projectId?: string }): Promise<string> {
   const projectId = needProjectId(options);
   const project = await getFirebaseProject(projectId);
   let site = project.resources?.hostingSite;

--- a/src/hosting/interactive.ts
+++ b/src/hosting/interactive.ts
@@ -16,7 +16,7 @@ const prompt =
 export async function interactiveCreateHostingSite(
   siteId: string,
   appId: string,
-  options: { projectId?: string, nonInteractive?: boolean }
+  options: { projectId?: string; nonInteractive?: boolean }
 ): Promise<Site> {
   const projectId = needProjectId(options);
   const projectNumber = await needProjectNumber(options);

--- a/src/hosting/interactive.ts
+++ b/src/hosting/interactive.ts
@@ -1,7 +1,6 @@
 import { FirebaseError } from "../error";
 import { logWarning } from "../utils";
 import { needProjectId, needProjectNumber } from "../projectUtils";
-import { Options } from "../options";
 import { promptOnce } from "../prompt";
 import { Site, createSite } from "./api";
 
@@ -17,7 +16,7 @@ const prompt =
 export async function interactiveCreateHostingSite(
   siteId: string,
   appId: string,
-  options: Options
+  options: { projectId?: string, nonInteractive?: boolean }
 ): Promise<Site> {
   const projectId = needProjectId(options);
   const projectNumber = await needProjectNumber(options);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Turned out that the check for a Hosting site was expecting a project ID in the setup function to exist in the options variable, but it didn't. Clear up those checks, and fix the issue where if _no_ project is selected, this still needs to continue.

Fixes #6527

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- `hosting init`
  - with no project selected
  - when selecting a project
  - without a hosting site
  - with a hosting site

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
