### PR TITLE
Add check for empty device list

### DIFF
--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -210,7 +210,7 @@ export const command = new Command("appdistribution:distribute <release-binary-f
     await requests.distribute(releaseName, testers, groups);
 
     // Run automated tests
-    if (testDevices) {
+    if (testDevices?.length) {
       utils.logBullet("starting automated tests (note: this feature is in beta)");
       const releaseTest = await requests.createReleaseTest(
         releaseName,


### PR DESCRIPTION
### Description

Bug fix: A bug was discovered in firebase-tools@13.0.1 where automated tests were being triggered without any test-devices specified.

### Scenarios Tested

- Kick off tests for a release
- Kick off a release without test-devices specified

### Sample Commands

N/A
