### PR TITLE
Fix invalid assignment error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,5 @@
 - Prevent the use of pinTags + minInstances on the same function, as the features are not mutually compatible (#6684)
 - Add force flag to delete backend (#6635).
 - Use framework build target in Vite builds (#6643).
-- Use framework build target in NODE_ENV for production Vite builds (#6644)
 - Let framework handle public directory with emulator. (#6674)
 - Dynamically import Vite to fix deprecated CJS build warning. (#6660)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,5 +2,6 @@
 - Prevent the use of pinTags + minInstances on the same function, as the features are not mutually compatible (#6684)
 - Add force flag to delete backend (#6635).
 - Use framework build target in Vite builds (#6643).
+- Use framework build target in NODE_ENV for production Vite builds (#6644)
 - Let framework handle public directory with emulator. (#6674)
 - Dynamically import Vite to fix deprecated CJS build warning. (#6660)

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -89,12 +89,16 @@ export async function build(root: string, target: string) {
 
   const originalNodeEnv = process.env.NODE_ENV;
 
-  let envKey = 'NODE_ENV'
+  let envKey = "NODE_ENV";
+  // Voluntarily making .env[key] not statically analyzable to avoid
+  // Webpack from converting it to "development" = target;
   process.env[envKey] = target;
 
   await build({ root, mode: target });
   process.chdir(cwd);
 
+  // Voluntarily making .env[key] not statically analyzable to avoid
+  // Webpack from converting it to "development" = target;
   process.env[envKey] = originalNodeEnv;
 
   return { rewrites: [{ source: "**", destination: "/index.html" }] };

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -89,7 +89,7 @@ export async function build(root: string, target: string) {
 
   const originalNodeEnv = process.env.NODE_ENV;
 
-  let envKey = "NODE_ENV";
+  const envKey = "NODE_ENV";
   // Voluntarily making .env[key] not statically analyzable to avoid
   // Webpack from converting it to "development" = target;
   process.env[envKey] = target;

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -89,7 +89,7 @@ export async function build(root: string, target: string) {
 
   const originalNodeEnv = process.env.NODE_ENV;
 
-  const envKey = "NODE_ENV";
+  const envKey: string = "NODE_ENV";
   // Voluntarily making .env[key] not statically analyzable to avoid
   // Webpack from converting it to "development" = target;
   process.env[envKey] = target;

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -89,6 +89,8 @@ export async function build(root: string, target: string) {
 
   const originalNodeEnv = process.env.NODE_ENV;
 
+  // Downcasting as `string` as otherwise it is inferred as `readonly 'NODE_ENV'`,
+  // but `env[key]` expects a non-readonly variable.
   const envKey: string = "NODE_ENV";
   // Voluntarily making .env[key] not statically analyzable to avoid
   // Webpack from converting it to "development" = target;

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -86,8 +86,16 @@ export async function build(root: string, target: string) {
   // SvelteKit uses process.cwd() unfortunately, chdir
   const cwd = process.cwd();
   process.chdir(root);
+
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  let envKey = 'NODE_ENV'
+  process.env[envKey] = target;
+
   await build({ root, mode: target });
   process.chdir(cwd);
+
+  process.env[envKey] = originalNodeEnv;
 
   return { rewrites: [{ source: "**", destination: "/index.html" }] };
 }

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -86,17 +86,8 @@ export async function build(root: string, target: string) {
   // SvelteKit uses process.cwd() unfortunately, chdir
   const cwd = process.cwd();
   process.chdir(root);
-
-  const originalNodeEnv = process.env.NODE_ENV;
-  // @ts-expect-error - NODE_ENV is `development` when building for production
-  // temporarily replace with target during build
-  process.env.NODE_ENV = target;
-
   await build({ root, mode: target });
   process.chdir(cwd);
-
-  // @ts-expect-error - restore NODE_ENV after build
-  process.env.NODE_ENV = originalNodeEnv;
 
   return { rewrites: [{ source: "**", destination: "/index.html" }] };
 }


### PR DESCRIPTION
~~This reverts commit d0972f7bbb31050bd7cfbcab718fe1c0fb8faa9a.~~


~~That ENV changes breaks bundling, as Webpack replaces `process.env.NODE_ENV = target;` to `"development" = target`, which is not valid~~

Fixed by making the expression non-statically analysable, which disables Webpack's shenanigans

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->


cc @leoortizz

