### PR TITLE
Add boolean type to queryString and fix app hosting delete backend call

### DIFF
--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -48,7 +48,7 @@ type RequestOptions<T> = RequestOptionsWithSignal<T> | RequestOptionsWithTimeout
 interface VerbOptions {
   method?: HttpMethod;
   headers?: HeadersInit;
-  queryParams?: URLSearchParams | { [key: string]: string | number };
+  queryParams?: URLSearchParams | { [key: string]: string | number | boolean };
 }
 
 interface ClientHandlingOptions {

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -297,8 +297,8 @@ export async function deleteBackend(
   location: string,
   backendId: string
 ): Promise<Operation> {
-  const name = `projects/${projectId}/locations/${location}/backends/${backendId}?force=true`;
-  const res = await client.delete<Operation>(name);
+  const name = `projects/${projectId}/locations/${location}/backends/${backendId}`;
+  const res = await client.delete<Operation>(name, { queryParams: { force: true } });
 
   return res.body;
 }


### PR DESCRIPTION
Adds `{ queryParams: { force: true }` to the apiv2 package