### PR TITLE
Jh idx no metadata calls

### DIFF
--- a/firebase-vscode/src/cli.ts
+++ b/firebase-vscode/src/cli.ts
@@ -60,19 +60,10 @@ async function getServiceAccount() {
     if (e.original?.message) {
       errorMessage += ` (original: ${e.original.message})`;
     }
-    if (process.env.MONOSPACE_ENV) {
-      // If it can't find a service account in Monospace, that's a blocking
-      // error and we should throw.
-      throw new Error(
-        `Unable to find service account. ` + `requireAuthError: ${errorMessage}`
-      );
-    } else {
-      // In other environments, it is common to not find a service account.
-      pluginLogger.debug(
-        `No service account found (this may be normal), ` +
-          `requireAuth error output: ${errorMessage}`
-      );
-    }
+    pluginLogger.debug(
+      `No service account found (this may be normal), ` +
+        `requireAuth error output: ${errorMessage}`
+    );
     return null;
   }
   if (process.env.WORKSPACE_SERVICE_ACCOUNT_EMAIL) {

--- a/firebase-vscode/src/core/project.ts
+++ b/firebase-vscode/src/core/project.ts
@@ -1,4 +1,4 @@
-import vscode, { Disposable, ExtensionContext, QuickPickItem } from "vscode";
+import vscode, { Disposable } from "vscode";
 import { ExtensionBrokerImpl } from "../extension-broker";
 import { computed, effect } from "@preact/signals-react";
 import { firebaseRC, updateFirebaseRCProject } from "./config";
@@ -6,7 +6,6 @@ import { FirebaseProjectMetadata } from "../types/project";
 import { currentUser, isServiceAccount } from "./user";
 import { listProjects } from "../cli";
 import { pluginLogger } from "../logger-wrapper";
-import { currentOptions } from "../options";
 import { globalSignal } from "../utils/globals";
 import { firstWhereDefined } from "../utils/signal";
 

--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -37,6 +37,9 @@ function getAuthClient(config: GoogleAuthOptions): GoogleAuth {
  * @param authScopes scopes to be obtained.
  */
 async function autoAuth(options: Options, authScopes: string[]): Promise<void | string> {
+  if (process.env.MONOSPACE_ENV) {
+    throw new FirebaseError("autoAuth not yet implemented for IDX. Please run 'firebase login'");
+  }
   const client = getAuthClient({ scopes: authScopes, projectId: options.project });
   const token = await client.getAccessToken();
   token !== null ? apiv2.setAccessToken(token) : false;


### PR DESCRIPTION
### Description
Removed some outdated service account checks, and short circuits autoAuth within IDX, so that we can fall back to running `firebase login`.
### Scenarios Tested
Uploaded to IDX, and verified that activate succeeds without hanging or kicking off the choose project flow.