### PR TITLE
Fixed an issue where `firestore:delete `would not use the emulator when it should

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Add support for Python 3.12. (#6679)
 - Bugfixes to internal utilities. (#6754)
+- Fixed an issue where `firestore:delete` wouldn't target the emulator when expected. (#6537)

--- a/src/deploy/functions/services/firestore.ts
+++ b/src/deploy/functions/services/firestore.ts
@@ -15,7 +15,7 @@ async function getDatabase(project: string, databaseId: string): Promise<firesto
   if (dbCache.has(key)) {
     return dbCache.get(key)!;
   }
-  const db = await firestore.getDatabase(project, databaseId);
+  const db = await firestore.getDatabase(project, databaseId, false);
   dbCache.set(key, db);
   return db;
 }

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -100,7 +100,7 @@ export const ALL_EXPERIMENTS = experiments({
 
   internalframeworks: {
     shortDescription: "Allow CLI option for Frameworks",
-    default: true,
+    default: false,
     public: false,
   },
 });

--- a/src/firestore/delete.ts
+++ b/src/firestore/delete.ts
@@ -394,7 +394,7 @@ export class FirestoreDelete {
 
       numPendingDeletes++;
       firestore
-        .deleteDocuments(this.project, toDelete)
+        .deleteDocuments(this.project, toDelete, true)
         .then((numDeleted) => {
           FirestoreDelete.progressBar.tick(numDeleted);
           numDocsDeleted += numDeleted;
@@ -481,7 +481,7 @@ export class FirestoreDelete {
     let initialDelete;
     if (this.isDocumentPath) {
       const doc = { name: this.root + "/" + this.path };
-      initialDelete = firestore.deleteDocument(doc).catch((err) => {
+      initialDelete = firestore.deleteDocument(doc, true).catch((err) => {
         logger.debug("deletePath:initialDelete:error", err);
         if (this.allDescendants) {
           // On a recursive delete, we are insensitive to
@@ -508,7 +508,7 @@ export class FirestoreDelete {
    */
   public deleteDatabase(): Promise<any[]> {
     return firestore
-      .listCollectionIds(this.project)
+      .listCollectionIds(this.project, true)
       .catch((err) => {
         logger.debug("deleteDatabase:listCollectionIds:error", err);
         return utils.reject("Unable to list collection IDs");

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -1,4 +1,4 @@
-import { firestoreOrigin } from "../api";
+import { firestoreOrigin, firestoreOriginOrEmulator } from "../api";
 import { Client } from "../apiv2";
 import { logger } from "../logger";
 
@@ -11,7 +11,7 @@ const prodOnlyClient = new Client({
 const emuOrProdClient = new Client({
   auth: true,
   apiVersion: "v1",
-  urlPrefix: firestoreOrigin,
+  urlPrefix: firestoreOriginOrEmulator,
 });
 
 export interface Database {
@@ -40,9 +40,9 @@ export interface Database {
 export async function getDatabase(
   project: string,
   database: string,
-  allowEmualtor: boolean = false,
+  allowEmulator: boolean = false,
 ): Promise<Database> {
-  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
+  const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
   const url = `projects/${project}/databases/${database}`;
   try {
     const resp = await apiClient.get<Database>(url);
@@ -63,9 +63,9 @@ export async function getDatabase(
  */
 export function listCollectionIds(
   project: string,
-  allowEmualtor: boolean = false,
+  allowEmulator: boolean = false,
 ): Promise<string[]> {
-  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
+  const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
   const url = "projects/" + project + "/databases/(default)/documents:listCollectionIds";
   const data = {
     // Maximum 32-bit integer
@@ -86,8 +86,8 @@ export function listCollectionIds(
  * @param {object} doc a Document object to delete.
  * @return {Promise} a promise for the delete operation.
  */
-export async function deleteDocument(doc: any, allowEmualtor: boolean = false): Promise<any> {
-  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
+export async function deleteDocument(doc: any, allowEmulator: boolean = false): Promise<any> {
+  const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
   return apiClient.delete(doc.name);
 }
 
@@ -104,9 +104,9 @@ export async function deleteDocument(doc: any, allowEmualtor: boolean = false): 
 export async function deleteDocuments(
   project: string,
   docs: any[],
-  allowEmualtor: boolean = false,
+  allowEmulator: boolean = false,
 ): Promise<number> {
-  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
+  const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
   const url = "projects/" + project + "/databases/(default)/documents:commit";
 
   const writes = docs.map((doc) => {

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -2,7 +2,13 @@ import { firestoreOrigin } from "../api";
 import { Client } from "../apiv2";
 import { logger } from "../logger";
 
-const apiClient = new Client({
+const prodOnlyClient = new Client({
+  auth: true,
+  apiVersion: "v1",
+  urlPrefix: firestoreOrigin,
+});
+
+const emuOrProdClient = new Client({
   auth: true,
   apiVersion: "v1",
   urlPrefix: firestoreOrigin,
@@ -31,7 +37,12 @@ export interface Database {
  * @param {string} project the Google Cloud project
  * @param {string} database the Firestore database name
  */
-export async function getDatabase(project: string, database: string): Promise<Database> {
+export async function getDatabase(
+  project: string,
+  database: string,
+  allowEmualtor: boolean = false,
+): Promise<Database> {
+  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
   const url = `projects/${project}/databases/${database}`;
   try {
     const resp = await apiClient.get<Database>(url);
@@ -50,7 +61,11 @@ export async function getDatabase(project: string, database: string): Promise<Da
  * @param {string} project the Google Cloud project ID.
  * @return {Promise<string[]>} a promise for an array of collection IDs.
  */
-export function listCollectionIds(project: string): Promise<string[]> {
+export function listCollectionIds(
+  project: string,
+  allowEmualtor: boolean = false,
+): Promise<string[]> {
+  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
   const url = "projects/" + project + "/databases/(default)/documents:listCollectionIds";
   const data = {
     // Maximum 32-bit integer
@@ -71,7 +86,8 @@ export function listCollectionIds(project: string): Promise<string[]> {
  * @param {object} doc a Document object to delete.
  * @return {Promise} a promise for the delete operation.
  */
-export async function deleteDocument(doc: any): Promise<any> {
+export async function deleteDocument(doc: any, allowEmualtor: boolean = false): Promise<any> {
+  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
   return apiClient.delete(doc.name);
 }
 
@@ -85,7 +101,12 @@ export async function deleteDocument(doc: any): Promise<any> {
  * @param {object[]} docs an array of Document objects to delete.
  * @return {Promise<number>} a promise for the number of deleted documents.
  */
-export async function deleteDocuments(project: string, docs: any[]): Promise<number> {
+export async function deleteDocuments(
+  project: string,
+  docs: any[],
+  allowEmualtor: boolean = false,
+): Promise<number> {
+  const apiClient = allowEmualtor ? emuOrProdClient : prodOnlyClient;
   const url = "projects/" + project + "/databases/(default)/documents:commit";
 
   const writes = docs.map((doc) => {


### PR DESCRIPTION
### Description
Fixed an issue where `firestore:delete `would not use the emulator when `FIRESTORE_EMULATOR_HOST` was set
Fixes #6537 
