### PR TITLE
Better handling of connection string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes issue where storage emulator throws an error due to non-standard whitespaces in filenames (#6834).
 - Fixes issue where some emulators would fail to start when their path contained a whitespace (#7313)
+- Adds prompt for Postgres connection string to `setup:emulators:dataconnect`.

--- a/src/commands/setup-emulators-dataconnect.ts
+++ b/src/commands/setup-emulators-dataconnect.ts
@@ -1,11 +1,32 @@
 import { Command } from "../command";
-import { downloadEmulator } from "../emulator/download";
 import { Emulators } from "../emulator/types";
+import { Options } from "../options";
+import { DEFAULT_POSTGRES_CONNECTION } from "../init/features/emulators";
+import { promptOnce } from "../prompt";
+import { logger } from "../logger";
+import { downloadIfNecessary } from "../emulator/downloadableEmulators";
 
 const NAME = Emulators.DATACONNECT;
 
 export const command = new Command(`setup:emulators:${NAME}`)
   .description(`downloads the ${NAME} emulator`)
-  .action(() => {
-    return downloadEmulator(NAME);
+  .action(async (options: Options) => {
+    await downloadIfNecessary(NAME);
+    if (!options.config) {
+      logger.info(
+        "Not currently in a Firebase project directory. Run this command from a project directory to configure the Data Connect emulator.",
+      );
+      return;
+    }
+    const dataconnectEmulatorConfig = options.rc.getDataconnect();
+    const defaultConnectionString =
+      dataconnectEmulatorConfig?.postgres?.localConnectionString ?? DEFAULT_POSTGRES_CONNECTION;
+    // TODO: Download Postgres
+    const localConnectionString = await promptOnce({
+      type: "input",
+      name: "localConnectionString",
+      message: `What is the connection string of the local Postgres instance you would like to use with the Data Connect emulator?`,
+      default: defaultConnectionString,
+    });
+    options.rc.setDataconnect(localConnectionString);
   });

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -1,4 +1,5 @@
 import * as childProcess from "child_process";
+import * as clc from "colorette";
 
 import { dataConnectLocalConnString } from "../api";
 import { Constants } from "./constants";
@@ -154,8 +155,9 @@ export class DataConnectEmulator implements EmulatorInstance {
   ): Promise<boolean> {
     const connectionString = localConnectionString ?? this.getLocalConectionString();
     if (!connectionString) {
-      this.logger.log("DEBUG", "No Postgres connection string found, not connecting to Postgres");
-      return false;
+      const msg = `No Postgres connection string found in '.firebaserc'. The Data Connect emulator will not be able to execute operations.
+Run ${clc.bold("firebase setup:emulators:dataconnect")} to set up a Postgres connection.`;
+      throw new FirebaseError(msg);
     }
     await this.emulatorClient.configureEmulator({ connectionString, database, serviceId });
     return true;

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -304,7 +304,7 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
   },
 };
 
-function getExecPath(name: DownloadableEmulators): string {
+export function getExecPath(name: DownloadableEmulators): string {
   const details = getDownloadDetails(name);
   return details.binaryPath || details.downloadPath;
 }

--- a/src/rc.ts
+++ b/src/rc.ts
@@ -241,6 +241,7 @@ export class RC {
 
   setDataconnect(localConnectionString: string) {
     this.data.dataconnectEmulatorConfig = { postgres: { localConnectionString } };
+    this.save();
   }
 
   /**


### PR DESCRIPTION
### Description
This PR does 2 things:
- Adding Postgres setup to 'setup:emulators:dataconnect'
- Error out if no connection string is set when we try to connect to postgres.

### Scenarios Tested
Running 'firebase setup:emulators:dataconnect' from outside a project directory, then inside a project directory
<img width="1722" alt="Screenshot 2024-06-17 at 4 06 06 PM" src="https://github.com/firebase/firebase-tools/assets/4635763/5b247695-1cce-4b76-b185-ad2af9ea22cc">

Try to start emulator with a connection string configured, error out, run the suggested command, and then successfully run the emulator
<img width="1487" alt="Screenshot 2024-06-17 at 4 25 21 PM" src="https://github.com/firebase/firebase-tools/assets/4635763/a18435f0-a0f3-44c7-b2eb-399786f16156">
