### PR TITLE
Handle schema migration errors when validateOnly=false

### DIFF
--- a/src/commands/dataconnect-sdk-generate.ts
+++ b/src/commands/dataconnect-sdk-generate.ts
@@ -30,7 +30,7 @@ export const command = new Command("dataconnect:sdk:generate")
       const dataconnectEmulator = new DataConnectEmulator(args);
       for (const conn of serviceInfo.connectorInfo) {
         const output = await dataconnectEmulator.generate(conn.connectorYaml.connectorId);
-        console.log(output);
+        logger.info(output);
         logger.info(`Generated SDKs for ${conn.connectorYaml.connectorId}`);
       }
     }

--- a/src/commands/dataconnect-sql-migrate.ts
+++ b/src/commands/dataconnect-sql-migrate.ts
@@ -32,8 +32,8 @@ export const command = new Command("dataconnect:sql:migrate [serviceId]")
       );
     }
     const diffs = await migrateSchema({
-      options, 
-      schema: serviceInfo.schema, 
+      options,
+      schema: serviceInfo.schema,
       allowNonInteractiveMigration: true,
       validateOnly: true,
     });

--- a/src/commands/dataconnect-sql-migrate.ts
+++ b/src/commands/dataconnect-sql-migrate.ts
@@ -31,11 +31,12 @@ export const command = new Command("dataconnect:sql:migrate [serviceId]")
         "dataconnect.yaml is missing field schema.datasource.postgresql.cloudsql.instanceId",
       );
     }
-    const diffs = await migrateSchema(
-      options,
-      serviceInfo.schema,
-      /** allowNonInteractiveMigration=*/ true,
-    );
+    const diffs = await migrateSchema({
+      options, 
+      schema: serviceInfo.schema, 
+      allowNonInteractiveMigration: true,
+      validateOnly: true,
+    });
     if (diffs.length) {
       logger.info(
         `Schema sucessfully migrated! Run 'firebase deploy' to deploy your new schema to your Data Connect service.`,

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -90,7 +90,7 @@ export async function deleteService(
 
 /** Schema methods */
 
-export async function getSchema(serviceName: string): Promise<types.Schema | undefined> {
+export async function getSchema(serviceName: string): Promise<types.Schema> {
   const res = await dataconnectClient().get<types.Schema>(
     `${serviceName}/schemas/${types.SCHEMA_ID}`,
   );

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -1,5 +1,4 @@
 import * as cloudSqlAdminClient from "../gcp/cloudsql/cloudsqladmin";
-import { execute } from "../gcp/cloudsql/connect";
 import * as utils from "../utils";
 import { grantRolesToCloudSqlServiceAccount } from "./checkIam";
 import { Instance } from "../gcp/cloudsql/types";
@@ -79,28 +78,6 @@ export async function provisionCloudSql(args: {
     await grantRolesToCloudSqlServiceAccount(projectId, instanceId, [GOOGLE_ML_INTEGRATION_ROLE]);
   }
   return connectionName;
-}
-
-export const REQUIRED_EXTENSIONS_COMMANDS = [
-  `CREATE SCHEMA IF NOT EXISTS "public"`,
-  `CREATE EXTENSION IF NOT EXISTS "uuid-ossp" with SCHEMA public`,
-  `CREATE EXTENSION IF NOT EXISTS "vector" with SCHEMA public`,
-  `CREATE EXTENSION IF NOT EXISTS "google_ml_integration" with SCHEMA public CASCADE`,
-];
-// TODO: This should not be hardcoded, instead should be returned during schema migration
-export async function installRequiredExtensions(
-  projectId: string,
-  instanceId: string,
-  databaseId: string,
-  username: string,
-) {
-  await execute(REQUIRED_EXTENSIONS_COMMANDS, {
-    projectId,
-    instanceId,
-    databaseId,
-    username,
-    silent: true,
-  });
 }
 
 /**

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -36,16 +36,14 @@ export async function diffSchema(schema: Schema): Promise<Diff[]> {
   return [];
 }
 
-export async function migrateSchema(args: 
-  {
-    options: Options,
-    schema: Schema,
-    allowNonInteractiveMigration: boolean,
-    validateOnly: boolean,
-  }
-): Promise<Diff[]> {
+export async function migrateSchema(args: {
+  options: Options;
+  schema: Schema;
+  allowNonInteractiveMigration: boolean;
+  validateOnly: boolean;
+}): Promise<Diff[]> {
   const { schema, validateOnly } = args;
-  
+
   const databaseId = schema.primaryDatasource.postgresql?.database;
   if (!databaseId) {
     throw new FirebaseError(
@@ -63,8 +61,7 @@ export async function migrateSchema(args:
   } catch (err: any) {
     const incompatible = getIncompatibleSchemaError(err);
     if (!incompatible) {
-      console.log("couldn't get incompatible err")
-      // If we got a different type of error, throw it 
+      // If we got a different type of error, throw it
       throw err;
     }
     // Try to migrate schema
@@ -73,21 +70,22 @@ export async function migrateSchema(args:
       incompatibleSchemaError: incompatible,
       instanceId,
       databaseId,
-    })
+    });
     // Then, try to upsert schema again. If there still is an error, just throw it now
     await upsertSchema(schema, validateOnly);
     return diffs;
   }
 }
 
-async function handleIncompatibleSchemaError (args: {
-  incompatibleSchemaError: IncompatibleSqlSchemaError,
-  options: Options,
-  instanceId: string,
-  databaseId: string,
-  allowNonInteractiveMigration: boolean,
+async function handleIncompatibleSchemaError(args: {
+  incompatibleSchemaError: IncompatibleSqlSchemaError;
+  options: Options;
+  instanceId: string;
+  databaseId: string;
+  allowNonInteractiveMigration: boolean;
 }): Promise<Diff[]> {
-  const { incompatibleSchemaError, options, instanceId, databaseId, allowNonInteractiveMigration } = args;
+  const { incompatibleSchemaError, options, instanceId, databaseId, allowNonInteractiveMigration } =
+    args;
   const projectId = needProjectId(options);
   const iamUser = await setupIAMUser(instanceId, databaseId, options);
   const choice = await promptForSchemaMigration(
@@ -187,7 +185,6 @@ function toString(diff: Diff) {
 function getIncompatibleSchemaError(err: any): IncompatibleSqlSchemaError | undefined {
   const original = err.context?.body.error;
   const details: any[] = original.details;
-  console.log(`details is ${JSON.stringify(details)}`)
   const incompatibles = details.filter((d) => d["@type"] === IMCOMPATIBLE_SCHEMA_ERROR_TYPESTRING);
   // Should never get multiple incompatible schema errors
   return incompatibles[0];

--- a/src/dataconnect/types.ts
+++ b/src/dataconnect/types.ts
@@ -32,6 +32,7 @@ export interface Datasource {
 export interface PostgreSql {
   database: string;
   cloudSql: CloudSqlInstance;
+  schemaValidation?: "STRICT" | "NONE" | "SQL_SCHEMA_VALIDATION_UNSPECIFIED";
 }
 
 export interface CloudSqlInstance {

--- a/src/deploy/dataconnect/release.ts
+++ b/src/deploy/dataconnect/release.ts
@@ -1,9 +1,8 @@
 import * as utils from "../../utils";
 import { Connector, ServiceInfo } from "../../dataconnect/types";
-import { listConnectors, upsertSchema, upsertConnector } from "../../dataconnect/client";
+import { listConnectors, upsertConnector } from "../../dataconnect/client";
 import { promptDeleteConnector } from "../../dataconnect/prompts";
 import { Options } from "../../options";
-import { FirebaseError } from "../../error";
 import { ResourceFilter } from "../../dataconnect/filters";
 import { migrateSchema } from "../../dataconnect/schemaMigration";
 
@@ -38,16 +37,13 @@ export default async function (
     .map((s) => s.schema);
 
   if (wantSchemas.length) {
-    utils.logLabeledBullet(
-      "dataconnect",
-      "Releasing Data Connect schemas...",
-    );
+    utils.logLabeledBullet("dataconnect", "Releasing Data Connect schemas...");
 
     // Then, migrate if needed and deploy schemas
     for (const s of wantSchemas) {
       await migrateSchema({
-        options, 
-        schema: s, 
+        options,
+        schema: s,
         allowNonInteractiveMigration: false,
         validateOnly: false,
       });

--- a/src/deploy/dataconnect/release.ts
+++ b/src/deploy/dataconnect/release.ts
@@ -38,24 +38,19 @@ export default async function (
     .map((s) => s.schema);
 
   if (wantSchemas.length) {
-    // If needed, migrate schemas
     utils.logLabeledBullet(
       "dataconnect",
-      "Checking if database schemas match Data Connect schemas...",
+      "Releasing Data Connect schemas...",
     );
+
+    // Then, migrate if needed and deploy schemas
     for (const s of wantSchemas) {
-      await migrateSchema(options, s, /** allowNonInteractiveMigration=*/ false);
-    }
-    // Then, deploy schemas
-    utils.logLabeledBullet("dataconnect", "Releasing schemas...");
-    const schemaPromises = await Promise.allSettled(wantSchemas.map((s) => upsertSchema(s)));
-    const failedSchemas = schemaPromises.filter(
-      (p): p is PromiseRejectedResult => p.status === "rejected",
-    );
-    if (failedSchemas.length) {
-      throw new FirebaseError(
-        `Errors while updating your schemas:\n ${failedSchemas.map((f) => f.reason).join("\n")}`,
-      );
+      await migrateSchema({
+        options, 
+        schema: s, 
+        allowNonInteractiveMigration: false,
+        validateOnly: false,
+      });
     }
     utils.logLabeledBullet("dataconnect", "Schemas released.");
   }

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -172,7 +172,7 @@ export async function setupIAMUser(
   return user;
 }
 
-function firebaseowner(databaseId: string) {
+export function firebaseowner(databaseId: string) {
   return `firebaseowner_${databaseId}_public`;
 }
 


### PR DESCRIPTION
### Description
2 big fixes for schema migration here:
- First, we now handle schema migration errors when validateOnly=false
- Second, we will actually set role to `firebaseowner _dbid_public` before doing migrations, so that it owns any tables create

### Scenarios Tested
I tested that deploy triggers schema migration even on a fresh project
I also tested that I can login on one account, run a schema migration that creates tables, then log in on another account and migrate those tables.

