### PR TITLE
Fix "could not assert Secret Manager permissions" Cloud Build error

### DIFF
--- a/src/init/features/apphosting/repo.ts
+++ b/src/init/features/apphosting/repo.ts
@@ -92,11 +92,11 @@ export async function linkGitHubRepository(
 ): Promise<gcb.Repository> {
   utils.logBullet(clc.bold(`${clc.yellow("===")} Set up a GitHub connection`));
   // Fetch the sentinel Oauth connection first which is needed to create further GitHub connections.
+  await ensureSecretManagerAdminGrant(projectId);
   const oauthConn = await getOrCreateOauthConnection(projectId, location);
   const existingConns = await listAppHostingConnections(projectId);
 
   if (existingConns.length === 0) {
-    await ensureSecretManagerAdminGrant(projectId);
     existingConns.push(
       await createFullyInstalledConnection(projectId, location, generateConnectionId(), oauthConn),
     );


### PR DESCRIPTION
Users are often running into this `could not assert Secret Manager permissions` error when onboarding to apphosting.

This occurs when the user has no Cloud Build repo connections (including the sentinel Oauth connection) and the secret manager admin role has not been granted to the Cloud Build P4SA. So when the user goes to create an Oauth connection first but Cloud Build has no permissions to save the oath token in secret manager, it throws the above error. 

To fix this we just need to ensure that the correct secret manager privileges are set to the Cloud Build P4SA before even creating the initial sentinel Oauth connection.