### PR TITLE
Change default dataconnect port back to 9399.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Internal bug fixes.

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -13,7 +13,7 @@ export const DEFAULT_PORTS: { [s in Emulators]: number } = {
   auth: 9099,
   storage: 9199,
   eventarc: 9299,
-  dataconnect: 9509,
+  dataconnect: 9399,
 };
 
 export const FIND_AVAILBLE_PORT_BY_DEFAULT: Record<Emulators, boolean> = {


### PR DESCRIPTION
This reverts an earlier change in PR #7149, which changed it to 9509.