### PR TITLE
Fixes issue where Auth emulator sign in with Google only shows default tenant

### DIFF
--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -172,7 +172,7 @@ export function registerHandlers(
     res.set("Content-Type", "text/html; charset=utf-8");
     const apiKey = req.query.apiKey as string | undefined;
     const providerId = req.query.providerId as string | undefined;
-    const tenantId = req.query.tenantId as string | undefined;
+    const tenantId = (req.query.tenantId || req.query.tid) as string | undefined;
     if (!apiKey || !providerId) {
       return res.status(400).json({
         authEmulator: {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

As mentioned [here](https://github.com/firebase/firebase-tools/issues/5623#issuecomment-1577324485), "other tenants than the default using the Google Auth Provider are not being listed in the popup sign-in screen". This may be because the link created looks like `http://127.0.0.1:9099/emulator/auth/handler?<other_query>&tid=second`. The link has a query of `tid` not `tenantId`

We are currently looking for the `tenantId` query.
```ts
const tenantId = req.query.tenantId as string | undefined;
```

Given that we may be using `tenantId` in the past(or other sdks), keeping both instead of replacing `tenantId` with `tid` might be a better option

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

See https://github.com/aalej/issues_5623-tid for a test case

Using the Auth emulator and Hosting emulator
1. Sign in with "default" tenant
2. Sign out
3. Sign in with "second" tenant
    1.  Users from the "default" must not be displayed
4. Sign out
5. Sign in with "default" tenant
    1.  Only users from the "default" must be displayed
6. Sign out
7. Sign in with "second" tenant
    1.  Only users from the "second" must be displayed

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase emulators:start --project <project_id>`