### PR TITLE
Vector config support

### DIFF
--- a/src/firestore/api-sort.ts
+++ b/src/firestore/api-sort.ts
@@ -180,6 +180,7 @@ export function compareFieldOverride(a: Spec.FieldOverride, b: Spec.FieldOverrid
  *   1) Field path.
  *   2) Sort order (if it exists).
  *   3) Array config (if it exists).
+ *   4) Vector config (if it exists).
  */
 function compareIndexField(a: API.IndexField, b: API.IndexField): number {
   if (a.fieldPath !== b.fieldPath) {
@@ -192,6 +193,10 @@ function compareIndexField(a: API.IndexField, b: API.IndexField): number {
 
   if (a.arrayConfig !== b.arrayConfig) {
     return compareArrayConfig(a.arrayConfig, b.arrayConfig);
+  }
+
+  if (a.vectorConfig !== b.vectorConfig) {
+    return compareVectorConfig(a.vectorConfig, b.vectorConfig);
   }
 
   return 0;
@@ -223,6 +228,19 @@ function compareOrder(a?: API.Order, b?: API.Order): number {
 
 function compareArrayConfig(a?: API.ArrayConfig, b?: API.ArrayConfig): number {
   return ARRAY_CONFIG_SEQUENCE.indexOf(a) - ARRAY_CONFIG_SEQUENCE.indexOf(b);
+}
+
+function compareVectorConfig(a?: API.VectorConfig, b?: API.VectorConfig): number {
+  if (a === undefined) {
+    if (b === undefined) {
+      return 0;
+    } else {
+      return 1
+    }
+  } else if (b === undefined) {
+    return -1;
+  }
+  return a.dimension - b.dimension;
 }
 
 /**

--- a/src/firestore/api-sort.ts
+++ b/src/firestore/api-sort.ts
@@ -231,13 +231,13 @@ function compareArrayConfig(a?: API.ArrayConfig, b?: API.ArrayConfig): number {
 }
 
 function compareVectorConfig(a?: API.VectorConfig, b?: API.VectorConfig): number {
-  if (a === undefined) {
-    if (b === undefined) {
+  if (!a) {
+    if (!b) {
       return 0;
     } else {
       return 1;
     }
-  } else if (b === undefined) {
+  } else if (!b) {
     return -1;
   }
   return a.dimension - b.dimension;

--- a/src/firestore/api-sort.ts
+++ b/src/firestore/api-sort.ts
@@ -235,7 +235,7 @@ function compareVectorConfig(a?: API.VectorConfig, b?: API.VectorConfig): number
     if (b === undefined) {
       return 0;
     } else {
-      return 1
+      return 1;
     }
   } else if (b === undefined) {
     return -1;

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -36,6 +36,13 @@ export enum StateTtl {
   NEEDS_REPAIR = "NEEDS_REPAIR",
 }
 
+export interface FlatIndex {}
+
+export interface VectorConfig {
+  dimension: number;
+  flat?: FlatIndex;
+}
+
 /**
  * An Index as it is represented in the Firestore v1beta2 indexes API.
  */
@@ -53,6 +60,7 @@ export interface IndexField {
   fieldPath: string;
   order?: Order;
   arrayConfig?: ArrayConfig;
+  vectorConfig?: VectorConfig;
 }
 
 /**

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -24,6 +24,11 @@ export enum ArrayConfig {
   CONTAINS = "CONTAINS",
 }
 
+export interface VectorConfig {
+  dimension: number;
+  flat?: {};
+}
+
 export enum State {
   CREATING = "CREATING",
   READY = "READY",
@@ -34,13 +39,6 @@ export enum StateTtl {
   CREATING = "CREATING",
   ACTIVE = "ACTIVE",
   NEEDS_REPAIR = "NEEDS_REPAIR",
-}
-
-export interface FlatIndex {}
-
-export interface VectorConfig {
-  dimension: number;
-  flat?: FlatIndex;
 }
 
 /**

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -297,7 +297,7 @@ export class FirestoreApi {
 
     index.fields.forEach((field: any) => {
       validator.assertHas(field, "fieldPath");
-      validator.assertHasOneOf(field, ["order", "arrayConfig"]);
+      validator.assertHasOneOf(field, ["order", "arrayConfig", "vectorConfig"]);
 
       if (field.order) {
         validator.assertEnum(field, "order", Object.keys(types.Order));
@@ -305,6 +305,11 @@ export class FirestoreApi {
 
       if (field.arrayConfig) {
         validator.assertEnum(field, "arrayConfig", Object.keys(types.ArrayConfig));
+      }
+
+      if (field.vectorConfig) {
+        validator.assertType("vectorConfig.dimension", field.vectorConfig.dimension, "number")
+        validator.assertHas(field.vectorConfig, "flat")
       }
     });
   }
@@ -548,6 +553,8 @@ export class FirestoreApi {
             f.order = field.order;
           } else if (field.arrayConfig) {
             f.arrayConfig = field.arrayConfig;
+          } else if (field.vectorConfig) {
+            f.vectorConfig = field.vectorConfig;
           } else if (field.mode === types.Mode.ARRAY_CONTAINS) {
             f.arrayConfig = types.ArrayConfig.CONTAINS;
           } else {

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -308,8 +308,8 @@ export class FirestoreApi {
       }
 
       if (field.vectorConfig) {
-        validator.assertType("vectorConfig.dimension", field.vectorConfig.dimension, "number")
-        validator.assertHas(field.vectorConfig, "flat")
+        validator.assertType("vectorConfig.dimension", field.vectorConfig.dimension, "number");
+        validator.assertHas(field.vectorConfig, "flat");
       }
     });
   }

--- a/src/firestore/pretty-print.ts
+++ b/src/firestore/pretty-print.ts
@@ -236,10 +236,18 @@ export class PrettyPrint {
         return;
       }
 
-      // Normal field indexes have an "order" while array indexes have an "arrayConfig",
-      // we want to display whichever one is present.
-      const orderOrArrayConfig = field.order ? field.order : field.arrayConfig;
-      result += `(${field.fieldPath},${orderOrArrayConfig}) `;
+      // Normal field indexes have an "order", array indexes have an
+      // "arrayConfig", and vector indexes have a "vectorConfig" we want to
+      // display whichever one is present.
+      var configString ;
+      if (field.order) {
+        configString = field.order;
+      } else if (field.arrayConfig) {
+        configString = field.arrayConfig;
+      } else if (field.vectorConfig) {
+        configString = `VECTOR<${field.vectorConfig.dimension}>`;
+      }
+      result += `(${field.fieldPath},${configString}) `;
     });
 
     return result;

--- a/src/firestore/pretty-print.ts
+++ b/src/firestore/pretty-print.ts
@@ -239,7 +239,7 @@ export class PrettyPrint {
       // Normal field indexes have an "order", array indexes have an
       // "arrayConfig", and vector indexes have a "vectorConfig" we want to
       // display whichever one is present.
-      var configString ;
+      let configString;
       if (field.order) {
         configString = field.order;
       } else if (field.arrayConfig) {

--- a/src/test/firestore/indexes.spec.ts
+++ b/src/test/firestore/indexes.spec.ts
@@ -75,16 +75,16 @@ describe("IndexValidation", () => {
             queryScope: "COLLECTION",
             fields: [
               {
-                "fieldPath": "embedding",
-                "vectorConfig": {
-                  "dimension": 100,
-                  "flat": {}
-                }
-              }
-            ]
+                fieldPath: "embedding",
+                vectorConfig: {
+                  dimension: 100,
+                  flat: {},
+                },
+              },
+            ],
           },
         ],
-      })
+      }),
     );
   });
 
@@ -96,13 +96,13 @@ describe("IndexValidation", () => {
           queryScope: "COLLECTION",
           fields: [
             {
-              "fieldPath": "embedding",
-              "vectorConfig": {
-                "dimension": 100,
-                "flat": {}
-              }
-            }
-          ]
+              fieldPath: "embedding",
+              vectorConfig: {
+                dimension: 100,
+                flat: {},
+              },
+            },
+          ],
         },
       ],
     });
@@ -117,13 +117,13 @@ describe("IndexValidation", () => {
           fields: [
             { fieldPath: "foo", order: "ASCENDING" },
             {
-              "fieldPath": "embedding",
-              "vectorConfig": {
-                "dimension": 100,
-                "flat": {}
-              }
-            }
-          ]
+              fieldPath: "embedding",
+              vectorConfig: {
+                dimension: 100,
+                flat: {},
+              },
+            },
+          ],
         },
       ],
     });
@@ -138,13 +138,13 @@ describe("IndexValidation", () => {
             queryScope: "COLLECTION",
             fields: [
               {
-                "fieldPath": "embedding",
-                "vectorConfig": {
-                  "dimension": "wrongType",
-                  "flat": {}
-                }
-              }
-            ]
+                fieldPath: "embedding",
+                vectorConfig: {
+                  dimension: "wrongType",
+                  flat: {},
+                },
+              },
+            ],
           },
         ],
       });
@@ -160,12 +160,12 @@ describe("IndexValidation", () => {
             queryScope: "COLLECTION",
             fields: [
               {
-                "fieldPath": "embedding",
-                "vectorConfig": {
-                  "dimension": 100,
-                }
-              }
-            ]
+                fieldPath: "embedding",
+                vectorConfig: {
+                  dimension: 100,
+                },
+              },
+            ],
           },
         ],
       });
@@ -647,7 +647,7 @@ describe("IndexSorting", () => {
           vectorConfig: {
             dimension: 100,
             flat: {},
-          }
+          },
         },
       ],
     };
@@ -661,7 +661,7 @@ describe("IndexSorting", () => {
           vectorConfig: {
             dimension: 200,
             flat: {},
-          }
+          },
         },
       ],
     };

--- a/src/test/firestore/indexes.spec.ts
+++ b/src/test/firestore/indexes.spec.ts
@@ -666,7 +666,19 @@ describe("IndexSorting", () => {
       ],
     };
 
-    expect([b, a, d, c, f, e].sort(sort.compareApiIndex)).to.eql([a, b, c, d, e, f]);
+    // This Index is invalid, but is used to verify sort ordering on undefined
+    // fields.
+    const g: API.Index = {
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/g",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "fieldA",
+        },
+      ],
+    };
+
+    expect([b, a, d, g, f, e, c].sort(sort.compareApiIndex)).to.eql([a, b, c, d, e, f, g]);
   });
 
   it("should correctly sort an array of API field overrides", () => {

--- a/src/test/firestore/pretty-print.test.ts
+++ b/src/test/firestore/pretty-print.test.ts
@@ -1,8 +1,6 @@
 import { expect } from "chai";
 import { PrettyPrint } from "../../firestore/pretty-print";
 import * as API from "../../firestore/api-types";
-import * as Spec from "../../firestore/api-spec";
-import * as sort from "../../firestore/api-sort";
 
 const printer = new PrettyPrint();
 

--- a/src/test/firestore/pretty-print.test.ts
+++ b/src/test/firestore/pretty-print.test.ts
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+import { PrettyPrint } from "../../firestore/pretty-print";
+import * as API from "../../firestore/api-types";
+import * as Spec from "../../firestore/api-spec";
+import * as sort from "../../firestore/api-sort";
+
+const printer = new PrettyPrint();
+
+describe("prettyIndexString", () => {
+  it("should correctly print an order type Index", () => {
+    expect(printer.prettyIndexString({
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        { fieldPath: "foo", order: API.Order.ASCENDING },
+        { fieldPath: "bar", order: API.Order.DESCENDING },
+      ],
+    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,DESCENDING) ");
+  });
+
+  it("should correctly print a contains type Index", () => {
+    expect(printer.prettyIndexString({
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        { fieldPath: "foo", order: API.Order.ASCENDING },
+        { fieldPath: "baz", arrayConfig: API.ArrayConfig.CONTAINS },
+      ],
+    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (baz,CONTAINS) ");
+  });
+
+  it("should correctly print a vector type Index", () => {
+    expect(printer.prettyIndexString({
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        { fieldPath: "foo", vectorConfig: {dimension: 100, flat: {}} },
+      ],
+    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,VECTOR<100>) ");
+  });
+
+  it("should correctly print a vector type Index with other fields", () => {
+    expect(printer.prettyIndexString({
+      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+      queryScope: API.QueryScope.COLLECTION,
+      fields: [
+        { fieldPath: "foo", order: API.Order.ASCENDING },
+        { fieldPath: "bar", vectorConfig: {dimension: 200, flat: {}} },
+      ],
+    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,VECTOR<200>) ");
+  });
+});

--- a/src/test/firestore/pretty-print.test.ts
+++ b/src/test/firestore/pretty-print.test.ts
@@ -18,7 +18,7 @@ describe("prettyIndexString", () => {
         },
         false,
       ),
-    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,DESCENDING) ");
+    ).to.contain("(foo,ASCENDING) (bar,DESCENDING) ");
   });
 
   it("should correctly print a contains type Index", () => {
@@ -34,7 +34,7 @@ describe("prettyIndexString", () => {
         },
         false,
       ),
-    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (baz,CONTAINS) ");
+    ).to.contain("(foo,ASCENDING) (baz,CONTAINS) ");
   });
 
   it("should correctly print a vector type Index", () => {
@@ -47,7 +47,7 @@ describe("prettyIndexString", () => {
         },
         false,
       ),
-    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,VECTOR<100>) ");
+    ).to.contain("(foo,VECTOR<100>) ");
   });
 
   it("should correctly print a vector type Index with other fields", () => {
@@ -63,6 +63,6 @@ describe("prettyIndexString", () => {
         },
         false,
       ),
-    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,VECTOR<200>) ");
+    ).to.contain("(foo,ASCENDING) (bar,VECTOR<200>) ");
   });
 });

--- a/src/test/firestore/pretty-print.test.ts
+++ b/src/test/firestore/pretty-print.test.ts
@@ -1,50 +1,68 @@
 import { expect } from "chai";
-import { PrettyPrint } from "../../firestore/pretty-print";
 import * as API from "../../firestore/api-types";
+import { PrettyPrint } from "../../firestore/pretty-print";
 
 const printer = new PrettyPrint();
 
 describe("prettyIndexString", () => {
   it("should correctly print an order type Index", () => {
-    expect(printer.prettyIndexString({
-      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
-      queryScope: API.QueryScope.COLLECTION,
-      fields: [
-        { fieldPath: "foo", order: API.Order.ASCENDING },
-        { fieldPath: "bar", order: API.Order.DESCENDING },
-      ],
-    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,DESCENDING) ");
+    expect(
+      printer.prettyIndexString(
+        {
+          name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+          queryScope: API.QueryScope.COLLECTION,
+          fields: [
+            { fieldPath: "foo", order: API.Order.ASCENDING },
+            { fieldPath: "bar", order: API.Order.DESCENDING },
+          ],
+        },
+        false,
+      ),
+    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,DESCENDING) ");
   });
 
   it("should correctly print a contains type Index", () => {
-    expect(printer.prettyIndexString({
-      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
-      queryScope: API.QueryScope.COLLECTION,
-      fields: [
-        { fieldPath: "foo", order: API.Order.ASCENDING },
-        { fieldPath: "baz", arrayConfig: API.ArrayConfig.CONTAINS },
-      ],
-    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (baz,CONTAINS) ");
+    expect(
+      printer.prettyIndexString(
+        {
+          name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+          queryScope: API.QueryScope.COLLECTION,
+          fields: [
+            { fieldPath: "foo", order: API.Order.ASCENDING },
+            { fieldPath: "baz", arrayConfig: API.ArrayConfig.CONTAINS },
+          ],
+        },
+        false,
+      ),
+    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (baz,CONTAINS) ");
   });
 
   it("should correctly print a vector type Index", () => {
-    expect(printer.prettyIndexString({
-      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
-      queryScope: API.QueryScope.COLLECTION,
-      fields: [
-        { fieldPath: "foo", vectorConfig: {dimension: 100, flat: {}} },
-      ],
-    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,VECTOR<100>) ");
+    expect(
+      printer.prettyIndexString(
+        {
+          name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+          queryScope: API.QueryScope.COLLECTION,
+          fields: [{ fieldPath: "foo", vectorConfig: { dimension: 100, flat: {} } }],
+        },
+        false,
+      ),
+    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,VECTOR<100>) ");
   });
 
   it("should correctly print a vector type Index with other fields", () => {
-    expect(printer.prettyIndexString({
-      name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
-      queryScope: API.QueryScope.COLLECTION,
-      fields: [
-        { fieldPath: "foo", order: API.Order.ASCENDING },
-        { fieldPath: "bar", vectorConfig: {dimension: 200, flat: {}} },
-      ],
-    }, false)).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,VECTOR<200>) ");
+    expect(
+      printer.prettyIndexString(
+        {
+          name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+          queryScope: API.QueryScope.COLLECTION,
+          fields: [
+            { fieldPath: "foo", order: API.Order.ASCENDING },
+            { fieldPath: "bar", vectorConfig: { dimension: 200, flat: {} } },
+          ],
+        },
+        false,
+      ),
+    ).to.equal("\u001b[36m(collectionB)\u001b[39m -- (foo,ASCENDING) (bar,VECTOR<200>) ");
   });
 });


### PR DESCRIPTION
### Description

Add support for the vectorConfig in Firestore Indexes, this is similar to the existing 'order' and 'arrayConfig' options that currently exist.

### Scenarios Tested

Tested vector configs with and without other existing index field types.

### Sample Commands

`firebase deploy --only firestore`
