### PR TITLE
Add support for Python 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-Bugfixes to internal utilities (#6754)
+- Add support for Python 3.12. (#6679)
+- Bugfixes to internal utilities. (#6754)

--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -15,6 +15,7 @@ const RUNTIMES: string[] = [
   "nodejs20",
   "python310",
   "python311",
+  "python312",
 ];
 // Experimental runtimes are part of the Runtime type, but are in a
 // different list to help guard against some day accidentally iterating over
@@ -47,6 +48,7 @@ const MESSAGE_FRIENDLY_RUNTIMES: Record<Runtime | DeprecatedRuntime, string> = {
   nodejs20: "Node.js 20",
   python310: "Python 3.10",
   python311: "Python 3.11",
+  python312: "Python 3.12",
 };
 
 /**

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -13,7 +13,7 @@ import { DEFAULT_VENV_DIR, runWithVirtualEnv, virtualEnvCmd } from "../../../../
 import { FirebaseError } from "../../../../error";
 import { Build } from "../../build";
 
-export const LATEST_VERSION: runtimes.Runtime = "python311";
+export const LATEST_VERSION: runtimes.Runtime = "python312";
 
 /**
  * Create a runtime delegate for the Python runtime, if applicable.
@@ -51,6 +51,8 @@ export function getPythonBinary(runtime: runtimes.Runtime): string {
     return "python3.10";
   } else if (runtime === "python311") {
     return "python3.11";
+  } else if (runtime === "python312") {
+    return "python3.12";
   }
   return "python";
 }

--- a/src/test/deploy/functions/runtimes/python/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/python/index.spec.ts
@@ -28,7 +28,7 @@ describe("PythonDelegate", () => {
 
     it("returns generic python binary given non-recognized python runtime", () => {
       platformMock.value("darwin");
-      const requestedRuntime = "python312";
+      const requestedRuntime = "python308";
       const delegate = new python.Delegate(PROJECT_ID, SOURCE_DIR, requestedRuntime);
 
       expect(delegate.getPythonBinary()).to.equal("python");


### PR DESCRIPTION
Fixes #6666

I've deployed a test application and verified that Python 3.12.1 was running. IDK where the integration tests are though, so I'll let the regular folks own quality control.