### PR TITLE
Propogate explicit service account to eventarc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+v2 event functions with explicit service accounts trigger eventarc to use that service account (#6859)

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -550,6 +550,9 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
       eventType: endpoint.eventTrigger.eventType,
       retryPolicy: "RETRY_POLICY_UNSPECIFIED",
     };
+    if (endpoint.serviceAccount) {
+      gcfFunction.eventTrigger.serviceAccountEmail = endpoint.serviceAccount;
+    }
     if (gcfFunction.eventTrigger.eventType === PUBSUB_PUBLISH_EVENT) {
       if (!endpoint.eventTrigger.eventFilters?.topic) {
         throw new FirebaseError(
@@ -588,7 +591,7 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
 
     endpoint.eventTrigger.retry
       ? (gcfFunction.eventTrigger.retryPolicy = "RETRY_POLICY_RETRY")
-      : (gcfFunction.eventTrigger!.retryPolicy = "RETRY_POLICY_DO_NOT_RETRY");
+      : (gcfFunction.eventTrigger.retryPolicy = "RETRY_POLICY_DO_NOT_RETRY");
 
     // By default, Functions Framework in GCFv2 opts to downcast incoming cloudevent messages to legacy formats.
     // Since Firebase Functions SDK expects messages in cloudevent format, we set FUNCTION_SIGNATURE_TYPE to tell

--- a/src/test/gcp/cloudfunctionsv2.spec.ts
+++ b/src/test/gcp/cloudfunctionsv2.spec.ts
@@ -321,6 +321,45 @@ describe("cloudfunctionsv2", () => {
       );
     });
 
+    it("should propagate serviceAccount to eventarc", () => {
+      const saEndpoint: backend.Endpoint = {
+        ...ENDPOINT,
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: events.v2.DATABASE_EVENTS[0],
+          eventFilters: {
+            ref: "ref",
+          },
+          retry: false,
+        },
+        serviceAccount: "sa",
+      };
+
+      const saGcfFunction: cloudfunctionsv2.InputCloudFunction = {
+        ...CLOUD_FUNCTION_V2,
+        eventTrigger: {
+          eventType: events.v2.DATABASE_EVENTS[0],
+          eventFilters: [
+            {
+              attribute: "ref",
+              value: "ref",
+            },
+          ],
+          retryPolicy: "RETRY_POLICY_DO_NOT_RETRY",
+          serviceAccountEmail: "sa",
+        },
+        serviceConfig: {
+          ...CLOUD_FUNCTION_V2.serviceConfig,
+          environmentVariables: {
+            FUNCTION_SIGNATURE_TYPE: "cloudevent",
+          },
+          serviceAccountEmail: "sa",
+        },
+      };
+
+      expect(cloudfunctionsv2.functionFromEndpoint(saEndpoint)).to.deep.equal(saGcfFunction);
+    });
+
     it("should correctly convert CPU and concurrency values", () => {
       const endpoint: backend.Endpoint = {
         ...ENDPOINT,


### PR DESCRIPTION
Another part of the fix to #6814. Similar to #6858, this propagates the function's service account through to the invoking service.