### PR TITLE
Ignore quota project in GCF source uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Released Firestore Emulator 1.19.4. This version fixes a minor bug with reserve ids and adds a `reset` endpoint for Datastore Mode.
 - Released PubSub Emulator 0.8.2. This version includes support for `no_wrapper` options.
 - Fixes issue where GitHub actions service account cannot add preview URLs to Auth authorized domains. (#6895)
+- Fixes issue where GOOGLE_CLOUD_QUOTA_PROJECT breaks functions source uploads (#6917)

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -32,6 +32,7 @@ interface BaseRequestOptions<T> extends VerbOptions {
   responseType?: "json" | "stream" | "xml";
   redirect?: "error" | "follow" | "manual";
   compress?: boolean;
+  ignoreQuotaProject?: boolean;
 }
 
 interface RequestOptionsWithSignal<T> extends BaseRequestOptions<T> {
@@ -226,7 +227,7 @@ export class Client {
       );
     }
 
-    let internalReqOptions: InternalClientRequestOptions<ReqT> = Object.assign(reqOptions, {
+    let internalReqOptions: InternalClientRequestOptions<ReqT> & ClientRequestOptions<ReqT> = Object.assign(reqOptions, {
       headers: new Headers(reqOptions.headers),
     });
 
@@ -268,7 +269,7 @@ export class Client {
         reqOptions.headers.set("Content-Type", "application/json");
       }
     }
-    if (GOOGLE_CLOUD_QUOTA_PROJECT && GOOGLE_CLOUD_QUOTA_PROJECT !== "") {
+    if (!reqOptions.ignoreQuotaProject && GOOGLE_CLOUD_QUOTA_PROJECT && GOOGLE_CLOUD_QUOTA_PROJECT !== "") {
       reqOptions.headers.set(GOOG_USER_PROJECT_HEADER, GOOGLE_CLOUD_QUOTA_PROJECT);
     }
     return reqOptions;

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -227,7 +227,7 @@ export class Client {
       );
     }
 
-    let internalReqOptions: InternalClientRequestOptions<ReqT> & ClientRequestOptions<ReqT> = Object.assign(reqOptions, {
+    let internalReqOptions: InternalClientRequestOptions<ReqT> = Object.assign(reqOptions, {
       headers: new Headers(reqOptions.headers),
     });
 

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -269,7 +269,11 @@ export class Client {
         reqOptions.headers.set("Content-Type", "application/json");
       }
     }
-    if (!reqOptions.ignoreQuotaProject && GOOGLE_CLOUD_QUOTA_PROJECT && GOOGLE_CLOUD_QUOTA_PROJECT !== "") {
+    if (
+      !reqOptions.ignoreQuotaProject &&
+      GOOGLE_CLOUD_QUOTA_PROJECT &&
+      GOOGLE_CLOUD_QUOTA_PROJECT !== ""
+    ) {
       reqOptions.headers.set(GOOG_USER_PROJECT_HEADER, GOOGLE_CLOUD_QUOTA_PROJECT);
     }
     return reqOptions;

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -31,12 +31,18 @@ async function uploadSourceV1(
     stream: fs.createReadStream(source.functionsSourceV1!),
   };
   if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
-    logLabeledWarning("functions", "GOOGLE_CLOUD_QUTOA_PROJECT is not usable when uploading source for Cloud Functions.");
+    logLabeledWarning(
+      "functions",
+      "GOOGLE_CLOUD_QUTOA_PROJECT is not usable when uploading source for Cloud Functions.",
+    );
   }
-  await gcs.upload(uploadOpts, uploadUrl, {
-    "x-goog-content-length-range": "0,104857600",
-  },
-  true // ignoreQuotaProject
+  await gcs.upload(
+    uploadOpts,
+    uploadUrl,
+    {
+      "x-goog-content-length-range": "0,104857600",
+    },
+    true, // ignoreQuotaProject
   );
   return uploadUrl;
 }
@@ -57,7 +63,10 @@ async function uploadSourceV2(
     stream: fs.createReadStream(source.functionsSourceV2!),
   };
   if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
-    logLabeledWarning("functions", "GOOGLE_CLOUD_QUTOA_PROJECT is not usable when uploading source for Cloud Functions.");
+    logLabeledWarning(
+      "functions",
+      "GOOGLE_CLOUD_QUTOA_PROJECT is not usable when uploading source for Cloud Functions.",
+    );
   }
   await gcs.upload(uploadOpts, res.uploadUrl, undefined, true /* ignoreQuotaProject */);
   return res.storageSource;

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -3,7 +3,7 @@ import * as clc from "colorette";
 import * as fs from "fs";
 
 import { checkHttpIam } from "./checkIam";
-import { logSuccess, logWarning } from "../../utils";
+import { logLabeledWarning, logSuccess, logWarning } from "../../utils";
 import { Options } from "../../options";
 import { configForCodebase } from "../../functions/projectConfig";
 import * as args from "./args";
@@ -30,9 +30,14 @@ async function uploadSourceV1(
     file: source.functionsSourceV1!,
     stream: fs.createReadStream(source.functionsSourceV1!),
   };
+  if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
+    logLabeledWarning("functions", "GOOGLE_CLOUD_QUTOA_PROJECT is not usable when uploading source for Cloud Functions.");
+  }
   await gcs.upload(uploadOpts, uploadUrl, {
     "x-goog-content-length-range": "0,104857600",
-  });
+  },
+  true // ignoreQuotaProject
+  );
   return uploadUrl;
 }
 
@@ -51,7 +56,10 @@ async function uploadSourceV2(
     file: source.functionsSourceV2!,
     stream: fs.createReadStream(source.functionsSourceV2!),
   };
-  await gcs.upload(uploadOpts, res.uploadUrl);
+  if (process.env.GOOGLE_CLOUD_QUOTA_PROJECT) {
+    logLabeledWarning("functions", "GOOGLE_CLOUD_QUTOA_PROJECT is not usable when uploading source for Cloud Functions.");
+  }
+  await gcs.upload(uploadOpts, res.uploadUrl, undefined, true /* ignoreQuotaProject */);
   return res.storageSource;
 }
 

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -182,6 +182,7 @@ export async function upload(
   source: any,
   uploadUrl: string,
   extraHeaders?: Record<string, string>,
+  ignoreQuotaProject?: boolean,
 ): Promise<any> {
   const url = new URL(uploadUrl);
   const localAPIClient = new Client({ urlPrefix: url.origin, auth: false });
@@ -196,6 +197,7 @@ export async function upload(
     },
     body: source.stream,
     skipLog: { resBody: true },
+    ignoreQuotaProject,
   });
   return {
     generation: res.response.headers.get("x-goog-generation"),

--- a/src/test/apiv2.spec.ts
+++ b/src/test/apiv2.spec.ts
@@ -324,6 +324,28 @@ describe("apiv2", () => {
       expect(nock.isDone()).to.be.true;
     });
 
+    it("should allow explicitly ignoring GOOGLE_CLOUD_QUOTA_PROJECT", async () => {
+      nock("https://example.com")
+        .get("/path/to/foo")
+        .reply(function (this: nock.ReplyFnContext, _url: string, _body: nock.Body): nock.ReplyFnResult {
+          expect(this.req.headers["x-goog-user-project"]).is.undefined;
+          return [200, { success: true }];
+        });
+      const prev = process.env["GOOGLE_CLOUD_QUOTA_PROJECT"];
+      process.env["GOOGLE_CLOUD_QUOTA_PROJECT"] = "unit tests, silly";
+
+      const c = new Client({ urlPrefix: "https://example.com" });
+      const r = await c.request({
+        method: "GET",
+        path: "/path/to/foo",
+        ignoreQuotaProject: true,
+      });
+      process.env["GOOGLE_CLOUD_QUOTA_PROJECT"] = prev;
+
+      expect(r.body).to.deep.equal({ success: true });
+      expect(nock.isDone()).to.be.true;
+    });
+
     it("should handle a 204 response with no data", async () => {
       nock("https://example.com").get("/path/to/foo").reply(204);
 

--- a/src/test/apiv2.spec.ts
+++ b/src/test/apiv2.spec.ts
@@ -327,7 +327,7 @@ describe("apiv2", () => {
     it("should allow explicitly ignoring GOOGLE_CLOUD_QUOTA_PROJECT", async () => {
       nock("https://example.com")
         .get("/path/to/foo")
-        .reply(function (this: nock.ReplyFnContext, _url: string, _body: nock.Body): nock.ReplyFnResult {
+        .reply(function (this: nock.ReplyFnContext): nock.ReplyFnResult {
           expect(this.req.headers["x-goog-user-project"]).is.undefined;
           return [200, { success: true }];
         });


### PR DESCRIPTION
Best fix for #6896 that we can do for now. I strongly suspect that GCS just can't handle signed URL uploads with quota projects.