### PR TITLE
Reconcile existing secrets management code.

### DIFF
--- a/src/apphosting/secrets/dialogs.ts
+++ b/src/apphosting/secrets/dialogs.ts
@@ -1,34 +1,17 @@
 import * as clc from "colorette";
 const Table = require("cli-table");
 
+import { MultiServiceAccounts, ServiceAccounts, serviceAccountsForBackend, toMulti } from ".";
 import * as apphosting from "../../gcp/apphosting";
 import * as prompt from "../../prompt";
-import * as gce from "../../gcp/computeEngine";
-import * as cloudbuild from "../../gcp/cloudbuild";
 import * as utils from "../../utils";
 import { logger } from "../../logger";
 
 interface BackendMetadata {
   location: string;
   id: string;
-  accounts: string[];
-}
-
-/**
- * Finds the explicit service account used for a backend or, for legacy cases,
- * the defaults for GCB and compute.
- */
-export function serviceAccountsForBackend(
-  projectNumber: string,
-  backend: apphosting.Backend,
-): string[] {
-  if (backend.serviceAccount) {
-    return [backend.serviceAccount];
-  }
-  return [
-    cloudbuild.getDefaultServiceAccount(projectNumber),
-    gce.getDefaultServiceAccount(projectNumber),
-  ];
+  build: string;
+  run: string;
 }
 
 /**
@@ -42,7 +25,7 @@ export function toMetadata(
   for (const backend of backends) {
     // Splits format projects/<unused>/locations/<location>/backends/<id>
     const [, , , location, , id] = backend.name.split("/");
-    metadata.push({ location, id, accounts: serviceAccountsForBackend(projectNumber, backend) });
+    metadata.push({ location, id, ...serviceAccountsForBackend(projectNumber, backend) });
   }
   return metadata.sort((left, right) => {
     const cmplocation = left.location.localeCompare(right.location);
@@ -52,6 +35,22 @@ export function toMetadata(
     return left.id.localeCompare(right.id);
   });
 }
+
+/** Displays a single service account or a comma separated list of service accounts. */
+export function serviceAccountDisplay(metadata: ServiceAccounts): string {
+  if (sameServiceAccount(metadata)) {
+    return metadata.run;
+  }
+  return `${metadata.build}, ${metadata.run}`;
+}
+
+function sameServiceAccount(metadata: ServiceAccounts): boolean {
+  return metadata.build === metadata.run;
+}
+
+const matchesServiceAccounts = (target: ServiceAccounts) => (test: ServiceAccounts) => {
+  return target.build === test.build && target.run === test.run;
+};
 
 /**
  * Given a list of BackendMetadata, creates the JSON necessary to power a cli table.
@@ -63,12 +62,36 @@ export function tableForBackends(
   const headers = [
     "location",
     "backend",
-    metadata.findIndex((val) => val.accounts.length > 1) === -1
-      ? "service account"
-      : "service accounts",
+    metadata.every(sameServiceAccount) ? "service account" : "service accounts",
   ];
-  const rows = metadata.map((m) => [m.location, m.id, m.accounts.join(", ")]);
+  const rows = metadata.map((m) => [m.location, m.id, serviceAccountDisplay(m)]);
   return [headers, rows];
+}
+
+/**
+ * Returns a MultiServiceAccounts for all selected service accounts in a ServiceAccount[].
+ * If a service account is ever a "build" account in input, it will be a "build" account in the
+ * output. Otherwise, it will be a "run" account.
+ */
+export function selectFromMetadata(
+  input: ServiceAccounts[],
+  selected: string[],
+): MultiServiceAccounts {
+  const buildAccounts = new Set<string>();
+  const runAccounts = new Set<string>();
+
+  for (const sa of selected) {
+    if (input.find((m) => m.build === sa)) {
+      buildAccounts.add(sa);
+    } else {
+      runAccounts.add(sa);
+    }
+  }
+
+  return {
+    build: [...buildAccounts],
+    run: [...runAccounts],
+  };
 }
 
 /** Common warning log that there are no backends. Exported to make tests easier. */
@@ -88,7 +111,7 @@ export async function selectBackendServiceAccounts(
   projectNumber: string,
   projectId: string,
   options: any,
-): Promise<string[]> {
+): Promise<MultiServiceAccounts> {
   const listBackends = await apphosting.listBackends(projectId, "-");
 
   if (listBackends.unreachable.length) {
@@ -101,7 +124,7 @@ export async function selectBackendServiceAccounts(
 
   if (!listBackends.backends.length) {
     utils.logLabeledWarning("apphosting", WARN_NO_BACKENDS);
-    return [];
+    return { build: [], run: [] };
   }
 
   if (listBackends.backends.length === 1) {
@@ -112,36 +135,29 @@ export async function selectBackendServiceAccounts(
         "To use this secret, your backend's service account must have secret accessor permission. Would you like to grant it now?",
     });
     if (grant) {
-      return serviceAccountsForBackend(projectNumber, listBackends.backends[0]);
+      return toMulti(serviceAccountsForBackend(projectNumber, listBackends.backends[0]));
     }
     utils.logLabeledBullet("apphosting", GRANT_ACCESS_IN_FUTURE);
-    return [];
+    return { build: [], run: [] };
   }
 
   const metadata: BackendMetadata[] = toMetadata(projectNumber, listBackends.backends);
 
-  // Use JSON.stringify because deep comparison is annoying in JS. Because the order of the service account list should be deterinistic,
-  // this shouldn't need a sort command.
-  const firstServiceAccounts = JSON.stringify(metadata[0].accounts);
-  const allSharedAccounts = metadata.every(
-    (val) => JSON.stringify(val.accounts) === firstServiceAccounts,
-  );
-  if (allSharedAccounts) {
+  if (metadata.every(matchesServiceAccounts(metadata[0]))) {
     const grant = await prompt.confirm({
       nonInteractive: options.nonInteractive,
       default: true,
       message:
         "To use this secret, your backend's service account must have secret accessor permission. All of your backends use " +
-        (metadata[0].accounts.length === 1
-          ? `service account ${metadata[0].accounts[0]}`
-          : `service accounts ${metadata[0].accounts.join(", ")}`) +
+        (sameServiceAccount(metadata[0]) ? "service account " : "service accounts ") +
+        serviceAccountDisplay(metadata[0]) +
         ". Granting access to one backend will grant access to all backends. Would you like to grant it now?",
     });
     if (grant) {
-      return metadata[0].accounts;
+      return selectFromMetadata(metadata, [metadata[0].build, metadata[0].run]);
     }
     utils.logLabeledBullet("apphosting", GRANT_ACCESS_IN_FUTURE);
-    return [];
+    return { build: [], run: [] };
   }
 
   utils.logLabeledBullet(
@@ -157,7 +173,8 @@ export async function selectBackendServiceAccounts(
   logger.info(table.toString());
 
   const allAccounts = metadata.reduce((accum: Set<string>, row) => {
-    row.accounts.forEach((sa) => accum.add(sa));
+    accum.add(row.build);
+    accum.add(row.run);
     return accum;
   }, new Set<string>());
   const chosen = await prompt.promptOnce({
@@ -170,5 +187,5 @@ export async function selectBackendServiceAccounts(
   if (!chosen.length) {
     utils.logLabeledBullet("apphosting", GRANT_ACCESS_IN_FUTURE);
   }
-  return chosen;
+  return selectFromMetadata(metadata, chosen);
 }

--- a/src/apphosting/secrets/index.ts
+++ b/src/apphosting/secrets/index.ts
@@ -3,21 +3,54 @@ import * as iam from "../../gcp/iam";
 import * as gcsm from "../../gcp/secretManager";
 import * as gcb from "../../gcp/cloudbuild";
 import * as gce from "../../gcp/computeEngine";
+import * as apphosting from "../../gcp/apphosting";
 import { FIREBASE_MANAGED } from "../../gcp/secretManager";
 import { isFunctionsManaged } from "../../gcp/secretManager";
 import * as utils from "../../utils";
 import * as prompt from "../../prompt";
 
-function fetchServiceAccounts(projectNumber: string): {
-  buildServiceAccount: string;
-  runServiceAccount: string;
-} {
-  // TODO: For now we will always return the default CBSA and CESA. When the getBackend call supports returning
-  // the attached service account in a given backend/location then return that value instead.
-  // Sample Call: await apphosting.getBackend(projectId, location, backendId); & make this function async
+/** Interface for holding the service account pair for a given Backend. */
+export interface ServiceAccounts {
+  build: string;
+  run: string;
+}
+
+/**
+ * Interface for holding a collection of service accounts we need to grant access to.
+ * Build accounts are special because they also need secret viewer permissions to view versions
+ * and pin to the latest. Run accounts only need version accessor.
+ */
+export interface MultiServiceAccounts {
+  build: string[];
+  run: string[];
+}
+
+/** Utility function to turn a single ServiceAccounts into a MultiServiceAccounts.  */
+export function toMulti(accounts: ServiceAccounts): MultiServiceAccounts {
+  const m: MultiServiceAccounts = { build: [accounts.build], run: [] };
+  if (accounts.build !== accounts.run) {
+    m.run.push(accounts.run);
+  }
+  return m;
+}
+
+/**
+ * Finds the explicit service account used for a backend or, for legacy cases,
+ * the defaults for GCB and compute.
+ */
+export function serviceAccountsForBackend(
+  projectNumber: string,
+  backend: apphosting.Backend,
+): ServiceAccounts {
+  if (backend.serviceAccount) {
+    return {
+      build: backend.serviceAccount,
+      run: backend.serviceAccount,
+    };
+  }
   return {
-    buildServiceAccount: gcb.getDefaultServiceAccount(projectNumber),
-    runServiceAccount: gce.getDefaultServiceAccount(projectNumber),
+    build: gcb.getDefaultServiceAccount(projectNumber),
+    run: gce.getDefaultServiceAccount(projectNumber),
   };
 }
 
@@ -25,48 +58,19 @@ function fetchServiceAccounts(projectNumber: string): {
  * Grants the corresponding service accounts the necessary access permissions to the provided secret.
  */
 export async function grantSecretAccess(
-  secretName: string,
-  location: string,
-  backendId: string,
-  projectId: string,
-  projectNumber: string,
+  secret: gcsm.Secret,
+  accounts: MultiServiceAccounts,
 ): Promise<void> {
-  const isExist = await gcsm.secretExists(projectId, secretName);
-  if (!isExist) {
-    throw new FirebaseError(`Secret ${secretName} does not exist in project ${projectId}`);
-  }
-
-  let serviceAccounts = { buildServiceAccount: "", runServiceAccount: "" };
-  try {
-    serviceAccounts = fetchServiceAccounts(projectNumber);
-  } catch (err: any) {
-    throw new FirebaseError(
-      `Failed to get backend ${backendId} at location ${location}. Please check the parameters you have provided.`,
-      { original: err },
-    );
-  }
-
-  const secret = {
-    projectId: projectId,
-    name: secretName,
-  };
-
-  // TODO: Document why Cloud Build SA needs viewer permission but Run doesn't.
-  // TODO: future proof for when therte is a single service account (currently will set the same
-  // secretAccessor permission twice)
   const newBindings: iam.Binding[] = [
     {
       role: "roles/secretmanager.secretAccessor",
-      members: [
-        `serviceAccount:${serviceAccounts.buildServiceAccount}`,
-        `serviceAccount:${serviceAccounts.runServiceAccount}`,
-      ],
+      members: [...accounts.build, ...accounts.run].map((sa) => `serviceAccount:${sa}`),
     },
     // Cloud Build needs the viewer role so that it can list secret versions and pin the Build to the
     // latest version.
     {
       role: "roles/secretmanager.viewer",
-      members: [`serviceAccount:${serviceAccounts.buildServiceAccount}`],
+      members: accounts.build.map((sa) => `serviceAccount:${sa}`),
     },
   ];
 

--- a/src/test/apphosting/secrets/dialogs.spec.ts
+++ b/src/test/apphosting/secrets/dialogs.spec.ts
@@ -29,8 +29,8 @@ describe("dialogs", () => {
   } as any as apphosting.Backend;
 
   const emptyMulti: secrets.MultiServiceAccounts = {
-    build: [],
-    run: [],
+    buildServiceAccounts: [],
+    runServiceAccounts: [],
   };
 
   describe("toMetadata", () => {
@@ -39,8 +39,8 @@ describe("dialogs", () => {
       const metadata = dialogs.toMetadata("number", [modernA2, modernA]);
 
       expect(metadata).to.deep.equal([
-        { location: "l", id: "modernA", build: "a", run: "a" },
-        { location: "l2", id: "modernA2", build: "a", run: "a" },
+        { location: "l", id: "modernA", buildServiceAccount: "a", runServiceAccount: "a" },
+        { location: "l2", id: "modernA2", buildServiceAccount: "a", runServiceAccount: "a" },
       ]);
     });
 
@@ -53,7 +53,7 @@ describe("dialogs", () => {
           id: "legacy",
           ...secrets.serviceAccountsForBackend("number", legacy),
         },
-        { location: "l", id: "modernA", build: "a", run: "a" },
+        { location: "l", id: "modernA", buildServiceAccount: "a", runServiceAccount: "a" },
       ]);
     });
 
@@ -65,15 +65,19 @@ describe("dialogs", () => {
           id: "legacy",
           ...secrets.serviceAccountsForBackend("number", legacy),
         },
-        { location: "l", id: "modernA", build: "a", run: "a" },
-        { location: "l2", id: "modernA2", build: "a", run: "a" },
+        { location: "l", id: "modernA", buildServiceAccount: "a", runServiceAccount: "a" },
+        { location: "l2", id: "modernA2", buildServiceAccount: "a", runServiceAccount: "a" },
       ]);
     });
   });
 
   it("serviceAccountDisplay", () => {
-    expect(dialogs.serviceAccountDisplay({ build: "build", run: "run" })).to.equal("build, run");
-    expect(dialogs.serviceAccountDisplay({ build: "common", run: "common" })).to.equal("common");
+    expect(
+      dialogs.serviceAccountDisplay({ buildServiceAccount: "build", runServiceAccount: "run" }),
+    ).to.equal("build, run");
+    expect(
+      dialogs.serviceAccountDisplay({ buildServiceAccount: "common", runServiceAccount: "common" }),
+    ).to.equal("common");
   });
 
   describe("tableForBackends", () => {
@@ -91,7 +95,11 @@ describe("dialogs", () => {
       const legacyAccounts = secrets.serviceAccountsForBackend("number", legacy);
       expect(table[0]).to.deep.equal(["location", "backend", "service accounts"]);
       expect(table[1]).to.deep.equal([
-        ["l", "legacy", `${legacyAccounts.build}, ${legacyAccounts.run}`],
+        [
+          "l",
+          "legacy",
+          `${legacyAccounts.buildServiceAccount}, ${legacyAccounts.runServiceAccount}`,
+        ],
         ["l", "modernA", "a"],
       ]);
     });
@@ -100,21 +108,21 @@ describe("dialogs", () => {
   it("selectFromMetadata", () => {
     const metadata: secrets.ServiceAccounts[] = [
       {
-        build: "build",
-        run: "run",
+        buildServiceAccount: "build",
+        runServiceAccount: "run",
       },
       {
-        build: "common",
-        run: "common",
+        buildServiceAccount: "common",
+        runServiceAccount: "common",
       },
       {
-        build: "omittedBuild",
-        run: "omittedRun",
+        buildServiceAccount: "omittedBuild",
+        runServiceAccount: "omittedRun",
       },
     ];
     expect(dialogs.selectFromMetadata(metadata, ["build", "run", "common"])).to.deep.equal({
-      build: ["build", "common"],
-      run: ["run"],
+      buildServiceAccounts: ["build", "common"],
+      runServiceAccounts: ["run"],
     });
   });
 
@@ -178,7 +186,10 @@ describe("dialogs", () => {
 
       await expect(
         dialogs.selectBackendServiceAccounts("number", "id", {}),
-      ).to.eventually.deep.equal({ build: [modernA.serviceAccount], run: [] });
+      ).to.eventually.deep.equal({
+        buildServiceAccounts: [modernA.serviceAccount],
+        runServiceAccounts: [],
+      });
 
       expect(prompt.confirm).to.have.been.calledWith({
         nonInteractive: undefined,
@@ -270,7 +281,10 @@ describe("dialogs", () => {
 
       await expect(
         dialogs.selectBackendServiceAccounts("number", "id", {}),
-      ).to.eventually.deep.equal({ build: [modernA.serviceAccount], run: [] });
+      ).to.eventually.deep.equal({
+        buildServiceAccounts: [modernA.serviceAccount],
+        runServiceAccounts: [],
+      });
 
       expect(prompt.confirm).to.have.been.calledWith({
         nonInteractive: undefined,
@@ -318,13 +332,18 @@ describe("dialogs", () => {
 
       await expect(
         dialogs.selectBackendServiceAccounts("number", "id", {}),
-      ).to.eventually.deep.equal({ build: ["a", "b"], run: [] });
+      ).to.eventually.deep.equal({ buildServiceAccounts: ["a", "b"], runServiceAccounts: [] });
 
       expect(prompt.promptOnce).to.have.been.calledWith({
         type: "checkbox",
         message:
           "Which service accounts would you like to grant access? Press Space to select accounts, then Enter to confirm your choices.",
-        choices: ["a", "b", legacyAccounts.build, legacyAccounts.run].sort(),
+        choices: [
+          "a",
+          "b",
+          legacyAccounts.buildServiceAccount,
+          legacyAccounts.runServiceAccount,
+        ].sort(),
       });
       expect(utils.logLabeledBullet).to.have.been.calledWith(
         "apphosting",
@@ -352,7 +371,12 @@ describe("dialogs", () => {
         type: "checkbox",
         message:
           "Which service accounts would you like to grant access? Press Space to select accounts, then Enter to confirm your choices.",
-        choices: ["a", "b", legacyAccounts.build, legacyAccounts.run].sort(),
+        choices: [
+          "a",
+          "b",
+          legacyAccounts.buildServiceAccount,
+          legacyAccounts.runServiceAccount,
+        ].sort(),
       });
       expect(utils.logLabeledBullet).to.have.been.calledWith(
         "apphosting",

--- a/src/test/apphosting/secrets/index.spec.ts
+++ b/src/test/apphosting/secrets/index.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 
+import * as apphosting from "../../../gcp/apphosting";
 import * as secrets from "../../../apphosting/secrets";
 import * as iam from "../../../gcp/iam";
 import * as gcb from "../../../gcp/cloudbuild";
@@ -8,7 +9,6 @@ import * as gce from "../../../gcp/computeEngine";
 import * as gcsmImport from "../../../gcp/secretManager";
 import * as utilsImport from "../../../utils";
 import * as promptImport from "../../../prompt";
-import { FirebaseError } from "../../../error";
 
 describe("secrets", () => {
   let gcsm: sinon.SinonStubbedInstance<typeof gcsmImport>;
@@ -21,13 +21,32 @@ describe("secrets", () => {
     prompt = sinon.stub(promptImport);
     gcsm.isFunctionsManaged.restore();
     gcsm.labels.restore();
-    gcsm.secretExists.throws("Unexpected secretExists call");
     gcsm.getIamPolicy.throws("Unexpected getIamPolicy call");
     gcsm.setIamPolicy.throws("Unexpected setIamPolicy call");
   });
 
   afterEach(() => {
     sinon.verifyAndRestore();
+  });
+
+  describe("serviceAccountsForbackend", () => {
+    it("uses explicit account", () => {
+      const backend = {
+        serviceAccount: "sa",
+      } as any as apphosting.Backend;
+      expect(secrets.serviceAccountsForBackend("number", backend)).to.deep.equal({
+        build: "sa",
+        run: "sa",
+      });
+    });
+
+    it("has a fallback for legacy SAs", () => {
+      const backend = {} as any as apphosting.Backend;
+      expect(secrets.serviceAccountsForBackend("number", backend)).to.deep.equal({
+        build: gcb.getDefaultServiceAccount("number"),
+        run: gce.getDefaultServiceAccount("number"),
+      });
+    });
   });
 
   describe("upsertSecret", () => {
@@ -167,71 +186,63 @@ describe("secrets", () => {
     });
   });
 
+  describe("toMulti", () => {
+    it("handles different service accounts", () => {
+      expect(secrets.toMulti({ build: "buildSA", run: "computeSA" })).to.deep.equal({
+        build: ["buildSA"],
+        run: ["computeSA"],
+      });
+    });
+
+    it("handles the same service account", () => {
+      expect(secrets.toMulti({ build: "explicitSA", run: "explicitSA" })).to.deep.equal({
+        build: ["explicitSA"],
+        run: [],
+      });
+    });
+  });
+
   describe("grantSecretAccess", () => {
-    const projectId = "projectId";
-    const projectNumber = "123456789";
-    const location = "us-central1";
-    const backendId = "backendId";
-    const secretName = "secretName";
+    const secret: gcsmImport.Secret = {
+      name: "secret",
+      projectId: "projectId",
+      replication: {},
+      labels: {},
+    };
     const existingPolicy: iam.Policy = {
       version: 1,
       etag: "tag",
       bindings: [
         {
           role: "roles/viewer",
-          members: [`serviceAccount:${gce.getDefaultServiceAccount(projectNumber)}`],
+          members: ["serviceAccount:existingSA"],
         },
       ],
     };
 
     it("should grant access to the appropriate service accounts", async () => {
-      gcsm.secretExists.resolves(true);
       gcsm.getIamPolicy.resolves(existingPolicy);
       gcsm.setIamPolicy.resolves();
 
-      await secrets.grantSecretAccess(secretName, location, backendId, projectId, projectNumber);
-
-      const secret = {
-        projectId: projectId,
-        name: secretName,
-      };
+      await secrets.grantSecretAccess(secret, { build: ["buildSA"], run: ["computeSA"] });
 
       const newBindings: iam.Binding[] = [
         {
           role: "roles/viewer",
-          members: [`serviceAccount:${gce.getDefaultServiceAccount(projectNumber)}`],
+          members: [`serviceAccount:existingSA`],
         },
         {
           role: "roles/secretmanager.secretAccessor",
-          members: [
-            `serviceAccount:${gcb.getDefaultServiceAccount(projectNumber)}`,
-            `serviceAccount:${gce.getDefaultServiceAccount(projectNumber)}`,
-          ],
+          members: ["serviceAccount:buildSA", "serviceAccount:computeSA"],
         },
         {
           role: "roles/secretmanager.viewer",
-          members: [`serviceAccount:${gcb.getDefaultServiceAccount(projectNumber)}`],
+          members: ["serviceAccount:buildSA"],
         },
       ];
 
-      expect(gcsm.secretExists).to.be.calledWith(projectId, secretName);
       expect(gcsm.getIamPolicy).to.be.calledWith(secret);
       expect(gcsm.setIamPolicy).to.be.calledWith(secret, newBindings);
-    });
-
-    it("does not grant access to a secret that doesn't exist", () => {
-      gcsm.secretExists.resolves(false);
-
-      expect(
-        secrets.grantSecretAccess(secretName, location, backendId, projectId, projectNumber),
-      ).to.be.rejectedWith(
-        FirebaseError,
-        `Secret ${secretName} does not exist in project ${projectId}`,
-      );
-
-      expect(gcsm.secretExists).to.be.calledWith(projectId, secretName);
-      expect(gcsm.secretExists).to.be.calledOnce;
-      expect(gcsm.setIamPolicy).to.not.have.been.called;
     });
   });
 });

--- a/src/test/apphosting/secrets/index.spec.ts
+++ b/src/test/apphosting/secrets/index.spec.ts
@@ -35,16 +35,16 @@ describe("secrets", () => {
         serviceAccount: "sa",
       } as any as apphosting.Backend;
       expect(secrets.serviceAccountsForBackend("number", backend)).to.deep.equal({
-        build: "sa",
-        run: "sa",
+        buildServiceAccount: "sa",
+        runServiceAccount: "sa",
       });
     });
 
     it("has a fallback for legacy SAs", () => {
       const backend = {} as any as apphosting.Backend;
       expect(secrets.serviceAccountsForBackend("number", backend)).to.deep.equal({
-        build: gcb.getDefaultServiceAccount("number"),
-        run: gce.getDefaultServiceAccount("number"),
+        buildServiceAccount: gcb.getDefaultServiceAccount("number"),
+        runServiceAccount: gce.getDefaultServiceAccount("number"),
       });
     });
   });
@@ -188,16 +188,20 @@ describe("secrets", () => {
 
   describe("toMulti", () => {
     it("handles different service accounts", () => {
-      expect(secrets.toMulti({ build: "buildSA", run: "computeSA" })).to.deep.equal({
-        build: ["buildSA"],
-        run: ["computeSA"],
+      expect(
+        secrets.toMulti({ buildServiceAccount: "buildSA", runServiceAccount: "computeSA" }),
+      ).to.deep.equal({
+        buildServiceAccounts: ["buildSA"],
+        runServiceAccounts: ["computeSA"],
       });
     });
 
     it("handles the same service account", () => {
-      expect(secrets.toMulti({ build: "explicitSA", run: "explicitSA" })).to.deep.equal({
-        build: ["explicitSA"],
-        run: [],
+      expect(
+        secrets.toMulti({ buildServiceAccount: "explicitSA", runServiceAccount: "explicitSA" }),
+      ).to.deep.equal({
+        buildServiceAccounts: ["explicitSA"],
+        runServiceAccounts: [],
       });
     });
   });
@@ -224,7 +228,10 @@ describe("secrets", () => {
       gcsm.getIamPolicy.resolves(existingPolicy);
       gcsm.setIamPolicy.resolves();
 
-      await secrets.grantSecretAccess(secret, { build: ["buildSA"], run: ["computeSA"] });
+      await secrets.grantSecretAccess(secret, {
+        buildServiceAccounts: ["buildSA"],
+        runServiceAccounts: ["computeSA"],
+      });
 
       const newBindings: iam.Binding[] = [
         {


### PR DESCRIPTION
Updated the original grant access code to accept a secret and a MultiServiceAccounts so that it can be used to grant access to multiple accounts at the same time. Logic for verifying a secret exists or getting a backend's service account are trivial and were moved into the command.

Updated the original secrets dialog to use the new MultiServiceAccounts type so that we can remember which accounts need the special access for Cloud Build to pin versions.