### PR TITLE
Auth emulator: send metadata timestamps as int instead of string

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -3267,8 +3267,12 @@ function generateBlockingFunctionJwt(
 
   if (user.lastLoginAt || user.createdAt) {
     jwt.user_record.metadata = {
-      last_sign_in_time: user.lastLoginAt,
-      creation_time: user.createdAt,
+      last_sign_in_time: user.lastLoginAt
+        ? new Date(parseInt(user.lastLoginAt, 10)).toISOString()
+        : undefined,
+      creation_time: user.createdAt
+          ? new Date(parseInt(user.createdAt, 10)).toISOString()
+          : undefined,
     };
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

In the auth emulator sign in blocking function, send `metadata.last_sign_in_time` and `metadata.creation_time` as numbers and not strings so that firebase-functions can handle them.

This is already implemented for calling Cloud Functions associated with other auth events: https://github.com/firebase/firebase-tools/blob/d01da701554ac3c33786dd6486469293e0c93253/src/emulator/auth/cloudFunctions.ts#L77-L84

But it's missing for the sign in blocking function call.

This results in sending string timestamps in the metadata:

    metadata: {
      last_sign_in_time: '1665001706543',
      creation_time: '1697150491509'
    }

This is unsupported by the firebase-functions framework on the other side, that expects a number: https://github.com/firebase/firebase-functions/blob/9c818713db511895a33378859ab1b9f2eef99179/src/common/providers/identity.ts#L363-L366

In particular, the way it uses it: https://github.com/firebase/firebase-functions/blob/9c818713db511895a33378859ab1b9f2eef99179/src/common/providers/identity.ts#L516-L521

```ts
    const creationTime = metadata?.creation_time
      ? new Date(metadata.creation_time).toUTCString()
      : null;
    const lastSignInTime = metadata?.last_sign_in_time
      ? new Date(metadata.last_sign_in_time).toUTCString()
      : null;
```

This results in e.g.:

```js
    new Date('1697150491509').toUTCString()
    => 'Invalid Date'
```

By sending a number, we make sure that the receiving end can process the timestamps.


### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- Signing in to the emulator as an existing user
