### PR TITLE
Improved data connect init

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -138,7 +138,6 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   await config.askWriteProjectFile(join(dir, "schema", "schema.gql"), SCHEMA_TEMPLATE);
   await config.askWriteProjectFile(join(dir, "connector", "queries.gql"), QUERIES_TEMPLATE);
   await config.askWriteProjectFile(join(dir, "connector", "mutations.gql"), MUTATIONS_TEMPLATE);
-  // TODO: Skip this for existing instances
   if (
     setup.projectId &&
     (newInstance || newDB) &&

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "fs";
 import { Config } from "../../../config";
 import { Setup } from "../..";
 import { provisionCloudSql } from "../../../dataconnect/provisionCloudSql";
+import * as cloudsql from "../../../gcp/cloudsql/cloudsqladmin";
 import { ensureApis } from "../../../dataconnect/ensureApis";
 import { listLocations } from "../../../dataconnect/client";
 
@@ -52,29 +53,60 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
     type: "input",
     default: "my-connector",
   });
-  const dir: string =
-    config.get("dataconnect.source") ||
-    (await promptOnce({
-      message: "What directory should be used for DataConnect config and schema?",
-      type: "input",
-      default: "dataconnect",
-    }));
+  const dir: string = config.get("dataconnect.source") || "dataconnect";
   if (!config.has("dataconnect")) {
     config.set("dataconnect.source", dir);
     config.set("dataconnect.location", locationId);
   }
-  // TODO: Listinstances from CloudSQL, and filter to only the free trial appropriate ones.
-  const cloudSqlInstanceId = await promptOnce({
-    message: `What CloudSQL instance ID in ${locationId} would you like to use (it will be created if it does not exist)?`,
-    type: "input",
-    default: `dataconnect-test`,
-  });
-  // TODO: ListDatabases from CloudSQL.
-  const cloudSqlDatabase = await promptOnce({
-    message: `Which database would you like to use from ${cloudSqlInstanceId} (it will be created if it does not exist)?`,
-    type: "input",
-    default: `dataconnect-test`,
-  });
+  let cloudSqlInstanceId = "";
+  let newInstance = false;
+  if (setup.projectId) {
+    const instances = await cloudsql.listInstances(setup.projectId);
+    const instancesInLocation = instances.filter((i) => i.region === locationId);
+    const choices = instancesInLocation.map((i) => {
+      return { name: i.name, value: i.name };
+    });
+    choices.push({ name: "Create a new instance", value: "" });
+    if (instancesInLocation.length) {
+      cloudSqlInstanceId = await promptOnce({
+        message: `Which CloudSSQL in ${locationId} would you like to use?`,
+        type: "list",
+        choices,
+      });
+    }
+  }
+  if (cloudSqlInstanceId === "") {
+    newInstance = true;
+    cloudSqlInstanceId = await promptOnce({
+      message: `What ID would you like to use for your new CloudSQL instance?`,
+      type: "input",
+      default: `dataconnect-test`,
+    });
+  }
+  let cloudSqlDatabase = "";
+  let newDB = false;
+  if (!newInstance && setup.projectId) {
+    const dbs = await cloudsql.listDatabases(setup.projectId, cloudSqlInstanceId);
+    const choices = dbs.map((d) => {
+      return { name: d.name, value: d.name };
+    });
+    choices.push({ name: "Create a new database", value: "" });
+    if (dbs.length) {
+      cloudSqlDatabase = await promptOnce({
+        message: `Which database in ${cloudSqlInstanceId} would you like to use?`,
+        type: "list",
+        choices,
+      });
+    }
+  }
+  if (cloudSqlDatabase === "") {
+    newDB = true;
+    cloudSqlDatabase = await promptOnce({
+      message: `What ID would you like to use for your new database in ${cloudSqlInstanceId}?`,
+      type: "input",
+      default: `dataconnect`,
+    });
+  }
 
   // postgresql://localhost:5432 is a default out of the box value for most installations of Postgres
   const defaultConnectionString =
@@ -109,6 +141,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   // TODO: Skip this for existing instances
   if (
     setup.projectId &&
+    (newInstance || newDB) &&
     (await confirm({
       message:
         "Would you like to provision your CloudSQL instance and database now? This will take a few minutes.",

--- a/templates/init/dataconnect/mutations.gql
+++ b/templates/init/dataconnect/mutations.gql
@@ -1,5 +1,4 @@
 # # Example mutations
-# # TODO: Replace with a really good illustrative example from devrel!
 # mutation createOrder($name: String!) {
 #   order_insert(data : {name: $name})
 # }

--- a/templates/init/dataconnect/queries.gql
+++ b/templates/init/dataconnect/queries.gql
@@ -1,5 +1,4 @@
 # # Example query
-# # TODO: Replace with a really good illustrative example from devrel!
 # query listOrders {
 #   orders {
 #     name

--- a/templates/init/dataconnect/schema.gql
+++ b/templates/init/dataconnect/schema.gql
@@ -1,5 +1,4 @@
 # # Example schema
-# # TODO: Replace with a really good illustrative example from devrel!
 # type Product @table {
 #   name: String!
 #   price: Int!


### PR DESCRIPTION
### Description
- Use list APIs for choosing instance and DB.
- Clean up some todos in template files.
- Skip provisioning question if using existing instance and DB.
- Removed 'what directory do you want to use' question.

### Scenarios Tested
-New instance, new db
- Existing instance, existing db
- exisiting instance, new db