### PR TITLE
Scheduled functions use 'serviceAccount' as the invoker if provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+v2 scheduled functions with explicit service accounts trigger eventarc to use that service account (#6858)

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -434,7 +434,9 @@ export class Fabricator {
         .run(() => run.setInvokerCreate(endpoint.project, serviceName, ["public"]))
         .catch(rethrowAs(endpoint, "set invoker"));
     } else if (backend.isScheduleTriggered(endpoint)) {
-      const invoker = [getDefaultComputeServiceAgent(this.projectNumber)];
+      const invoker = endpoint.serviceAccount
+        ? [endpoint.serviceAccount]
+        : [getDefaultComputeServiceAgent(this.projectNumber)];
       await this.executor
         .run(() => run.setInvokerCreate(endpoint.project, serviceName, invoker))
         .catch(rethrowAs(endpoint, "set invoker"));
@@ -539,7 +541,9 @@ export class Fabricator {
     ) {
       invoker = ["public"];
     } else if (backend.isScheduleTriggered(endpoint)) {
-      invoker = [getDefaultComputeServiceAgent(this.projectNumber)];
+      invoker = endpoint.serviceAccount
+        ? [endpoint.serviceAccount]
+        : [getDefaultComputeServiceAgent(this.projectNumber)];
     }
 
     if (invoker) {

--- a/src/gcp/cloudscheduler.ts
+++ b/src/gcp/cloudscheduler.ts
@@ -245,9 +245,8 @@ export function jobFromEndpoint(
       uri: endpoint.uri!,
       httpMethod: "POST",
       oidcToken: {
-        // TODO(colerogers): revisit adding 'invoker' to the container contract
-        // for schedule functions and use as the odic token service account.
-        serviceAccountEmail: getDefaultComputeServiceAgent(projectNumber),
+        serviceAccountEmail:
+          endpoint.serviceAccount ?? getDefaultComputeServiceAgent(projectNumber),
       },
     };
   } else {


### PR DESCRIPTION
Fix for #6814 

Previously we always used the default compute service account for the calls from Cloud Scheduler to Cloud Functions. This is unnecessary, as the user will now require actAs permissions on possibly two service accounts, and can cause errors if this default compute service account has been deleted.

Now, when serviceAccount is specified on the function, it is used both as the service account the container runs as, the valid invoker for the function, and the service account Cloud Scheduler uses to invoke the function. This slightly shifts an edge case regarding which service account the Cloud Scheduler service agent must have actAs permissions over, but that IAM concern has always existed.