### PR TITLE
Fixing emulator timeout issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Increased the timeout for waitng for emulators to start to 60s.
+- Increased the timeout for waiting for emulators to start to 60s. (#7091)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Increased the timeout for waitng for emulators to start to 60s.

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -69,6 +69,7 @@ export class DataConnectEmulator implements EmulatorInstance {
       host,
       port,
       pid: getPID(Emulators.DATACONNECT),
+      timeout: 10_000,
     };
   }
   getName(): Emulators {

--- a/src/emulator/portUtils.ts
+++ b/src/emulator/portUtils.ts
@@ -160,11 +160,14 @@ export async function checkListenable(
 }
 
 /**
- * Wait for a port to be available on the given host. Checks every 250ms for up to 5s.
+ * Wait for a port to be available on the given host. Checks every 250ms for up to timeout (default 60s).
  */
-export async function waitForPortUsed(port: number, host: string): Promise<void> {
+export async function waitForPortUsed(
+  port: number,
+  host: string,
+  timeout: number = 60_000,
+): Promise<void> {
   const interval = 200;
-  const timeout = 5_000;
   try {
     await tcpport.waitUntilUsedOnHost(port, host, interval, timeout);
   } catch (e: any) {

--- a/src/emulator/registry.ts
+++ b/src/emulator/registry.ts
@@ -35,7 +35,7 @@ export class EmulatorRegistry {
     // No need to wait for the Extensions emulator to close its port, since it runs on the Functions emulator.
     if (instance.getName() !== Emulators.EXTENSIONS) {
       const info = instance.getInfo();
-      await portUtils.waitForPortUsed(info.port, connectableHostname(info.host));
+      await portUtils.waitForPortUsed(info.port, connectableHostname(info.host), info.timeout);
     }
   }
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -138,12 +138,15 @@ export interface EmulatorInfo {
   pid?: number;
   reservedPorts?: number[];
 
-  /** All addresses that an emulator listens on. */
+  // All addresses that an emulator listens on.
   listen?: ListenSpec[];
 
-  /** The primary IP address that the emulator listens on. */
+  // The primary IP address that the emulator listens on.
   host: string;
   port: number;
+
+  // How long to wait for the emulator to start before erroring out.
+  timeout?: number;
 }
 
 export interface DownloadableEmulatorCommand {


### PR DESCRIPTION
### Description
Increase the timeout waiting for emulators to start back up to 60s.
Fixes #7091.
