### PR TITLE
Allow GCB repos to be reused in backend.

### DIFF
--- a/src/init/features/frameworks/repo.ts
+++ b/src/init/features/frameworks/repo.ts
@@ -240,10 +240,6 @@ export async function getOrCreateRepository(
   let repo: gcb.Repository;
   try {
     repo = await gcb.getRepository(projectId, location, connectionId, repositoryId);
-    const repoSlug = extractRepoSlugFromUri(repo.remoteUri);
-    if (repoSlug) {
-      throw new FirebaseError(`${repoSlug} has already been linked.`);
-    }
   } catch (err: unknown) {
     if ((err as FirebaseError).status === 404) {
       const op = await gcb.createRepository(

--- a/src/test/init/frameworks/repo.spec.ts
+++ b/src/test/init/frameworks/repo.spec.ts
@@ -128,6 +128,21 @@ describe("composer", () => {
       );
     });
 
+    it("re-uses existing repository it already exists", async () => {
+      getConnectionStub.resolves(completeConn);
+      fetchLinkableRepositoriesStub.resolves(repos);
+      promptOnceStub.onFirstCall().resolves(repos.repositories[0].remoteUri);
+      getRepositoryStub.resolves(repos.repositories[0]);
+
+      const r = await repo.getOrCreateRepository(
+        projectId,
+        location,
+        connectionId,
+        repos.repositories[0].remoteUri
+      );
+      expect(r).to.be.deep.equal(repos.repositories[0]);
+    });
+
     it("throws error if no linkable repositories are available", async () => {
       getConnectionStub.resolves(pendingConn);
       fetchLinkableRepositoriesStub.resolves({ repositories: [] });


### PR DESCRIPTION
Previously, we assumed that each new GCB Repository resource would be associated with at most 1 backends. Our new data model now allows GCB Repository to be reused across different backends. Updating code to reflect the change.