### PR TITLE
Fix service_location not passed to dataconnect binary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 - Fixes an issue where dataconnect:sql:migrate still prompts for confirmation even with `--force`. (#7208)
 - Update to Firebase Data Connect Emulator version 1.1.18 which contains code generation bug fixes, surfacing schema migration errors when a diff remains after migration, and a fix to allow the local connection string to be empty at startup.
 - Fixes an issue where the dataconnect emulator listens on all addresses by default instead of just localhost (#7211).
-- Fixes Data Connect generated SDK sometimes using the wrong location (GCP region).
+- Fixes Data Connect generated SDK sometimes using the wrong location (GCP region) (#7217).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes an issue where dataconnect:sql:migrate still prompts for confirmation even with `--force`. (#7208)
 - Update to Firebase Data Connect Emulator version 1.1.18 which contains code generation bug fixes, surfacing schema migration errors when a diff remains after migration, and a fix to allow the local connection string to be empty at startup.
 - Fixes an issue where the dataconnect emulator listens on all addresses by default instead of just localhost (#7211).
+- Fixes Data Connect generated SDK sometimes using the wrong location (GCP region).

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -281,7 +281,13 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
   dataconnect: {
     binary: getExecPath(Emulators.DATACONNECT),
     args: ["dev"],
-    optionalArgs: ["listen", "config_dir", "local_connection_string", "project_id"],
+    optionalArgs: [
+      "listen",
+      "config_dir",
+      "local_connection_string",
+      "project_id",
+      "service_location",
+    ],
     joinArgs: true,
     shell: true,
   },


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

See title

### Scenarios Tested

Ran `firebase emulators:start` locally and looked at `pgrep -a dataconnect` full command line to make sure the argument gets passed

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
