### PR TITLE
Add deployment-tool labels to all FAH APIs

### DIFF
--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -3,6 +3,7 @@ import { Client } from "../apiv2";
 import { needProjectId } from "../projectUtils";
 import { apphostingOrigin } from "../api";
 import { ensure } from "../ensureApiEnabled";
+import * as deploymentTool from "../deploymentTool";
 
 export const API_HOST = new URL(apphostingOrigin).host;
 export const API_VERSION = "v1alpha";
@@ -256,7 +257,13 @@ export async function createBackend(
 ): Promise<Operation> {
   const res = await client.post<Omit<Backend, BackendOutputOnlyFields>, Operation>(
     `projects/${projectId}/locations/${location}/backends`,
-    backendReqBoby,
+    {
+      ...backendReqBoby,
+      labels: {
+        ...backendReqBoby.labels,
+        ...deploymentTool.labels(),
+      },
+    },
     { queryParams: { backendId } },
   );
 
@@ -329,7 +336,13 @@ export async function createBuild(
 ): Promise<Operation> {
   const res = await client.post<Omit<BuildInput, "name">, Operation>(
     `projects/${projectId}/locations/${location}/backends/${backendId}/builds`,
-    buildInput,
+    {
+      ...buildInput,
+      labels: {
+        ...buildInput.labels,
+        ...deploymentTool.labels(),
+      },
+    },
     { queryParams: { buildId } },
   );
   return res.body;
@@ -347,7 +360,13 @@ export async function createRollout(
 ): Promise<Operation> {
   const res = await client.post<Omit<Rollout, RolloutOutputOnlyFields | "name">, Operation>(
     `projects/${projectId}/locations/${location}/backends/${backendId}/rollouts`,
-    rollout,
+    {
+      ...rollout,
+      labels: {
+        ...rollout.labels,
+        ...deploymentTool.labels(),
+      },
+    },
     { queryParams: { rolloutId } },
   );
   return res.body;


### PR DESCRIPTION
This change will let us run queries to track whether users are creating backends from the CLI or console as well as tracking whether rollouts are from the CLI, console, or continuous deployment.