### PR TITLE
fix copied functions dist dir files for Next.js when source config ends with slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Increased the timeout for waiting for emulators to start to 60s. (#7091)
 - Fixes infinite loop when trying to create a Hosting site.
+- Fix copied functions dist dir files for Next.js when source config ends with slash (#7099)

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -658,7 +658,9 @@ export async function ɵcodegenFunctionsDirectory(
 
   await Promise.all(
     productionDistDirfiles.map((file) =>
-      copy(file, file.replace(sourceDir, destDir), { recursive: true }),
+      copy(join(sourceDir, distDir, file), join(destDir, distDir, file), {
+        recursive: true,
+      }),
     ),
   );
 

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -464,6 +464,8 @@ export function getRoutesWithServerAction(
 
 /**
  * Get files in the dist directory to be deployed to Firebase, ignoring development files.
+ *
+ * Return relative paths to the dist directory.
  */
 export async function getProductionDistDirFiles(
   sourceDir: string,
@@ -476,7 +478,7 @@ export async function getProductionDistDirFiles(
         ignore: [join("cache", "webpack", "*-development", "**"), join("cache", "eslint", "**")],
         cwd: join(sourceDir, distDir),
         nodir: true,
-        absolute: true,
+        absolute: false,
         realpath: IS_WINDOWS,
       },
       (err, matches) => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`path.replace` was breaking when source dir was e.g. `web/`, causing the final folder to be `.hosting/functions.next` instead of `.hosting/functions/.next`. Fixes #7062

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
