### PR TITLE
Support export in env parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where including `export` in .env files caused parsing errors. (#6629)

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -45,7 +45,7 @@ const RESERVED_KEYS = [
 const LINE_RE = new RegExp(
   "^" +                      // begin line
   "\\s*" +                   //   leading whitespaces
-  "(export)?" +                       // Optional 'export'
+  "(?:export)?" +                       // Optional 'export' in a non-capture group
   "\\s*" +                   //   more whitespaces
   "([\\w./]+)" +                 //   key
   "\\s*=[\\f\\t\\v]*" +              //   separator (=)

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -45,6 +45,8 @@ const RESERVED_KEYS = [
 const LINE_RE = new RegExp(
   "^" +                      // begin line
   "\\s*" +                   //   leading whitespaces
+  "(export)?" +                       // Optional 'export'
+  "\\s*" +                   //   more whitespaces
   "([\\w./]+)" +                 //   key
   "\\s*=[\\f\\t\\v]*" +              //   separator (=)
   "(" +                      //   begin optional value

--- a/src/test/functions/env.spec.ts
+++ b/src/test/functions/env.spec.ts
@@ -16,6 +16,11 @@ describe("functions/env", () => {
         want: { FOO: "foo" },
       },
       {
+        description: "should parse exported values",
+        input: "export FOO=foo",
+        want: { FOO: "foo" },
+      },
+      {
         description: "should parse values with trailing spaces (single quotes)",
         input: "FOO='foo'        ",
         want: { FOO: "foo" },


### PR DESCRIPTION
### Description
Allow .env files to include export at the start of lines. Fixes #6629

