### PR TITLE
Fix res.body.connectors is not iterable error on deploy --only dataconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,1 @@
-- Fixes issue where storage emulator throws an error due to non-standard whitespaces in filenames (#6834).
-- Fixes issue where some emulators would fail to start when their path contained a whitespace (#7313)
-- Adds prompt for Postgres connection string to `setup:emulators:dataconnect`.
-- Updates Data Connect emulator to v1.2.2, which includes support for generating Swift SDKs and a number of bug fixes.
+- Fixes issue where `deploy --only dataconnect` would error out with `cannot read property undefined`.

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -154,15 +154,15 @@ export async function listConnectors(serviceName: string) {
   const connectors: types.Connector[] = [];
   const getNextPage = async (pageToken = "") => {
     const res = await dataconnectClient().get<{
-      connectors: types.Connector[];
-      nextPageToken: string;
+      connectors?: types.Connector[];
+      nextPageToken?: string;
     }>(`${serviceName}/connectors`, {
       queryParams: {
         pageSize: PAGE_SIZE_MAX,
         pageToken,
       },
     });
-    connectors.push(...res.body.connectors);
+    connectors.push(...(res.body.connectors || []));
     if (res.body.nextPageToken) {
       await getNextPage(res.body.nextPageToken);
     }


### PR DESCRIPTION

### Description
Forgot that OnePlatform returns empty arrays as undefined :(

### Scenarios Tested
Successfully deployed a new service, and ran `dataconnect:services:list` on a project with multiple services without connectors.
