### PR TITLE
Remove CreateBuild validate_only retry now that the server ensures the build exists prior to returning

### DIFF
--- a/src/init/features/apphosting/index.ts
+++ b/src/init/features/apphosting/index.ts
@@ -284,44 +284,9 @@ export async function orchestrateRollout(
   const buildId = await apphosting.getNextRolloutId(projectId, location, backendId, 1);
   const buildOp = await apphosting.createBuild(projectId, location, backendId, buildId, buildInput);
 
-  const rolloutBody = {
+  const rolloutOp = await apphosting.createRollout(projectId, location, backendId, buildId, {
     build: `projects/${projectId}/locations/${location}/backends/${backendId}/builds/${buildId}`,
-  };
-
-  let tries = 0;
-  let done = false;
-  while (!done) {
-    tries++;
-    try {
-      const validateOnly = true;
-      await apphosting.createRollout(
-        projectId,
-        location,
-        backendId,
-        buildId,
-        rolloutBody,
-        validateOnly,
-      );
-      done = true;
-    } catch (err: unknown) {
-      if (err instanceof FirebaseError && err.status === 400) {
-        if (tries >= 5) {
-          throw err;
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      } else {
-        throw err;
-      }
-    }
-  }
-
-  const rolloutOp = await apphosting.createRollout(
-    projectId,
-    location,
-    backendId,
-    buildId,
-    rolloutBody,
-  );
+  });
 
   const rolloutPoll = poller.pollOperation<Rollout>({
     ...apphostingPollerOptions,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

We previously added this retry logic in since the server would sometimes return from `CreateBuild` while the `Build` resource was still finalizing. This retry logic has since been implemented in the server so we can remove it from clients.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
