### PR TITLE
Correction of a problem where export to dotenv fails if the config value is operated with empty characters in the 1st gen of functions.

### DIFF
--- a/src/functions/runtimeConfigExport.ts
+++ b/src/functions/runtimeConfigExport.ts
@@ -178,7 +178,7 @@ const CHARACTERS_TO_ESCAPE_SEQUENCES: Record<string, string> = {
 
 function escape(s: string): string {
   // Escape newlines, tabs, backslashes and quotes
-  return s.replace(/[\n\r\t\v\\"']/g, (ch) => CHARACTERS_TO_ESCAPE_SEQUENCES[ch]);
+  return (s || '').replace(/[\n\r\t\v\\"']/g, (ch) => CHARACTERS_TO_ESCAPE_SEQUENCES[ch]);
 }
 
 /**


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Correction of a problem where export to dotenv fails if the config value is operated with empty characters in the 1st gen of functions.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
