### PR TITLE
Fix functions emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where the Functions emulator would choose the wrong runtime if none was listed in `firebase.json`. (#6965)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -494,15 +494,11 @@ export async function startAll(
     for (const cfg of functionsCfg) {
       const functionsDir = path.join(projectDir, cfg.source);
       let runtime = (options.extDevRuntime ?? cfg.runtime) as Runtime | undefined;
-      if (!runtime) {
-        // N.B: extensions are wonky. They don't typically include an engine
-        // in package.json and there is no firebase.json for their runtime
-        // name. extensions.yaml has resources[].properties.runtime, but this
-        // varies per function! This default will work for now, but will break
-        // once extensions support python.
-        runtime = latest("nodejs");
-      }
-      if (!isRuntime(runtime)) {
+      // N.B. (Issue #6965) it's OK for runtime to be undefined because the functions discovery process
+      // will dynamically detect it later.
+      // TODO: does runtime even need to be a part of EmultableBackend now that we have dynamic runtime
+      // detection? Might be an extensions thing.
+      if (runtime && !isRuntime(runtime)) {
         throw new FirebaseError(
           `Cannot load functions from ${functionsDir} because it has invalid runtime ${runtime as string}`,
         );

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -53,7 +53,7 @@ import { requiresJava } from "./downloadableEmulators";
 import { prepareFrameworks } from "../frameworks";
 import * as experiments from "../experiments";
 import { EmulatorListenConfig, PortName, resolveHostAndAssignPorts } from "./portUtils";
-import { Runtime, isRuntime, latest } from "../deploy/functions/runtimes/supported";
+import { Runtime, isRuntime } from "../deploy/functions/runtimes/supported";
 
 const START_LOGGING_EMULATOR = utils.envOverride(
   "START_LOGGING_EMULATOR",
@@ -493,7 +493,7 @@ export async function startAll(
 
     for (const cfg of functionsCfg) {
       const functionsDir = path.join(projectDir, cfg.source);
-      let runtime = (options.extDevRuntime ?? cfg.runtime) as Runtime | undefined;
+      const runtime = (options.extDevRuntime ?? cfg.runtime) as Runtime | undefined;
       // N.B. (Issue #6965) it's OK for runtime to be undefined because the functions discovery process
       // will dynamically detect it later.
       // TODO: does runtime even need to be a part of EmultableBackend now that we have dynamic runtime


### PR DESCRIPTION
A fallback runtime is completely unnecessary given our ability to dynamically detect it. In fact, it _breaks_ dynamic detection!

Fixes #6965