### PR TITLE
Skip creating env variables with undefined values

### DIFF
--- a/src/functions/runtimeConfigExport.ts
+++ b/src/functions/runtimeConfigExport.ts
@@ -19,7 +19,7 @@ export interface ProjectConfigInfo {
 export interface EnvMap {
   origKey: string;
   newKey: string;
-  value: string;
+  value?: string;
   err?: string;
 }
 
@@ -185,7 +185,9 @@ function escape(s: string): string {
  * Convert env var mapping to  dotenv compatible string.
  */
 export function toDotenvFormat(envs: EnvMap[], header = ""): string {
-  const lines = envs.map(({ newKey, value }) => `${newKey}="${escape(value)}"`);
+  const lines = envs
+    .filter((env) => env.value !== undefined)
+    .map(({ newKey, value }) => `${newKey}="${escape(value!)}"`);
   const maxLineLen = Math.max(...lines.map((l) => l.length));
   return (
     `${header}\n` +

--- a/src/test/functions/runtimeConfigExport.spec.ts
+++ b/src/test/functions/runtimeConfigExport.spec.ts
@@ -131,6 +131,18 @@ describe("functions-config-export", () => {
       expect(errors).to.be.empty;
     });
 
+    it("should produce valid dotenv file with keys and skip undefined values", () => {
+      const dotenv = configExport.toDotenvFormat([
+        { origKey: "service.api.url", newKey: "SERVICE_API_URL", value: "hello" },
+        { origKey: "service.api.name", newKey: "SERVICE_API_NAME", value: undefined },
+      ]);
+      const { envs, errors } = env.parse(dotenv);
+      expect(envs).to.be.deep.equal({
+        SERVICE_API_URL: "hello",
+      });
+      expect(errors).to.be.empty;
+    });
+
     it("should preserve newline characters", () => {
       const dotenv = configExport.toDotenvFormat([
         { origKey: "service.api.url", newKey: "SERVICE_API_URL", value: "hello\nthere\nworld" },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #7036. From what I can gather, it is possible that env values can be `undefined`. 

I think we should skip the creation of  env if their value is `undefined`.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

1. Run `firebase functions:config:set test.user=test-user`
1. Run `firebase functions:config:set some.random.planet=`
1. Run `
    - Outputs the ff JSON object, where `some.random` doesn't have a value
```json
{
  "some": {
    "random": {}
  },
  "test": {
    "user": "test-user"
  }
```
1. Run `firebase functions:config:export`
```
i  Importing functions configs from projects [PROJECT_ID]
i  Importing configs from projects: [PROJECT_ID]
✔  Wrote functions/.env.default
✔  Wrote functions/.env.local
✔  Wrote functions/.env
```
