### PR TITLE
Update log message for emulator phone code

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -975,7 +975,7 @@ function sendVerificationCode(
   // a real text message out to the phone number.
   EmulatorLogger.forEmulator(Emulators.AUTH).log(
     "BULLET",
-    `To verify the phone number ${phoneNumber}, use the code ${code}.`,
+    `Use the code ${code} to verify the phone number ${phoneNumber}.`,
   );
 
   return {


### PR DESCRIPTION
When I highlight the verification code to copy-paste by double-clicking it, it inadvertently selects the period at the end of the sentence. Rearranging this log message solves this problem and saves me a second every time I get verification codes.