### PR TITLE
App Hosting - Allow users to manage their github installation when "missing a repo" option is chosen

### DIFF
--- a/src/apphosting/githubConnections.ts
+++ b/src/apphosting/githubConnections.ts
@@ -116,6 +116,7 @@ export async function linkGitHubRepository(
           location,
           generateConnectionId(),
           oauthConn,
+          /** withNewInstallation= */ true,
         ),
       );
     }
@@ -149,9 +150,10 @@ async function createFullyInstalledConnection(
   location: string,
   connectionId: string,
   oauthConn: devConnect.Connection,
+  withNewInstallation = false,
 ): Promise<devConnect.Connection> {
   let conn = await createConnection(projectId, location, connectionId, {
-    appInstallationId: oauthConn.githubConfig?.appInstallationId,
+    appInstallationId: withNewInstallation ? undefined : oauthConn.githubConfig?.appInstallationId,
     authorizerCredential: oauthConn.githubConfig?.authorizerCredential,
   });
 

--- a/src/apphosting/githubConnections.ts
+++ b/src/apphosting/githubConnections.ts
@@ -144,6 +144,13 @@ export async function linkGitHubRepository(
  * side (ie associated with an account/org and some subset of repos within that scope).
  * Copies over Oauth creds from the sentinel Oauth connection to save the user from having to
  * reauthenticate with GitHub.
+ * @param projectId user's Firebase projectID
+ * @param location region where backend is being created
+ * @param connectionId id of connection to be created
+ * @param oauthConn user's oauth connection
+ * @param withNewInstallation Defaults to false if not set, and the Oauth connection's
+ *                            Installation Id is re-used when creating a new connection.
+ *                            If true the Oauth connection's installation Id is not re-used.
  */
 async function createFullyInstalledConnection(
   projectId: string,


### PR DESCRIPTION
This is a bug fix. Currently when the `Missing a repo? Select this option to configure your GitHub connection settings` option is chosen a new connection is re-created with existing oauth credentials so nothing happens.

Now, when user selects this option a new connection is created but without the GitHub Installation ID, this sends user to the Dev Connect installation management page from which they can create a new installation with another GitHub org or account, or change the repo access settings for an existing GitHub app installation.
