### PR TITLE
Refactor: extract template helpers into templates.ts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,8 +150,8 @@ are unavailable to Pull Requests coming from forks of the repository.
 | `src`           | Contains shared/support code for the commands             |
 | `src/bin`       | Contains the runnable script. You shouldn't need to touch this content. |
 | `src/commands`  | Contains code for the commands, organized by one-file-per-command with dashes. |
-| `src/templates` | Contains static files needed for various reasons (inittemplates, login success HTML, etc.) |
 | `src/test`      | Contains test helpers. Actual tests (`*.spec.ts`) should be colocated with source files. |
+| `templates`     | Contains static files needed for various reasons (init templates, login success HTML, etc.) |
 
 ## Building CLI commands
 

--- a/firebase-vscode/webpack.common.js
+++ b/firebase-vscode/webpack.common.js
@@ -223,7 +223,7 @@ function makeWebConfig(entryName, entryPath = "") {
   return {
     name: entryName,
     mode: "none", // this leaves the source code as close as possible to the original (when packaging we set this to 'production')
-    entry: "./" + path.join("webviews", entryPath,`${entryName}.entry.tsx`),
+    entry: "./" + path.join("webviews", entryPath, `${entryName}.entry.tsx`),
     output: {
       // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
       path: path.resolve(__dirname, "dist"),

--- a/firebase-vscode/webpack.common.js
+++ b/firebase-vscode/webpack.common.js
@@ -111,12 +111,6 @@ const extensionConfig = {
         loader: "string-replace-loader",
         options: {
           multiple: [
-            // CLI code has absolute path to templates/. We copy templates/
-            // into dist, and this is the correct path now.
-            {
-              search: /(\.|\.\.)[\.\/]+templates/g,
-              replace: "./templates",
-            },
             // CLI code has absolute path to schema/. We copy schema/
             // into dist, and this is the correct path now.
             {

--- a/src/commands/ext-dev-init.ts
+++ b/src/commands/ext-dev-init.ts
@@ -1,5 +1,3 @@
-import * as fs from "fs";
-import * as path from "path";
 import { marked } from "marked";
 import * as TerminalRenderer from "marked-terminal";
 
@@ -10,27 +8,19 @@ import { FirebaseError } from "../error";
 import { promptOnce } from "../prompt";
 import { logger } from "../logger";
 import * as npmDependencies from "../init/features/functions/npm-dependencies";
+import { readTemplateSync } from "../templates";
 marked.setOptions({
   renderer: new TerminalRenderer(),
 });
 
-const TEMPLATE_ROOT = path.resolve(__dirname, "../../templates/extensions/");
-const FUNCTIONS_ROOT = path.resolve(__dirname, "../../templates/init/functions/");
-
 function readCommonTemplates() {
   return {
-    integrationTestFirebaseJsonTemplate: fs.readFileSync(
-      path.join(TEMPLATE_ROOT, "integration-test.json"),
-      "utf8",
-    ),
-    integrationTestEnvTemplate: fs.readFileSync(
-      path.join(TEMPLATE_ROOT, "integration-test.env"),
-      "utf8",
-    ),
-    extSpecTemplate: fs.readFileSync(path.join(TEMPLATE_ROOT, "extension.yaml"), "utf8"),
-    preinstallTemplate: fs.readFileSync(path.join(TEMPLATE_ROOT, "PREINSTALL.md"), "utf8"),
-    postinstallTemplate: fs.readFileSync(path.join(TEMPLATE_ROOT, "POSTINSTALL.md"), "utf8"),
-    changelogTemplate: fs.readFileSync(path.join(TEMPLATE_ROOT, "CL-template.md"), "utf8"),
+    integrationTestFirebaseJsonTemplate: readTemplateSync("extensions/integration-test.json"),
+    integrationTestEnvTemplate: readTemplateSync("extensions/integration-test.env"),
+    extSpecTemplate: readTemplateSync("extensions/extension.yaml"),
+    preinstallTemplate: readTemplateSync("extensions/PREINSTALL.md"),
+    postinstallTemplate: readTemplateSync("extensions/POSTINSTALL.md"),
+    changelogTemplate: readTemplateSync("extensions/CL-template.md"),
   };
 }
 
@@ -45,6 +35,7 @@ export const command = new Command("ext:dev:init")
     const config = new Config({}, { projectDir: cwd, cwd: cwd });
 
     try {
+      let welcome: string;
       const lang = await promptOnce({
         type: "list",
         name: "language",
@@ -64,10 +55,12 @@ export const command = new Command("ext:dev:init")
       switch (lang) {
         case "javascript": {
           await javascriptSelected(config);
+          welcome = readTemplateSync("extensions/javascript/WELCOME.md");
           break;
         }
         case "typescript": {
           await typescriptSelected(config);
+          welcome = readTemplateSync("extensions/typescript/WELCOME.md");
           break;
         }
         default: {
@@ -77,7 +70,6 @@ export const command = new Command("ext:dev:init")
 
       await npmDependencies.askInstallDependencies({ source: "functions" }, config);
 
-      const welcome = fs.readFileSync(path.join(TEMPLATE_ROOT, lang, "WELCOME.md"), "utf8");
       return logger.info("\n" + marked(welcome));
     } catch (err: any) {
       if (!(err instanceof FirebaseError)) {
@@ -97,39 +89,15 @@ export const command = new Command("ext:dev:init")
  * @param {Config} config configuration options
  */
 async function typescriptSelected(config: Config): Promise<void> {
-  const packageLintingTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "package.lint.json"),
-    "utf8",
-  );
-  const packageNoLintingTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "package.nolint.json"),
-    "utf8",
-  );
-  const tsconfigTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "tsconfig.json"),
-    "utf8",
-  );
-  const tsconfigDevTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "tsconfig.dev.json"),
-    "utf8",
-  );
-  const indexTemplate = fs.readFileSync(path.join(TEMPLATE_ROOT, "typescript", "index.ts"), "utf8");
-  const integrationTestTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "integration-test.ts"),
-    "utf8",
-  );
-  const gitignoreTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "_gitignore"),
-    "utf8",
-  );
-  const mocharcTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "typescript", "_mocharc"),
-    "utf8",
-  );
-  const eslintTemplate = fs.readFileSync(
-    path.join(FUNCTIONS_ROOT, "typescript", "_eslintrc"),
-    "utf8",
-  );
+  const packageLintingTemplate = readTemplateSync("extensions/typescript/package.lint.json");
+  const packageNoLintingTemplate = readTemplateSync("extensions/typescript/package.nolint.json");
+  const tsconfigTemplate = readTemplateSync("extensions/typescript/tsconfig.json");
+  const tsconfigDevTemplate = readTemplateSync("extensions/typescript/tsconfig.dev.json");
+  const indexTemplate = readTemplateSync("extensions/typescript/index.ts");
+  const integrationTestTemplate = readTemplateSync("extensions/typescript/integration-test.ts");
+  const gitignoreTemplate = readTemplateSync("extensions/typescript/_gitignore");
+  const mocharcTemplate = readTemplateSync("extensions/typescript/_mocharc");
+  const eslintTemplate = readTemplateSync("init/functions/typescript/_eslintrc");
 
   const lint = await promptOnce({
     name: "lint",
@@ -174,27 +142,12 @@ async function typescriptSelected(config: Config): Promise<void> {
  * @param {Config} config configuration options
  */
 async function javascriptSelected(config: Config): Promise<void> {
-  const indexTemplate = fs.readFileSync(path.join(TEMPLATE_ROOT, "javascript", "index.js"), "utf8");
-  const integrationTestTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "javascript", "integration-test.js"),
-    "utf8",
-  );
-  const packageLintingTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "javascript", "package.lint.json"),
-    "utf8",
-  );
-  const packageNoLintingTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "javascript", "package.nolint.json"),
-    "utf8",
-  );
-  const gitignoreTemplate = fs.readFileSync(
-    path.join(TEMPLATE_ROOT, "javascript", "_gitignore"),
-    "utf8",
-  );
-  const eslintTemplate = fs.readFileSync(
-    path.join(FUNCTIONS_ROOT, "javascript", "_eslintrc"),
-    "utf8",
-  );
+  const indexTemplate = readTemplateSync("extensions/javascript/index.js");
+  const integrationTestTemplate = readTemplateSync("extensions/javascript/integration-test.js");
+  const packageLintingTemplate = readTemplateSync("extensions/javascript/package.lint.json");
+  const packageNoLintingTemplate = readTemplateSync("extensions/javascript/package.nolint.json");
+  const gitignoreTemplate = readTemplateSync("extensions/javascript/_gitignore");
+  const eslintTemplate = readTemplateSync("init/functions/javascript/_eslintrc");
 
   const lint = await promptOnce({
     name: "lint",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,5 +1,4 @@
 import * as clc from "colorette";
-import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 
@@ -14,12 +13,12 @@ import * as fsutils from "../fsutils";
 import * as utils from "../utils";
 import { Options } from "../options";
 import { isEnabled } from "../experiments";
+import { readTemplateSync } from "../templates";
 
 const homeDir = os.homedir();
 
-const TEMPLATE_ROOT = path.resolve(__dirname, "../../templates/");
-const BANNER_TEXT = fs.readFileSync(path.join(TEMPLATE_ROOT, "banner.txt"), "utf8");
-const GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
+const BANNER_TEXT = readTemplateSync("banner.txt");
+const GITIGNORE_TEMPLATE = readTemplateSync("_gitignore");
 
 function isOutside(from: string, to: string): boolean {
   return !!/^\.\./.exec(path.relative(from, to));

--- a/src/emulator/storage/rules/config.ts
+++ b/src/emulator/storage/rules/config.ts
@@ -6,6 +6,7 @@ import { SourceFile } from "./types";
 import { Constants } from "../../constants";
 import { Emulators } from "../../types";
 import { EmulatorLogger } from "../../emulatorLogger";
+import { absoluteTemplateFilePath } from "../../../templates";
 
 function getSourceFile(rules: string, options: Options): SourceFile {
   const path = options.config.path(rules);
@@ -79,6 +80,7 @@ export function getStorageRulesConfig(
 }
 
 function defaultStorageRules(): SourceFile {
-  const path = __dirname + "/../../../../templates/emulators/default_storage.rules";
-  return { name: path, content: readFile(path) };
+  const defaultRulesPath = "emulators/default_storage.rules";
+  const name = absoluteTemplateFilePath(defaultRulesPath);
+  return { name, content: readFile(name) };
 }

--- a/src/hosting/implicitInit.ts
+++ b/src/hosting/implicitInit.ts
@@ -1,14 +1,14 @@
 import * as _ from "lodash";
 import * as clc from "colorette";
-import * as fs from "fs";
 
 import { fetchWebSetup, getCachedWebSetup } from "../fetchWebSetup";
 import * as utils from "../utils";
 import { logger } from "../logger";
 import { EmulatorRegistry } from "../emulator/registry";
 import { EMULATORS_SUPPORTED_BY_USE_EMULATOR, Emulators } from "../emulator/types";
+import { readTemplateSync } from "../templates";
 
-const INIT_TEMPLATE = fs.readFileSync(__dirname + "/../../templates/hosting/init.js", "utf8");
+const INIT_TEMPLATE = readTemplateSync("hosting/init.js");
 
 export interface TemplateServerResponse {
   // __init.js content with only initializeApp()

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -1,6 +1,5 @@
-import { join, resolve } from "path";
+import { join } from "path";
 import { confirm, promptOnce } from "../../../prompt";
-import { readFileSync } from "fs";
 import { Config } from "../../../config";
 import { Setup } from "../..";
 import { provisionCloudSql } from "../../../dataconnect/provisionCloudSql";
@@ -12,14 +11,15 @@ import { Schema, Service } from "../../../dataconnect/types";
 import { DEFAULT_POSTGRES_CONNECTION } from "../emulators";
 import { parseCloudSQLInstanceName, parseServiceName } from "../../../dataconnect/names";
 import { logger } from "../../../logger";
+import { readTemplateSync } from "../../../templates";
 
-const TEMPLATE_ROOT = resolve(__dirname, "../../../../templates/init/dataconnect/");
+const TEMPLATE_ROOT = "init/dataconnect/";
 
-const DATACONNECT_YAML_TEMPLATE = readFileSync(join(TEMPLATE_ROOT, "dataconnect.yaml"), "utf8");
-const CONNECTOR_YAML_TEMPLATE = readFileSync(join(TEMPLATE_ROOT, "connector.yaml"), "utf8");
-const SCHEMA_TEMPLATE = readFileSync(join(TEMPLATE_ROOT, "schema.gql"), "utf8");
-const QUERIES_TEMPLATE = readFileSync(join(TEMPLATE_ROOT, "queries.gql"), "utf8");
-const MUTATIONS_TEMPLATE = readFileSync(join(TEMPLATE_ROOT, "mutations.gql"), "utf8");
+const DATACONNECT_YAML_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "dataconnect.yaml");
+const CONNECTOR_YAML_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "connector.yaml");
+const SCHEMA_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "schema.gql");
+const QUERIES_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "queries.gql");
+const MUTATIONS_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "mutations.gql");
 
 interface RequiredInfo {
   serviceId: string;

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -13,13 +13,11 @@ import { parseCloudSQLInstanceName, parseServiceName } from "../../../dataconnec
 import { logger } from "../../../logger";
 import { readTemplateSync } from "../../../templates";
 
-const TEMPLATE_ROOT = "init/dataconnect/";
-
-const DATACONNECT_YAML_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "dataconnect.yaml");
-const CONNECTOR_YAML_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "connector.yaml");
-const SCHEMA_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "schema.gql");
-const QUERIES_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "queries.gql");
-const MUTATIONS_TEMPLATE = readTemplateSync(TEMPLATE_ROOT + "mutations.gql");
+const DATACONNECT_YAML_TEMPLATE = readTemplateSync("init/dataconnect/dataconnect.yaml");
+const CONNECTOR_YAML_TEMPLATE = readTemplateSync("init/dataconnect/connector.yaml");
+const SCHEMA_TEMPLATE = readTemplateSync("init/dataconnect/schema.gql");
+const QUERIES_TEMPLATE = readTemplateSync("init/dataconnect/queries.gql");
+const MUTATIONS_TEMPLATE = readTemplateSync("init/dataconnect/mutations.gql");
 
 interface RequiredInfo {
   serviceId: string;

--- a/src/init/features/firestore/indexes.ts
+++ b/src/init/features/firestore/indexes.ts
@@ -1,18 +1,15 @@
 import * as clc from "colorette";
-import * as fs from "fs";
 
 import { FirebaseError } from "../../../error";
 import * as api from "../../../firestore/api";
 import * as fsutils from "../../../fsutils";
 import { prompt, promptOnce } from "../../../prompt";
 import { logger } from "../../../logger";
+import { readTemplateSync } from "../../../templates";
 
 const indexes = new api.FirestoreApi();
 
-const INDEXES_TEMPLATE = fs.readFileSync(
-  __dirname + "/../../../../templates/init/firestore/firestore.indexes.json",
-  "utf8",
-);
+const INDEXES_TEMPLATE = readTemplateSync("init/firestore/firestore.indexes.json");
 
 export function initIndexes(setup: any, config: any): Promise<any> {
   logger.info();

--- a/src/init/features/firestore/rules.ts
+++ b/src/init/features/firestore/rules.ts
@@ -1,18 +1,15 @@
 import * as clc from "colorette";
-import * as fs from "fs";
 
 import * as gcp from "../../../gcp";
 import * as fsutils from "../../../fsutils";
 import { prompt, promptOnce } from "../../../prompt";
 import { logger } from "../../../logger";
 import * as utils from "../../../utils";
+import { readTemplateSync } from "../../../templates";
 
 const DEFAULT_RULES_FILE = "firestore.rules";
 
-const RULES_TEMPLATE = fs.readFileSync(
-  __dirname + "/../../../../templates/init/firestore/firestore.rules",
-  "utf8",
-);
+const RULES_TEMPLATE = readTemplateSync("init/firestore/firestore.rules");
 
 export function initRules(setup: any, config: any): Promise<any> {
   logger.info();

--- a/src/init/features/functions/javascript.ts
+++ b/src/init/features/functions/javascript.ts
@@ -1,22 +1,15 @@
-import * as fs from "fs";
-import * as path from "path";
-
 import { askInstallDependencies } from "./npm-dependencies";
 import { prompt } from "../../../prompt";
 import { configForCodebase } from "../../../functions/projectConfig";
+import { readTemplateSync } from "../../../templates";
 
-const TEMPLATE_ROOT = path.resolve(__dirname, "../../../../templates/init/functions/javascript/");
-const INDEX_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "index.js"), "utf8");
-const PACKAGE_LINTING_TEMPLATE = fs.readFileSync(
-  path.join(TEMPLATE_ROOT, "package.lint.json"),
-  "utf8",
+const INDEX_TEMPLATE = readTemplateSync("init/functions/javascript/index.js");
+const PACKAGE_LINTING_TEMPLATE = readTemplateSync("init/functions/javascript/package.lint.json");
+const PACKAGE_NO_LINTING_TEMPLATE = readTemplateSync(
+  "init/functions/javascript/package.nolint.json",
 );
-const PACKAGE_NO_LINTING_TEMPLATE = fs.readFileSync(
-  path.join(TEMPLATE_ROOT, "package.nolint.json"),
-  "utf8",
-);
-const ESLINT_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_eslintrc"), "utf8");
-const GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
+const ESLINT_TEMPLATE = readTemplateSync("init/functions/javascript/_eslintrc");
+const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/javascript/_gitignore");
 
 export function setup(setup: any, config: any): Promise<any> {
   return prompt(setup.functions, [

--- a/src/init/features/functions/python.ts
+++ b/src/init/features/functions/python.ts
@@ -1,17 +1,15 @@
-import * as fs from "fs";
 import * as spawn from "cross-spawn";
-import * as path from "path";
 
 import { Config } from "../../../config";
 import { getPythonBinary } from "../../../deploy/functions/runtimes/python";
 import { runWithVirtualEnv } from "../../../functions/python";
 import { promptOnce } from "../../../prompt";
 import { latest } from "../../../deploy/functions/runtimes/supported";
+import { readTemplateSync } from "../../../templates";
 
-const TEMPLATE_ROOT = path.resolve(__dirname, "../../../../templates/init/functions/python");
-const MAIN_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "main.py"), "utf8");
-const REQUIREMENTS_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "requirements.txt"), "utf8");
-const GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
+const MAIN_TEMPLATE = readTemplateSync("init/functions/python/main.py");
+const REQUIREMENTS_TEMPLATE = readTemplateSync("init/functions/python/requirements.txt");
+const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/python/_gitignore");
 
 /**
  * Create a Python Firebase Functions project.

--- a/src/init/features/functions/typescript.ts
+++ b/src/init/features/functions/typescript.ts
@@ -1,27 +1,17 @@
-import * as fs from "fs";
-import * as path from "path";
-
 import { askInstallDependencies } from "./npm-dependencies";
 import { prompt } from "../../../prompt";
 import { configForCodebase } from "../../../functions/projectConfig";
+import { readTemplateSync } from "../../../templates";
 
-const TEMPLATE_ROOT = path.resolve(__dirname, "../../../../templates/init/functions/typescript/");
-const PACKAGE_LINTING_TEMPLATE = fs.readFileSync(
-  path.join(TEMPLATE_ROOT, "package.lint.json"),
-  "utf8",
+const PACKAGE_LINTING_TEMPLATE = readTemplateSync("init/functions/typescript/package.lint.json");
+const PACKAGE_NO_LINTING_TEMPLATE = readTemplateSync(
+  "init/functions/typescript/package.nolint.json",
 );
-const PACKAGE_NO_LINTING_TEMPLATE = fs.readFileSync(
-  path.join(TEMPLATE_ROOT, "package.nolint.json"),
-  "utf8",
-);
-const ESLINT_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_eslintrc"), "utf8");
-const TSCONFIG_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "tsconfig.json"), "utf8");
-const TSCONFIG_DEV_TEMPLATE = fs.readFileSync(
-  path.join(TEMPLATE_ROOT, "tsconfig.dev.json"),
-  "utf8",
-);
-const INDEX_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "index.ts"), "utf8");
-const GITIGNORE_TEMPLATE = fs.readFileSync(path.join(TEMPLATE_ROOT, "_gitignore"), "utf8");
+const ESLINT_TEMPLATE = readTemplateSync("init/functions/typescript/_eslintrc");
+const TSCONFIG_TEMPLATE = readTemplateSync("init/functions/typescript/tsconfig.json");
+const TSCONFIG_DEV_TEMPLATE = readTemplateSync("init/functions/typescript/tsconfig.dev.json");
+const INDEX_TEMPLATE = readTemplateSync("init/functions/typescript/index.ts");
+const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/typescript/_gitignore");
 
 export function setup(setup: any, config: any): Promise<any> {
   return prompt(setup.functions, [

--- a/src/init/features/hosting/index.ts
+++ b/src/init/features/hosting/index.ts
@@ -1,5 +1,4 @@
 import * as clc from "colorette";
-import * as fs from "fs";
 import { sync as rimraf } from "rimraf";
 import { join } from "path";
 
@@ -14,15 +13,10 @@ import { errNoDefaultSite, getDefaultHostingSite } from "../../../getDefaultHost
 import { Options } from "../../../options";
 import { last, logSuccess } from "../../../utils";
 import { interactiveCreateHostingSite } from "../../../hosting/interactive";
+import { readTemplateSync } from "../../../templates";
 
-const INDEX_TEMPLATE = fs.readFileSync(
-  __dirname + "/../../../../templates/init/hosting/index.html",
-  "utf8",
-);
-const MISSING_TEMPLATE = fs.readFileSync(
-  __dirname + "/../../../../templates/init/hosting/404.html",
-  "utf8",
-);
+const INDEX_TEMPLATE = readTemplateSync("init/hosting/index.html");
+const MISSING_TEMPLATE = readTemplateSync("init/hosting/404.html");
 const DEFAULT_IGNORES = ["firebase.json", "**/.*", "**/node_modules/**"];
 
 /**

--- a/src/init/features/storage.ts
+++ b/src/init/features/storage.ts
@@ -1,14 +1,11 @@
 import * as clc from "colorette";
-import * as fs from "fs";
 
 import { logger } from "../../logger";
 import { promptOnce } from "../../prompt";
 import { ensureLocationSet } from "../../ensureCloudResourceLocation";
+import { readTemplateSync } from "../../templates";
 
-const RULES_TEMPLATE = fs.readFileSync(
-  __dirname + "/../../../templates/init/storage/storage.rules",
-  "utf8",
-);
+const RULES_TEMPLATE = readTemplateSync("init/storage/storage.rules");
 
 export async function doSetup(setup: any, config: any): Promise<void> {
   setup.config.storage = {};

--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -1,10 +1,9 @@
-import * as fs from "fs";
-
 import { Client } from "../apiv2";
 import { firebaseApiOrigin } from "../api";
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
 import { pollOperation } from "../operation-poller";
+import { readTemplateSync } from "../templates";
 
 const TIMEOUT_MILLIS = 30000;
 export const APP_LIST_PAGE_SIZE = 100;
@@ -297,7 +296,7 @@ function getAppConfigResourceString(appId: string, platform: AppPlatform): strin
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function parseConfigFromResponse(responseBody: any, platform: AppPlatform): AppConfigurationData {
   if (platform === AppPlatform.WEB) {
-    const JS_TEMPLATE = fs.readFileSync(__dirname + "/../../templates/setup/web.js", "utf8");
+    const JS_TEMPLATE = readTemplateSync("setup/web.js");
     return {
       fileName: WEB_CONFIG_FILE_NAME,
       fileContents: JS_TEMPLATE.replace("{/*--CONFIG--*/}", JSON.stringify(responseBody, null, 2)),

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "fs";
 import { readFile } from "fs/promises";
 import { resolve } from "path";
+import { isVSCodeExtension } from "./utils";
 
-const TEMPLATE_ROOT = resolve(__dirname, "../templates/");
 const TEMPLATE_ENCODING = "utf8";
 
 /**
@@ -10,7 +10,14 @@ const TEMPLATE_ENCODING = "utf8";
  * @param relPath file path relative to the /templates directory under root.
  */
 export function absoluteTemplateFilePath(relPath: string): string {
-  return resolve(TEMPLATE_ROOT, relPath);
+  if (isVSCodeExtension()) {
+    // In the VSCE, the /templates directory is copied into dist, which makes it
+    // right next to the compilation result files (from source code like this).
+    // See CopyPlugin in `../firebase-vscode/webpack.common.js`.
+    return resolve(__dirname, "templates", relPath);
+  }
+  // Otherwise, the /templates directory is one level above /src or /lib.
+  return resolve(__dirname, "../templates", relPath);
 }
 
 /**

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -10,8 +10,7 @@ const TEMPLATE_ENCODING = "utf8";
  * @param relPath file path relative to the /templates directory under root.
  */
 export function absoluteTemplateFilePath(relPath: string): string {
-  const p = resolve(TEMPLATE_ROOT, relPath);
-  return readFileSync(p, TEMPLATE_ENCODING);
+  return resolve(TEMPLATE_ROOT, relPath);
 }
 
 /**

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -12,8 +12,8 @@ const TEMPLATE_ENCODING = "utf8";
 export function absoluteTemplateFilePath(relPath: string): string {
   if (isVSCodeExtension()) {
     // In the VSCE, the /templates directory is copied into dist, which makes it
-    // right next to the compilation result files (from source code like this).
-    // See CopyPlugin in `../firebase-vscode/webpack.common.js`.
+    // right next to the compiled files (from various sources including this
+    // TS file). See CopyPlugin in `../firebase-vscode/webpack.common.js`.
     return resolve(__dirname, "templates", relPath);
   }
   // Otherwise, the /templates directory is one level above /src or /lib.

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "fs";
+import { readFile } from "fs/promises";
+import { resolve } from "path";
+
+const TEMPLATE_ROOT = resolve(__dirname, "../templates/");
+const TEMPLATE_ENCODING = "utf8";
+
+/**
+ * Get an absolute template file path. (Prefer readTemplateSync instead.)
+ * @param relPath file path relative to the /templates directory under root.
+ */
+export function absoluteTemplateFilePath(relPath: string): string {
+  const p = resolve(TEMPLATE_ROOT, relPath);
+  return readFileSync(p, TEMPLATE_ENCODING);
+}
+
+/**
+ * Read a template file synchronously.
+ * @param relPath file path relative to the /templates directory under root.
+ */
+export function readTemplateSync(relPath: string): string {
+  return readFileSync(absoluteTemplateFilePath(relPath), TEMPLATE_ENCODING);
+}
+
+/**
+ * Read a template file asynchronously.
+ * @param relPath file path relative to the /templates directory under root.
+ */
+export function readTemplate(relPath: string): Promise<string> {
+  return readFile(absoluteTemplateFilePath(relPath), TEMPLATE_ENCODING);
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -23,6 +23,7 @@ import { FirebaseError } from "./error";
 import { logger, LogLevel } from "./logger";
 import { LogDataOrUndefined } from "./emulator/loggingEmulator";
 import { promptOnce } from "./prompt";
+import { readTemplateSync } from "./templates";
 
 export const IS_WINDOWS = process.platform === "win32";
 const SUCCESS_CHAR = IS_WINDOWS ? "+" : "✔";
@@ -800,8 +801,7 @@ export async function openInBrowserPopup(
   url: string,
   buttonText: string,
 ): Promise<{ url: string; cleanup: () => void }> {
-  const popupPage = fs
-    .readFileSync(path.join(__dirname, "../templates/popup.html"), { encoding: "utf-8" })
+  const popupPage = readTemplateSync("popup.html")
     .replace("${url}", url)
     .replace("${buttonText}", buttonText);
 


### PR DESCRIPTION
### Description

This makes template file paths all relative to `/templates/` and removes a lot of `__dirname` usages.

It allows source files to be moved around using TypeScript refactoring without breaking template paths.

Note that unlike #7332, moving template files themselves still requires manually updating string literals. (I've considered adding manifest files to templates but gave up since `/templates` are not in `/src`.)

### Scenarios Tested

See integration tests. Not every change is covered by tests though -- we may have to rely on careful code reviews on others.

### Sample Commands

N/A
