### PR TITLE
Use relative path for deploying schema and operations.

### DIFF
--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -59,7 +59,8 @@ function validateConnectorYaml(unvalidated: any): ConnectorYaml {
 
 export async function readGQLFiles(sourceDir: string): Promise<File[]> {
   const files = await fs.readdir(sourceDir);
-  return files.filter((f) => f.endsWith(".gql")).map((f) => toFile(sourceDir, f));
+  // TODO: Handle files in subdirectories such as `foo/a.gql` and `bar/baz/b.gql`.
+  return files.filter((f) => f.endsWith(".gql") || f.endsWith(".graphql")).map((f) => toFile(sourceDir, f));
 }
 
 function toFile(sourceDir: string, relPath: string): File {

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -60,7 +60,9 @@ function validateConnectorYaml(unvalidated: any): ConnectorYaml {
 export async function readGQLFiles(sourceDir: string): Promise<File[]> {
   const files = await fs.readdir(sourceDir);
   // TODO: Handle files in subdirectories such as `foo/a.gql` and `bar/baz/b.gql`.
-  return files.filter((f) => f.endsWith(".gql") || f.endsWith(".graphql")).map((f) => toFile(sourceDir, f));
+  return files
+    .filter((f) => f.endsWith(".gql") || f.endsWith(".graphql"))
+    .map((f) => toFile(sourceDir, f));
 }
 
 function toFile(sourceDir: string, relPath: string): File {

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -59,17 +59,18 @@ function validateConnectorYaml(unvalidated: any): ConnectorYaml {
 
 export async function readGQLFiles(sourceDir: string): Promise<File[]> {
   const files = await fs.readdir(sourceDir);
-  return files.filter((f) => f.endsWith(".gql")).map((f) => toFile(path.join(sourceDir, f)));
+  return files.filter((f) => f.endsWith(".gql")).map((f) => toFile(sourceDir, f));
 }
 
-function toFile(path: string): File {
-  if (!fs.existsSync(path)) {
-    throw new FirebaseError(`file ${path} not found`);
+function toFile(sourceDir: string, relPath: string): File {
+  const fullPath = path.join(sourceDir, relPath);
+  if (!fs.existsSync(fullPath)) {
+    throw new FirebaseError(`file ${fullPath} not found`);
   }
-  const file = fs.readFileSync(path).toString();
+  const content = fs.readFileSync(fullPath).toString();
   return {
-    path: path,
-    content: file,
+    path: relPath,
+    content,
   };
 }
 


### PR DESCRIPTION
Not tested at all, not sure what this will break.

But I did look at all references of `File.path` and this is the only use site, so should be relatively safe