### PR TITLE
Format Data Connect GQL error in a way thats friendly to editor

### DIFF
--- a/src/dataconnect/graphqlError.ts
+++ b/src/dataconnect/graphqlError.ts
@@ -3,8 +3,8 @@ import { GraphqlError } from "./types";
 export function prettify(err: GraphqlError): string {
   const message = err.message;
   let header = err.extensions.file ?? "";
-  for (const loc of err.locations) {
-    header += `(${loc.line}, ${loc.column})`;
+  if (err.locations) {
+    header += `:${err.locations[0].line}`;
   }
   return header.length ? `${header}: ${message}` : message;
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Improve GQL error message format. So I can link on the line and opens up in editor nicely.

### Scenarios Tested

<img width="805" alt="Screenshot 2024-05-08 at 1 55 39 PM" src="https://github.com/firebase/firebase-tools/assets/9068391/d3d94938-f3fb-4508-9ab0-3474b54caa8d">



### Sample Commands

```
firebase deploy --only dataconnect
```
<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
