### PR TITLE
Add a warning when running dataconnect:sdk:generate without any sdks …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added a warning to `firebase dataconnect:sdk:generate` when no generated SDKs are configured.

--- a/src/commands/dataconnect-sdk-generate.ts
+++ b/src/commands/dataconnect-sdk-generate.ts
@@ -21,6 +21,20 @@ export const command = new Command("dataconnect:sdk:generate")
         configDir = path.resolve(path.join(cwd), configDir);
       }
       const serviceInfo = await load(projectId, service.location, configDir);
+      const hasGeneratables = serviceInfo.connectorInfo.some((c) => {
+        return (
+          c.connectorYaml.generate?.javascriptSdk ||
+          c.connectorYaml.generate?.kotlinSdk ||
+          c.connectorYaml.generate?.swiftSdk
+        );
+      });
+      if (!hasGeneratables) {
+        logger.warn("No generated SDKs have been declared in connector.yaml files.");
+        logger.warn(
+          "See https://firebase.google.com/docs/data-connect/quickstart#configure-sdk-outputs for examples of how to configure generated SDKs.",
+        );
+        return;
+      }
       for (const conn of serviceInfo.connectorInfo) {
         const output = await DataConnectEmulator.generate({
           configDir,


### PR DESCRIPTION
### Description
Very good suggestion from the GPP testers - adding a warning when running this commadn without any SDKs configured.

### Scenarios Tested
No SDKs configured:
<img width="1340" alt="Screenshot 2024-06-07 at 10 15 10 AM" src="https://github.com/firebase/firebase-tools/assets/4635763/81efb701-04ce-43c3-8dbd-08ed389ca601">
SDK configured:
<img width="852" alt="Screenshot 2024-06-07 at 10 17 38 AM" src="https://github.com/firebase/firebase-tools/assets/4635763/1437a6aa-760d-48dd-beeb-a5a861ca8393">
