### PR TITLE
Fix Deep* types in metaprogramming. Simplify API libraries

### DIFF
--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -5,9 +5,17 @@
 // 'npm run generate:json-schema' to regenerate the schema files.
 //
 
-import { RequireAtLeastOne } from "./metaprogramming";
 import type { HttpsOptions } from "firebase-functions/v2/https";
 import { IngressSetting, MemoryOption, VpcEgressSetting } from "firebase-functions/v2/options";
+/**
+ * Creates a type that requires at least one key to be present in an interface
+ * type. For example, RequireAtLeastOne<{ foo: string; bar: string }> can hold
+ * a value of { foo: "a" }, { bar: "b" }, or { foo: "a", bar: "b" } but not {}
+ * Sourced from - https://docs.microsoft.com/en-us/javascript/api/@azure/keyvault-certificates/requireatleastone?view=azure-node-latest
+ */
+export type RequireAtLeastOne<T> = {
+  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<keyof T, K>>>;
+}[keyof T];
 
 // should be sourced from - https://github.com/firebase/firebase-tools/blob/master/src/deploy/functions/runtimes/index.ts#L15
 type CloudFunctionRuntimes =

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -319,8 +319,8 @@ export async function deleteBackend(
   location: string,
   backendId: string,
 ): Promise<Operation> {
-  const name = `projects/${projectId}/locations/${location}/backends/${backendId}?force=true`;
-  const res = await client.delete<Operation>(name);
+  const name = `projects/${projectId}/locations/${location}/backends/${backendId}`;
+  const res = await client.delete<Operation>(name, { queryParams: { force: "true" } });
 
   return res.body;
 }
@@ -450,7 +450,9 @@ export async function updateTraffic(
   backendId: string,
   traffic: DeepOmit<Traffic, TrafficOutputOnlyFields | "name">,
 ): Promise<Operation> {
-  const fieldMasks = proto.fieldMasks(traffic);
+  // BUG(b/322891558): setting deep fields on rolloutPolicy doesn't work for some
+  // reason. Prevent recursion into that field.
+  const fieldMasks = proto.fieldMasks(traffic, "rolloutPolicy");
   const queryParams = {
     updateMask: fieldMasks.join(","),
   };

--- a/src/hosting/config.ts
+++ b/src/hosting/config.ts
@@ -13,7 +13,6 @@ import {
   HostingSource,
 } from "../firebaseConfig";
 import { partition } from "../functional";
-import { RequireAtLeastOne } from "../metaprogramming";
 import { dirExistsSync } from "../fsutils";
 import { resolveProjectPath } from "../projectPath";
 import { HostingOptions } from "./options";
@@ -117,10 +116,8 @@ export function extract(options: HostingOptions): HostingMultiple {
 
   if (!Array.isArray(config.hosting)) {
     // Upgrade the type because we pinky swear to ensure site exists as a backup.
-    const res = cloneDeep(config.hosting) as unknown as RequireAtLeastOne<{
-      site: string;
-      target: string;
-    }>;
+    const res = cloneDeep(config.hosting) as unknown as HostingMultiple[number];
+
     // earlier the default RTDB instance was used as the hosting site
     // because it used to be created along with the Firebase project.
     // RTDB instance creation is now deferred and decoupled from project creation.

--- a/src/hosting/options.ts
+++ b/src/hosting/options.ts
@@ -1,5 +1,5 @@
 import { FirebaseConfig } from "../firebaseConfig";
-import { Implements } from "../metaprogramming";
+import { assertImplements } from "../metaprogramming";
 import { Options } from "../options";
 import { HostingResolved } from "./config";
 
@@ -27,5 +27,4 @@ export interface HostingOptions {
 
 // This line caues a compile-time error if HostingOptions has a field that is
 // missing in Options or incompatible with the type in Options.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const optionsAreHostingOptions: Implements<Options, HostingOptions> = true;
+assertImplements<Options, HostingOptions>();

--- a/src/init/features/apphosting/index.ts
+++ b/src/init/features/apphosting/index.ts
@@ -9,7 +9,6 @@ import {
   BackendOutputOnlyFields,
   API_VERSION,
   Build,
-  BuildInput,
   Rollout,
 } from "../../../gcp/apphosting";
 import { Repository } from "../../../gcp/cloudbuild";
@@ -18,6 +17,7 @@ import { promptOnce } from "../../../prompt";
 import { DEFAULT_REGION } from "./constants";
 import { ensure } from "../../../ensureApiEnabled";
 import * as deploymentTool from "../../../deploymentTool";
+import { DeepOmit } from "../../../metaprogramming";
 
 const apphostingPollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
   apiOrigin: apphostingOrigin,
@@ -86,7 +86,7 @@ export async function doSetup(setup: any, projectId: string): Promise<void> {
     default: "main",
     message: "Pick a branch for continuous deployment",
   });
-  const traffic: Omit<apphosting.TrafficInput, "name"> = {
+  const traffic: DeepOmit<apphosting.Traffic, apphosting.TrafficOutputOnlyFields | "name"> = {
     rolloutPolicy: {
       codebaseBranch: branch,
       stages: [
@@ -157,7 +157,7 @@ async function promptLocation(projectId: string, locations: string[]): Promise<s
   })) as string;
 }
 
-function toBackend(cloudBuildConnRepo: Repository): Omit<Backend, BackendOutputOnlyFields> {
+function toBackend(cloudBuildConnRepo: Repository): DeepOmit<Backend, BackendOutputOnlyFields> {
   return {
     servingLocality: "GLOBAL_ACCESS",
     codebase: {
@@ -206,7 +206,7 @@ export async function onboardRollout(
   projectId: string,
   location: string,
   backendId: string,
-  buildInput: Omit<BuildInput, "name">,
+  buildInput: DeepOmit<Build, apphosting.BuildOutputOnlyFields | "name">,
 ): Promise<{ rollout: Rollout; build: Build }> {
   logBullet("Starting a new rollout... this may take a few minutes.");
   const buildId = await apphosting.getNextRolloutId(projectId, location, backendId, 1);

--- a/src/metaprogramming.ts
+++ b/src/metaprogramming.ts
@@ -1,25 +1,14 @@
-type Primitive = string | number | boolean | Function;
+/** Used to statically check that a type extends another */
 
 /**
- * Assert that one implementation conforms to another in a static type assertion.
- * This is useful because unlike trying to cast a value from one type
- * to another, this will exhaustively check all fields as they are added.
- * Usage: const test: Implements<A, B> = true;
- * This line will fail to compile with "true cannot be assigned to never" if
- * A does not implement B.
+ * Statically verify that one type implements another.
+ * This is very useful to say assertImplements<fieldMasks, RecursiveKeyOf<T>>();
  */
-export type Implements<Test, MaybeBase> = Test extends MaybeBase ? true : never;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+export function assertImplements<Test extends MaybeBase, MaybeBase>(): void {}
 
-/**
- * Creates a type that requires at least one key to be present in an interface
- * type. For example, RequireAtLeastOne<{ foo: string; bar: string }> can hold
- * a value of { foo: "a" }, { bar: "b" }, or { foo: "a", bar: "b" } but not {}
- * Sourced from - https://docs.microsoft.com/en-us/javascript/api/@azure/keyvault-certificates/requireatleastone?view=azure-node-latest
- */
-export type RequireAtLeastOne<T> = {
-  [K in keyof T]-?: Required<Pick<T, K>> & Partial<Pick<T, Exclude<keyof T, K>>>;
-}[keyof T];
-
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Primitive = number | string | null | undefined | Date | Function;
 /**
  * RecursiveKeyOf is a type for keys of an objet usind dots for subfields.
  * For a given object: {a: {b: {c: number}}, d } the RecursiveKeysOf are
@@ -27,11 +16,13 @@ export type RequireAtLeastOne<T> = {
  */
 export type RecursiveKeyOf<T> = T extends Primitive
   ? never
-  :
-      | (keyof T & string)
-      | {
-          [P in keyof T & string]: RecursiveSubKeys<T, P>;
-        }[keyof T & string];
+  : T extends (infer Elem)[]
+    ? RecursiveSubKeys<Elem, keyof Elem & string>
+    :
+        | (keyof T & string)
+        | {
+            [P in keyof Required<T> & string]: RecursiveSubKeys<Required<T>, P>;
+          }[keyof T & string];
 
 type RecursiveSubKeys<T, P extends keyof T & string> = T[P] extends (infer Elem)[]
   ? `${P}.${RecursiveKeyOf<Elem>}`
@@ -39,18 +30,13 @@ type RecursiveSubKeys<T, P extends keyof T & string> = T[P] extends (infer Elem)
     ? `${P}.${RecursiveKeyOf<T[P]>}`
     : never;
 
-/**
- * LeafKeysOf is like RecursiveKeysOf but omits the keys for any object.
- * For a given object: {a: {b: {c: number}}, d } the LeafKeysOf are
- * 'a.b.c' | 'd'
- */
-export type LeafKeysOf<T extends object> = {
-  [Key in keyof T & (string | number)]: T[Key] extends unknown[]
-    ? `${Key}`
-    : T[Key] extends object
-      ? `${Key}.${RecursiveKeyOf<T[Key]>}`
-      : `${Key}`;
-}[keyof T & (string | number)];
+export type DeepExtract<RecursiveKeys extends string, Select extends string> = [
+  RecursiveKeys extends `${infer Head}.${infer Rest}`
+    ? Head extends Select
+      ? Head
+      : DeepExtract<TailsOf<RecursiveKeys, Head>, Rest>
+    : Extract<RecursiveKeys, Select>,
+][number];
 
 /**
  * SameType is used in testing to verify that two types are the same.
@@ -67,26 +53,44 @@ type TailsOf<T extends string, Head extends string> = [
   T extends `${Head}.${infer Tail}` ? Tail : never,
 ][number];
 
+type RequiredFields<T> = {
+  [K in keyof T as (object extends Pick<T, K> ? never : K) & string]: T[K];
+};
+
+type OptionalFields<T> = {
+  [K in keyof T as (object extends Pick<T, K> ? K : never) & string]?: T[K];
+};
+
 /**
  * DeepOmit allows you to omit fields from a nested structure using recursive keys.
  */
 export type DeepOmit<T extends object, Keys extends RecursiveKeyOf<T>> = DeepOmitUnsafe<T, Keys>;
 
-type DeepOmitUnsafe<T, Keys extends string> = {
-  [Key in Exclude<keyof T, Keys>]: Key extends Keys
-    ? T[Key] | undefined
-    : Key extends HeadOf<Keys>
-      ? DeepOmitUnsafe<T[Key], TailsOf<Keys, Key>>
-      : T[Key];
-};
+type DeepOmitUnsafe<T, Keys extends string> = T extends (infer Elem)[]
+  ? Array<DeepOmitUnsafe<Elem, Keys>>
+  : {
+      [Key in Exclude<keyof RequiredFields<T>, Keys>]: Key extends HeadOf<Keys>
+        ? DeepOmitUnsafe<T[Key], TailsOf<Keys, Key>>
+        : T[Key];
+    } & {
+      [Key in Exclude<keyof OptionalFields<T>, Keys>]?: Key extends HeadOf<Keys>
+        ? DeepOmitUnsafe<T[Key], TailsOf<Keys, Key>>
+        : T[Key];
+    };
 
 export type DeepPick<T extends object, Keys extends RecursiveKeyOf<T>> = DeepPickUnsafe<T, Keys>;
 
-type DeepPickUnsafe<T, Keys extends string> = {
-  [Key in Extract<keyof T, HeadOf<Keys>>]: Key extends Keys
-    ? T[Key]
-    : DeepPickUnsafe<T[Key], TailsOf<Keys, Key>>;
-};
+type DeepPickUnsafe<T, Keys extends string> = T extends (infer Elem)[]
+  ? Array<DeepOmitUnsafe<Elem, Keys>>
+  : {
+      [Key in Extract<keyof RequiredFields<T>, HeadOf<Keys>>]: Key extends Keys
+        ? T[Key]
+        : DeepPickUnsafe<T[Key], TailsOf<Keys, Key>>;
+    } & {
+      [Key in Extract<keyof OptionalFields<T>, HeadOf<Keys>>]?: Key extends Keys
+        ? T[Key]
+        : DeepPickUnsafe<T[Key], TailsOf<Keys, Key>>;
+    };
 
 /**
  * Make properties of an object required.
@@ -100,9 +104,7 @@ type DeepPickUnsafe<T, Keys extends string> = {
  * type Bar = RequireKeys<Foo, "a" | "b">
  * // Property "a" and "b" are now required.
  */
-export type RequireKeys<T extends object, Keys extends keyof T> = T & {
-  [Key in Keys]: T[Key];
-};
+export type RequireKeys<T extends object, Keys extends keyof T> = T & Required<Pick<T, Keys>>;
 
 /** In the array LeafElems<[[["a"], "b"], ["c"]]> is "a" | "b" | "c" */
 export type LeafElems<T> =
@@ -113,5 +115,5 @@ export type LeafElems<T> =
  * LeafValues is number | string
  */
 export type LeafValues<T extends object> = {
-  [Key in keyof T]: T[Key] extends object ? LeafValues<T[Key]> : T[Key];
-}[keyof T];
+  [Key in keyof T & string]: T[Key] extends object ? LeafValues<T[Key]> : T[Key];
+}[keyof T & string];

--- a/src/metaprogramming.ts
+++ b/src/metaprogramming.ts
@@ -1,4 +1,5 @@
-/** Used to statically check that a type extends another */
+// eslint-disable-next-line @typescript-eslint/ban-types
+type Primitive = number | string | null | undefined | Date | Function;
 
 /**
  * Statically verify that one type implements another.
@@ -7,8 +8,6 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
 export function assertImplements<Test extends MaybeBase, MaybeBase>(): void {}
 
-// eslint-disable-next-line @typescript-eslint/ban-types
-type Primitive = number | string | null | undefined | Date | Function;
 /**
  * RecursiveKeyOf is a type for keys of an objet usind dots for subfields.
  * For a given object: {a: {b: {c: number}}, d } the RecursiveKeysOf are

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -379,6 +379,7 @@ describe("cloudfunctionsv2", () => {
         serviceConfig: {
           ...HAVE_CLOUD_FUNCTION_V2.serviceConfig,
           service: "projects/p/locations/l/services/service-id",
+          uri: RUN_URI,
         },
       };
       expect(cloudfunctionsv2.endpointFromFunction(fn)).to.deep.equal({
@@ -617,6 +618,8 @@ describe("cloudfunctionsv2", () => {
             vpcConnector: vpc.connector,
             vpcConnectorEgressSettings: vpc.egressSettings,
             availableMemory: "128Mi",
+            uri: RUN_URI,
+            service: "service",
           },
           labels: {
             foo: "bar",
@@ -654,6 +657,8 @@ describe("cloudfunctionsv2", () => {
           serviceConfig: {
             ...HAVE_CLOUD_FUNCTION_V2.serviceConfig,
             ...extraGcfFields,
+            uri: RUN_URI,
+            service: "service",
           },
         }),
       ).to.deep.equal({

--- a/src/test/gcp/proto.spec.ts
+++ b/src/test/gcp/proto.spec.ts
@@ -108,7 +108,7 @@ describe("proto", () => {
         number: 1,
         string: "foo",
         array: ["hello", "world"],
-      };
+      } as const;
       expect(proto.fieldMasks(obj).sort()).to.deep.equal(["number", "string", "array"].sort());
     });
 
@@ -117,7 +117,7 @@ describe("proto", () => {
         undefined: undefined,
         null: null,
         empty: {},
-      };
+      } as const;
 
       expect(proto.fieldMasks(obj).sort()).to.deep.equal(["undefined", "null", "empty"].sort());
     });
@@ -128,7 +128,7 @@ describe("proto", () => {
         nested: {
           key: "value",
         },
-      };
+      } as const;
       expect(proto.fieldMasks(obj).sort()).to.deep.equal(["top", "nested.key"].sort());
     });
 
@@ -137,7 +137,7 @@ describe("proto", () => {
         failurePolicy: {
           retry: {},
         },
-      };
+      } as const;
       expect(proto.fieldMasks(obj)).to.deep.equal(["failurePolicy.retry"]);
     });
 

--- a/src/test/hosting/config.spec.ts
+++ b/src/test/hosting/config.spec.ts
@@ -4,7 +4,6 @@ import { HostingConfig, HostingMultiple, HostingSingle } from "../../firebaseCon
 
 import * as config from "../../hosting/config";
 import { HostingOptions } from "../../hosting/options";
-import { RequireAtLeastOne } from "../../metaprogramming";
 import { cloneDeep } from "../../utils";
 import { setEnabled } from "../../experiments";
 
@@ -103,10 +102,7 @@ describe("config", () => {
         desc: string;
         cfg: HostingMultiple;
         only?: string;
-      } & RequireAtLeastOne<{
-        want?: HostingMultiple;
-        wantErr?: RegExp;
-      }>
+      } & ({ want: HostingMultiple } | { wantErr: RegExp })
     > = [
       {
         desc: "a normal hosting config, specifying the default site",
@@ -165,7 +161,7 @@ describe("config", () => {
 
     for (const t of tests) {
       it(`should be able to parse ${t.desc}`, () => {
-        if (t.wantErr) {
+        if ("wantErr" in t) {
           expect(() => config.filterOnly(t.cfg, t.only)).to.throw(FirebaseError, t.wantErr);
         } else {
           const got = config.filterOnly(t.cfg, t.only);
@@ -181,10 +177,7 @@ describe("config", () => {
         desc: string;
         cfg: HostingMultiple;
         except?: string;
-      } & RequireAtLeastOne<{
-        want: HostingMultiple;
-        wantErr: RegExp;
-      }>
+      } & ({ want: HostingMultiple } | { wantErr: RegExp })
     > = [
       {
         desc: "a hosting config with multiple sites, no targets, omitting the second site",
@@ -231,7 +224,7 @@ describe("config", () => {
 
     for (const t of tests) {
       it(`should be able to parse ${t.desc}`, () => {
-        if (t.wantErr) {
+        if ("wantErr" in t) {
           expect(() => config.filterExcept(t.cfg, t.except)).to.throw(FirebaseError, t.wantErr);
         } else {
           const got = config.filterExcept(t.cfg, t.except);

--- a/src/test/metapgrogramming.spec.ts
+++ b/src/test/metapgrogramming.spec.ts
@@ -1,8 +1,18 @@
 import { expect } from "chai";
-import { SameType, RecursiveKeyOf, LeafElems, DeepPick, DeepOmit } from "../metaprogramming";
+import {
+  SameType,
+  RecursiveKeyOf,
+  LeafElems,
+  DeepPick,
+  DeepOmit,
+  RequireKeys,
+  DeepExtract,
+} from "../metaprogramming";
 
 describe("metaprogramming", () => {
   it("can calcluate recursive keys", () => {
+    // BUG BUG BUG: String literals seem to extend each other? I can break the
+    // test and it still passes.
     const test: SameType<
       RecursiveKeyOf<{
         a: number;
@@ -11,9 +21,10 @@ describe("metaprogramming", () => {
           d: {
             e: number;
           };
+          f: Array<{ g: number }>;
         };
       }>,
-      "a" | "a.b" | "a.b.c" | "a.b.d" | "a.b.d.e"
+      "a" | "a.b" | "a.b.c" | "a.b.d" | "a.b.d.e" | "a.b.f.g"
     > = true;
     expect(test).to.be.true;
   });
@@ -27,23 +38,30 @@ describe("metaprogramming", () => {
     interface original {
       a: number;
       b: {
-        c: boolean;
+        c?: boolean;
         d: {
           e: number;
         };
         g: boolean;
       };
-      h: number;
+      c?: {
+        d: number;
+      };
+      h?: number;
     }
 
     interface expected {
       a: number;
       b: {
-        c: boolean;
+        c?: boolean;
       };
+      c?: {
+        d: number;
+      };
+      h?: number;
     }
 
-    const test: SameType<DeepPick<original, "a" | "b.c">, expected> = true;
+    const test: SameType<DeepPick<original, "a" | "b.c" | "c" | "h">, expected> = true;
     expect(test).to.be.true;
   });
 
@@ -53,24 +71,48 @@ describe("metaprogramming", () => {
       b: {
         c: boolean;
         d: {
-          e: number;
+          e?: number;
         };
         g: boolean;
       };
-      h: number;
+      h?: number;
+      g: number;
     }
 
     interface expected {
       b: {
         d: {
-          e: number;
+          e?: number;
         };
         g: boolean;
       };
-      h: number;
+      h?: number;
+      g: number;
     }
 
     const test: SameType<DeepOmit<original, "a" | "b.c">, expected> = true;
     expect(test).to.be.true;
+  });
+
+  it("can require keys", () => {
+    interface original {
+      a?: number;
+      b?: number;
+    }
+
+    interface expected {
+      a: number;
+      b?: number;
+    }
+
+    const test: SameType<RequireKeys<original, "a">, expected> = true;
+    expect(test).to.be.true;
+  });
+
+  it("Can DeepExtract", () => {
+    type test = "a" | "b.c" | "b.d.e" | "b.d.f" | "b.g";
+    type extract = "a" | "b.c" | "b.d";
+    type expected = "a" | "b.c" | "b.d.e" | "b.d.f";
+    const test: SameType<DeepExtract<test, extract>, expected> = true;
   });
 });


### PR DESCRIPTION
What it says on the label. This allows us to stop overriding fields with omits to do deep omit types to create "input" types.