### PR TITLE
Install missing dependencies during clean install by default

### DIFF
--- a/scripts/clean-install.sh
+++ b/scripts/clean-install.sh
@@ -11,7 +11,7 @@ trap cleanup EXIT
 
 rm -rf ./clean || true
 echo "Running clean-publish --without-publish, as we would before publishing to npm..."
-npx clean-publish --without-publish --before-script ./scripts/clean-shrinkwrap.sh --temp-dir clean
+npx --yes clean-publish --without-publish --before-script ./scripts/clean-shrinkwrap.sh --temp-dir clean
 echo "Ran clean-publish --without-publish."
 echo "Packaging cleaned firebase-tools..."
 cd ./clean


### PR DESCRIPTION
Currently npx prompts for confirmation from user to install missing dependencies when running the script. However, there is now a use case (b/299490916) that requires the script to be run unattendedly. `--yes` suppresses the prompt (https://docs.npmjs.com/cli/v10/commands/npx).

See b/299490916 and go/firebase-3p-frameworks-compatibility-testing for more details.