### PR TITLE
Fixing issues with init dataconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes some cases where `firebase init dataconnect` did not write project files correctly.

--- a/scripts/publish-vsce.sh
+++ b/scripts/publish-vsce.sh
@@ -28,7 +28,7 @@ echo "Making a $VERSION version of VSCode..."
 npm version $VERSION
 NEW_VSCODE_VERSION=$(jq -r ".version" package.json)
 NEXT_HEADER="## NEXT"
-NEW_HEADER="## NEXT \n\n## $NEW_VSCODE_VERSION\n\n- Updated internal firebase-tools dependency to $CLI_VERSION"
+NEW_HEADER="## NEXT\n\n## $NEW_VSCODE_VERSION\n\n- Updated internal firebase-tools dependency to $CLI_VERSION"
 sed -i -e "s/$NEXT_HEADER/$NEW_HEADER/g" CHANGELOG.md
 echo "Made a $VERSION version of VSCode."
 

--- a/src/dataconnect/names.ts
+++ b/src/dataconnect/names.ts
@@ -60,3 +60,32 @@ export function parseConnectorName(connectorName: string): connectorName {
     toString,
   };
 }
+
+interface cloudSQLInstanceName {
+  projectId: string;
+  location: string;
+  instanceId: string;
+  toString(): string;
+}
+
+const cloudSQLInstanceNameRegex =
+  /projects\/(?<projectId>[^\/]+)\/locations\/(?<location>[^\/]+)\/instances\/(?<instanceId>[^\/]+)/;
+
+export function parseCloudSQLInstanceName(cloudSQLInstanceName: string): cloudSQLInstanceName {
+  const res = cloudSQLInstanceNameRegex.exec(cloudSQLInstanceName);
+  const projectId = res?.groups?.projectId;
+  const location = res?.groups?.location;
+  const instanceId = res?.groups?.instanceId;
+  if (!projectId || !location || !instanceId) {
+    throw new FirebaseError(`${cloudSQLInstanceName} is not a valid cloudSQL instance name`);
+  }
+  const toString = () => {
+    return `projects/${projectId}/locations/${location}/services/${instanceId}`;
+  };
+  return {
+    projectId,
+    location,
+    instanceId,
+    toString,
+  };
+}

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -10,7 +10,7 @@ import { ensureApis } from "../../../dataconnect/ensureApis";
 import { listLocations, listAllServices, getSchema } from "../../../dataconnect/client";
 import { Schema, Service } from "../../../dataconnect/types";
 import { DEFAULT_POSTGRES_CONNECTION } from "../emulators";
-import { parseServiceName } from "../../../dataconnect/names";
+import { parseCloudSQLInstanceName, parseServiceName } from "../../../dataconnect/names";
 import { logger } from "../../../logger";
 
 const TEMPLATE_ROOT = resolve(__dirname, "../../../../templates/init/dataconnect/");
@@ -67,6 +67,10 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   const subbedDataconnectYaml = subValues(DATACONNECT_YAML_TEMPLATE, info);
   const subbedConnectorYaml = subValues(CONNECTOR_YAML_TEMPLATE, info);
 
+  if (!config.has("dataconnect")) {
+    config.set("dataconnect.source", dir);
+    config.set("dataconnect.location", info.locationId);
+  }
   await config.askWriteProjectFile(join(dir, "dataconnect.yaml"), subbedDataconnectYaml);
   await config.askWriteProjectFile(join(dir, "schema", "schema.gql"), SCHEMA_TEMPLATE);
   await config.askWriteProjectFile(
@@ -78,6 +82,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
     join(dir, info.connectorId, "mutations.gql"),
     MUTATIONS_TEMPLATE,
   );
+
   if (
     setup.projectId &&
     (info.isNewInstance || info.isNewDatabase) &&
@@ -156,8 +161,12 @@ async function promptForService(setup: Setup, info: RequiredInfo): Promise<Requi
         info.serviceId = serviceName.serviceId;
         info.locationId = serviceName.location;
         if (choice.schema) {
-          info.cloudSqlInstanceId =
-            choice.schema.primaryDatasource.postgresql?.cloudSql.instance ?? "";
+          if (choice.schema.primaryDatasource.postgresql?.cloudSql.instance) {
+            const instanceName = parseCloudSQLInstanceName(
+              choice.schema.primaryDatasource.postgresql?.cloudSql.instance,
+            );
+            info.cloudSqlInstanceId = instanceName.instanceId;
+          }
           info.cloudSqlDatabase = choice.schema.primaryDatasource.postgresql?.database ?? "";
         }
       }
@@ -240,11 +249,6 @@ async function promptForDatabase(
   config: Config,
   info: RequiredInfo,
 ): Promise<RequiredInfo> {
-  const dir: string = config.get("dataconnect.source") || "dataconnect";
-  if (!config.has("dataconnect")) {
-    config.set("dataconnect.source", dir);
-    config.set("dataconnect.location", info.locationId);
-  }
   if (!info.isNewInstance && setup.projectId) {
     try {
       const dbs = await cloudsql.listDatabases(setup.projectId, info.cloudSqlInstanceId);


### PR DESCRIPTION
### Description
Fixes 2 issues reported by testers for  fresh from console instances:
- dataconnect block was not added to firebase.json
- Instance name was being written to dataconnect.yaml instead of instanceId when 

### Scenarios Tested
Fresh from console case:
<img width="918" alt="Screenshot 2024-06-07 at 9 47 37 AM" src="https://github.com/firebase/firebase-tools/assets/4635763/4bf738a2-4cce-47ae-9daf-fa0acc088da0">
