### PR TITLE
Fix e2e tests not working with latest VScode version

### DIFF
--- a/firebase-vscode/src/test/runTest.ts
+++ b/firebase-vscode/src/test/runTest.ts
@@ -13,7 +13,12 @@ async function main() {
     const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
     // Download VS Code, unzip it and run the integration test
-    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      // Workaround for https://github.com/webdriverio-community/wdio-vscode-service/issues/101#issuecomment-1928159399
+      version: "1.85.0",
+    });
   } catch (err) {
     console.error("Failed to run tests");
     process.exit(1);

--- a/firebase-vscode/src/test/wdio.conf.ts
+++ b/firebase-vscode/src/test/wdio.conf.ts
@@ -23,7 +23,8 @@ export const config: Options.Testrunner = {
   capabilities: [
     {
       browserName: "vscode",
-      browserVersion: "stable", // also possible: "insiders" or a specific version e.g. "1.80.0"
+      // Workaround for https://github.com/webdriverio-community/wdio-vscode-service/issues/101#issuecomment-1928159399
+      browserVersion: "1.85.0", // also possible: "insiders" or a specific version e.g. "1.80.0"
       "wdio:vscodeOptions": {
         // points to directory where extension package.json is located
         extensionPath: path.join(__dirname, "..", ".."),


### PR DESCRIPTION
### Description

The e2e command currently fails to run due to a newer VScode version

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
