### PR TITLE
Dynamically load available locations from App Hosting API

### DIFF
--- a/src/commands/frameworks-backends-create.ts
+++ b/src/commands/frameworks-backends-create.ts
@@ -7,6 +7,7 @@ import { ensureApiEnabled } from "../gcp/frameworks";
 
 export const command = new Command("backends:create")
   .description("Create a backend in a Firebase project")
+  .option("-l, --location <location>", "Specify the region of the backend", "")
   .before(ensureApiEnabled)
   .before(requireInteractive)
   .action(async (options: Options) => {

--- a/src/commands/frameworks-backends-delete.ts
+++ b/src/commands/frameworks-backends-delete.ts
@@ -6,7 +6,7 @@ import * as gcp from "../gcp/frameworks";
 import { promptOnce } from "../prompt";
 import * as utils from "../utils";
 import { logger } from "../logger";
-import { DEFAULT_REGION, ALLOWED_REGIONS } from "../init/features/frameworks/constants";
+import { DEFAULT_REGION } from "../init/features/frameworks/constants";
 import { ensureApiEnabled } from "../gcp/frameworks";
 
 const Table = require("cli-table");
@@ -36,12 +36,13 @@ export const command = new Command("backends:delete")
     }
 
     if (!location) {
+      const allowedLocations = (await gcp.listLocations(projectId)).map((loc) => loc.locationId);
       location = await promptOnce({
         name: "region",
         type: "list",
         default: DEFAULT_REGION,
         message: "Please select the region of the backend you'd like to delete:",
-        choices: ALLOWED_REGIONS,
+        choices: allowedLocations,
       });
     }
 

--- a/src/gcp/frameworks.ts
+++ b/src/gcp/frameworks.ts
@@ -125,7 +125,6 @@ export async function getBackend(
 ): Promise<Backend> {
   const name = `projects/${projectId}/locations/${location}/backends/${backendId}`;
   const res = await client.get<Backend>(name);
-
   return res.body;
 }
 
@@ -173,6 +172,32 @@ export async function createBuild(
   );
 
   return res.body;
+}
+
+export interface Location {
+  name: string;
+  locationId: string;
+}
+
+interface ListLocationsResponse {
+  locations: Location[];
+  nextPageToken?: string;
+}
+
+/**
+ * Lists information about the supported locations.
+ */
+export async function listLocations(projectId: string): Promise<Location[]> {
+  let pageToken;
+  let locations: Location[] = [];
+  do {
+    const response = await client.get<ListLocationsResponse>(`projects/${projectId}/locations`);
+    if (response.body.locations && response.body.locations.length > 0) {
+      locations = locations.concat(response.body.locations);
+    }
+    pageToken = response.body.nextPageToken;
+  } while (pageToken);
+  return locations;
 }
 
 /**

--- a/src/init/features/frameworks/constants.ts
+++ b/src/init/features/frameworks/constants.ts
@@ -1,4 +1,3 @@
 export const DEFAULT_REGION = "us-central1";
-export const ALLOWED_REGIONS = [{ name: "us-central1 (Iowa)", value: "us-central1" }];
 export const DEFAULT_DEPLOY_METHOD = "github";
 export const ALLOWED_DEPLOY_METHODS = [{ name: "Deploy using github", value: "github" }];


### PR DESCRIPTION
Instead of hard-coding supported regions, we dynamically fetch the list of supported regions from the API.

This is great especially when a org policy is set to restrict region availability for a project!