### PR TITLE
[Typo] Fix a few typos on the Auth emulator(and firestore)

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1654,7 +1654,7 @@ async function signInWithIdp(
     }
   } else {
     if (!response.localId) {
-      throw new Error("Internal assertion error: localId not set for exising user.");
+      throw new Error("Internal assertion error: localId not set for existing user.");
     }
 
     const maybeUser = state.getUserByLocalId(response.localId);
@@ -3332,7 +3332,7 @@ export interface IdpJwtPayload {
   /** Unique identifier of user at IDP. Also known as "rawId" in Firebase Auth. */
   sub: string;
 
-  // Issuer (IDP identifer / URL) and Audience (Developer app ID), ignored.
+  // Issuer (IDP identifier / URL) and Audience (Developer app ID), ignored.
   iss: string; // Ignored
   aud: string; // Ignored
 

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -123,7 +123,7 @@ export async function createApp(
   const app = express();
   app.set("json spaces", 2);
 
-  // Retrun access-control-allow-private-network heder if requested
+  // Return access-control-allow-private-network heder if requested
   // Enables accessing locahost when site is exposed via tunnel see https://github.com/firebase/firebase-tools/issues/4227
   // Aligns with https://wicg.github.io/private-network-access/#headers
   // Replace with cors option if adopted, see https://github.com/expressjs/cors/issues/236
@@ -298,7 +298,7 @@ export async function createApp(
         return true;
       },
       byte() {
-        // Disable the "byte" format validation to allow stuffing arbitary
+        // Disable the "byte" format validation to allow stuffing arbitrary
         // strings in passwordHash etc. Needed because the emulator generates
         // non-base64 hash strings like "fakeHash:salt=foo:password=bar".
         return true;

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -25,7 +25,7 @@ export function createApp(
     `Temp file directory for storage emulator: ${storageLayer.dirPath}`
   );
 
-  // Retrun access-control-allow-private-network header if requested
+  // Return access-control-allow-private-network header if requested
   // Enables accessing locahost when site is exposed via tunnel see https://github.com/firebase/firebase-tools/issues/4227
   // Aligns with https://wicg.github.io/private-network-access/#headers
   // Replace with cors option if adopted, see https://github.com/expressjs/cors/issues/236

--- a/src/firestore/delete.ts
+++ b/src/firestore/delete.ts
@@ -536,7 +536,7 @@ export class FirestoreDelete {
    * Check if a path has any children. Useful for determining
    * if deleting a path will affect more than one document.
    *
-   * @return a promise that retruns true if the path has children and false otherwise.
+   * @return a promise that returns true if the path has children and false otherwise.
    */
   public checkHasChildren(): Promise<boolean> {
     return this.getDescendantBatch(true, 1).then((docs) => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Typos

- Auth emulator
   - exising -> existing
   - identifer -> identifier
   - arbitary -> arbitrary
   - retrun -> return

- Firestore
   -  retruns -> returns