### PR TITLE
Prompt required IAM permission during frameworks onboarding.

### DIFF
--- a/src/gcp/cloudbuild.ts
+++ b/src/gcp/cloudbuild.ts
@@ -209,3 +209,10 @@ export async function deleteRepository(
   const res = await client.delete<Operation>(name);
   return res.body;
 }
+
+/**
+ * Returns email associated with the Cloud Build Service Agent.
+ */
+export function serviceAgentEmail(projectNumber: string): string {
+  return `service-${projectNumber}@gcp-sa-cloudbuild.iam.gserviceaccount.com`;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -767,7 +767,10 @@ export async function openInBrowser(url: string): Promise<void> {
 /**
  * Like openInBrowser but opens the url in a popup.
  */
-export async function openInBrowserPopup(url: string, buttonText: string): Promise<() => void> {
+export async function openInBrowserPopup(
+  url: string,
+  buttonText: string
+): Promise<{ url: string; cleanup: () => void }> {
   const popupPage = fs
     .readFileSync(path.join(__dirname, "../templates/popup.html"), { encoding: "utf-8" })
     .replace("${url}", url)
@@ -787,10 +790,12 @@ export async function openInBrowserPopup(url: string, buttonText: string): Promi
   server.listen(port);
 
   const popupPageUri = `http://localhost:${port}`;
-  logger.info(popupPageUri);
   await openInBrowser(popupPageUri);
 
-  return () => {
-    server.close();
+  return {
+    url: popupPageUri,
+    cleanup: () => {
+      server.close();
+    },
   };
 }


### PR DESCRIPTION
Before the CLI attempts to create a connection to GitHub using the Cloud Build API, the CLI now prompts the user if they want the CLI to grant the necessary IAM permissions on the Cloud Build Service Agent (as documented in the [Cloud Build public doc](https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github?generation=2nd-gen#iam_perms)):

```
i To create a new GitHub connection, Secret Manager Admin role (roles/secretmanager.admin) is required on the Cloud Build Service Agent.
? Grant the required role to the Cloud Build Service Agent? Yes
✅ Successfully granted the required role!
```