### PR TITLE
fix: Some emulators would fail to start if there was a whitespace in the path 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes issue where storage emulator throws an error due to non-standard whitespaces in filenames (#6834).
+- Fixes issue where some emulators would fail to start when their path contained a whitespace (#7313)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -273,7 +273,7 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
     shell: false,
   },
   pubsub: {
-    binary: getExecPath(Emulators.PUBSUB)!,
+    binary: `"${getExecPath(Emulators.PUBSUB)!}"`,
     args: [],
     optionalArgs: ["port", "host"],
     joinArgs: true,
@@ -287,7 +287,7 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
     shell: false,
   },
   dataconnect: {
-    binary: getExecPath(Emulators.DATACONNECT),
+    binary: `"${getExecPath(Emulators.DATACONNECT)}"`,
     args: ["dev"],
     optionalArgs: [
       "listen",


### PR DESCRIPTION

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This fixes the issue described in #7313.
The binary paths where not surrounded by quotation marks so when a path contained a whitespace it would fail.
This affected the pubsub emulator and probably also the data connect emulator though I can't test it as I am not on the close preview.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
Tested running the pubsub emulator `firebase emulators:start --only pubsub`
