### PR TITLE
Fix compatibility issue with Intel-based Macs uploading symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Data Connect emulator now reuses existing instances if they are emulating the same service.
 - Fixes issue where `deploy --only dataconnect` would error out with `cannot read property undefined`.
+- Fixes compatibility issue when uploading native symbols to Crashlytics on Intel-based Macs.

--- a/src/crashlytics/buildToolsJarHelper.ts
+++ b/src/crashlytics/buildToolsJarHelper.ts
@@ -13,7 +13,7 @@ const JAR_CACHE_DIR =
   process.env.FIREBASE_CRASHLYTICS_BUILDTOOLS_PATH ||
   path.join(os.homedir(), ".cache", "firebase", "crashlytics", "buildtools");
 
-const JAR_VERSION = "3.0.0";
+const JAR_VERSION = "3.0.2";
 const JAR_URL = `https://dl.google.com/android/maven2/com/google/firebase/firebase-crashlytics-buildtools/${JAR_VERSION}/firebase-crashlytics-buildtools-${JAR_VERSION}.jar`;
 
 /**


### PR DESCRIPTION
This pulls in the latest Crashlytics buildtools jar, that fixes the Intel-based Macs compatibility issue.