### PR TITLE
Fix first rendering of the result view

### DIFF
--- a/firebase-vscode/common/messaging/protocol.ts
+++ b/firebase-vscode/common/messaging/protocol.ts
@@ -110,6 +110,9 @@ export interface WebviewToExtensionParamsMap {
 
   /** Deploy all connectors/services to production */
   "fdc.deploy-all": void;
+
+  // Initialize "result" tab.
+  getDataConnectResults: void;
 }
 
 export interface DataConnectResults {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

When executing queries for the first time,
the result pannel initially does not show anything until a second query is initiated.

This is because the list of "execution items"
is updated before the execution panel becomes visible.
As such, the result view didn't have the opportunity to listen to notifyDataConnectResults yet.

This PR adds the equivalent of getInitialData for notifyDataConnectResults

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
