### PR TITLE
Make FIREBASE_FRAMEWORKS_VERSION injectable for testing

### DIFF
--- a/src/frameworks/constants.ts
+++ b/src/frameworks/constants.ts
@@ -1,5 +1,6 @@
 import { SupportLevel } from "./interfaces";
 import * as clc from "colorette";
+import * as experiments from "../experiments";
 
 export const NPM_COMMAND_TIMEOUT_MILLIES = 10_000;
 
@@ -25,7 +26,10 @@ export const FEATURE_REQUEST_URL =
   "https://github.com/firebase/firebase-tools/issues/new?template=feature_request.md";
 export const MAILING_LIST_URL = "https://goo.gle/41enW5X";
 
-export const FIREBASE_FRAMEWORKS_VERSION = "^0.10.4";
+export const DEFAULT_FIREBASE_FRAMEWORKS_VERSION = "^0.10.4";
+export const FIREBASE_FRAMEWORKS_VERSION =
+  (experiments.isEnabled("internaltesting") && process.env.FIREBASE_FRAMEWORKS_VERSION) ||
+  DEFAULT_FIREBASE_FRAMEWORKS_VERSION;
 export const FIREBASE_FUNCTIONS_VERSION = "^4.3.0";
 export const FIREBASE_ADMIN_VERSION = "^11.0.1";
 export const SHARP_VERSION = "^0.32.1";

--- a/src/frameworks/constants.ts
+++ b/src/frameworks/constants.ts
@@ -26,7 +26,7 @@ export const FEATURE_REQUEST_URL =
   "https://github.com/firebase/firebase-tools/issues/new?template=feature_request.md";
 export const MAILING_LIST_URL = "https://goo.gle/41enW5X";
 
-export const DEFAULT_FIREBASE_FRAMEWORKS_VERSION = "^0.10.4";
+const DEFAULT_FIREBASE_FRAMEWORKS_VERSION = "^0.10.4";
 export const FIREBASE_FRAMEWORKS_VERSION =
   (experiments.isEnabled("internaltesting") && process.env.FIREBASE_FRAMEWORKS_VERSION) ||
   DEFAULT_FIREBASE_FRAMEWORKS_VERSION;


### PR DESCRIPTION
When `internaltesting` experiment is enabled, the value for `FIREBASE_FRAMEWORKS_VERSION` shall be derived from the environment variable with the same name.

This is only intended for testing purposes. Code behavior for production usage does not change.

This is to make it possible for `firebase-tools` to wire with `firebase-framework-tools` source code locally. See b/299490916 and go/firebase-3p-frameworks-compatibility-testing for more details.