### PR TITLE
Fixes a deployment crash when resetting min instances to 0 in v1 functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes bug where `firebase deploy --only firestore:rules,firestore:indexes` does not update rules and indexes. (#6966)
 - Add Firebase console link after creating or restoring a Firestore database (#6949)
 - Increase supported Astro version to 4 (#6960)
+- Fixes a deployment crash when resetting min instances to 0 in v1 functions (#6990)

--- a/src/deploy/functions/pricing.ts
+++ b/src/deploy/functions/pricing.ts
@@ -132,7 +132,7 @@ const MB_TO_GHZ = {
 
 /** Whether we have information in our price sheet to calculate the minInstance cost. */
 export function canCalculateMinInstanceCost(endpoint: backend.Endpoint): boolean {
-  if (!endpoint.minInstances) {
+  if (endpoint.minInstances === undefined || endpoint.minInstances === null) {
     return true;
   }
 
@@ -172,7 +172,7 @@ export function monthlyMinInstanceCost(endpoints: backend.Endpoint[]): number {
   };
 
   for (const endpoint of endpoints) {
-    if (!endpoint.minInstances) {
+    if (endpoint.minInstances === undefined || endpoint.minInstances === null) {
       continue;
     }
 


### PR DESCRIPTION
Fixes a fasly check that would treat 0 min instances as false instead of true and crash the deployment - #6980