### PR TITLE
Print tables consistently for apphosting:backend:get and apphosting:backend:list commands

### DIFF
--- a/src/commands/apphosting-backends-get.ts
+++ b/src/commands/apphosting-backends-get.ts
@@ -2,13 +2,10 @@ import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
 import { FirebaseError } from "../error";
-import { logger } from "../logger";
 import { logWarning } from "../utils";
 import * as apphosting from "../gcp/apphosting";
+import { printBackendsTable } from "./apphosting-backends-list";
 
-const Table = require("cli-table");
-const COLUMN_LENGTH = 20;
-const TABLE_HEAD = ["Backend Id", "Repository", "Location", "URL", "Created Date", "Updated Date"];
 export const command = new Command("apphosting:backends:get <backendId>")
   .description("get backend details of a Firebase project")
   .option("-l, --location <location>", "app backend location", "-")
@@ -18,21 +15,14 @@ export const command = new Command("apphosting:backends:get <backendId>")
     const location = options.location as string;
 
     let backendsList: apphosting.Backend[] = [];
-    const table = new Table({
-      head: TABLE_HEAD,
-      style: { head: ["green"] },
-    });
-    table.colWidths = COLUMN_LENGTH;
     try {
       if (location !== "-") {
         const backendInRegion = await apphosting.getBackend(projectId, location, backendId);
         backendsList.push(backendInRegion);
-        populateTable(backendInRegion, table);
       } else {
         const resp = await apphosting.listBackends(projectId, "-");
         const allBackends = resp.backends || [];
         backendsList = allBackends.filter((bkd) => bkd.name.split("/").pop() === backendId);
-        backendsList.forEach((bkd) => populateTable(bkd, table));
       }
     } catch (err: any) {
       throw new FirebaseError(
@@ -44,27 +34,6 @@ export const command = new Command("apphosting:backends:get <backendId>")
       logWarning(`Found no backend with id: ${backendId}`);
       return;
     }
-    logger.info(table.toString());
+    printBackendsTable(backendsList);
     return backendsList[0];
   });
-
-function populateTable(backend: apphosting.Backend, table: any) {
-  const [location, , backendId] = backend.name.split("/").slice(3, 6);
-  const entry = [
-    backendId,
-    backend.codebase.repository?.split("/").pop(),
-    location,
-    backend.uri,
-    backend.createTime,
-    backend.updateTime,
-  ];
-  const newRow = entry.map((name) => {
-    const maxCellWidth = COLUMN_LENGTH - 2;
-    const chunks = [];
-    for (let i = 0; name && i < name.length; i += maxCellWidth) {
-      chunks.push(name.substring(i, i + maxCellWidth));
-    }
-    return chunks.join("\n");
-  });
-  table.push(newRow);
-}


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

The tables being printed when listing out backends for `apphosting:backend` `list`, `get`, and `delete` commands were inconsistent. This PR abstracts out the code used to print the backend tables to provide consistency and to avoid code duplication. 

Before:

![Screenshot 2024-02-24 at 5 18 57 PM](https://github.com/firebase/firebase-tools/assets/14209679/f2aeb9c3-4af8-4744-8b94-bb01d8c28b59)


After:

![Screenshot 2024-02-24 at 6 20 43 PM](https://github.com/firebase/firebase-tools/assets/14209679/50a695ee-cf6a-42a4-a884-6e18d124dc4e)

