### PR TITLE
Added a simple warning around vector embeds

### DIFF
--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -7,7 +7,7 @@ import { EmulatorInfo, EmulatorInstance, Emulators } from "./types";
 import { FirebaseError } from "../error";
 import { EmulatorLogger } from "./emulatorLogger";
 import { RC } from "../rc";
-import { BuildResult } from "../dataconnect/types";
+import { BuildResult, requiresVector } from "../dataconnect/types";
 
 export interface DataConnectEmulatorArgs {
   projectId?: string;
@@ -22,9 +22,17 @@ export class DataConnectEmulator implements EmulatorInstance {
   constructor(private args: DataConnectEmulatorArgs) {}
   private logger = EmulatorLogger.forEmulator(Emulators.DATACONNECT);
 
-  start(): Promise<void> {
+  async start(): Promise<void> {
     const port = this.args.port || Constants.getDefaultPort(Emulators.DATACONNECT);
     this.logger.log("DEBUG", `Using Postgres connection string: ${this.getLocalConectionString()}`);
+    const info = await this.build();
+    if (requiresVector(info.metadata)) {
+      if (Constants.isDemoProject(this.args.projectId)) {
+        this.logger.logLabeled("WARN", "Data Connect", "Detected a 'demo-' project, but vector embeddings require a real project. Operations that use vector_embed will fail.");
+      } else {
+        this.logger.logLabeled("WARN", "Data Connect", "Operations that use vector_embed will make calls to production Vertex AI");
+      }
+    }
     return start(Emulators.DATACONNECT, {
       ...this.args,
       http_port: port,

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -28,9 +28,17 @@ export class DataConnectEmulator implements EmulatorInstance {
     const info = await this.build();
     if (requiresVector(info.metadata)) {
       if (Constants.isDemoProject(this.args.projectId)) {
-        this.logger.logLabeled("WARN", "Data Connect", "Detected a 'demo-' project, but vector embeddings require a real project. Operations that use vector_embed will fail.");
+        this.logger.logLabeled(
+          "WARN",
+          "Data Connect",
+          "Detected a 'demo-' project, but vector embeddings require a real project. Operations that use vector_embed will fail.",
+        );
       } else {
-        this.logger.logLabeled("WARN", "Data Connect", "Operations that use vector_embed will make calls to production Vertex AI");
+        this.logger.logLabeled(
+          "WARN",
+          "Data Connect",
+          "Operations that use vector_embed will make calls to production Vertex AI",
+        );
       }
     }
     return start(Emulators.DATACONNECT, {


### PR DESCRIPTION
### Description
Added a simple warning that vector embeddings will use production APIs/fail if they are not available. Feel free to suggest different language here, but I feel pretty strongly that we ought to call out any production calls from the emulator suite
