### PR TITLE
Refactor createBackend and other utility functions.

### DIFF
--- a/src/test/init/frameworks/index.spec.ts
+++ b/src/test/init/frameworks/index.spec.ts
@@ -4,7 +4,8 @@ import { expect } from "chai";
 import * as gcp from "../../../gcp/frameworks";
 import * as repo from "../../../init/features/frameworks/repo";
 import * as poller from "../../../operation-poller";
-import { createBackend, getOrCreateBackend } from "../../../init/features/frameworks/index";
+import * as prompt from "../../../prompt";
+import { createBackend, onboardBackend } from "../../../init/features/frameworks/index";
 import { FirebaseError } from "../../../error";
 
 describe("operationsConverter", () => {
@@ -14,6 +15,7 @@ describe("operationsConverter", () => {
   let createBackendStub: sinon.SinonStub;
   let getBackendStub: sinon.SinonStub;
   let linkGitHubRepositoryStub: sinon.SinonStub;
+  let promptOnce: sinon.SinonStub;
 
   beforeEach(() => {
     pollOperationStub = sandbox
@@ -24,20 +26,23 @@ describe("operationsConverter", () => {
     linkGitHubRepositoryStub = sandbox
       .stub(repo, "linkGitHubRepository")
       .throws("Unexpected getBackend call");
+    promptOnce = sandbox.stub(prompt, "promptOnce").throws("Unexpected promptOnce call");
   });
 
   afterEach(() => {
     sandbox.verifyAndRestore();
   });
 
-  describe("createBackend", () => {
+  describe("onboardBackend", () => {
     const projectId = "projectId";
     const location = "us-central1";
     const backendId = "backendId";
+
     const op = {
       name: `projects/${projectId}/locations/${location}/backends/${backendId}`,
       done: true,
     };
+
     const completeBackend = {
       name: `projects/${projectId}/locations/${location}/backends/${backendId}`,
       labels: {},
@@ -45,21 +50,14 @@ describe("operationsConverter", () => {
       updateTime: "1",
       uri: "https://placeholder.com",
     };
-    const setup = {
-      frameworks: {
-        region: location,
-        serviceName: backendId,
-        existingBackend: true,
-        deployMethod: "github",
-        branchName: "main",
-      },
-    };
+
     const cloudBuildConnRepo = {
       name: `projects/${projectId}/locations/${location}/connections/framework-${location}/repositories/repoId`,
       remoteUri: "remoteUri",
       createTime: "0",
       updateTime: "1",
     };
+
     const backendInput: Omit<gcp.Backend, gcp.BackendOutputOnlyFields> = {
       servingLocality: "GLOBAL_ACCESS",
       codebase: {
@@ -68,6 +66,7 @@ describe("operationsConverter", () => {
       },
       labels: {},
     };
+
     it("should createBackend", async () => {
       createBackendStub.resolves(op);
       pollOperationStub.resolves(completeBackend);
@@ -77,27 +76,18 @@ describe("operationsConverter", () => {
       expect(createBackendStub).to.be.calledWith(projectId, location, backendInput);
     });
 
-    it("should return a backend, if user wants use the exiting backend", async () => {
-      getBackendStub.resolves(completeBackend);
-
-      const result = await getOrCreateBackend("projectId", setup);
-
-      expect(result).to.deep.equal(completeBackend);
-      expect(getBackendStub.calledOnceWithExactly(projectId, location, backendId)).to.be.true;
-    });
-
-    it("should create a new backend, if backend doesn't exist", async () => {
+    it("should onboard a new backend", async () => {
       const newBackendId = "newBackendId";
       const newPath = `projects/${projectId}/locations/${location}/backends/${newBackendId}`;
-      setup.frameworks.serviceName = newBackendId;
       op.name = newPath;
       completeBackend.name = newPath;
       getBackendStub.throws(new FirebaseError("error", { status: 404 }));
       linkGitHubRepositoryStub.resolves(cloudBuildConnRepo);
       createBackendStub.resolves(op);
       pollOperationStub.resolves(completeBackend);
+      promptOnce.resolves("main");
 
-      const result = await getOrCreateBackend(projectId, setup);
+      const result = await onboardBackend(projectId, location, backendId);
 
       expect(result).to.deep.equal(completeBackend);
       expect(createBackendStub).to.be.calledWith(projectId, location, backendInput);


### PR DESCRIPTION
As written, various utility command used for onboarding uses untyped `setup` object. Making a small refactoring here to explicitly pull out `backenId`, `locations`, and other variables that's used throughout the module.