### PR TITLE
`sql:migrate --force` shouldn't prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixes an issue where dataconnect:sql:migrate still prompts for confirmation even with `--force`
+- Fixes an issue where dataconnect:sql:migrate still prompts for confirmation even with `--force`. (#7208)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes an issue where dataconnect:sql:migrate still prompts for confirmation even with `--force`

--- a/src/commands/dataconnect-sql-migrate.ts
+++ b/src/commands/dataconnect-sql-migrate.ts
@@ -34,7 +34,6 @@ export const command = new Command("dataconnect:sql:migrate [serviceId]")
     const diffs = await migrateSchema({
       options,
       schema: serviceInfo.schema,
-      allowNonInteractiveMigration: true,
       validateOnly: true,
     });
     if (diffs.length) {

--- a/src/deploy/dataconnect/release.ts
+++ b/src/deploy/dataconnect/release.ts
@@ -44,7 +44,6 @@ export default async function (
       await migrateSchema({
         options,
         schema: s,
-        allowNonInteractiveMigration: false,
         validateOnly: false,
       });
     }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`firebase dataconnect:sql:migrate --force` should never prompt.

`firebase dataconnect:sql:migrate` should prompt for schema migrations and then abort if there is invalid connectors. This way developers can see the SQL before taking the suggesting and run it `--force`.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

#### Without invalid connectors
`firebase dataconnect:sql:migrate`
<img width="1174" alt="Screenshot 2024-05-22 at 12 20 37 PM" src="https://github.com/firebase/firebase-tools/assets/9068391/47a06385-6e3a-4fac-a94c-aa2a616acee9">


`firebase dataconnect:sql:migrate --force`
<img width="1174" alt="Screenshot 2024-05-22 at 12 21 27 PM" src="https://github.com/firebase/firebase-tools/assets/9068391/76f3de7a-5942-4324-86b2-16807ab2c09d">

#### With invalid connectors
`firebase dataconnect:sql:migrate`
<img width="1175" alt="Screenshot 2024-05-22 at 12 23 41 PM" src="https://github.com/firebase/firebase-tools/assets/9068391/6cd74f2c-2a57-47f0-913d-bb0482b73564">

`firebase dataconnect:sql:migrate --force`
<img width="1175" alt="Screenshot 2024-05-22 at 12 24 44 PM" src="https://github.com/firebase/firebase-tools/assets/9068391/e2b55c53-2c73-4077-a21f-f33ec1233bbb">

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
