### PR TITLE
Fix for the default import of strip-ansi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix Next.js dynamic and static OG images. (#6592)
+- Address a regression introduced in 3.0.1 when emulating Vite applications. (#6599)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fix Next.js dynamic and static OG images. (#6592)
-- Address a regression introduced in 3.0.1 when emulating Vite applications. (#6599)
+- Address a regression introduced in 13.0.1 when emulating Vite applications. (#6599)

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -3,7 +3,7 @@ import { spawn } from "cross-spawn";
 import { existsSync } from "fs";
 import { copy, pathExists } from "fs-extra";
 import { join } from "path";
-import stripAnsi from "strip-ansi";
+const stripAnsi = require("strip-ansi");
 import { FrameworkType, SupportLevel } from "../interfaces";
 import { promptOnce } from "../../prompt";
 import {


### PR DESCRIPTION
Synthetic default imports strikes again! Isn't esModuleInterop fun.

Require strip-ansi like the rest of the Codebase. Fixes #6597