### PR TITLE
fix Next.js path issue on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Release Firestore Emulator version 1.19.5 which adds support for import and export in Datastore Mode (#7020).
-- fix non static check for not-found route in Next.js 14.2 (#7012)
+- Fix non static check for not-found route in Next.js 14.2 (#7012)
+- Fix Next.js path issue on Windows (#7031)

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -477,6 +477,7 @@ export async function getProductionDistDirFiles(
         cwd: join(sourceDir, distDir),
         nodir: true,
         absolute: true,
+        realpath: IS_WINDOWS,
       },
       (err, matches) => {
         if (err) reject(err);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

The `glob` call being used to remove development only files from Next.js backends(#6731) is returning posix paths, which breaks the string replace done on Windows here: https://github.com/firebase/firebase-tools/blob/ae1562de37dcb63570d76059ab7927ffe571551c/src/frameworks/next/index.ts#L661 

Using the `realpath` option in Windows makes `glob` return the proper paths.

Fixes #7022 

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
