### PR TITLE
On-change re-compilation of cloud functions when working with TypeScript via Emulator

### DIFF
--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -4,7 +4,7 @@
     "lint": "eslint --ext .js,.ts .",
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "serve": "npm run build && firebase emulators:start --only functions",
+    "serve": "npm run build -- --watch | firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "serve": "npm run build && firebase emulators:start --only functions",
+    "serve": "npm run build -- --watch | firebase emulators:start --only functions",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

I noticed when serving Cloud Functions written in TypeScript via the Firebase Emulator, that my changes were not getting recompiled and I had to run `npm run serve` each time I made a change for them to take effect.

This change adds a `--watch` parameter to `npm run build` script supported natively by the installed TypeScript version, and runs the command in parallel to `firebase emulators:start --only functions` so one doesn't have to re-run the `npm run serve` script each time a change is made.