### PR TITLE
Add support for automated tests in App Distribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Added rudimentary email enumeration protection for auth emulator. (#6702)
+- You can now run customized automated tests on your Android apps in App Distribution, with the Automated Tester feature (beta). This feature automatically runs tests on your Android apps on virtual and physical devices at different API levels. To learn how to run an automated test, see [Run an automated test for Android apps](https://firebase.google.com/docs/app-distribution/android-automated-tester). (#6730)

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -6,113 +6,16 @@ import { Distribution } from "./distribution";
 import { FirebaseError } from "../error";
 import { Client } from "../apiv2";
 import { appDistributionOrigin } from "../api";
-
-/**
- * Helper interface for an app that is provisioned with App Distribution
- */
-export interface AabInfo {
-  name: string;
-  integrationState: IntegrationState;
-  testCertificate: TestCertificate | null;
-}
-
-export interface TestCertificate {
-  hashSha1: string;
-  hashSha256: string;
-  hashMd5: string;
-}
-
-/** Enum representing the App Bundles state for the App */
-export enum IntegrationState {
-  AAB_INTEGRATION_STATE_UNSPECIFIED = "AAB_INTEGRATION_STATE_UNSPECIFIED",
-  INTEGRATED = "INTEGRATED",
-  PLAY_ACCOUNT_NOT_LINKED = "PLAY_ACCOUNT_NOT_LINKED",
-  NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT = "NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT",
-  APP_NOT_PUBLISHED = "APP_NOT_PUBLISHED",
-  AAB_STATE_UNAVAILABLE = "AAB_STATE_UNAVAILABLE",
-  PLAY_IAS_TERMS_NOT_ACCEPTED = "PLAY_IAS_TERMS_NOT_ACCEPTED",
-}
-
-export enum UploadReleaseResult {
-  UPLOAD_RELEASE_RESULT_UNSPECIFIED = "UPLOAD_RELEASE_RESULT_UNSPECIFIED",
-  RELEASE_CREATED = "RELEASE_CREATED",
-  RELEASE_UPDATED = "RELEASE_UPDATED",
-  RELEASE_UNMODIFIED = "RELEASE_UNMODIFIED",
-}
-
-export interface Release {
-  name: string;
-  releaseNotes: ReleaseNotes;
-  displayVersion: string;
-  buildVersion: string;
-  createTime: Date;
-  firebaseConsoleUri: string;
-  testingUri: string;
-  binaryDownloadUri: string;
-}
-
-export interface ReleaseNotes {
-  text: string;
-}
-
-export interface UploadReleaseResponse {
-  result: UploadReleaseResult;
-  release: Release;
-}
-
-export interface BatchRemoveTestersResponse {
-  emails: string[];
-}
-
-export interface Group {
-  name: string;
-  displayName: string;
-  testerCount?: number;
-  releaseCount?: number;
-  inviteLinkCount?: number;
-}
-
-export interface CreateReleaseTestRequest {
-  releaseTest: ReleaseTest;
-}
-
-export enum TestState {
-  IN_PROGRESS = "IN_PROGRESS",
-  PASSED = "PASSED",
-  FAILED = "FAILED",
-  INCONCLUSIVE = "INCONCLUSIVE",
-}
-
-export interface TestDevice {
-  model: string;
-  version: string;
-  locale: string;
-  orientation: string;
-}
-
-export interface DeviceExecution {
-  device: TestDevice;
-  state?: TestState;
-  failedReason?: string;
-  inconclusiveReason?: string;
-}
-
-export interface FieldHints {
-  usernameResourceName?: string;
-  passwordResourceName?: string;
-}
-
-export interface LoginCredential {
-  username?: string;
-  password?: string;
-  fieldHints?: FieldHints;
-}
-
-export interface ReleaseTest {
-  name?: string;
-  deviceExecutions: DeviceExecution[];
-  loginCredential?: LoginCredential;
-}
+import {
+  AabInfo,
+  BatchRemoveTestersResponse,
+  DeviceExecution,
+  Group,
+  LoginCredential,
+  ReleaseTest,
+  TestDevice,
+  UploadReleaseResponse,
+} from "./types";
 
 /**
  * Makes RPCs to the App Distribution server backend.
@@ -321,7 +224,6 @@ export class AppDistributionClient {
           loginCredential,
         },
       });
-      utils.logSuccess(`Release test created successfully`);
       return response.body;
     } catch (err: any) {
       throw new FirebaseError(`Failed to create release test ${err}`);

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -98,8 +98,8 @@ export interface DeviceExecution {
 }
 
 export interface FieldHints {
-  usernameResource?: string;
-  passwordResource?: string;
+  usernameResourceName?: string;
+  passwordResourceName?: string;
 }
 
 export interface LoginCredential {
@@ -112,13 +112,6 @@ export interface ReleaseTest {
   name?: string;
   deviceExecutions: DeviceExecution[];
   loginCredential?: LoginCredential;
-}
-
-export interface TestConfig {
-  username?: string;
-  password?: string;
-  usernameResource?: string;
-  passwordResource?: string;
 }
 
 /**

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -9,9 +9,9 @@ import { appDistributionOrigin } from "../api";
 import {
   AabInfo,
   BatchRemoveTestersResponse,
-  DeviceExecution,
   Group,
   LoginCredential,
+  mapDeviceToExecution,
   ReleaseTest,
   TestDevice,
   UploadReleaseResponse,
@@ -220,7 +220,7 @@ export class AppDistributionClient {
         method: "POST",
         path: `${releaseName}/tests`,
         body: {
-          deviceExecutions: devices.map((d) => this.mapDeviceToExecution(d)),
+          deviceExecutions: devices.map(mapDeviceToExecution),
           loginCredential,
         },
       });
@@ -233,16 +233,5 @@ export class AppDistributionClient {
   async getReleaseTest(releaseTestName: string): Promise<ReleaseTest> {
     const response = await this.appDistroV1AlphaClient.get<ReleaseTest>(releaseTestName);
     return response.body;
-  }
-
-  private mapDeviceToExecution(device: TestDevice): DeviceExecution {
-    return {
-      device: {
-        model: device.model,
-        version: device.version,
-        orientation: device.orientation,
-        locale: device.locale,
-      },
-    };
   }
 }

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -317,12 +317,12 @@ export class AppDistributionClient {
         method: "POST",
         path: `${releaseName}/tests`,
         body: {
-          deviceExecutions: devices.map(d => this.mapDeviceToExecution(d)),
+          deviceExecutions: devices.map((d) => this.mapDeviceToExecution(d)),
           loginCredential,
         },
       });
       utils.logSuccess(`Release test created successfully`);
-      return response.body
+      return response.body;
     } catch (err: any) {
       throw new FirebaseError(`Failed to create release test ${err}`);
     }
@@ -340,7 +340,7 @@ export class AppDistributionClient {
         version: device.version,
         orientation: device.orientation,
         locale: device.locale,
-      }
+      },
     };
   }
 }

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs-extra";
 import { FirebaseError } from "../error";
 import { needProjectNumber } from "../projectUtils";
-import { FieldHints, LoginCredential, TestDevice } from "./client";
+import { FieldHints, LoginCredential, TestDevice } from "./types";
 
 /**
  * Takes in comma separated string or a path to a comma/new line separated file
@@ -81,13 +81,11 @@ export function getTestDevices(value: string, file: string): TestDevice[] {
     return [];
   }
 
-  // The value is split into a string[]
-  const deviceStrings = value
+  return value
     .split(/[;\n]/)
     .map((entry) => entry.trim())
-    .filter((entry) => !!entry);
-
-  return deviceStrings.map((str) => parseTestDevice(str));
+    .filter((entry) => !!entry)
+    .map((str) => parseTestDevice(str));
 }
 
 function parseTestDevice(testDeviceString: string): TestDevice {
@@ -134,9 +132,15 @@ function parseTestDevice(testDeviceString: string): TestDevice {
 export function getLoginCredential(
   username?: string,
   password?: string,
+  passwordFile?: string,
   usernameResourceName?: string,
   passwordResourceName?: string,
 ): LoginCredential | undefined {
+  if (!password && passwordFile) {
+    ensureFileExists(passwordFile);
+    password = fs.readFileSync(passwordFile, "utf8");
+  }
+
   if (isPresenceMismatched(usernameResourceName, passwordResourceName)) {
     throw new FirebaseError(
       "Username and password resource names for automated tests need to be specified together.",

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -1,6 +1,10 @@
 import * as fs from "fs-extra";
 import { FirebaseError } from "../error";
 import { needProjectNumber } from "../projectUtils";
+import { FieldHints, LoginCredential, TestDevice } from "./client";
+import * as utils from "../utils";
+
+const testDeviceRegex = /model=([^,]+),version=([^,]+),locale=([^,]+),orientation=([^,]+)/
 
 /**
  * Takes in comma separated string or a path to a comma/new line separated file
@@ -48,6 +52,7 @@ function splitter(value: string): string[] {
     .map((entry) => entry.trim())
     .filter((entry) => !!entry);
 }
+
 // Gets project name from project number
 export async function getProjectName(options: any): Promise<string> {
   const projectNumber = await needProjectNumber(options);
@@ -61,4 +66,95 @@ export function getAppName(options: any): string {
   }
   const appId = options.app;
   return `projects/${appId.split(":")[1]}/apps/${appId}`;
+}
+
+/**
+ * Takes in comma separated string or a path to a comma/new line separated file
+ * and converts the input into a string[] of test device strings. Value takes precedent
+ * over file.
+ */
+export function getTestDevices(value: string, file: string): TestDevice[] {
+  // If there is no value then the file gets parsed into a string to be split
+  if (!value && file) {
+    ensureFileExists(file);
+    value = fs.readFileSync(file, "utf8");
+  }
+
+  if (!value) {
+    return [];
+  }
+
+  // The value is split into a string[]
+  utils.logWarning(`DEBUG - value: ${value}`);
+  let deviceStrings = value
+      .split(/[;\n]/)
+      .map((entry) => entry.trim())
+      .filter((entry) => !!entry);
+  utils.logWarning(`DEBUG - deviceStrings: ${deviceStrings}`);
+
+  return deviceStrings.map(str => parseTestDevice(str))
+}
+
+function parseTestDevice(testDeviceString: string): TestDevice {
+  const entries = testDeviceString.split(',');
+  const allowedKeys = new Set(["model", "version", "orientation", "locale"]);
+  let model: string|undefined;
+  let version: string|undefined;
+  let orientation: string|undefined;
+  let locale: string|undefined;
+  for (let entry of entries) {
+    const keyAndValue = entry.split('=');
+    switch (keyAndValue[0]) {
+      case "model":
+        model = keyAndValue[1];
+        break;
+      case "version":
+        version = keyAndValue[1];
+        break;
+      case "orientation":
+        orientation = keyAndValue[1];
+        break;
+      case "locale":
+        locale = keyAndValue[1];
+        break;
+      default:
+        throw new FirebaseError(`Unrecognized key in test devices. Can only contain ${Array.from(allowedKeys).join(',')}`);
+    }
+  }
+  const match = testDeviceString.match(testDeviceRegex)
+
+  if (!model || !version || !orientation || !locale) {
+    throw new FirebaseError("Test devices must be in the format 'model=<model-id>,version=<os-version-id>,locale=<locale>,orientation=<orientation>'");
+  }
+  return { model, version, locale, orientation };
+}
+
+export function getLoginCredential(
+  username?: string,
+  password?: string,
+  usernameResource?: string,
+  passwordResource?: string,
+) {
+  if (isPresenceMismatched(usernameResource, passwordResource)) {
+    throw new FirebaseError("Username and password resource names for automated tests need to be specified together.");
+  }
+  let fieldHints: FieldHints|undefined;
+  if (usernameResource && passwordResource) {
+    fieldHints = { usernameResource, passwordResource };
+  }
+
+  if (isPresenceMismatched(username, password)) {
+    throw new FirebaseError("Username and password for automated tests need to be specified together.");
+  }
+  let loginCredential: LoginCredential|undefined;
+  if (username && password) {
+    loginCredential = { username, password, fieldHints };
+  } else if (fieldHints) {
+    throw new FirebaseError("Must specify username and password for automated tests if resource names are set");
+  }
+  return loginCredential;
+}
+
+function isPresenceMismatched(value1?: string, value2?: string) {
+  return (value1 && !value2) || (!value1 && value2);
 }

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -85,12 +85,10 @@ export function getTestDevices(value: string, file: string): TestDevice[] {
   }
 
   // The value is split into a string[]
-  utils.logWarning(`DEBUG - value: ${value}`);
   let deviceStrings = value
       .split(/[;\n]/)
       .map((entry) => entry.trim())
       .filter((entry) => !!entry);
-  utils.logWarning(`DEBUG - deviceStrings: ${deviceStrings}`);
 
   return deviceStrings.map(str => parseTestDevice(str))
 }
@@ -132,15 +130,15 @@ function parseTestDevice(testDeviceString: string): TestDevice {
 export function getLoginCredential(
   username?: string,
   password?: string,
-  usernameResource?: string,
-  passwordResource?: string,
+  usernameResourceName?: string,
+  passwordResourceName?: string,
 ) {
-  if (isPresenceMismatched(usernameResource, passwordResource)) {
+  if (isPresenceMismatched(usernameResourceName, passwordResourceName)) {
     throw new FirebaseError("Username and password resource names for automated tests need to be specified together.");
   }
   let fieldHints: FieldHints|undefined;
-  if (usernameResource && passwordResource) {
-    fieldHints = { usernameResource, passwordResource };
+  if (usernameResourceName && passwordResourceName) {
+    fieldHints = { usernameResourceName, passwordResourceName };
   }
 
   if (isPresenceMismatched(username, password)) {

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -138,7 +138,7 @@ export function getLoginCredential(
 ): LoginCredential | undefined {
   if (!password && passwordFile) {
     ensureFileExists(passwordFile);
-    password = fs.readFileSync(passwordFile, "utf8");
+    password = fs.readFileSync(passwordFile, "utf8").trim();
   }
 
   if (isPresenceMismatched(usernameResourceName, passwordResourceName)) {

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -2,9 +2,6 @@ import * as fs from "fs-extra";
 import { FirebaseError } from "../error";
 import { needProjectNumber } from "../projectUtils";
 import { FieldHints, LoginCredential, TestDevice } from "./client";
-import * as utils from "../utils";
-
-const testDeviceRegex = /model=([^,]+),version=([^,]+),locale=([^,]+),orientation=([^,]+)/
 
 /**
  * Takes in comma separated string or a path to a comma/new line separated file
@@ -85,23 +82,23 @@ export function getTestDevices(value: string, file: string): TestDevice[] {
   }
 
   // The value is split into a string[]
-  let deviceStrings = value
-      .split(/[;\n]/)
-      .map((entry) => entry.trim())
-      .filter((entry) => !!entry);
+  const deviceStrings = value
+    .split(/[;\n]/)
+    .map((entry) => entry.trim())
+    .filter((entry) => !!entry);
 
-  return deviceStrings.map(str => parseTestDevice(str))
+  return deviceStrings.map((str) => parseTestDevice(str));
 }
 
 function parseTestDevice(testDeviceString: string): TestDevice {
-  const entries = testDeviceString.split(',');
+  const entries = testDeviceString.split(",");
   const allowedKeys = new Set(["model", "version", "orientation", "locale"]);
-  let model: string|undefined;
-  let version: string|undefined;
-  let orientation: string|undefined;
-  let locale: string|undefined;
-  for (let entry of entries) {
-    const keyAndValue = entry.split('=');
+  let model: string | undefined;
+  let version: string | undefined;
+  let orientation: string | undefined;
+  let locale: string | undefined;
+  for (const entry of entries) {
+    const keyAndValue = entry.split("=");
     switch (keyAndValue[0]) {
       case "model":
         model = keyAndValue[1];
@@ -116,13 +113,16 @@ function parseTestDevice(testDeviceString: string): TestDevice {
         locale = keyAndValue[1];
         break;
       default:
-        throw new FirebaseError(`Unrecognized key in test devices. Can only contain ${Array.from(allowedKeys).join(',')}`);
+        throw new FirebaseError(
+          `Unrecognized key in test devices. Can only contain ${Array.from(allowedKeys).join(",")}`,
+        );
     }
   }
-  const match = testDeviceString.match(testDeviceRegex)
 
   if (!model || !version || !orientation || !locale) {
-    throw new FirebaseError("Test devices must be in the format 'model=<model-id>,version=<os-version-id>,locale=<locale>,orientation=<orientation>'");
+    throw new FirebaseError(
+      "Test devices must be in the format 'model=<model-id>,version=<os-version-id>,locale=<locale>,orientation=<orientation>'",
+    );
   }
   return { model, version, locale, orientation };
 }
@@ -134,21 +134,27 @@ export function getLoginCredential(
   passwordResourceName?: string,
 ) {
   if (isPresenceMismatched(usernameResourceName, passwordResourceName)) {
-    throw new FirebaseError("Username and password resource names for automated tests need to be specified together.");
+    throw new FirebaseError(
+      "Username and password resource names for automated tests need to be specified together.",
+    );
   }
-  let fieldHints: FieldHints|undefined;
+  let fieldHints: FieldHints | undefined;
   if (usernameResourceName && passwordResourceName) {
     fieldHints = { usernameResourceName, passwordResourceName };
   }
 
   if (isPresenceMismatched(username, password)) {
-    throw new FirebaseError("Username and password for automated tests need to be specified together.");
+    throw new FirebaseError(
+      "Username and password for automated tests need to be specified together.",
+    );
   }
-  let loginCredential: LoginCredential|undefined;
+  let loginCredential: LoginCredential | undefined;
   if (username && password) {
     loginCredential = { username, password, fieldHints };
   } else if (fieldHints) {
-    throw new FirebaseError("Must specify username and password for automated tests if resource names are set");
+    throw new FirebaseError(
+      "Must specify username and password for automated tests if resource names are set",
+    );
   }
   return loginCredential;
 }

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -114,7 +114,7 @@ function parseTestDevice(testDeviceString: string): TestDevice {
         break;
       default:
         throw new FirebaseError(
-          `Unrecognized key in test devices. Can only contain ${Array.from(allowedKeys).join(",")}`,
+          `Unrecognized key in test devices. Can only contain ${Array.from(allowedKeys).join(", ")}`,
         );
     }
   }
@@ -127,12 +127,16 @@ function parseTestDevice(testDeviceString: string): TestDevice {
   return { model, version, locale, orientation };
 }
 
+/**
+ * Takes option values for username and password related options and returns a LoginCredential
+ * object that can be passed to the API.
+ */
 export function getLoginCredential(
   username?: string,
   password?: string,
   usernameResourceName?: string,
   passwordResourceName?: string,
-) {
+): LoginCredential | undefined {
   if (isPresenceMismatched(usernameResourceName, passwordResourceName)) {
     throw new FirebaseError(
       "Username and password resource names for automated tests need to be specified together.",

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -129,13 +129,15 @@ function parseTestDevice(testDeviceString: string): TestDevice {
  * Takes option values for username and password related options and returns a LoginCredential
  * object that can be passed to the API.
  */
-export function getLoginCredential(
-  username?: string,
-  password?: string,
-  passwordFile?: string,
-  usernameResourceName?: string,
-  passwordResourceName?: string,
-): LoginCredential | undefined {
+export function getLoginCredential(args: {
+  username?: string;
+  password?: string;
+  passwordFile?: string;
+  usernameResourceName?: string;
+  passwordResourceName?: string;
+}): LoginCredential | undefined {
+  const { username, passwordFile, usernameResourceName, passwordResourceName } = args;
+  let password = args.password;
   if (!password && passwordFile) {
     ensureFileExists(passwordFile);
     password = fs.readFileSync(passwordFile, "utf8").trim();
@@ -148,7 +150,10 @@ export function getLoginCredential(
   }
   let fieldHints: FieldHints | undefined;
   if (usernameResourceName && passwordResourceName) {
-    fieldHints = { usernameResourceName, passwordResourceName };
+    fieldHints = {
+      usernameResourceName: usernameResourceName,
+      passwordResourceName: passwordResourceName,
+    };
   }
 
   if (isPresenceMismatched(username, password)) {

--- a/src/appdistribution/types.ts
+++ b/src/appdistribution/types.ts
@@ -83,6 +83,17 @@ export interface DeviceExecution {
   inconclusiveReason?: string;
 }
 
+export function mapDeviceToExecution(device: TestDevice): DeviceExecution {
+  return {
+    device: {
+      model: device.model,
+      version: device.version,
+      orientation: device.orientation,
+      locale: device.locale,
+    },
+  };
+}
+
 export interface FieldHints {
   usernameResourceName?: string;
   passwordResourceName?: string;

--- a/src/appdistribution/types.ts
+++ b/src/appdistribution/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Helper interface for an app that is provisioned with App Distribution
+ */
+export interface AabInfo {
+  name: string;
+  integrationState: IntegrationState;
+  testCertificate: TestCertificate | null;
+}
+
+export interface TestCertificate {
+  hashSha1: string;
+  hashSha256: string;
+  hashMd5: string;
+}
+
+/** Enum representing the App Bundles state for the App */
+export enum IntegrationState {
+  AAB_INTEGRATION_STATE_UNSPECIFIED = "AAB_INTEGRATION_STATE_UNSPECIFIED",
+  INTEGRATED = "INTEGRATED",
+  PLAY_ACCOUNT_NOT_LINKED = "PLAY_ACCOUNT_NOT_LINKED",
+  NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT = "NO_APP_WITH_GIVEN_BUNDLE_ID_IN_PLAY_ACCOUNT",
+  APP_NOT_PUBLISHED = "APP_NOT_PUBLISHED",
+  AAB_STATE_UNAVAILABLE = "AAB_STATE_UNAVAILABLE",
+  PLAY_IAS_TERMS_NOT_ACCEPTED = "PLAY_IAS_TERMS_NOT_ACCEPTED",
+}
+
+export enum UploadReleaseResult {
+  UPLOAD_RELEASE_RESULT_UNSPECIFIED = "UPLOAD_RELEASE_RESULT_UNSPECIFIED",
+  RELEASE_CREATED = "RELEASE_CREATED",
+  RELEASE_UPDATED = "RELEASE_UPDATED",
+  RELEASE_UNMODIFIED = "RELEASE_UNMODIFIED",
+}
+
+export interface Release {
+  name: string;
+  releaseNotes: ReleaseNotes;
+  displayVersion: string;
+  buildVersion: string;
+  createTime: Date;
+  firebaseConsoleUri: string;
+  testingUri: string;
+  binaryDownloadUri: string;
+}
+
+export interface ReleaseNotes {
+  text: string;
+}
+
+export interface UploadReleaseResponse {
+  result: UploadReleaseResult;
+  release: Release;
+}
+
+export interface BatchRemoveTestersResponse {
+  emails: string[];
+}
+
+export interface Group {
+  name: string;
+  displayName: string;
+  testerCount?: number;
+  releaseCount?: number;
+  inviteLinkCount?: number;
+}
+
+export interface CreateReleaseTestRequest {
+  releaseTest: ReleaseTest;
+}
+
+export interface TestDevice {
+  model: string;
+  version: string;
+  locale: string;
+  orientation: string;
+}
+
+export type TestState = "IN_PROGRESS" | "PASSED" | "FAILED" | "INCONCLUSIVE";
+
+export interface DeviceExecution {
+  device: TestDevice;
+  state?: TestState;
+  failedReason?: string;
+  inconclusiveReason?: string;
+}
+
+export interface FieldHints {
+  usernameResourceName?: string;
+  passwordResourceName?: string;
+}
+
+export interface LoginCredential {
+  username?: string;
+  password?: string;
+  fieldHints?: FieldHints;
+}
+
+export interface ReleaseTest {
+  name?: string;
+  deviceExecutions: DeviceExecution[];
+  loginCredential?: LoginCredential;
+}

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -83,13 +83,13 @@ export const command = new Command("appdistribution:distribute <release-binary-f
     const testers = getTestersOrGroups(options.testers, options.testersFile);
     const groups = getTestersOrGroups(options.groups, options.groupsFile);
     const testDevices = getTestDevices(options.testDevices, options.testDevicesFile);
-    const loginCredential = getLoginCredential(
-      options.testUsername,
-      options.testPassword,
-      options.testPasswordFile,
-      options.testUsernameResource,
-      options.testPasswordResource,
-    );
+    const loginCredential = getLoginCredential({
+      username: options.testUsername,
+      password: options.testPassword,
+      passwordFile: options.testPasswordFile,
+      usernameResourceName: options.testUsernameResource,
+      passwordResourceName: options.testPasswordResource,
+    });
     const requests = new AppDistributionClient();
     let aabInfo: AabInfo | undefined;
 

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -21,7 +21,7 @@ import {
   getTestersOrGroups,
 } from "../appdistribution/options-parser-util";
 
-const TEST_MAX_POLLING_RETRIES = 25;
+const TEST_MAX_POLLING_RETRIES = 40;
 const TEST_POLLING_INTERVAL_MILLIS = 30_000;
 
 function getReleaseNotes(releaseNotes: string, releaseNotesFile: string): string {

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -58,10 +58,10 @@ export const command = new Command("appdistribution:distribute <release-binary-f
     "--test-devices-file <string>",
     "path to file containing a list of semicolon- or newline-separated devices to run automated tests on, in the format 'model=<model-id>,version=<os-version-id>,locale=<locale>,orientation=<orientation>'. Run 'gcloud firebase test android|ios models list' to see available devices",
   )
-  .option("--test-username", "username for automatic login")
-  .option("--test-password", "password for automatic login")
-  .option("--test-username-resource", "resource name of the username field for automatic login")
-  .option("--test-password-resource", "resource name of the password field for automatic login")
+  .option("--test-username <string>", "username for automatic login")
+  .option("--test-password <string>", "password for automatic login")
+  .option("--test-username-resource <string>", "resource name of the username field for automatic login")
+  .option("--test-password-resource <string>", "resource name of the password field for automatic login")
   .option("--test-async", "don't wait for automatic test results")
   .before(requireAuth)
   .action(async (file: string, options: any) => {
@@ -195,7 +195,9 @@ export const command = new Command("appdistribution:distribute <release-binary-f
     if (testDevices) {
       const releaseTest =
         await requests.createReleaseTest(releaseName, testDevices, loginCredential);
-      await awaitTestResults(releaseTest.name!, requests);
+      if (!options.testAsync) {
+        await awaitTestResults(releaseTest.name!, requests);
+      }
     }
   });
 

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -72,8 +72,8 @@ export const command = new Command("appdistribution:distribute <release-binary-f
     "resource name for the password field for automatic login",
   )
   .option(
-    "--test-async",
-    "run tests asynchronously. Visit the Firebase console for the automatic test results.",
+    "--test-non-blocking",
+    "run automated tests without waiting for them to complete. Visit the Firebase console for the test results.",
   )
   .before(requireAuth)
   .action(async (file: string, options: any) => {
@@ -218,7 +218,7 @@ export const command = new Command("appdistribution:distribute <release-binary-f
         loginCredential,
       );
       utils.logSuccess(`Release test created successfully`);
-      if (!options.testAsync) {
+      if (!options.testNonBlocking) {
         await awaitTestResults(releaseTest.name!, requests);
       }
     }

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -336,9 +336,7 @@ describe("distribution", () => {
     });
 
     it("should resolve with ReleaseTest when request succeeds", async () => {
-      nock(appDistributionOrigin)
-        .post(`/v1alpha/${releaseName}`)
-        .reply(200, mockReleaseTest);
+      nock(appDistributionOrigin).post(`/v1alpha/${releaseName}`).reply(200, mockReleaseTest);
       await expect(
         appDistributionClient.createReleaseTest(releaseName, mockDevices),
       ).to.be.eventually.deep.eq(mockReleaseTest);
@@ -372,19 +370,15 @@ describe("distribution", () => {
       nock(appDistributionOrigin)
         .get(`/v1alpha/${releaseTestName}`)
         .reply(400, { error: { status: "FAILED_PRECONDITION" } });
-      await expect(
-        appDistributionClient.getReleaseTest(releaseTestName),
-      ).to.be.rejected;
+      await expect(appDistributionClient.getReleaseTest(releaseTestName)).to.be.rejected;
       expect(nock.isDone()).to.be.true;
     });
 
     it("should resolve with ReleaseTest when request succeeds", async () => {
-      nock(appDistributionOrigin)
-        .get(`/v1alpha/${releaseTestName}`)
-        .reply(200, mockReleaseTest);
-      await expect(
-        appDistributionClient.getReleaseTest(releaseTestName),
-      ).to.be.eventually.deep.eq(mockReleaseTest);
+      nock(appDistributionOrigin).get(`/v1alpha/${releaseTestName}`).reply(200, mockReleaseTest);
+      await expect(appDistributionClient.getReleaseTest(releaseTestName)).to.be.eventually.deep.eq(
+        mockReleaseTest,
+      );
       expect(nock.isDone()).to.be.true;
     });
   });

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -327,7 +327,7 @@ describe("distribution", () => {
 
     it("should throw error if request fails", async () => {
       nock(appDistributionOrigin)
-        .post(`/v1alpha/${releaseName}`)
+        .post(`/v1alpha/${releaseName}/tests`)
         .reply(400, { error: { status: "FAILED_PRECONDITION" } });
       await expect(
         appDistributionClient.createReleaseTest(releaseName, mockDevices),
@@ -336,7 +336,7 @@ describe("distribution", () => {
     });
 
     it("should resolve with ReleaseTest when request succeeds", async () => {
-      nock(appDistributionOrigin).post(`/v1alpha/${releaseName}`).reply(200, mockReleaseTest);
+      nock(appDistributionOrigin).post(`/v1alpha/${releaseName}/tests`).reply(200, mockReleaseTest);
       await expect(
         appDistributionClient.createReleaseTest(releaseName, mockDevices),
       ).to.be.eventually.deep.eq(mockReleaseTest);

--- a/src/test/appdistro/client.spec.ts
+++ b/src/test/appdistro/client.spec.ts
@@ -6,13 +6,8 @@ import * as rimraf from "rimraf";
 import * as sinon from "sinon";
 import * as tmp from "tmp";
 
-import {
-  AppDistributionClient,
-  BatchRemoveTestersResponse,
-  Group,
-  TestDevice,
-  TestState,
-} from "../../appdistribution/client";
+import { AppDistributionClient } from "../../appdistribution/client";
+import { BatchRemoveTestersResponse, Group, TestDevice } from "../../appdistribution/types";
 import { appDistributionOrigin } from "../../api";
 import { Distribution } from "../../appdistribution/distribution";
 import { FirebaseError } from "../../error";
@@ -322,7 +317,7 @@ describe("distribution", () => {
     const mockReleaseTest = {
       name: `${releaseName}/tests/fake-test-id`,
       devices: mockDevices,
-      state: TestState.IN_PROGRESS,
+      state: "IN_PROGRESS",
     };
 
     it("should throw error if request fails", async () => {
@@ -363,7 +358,7 @@ describe("distribution", () => {
     const mockReleaseTest = {
       name: releaseTestName,
       devices: mockDevices,
-      state: TestState.IN_PROGRESS,
+      state: "IN_PROGRESS",
     };
 
     it("should throw error if request fails", async () => {

--- a/src/test/appdistro/options-parser-util.spec.ts
+++ b/src/test/appdistro/options-parser-util.spec.ts
@@ -11,7 +11,7 @@ tmp.setGracefulCleanup();
 describe("options-parser-util", () => {
   const tempdir = tmp.dirSync();
   const passwordFile = join(tempdir.name, "password.txt");
-  fs.outputFileSync(passwordFile, "password-from-file");
+  fs.outputFileSync(passwordFile, "password-from-file\n");
 
   after(() => {
     rimraf.sync(tempdir.name);

--- a/src/test/appdistro/options-parser-util.spec.ts
+++ b/src/test/appdistro/options-parser-util.spec.ts
@@ -1,0 +1,134 @@
+import { expect } from "chai";
+import { getLoginCredential, getTestDevices } from "../../appdistribution/options-parser-util";
+import { FirebaseError } from "../../error";
+
+describe.only("options-parser-util", () => {
+  describe("getTestDevices", () => {
+    it("parses a test device", () => {
+      const optionValue = "model=modelname,version=123,orientation=landscape,locale=en_US";
+
+      const result = getTestDevices(optionValue, "");
+
+      expect(result).to.deep.equal([{
+        model: "modelname",
+        version: "123",
+        orientation: "landscape",
+        locale: "en_US",
+      }]);
+    });
+
+    it("parses multiple semicolon-separated test devices", () => {
+      const optionValue =
+        "model=modelname,version=123,orientation=landscape,locale=en_US;model=modelname2,version=456,orientation=portrait,locale=es";
+
+      const result = getTestDevices(optionValue, "");
+
+      expect(result).to.deep.equal([
+        {
+          model: "modelname",
+          version: "123",
+          orientation: "landscape",
+          locale: "en_US",
+        },
+        {
+          model: "modelname2",
+          version: "456",
+          orientation: "portrait",
+          locale: "es",
+        }
+      ]);
+    });
+
+    it("parses multiple newline-separated test devices", () => {
+      const optionValue =
+        "model=modelname,version=123,orientation=landscape,locale=en_US\nmodel=modelname2,version=456,orientation=portrait,locale=es";
+
+      const result = getTestDevices(optionValue, "");
+
+      expect(result).to.deep.equal([
+        {
+          model: "modelname",
+          version: "123",
+          orientation: "landscape",
+          locale: "en_US",
+        },
+        {
+          model: "modelname2",
+          version: "456",
+          orientation: "portrait",
+          locale: "es",
+        }
+      ]);
+    });
+
+    it("throws an error with correct format when missing a field", () => {
+      const optionValue = "model=modelname,version=123,locale=en_US";
+
+      expect(() => getTestDevices(optionValue, "")).to.throw(
+        FirebaseError,
+        "model=<model-id>,version=<os-version-id>,locale=<locale>,orientation=<orientation>",
+      );
+    });
+
+    it("throws an error with expected fields when field is unexpected", () => {
+      const optionValue = "model=modelname,version=123,orientation=landscape,locale=en_US,notafield=blah";
+
+      expect(() => getTestDevices(optionValue, "")).to.throw(
+        FirebaseError,
+        "model, version, orientation, locale",
+      );
+    });
+  });
+
+  describe("getLoginCredential", () => {
+    it("returns credential for username and password", () => {
+      const result = getLoginCredential("user", "123");
+
+      expect(result).to.deep.equal({
+        username: "user",
+        password: "123",
+        fieldHints: undefined,
+      });
+    });
+
+    it("returns undefined when no options provided", () => {
+      const result = getLoginCredential();
+
+      expect(result).to.be.undefined
+    });
+
+    it("returns credential for username, password, and resource names", () => {
+      const result = getLoginCredential("user", "123", "username_resource_id", "password_resource_id");
+
+      expect(result).to.deep.equal({
+        username: "user",
+        password: "123",
+        fieldHints: {
+          usernameResourceName: "username_resource_id",
+          passwordResourceName: "password_resource_id",
+        },
+      });
+    });
+
+    it("throws error when username and password not provided together", () => {
+      expect(() => getLoginCredential("user", undefined)).to.throw(
+        FirebaseError,
+        "Username and password for automated tests need to be specified together"
+      );
+    });
+
+    it("throws error when username but not password resources not provided together", () => {
+      expect(() => getLoginCredential("user", "123", undefined, "password_resource_id")).to.throw(
+        FirebaseError,
+        "Username and password resource names for automated tests need to be specified together"
+      );
+    });
+
+    it("throws error when resource names provided without username and password", () => {
+      expect(() => getLoginCredential(undefined, undefined, "username_resource_id", "password_resource_id")).to.throw(
+        FirebaseError,
+        "Must specify username and password"
+      );
+    });
+  });
+});

--- a/src/test/appdistro/options-parser-util.spec.ts
+++ b/src/test/appdistro/options-parser-util.spec.ts
@@ -2,19 +2,21 @@ import { expect } from "chai";
 import { getLoginCredential, getTestDevices } from "../../appdistribution/options-parser-util";
 import { FirebaseError } from "../../error";
 
-describe.only("options-parser-util", () => {
+describe("options-parser-util", () => {
   describe("getTestDevices", () => {
     it("parses a test device", () => {
       const optionValue = "model=modelname,version=123,orientation=landscape,locale=en_US";
 
       const result = getTestDevices(optionValue, "");
 
-      expect(result).to.deep.equal([{
-        model: "modelname",
-        version: "123",
-        orientation: "landscape",
-        locale: "en_US",
-      }]);
+      expect(result).to.deep.equal([
+        {
+          model: "modelname",
+          version: "123",
+          orientation: "landscape",
+          locale: "en_US",
+        },
+      ]);
     });
 
     it("parses multiple semicolon-separated test devices", () => {
@@ -35,7 +37,7 @@ describe.only("options-parser-util", () => {
           version: "456",
           orientation: "portrait",
           locale: "es",
-        }
+        },
       ]);
     });
 
@@ -57,7 +59,7 @@ describe.only("options-parser-util", () => {
           version: "456",
           orientation: "portrait",
           locale: "es",
-        }
+        },
       ]);
     });
 
@@ -71,7 +73,8 @@ describe.only("options-parser-util", () => {
     });
 
     it("throws an error with expected fields when field is unexpected", () => {
-      const optionValue = "model=modelname,version=123,orientation=landscape,locale=en_US,notafield=blah";
+      const optionValue =
+        "model=modelname,version=123,orientation=landscape,locale=en_US,notafield=blah";
 
       expect(() => getTestDevices(optionValue, "")).to.throw(
         FirebaseError,
@@ -94,11 +97,16 @@ describe.only("options-parser-util", () => {
     it("returns undefined when no options provided", () => {
       const result = getLoginCredential();
 
-      expect(result).to.be.undefined
+      expect(result).to.be.undefined;
     });
 
     it("returns credential for username, password, and resource names", () => {
-      const result = getLoginCredential("user", "123", "username_resource_id", "password_resource_id");
+      const result = getLoginCredential(
+        "user",
+        "123",
+        "username_resource_id",
+        "password_resource_id",
+      );
 
       expect(result).to.deep.equal({
         username: "user",
@@ -113,22 +121,21 @@ describe.only("options-parser-util", () => {
     it("throws error when username and password not provided together", () => {
       expect(() => getLoginCredential("user", undefined)).to.throw(
         FirebaseError,
-        "Username and password for automated tests need to be specified together"
+        "Username and password for automated tests need to be specified together",
       );
     });
 
     it("throws error when username but not password resources not provided together", () => {
       expect(() => getLoginCredential("user", "123", undefined, "password_resource_id")).to.throw(
         FirebaseError,
-        "Username and password resource names for automated tests need to be specified together"
+        "Username and password resource names for automated tests need to be specified together",
       );
     });
 
     it("throws error when resource names provided without username and password", () => {
-      expect(() => getLoginCredential(undefined, undefined, "username_resource_id", "password_resource_id")).to.throw(
-        FirebaseError,
-        "Must specify username and password"
-      );
+      expect(() =>
+        getLoginCredential(undefined, undefined, "username_resource_id", "password_resource_id"),
+      ).to.throw(FirebaseError, "Must specify username and password");
     });
   });
 });

--- a/src/test/appdistro/options-parser-util.spec.ts
+++ b/src/test/appdistro/options-parser-util.spec.ts
@@ -99,7 +99,7 @@ describe("options-parser-util", () => {
 
   describe("getLoginCredential", () => {
     it("returns credential for username and password", () => {
-      const result = getLoginCredential("user", "123");
+      const result = getLoginCredential({ username: "user", password: "123" });
 
       expect(result).to.deep.equal({
         username: "user",
@@ -109,7 +109,7 @@ describe("options-parser-util", () => {
     });
 
     it("returns credential for username and passwordFile", () => {
-      const result = getLoginCredential("user", undefined, passwordFile);
+      const result = getLoginCredential({ username: "user", passwordFile });
 
       expect(result).to.deep.equal({
         username: "user",
@@ -119,19 +119,18 @@ describe("options-parser-util", () => {
     });
 
     it("returns undefined when no options provided", () => {
-      const result = getLoginCredential();
+      const result = getLoginCredential({});
 
       expect(result).to.be.undefined;
     });
 
     it("returns credential for username, password, and resource names", () => {
-      const result = getLoginCredential(
-        "user",
-        "123",
-        undefined,
-        "username_resource_id",
-        "password_resource_id",
-      );
+      const result = getLoginCredential({
+        username: "user",
+        password: "123",
+        usernameResourceName: "username_resource_id",
+        passwordResourceName: "password_resource_id",
+      });
 
       expect(result).to.deep.equal({
         username: "user",
@@ -144,13 +143,12 @@ describe("options-parser-util", () => {
     });
 
     it("returns credential for username, passwordFile, and resource names", () => {
-      const result = getLoginCredential(
-        "user",
-        undefined,
+      const result = getLoginCredential({
+        username: "user",
         passwordFile,
-        "username_resource_id",
-        "password_resource_id",
-      );
+        usernameResourceName: "username_resource_id",
+        passwordResourceName: "password_resource_id",
+      });
 
       expect(result).to.deep.equal({
         username: "user",
@@ -163,24 +161,32 @@ describe("options-parser-util", () => {
     });
 
     it("throws error when username and password not provided together", () => {
-      expect(() => getLoginCredential("user", undefined, undefined)).to.throw(
+      expect(() => getLoginCredential({ username: "user" })).to.throw(
         FirebaseError,
         "Username and password for automated tests need to be specified together",
       );
     });
 
-    it("throws error when username but not password resource provided", () => {
+    it("throws error when password (but not username) resource provided", () => {
       expect(() =>
-        getLoginCredential("user", "123", undefined, undefined, "password_resource_id"),
+        getLoginCredential({
+          username: "user",
+          password: "123",
+          passwordResourceName: "password_resource_id",
+        }),
       ).to.throw(
         FirebaseError,
         "Username and password resource names for automated tests need to be specified together",
       );
     });
 
-    it("throws error when password but not username resource provided", () => {
+    it("throws error when password file and password (but not username) resource provided", () => {
       expect(() =>
-        getLoginCredential("user", undefined, passwordFile, undefined, "password_resource_id"),
+        getLoginCredential({
+          username: "user",
+          passwordFile,
+          passwordResourceName: "password_resource_id",
+        }),
       ).to.throw(
         FirebaseError,
         "Username and password resource names for automated tests need to be specified together",
@@ -189,13 +195,10 @@ describe("options-parser-util", () => {
 
     it("throws error when resource names provided without username and password", () => {
       expect(() =>
-        getLoginCredential(
-          undefined,
-          undefined,
-          undefined,
-          "username_resource_id",
-          "password_resource_id",
-        ),
+        getLoginCredential({
+          usernameResourceName: "username_resource_id",
+          passwordResourceName: "password_resource_id",
+        }),
       ).to.throw(FirebaseError, "Must specify username and password");
     });
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Adding `--test-devices` and related flags to `appdistribution:distribute` action. This will trigger the new Automated Tester feature.

### Scenarios Tested

- Kick off tests for a release
- Kick off tests async
- Kick off tests with username/password
- Kick off tests with username/password and resource IDs
- Kick off tests with username but not password (error case)
- Kick off tests with username resource but not password resource (error case)
- Kick off tests with username/password resource but not username/password (error case)

### Sample Commands

`firebase appdistribution:distribute --app <app id> <path> --test-devices <devices>`
`firebase appdistribution:distribute --app <app id> <path> --test-devices <devices> --test-async`
`firebase appdistribution:distribute --app <app id> <path> --test-devices <devices> --test-username <user> --test-password <password>`
`firebase appdistribution:distribute --app <app id> <path> --test-devices <devices> --test-username <user> --test-password <password> --test-username-resource <resource id> --test-password-resource <resource id>`
