### PR TITLE
check whether app `not-found` is static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Added the ability to deploy Angular apps using [the new application-builder](https://angular.dev/tools/cli/esbuild). (#6480)
 - Fixed an issue where `--non-interactive` flag is not respected in Firestore indexes deploys. (#6539)
 - Fixed an issue where `login:use` would not work outside of a Firebase project directory. (#6526)
+- Prevent app router static `not-found` requiring a Cloud Function in Next.js deployments. (#6558)

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -209,18 +209,16 @@ export async function build(dir: string): Promise<BuildResult> {
     headers.push(...headersFromMetaFiles);
 
     if (appPathsManifest) {
-      let unrenderedServerComponents = getNonStaticServerComponents(
+      const unrenderedServerComponents = getNonStaticServerComponents(
         appPathsManifest,
         appPathRoutesManifest,
         prerenderedRoutes,
         dynamicRoutes
       );
 
-      if (unrenderedServerComponents.includes("/_not-found")) {
+      if (unrenderedServerComponents.has("/_not-found")) {
         if (await hasStaticAppNotFoundComponent(dir, distDir)) {
-          unrenderedServerComponents = unrenderedServerComponents.filter(
-            (path) => path !== "/_not-found"
-          );
+          unrenderedServerComponents.delete("/_not-found");
         }
       }
 

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -216,10 +216,11 @@ export async function build(dir: string): Promise<BuildResult> {
         dynamicRoutes
       );
 
-      if (unrenderedServerComponents.has("/_not-found")) {
-        if (await hasStaticAppNotFoundComponent(dir, distDir)) {
-          unrenderedServerComponents.delete("/_not-found");
-        }
+      if (
+        unrenderedServerComponents.has("/_not-found") &&
+        (await hasStaticAppNotFoundComponent(dir, distDir))
+      ) {
+        unrenderedServerComponents.delete("/_not-found");
       }
 
       for (const key of unrenderedServerComponents) {

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -407,3 +407,17 @@ export function getNextVersion(cwd: string): string | undefined {
 
   return nextVersionSemver.toString();
 }
+
+/**
+ * Whether the Next.js project has a static `not-found` page in the app directory.
+ *
+ * The Next.js build manifests are misleading regarding the existence of a static
+ * `not-found` component. Therefore, we check if a `_not-found.html` file exists
+ * in the generated app directory files to know whether `not-found` is static.
+ */
+export async function hasStaticAppNotFoundComponent(
+  sourceDir: string,
+  distDir: string
+): Promise<boolean> {
+  return pathExists(join(sourceDir, distDir, "server", "app", "_not-found.html"));
+}

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -338,7 +338,7 @@ export function getNonStaticServerComponents(
   appPathRoutesManifest: AppPathRoutesManifest,
   prerenderedRoutes: string[],
   dynamicRoutes: string[]
-): string[] {
+): Set<string> {
   const nonStaticServerComponents = Object.entries(appPathsManifest)
     .filter(([it, src]) => {
       if (extname(src) !== ".js") return;
@@ -347,7 +347,7 @@ export function getNonStaticServerComponents(
     })
     .map(([it]) => it);
 
-  return nonStaticServerComponents;
+  return new Set(nonStaticServerComponents);
 }
 
 /**

--- a/src/test/frameworks/next/utils.spec.ts
+++ b/src/test/frameworks/next/utils.spec.ts
@@ -461,7 +461,7 @@ describe("Next.js utils", () => {
           Object.keys(prerenderManifest.routes),
           Object.keys(prerenderManifest.dynamicRoutes)
         )
-      ).to.deep.equal(["/api/test/route"]);
+      ).to.deep.equal(new Set(["/api/test/route"]));
     });
   });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Prevent requiring a Cloud Function when the `not-found` page is static or non-existent in the project. At the moment, the `not-found` component in the app router is being identified as dynamic due to inconsistencies with Next.js manifests.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

- not having a `not-found` component
- having a static `not-found` component
- having a dynamic `not-found` component with the route segment config `export const dynamic = 'force-dynamic'`

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
