### PR TITLE
Add dataconnect e2e test to CI

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -93,6 +93,7 @@ jobs:
           - npm run test:storage-emulator-integration
           - npm run test:triggers-end-to-end
           - npm run test:triggers-end-to-end:inspect
+          - npm run test:dataconnect-deploy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -148,6 +149,7 @@ jobs:
           - npm run test:triggers-end-to-end:inspect
           - npm run test:storage-deploy
           # - npm run test:storage-emulator-integration
+          - npm run test:dataconnect-deploy
     steps:
       - name: Setup Java JDK
         uses: actions/setup-java@v3.3.0


### PR DESCRIPTION
### Description
Add `test:dataconnect-deploy` to our CI. Once this is passing consistently, I'll also add it to the required checks and it will block merging if it fails.

I do need to add the target project to our allowlist before this will pass. Somehow, I never got access to that project in the handoff from @bkendall, so looking around for someone who does have access so I can grab the project number