### PR TITLE
Feature: login:use can be used outside of Firebase project to change the global default account.

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -188,9 +188,7 @@ export async function loginAdditionalAccount(useLocalhost: boolean, email?: stri
     utils.logWarning(`Already logged in as ${resultEmail}.`);
     updateAccount(newAccount);
   } else {
-    const additionalAccounts = getAdditionalAccounts();
-    additionalAccounts.push(newAccount);
-    configstore.set("additionalAccounts", additionalAccounts);
+    addAdditionalAccount(newAccount);
   }
 
   return newAccount;
@@ -725,4 +723,10 @@ export async function logout(refreshToken: string) {
       original: err,
     });
   }
+}
+
+export function addAdditionalAccount(account: Account) {
+  const additionalAccounts = getAdditionalAccounts();
+  additionalAccounts.push(account);
+  configstore.set("additionalAccounts", additionalAccounts);
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -725,7 +725,11 @@ export async function logout(refreshToken: string) {
   }
 }
 
-export function addAdditionalAccount(account: Account) {
+/**
+ * adds an account to the list of additional accounts.
+ * @param account the account to add.
+ */
+export function addAdditionalAccount(account: Account): void {
   const additionalAccounts = getAdditionalAccounts();
   additionalAccounts.push(account);
   configstore.set("additionalAccounts", additionalAccounts);

--- a/src/commands/login-use.ts
+++ b/src/commands/login-use.ts
@@ -6,7 +6,7 @@ import * as auth from "../auth";
 import { FirebaseError } from "../error";
 
 export const command = new Command("login:use <email>")
-  .description("set the default account to use for this project directory")
+  .description("set the default account to use for this project directory or the global default account if not in a Firebase project directory")
   .action((email: string, options: any) => {
     const allAccounts = auth.getAllAccounts();
     const accountExists = allAccounts.some((a) => a.user.email === email);
@@ -19,12 +19,52 @@ export const command = new Command("login:use <email>")
     }
 
     const projectDir = options.projectRoot as string | null;
-    if (!projectDir) {
-      throw new FirebaseError("Could not determine active Firebase project directory");
+    utils.logWarning(`projectDir: ${projectDir}`);
+    // if (!projectDir) {
+    //   throw new FirebaseError("Could not determine active Firebase project directory");
+    // }
+
+    // auth.setProjectAccount(projectDir, email);
+    // utils.logSuccess(`Set default account ${email} for current project directory.`);
+
+    // return email;
+
+    // if current directory is a Firebase project directory, set the default account for this project directory
+    // otherwise, set the global default account
+    if (projectDir) {
+      if (options.user.email === email) {
+        throw new FirebaseError(`Already using account ${email} for this project directory.`)
+      }
+
+      auth.setProjectAccount(projectDir, email);
+      utils.logSuccess(`Set default account ${email} for current project directory.`);
+
+      return email;
+    } else {
+      if (options.user.email === email) {
+        throw new FirebaseError(`Already using account ${email} for the global default account.`)
+      }
+      const newDefaultAccount = allAccounts.find((a) => a.user.email === email);
+      if (!newDefaultAccount) {
+        // should never happen
+        throw new FirebaseError(
+          `Account ${email} does not exist, run "${clc.bold(
+            "firebase login:list"
+          )}" to see valid accounts`
+        );
+      }
+      const oldDefaultAccount = auth.getGlobalDefaultAccount();
+      if (!oldDefaultAccount) {
+        // should never happen
+        throw new FirebaseError("Could not determine global default account");
+      }
+      // set new default account and removes it from additional accounts
+      auth.setGlobalDefaultAccount(newDefaultAccount!);
+      // add old default account as additional account
+      auth.addAdditionalAccount(oldDefaultAccount!);
+
+      utils.logSuccess(`Set global default account to ${email}.`);
+
+      return email;
     }
-
-    auth.setProjectAccount(projectDir, email);
-    utils.logSuccess(`Set default account ${email} for current project directory.`);
-
-    return email;
   });

--- a/src/commands/login-use.ts
+++ b/src/commands/login-use.ts
@@ -6,7 +6,9 @@ import * as auth from "../auth";
 import { FirebaseError } from "../error";
 
 export const command = new Command("login:use <email>")
-  .description("set the default account to use for this project directory or the global default account if not in a Firebase project directory")
+  .description(
+    "set the default account to use for this project directory or the global default account if not in a Firebase project directory"
+  )
   .action((email: string, options: any) => {
     const allAccounts = auth.getAllAccounts();
     const accountExists = allAccounts.some((a) => a.user.email === email);
@@ -19,13 +21,12 @@ export const command = new Command("login:use <email>")
     }
 
     const projectDir = options.projectRoot as string | null;
-    utils.logWarning(`projectDir: ${projectDir}`);
 
     // if current directory is a Firebase project directory, set the default account for this project directory
     // otherwise, set the global default account
     if (projectDir) {
       if (options.user.email === email) {
-        throw new FirebaseError(`Already using account ${email} for this project directory.`)
+        throw new FirebaseError(`Already using account ${email} for this project directory.`);
       }
 
       auth.setProjectAccount(projectDir, email);
@@ -34,7 +35,7 @@ export const command = new Command("login:use <email>")
       return email;
     } else {
       if (options.user.email === email) {
-        throw new FirebaseError(`Already using account ${email} for the global default account.`)
+        throw new FirebaseError(`Already using account ${email} for the global default account.`);
       }
       const newDefaultAccount = allAccounts.find((a) => a.user.email === email);
       if (!newDefaultAccount) {
@@ -51,9 +52,9 @@ export const command = new Command("login:use <email>")
         throw new FirebaseError("Could not determine global default account");
       }
       // set new default account and removes it from additional accounts
-      auth.setGlobalDefaultAccount(newDefaultAccount!);
+      auth.setGlobalDefaultAccount(newDefaultAccount);
       // add old default account as additional account
-      auth.addAdditionalAccount(oldDefaultAccount!);
+      auth.addAdditionalAccount(oldDefaultAccount);
 
       utils.logSuccess(`Set global default account to ${email}.`);
 

--- a/src/commands/login-use.ts
+++ b/src/commands/login-use.ts
@@ -20,14 +20,6 @@ export const command = new Command("login:use <email>")
 
     const projectDir = options.projectRoot as string | null;
     utils.logWarning(`projectDir: ${projectDir}`);
-    // if (!projectDir) {
-    //   throw new FirebaseError("Could not determine active Firebase project directory");
-    // }
-
-    // auth.setProjectAccount(projectDir, email);
-    // utils.logSuccess(`Set default account ${email} for current project directory.`);
-
-    // return email;
 
     // if current directory is a Firebase project directory, set the default account for this project directory
     // otherwise, set the global default account


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
 
issue: #6526 
(feature): It makes it possible to use `firebase login:use <email>` command outside a Firebase project which previously raised an error that said `Error: Could not determine active Firebase project directory`. The new feature DOES NOT EFFECT how we use this command in a Firebase project. It works exactly the same as before (except for raising an error if you try to use the current default account as the new one. See minor change below).  When you use the command outside of a Firebase project, it now changes the global default account to the specified account.

(minor change): In addition to the feature request in the issue, It raises an error when you try to change to the account that's already in use. prior to this, it did not check if it was the same account and doing unnecessary executions.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- regardless of the directory:
    - Checked if an error is raised when they try to set the current account as the new account. 
    - Checked if an error is raised when they try to use an email not added to the CLI.

- when setting a different account inside of a Firebase project:
    - Checked if nothing changed from prior to implementing this feature. (No code was changed so it should work the same)

- when setting a different account outside of a Firebase project:
    - Checked if `new accounts`'s User and Token was set as global default account and removed from `additionalAccounts`, and the `previous global account`'s  User and Token was added to the `additionalAccounts`. 

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

1. In a Firebase project:
    (As before) When you set a different email.
    ```
    firebase login:use <email>

    ✔  Set default account <email> for current project directory.
    ```

    (New) When you try to set the account to the one already set.
    ```
    firebase login:use <email>

    Error: Already using account <email> for this project directory.
    ```

 2. Outside of a Firebase project:
    (New) When you set a different email to the global default account.
    ```
    firebase login:use <email>

    ✔  Set global default account to <email>.
    ```

    (New) When you try to set the account to the one already set.
    ```
    firebase login:use <email>

    Error: Already using account <email> for the global default account.
    ```

