### PR TITLE
Fix/storage emulator json stream

### DIFF
--- a/src/emulator/jsonUtils.ts
+++ b/src/emulator/jsonUtils.ts
@@ -1,0 +1,88 @@
+type MatchingBracketsAccumulator = {
+  matching: "none" | "square" | "curly";
+  squareUnclosed: number;
+  curlyUnclosed: number;
+  matches: number[];
+  escapes: number;
+  isString: boolean;
+};
+
+const merge = (
+  j1: MatchingBracketsAccumulator,
+  j2: MatchingBracketsAccumulator
+): MatchingBracketsAccumulator => ({
+  matching: j2.matching,
+  curlyUnclosed: j1.curlyUnclosed + j2.curlyUnclosed,
+  squareUnclosed: j1.squareUnclosed + j2.squareUnclosed,
+  escapes: j1.escapes + j2.escapes,
+  matches: [...j1.matches, ...j2.matches],
+  isString: j2.isString,
+});
+const defaultMatchingBrackets: MatchingBracketsAccumulator = {
+  matching: "none",
+  escapes: 0,
+  matches: [0],
+  curlyUnclosed: 0,
+  squareUnclosed: 0,
+  isString: false,
+};
+
+const _getCountScore = (isEscaped: boolean, char: string) => (inc: string, dec: string) =>
+  isEscaped ? 0 : inc === char ? 1 : dec === char ? -1 : 0;
+
+const getMatchingBracketIndices = (s: string): number[] => {
+  const res = s.split("").reduce((acc, c, index) => {
+    const isEscaped = acc.escapes % 2 === 1;
+    const isString = !isEscaped && c === '"' ? !acc.isString : acc.isString;
+    const getCountScore = _getCountScore(isEscaped || isString, c);
+    const curlyUnclosed = getCountScore("{", "}");
+    const squareUnclosed = getCountScore("[", "]");
+    const completedMatch =
+      (acc.matching === "curly" && acc.curlyUnclosed + curlyUnclosed === 0) ||
+      (acc.matching === "square" && acc.squareUnclosed + squareUnclosed === 0);
+    const matching = completedMatch
+      ? "none"
+      : acc.matching === "none" && curlyUnclosed === 1
+      ? "curly"
+      : acc.matching === "none" && squareUnclosed === 1
+      ? "square"
+      : acc.matching;
+
+    const res = merge(acc, {
+      escapes: c === "\\" ? 1 : -1 * acc.escapes,
+      curlyUnclosed,
+      matching,
+      matches: completedMatch
+        ? [index + 1]
+        : acc.matching === "none" && matching !== "none"
+        ? [index]
+        : [],
+      squareUnclosed,
+      isString,
+    });
+    return res;
+  }, defaultMatchingBrackets);
+  return res.matches;
+};
+
+type ParseError = { type: "parse-error"; value: string };
+const parseError = (value: string): ParseError => ({ type: "parse-error", value });
+type ParseSuccess = { type: "success"; value: object };
+const parseSuccess = (value: object): ParseSuccess => ({ type: "success", value });
+type ParseResponse = ParseError | ParseSuccess;
+
+export const parseStr = (s: string): ParseResponse[] => {
+  const indices = getMatchingBracketIndices(s);
+  return indices
+    .map((start, index) => {
+      const finish = indices[index + 1] ?? s.length;
+      const strObj = s.slice(start, finish);
+      try {
+        const value: object = JSON.parse(strObj);
+        return parseSuccess(value);
+      } catch (error) {
+        return parseError(strObj);
+      }
+    })
+    .filter((v) => v.type === "success" || (v.type === "parse-error" && Boolean(v.value)));
+};

--- a/src/emulator/storage/rules/runtime.ts
+++ b/src/emulator/storage/rules/runtime.ts
@@ -31,6 +31,7 @@ import {
   handleEmulatorProcessError,
 } from "../../downloadableEmulators";
 import { EmulatorRegistry } from "../../registry";
+import { parseStr } from "../../jsonUtils";
 
 const lock = new AsyncLock();
 const synchonizationKey = "key";
@@ -187,35 +188,32 @@ export class StorageRulesRuntime {
     this._childprocess.stdout?.on("data", (buf: Buffer) => {
       const serializedRuntimeActionResponse = buf.toString("utf-8").trim();
       if (serializedRuntimeActionResponse !== "") {
-        let rap;
-        try {
-          rap = JSON.parse(serializedRuntimeActionResponse) as RuntimeActionResponse;
-        } catch (err: any) {
-          EmulatorLogger.forEmulator(Emulators.STORAGE).log(
-            "INFO",
-            serializedRuntimeActionResponse
-          );
-          return;
-        }
+        for (const parsedRap of parseStr(serializedRuntimeActionResponse)) {
+          if (parsedRap.type === "parse-error") {
+            EmulatorLogger.forEmulator(Emulators.STORAGE).log("INFO", parsedRap.value);
+            return;
+          }
+          const rap = parsedRap.value as RuntimeActionResponse;
 
-        const id = rap.id ?? rap.server_request_id;
-        if (id === undefined) {
-          console.log(`Received no ID from server response ${serializedRuntimeActionResponse}`);
-          return;
-        }
+          const id = rap.id ?? rap.server_request_id;
+          if (id === undefined) {
+            console.log(`Received no ID from server response ${serializedRuntimeActionResponse}`);
+            return;
+          }
 
-        const request = this._requests[id];
+          const request = this._requests[id];
 
-        if (rap.status !== "ok" && !("action" in rap)) {
-          console.warn(`[RULES] ${rap.status}: ${rap.message}`);
-          rap.errors.forEach(console.warn.bind(console));
-          return;
-        }
+          if (rap.status !== "ok" && !("action" in rap)) {
+            console.warn(`[RULES] ${rap.status}: ${rap.message}`);
+            rap.errors.forEach(console.warn.bind(console));
+            return;
+          }
 
-        if (request) {
-          request.handler(rap);
-        } else {
-          console.log(`No handler for event ${serializedRuntimeActionResponse}`);
+          if (request) {
+            request.handler(rap);
+          } else {
+            console.log(`No handler for event ${serializedRuntimeActionResponse}`);
+          }
         }
       }
     });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Sometimes the storage emulator fails to resolve and the network request remains in a pending state.
The problem comes from the java subprocess. When a received chunk includes a non-json log or 2 json objects the parse command fails, logs, and returns. 
The fix I implemented is finding matching brackets and parsing the content in those.

Linked issue: #6194

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

[FIXED]: When users add `debug(...)` to storage.rules files, the requests intermittently hang.
[FIXED]: When hundreds of requests go out sometimes response get tangled.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
