### PR TITLE
Respect GOOGLE_CLOUD_QUOTA_PROJECT env var when it is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Released Firestore emulator v1.19.2, which fixes some bugs affecting client SDKs when in Datastore Mode.
 - Fix demo projects + web frameworks with emulators (#6737)
 - Fix Next.js static routes with server actions (#6664)
+- Fixed an issue where `GOOGLE_CLOUD_QUOTA_PROJECT` was not correctly respected. (#6801)

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -18,7 +18,10 @@ import * as FormData from "form-data";
 const pkg = require("../package.json");
 const CLI_VERSION: string = pkg.version;
 
-const GOOG_QUOTA_USER = "x-goog-quota-user";
+const GOOG_QUOTA_USER_HEADER = "x-goog-quota-user";
+
+const GOOG_USER_PROJECT_HEADER = "x-goog-user-project";
+const GOOGLE_CLOUD_QUOTA_PROJECT = process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
 
 export type HttpMethod = "GET" | "PUT" | "POST" | "DELETE" | "PATCH" | "OPTIONS" | "HEAD";
 
@@ -265,6 +268,9 @@ export class Client {
         reqOptions.headers.set("Content-Type", "application/json");
       }
     }
+    if (GOOGLE_CLOUD_QUOTA_PROJECT && GOOGLE_CLOUD_QUOTA_PROJECT !== "") {
+      reqOptions.headers.set(GOOG_USER_PROJECT_HEADER, GOOGLE_CLOUD_QUOTA_PROJECT);
+    }
     return reqOptions;
   }
 
@@ -467,10 +473,10 @@ export class Client {
     const logURL = this.requestURL(options);
     logger.debug(`>>> [apiv2][query] ${options.method} ${logURL} ${queryParamsLog}`);
     const headers = options.headers;
-    if (headers && headers.has(GOOG_QUOTA_USER)) {
+    if (headers && headers.has(GOOG_QUOTA_USER_HEADER)) {
       logger.debug(
         `>>> [apiv2][(partial)header] ${options.method} ${logURL} x-goog-quota-user=${
-          headers.get(GOOG_QUOTA_USER) || ""
+          headers.get(GOOG_QUOTA_USER_HEADER) || ""
         }`,
       );
     }

--- a/src/test/apiv2.spec.ts
+++ b/src/test/apiv2.spec.ts
@@ -319,7 +319,7 @@ describe("apiv2", () => {
         headers: { "x-goog-user-project": "unit tests, silly" },
       });
       process.env["GOOGLE_CLOUD_QUOTA_PROJECT"] = prev;
-      
+
       expect(r.body).to.deep.equal({ success: true });
       expect(nock.isDone()).to.be.true;
     });

--- a/src/test/apiv2.spec.ts
+++ b/src/test/apiv2.spec.ts
@@ -304,6 +304,26 @@ describe("apiv2", () => {
       expect(nock.isDone()).to.be.true;
     });
 
+    it("should make a basic GET request and set x-goog-user-project if  GOOGLE_CLOUD_QUOTA_PROJECT is set", async () => {
+      nock("https://example.com")
+        .get("/path/to/foo")
+        .matchHeader("x-goog-user-project", "unit tests, silly")
+        .reply(200, { success: true });
+      const prev = process.env["GOOGLE_CLOUD_QUOTA_PROJECT"];
+      process.env["GOOGLE_CLOUD_QUOTA_PROJECT"] = "unit tests, silly";
+
+      const c = new Client({ urlPrefix: "https://example.com" });
+      const r = await c.request({
+        method: "GET",
+        path: "/path/to/foo",
+        headers: { "x-goog-user-project": "unit tests, silly" },
+      });
+      process.env["GOOGLE_CLOUD_QUOTA_PROJECT"] = prev;
+      
+      expect(r.body).to.deep.equal({ success: true });
+      expect(nock.isDone()).to.be.true;
+    });
+
     it("should handle a 204 response with no data", async () => {
       nock("https://example.com").get("/path/to/foo").reply(204);
 


### PR DESCRIPTION

### Description
When GOOGLE_CLOUD_QUOTA_PROJECT is set, we should set `x-goog-user-project` on outgoing API requests.

This is a common standard accross many google libraries (https://cloud.google.com/docs/quotas/set-quota-project), and we've had a few different cases where this would be useful. It also fixes #6801.

However, I don't have the most thorough understand of how the various x-goog headers work, and whether this is the correct/narrowest one to set here. I'd love a review from someone who is well versed in this.
