### PR TITLE
Update to the latest version of the Crashlytics buildtools, v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Improved handling of 'fresh from Console' services during `init dataconnect`.
 - Add support for node22 in function deployments (#7252).
 - Update to Firebase Data Connect Emulator v1.2.0, which adds support for Postgres 16 and creates the Postgres database specified in dataconnect.yaml or .firebaserc if it does not already exist.
+- Update to the latest version of the Crashlytics buildtools, v3.

--- a/src/crashlytics/buildToolsJarHelper.ts
+++ b/src/crashlytics/buildToolsJarHelper.ts
@@ -13,7 +13,7 @@ const JAR_CACHE_DIR =
   process.env.FIREBASE_CRASHLYTICS_BUILDTOOLS_PATH ||
   path.join(os.homedir(), ".cache", "firebase", "crashlytics", "buildtools");
 
-const JAR_VERSION = "2.9.2";
+const JAR_VERSION = "3.0.0";
 const JAR_URL = `https://dl.google.com/android/maven2/com/google/firebase/firebase-crashlytics-buildtools/${JAR_VERSION}/firebase-crashlytics-buildtools-${JAR_VERSION}.jar`;
 
 /**
@@ -22,6 +22,7 @@ const JAR_URL = `https://dl.google.com/android/maven2/com/google/firebase/fireba
 export async function fetchBuildtoolsJar(): Promise<string> {
   // If you set CRASHLYTICS_LOCAL_JAR to a path it will override the downloaded buildtools.jar
   if (process.env.CRASHLYTICS_LOCAL_JAR) {
+    logger.debug(`Using local Crashlytics Jar override at ${process.env.CRASHLYTICS_LOCAL_JAR}`);
     return process.env.CRASHLYTICS_LOCAL_JAR;
   }
 


### PR DESCRIPTION
Update to the latest version of the Crashlytics buildtools jar, v3. This pulls in the latest breakpad, which supports compressed headers used in Go binaries.