### PR TITLE
Adding recursive service delete + more

### DIFF
--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -72,7 +72,7 @@ async function deleteService(serviceName: string): Promise<types.Service> {
   return pollRes;
 }
 
-export async function deleteServiceAndChildResources(serviceName: string) {
+export async function deleteServiceAndChildResources(serviceName: string): Promise<void> {
   const connectors = await listConnectors(serviceName);
   await Promise.all(connectors.map(async (c) => deleteConnector(c.name)));
   try {
@@ -162,9 +162,7 @@ export async function listConnectors(serviceName: string) {
         pageToken,
       },
     });
-    if (Array.isArray(res.body.connectors)) {
-      connectors.push(...res.body.connectors);
-    }
+    connectors.push(...res.body.connectors);
     if (res.body.nextPageToken) {
       await getNextPage(res.body.nextPageToken);
     }

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -4,6 +4,8 @@ import * as operationPoller from "../operation-poller";
 import * as types from "./types";
 
 const DATACONNECT_API_VERSION = "v1alpha";
+const PAGE_SIZE_MAX = 100;
+
 const dataconnectClient = () =>
   new Client({
     urlPrefix: dataconnectOrigin(),
@@ -23,6 +25,11 @@ export async function listLocations(projectId: string): Promise<string[]> {
 }
 
 /** Service methods */
+export async function getService(serviceName: string): Promise<types.Service> {
+  const res = await dataconnectClient().get<types.Service>(serviceName);
+  return res.body;
+}
+
 export async function listAllServices(projectId: string): Promise<types.Service[]> {
   const res = await dataconnectClient().get<{ services: types.Service[] }>(
     `/projects/${projectId}/locations/-/services`,
@@ -54,21 +61,23 @@ export async function createService(
   return pollRes;
 }
 
-export async function deleteService(
-  projectId: string,
-  locationId: string,
-  serviceId: string,
-): Promise<types.Service> {
+async function deleteService(serviceName: string): Promise<types.Service> {
   // NOTE(fredzqm): Don't force delete yet. Backend would leave orphaned resources.
-  const op = await dataconnectClient().delete<types.Service>(
-    `projects/${projectId}/locations/${locationId}/services/${serviceId}`,
-  );
+  const op = await dataconnectClient().delete<types.Service>(serviceName);
   const pollRes = await operationPoller.pollOperation<types.Service>({
     apiOrigin: dataconnectOrigin(),
     apiVersion: DATACONNECT_API_VERSION,
     operationResourceName: op.body.name,
   });
   return pollRes;
+}
+
+export async function deleteServiceAndChildResources(serviceName: string) {
+  const service = await getService(serviceName);
+  const connectors = await listConnectors(service.name);
+  await Promise.all(connectors.map(async (c) => deleteConnector(c.name)));
+  await deleteSchema(service.name);
+  await deleteService(service.name);
 }
 
 /** Schema methods */
@@ -107,6 +116,18 @@ export async function upsertSchema(
   });
 }
 
+export async function deleteSchema(serviceName: string): Promise<void> {
+  const op = await dataconnectClient().delete<types.Schema>(
+    `${serviceName}/schemas/${types.SCHEMA_ID}`,
+  );
+  await operationPoller.pollOperation<void>({
+    apiOrigin: dataconnectOrigin(),
+    apiVersion: DATACONNECT_API_VERSION,
+    operationResourceName: op.body.name,
+  });
+  return;
+}
+
 /** Connector methods */
 
 export async function getConnector(name: string): Promise<types.Connector> {
@@ -115,15 +136,36 @@ export async function getConnector(name: string): Promise<types.Connector> {
 }
 
 export async function deleteConnector(name: string): Promise<void> {
-  const res = await dataconnectClient().delete<void>(name);
-  return res.body;
+  const op = await dataconnectClient().delete<types.Connector>(name);
+  await operationPoller.pollOperation<void>({
+    apiOrigin: dataconnectOrigin(),
+    apiVersion: DATACONNECT_API_VERSION,
+    operationResourceName: op.body.name,
+  });
+  return;
 }
 
 export async function listConnectors(serviceName: string) {
-  const res = await dataconnectClient().get<{ connectors: types.Connector[] }>(
-    `${serviceName}/connectors`,
-  );
-  return res.body?.connectors || [];
+  const connectors: types.Connector[] = [];
+  const getNextPage = async (pageToken = "") => {
+    const res = await dataconnectClient().get<{
+      connectors: types.Connector[];
+      nextPageToken: string;
+    }>(`${serviceName}/connectors`, {
+      queryParams: {
+        pageSize: PAGE_SIZE_MAX,
+        pageToken,
+      },
+    });
+    if (Array.isArray(res.body.connectors)) {
+      connectors.push(...res.body.connectors);
+    }
+    if (res.body.nextPageToken) {
+      await getNextPage(res.body.nextPageToken);
+    }
+  };
+  await getNextPage();
+  return connectors;
 }
 
 export async function upsertConnector(connector: types.Connector) {

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -73,11 +73,16 @@ async function deleteService(serviceName: string): Promise<types.Service> {
 }
 
 export async function deleteServiceAndChildResources(serviceName: string) {
-  const service = await getService(serviceName);
-  const connectors = await listConnectors(service.name);
+  const connectors = await listConnectors(serviceName);
   await Promise.all(connectors.map(async (c) => deleteConnector(c.name)));
-  await deleteSchema(service.name);
-  await deleteService(service.name);
+  try {
+    await deleteSchema(serviceName);
+  } catch (err: any) {
+    if (err.status !== 404) {
+      throw err;
+    }
+  }
+  await deleteService(serviceName);
 }
 
 /** Schema methods */

--- a/src/test/dataconnect/client.spec.ts
+++ b/src/test/dataconnect/client.spec.ts
@@ -1,0 +1,80 @@
+import { expect } from "chai";
+import * as nock from "nock";
+
+import * as client from "../../dataconnect/client";
+import { dataconnectOrigin } from "../../api";
+
+describe("DataConnect control plane client", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+  describe("deleteServiceAndChildResources", () => {
+    it("Should delete all child resources", async () => {
+      const testService = "projects/test/locations/us-central1/services/test-service";
+      const fake = nock(dataconnectOrigin());
+      fake.get(`/v1alpha/${testService}/connectors?pageSize=100&pageToken=`).reply(200, {
+        connectors: [
+          { name: `${testService}/connectors/c1` },
+          { name: `${testService}/connectors/c2` },
+        ],
+      });
+      fake
+        .delete(`/v1alpha/${testService}/connectors/c1`)
+        .reply(200, { name: "projects/test/operations/abc123" });
+      fake
+        .delete(`/v1alpha/${testService}/connectors/c2`)
+        .reply(200, { name: "projects/test/operations/def456" });
+      fake
+        .delete(`/v1alpha/${testService}/schemas/main`)
+        .reply(200, { name: "projects/test/operations/ghi123" });
+      fake
+        .delete(`/v1alpha/${testService}`)
+        .reply(200, { name: "projects/test/operations/jkl456" });
+      fake.get("/v1alpha/projects/test/operations/abc123").reply(200, { done: true });
+      fake.get("/v1alpha/projects/test/operations/def456").reply(200, { done: true });
+      fake.get("/v1alpha/projects/test/operations/ghi123").reply(200, { done: true });
+      fake.get("/v1alpha/projects/test/operations/jkl456").reply(200, { done: true });
+
+      await client.deleteServiceAndChildResources(testService);
+
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("Suceed when there are no connectors", async () => {
+      const testService = "projects/test/locations/us-central1/services/test-service";
+      const fake = nock(dataconnectOrigin());
+      fake.get(`/v1alpha/${testService}/connectors?pageSize=100&pageToken=`).reply(200, {
+        connectors: [],
+      });
+      fake
+        .delete(`/v1alpha/${testService}/schemas/main`)
+        .reply(200, { name: "projects/test/operations/ghi123" });
+      fake
+        .delete(`/v1alpha/${testService}`)
+        .reply(200, { name: "projects/test/operations/jkl456" });
+      fake.get("/v1alpha/projects/test/operations/ghi123").reply(200, { done: true });
+      fake.get("/v1alpha/projects/test/operations/jkl456").reply(200, { done: true });
+
+      await client.deleteServiceAndChildResources(testService);
+
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("Suceed when there is no schema", async () => {
+      const testService = "projects/test/locations/us-central1/services/test-service";
+      const fake = nock(dataconnectOrigin());
+      fake.get(`/v1alpha/${testService}/connectors?pageSize=100&pageToken=`).reply(200, {
+        connectors: [],
+      });
+      fake.delete(`/v1alpha/${testService}/schemas/main`).reply(404, {});
+      fake
+        .delete(`/v1alpha/${testService}`)
+        .reply(200, { name: "projects/test/operations/jkl456" });
+      fake.get("/v1alpha/projects/test/operations/jkl456").reply(200, { done: true });
+
+      await client.deleteServiceAndChildResources(testService);
+
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
### Description
Round of improvemetns to client.ts
- Added a recursive delete service function
- Added automatic pagination to listConnectors
- Correctly poll on the returned operation for deleteSchema/deleteConnector

### Scenarios Tested
Tested this as part of #7309 - gonna add unit tests for deleteServiceAndChildResources tomorrow as well.