### PR TITLE
Memoize firestore.getDatabase API calls when deploying Firestore functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where deploying Firestore function resulted in redudant API calls to the Firestore API (#6583).

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -8,7 +8,7 @@ const apiClient = new Client({
   urlPrefix: firestoreOrigin,
 });
 
-interface Database {
+export interface Database {
   name: string;
   uid: string;
   createTime: string;


### PR DESCRIPTION
During deployment of a 2nd Gen Firestore functions, the CLI retrieves metadata associated with the Firestore database in order to ensure that the region of the Firestore database matches the region of the deployed function:

https://github.com/firebase/firebase-tools/blob/1f4f6f494fd7a8a29887a8306930cda56aa7e13b/src/deploy/functions/services/firestore.ts#L9-L15

Unfortunately, when a large number of functions are deployed that each target a different Firestore instance (you are allowed to have multiple instances of Firestore on a single GCP project), developer will likely see a quota exceeds error:

```
Quota exceeded for quota metric 'Database operation requests' and limit 'Database Operations Per Minute' of service 'firestore.googleapis.com' for consumer ...
```

We mitigate the issue by memoizing the API calls. This should help with cases where multiple firestore functions are associated with a database, but wouldn't help if developer is setting up and deploying 60+ unique functions.

Mitigates https://github.com/firebase/firebase-tools/issues/6574