### PR TITLE
fix: rm only the content of `exportPath`

### DIFF
--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -133,8 +133,11 @@ export class HubExport {
     // Remove any existing data in the directory and then swap it with the
     // temp directory.
     logger.debug(`hubExport: swapping ${this.tmpDir} with ${this.exportPath}`);
-    rimraf.sync(this.exportPath);
-    fse.moveSync(this.tmpDir, this.exportPath);
+    // glob must use posix style paths even on windows
+    const exportPathGlob = path.join(this.exportPath.split(path.sep).join(path.posix.sep), '*');
+    rimraf.sync(exportPathGlob);
+    fse.copySync(this.tmpDir, this.exportPath);
+    rimraf.sync(this.tmpDir);
   }
 
   private async exportFirestore(metadata: ExportMetadata): Promise<void> {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
I was having trouble with exporting emulator data when I ran an emulator with Docker.
It was really hard to find the reason, but I finally found it:
- Emulator tries to remove the export path recursively.
  - docker volumes can not be removed, but `rimraf` doesn't throw any error (This is the issue of `rimraf@3`. The latest version raises an error as you expect)
- then , emulator tries to move the temp data directory to the export path that still exists, so `dest already exists` is raised.
<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Then, the change I made is here:
- Remove the content of the export path, instead of the export path itself
- Then copy the temp directory to the export path
- Remove the temp directory

#### reproduction
I prepared a different branch for reproduction. You can get the error below with `docker compose up --build`
https://github.com/m-shaka/firebase-tools/tree/docker-repro

```
firebase_emulator-1  | i  auth: Importing config from /firebase-export/auth_export/config.json
firebase_emulator-1  | i  auth: Importing accounts from /firebase-export/auth_export/accounts.json
firebase_emulator-1  | i  Running script: 'exit 1'
firebase_emulator-1  | /bin/sh: exit 1: not found
firebase_emulator-1  | ⚠  Script exited unsuccessfully (code 127)
firebase_emulator-1  | i  Automatically exporting data using --export-on-exit "/firebase-export" please wait for the export to finish...
firebase_emulator-1  | i  Found running emulator hub for project test at http://127.0.0.1:4400
firebase_emulator-1  | i  Exporting data to: /firebase-export
firebase_emulator-1  | i  emulators: Received export request. Exporting data to /firebase-export.
firebase_emulator-1  | ⚠  emulators: Export failed: dest already exists.
```

### Scenarios Tested
- export data on MacOS (v14.1.2)
- export data on Docker container (Docker for Mac version: 20.10.12)

I'm sorry that I didn't test on Windows
<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
