### PR TITLE
Disable metadata service detection in the emulator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Inject an environment variable in the node functions emulator to tell the google-gax SDK not to look for the metadata service. (#6860)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1349,6 +1349,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       cwd: backend.functionsDir,
       env: {
         node: backend.bin,
+        METADATA_SERVER_DETECTION: "none",
         ...process.env,
         ...envs,
         PORT: socketPath,
@@ -1451,7 +1452,6 @@ export class FunctionsEmulator implements EmulatorInstance {
   /**
    * Gets the address of a running emulator, either from explicit args or by
    * consulting the emulator registry.
-   *
    * @param emulator
    */
   private getEmulatorInfo(emulator: Emulators): EmulatorInfo | undefined {


### PR DESCRIPTION
Fix for #6765. The latest version of google-gax attempts to read from the metadata server (on an internal IP address). Setting the environment variable METADATA_SERVER_DETECTION=none by default will turn this behavior off. This is overridable with .env.local.