### PR TITLE
DeveloperConnect: make `fetchLinkableGitRepositories` list all linkable git repositories

### DIFF
--- a/src/gcp/devConnect.ts
+++ b/src/gcp/devConnect.ts
@@ -1,7 +1,7 @@
 import { Client } from "../apiv2";
 import { developerConnectOrigin, developerConnectP4SAOrigin } from "../api";
 
-const PAGE_SIZE_MAX = 100;
+const PAGE_SIZE_MAX = 1000;
 
 export const client = new Client({
   urlPrefix: developerConnectOrigin,
@@ -155,7 +155,10 @@ export async function getConnection(
 /**
  * List Developer Connect Connections
  */
-export async function listConnections(projectId: string, location: string): Promise<Connection[]> {
+export async function listAllConnections(
+  projectId: string,
+  location: string,
+): Promise<Connection[]> {
   const conns: Connection[] = [];
   const getNextPage = async (pageToken = ""): Promise<void> => {
     const res = await client.get<{
@@ -181,22 +184,33 @@ export async function listConnections(projectId: string, location: string): Prom
 /**
  * Gets a list of repositories that can be added to the provided Connection.
  */
-export async function fetchLinkableGitRepositories(
+export async function listAllLinkableGitRepositories(
   projectId: string,
   location: string,
   connectionId: string,
-  pageToken = "",
-  pageSize = 1000,
-): Promise<LinkableGitRepositories> {
+): Promise<LinkableGitRepository[]> {
   const name = `projects/${projectId}/locations/${location}/connections/${connectionId}:fetchLinkableRepositories`;
-  const res = await client.get<LinkableGitRepositories>(name, {
-    queryParams: {
-      pageSize,
-      pageToken,
-    },
-  });
+  const repos: LinkableGitRepository[] = [];
 
-  return res.body;
+  const getNextPage = async (pageToken = ""): Promise<void> => {
+    const res = await client.get<LinkableGitRepositories>(name, {
+      queryParams: {
+        PAGE_SIZE_MAX,
+        pageToken,
+      },
+    });
+
+    if (Array.isArray(res.body.repositories)) {
+      repos.push(...res.body.repositories);
+    }
+
+    if (res.body.nextPageToken) {
+      await getNextPage(res.body.nextPageToken);
+    }
+  };
+
+  await getNextPage();
+  return repos;
 }
 
 /**

--- a/src/test/gcp/devconnect.spec.ts
+++ b/src/test/gcp/devconnect.spec.ts
@@ -62,9 +62,46 @@ describe("developer connect", () => {
           },
         });
 
-      const conns = await devconnect.listConnections(projectId, location);
+      const conns = await devconnect.listAllConnections(projectId, location);
       expect(get).callCount(3);
       expect(conns).to.deep.equal([firstConnection, secondConnection, thirdConnection]);
+    });
+  });
+  describe("listAllLinkableGitRepositories", () => {
+    it("interates through all pages and returns a single list", async () => {
+      const firstRepo = { cloneUri: "repo1" };
+      const secondRepo = { cloneUri: "repo2" };
+      const thirdRepo = { cloneUri: "repo3" };
+
+      get
+        .onFirstCall()
+        .returns({
+          body: {
+            repositories: [firstRepo],
+            nextPageToken: "someToken",
+          },
+        })
+        .onSecondCall()
+        .returns({
+          body: {
+            repositories: [secondRepo],
+            nextPageToken: "someToken2",
+          },
+        })
+        .onThirdCall()
+        .returns({
+          body: {
+            repositories: [thirdRepo],
+          },
+        });
+
+      const conns = await devconnect.listAllLinkableGitRepositories(
+        projectId,
+        location,
+        connectionId,
+      );
+      expect(get).callCount(3);
+      expect(conns).to.deep.equal([firstRepo, secondRepo, thirdRepo]);
     });
   });
 });


### PR DESCRIPTION
### Description

Instead of fetching a certain page of linkable git repos, `fetchLinkableGitRepositories` has been updated to fetch all linkable git repositories, iterating over all pages. This will behave similar to `listConnections` (renamed to `listAllConnections`)

Follow up from: https://github.com/firebase/firebase-tools/pull/6887/files/d8841df93bac3c0dbcb8773783db627015842094#r1530608858
