### PR TITLE
Release Firebase Data Connect Emulator v1.1.19.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Update to Firebase Data Connect Emulator version 1.1.19 which fixes serving IPv4 connections properly (127.0.0.1:9399 by default).

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -57,14 +57,14 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
   dataconnect:
     process.platform === "darwin"
       ? {
-          version: "1.1.18",
-          expectedSize: 25836736,
-          expectedChecksum: "28a760826968c86cff7e2137b7a487cf",
+          version: "1.1.19",
+          expectedSize: 25836864,
+          expectedChecksum: "b31ba00789b82a30f0dee1c03b8f74ce",
         }
       : {
-          version: "1.1.18",
+          version: "1.1.19",
           expectedSize: 23247120,
-          expectedChecksum: "ff2d10655fd0ad16c0fd07e1ca6dac3e",
+          expectedChecksum: "56d6cb2ad85474d3a67999e35d2916a1",
         },
 };
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

See changelog

### Scenarios Tested

Ran grpc_cli locally against `firebase emulators:start` and verified that it responds to both IPv4 and IPv6.

### Sample Commands

N/A
