### PR TITLE
Provision default compute service account

### DIFF
--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -8,7 +8,11 @@ import { ensureApiEnabled } from "../gcp/apphosting";
 export const command = new Command("apphosting:backends:create")
   .description("Create a backend in a Firebase project")
   .option("-l, --location <location>", "Specify the region of the backend", "")
-  .option("-s, --service-account <serviceAccount>", "Specify the service account used to run the server", "")
+  .option(
+    "-s, --service-account <serviceAccount>",
+    "Specify the service account used to run the server",
+    "",
+  )
   .before(ensureApiEnabled)
   .before(requireInteractive)
   .action(async (options: Options) => {

--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -8,10 +8,12 @@ import { ensureApiEnabled } from "../gcp/apphosting";
 export const command = new Command("apphosting:backends:create")
   .description("Create a backend in a Firebase project")
   .option("-l, --location <location>", "Specify the region of the backend", "")
+  .option("-s, --service-account <serviceAccount>", "Specify the service account used to run the server", "")
   .before(ensureApiEnabled)
   .before(requireInteractive)
   .action(async (options: Options) => {
     const projectId = needProjectId(options);
     const location = options.location;
-    await doSetup(projectId, location as string | null);
+    const serviceAccount = options.serviceAccount;
+    await doSetup(projectId, location as string | null, serviceAccount as string | null);
   });

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -41,6 +41,7 @@ export interface Backend {
   createTime: string;
   updateTime: string;
   uri: string;
+  computeServiceAccount?: string;
 }
 
 export type BackendOutputOnlyFields = "name" | "createTime" | "updateTime" | "uri";

--- a/src/init/features/apphosting/index.ts
+++ b/src/init/features/apphosting/index.ts
@@ -12,7 +12,7 @@ import {
   Rollout,
 } from "../../../gcp/apphosting";
 import { addServiceAccountToRoles } from "../../../gcp/resourceManager";
-import { ServiceAccount, createServiceAccount } from "../../../gcp/iam";
+import { createServiceAccount } from "../../../gcp/iam";
 import { Repository } from "../../../gcp/cloudbuild";
 import { FirebaseError } from "../../../error";
 import { promptOnce } from "../../../prompt";

--- a/src/test/init/apphosting/index.spec.ts
+++ b/src/test/init/apphosting/index.spec.ts
@@ -106,6 +106,8 @@ describe("operationsConverter", () => {
       );
 
       // CreateBackend should be called twice; once initially and once after the service account was created
+      expect(createServiceAccountStub).to.be.calledOnce;
+      expect(addServiceAccountToRolesStub).to.be.calledOnce;
       expect(createBackendStub).to.be.calledTwice;
     });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Creates the default compute service account if it doesn't exist when creating new backends. Also adds a --service-account flag to override the default behavior.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
