### PR TITLE
FAH uses ids using the same naming policy as rolloutPolicy

### DIFF
--- a/src/commands/apphosting-builds-create.ts
+++ b/src/commands/apphosting-builds-create.ts
@@ -2,7 +2,6 @@ import * as apphosting from "../gcp/apphosting";
 import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
-import { generateId } from "../utils";
 import { needProjectId } from "../projectUtils";
 
 export const command = new Command("apphosting:builds:create <backendId>")
@@ -14,7 +13,9 @@ export const command = new Command("apphosting:builds:create <backendId>")
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
     const location = options.location as string;
-    const buildId = (options.buildId as string) || generateId();
+    const buildId =
+      (options.buildId as string) ||
+      (await apphosting.getNextBuildId(projectId, location, backendId));
     const branch = options.branch as string;
 
     const op = await apphosting.createBuild(projectId, location, backendId, buildId, {

--- a/src/commands/apphosting-builds-create.ts
+++ b/src/commands/apphosting-builds-create.ts
@@ -15,7 +15,7 @@ export const command = new Command("apphosting:builds:create <backendId>")
     const location = options.location as string;
     const buildId =
       (options.buildId as string) ||
-      (await apphosting.getNextBuildId(projectId, location, backendId));
+      (await apphosting.getNextRolloutId(projectId, location, backendId));
     const branch = options.branch as string;
 
     const op = await apphosting.createBuild(projectId, location, backendId, buildId, {

--- a/src/commands/apphosting-rollouts-create.ts
+++ b/src/commands/apphosting-rollouts-create.ts
@@ -3,7 +3,6 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
-import { generateId } from "../utils";
 
 export const command = new Command("apphosting:rollouts:create <backendId> <buildId>")
   .description("Create a build for an App Hosting backend")
@@ -13,7 +12,10 @@ export const command = new Command("apphosting:rollouts:create <backendId> <buil
   .action(async (backendId: string, buildId: string, options: Options) => {
     const projectId = needProjectId(options);
     const location = options.location as string;
-    const rolloutId = (options.buildId as string) || generateId();
+    // TODO: Should we just reuse the buildId?
+    const rolloutId =
+      (options.buildId as string) ||
+      (await apphosting.getNextBuildId(projectId, location, backendId));
     const build = `projects/${projectId}/backends/${backendId}/builds/${buildId}`;
     const op = await apphosting.createRollout(projectId, location, backendId, rolloutId, {
       build,

--- a/src/commands/apphosting-rollouts-create.ts
+++ b/src/commands/apphosting-rollouts-create.ts
@@ -15,7 +15,7 @@ export const command = new Command("apphosting:rollouts:create <backendId> <buil
     // TODO: Should we just reuse the buildId?
     const rolloutId =
       (options.buildId as string) ||
-      (await apphosting.getNextBuildId(projectId, location, backendId));
+      (await apphosting.getNextRolloutId(projectId, location, backendId));
     const build = `projects/${projectId}/backends/${backendId}/builds/${buildId}`;
     const op = await apphosting.createRollout(projectId, location, backendId, rolloutId, {
       build,

--- a/src/commands/apphosting-rollouts-list.ts
+++ b/src/commands/apphosting-rollouts-list.ts
@@ -16,6 +16,11 @@ export const command = new Command("apphosting:rollouts:list <backendId>")
     const projectId = needProjectId(options);
     const location = options.location as string;
     const rollouts = await apphosting.listRollouts(projectId, location, backendId);
-    logger.info(JSON.stringify(rollouts, null, 2));
+    if (rollouts.unreachable) {
+      logger.error(
+        `WARNING: the following locations were unreachable: ${rollouts.unreachable.join(", ")}`,
+      );
+    }
+    logger.info(JSON.stringify(rollouts.rollouts, null, 2));
     return rollouts;
   });

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -356,8 +356,8 @@ export async function listBuilds(
   backendId: string,
 ): Promise<ListBuildsResponse> {
   const name = `projects/${projectId}/locations/${location}/backends/${backendId}/builds`;
-  let pageToken: string | undefined = undefined;
-  const res: ListBuildsResponse = {
+  let pageToken: string | undefined;
+  const res: implements ListBuildsResponse = {
     builds: [],
     unreachable: [],
   };
@@ -365,8 +365,8 @@ export async function listBuilds(
   do {
     const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
     const int = await client.get<ListBuildsResponse>(name, { queryParams });
-    res.builds.splice(res.builds.length, 0, ...(int.body.builds || []));
-    res.unreachable?.splice(res.unreachable.length, 0, ...(int.body.unreachable || []));
+    res.builds.push(...(int.body.builds || []));
+    res.unreachable.push(...(int.body.unreachable || []));
     pageToken = int.body.nextPageToken;
   } while (pageToken);
 
@@ -520,7 +520,6 @@ export async function ensureApiEnabled(options: any): Promise<void> {
 /**
  * Generates the next build ID to fit with the naming scheme of the backend API.
  * @param counter Overrides the counter to use, avoiding an API call.
- * @return
  */
 export async function getNextRolloutId(
   projectId: string,
@@ -531,7 +530,7 @@ export async function getNextRolloutId(
   const date = new Date();
   const year = date.getUTCFullYear();
   // Note: month is 0 based in JS
-  const month = String(date.getUTCMonth()).padStart(2, "0");
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
   const day = String(date.getUTCDay()).padStart(2, "0");
 
   if (counter) {

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -357,7 +357,7 @@ export async function listBuilds(
 ): Promise<ListBuildsResponse> {
   const name = `projects/${projectId}/locations/${location}/backends/${backendId}/builds`;
   let pageToken: string | undefined;
-  const res: implements ListBuildsResponse = {
+  const res: ListBuildsResponse = {
     builds: [],
     unreachable: [],
   };
@@ -366,7 +366,7 @@ export async function listBuilds(
     const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
     const int = await client.get<ListBuildsResponse>(name, { queryParams });
     res.builds.push(...(int.body.builds || []));
-    res.unreachable.push(...(int.body.unreachable || []));
+    res.unreachable?.push(...(int.body.unreachable || []));
     pageToken = int.body.nextPageToken;
   } while (pageToken);
 
@@ -441,7 +441,7 @@ export async function listRollouts(
     const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
     const int = await client.get<ListRolloutsResponse>(name, { queryParams });
     res.rollouts.splice(res.rollouts.length, 0, ...(int.body.rollouts || []));
-    res.unreachable?.splice(res.unreachable.length, 0, ...(int.body.unreachable || []));
+    res.unreachable.splice(res.unreachable.length, 0, ...(int.body.unreachable || []));
     pageToken = int.body.nextPageToken;
   } while (pageToken);
 

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -558,5 +558,5 @@ export async function getNextRolloutId(
       highest = n;
     }
   }
-  return `build-${year}-${month}-${day}-${highest + 1}`;
+  return `build-${year}-${month}-${day}-${String(highest + 1).padStart(3, "0")}`;
 }

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -516,7 +516,7 @@ export async function ensureApiEnabled(options: any): Promise<void> {
  * @param counter Overrides the counter to use, avoiding an API call.
  * @return
  */
-export async function getNextBuildId(
+export async function getNextRolloutId(
   projectId: string,
   location: string,
   backendId: string,

--- a/src/init/features/apphosting/index.ts
+++ b/src/init/features/apphosting/index.ts
@@ -182,7 +182,7 @@ export async function onboardRollout(
   buildInput: Omit<BuildInput, "name">,
 ): Promise<{ rollout: Rollout; build: Build }> {
   logBullet("Starting a new rollout... this may take a few minutes.");
-  const buildId = await apphosting.getNextBuildId(projectId, location, backendId, 1);
+  const buildId = await apphosting.getNextRolloutId(projectId, location, backendId, 1);
   const buildOp = await apphosting.createBuild(projectId, location, backendId, buildId, buildInput);
 
   const rolloutOp = await apphosting.createRollout(projectId, location, backendId, buildId, {

--- a/src/test/gcp/apphosting.spec.ts
+++ b/src/test/gcp/apphosting.spec.ts
@@ -22,7 +22,7 @@ describe("apphosting", () => {
     }
 
     it("Should handle explicit counters", async () => {
-      const id = await apphosting.getNextBuildId("unused", "unused", "unused", 1);
+      const id = await apphosting.getNextRolloutId("unused", "unused", "unused", 1);
       expect(id).matches(new RegExp(`^${idPrefix(new Date())}-1$`));
       expect(listRollouts).to.not.have.been.called;
     });
@@ -34,7 +34,7 @@ describe("apphosting", () => {
       });
 
       await expect(
-        apphosting.getNextBuildId("project", "us-central1", "backend"),
+        apphosting.getNextRolloutId("project", "us-central1", "backend"),
       ).to.be.rejectedWith(/unreachable .*us-central1/);
       expect(listRollouts).to.have.been.calledWith("project", "us-central1", "backend");
     });
@@ -45,7 +45,7 @@ describe("apphosting", () => {
         unreachable: [],
       });
 
-      const id = await apphosting.getNextBuildId("project", "location", "backend");
+      const id = await apphosting.getNextRolloutId("project", "location", "backend");
       expect(id).equals(`${idPrefix(new Date())}-1`);
       expect(listRollouts).to.have.been.calledWith("project", "location", "backend");
     });
@@ -67,7 +67,7 @@ describe("apphosting", () => {
         unreachable: [],
       });
 
-      const id = await apphosting.getNextBuildId("project", "location", "backend");
+      const id = await apphosting.getNextRolloutId("project", "location", "backend");
       expect(id).to.equal(`${idPrefix(today)}-2`);
     });
 
@@ -85,7 +85,7 @@ describe("apphosting", () => {
         unreachable: [],
       });
 
-      const id = await apphosting.getNextBuildId("project", "location", "backend");
+      const id = await apphosting.getNextRolloutId("project", "location", "backend");
       expect(id).to.equal(`${idPrefix(today)}-1`);
     });
   });

--- a/src/test/gcp/apphosting.spec.ts
+++ b/src/test/gcp/apphosting.spec.ts
@@ -21,13 +21,13 @@ describe("apphosting", () => {
       return `build-${year}-${month}-${day}`;
     }
 
-    it("Should handle explicit counters", async () => {
+    it("should handle explicit counters", async () => {
       const id = await apphosting.getNextRolloutId("unused", "unused", "unused", 1);
       expect(id).matches(new RegExp(`^${idPrefix(new Date())}-001$`));
       expect(listRollouts).to.not.have.been.called;
     });
 
-    it("Should handle missing regions", async () => {
+    it("should handle missing regions", async () => {
       listRollouts.returns({
         rollouts: [],
         unreachable: ["us-central1"],
@@ -39,7 +39,7 @@ describe("apphosting", () => {
       expect(listRollouts).to.have.been.calledWith("project", "us-central1", "backend");
     });
 
-    it("Should handle the first build of a day", async () => {
+    it("should handle the first build of a day", async () => {
       listRollouts.returns({
         rollouts: [],
         unreachable: [],
@@ -50,7 +50,7 @@ describe("apphosting", () => {
       expect(listRollouts).to.have.been.calledWith("project", "location", "backend");
     });
 
-    it("Should increment from the correct date", async () => {
+    it("should increment from the correct date", async () => {
       const today = new Date();
       const yesterday = new Date();
       yesterday.setDate(today.getDate() - 1);
@@ -71,7 +71,7 @@ describe("apphosting", () => {
       expect(id).to.equal(`${idPrefix(today)}-002`);
     });
 
-    it("Should handle the first build of the day", async () => {
+    it("should handle the first build of the day", async () => {
       const today = new Date();
       const yesterday = new Date();
       yesterday.setDate(today.getDate() - 1);

--- a/src/test/gcp/apphosting.spec.ts
+++ b/src/test/gcp/apphosting.spec.ts
@@ -1,0 +1,164 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as apphosting from "../../gcp/apphosting";
+
+describe("apphosting", () => {
+  describe("getNextBuildId", () => {
+    let listRollouts: sinon.SinonStub;
+
+    beforeEach(() => {
+      listRollouts = sinon.stub(apphosting, "listRollouts");
+    });
+
+    afterEach(() => {
+      listRollouts.restore();
+    });
+
+    function idPrefix(date: Date): string {
+      const year = date.getUTCFullYear();
+      const month = String(date.getUTCDay()).padStart(2, "0");
+      const day = String(date.getUTCDay()).padStart(2, "0");
+      return `build-${year}-${month}-${day}`;
+    }
+
+    it("Should handle explicit counters", async () => {
+      const id = await apphosting.getNextBuildId("unused", "unused", "unused", 1);
+      expect(id).matches(new RegExp(`^${idPrefix(new Date())}-1$`));
+      expect(listRollouts).to.not.have.been.called;
+    });
+
+    it("Should handle missing regions", async () => {
+      listRollouts.returns({
+        rollouts: [],
+        unreachable: ["us-central1"],
+      });
+
+      await expect(
+        apphosting.getNextBuildId("project", "us-central1", "backend"),
+      ).to.be.rejectedWith(/unreachable .*us-central1/);
+      expect(listRollouts).to.have.been.calledWith("project", "us-central1", "backend");
+    });
+
+    it("Should handle the first build of a day", async () => {
+      listRollouts.returns({
+        rollouts: [],
+        unreachable: [],
+      });
+
+      const id = await apphosting.getNextBuildId("project", "location", "backend");
+      expect(id).equals(`${idPrefix(new Date())}-1`);
+      expect(listRollouts).to.have.been.calledWith("project", "location", "backend");
+    });
+
+    it("Should increment from the correct date", async () => {
+      const today = new Date();
+      const yesterday = new Date();
+      yesterday.setDate(today.getDate() - 1);
+
+      listRollouts.returns({
+        rollouts: [
+          {
+            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(yesterday)}-5`,
+          },
+          {
+            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(today)}-1`,
+          },
+        ],
+        unreachable: [],
+      });
+
+      const id = await apphosting.getNextBuildId("project", "location", "backend");
+      expect(id).to.equal(`${idPrefix(today)}-2`);
+    });
+
+    it("Should handle the first build of the day", async () => {
+      const today = new Date();
+      const yesterday = new Date();
+      yesterday.setDate(today.getDate() - 1);
+
+      listRollouts.returns({
+        rollouts: [
+          {
+            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(yesterday)}-5`,
+          },
+        ],
+        unreachable: [],
+      });
+
+      const id = await apphosting.getNextBuildId("project", "location", "backend");
+      expect(id).to.equal(`${idPrefix(today)}-1`);
+    });
+  });
+
+  describe("list APIs", () => {
+    let get: sinon.SinonStub;
+
+    beforeEach(() => {
+      get = sinon.stub(apphosting.client, "get");
+    });
+
+    afterEach(() => {
+      get.restore();
+    });
+
+    it("paginates listBuilds", async () => {
+      get.onFirstCall().resolves({
+        body: {
+          builds: [
+            {
+              name: "abc",
+            },
+          ],
+          nextPageToken: "2",
+        },
+      });
+      get.onSecondCall().resolves({
+        body: {
+          unreachable: ["us-central1"],
+        },
+      });
+      await expect(apphosting.listBuilds("p", "l", "b")).to.eventually.deep.equal({
+        builds: [
+          {
+            name: "abc",
+          },
+        ],
+        unreachable: ["us-central1"],
+      });
+      expect(get).to.have.been.calledTwice;
+      expect(get).to.have.been.calledWithMatch("projects/p/locations/l/backends/b/builds", {
+        queryParams: { nextPageToken: "2" },
+      });
+    });
+
+    it("paginates listRollouts", async () => {
+      get.onFirstCall().resolves({
+        body: {
+          rollouts: [
+            {
+              name: "abc",
+            },
+          ],
+          nextPageToken: "2",
+        },
+      });
+      get.onSecondCall().resolves({
+        body: {
+          unreachable: ["us-central1"],
+        },
+      });
+      await expect(apphosting.listRollouts("p", "l", "b")).to.eventually.deep.equal({
+        rollouts: [
+          {
+            name: "abc",
+          },
+        ],
+        unreachable: ["us-central1"],
+      });
+      expect(get).to.have.been.calledTwice;
+      expect(get).to.have.been.calledWithMatch("projects/p/locations/l/backends/b/rollouts", {
+        queryParams: { nextPageToken: "2" },
+      });
+    });
+  });
+});

--- a/src/test/gcp/apphosting.spec.ts
+++ b/src/test/gcp/apphosting.spec.ts
@@ -23,7 +23,7 @@ describe("apphosting", () => {
 
     it("Should handle explicit counters", async () => {
       const id = await apphosting.getNextRolloutId("unused", "unused", "unused", 1);
-      expect(id).matches(new RegExp(`^${idPrefix(new Date())}-1$`));
+      expect(id).matches(new RegExp(`^${idPrefix(new Date())}-001$`));
       expect(listRollouts).to.not.have.been.called;
     });
 
@@ -58,17 +58,17 @@ describe("apphosting", () => {
       listRollouts.returns({
         rollouts: [
           {
-            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(yesterday)}-5`,
+            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(yesterday)}-005`,
           },
           {
-            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(today)}-1`,
+            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(today)}-001`,
           },
         ],
         unreachable: [],
       });
 
       const id = await apphosting.getNextRolloutId("project", "location", "backend");
-      expect(id).to.equal(`${idPrefix(today)}-2`);
+      expect(id).to.equal(`${idPrefix(today)}-002`);
     });
 
     it("Should handle the first build of the day", async () => {
@@ -79,14 +79,14 @@ describe("apphosting", () => {
       listRollouts.returns({
         rollouts: [
           {
-            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(yesterday)}-5`,
+            name: `projects/project/locations/location/backends/backend/rollouts/${idPrefix(yesterday)}-005`,
           },
         ],
         unreachable: [],
       });
 
       const id = await apphosting.getNextRolloutId("project", "location", "backend");
-      expect(id).to.equal(`${idPrefix(today)}-1`);
+      expect(id).to.equal(`${idPrefix(today)}-001`);
     });
   });
 

--- a/src/test/gcp/apphosting.spec.ts
+++ b/src/test/gcp/apphosting.spec.ts
@@ -46,7 +46,7 @@ describe("apphosting", () => {
       });
 
       const id = await apphosting.getNextRolloutId("project", "location", "backend");
-      expect(id).equals(`${idPrefix(new Date())}-1`);
+      expect(id).equals(`${idPrefix(new Date())}-001`);
       expect(listRollouts).to.have.been.calledWith("project", "location", "backend");
     });
 
@@ -127,7 +127,7 @@ describe("apphosting", () => {
       });
       expect(get).to.have.been.calledTwice;
       expect(get).to.have.been.calledWithMatch("projects/p/locations/l/backends/b/builds", {
-        queryParams: { nextPageToken: "2" },
+        queryParams: { pageToken: "2" },
       });
     });
 
@@ -157,7 +157,7 @@ describe("apphosting", () => {
       });
       expect(get).to.have.been.calledTwice;
       expect(get).to.have.been.calledWithMatch("projects/p/locations/l/backends/b/rollouts", {
-        queryParams: { nextPageToken: "2" },
+        queryParams: { pageToken: "2" },
       });
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -534,7 +534,6 @@ export async function promiseWithSpinner<T>(action: () => Promise<T>, message: s
  * server creation (e.g. right after `.listen`), BEFORE any connections.
  *
  * Inspired by https://github.com/isaacs/server-destroy/blob/master/index.js
- *
  * @return a function that destroys all connections and closes the server
  */
 export function createDestroyer(server: http.Server): () => Promise<void> {
@@ -607,7 +606,10 @@ export function thirtyDaysFromNow(): Date {
   return new Date(Date.now() + THIRTY_DAYS_IN_MILLISECONDS);
 }
 
-export function assertIsString(val: any, message?: string): asserts val is string {
+/**
+ * Verifies val is a string.
+ */
+export function assertIsString(val: unknown, message?: string): asserts val is string {
   if (typeof val !== "string") {
     throw new AssertionError({
       message: message || `expected "string" but got "${typeof val}"`,
@@ -615,7 +617,10 @@ export function assertIsString(val: any, message?: string): asserts val is strin
   }
 }
 
-export function assertIsNumber(val: any, message?: string): asserts val is number {
+/**
+ * Verifies val is a number.
+ */
+export function assertIsNumber(val: unknown, message?: string): asserts val is number {
   if (typeof val !== "number") {
     throw new AssertionError({
       message: message || `expected "number" but got "${typeof val}"`,
@@ -623,8 +628,11 @@ export function assertIsNumber(val: any, message?: string): asserts val is numbe
   }
 }
 
+/**
+ * Assert val is a string or undefined.
+ */
 export function assertIsStringOrUndefined(
-  val: any,
+  val: unknown,
   message?: string,
 ): asserts val is string | undefined {
   if (!(val === undefined || typeof val === "string")) {
@@ -812,21 +820,4 @@ export function getHostnameFromUrl(url: string): string | null {
   } catch (e: unknown) {
     return null;
   }
-}
-
-/**
- * Generate id meeting the following criterias:
- *  - Lowercase, digits, and hyphens only
- *  - Must begin with letter
- *  - Cannot end with hyphen
- */
-export function generateId(n = 6): string {
-  const letters = "abcdefghijklmnopqrstuvwxyz";
-  const allChars = "01234567890-abcdefghijklmnopqrstuvwxyz";
-  let id = letters[Math.floor(Math.random() * letters.length)];
-  for (let i = 1; i < n; i++) {
-    const idx = Math.floor(Math.random() * allChars.length);
-    id += allChars[idx];
-  }
-  return id;
 }


### PR DESCRIPTION
Additionally added listRollouts and fixed listBuilds so that it paginates over multiple requests and preserves the list of unavailable regions (and handles them)