### PR TITLE
feat: support source deploy option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Adds `--source` option to `firebase deploy` command to specify the source directory to deploy functions from.

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -78,6 +78,10 @@ export const command = new Command("deploy")
     "delete Cloud Functions missing from the current working directory and bypass interactive prompts",
   )
   .option("-p, --public <path>", "override the Hosting public directory specified in firebase.json")
+  .option(
+    "-s, --source <path>",
+    "override the Functions source directory specified in firebase.json",
+  )
   .option("-m, --message <message>", "an optional message describing this deploy")
   .option(
     "--only <targets>",

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -48,6 +48,17 @@ import { assertExhaustive } from "../../functional";
 
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
 
+function handleSourceDirectoryFlag(options: Options): void {
+  // Allow the public directory to be overridden by the --public flag
+  if (options.source) {
+    if (Array.isArray(options.config.get("functions"))) {
+      throw new FirebaseError("Cannot specify --source option with multiple codebases.");
+    }
+
+    options.config.set("functions.source", options.source);
+  }
+}
+
 /**
  * Prepare functions codebases for deploy.
  */
@@ -56,6 +67,8 @@ export async function prepare(
   options: Options,
   payload: args.Payload,
 ): Promise<void> {
+  handleSourceDirectoryFlag(options);
+
   const projectId = needProjectId(options);
   const projectNumber = await needProjectNumber(options);
 


### PR DESCRIPTION
### Description

This PR adds an option to the Firebase CLI to override the `functions.source` config option on `firebase deploy`. This is much like the option which overrides the public directory when deploying to Hosting.

The use case is where a user deploys a functions package whose structure is not supported by Firebase, such as a monorepo package. When deploying a functions package in a monorepo, a common strategy is to create a directory which contains the functions _and_ other internal monorepo dependencies, and deploy that. One such example is [isolate-package](https://github.com/0x80/isolate-package). Other strategies are mentioned in #653.

### Scenarios Tested

- Tested running `firebase deploy --only functions --source apps/functions/deploy`, which deploys the `deploy` directory.
- Tested running `firebase deploy --only functions`, which deploys the folder specified in `firebase.json`.

### Sample Commands

`firebase deploy --only functions --source apps/functions/deploy`
`firebase deploy --only functions -s apps/functions/deploy`
`firebase deploy --source apps/functions/deploy`
`firebase deploy -s apps/functions/deploy`
