### PR TITLE
Add developer connect debug commands

### DIFF
--- a/src/apphosting/githubConnections.ts
+++ b/src/apphosting/githubConnections.ts
@@ -443,3 +443,17 @@ export async function fetchAllRepositories(
   }
   return { cloneUris: Object.keys(cloneUriToConnection), cloneUriToConnection };
 }
+
+/**
+ * checks if the given connection name is an apphosting connection
+ */
+export function isApphostingConnection(name: string): boolean {
+  const match = CONNECTION_NAME_REGEX.exec(name);
+
+  if (!match || typeof match.groups === undefined) {
+    return false;
+  }
+
+  const { id } = match.groups as unknown as ConnectionNameParts;
+  return APPHOSTING_CONN_PATTERN.test(id) || id === APPHOSTING_OAUTH_CONN_NAME;
+}

--- a/src/commands/apphosting-connections-delete.ts
+++ b/src/commands/apphosting-connections-delete.ts
@@ -1,0 +1,40 @@
+import { Command } from "../command";
+import { Options } from "../options";
+import { needProjectId } from "../projectUtils";
+import requireInteractive from "../requireInteractive";
+import {
+  deleteAllDeveloperConnectAppHostingConnection,
+  deleteDeveloperConnectAppHostingConnection,
+} from "../apphosting";
+import { FirebaseError } from "../error";
+
+export const command = new Command("apphosting:connections:delete")
+  .description("deletes all connections for the current project")
+  .option("-l, --location <location>", "specify the region of the connection")
+  .option("-c, --connectionId <connectionId>", "specify the id of connection you want to delete")
+  .option("-a, --all", "deletes all apphosting connections for this project", false)
+  .before(requireInteractive)
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    const location = options.location as string | null;
+    const connectionId = options.connectionId as string | null;
+    const deleteAll = options.all as boolean;
+
+    if (!connectionId && deleteAll === false) {
+      throw new FirebaseError(
+        "To delete a connection a connectionId is required. See `firebase apphosting:backends:delete --help`",
+      );
+    }
+
+    if (!location) {
+      throw new FirebaseError(
+        "A location is required. See `firebase apphosting:backends:delete --help`",
+      );
+    }
+
+    if (connectionId) {
+      await deleteDeveloperConnectAppHostingConnection(projectId, location, connectionId);
+    } else if (deleteAll) {
+      await deleteAllDeveloperConnectAppHostingConnection(projectId, location);
+    }
+  });

--- a/src/commands/apphosting-connections-list.ts
+++ b/src/commands/apphosting-connections-list.ts
@@ -1,0 +1,29 @@
+import { Command } from "../command";
+import { Options } from "../options";
+import { needProjectId } from "../projectUtils";
+import requireInteractive from "../requireInteractive";
+import { listDeveloperConnectAppHostingConnections } from "../apphosting";
+import { logBullet } from "../utils";
+import { FirebaseError } from "../error";
+
+export const command = new Command("apphosting:connections:list")
+  .description("lists all dev connect connections for the current project")
+  .option("-l, --location <location>", "specify the region of the connection")
+  .before(requireInteractive)
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    const location = options.location as string | null;
+
+    if (!location) {
+      throw new FirebaseError(
+        "A location is requried. See `firebase apphosting:connections:list --help`",
+      );
+    }
+
+    const connections = await listDeveloperConnectAppHostingConnections(projectId, location);
+
+    for (let i = 0; i < connections.length; i++) {
+      const connection = connections[i];
+      logBullet(connection.name);
+    }
+  });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -180,6 +180,9 @@ export function load(client: any): any {
       client.apphosting.rollouts = {};
       client.apphosting.rollouts.create = loadCommand("apphosting-rollouts-create");
       client.apphosting.rollouts.list = loadCommand("apphosting-rollouts-list");
+      client.apphosting.connections = {};
+      client.apphosting.connections.delete = loadCommand("apphosting-connections-delete");
+      client.apphosting.connections.list = loadCommand("apphosting-connections-list");
     }
   }
   client.login = loadCommand("login");


### PR DESCRIPTION
### Description

Adds `apphosting:connections:list` and `apphosting:connections:delete` commands for debug purposes. These would be really helpful as we continue to test the developer connect integration since the developer connect UI is not ready yet. 

These commands are gated by the `internaltesting` flag.

### Sample Commands

- To list all dev connect apphosting connections in a region: `firebase apphosting:connections:list --location="us-central1" --project="<project>"`
- To delete a dev connect apphosting connection: `firebase apphosting:connections:delete --location="us-central1" --connectionId="some-id" --project=<project>`
- To delete all dev connect apphosting connections: `firebase apphosting:connections:list --location="us-central1" --project=<project> --all`
