### PR TITLE
Updating extensions-emulator-test to modern dep versions

### DIFF
--- a/scripts/extensions-emulator-tests/functions/package.json
+++ b/scripts/extensions-emulator-tests/functions/package.json
@@ -6,8 +6,8 @@
     "node": "20"
   },
   "dependencies": {
-    "firebase-admin": "^9.3.0",
-    "firebase-functions": "^3.22.0",
+    "firebase-admin": "^12.1.0",
+    "firebase-functions": "^5.0.0",
     "fs-extra": "^5.0.0",
     "rimraf": "^3.0.0"
   },


### PR DESCRIPTION
### Description
Update extensions emulator test to use more recent versions of firebase-admin and firebase-functions. 

The previous version of firebase-admin is pulling in a version of jwt that has a security vulnerability. It has 0 effect on the security of firebase-tools, but I've been getting autoassigned bugs to remediate it.

