### PR TITLE
remove prettier types

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -102,7 +102,6 @@
         "@types/multer": "^1.4.3",
         "@types/node": "^14.18.18",
         "@types/node-fetch": "^2.5.12",
-        "@types/prettier": "^3.0.0",
         "@types/progress": "^2.0.3",
         "@types/puppeteer": "^5.4.2",
         "@types/react": "^18.0.20",
@@ -3810,16 +3809,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
-    },
-    "node_modules/@types/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
-      "deprecated": "This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "prettier": "*"
-      }
     },
     "node_modules/@types/progress": {
       "version": "2.0.7",
@@ -21680,15 +21669,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-6.0.3.tgz",
       "integrity": "sha512-SuT16Q1K51EAVPz1K29DJ/sXjhSQ0zjvsypYJ6tlwVsRV9jwW5Adq2ch8Dq8kDBCkYnELS7N7VNCSB5nC56t/g==",
       "dev": true
-    },
-    "@types/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-mFMBfMOz8QxhYVbuINtswBp9VL2b4Y0QqYHwqLz3YbgtfAcat2Dl6Y1o4e22S/OVE6Ebl9m7wWiMT2lSbAs1wA==",
-      "dev": true,
-      "requires": {
-        "prettier": "*"
-      }
     },
     "@types/progress": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -183,7 +183,6 @@
     "@types/multer": "^1.4.3",
     "@types/node": "^14.18.18",
     "@types/node-fetch": "^2.5.12",
-    "@types/prettier": "^3.0.0",
     "@types/progress": "^2.0.3",
     "@types/puppeteer": "^5.4.2",
     "@types/react": "^18.0.20",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

> npm WARN deprecated @types/prettier@3.0.0: This is a stub types definition. prettier provides its own type definitions, so you do not need this installed.

Okay then.