### PR TITLE
Add missing changelog entry for Firestore backup/restore commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added new commands for managing Firestore backups and restoring databases (#6778)


### PR DESCRIPTION
Forgot to include on #6778
