### PR TITLE
Fix issue where emulator throws an error due to non-standard whitespaces in filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes issue where storage emulator throws an error due to non-standard whitespaces in filenames (#6834).

--- a/scripts/storage-emulator-integration/conformance/firebase-js-sdk.test.ts
+++ b/scripts/storage-emulator-integration/conformance/firebase-js-sdk.test.ts
@@ -474,7 +474,7 @@ describe("Firebase Storage JavaScript SDK conformance tests", () => {
           TEST_ENV.requestClient.get(downloadUrl, (response) => {
             let data = Buffer.alloc(0);
             expect(response.headers["content-disposition"]).to.be.eql(
-              "attachment; filename=testFile",
+              "attachment; filename*=testFile",
             );
             response
               .on("data", (chunk) => {

--- a/scripts/storage-emulator-integration/conformance/gcs.endpoints.test.ts
+++ b/scripts/storage-emulator-integration/conformance/gcs.endpoints.test.ts
@@ -99,7 +99,7 @@ describe("GCS endpoint conformance tests", () => {
         .then((res) => res);
 
       expect(res.header["content-type"]).to.be.eql("application/octet-stream");
-      expect(res.header["content-disposition"]).to.be.eql("attachment; filename=testFile");
+      expect(res.header["content-disposition"]).to.be.eql("attachment; filename*=testFile");
     });
   });
 

--- a/src/emulator/storage/apis/shared.ts
+++ b/src/emulator/storage/apis/shared.ts
@@ -2,6 +2,7 @@ import { gunzipSync } from "zlib";
 import { StoredFileMetadata } from "../metadata";
 import { Request, Response } from "express";
 import { crc32cToString } from "../crc";
+import { encodeRFC5987 } from "../rfc";
 
 /** Populates an object media GET Express response. */
 export function sendFileBytes(
@@ -26,7 +27,7 @@ export function sendFileBytes(
   const fileName = md.name.split("/").pop();
   res.setHeader(
     "Content-Disposition",
-    `${md.contentDisposition || "attachment"}; filename=${fileName}`,
+    `${md.contentDisposition || "attachment"}; filename*=${encodeRFC5987(fileName!)}`,
   );
   if (didGunzip) {
     // Set to mirror server behavior and supress express's "content-length" header.

--- a/src/emulator/storage/rfc.ts
+++ b/src/emulator/storage/rfc.ts
@@ -1,0 +1,12 @@
+/**
+ * Adapted from:
+ *  - https://datatracker.ietf.org/doc/html/rfc5987
+ *  - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#examples
+ *
+ * @returns RFC5987 encoded string
+ */
+export function encodeRFC5987(str: string): string {
+  return encodeURIComponent(str)
+    .replace(/['()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replace(/%(7C|60|5E)/g, (str, hex) => String.fromCharCode(parseInt(hex, 16)));
+}


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #6834 

Encodes the Content-Disposition header. See [reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_content-disposition_and_link_headers)'s example section

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Tested the scenario:
1. Opening the file with non-standard whitespace directly from console UI
1. Downloading the file with non-standard whitespace via using a Web Application
1. Uploading a file with non-standard whitespace  that triggers `onFinalize()` Cloud Function which downloads the file

See https://github.com/aalej/issues-6834-pr-test 

#### Scenario 1

1. Run `firebase emulators:start --project demo-project --import ./emulator-data`
2. Go to http://127.0.0.1:4000/storage/demo-project.appspot.com
3. Click "invalid whitespace.png"
   - Image loads

#### Scenario 2

1. Run `firebase emulators:start --project demo-project --import ./emulator-data`
2. On a new terminal, run `cd web-app`, then `npm run start`
3. Go to http://localhost:3000/
4. Click "Download" button
    - Image is loaded on the UI

#### Scenario 3

1. Run `firebase emulators:start --project demo-project`
2. Go to http://127.0.0.1:4000/storage/demo-project.appspot.com
3. Upload file located in `./images/invalid whitespace.png`
    - Function finishes executing
```
i  functions: Beginning execution of "us-central1-firstGenGenerateThumbnail"
i  functions: Finished "us-central1-firstGenGenerateThumbnail" in 119.516208ms
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

N/A
