### PR TITLE
add ignoreQuotaProject flag to downloadToTmp

### DIFF
--- a/src/downloadUtils.ts
+++ b/src/downloadUtils.ts
@@ -18,6 +18,7 @@ export async function downloadToTmp(remoteUrl: string): Promise<string> {
   const writeStream = fs.createWriteStream(tmpfile.name);
 
   const res = await c.request<void, NodeJS.ReadableStream>({
+    ignoreQuotaProject: true,
     method: "GET",
     path: u.pathname,
     queryParams: u.searchParams,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fix for issue reported here: https://github.com/firebase/firebase-tools/issues/6975

The presence of a `GOOGLE_CLOUD_QUOTA_PROJECT` env var causes the firestore emulator download to fail. 

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Tested with and without the environment variable.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
