### PR TITLE
Manage GCB connection resources more efficiently

### DIFF
--- a/src/gcp/cloudbuild.ts
+++ b/src/gcp/cloudbuild.ts
@@ -85,14 +85,15 @@ interface LinkableRepositories {
 export async function createConnection(
   projectId: string,
   location: string,
-  connectionId: string
+  connectionId: string,
+  githubConfig: GitHubConfig = {}
 ): Promise<Operation> {
   const res = await client.post<
     Omit<Omit<Connection, "name">, ConnectionOutputOnlyFields>,
     Operation
   >(
     `projects/${projectId}/locations/${location}/connections`,
-    { githubConfig: {} },
+    { githubConfig },
     { queryParams: { connectionId } }
   );
   return res.body;

--- a/src/init/features/frameworks/index.ts
+++ b/src/init/features/frameworks/index.ts
@@ -1,16 +1,16 @@
 import * as clc from "colorette";
 import * as utils from "../../../utils";
+import * as repo from "./repo";
+import * as poller from "../../../operation-poller";
+import * as gcp from "../../../gcp/frameworks";
+import { frameworksOrigin } from "../../../api";
+import { Backend, BackendOutputOnlyFields } from "../../../gcp/frameworks";
+import { Repository } from "../../../gcp/cloudbuild";
+import { API_VERSION } from "../../../gcp/frameworks";
+import { FirebaseError } from "../../../error";
 import { logger } from "../../../logger";
 import { promptOnce } from "../../../prompt";
 import { DEFAULT_REGION, ALLOWED_REGIONS } from "./constants";
-import * as repo from "./repo";
-import { Backend, BackendOutputOnlyFields } from "../../../gcp/frameworks";
-import { Repository } from "../../../gcp/cloudbuild";
-import * as poller from "../../../operation-poller";
-import { frameworksOrigin } from "../../../api";
-import * as gcp from "../../../gcp/frameworks";
-import { API_VERSION } from "../../../gcp/frameworks";
-import { FirebaseError } from "../../../error";
 
 const frameworksPollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
   apiOrigin: frameworksOrigin,
@@ -53,6 +53,7 @@ export async function doSetup(setup: any, projectId: string): Promise<void> {
   utils.logSuccess(`Region set to ${setup.frameworks.region}.`);
 
   const backend: Backend | undefined = await getOrCreateBackend(projectId, setup);
+
   if (backend) {
     logger.info();
     utils.logSuccess(`Successfully created backend:\n ${backend.name}`);

--- a/src/test/init/frameworks/repo.spec.ts
+++ b/src/test/init/frameworks/repo.spec.ts
@@ -136,6 +136,29 @@ describe("composer", () => {
     });
   });
 
+  describe("parseConnectionName", () => {
+    it("should parse valid connection name", () => {
+      const str = "projects/my-project/locations/us-central1/connections/my-conn";
+
+      const expected = {
+        projectId: "my-project",
+        location: "us-central1",
+        id: "my-conn",
+      };
+
+      expect(repo.parseConnectionName(str)).to.deep.equal(expected);
+    });
+
+    it("should return undefined for invalid", () => {
+      expect(
+        repo.parseConnectionName(
+          "projects/my-project/locations/us-central1/connections/my-conn/repositories/repo"
+        )
+      ).to.be.undefined;
+      expect(repo.parseConnectionName("foobar")).to.be.undefined;
+    });
+  });
+
   describe("listFrameworksConnections", () => {
     const sandbox: sinon.SinonSandbox = sinon.createSandbox();
     let listConnectionsStub: sinon.SinonStub;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { Socket } from "node:net";
+
 import * as _ from "lodash";
 import * as url from "url";
 import * as http from "http";
@@ -10,12 +14,12 @@ import * as winston from "winston";
 import { SPLAT } from "triple-beam";
 import { AssertionError } from "assert";
 const stripAnsi = require("strip-ansi");
+import { getPortPromise as getPort } from "portfinder";
 
 import { configstore } from "./configstore";
 import { FirebaseError } from "./error";
 import { logger, LogLevel } from "./logger";
 import { LogDataOrUndefined } from "./emulator/loggingEmulator";
-import { Socket } from "net";
 
 const IS_WINDOWS = process.platform === "win32";
 const SUCCESS_CHAR = IS_WINDOWS ? "+" : "✔";
@@ -758,4 +762,35 @@ export function connectableHostname(hostname: string): string {
  */
 export async function openInBrowser(url: string): Promise<void> {
   await open(url);
+}
+
+/**
+ * Like openInBrowser but opens the url in a popup.
+ */
+export async function openInBrowserPopup(url: string, buttonText: string): Promise<() => void> {
+  const popupPage = fs
+    .readFileSync(path.join(__dirname, "../templates/popup.html"), { encoding: "utf-8" })
+    .replace("${url}", url)
+    .replace("${buttonText}", buttonText);
+
+  const port = await getPort();
+
+  const server = http.createServer((req, res) => {
+    res.writeHead(200, {
+      "Content-Length": popupPage.length,
+      "Content-Type": "text/html",
+    });
+    res.end(popupPage);
+    req.socket.destroy();
+  });
+
+  server.listen(port);
+
+  const popupPageUri = `http://localhost:${port}`;
+  logger.info(popupPageUri);
+  await openInBrowser(popupPageUri);
+
+  return () => {
+    server.close();
+  };
 }

--- a/templates/popup.html
+++ b/templates/popup.html
@@ -1,0 +1,64 @@
+<head>
+  <style>
+    div {
+      font-family: sans-serif;
+    }
+    #popup {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      width: 100vw;
+      text-align: center;
+    }
+    #popup button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 0.375rem;
+      font-size: 1.5rem;
+      font-weight: 500;
+      height: 2.5rem;
+      padding: 0.5rem 1rem;
+      background-color: black;
+      color: white;
+      outline: none;
+      transition: background-color 150ms ease-in-out;
+      margin-bottom: 20px;
+    }
+    #popup button:hover {
+      background-color: #333;
+    }
+    #popup button:disabled {
+      opacity: 0.5;
+      pointer-events: none;
+    }
+    #message {
+      height: 20px;
+      margin-bottom: 20px;
+      color: gray;
+      font-size: 1.5rem;
+    }
+  </style>
+</head>
+<body>
+  <div id="popup">
+    <button id="popupBtn" onclick="openPopup()">${buttonText}</button>
+    <div id="message">(Close this window after authorizing the app)</div>
+  </div>
+  <script>
+    function openPopup() {
+      var w = window.open("${url}", "newwindow", "popup=1");
+      var m = document.getElementById("message");
+      var d = document.getElementById("popupBtn");
+      var timer = setInterval(function () {
+        if (w.closed) {
+          m.innerText = "You can close this page now";
+          d.disabled = true;
+          clearInterval(timer);
+        }
+      }, 1000);
+    }
+  </script>
+</body>


### PR DESCRIPTION
During onboarding, the CLI will create only the necessary GCB connection and repositories.

Unlike previous implemention where a connection was created per project/region, the new algorithm manages a single "oauth" connection resource and the same project/region connection. The new implementation also biases heavily towards reusing the GCB connection when any valid connection already exists in the project.

See internal doc for more detail.

The specific format for naming the GCB connection resource is one shared with the Firebase console so that all Firebase client manages the GCB resource in the same way.