### PR TITLE
Finally wrap up the secrets:set command 🎉 

### DIFF
--- a/src/apphosting/config.ts
+++ b/src/apphosting/config.ts
@@ -12,21 +12,14 @@ export interface RunConfig {
   maxInstances?: number;
 }
 
-interface HasSecret {
-  secret: string;
-  value: never;
-}
-interface HasValue {
-  secret: never;
-  value: string;
-}
-
 /** Where an environment variable can be provided. */
 export type Availability = "BUILD" | "RUNTIME";
 
 /** Config for an environment variable. */
-export type Env = (HasSecret | HasValue) & {
+export type Env = {
   variable: string;
+  secret?: string;
+  value?: string;
   availability?: Availability[];
 };
 

--- a/src/commands/apphosting-secrets-grantaccess.ts
+++ b/src/commands/apphosting-secrets-grantaccess.ts
@@ -43,21 +43,14 @@ export const command = new Command("apphosting:secrets:grantaccess <secretName>"
 
     // TODO: consider showing dialog if both --location and --backend are missing
 
-    let secret: secretManager.Secret;
-    try {
-      secret = await secretManager.getSecret(projectId, secretName);
-    } catch (err: any) {
-      if (err.status === 404) {
-        throw new FirebaseError(`Cannot find secret ${secretName}`);
-      }
-      throw new FirebaseError(`Unexpected error loading secret ${secretName}`, {
-        original: err as Error,
-      });
+    const exists = await secretManager.secretExists(projectId, secretName);
+    if (!exists) {
+      throw new FirebaseError(`Cannot find secret ${secretName}`);
     }
 
     const backendId = options.backend as string;
     const backend = await apphosting.getBackend(projectId, location, backendId);
     const accounts = secrets.toMulti(secrets.serviceAccountsForBackend(projectNumber, backend));
 
-    await secrets.grantSecretAccess(secret, accounts);
+    await secrets.grantSecretAccess(projectId, secretName, accounts);
   });

--- a/src/commands/apphosting-secrets-set.ts
+++ b/src/commands/apphosting-secrets-set.ts
@@ -78,8 +78,9 @@ export const command = new Command("apphosting:secrets:set <secretName>")
       logWarning(
         `To use this secret your backend, you must grant access. You can do so in the future with ${clc.bold("firebase apphosting:secrets:grantAccess")}`,
       );
+    } else {
+      await secrets.grantSecretAccess(projectId, secretName, accounts);
     }
-    await secrets.grantSecretAccess(projectId, secretName, accounts);
 
     // Note: The API proposal suggested that we would check if the env exists. This is stupidly hard because the YAML may not exist yet.
     let path = config.yamlPath(process.cwd());

--- a/src/commands/apphosting-secrets-set.ts
+++ b/src/commands/apphosting-secrets-set.ts
@@ -1,0 +1,115 @@
+import * as tty from "tty";
+import * as clc from "colorette";
+import { join } from "path";
+
+import { Command } from "../command";
+import { Options } from "../options";
+import { needProjectId, needProjectNumber } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
+import * as fs from "fs";
+import * as gcsm from "../gcp/secretManager";
+import * as apphosting from "../gcp/apphosting";
+import { requirePermissions } from "../requirePermissions";
+import { confirm, promptOnce } from "../prompt";
+import * as secrets from "../apphosting/secrets";
+import * as dialogs from "../apphosting/secrets/dialogs";
+import * as config from "../apphosting/config";
+import { logSuccess, logWarning } from "../utils";
+
+export const command = new Command("apphosting:secrets:set <secretName>")
+  .description("grant service accounts permissions to the provided secret")
+  .option("-l, --location <location>", "optional location to retrict secret replication")
+  // TODO: What is the right --force behavior for granting access? Seems correct to grant permissions
+  // if there is only one set of accounts, but should maybe fail if there are more than one set of
+  // accounts for different backends?
+  .withForce("Automatically create a secret, grant permissions, and add to YAML.")
+  .before(requireAuth)
+  .before(gcsm.ensureApi)
+  .before(apphosting.ensureApiEnabled)
+  .before(requirePermissions, [
+    "secretmanager.secrets.create",
+    "secretmanager.secrets.get",
+    "secretmanager.secrets.update",
+    "secretmanager.versions.add",
+    "secretmanager.secrets.getIamPolicy",
+    "secretmanager.secrets.setIamPolicy",
+  ])
+  .option(
+    "--data-file <dataFile>",
+    'File path from which to read secret data. Set to "-" to read the secret data from stdin.',
+  )
+  .action(async (secretName: string, options: Options) => {
+    const howToAccess = `You can access the contents of the secret's latest value with ${clc.bold(`firebase apphosting:secrets:access ${secretName}`)}`;
+    const projectId = needProjectId(options);
+    const projectNumber = await needProjectNumber(options);
+
+    const created = secrets.upsertSecret(projectId, secretName, options.location as string);
+    if (created === null) {
+      return;
+    }
+
+    let secretValue;
+    if ((!options.dataFile || options.dataFile === "-") && tty.isatty(0)) {
+      secretValue = await promptOnce({
+        type: "password",
+        message: `Enter a value for ${secretName}`,
+      });
+    } else {
+      let dataFile: string | number = 0;
+      if (options.dataFile && options.dataFile !== "-") {
+        dataFile = options.dataFile as string;
+      }
+      secretValue = fs.readFileSync(dataFile, "utf-8");
+    }
+
+    if (!created) {
+      const version = await gcsm.addVersion(projectId, secretName, secretValue);
+      logSuccess(`Created new secret version ${gcsm.toSecretVersionResourceName(version)}`);
+      logSuccess(howToAccess);
+      return;
+    }
+
+    logSuccess(`Created new secret projects/${projectId}/secrets/${secretName}`);
+    logSuccess(howToAccess);
+
+    const accounts = await dialogs.selectBackendServiceAccounts(projectNumber, projectId, options);
+    // If we're not granting permissions, there's no point in adding to YAML either.
+    if (!accounts.build.length && !accounts.run.length) {
+      logWarning(
+        `To use this secret your backend, you must grant access. You can do so in the future with ${clc.bold("firebase apphosting:secrets:grantAccess")}`,
+      );
+    }
+    await secrets.grantSecretAccess(projectId, secretName, accounts);
+
+    // Note: The API proposal suggested that we would check if the env exists. This is stupidly hard because the YAML may not exist yet.
+    let path = config.yamlPath(process.cwd());
+    let yaml: config.Config = {};
+    if (path) {
+      yaml = config.load(path);
+      if (yaml.env?.find((env) => env.variable === secretName)) {
+        return;
+      }
+    }
+    const addToYaml = await confirm({
+      message: "Would you like to add this secret to apphosting.yaml?",
+      default: true,
+    });
+    if (!addToYaml) {
+      return;
+    }
+    if (!path) {
+      path = await promptOnce({
+        message:
+          "It looks like you don't have an apphosting.yaml yet. Where would you like to store it?",
+        default: process.cwd(),
+      });
+      path = join(path, "apphosting.yaml");
+    }
+    const envName = await dialogs.envVarForSecret(secretName);
+    yaml.env = yaml.env || [];
+    yaml.env.push({
+      variable: envName,
+      secret: secretName,
+    });
+    config.store(path, yaml);
+  });

--- a/src/commands/apphosting-secrets-set.ts
+++ b/src/commands/apphosting-secrets-set.ts
@@ -74,7 +74,7 @@ export const command = new Command("apphosting:secrets:set <secretName>")
 
     const accounts = await dialogs.selectBackendServiceAccounts(projectNumber, projectId, options);
     // If we're not granting permissions, there's no point in adding to YAML either.
-    if (!accounts.build.length && !accounts.run.length) {
+    if (!accounts.buildServiceAccounts.length && !accounts.runServiceAccounts.length) {
       logWarning(
         `To use this secret your backend, you must grant access. You can do so in the future with ${clc.bold("firebase apphosting:secrets:grantAccess")}`,
       );

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -172,6 +172,7 @@ export function load(client: any): any {
     client.apphosting.builds.get = loadCommand("apphosting-builds-get");
     client.apphosting.builds.create = loadCommand("apphosting-builds-create");
     client.apphosting.secrets = {};
+    client.apphosting.secrets.set = loadCommand("apphosting-secrets-set");
     client.apphosting.secrets.grantaccess = loadCommand("apphosting-secrets-grantaccess");
     client.apphosting.secrets.describe = loadCommand("apphosting-secrets-describe");
     client.apphosting.rollouts = {};

--- a/src/test/apphosting/secrets/dialogs.spec.ts
+++ b/src/test/apphosting/secrets/dialogs.spec.ts
@@ -388,4 +388,81 @@ describe("dialogs", () => {
       );
     });
   });
+
+  describe("envVarForSecret", () => {
+    let prompt: sinon.SinonStubbedInstance<typeof promptImport>;
+    let utils: sinon.SinonStubbedInstance<typeof utilsImport>;
+
+    beforeEach(() => {
+      prompt = sinon.stub(promptImport);
+      utils = sinon.stub(utilsImport);
+    });
+
+    afterEach(() => {
+      sinon.verifyAndRestore();
+    });
+
+    it("accepts a valid env var", async () => {
+      await expect(dialogs.envVarForSecret("VALID_KEY")).to.eventually.equal("VALID_KEY");
+      expect(prompt.promptOnce).to.not.have.been.called;
+    });
+
+    it("suggests a valid upper case name", async () => {
+      prompt.promptOnce.resolves("SECRET_VALUE");
+
+      await expect(dialogs.envVarForSecret("secret-value")).to.eventually.equal("SECRET_VALUE");
+      expect(prompt.promptOnce).to.have.been.calledWithMatch({
+        message: "What environment variable name would you like to use?",
+        default: "SECRET_VALUE",
+      });
+    });
+
+    it("prevents invalid keys", async () => {
+      prompt.promptOnce.onFirstCall().resolves("secret-value");
+      prompt.promptOnce.onSecondCall().resolves("SECRET_VALUE");
+
+      await expect(dialogs.envVarForSecret("secret-value")).to.eventually.equal("SECRET_VALUE");
+      expect(prompt.promptOnce).to.have.been.calledWithMatch({
+        message: "What environment variable name would you like to use?",
+        default: "SECRET_VALUE",
+      });
+      expect(prompt.promptOnce).to.have.been.calledTwice;
+      expect(utils.logLabeledError).to.have.been.calledWith(
+        "apphosting",
+        "Key secret-value must start with an uppercase ASCII letter or underscore, and then consist of uppercase ASCII letters, digits, and underscores.",
+      );
+    });
+
+    it("prevents reserved keys", async () => {
+      prompt.promptOnce.onFirstCall().resolves("PORT");
+      prompt.promptOnce.onSecondCall().resolves("SECRET_VALUE");
+
+      await expect(dialogs.envVarForSecret("secret-value")).to.eventually.equal("SECRET_VALUE");
+      expect(prompt.promptOnce).to.have.been.calledWithMatch({
+        message: "What environment variable name would you like to use?",
+        default: "SECRET_VALUE",
+      });
+      expect(prompt.promptOnce).to.have.been.calledTwice;
+      expect(utils.logLabeledError).to.have.been.calledWith(
+        "apphosting",
+        "Key PORT is reserved for internal use.",
+      );
+    });
+
+    it("prevents reserved prefixes", async () => {
+      prompt.promptOnce.onFirstCall().resolves("X_GOOGLE_SECRET");
+      prompt.promptOnce.onSecondCall().resolves("SECRET_VALUE");
+
+      await expect(dialogs.envVarForSecret("secret-value")).to.eventually.equal("SECRET_VALUE");
+      expect(prompt.promptOnce).to.have.been.calledWithMatch({
+        message: "What environment variable name would you like to use?",
+        default: "SECRET_VALUE",
+      });
+      expect(prompt.promptOnce).to.have.been.calledTwice;
+      expect(utils.logLabeledError).to.have.been.calledWithMatch(
+        "apphosting",
+        /Key X_GOOGLE_SECRET starts with a reserved prefix/,
+      );
+    });
+  });
 });

--- a/src/test/apphosting/secrets/index.spec.ts
+++ b/src/test/apphosting/secrets/index.spec.ts
@@ -207,11 +207,9 @@ describe("secrets", () => {
   });
 
   describe("grantSecretAccess", () => {
-    const secret: gcsmImport.Secret = {
+    const secret = {
       name: "secret",
       projectId: "projectId",
-      replication: {},
-      labels: {},
     };
     const existingPolicy: iam.Policy = {
       version: 1,
@@ -228,7 +226,7 @@ describe("secrets", () => {
       gcsm.getIamPolicy.resolves(existingPolicy);
       gcsm.setIamPolicy.resolves();
 
-      await secrets.grantSecretAccess(secret, {
+      await secrets.grantSecretAccess(secret.projectId, secret.name, {
         buildServiceAccounts: ["buildSA"],
         runServiceAccounts: ["computeSA"],
       });
@@ -248,8 +246,8 @@ describe("secrets", () => {
         },
       ];
 
-      expect(gcsm.getIamPolicy).to.be.calledWith(secret);
-      expect(gcsm.setIamPolicy).to.be.calledWith(secret, newBindings);
+      expect(gcsm.getIamPolicy).to.be.calledWithMatch(secret);
+      expect(gcsm.setIamPolicy).to.be.calledWithMatch(secret, newBindings);
     });
   });
 });


### PR DESCRIPTION
Implement the full spec of the `firebase apphosting:secrets:set` command.

Confirmed this works by checking the Cloud Console to see that the secret was created with the correct permissions and that apphosting.yaml was created. Did not test a deploy because I am not aware whether the bug where values aren't propagated to runtime environments has been fixed.

This will need further polish. E.g. we need to discuss what to do in a non-interactive environment or when `--force` is set. We may also have to update the YAML handling to make sure we're only doing delta edits to minimize git diffs.