### PR TITLE
Fix bug in test fixtures for build ID generation

### DIFF
--- a/src/test/gcp/apphosting.spec.ts
+++ b/src/test/gcp/apphosting.spec.ts
@@ -16,7 +16,7 @@ describe("apphosting", () => {
 
     function idPrefix(date: Date): string {
       const year = date.getUTCFullYear();
-      const month = String(date.getUTCDay()).padStart(2, "0");
+      const month = String(date.getUTCMonth() + 1).padStart(2, "0");
       const day = String(date.getUTCDay()).padStart(2, "0");
       return `build-${year}-${month}-${day}`;
     }


### PR DESCRIPTION
1. Day was being used instead of month in test slug
2. Month was not being +1d to make 1-based.
