### PR TITLE
Release Firestore Emulator v1.19.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Release Firestore Emulator 1.19.3 which fixes ancestor and namespace scope queries for Datastore Mode. This release also fixes internal errors seen across REST API and firebase-js-sdk.
 Inject an environment variable in the node functions emulator to tell the google-gax SDK not to look for the metadata service. (#6860)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Release Firestore Emulator 1.19.3 which fixes ancestor and namespace scope queries for Datastore Mode. This release also fixes internal errors seen across REST API and firebase-js-sdk.
-  Inject an environment variable in the node functions emulator to tell the google-gax SDK not to look for the metadata service. (#6860)
+- Inject an environment variable in the node functions emulator to tell the google-gax SDK not to look for the metadata service. (#6860)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Release Firestore Emulator 1.19.3 which fixes ancestor and namespace scope queries for Datastore Mode. This release also fixes internal errors seen across REST API and firebase-js-sdk.
-Inject an environment variable in the node functions emulator to tell the google-gax SDK not to look for the metadata service. (#6860)
+  Inject an environment variable in the node functions emulator to tell the google-gax SDK not to look for the metadata service. (#6860)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -33,9 +33,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "2fd771101c0e1f7898c04c9204f2ce63",
   },
   firestore: {
-    version: "1.19.2",
-    expectedSize: 67203281,
-    expectedChecksum: "167205aea99351c08ef293f35009a63c",
+    version: "1.19.3",
+    expectedSize: 67296394,
+    expectedChecksum: "08a9b882a5c38570b6333f3931b1e52b",
   },
   storage: {
     version: "1.1.3",


### PR DESCRIPTION
### Description

This PR updates the Firestore Emulator to v1.19.3

### Scenarios Tested

```
node lib/bin/firebase.js emulators:start --only firestore 
(node:20889) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
⚠  Could not find config (firebase.json) so using defaults.
i  emulators: Starting emulators: firestore
⚠  firestore: Did not find a Cloud Firestore rules file specified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator UI websocket is running on 9150.
⚠  emulators: The Emulator UI is not starting, either because none of the running emulators have a UI component or the Emulator UI cannot determine the Project ID. Pass the --project flag to specify a project.

```
