### PR TITLE
Change with-dev-connect flag to with-cloud-build-repos

### DIFF
--- a/src/apphosting/index.ts
+++ b/src/apphosting/index.ts
@@ -44,10 +44,10 @@ export async function doSetup(
   webAppName: string | null,
   location: string | null,
   serviceAccount: string | null,
-  withDevConnect: boolean,
+  withCloudBuildRepos: boolean,
 ): Promise<void> {
   await Promise.all([
-    ...(withDevConnect ? [ensure(projectId, developerConnectOrigin(), "apphosting", true)] : []),
+    ensure(projectId, developerConnectOrigin(), "apphosting", true),
     ensure(projectId, cloudbuildOrigin(), "apphosting", true),
     ensure(projectId, secretManagerOrigin(), "apphosting", true),
     ensure(projectId, cloudRunApiOrigin(), "apphosting", true),
@@ -87,9 +87,9 @@ export async function doSetup(
     logWarning(`Firebase web app not set`);
   }
 
-  const gitRepositoryConnection: Repository | GitRepositoryLink = withDevConnect
-    ? await githubConnections.linkGitHubRepository(projectId, location)
-    : await repo.linkGitHubRepository(projectId, location);
+  const gitRepositoryConnection: Repository | GitRepositoryLink = withCloudBuildRepos
+    ? await repo.linkGitHubRepository(projectId, location)
+    : await githubConnections.linkGitHubRepository(projectId, location);
 
   const rootDir = await promptOnce({
     name: "rootDir",

--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -18,9 +18,8 @@ export const command = new Command("apphosting:backends:create")
     "",
   )
   .option(
-    "-w, --with-dev-connect",
-    "use the Developer Connect flow instead of Cloud Build Repositories (testing)",
-    true,
+    "-w, --with-cloud-build-repos",
+    "use Cloud Build Repositories flow instead of the Developer Connect flow",
   )
   .before(ensureApiEnabled)
   .before(requireInteractive)
@@ -29,13 +28,13 @@ export const command = new Command("apphosting:backends:create")
     const webApp = options.app;
     const location = options.location;
     const serviceAccount = options.serviceAccount;
-    const withDevConnect = options.withDevConnect as boolean;
+    const withCloudBuildRepos = options.withCloudBuildRepos as boolean;
 
     await doSetup(
       projectId,
       webApp as string | null,
       location as string | null,
       serviceAccount as string | null,
-      withDevConnect,
+      withCloudBuildRepos,
     );
   });


### PR DESCRIPTION
App Hosting CLI now defaults to using developer connect. We need to still be able to fall back to using cloud build Repos.