### PR TITLE
fix: Stop timeout on loading code in functions and simply warn

### DIFF
--- a/src/test/deploy/functions/runtimes/discovery/index.spec.ts
+++ b/src/test/deploy/functions/runtimes/discovery/index.spec.ts
@@ -106,4 +106,14 @@ describe("detectFromPort", () => {
     const parsed = await discovery.detectFromPort(8080, "project", "nodejs16");
     expect(parsed).to.deep.equal(BUILD);
   });
+
+  it("can read huge, slow loading codes", async () => {
+    nock("http://127.0.0.1:8080")
+      .get("/__/functions.yaml")
+      .delay(15 * 1000)
+      .reply(200, YAML_TEXT);
+
+    const parsed = await discovery.detectFromPort(8080, "project", "nodejs16");
+    expect(parsed).to.deep.equal(BUILD);
+  }).timeout(20 * 1000);
 });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

fix #7165

On a low-spec machine or Windows, it is slower than the actual deployment environment and may take more than 10 seconds to load the source code for functions. ( https://github.com/microsoft/Windows-Dev-Performance/issues/17 )

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

We now have `emulators:start` working in our production code.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
