### PR TITLE
Remove dash from default database name.

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -263,7 +263,7 @@ async function promptForDatabase(
     info.cloudSqlDatabase = await promptOnce({
       message: `What ID would you like to use for your new database in ${info.cloudSqlInstanceId}?`,
       type: "input",
-      default: `fdc-db`,
+      default: `fdcdb`,
     });
   }
   return info;


### PR DESCRIPTION
`fdc-db` is not a valid Postgres identifier and requires quoting, which makes SQL statements annoying.
