### PR TITLE
Use shell:true for Pub/Sub emulator on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-- Release Firestore Emulator version 1.19.5 which adds support for import and export in Datastore Mode (#7020).
+- Release Firestore Emulator version 1.19.5 which adds support for import and export in Datastore Mode. (#7020)
 - Fix non static check for not-found route in Next.js 14.2 (#7012)
 - Fix Next.js path issue on Windows (#7031)
+- Fixes an issue where the Pub/Sub emulator would not start on Windows due to CVE-2024-27980. (#7026)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -378,7 +378,7 @@ async function _runBinary(
       if (command.shell && utils.IS_WINDOWS) {
         opts.shell = true;
       }
-      emulator.instance = childProcess.spawn(command.binary, command.args);
+      emulator.instance = childProcess.spawn(command.binary, command.args, opts);
     } catch (e: any) {
       if (e.code === "EACCES") {
         // Known issue when WSL users don't have java

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -181,6 +181,7 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
       "single_project_mode",
     ],
     joinArgs: false,
+    shell: false,
   },
   firestore: {
     binary: "java",
@@ -204,6 +205,7 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
       // "single_project_mode_error",
     ],
     joinArgs: false,
+    shell: false,
   },
   storage: {
     // This is for the Storage Emulator rules runtime, which is started
@@ -219,18 +221,21 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
     ],
     optionalArgs: [],
     joinArgs: false,
+    shell: false,
   },
   pubsub: {
     binary: getExecPath(Emulators.PUBSUB)!,
     args: [],
     optionalArgs: ["port", "host"],
     joinArgs: true,
+    shell: true,
   },
   ui: {
     binary: "node",
     args: [getExecPath(Emulators.UI)],
     optionalArgs: [],
     joinArgs: false,
+    shell: false,
   },
 };
 
@@ -306,6 +311,7 @@ export function _getCommand(
     args: cmdLineArgs,
     optionalArgs: baseCmd.optionalArgs,
     joinArgs: baseCmd.joinArgs,
+    shell: baseCmd.shell,
   };
 }
 
@@ -360,7 +366,7 @@ async function _runBinary(
     const logger = EmulatorLogger.forEmulator(emulator.name);
     emulator.stdout = fs.createWriteStream(getLogFileName(emulator.name));
     try {
-      emulator.instance = childProcess.spawn(command.binary, command.args, {
+      const opts: childProcess.SpawnOptions = {
         env: { ...process.env, ...extraEnv },
         // `detached` must be true as else a SIGINT (Ctrl-c) will stop the child process before we can handle a
         // graceful shutdown and call `downloadableEmulators.stop(...)` ourselves.
@@ -368,7 +374,11 @@ async function _runBinary(
         // related to this issue: https://github.com/grpc/grpc-java/pull/6512
         detached: true,
         stdio: ["inherit", "pipe", "pipe"],
-      });
+      };
+      if (command.shell && utils.IS_WINDOWS) {
+        opts.shell = true;
+      }
+      emulator.instance = childProcess.spawn(command.binary, command.args);
     } catch (e: any) {
       if (e.code === "EACCES") {
         // Known issue when WSL users don't have java

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -147,6 +147,7 @@ export interface DownloadableEmulatorCommand {
   args: string[];
   optionalArgs: string[];
   joinArgs: boolean;
+  shell: boolean;
 }
 
 export interface EmulatorDownloadOptions {

--- a/src/functions/python.ts
+++ b/src/functions/python.ts
@@ -2,6 +2,7 @@ import * as path from "path";
 import * as spawn from "cross-spawn";
 import * as cp from "child_process";
 import { logger } from "../logger";
+import { IS_WINDOWS } from "../utils";
 
 /**
  * Default directory for python virtual environment.
@@ -12,12 +13,11 @@ export const DEFAULT_VENV_DIR = "venv";
  *  Get command for running Python virtual environment for given platform.
  */
 export function virtualEnvCmd(cwd: string, venvDir: string): { command: string; args: string[] } {
-  const activateScriptPath =
-    process.platform === "win32" ? ["Scripts", "activate.bat"] : ["bin", "activate"];
+  const activateScriptPath = IS_WINDOWS ? ["Scripts", "activate.bat"] : ["bin", "activate"];
   const venvActivate = `"${path.join(cwd, venvDir, ...activateScriptPath)}"`;
   return {
-    command: process.platform === "win32" ? venvActivate : ".",
-    args: [process.platform === "win32" ? "" : venvActivate],
+    command: IS_WINDOWS ? venvActivate : ".",
+    args: [IS_WINDOWS ? "" : venvActivate],
   };
 }
 


### PR DESCRIPTION

### Description
Fixes #7026. 

https://github.com/nodejs/node/issues/52554 [Release Blog Post](https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2#command-injection-via-args-parameter-of-child_processspawn-without-shell-option-enabled-on-windows-cve-2024-27980---high) causes spawn/spawnSync to error out when executing bat/cmd files directly without the `shell:true` option.
