### PR TITLE
fix(localFunction.ts): data was incorrectly not keyed to 'data' when passed into second argument of apiv2 post method

### DIFF
--- a/src/localFunction.ts
+++ b/src/localFunction.ts
@@ -50,7 +50,7 @@ export default class LocalFunction {
 
     const client = new Client({ urlPrefix: this.url, auth: false });
     void client
-      .post<any, any>("", data, { headers })
+      .post<any, any>("", { data }, { headers })
       .then((res) => {
         this.requestCallBack<any>(undefined, res, res.body);
       })


### PR DESCRIPTION
### Description

Fixed a regression introduced from v12.9.1 to v13.0.0 where HTTPS Callable functions could not be executed from the Firebase Functions Shell. The following error would be shown when executing the function according to the public [documentation](https://firebase.google.com/docs/functions/local-shell#invoke_https_callable_functions):
> {"severity":"WARNING","message":"Request body is missing data."}
> {"severity":"ERROR","message":"Error: Invalid request, unable to process.\n    at entryFromArgs (/workspace/agora/node_modules/firebase-functions/lib/logger/index.js:130:19)\n    at Object.error (/workspace/agora/node_modules/firebase-functions/lib/logger/index.js:116:11)\n    at /workspace/agora/node_modules/firebase-functions/lib/common/providers/https.js:405:24\n    at /workspace/agora/node_modules/firebase-functions/lib/common/providers/https.js:394:25\n    at cors (/workspace/agora/node_modules/cors/lib/index.js:188:7)\n    at /workspace/agora/node_modules/cors/lib/index.js:224:17\n    at originCallback (/workspace/agora/node_modules/cors/lib/index.js:214:15)\n    at /workspace/agora/node_modules/cors/lib/index.js:219:13\n    at optionsCallback (/workspace/agora/node_modules/cors/lib/index.js:199:9)\n    at corsMiddleware (/workspace/agora/node_modules/cors/lib/index.js:204:7)"}

A temporary workaround until this PR is merged in is to invoke the desired HTTPS Callable fuction with a top-level `data` key for the argument passed into it's first parameter. Using the documentation's example, instead of:
```
myCallableFunction({'foo': 'bar'}) // Does not work
```
run:
```
myCallableFunction({ data: {'foo': 'bar'}})
```

### Scenarios Tested

I manually tested the firebase functions:shell after my change. I believe localFunction.ts is only used by functionsShellCommandAction.js so this should be sufficient.
