### PR TITLE
Fixing unsafe array spreads on Hosting deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 - Fixed issue where Auth emulator sign in with Google only shows default tenant. (#6683)
 - Prevent the use of pinTags + minInstances on the same function, as the features are not mutually compatible (#6684)
-- Add force flag to delete backend (#6635).
+- Added force flag to delete backend (#6635).
 - Use framework build target in Vite builds (#6643).
 - Use framework build target in NODE_ENV for production Vite builds (#6644)
 - Let framework handle public directory with emulator. (#6674)
 - Dynamically import Vite to fix deprecated CJS build warning. (#6660)
+- Fixed unsafe array spreads on Hosting deploys. (#6712)

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -312,14 +312,11 @@ export async function listChannels(
   let nextPageToken = "";
   for (;;) {
     try {
-      const res = await apiClient.get<{ nextPageToken?: string; channels: Channel[] }>(
+      const res = await apiClient.get<{ nextPageToken?: string; channels?: Channel[] }>(
         `/projects/${project}/sites/${site}/channels`,
         { queryParams: { pageToken: nextPageToken, pageSize: 10 } }
       );
-      const c = res.body.channels;
-      if (c) {
-        channels.push(...c);
-      }
+      channels.push(...(res.body.channels ?? []));
       nextPageToken = res.body.nextPageToken || "";
       if (!nextPageToken) {
         return channels;
@@ -431,7 +428,7 @@ export async function updateVersion(
 }
 
 interface ListVersionsResponse {
-  versions: Version[];
+  versions?: Version[];
   nextPageToken?: string;
 }
 
@@ -449,8 +446,8 @@ export async function listVersions(site: string): Promise<Version[]> {
     const res = await apiClient.get<ListVersionsResponse>(`projects/-/sites/${site}/versions`, {
       queryParams,
     });
-    versions.push(...(res.body?.versions || []));
-    pageToken = res.body?.nextPageToken;
+    versions.push(...(res.body.versions ?? []));
+    pageToken = res.body.nextPageToken;
   } while (pageToken);
   return versions;
 }
@@ -515,14 +512,11 @@ export async function listSites(project: string): Promise<Site[]> {
   let nextPageToken = "";
   for (;;) {
     try {
-      const res = await apiClient.get<{ sites: Site[]; nextPageToken?: string }>(
+      const res = await apiClient.get<{ sites?: Site[]; nextPageToken?: string }>(
         `/projects/${project}/sites`,
         { queryParams: { pageToken: nextPageToken, pageSize: 10 } }
       );
-      const c = res.body?.sites || [];
-      if (c) {
-        sites.push(...c);
-      }
+      sites.push(...(res.body.sites ?? []));
       nextPageToken = res.body.nextPageToken || "";
       if (!nextPageToken) {
         return sites;

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -449,8 +449,8 @@ export async function listVersions(site: string): Promise<Version[]> {
     const res = await apiClient.get<ListVersionsResponse>(`projects/-/sites/${site}/versions`, {
       queryParams,
     });
-    versions.push(...res.body.versions);
-    pageToken = res.body.nextPageToken;
+    versions.push(...(res.body?.versions || []));
+    pageToken = res.body?.nextPageToken;
   } while (pageToken);
   return versions;
 }
@@ -519,7 +519,7 @@ export async function listSites(project: string): Promise<Site[]> {
         `/projects/${project}/sites`,
         { queryParams: { pageToken: nextPageToken, pageSize: 10 } }
       );
-      const c = res.body.sites;
+      const c = res.body?.sites || [];
       if (c) {
         sites.push(...c);
       }

--- a/src/test/hosting/api.spec.ts
+++ b/src/test/hosting/api.spec.ts
@@ -104,6 +104,18 @@ describe("hosting", () => {
       expect(nock.isDone()).to.be.true;
     });
 
+    it("should return 0 channels if none are returned", async () => {
+      nock(hostingApiOrigin)
+        .get(`/v1beta1/projects/${PROJECT_ID}/sites/${SITE}/channels`)
+        .query({ pageToken: "", pageSize: 10 })
+        .reply(200, {});
+
+      const res = await hostingApi.listChannels(PROJECT_ID, SITE);
+
+      expect(res).to.deep.equal([]);
+      expect(nock.isDone()).to.be.true;
+    });
+
     it("should make multiple API requests to list channels", async () => {
       nock(hostingApiOrigin)
         .get(`/v1beta1/projects/${PROJECT_ID}/sites/${SITE}/channels`)
@@ -358,6 +370,15 @@ describe("hosting", () => {
       name: `projects/-/sites/${SITE}/versions/v2`,
     };
 
+    it("returns no versions if no versions are returned", async () => {
+      nock(hostingApiOrigin).get(`/v1beta1/projects/-/sites/${SITE}/versions`).reply(200, {});
+      nock(hostingApiOrigin);
+
+      const versions = await hostingApi.listVersions(SITE);
+      expect(versions).deep.equals([]);
+      expect(nock.isDone()).to.be.true;
+    });
+
     it("returns a single page of versions", async () => {
       nock(hostingApiOrigin)
         .get(`/v1beta1/projects/-/sites/${SITE}/versions`)
@@ -549,6 +570,18 @@ describe("hosting", () => {
       const res = await hostingApi.listSites(PROJECT_ID);
 
       expect(res).to.deep.equal([{ name: "site01" }]);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should return no sites if none are returned", async () => {
+      nock(hostingApiOrigin)
+        .get(`/v1beta1/projects/${PROJECT_ID}/sites`)
+        .query({ pageToken: "", pageSize: 10 })
+        .reply(200, {});
+
+      const res = await hostingApi.listSites(PROJECT_ID);
+
+      expect(res).to.deep.equal([]);
       expect(nock.isDone()).to.be.true;
     });
 


### PR DESCRIPTION

### Description
Fixing some unsafe array spreads in the Hosting API client. This was inspired by #6172 - I'm not sure why the backend is not returning versions there (and we might wanna look into that more), but either way we should not blow up there.
Fixes #6712 

