### PR TITLE
App Hosting: Take optional web app Id instead of  web app name

### DIFF
--- a/src/apphosting/app.ts
+++ b/src/apphosting/app.ts
@@ -16,8 +16,8 @@ type FirebaseWebApp = { name: string; id: string };
 
 /**
  * If firebaseWebAppId is provided and a matching web app exists, it is
- * returned. If firebaseWebAppId is a new web app with the given backendId is
- * created.
+ * returned. If firebaseWebAppId is not provided, a new web app with the given
+ * backendId is created.
  * @param projectId user's projectId
  * @param firebaseWebAppId (optional) id of an existing Firebase web app
  * @param backendId name of the app hosting backend

--- a/src/apphosting/app.ts
+++ b/src/apphosting/app.ts
@@ -34,7 +34,7 @@ async function getOrCreateWebApp(
     const webApp = webAppsInProject.find((app) => app.appId === firebaseWebAppId);
     if (webApp === undefined) {
       throw new FirebaseError(
-        `The web app with Id '${firebaseWebAppId}' does not exist in project ${projectId}`,
+        `The web app '${firebaseWebAppId}' does not exist in project ${projectId}`,
       );
     }
 

--- a/src/apphosting/app.ts
+++ b/src/apphosting/app.ts
@@ -1,6 +1,6 @@
 import { AppMetadata, AppPlatform, createWebApp, listFirebaseApps } from "../management/apps";
 import { FirebaseError } from "../error";
-import { logWarning } from "../utils";
+import { logSuccess, logWarning } from "../utils";
 
 const CREATE_NEW_FIREBASE_WEB_APP = "CREATE_NEW_WEB_APP";
 const CONTINUE_WITHOUT_SELECTING_FIREBASE_WEB_APP = "CONTINUE_WITHOUT_SELECTING_FIREBASE_WEB_APP";
@@ -15,36 +15,32 @@ export const webApps = {
 type FirebaseWebApp = { name: string; id: string };
 
 /**
- * If firebaseWebAppName is provided and a matching web app exists, it is
- * returned. If firebaseWebAppName is not provided then the user is prompted to
- * choose from one of their existing web apps or to create a new one or to skip
- * without selecting a web app. If user chooses to create a new web app,
- * a new web app with the given backendId is created. If user chooses to skip
- * without selecting a web app nothing is returned.
+ * If firebaseWebAppId is provided and a matching web app exists, it is
+ * returned. If firebaseWebAppId is a new web app with the given backendId is
+ * created.
  * @param projectId user's projectId
- * @param firebaseWebAppName (optional) name of an existing Firebase web app
+ * @param firebaseWebAppId (optional) id of an existing Firebase web app
  * @param backendId name of the app hosting backend
  * @return app name and app id
  */
 async function getOrCreateWebApp(
   projectId: string,
-  firebaseWebAppName: string | null,
+  firebaseWebAppId: string | null,
   backendId: string,
 ): Promise<FirebaseWebApp | undefined> {
   const webAppsInProject = await listFirebaseApps(projectId, AppPlatform.WEB);
-  const existingUserProjectWebApps = firebaseAppsToMap(webAppsInProject);
 
-  if (firebaseWebAppName) {
-    if (existingUserProjectWebApps.get(firebaseWebAppName) === undefined) {
+  if (firebaseWebAppId) {
+    const webApp = webAppsInProject.find((app) => app.appId === firebaseWebAppId);
+    if (webApp === undefined) {
       throw new FirebaseError(
-        `The web app '${firebaseWebAppName}' does not exist in project ${projectId}`,
+        `The web app with Id '${firebaseWebAppId}' does not exist in project ${projectId}`,
       );
     }
 
     return {
-      name: firebaseWebAppName,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      id: existingUserProjectWebApps.get(firebaseWebAppName)!,
+      name: webApp.displayName ?? webApp.appId,
+      id: webApp.appId,
     };
   }
 
@@ -52,6 +48,7 @@ async function getOrCreateWebApp(
 
   try {
     const app = await createWebApp(projectId, { displayName: webAppName });
+    logSuccess(`Created a new Firebase web app named "${webAppName}"`);
     return { name: app.displayName, id: app.appId };
   } catch (e) {
     if (isQuotaError(e)) {

--- a/src/apphosting/index.ts
+++ b/src/apphosting/index.ts
@@ -106,9 +106,7 @@ export async function doSetup(
   });
 
   const webApp = await webApps.getOrCreateWebApp(projectId, webAppName, backendId);
-  if (webApp) {
-    logSuccess(`Created a new Firebase web app named "${webApp.name}"`);
-  } else {
+  if (!webApp) {
     logWarning(`Firebase web app not set`);
   }
 

--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -11,7 +11,7 @@ export const command = new Command("apphosting:backends:create")
   .description("create a Firebase App Hosting backend")
   .option(
     "-a, --app <webAppId>",
-    "specify an existing Firebase web app to associate your App Hosting backend with",
+    "specify an existing Firebase web app's ID to associate your App Hosting backend with",
   )
   .option("-l, --location <location>", "specify the location of the backend", "")
   .option(

--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -10,7 +10,7 @@ import { requireTosAcceptance } from "../requireTosAcceptance";
 export const command = new Command("apphosting:backends:create")
   .description("create a Firebase App Hosting backend")
   .option(
-    "-a, --app <webApp>",
+    "-a, --app <webAppId>",
     "specify an existing Firebase web app to associate your App Hosting backend with",
   )
   .option("-l, --location <location>", "specify the location of the backend", "")
@@ -24,13 +24,13 @@ export const command = new Command("apphosting:backends:create")
   .before(requireTosAcceptance(APPHOSTING_TOS_ID))
   .action(async (options: Options) => {
     const projectId = needProjectId(options);
-    const webApp = options.app;
+    const webAppId = options.app;
     const location = options.location;
     const serviceAccount = options.serviceAccount;
 
     await doSetup(
       projectId,
-      webApp as string | null,
+      webAppId as string | null,
       location as string | null,
       serviceAccount as string | null,
     );

--- a/src/test/apphosting/app.spec.ts
+++ b/src/test/apphosting/app.spec.ts
@@ -42,7 +42,7 @@ describe("app", () => {
         webApps.getOrCreateWebApp(projectId, "nonExistentWebApp", backendId),
       ).to.be.rejectedWith(
         FirebaseError,
-        "The web app 'nonExistentWebApp' does not exist in project projectId",
+        "The web app with Id 'nonExistentWebApp' does not exist in project projectId",
       );
     });
 

--- a/src/test/apphosting/app.spec.ts
+++ b/src/test/apphosting/app.spec.ts
@@ -42,7 +42,7 @@ describe("app", () => {
         webApps.getOrCreateWebApp(projectId, "nonExistentWebApp", backendId),
       ).to.be.rejectedWith(
         FirebaseError,
-        "The web app with Id 'nonExistentWebApp' does not exist in project projectId",
+        "The web app 'nonExistentWebApp' does not exist in project projectId",
       );
     });
 


### PR DESCRIPTION
There can be multiple Firebase apps with the same name. Need to use appId instead.
