### PR TITLE
Change default database name to `postgres`.

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -113,7 +113,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
     cloudSqlDatabase = await promptOnce({
       message: `What ID would you like to use for your new database in ${cloudSqlInstanceId}?`,
       type: "input",
-      default: `dataconnect`,
+      default: `postgres`,
     });
   }
 


### PR DESCRIPTION
This DB name is always present in most Postgres setups.