### PR TITLE
Add firebase.selectProject command

### DIFF
--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -17,6 +17,12 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "firebase.selectProject",
+        "title": "Switch project"
+      }
+    ],
     "configuration": {
       "title": "Firebase VS Code Extension",
       "properties": {


### PR DESCRIPTION
### Description

This exposes a `firebase.selectProject` command, which users can bind to a shortcut.

This command will be reused by statusbar changes for Firemat

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
