### PR TITLE
Set a reasonable default dataconnect generated SDK output path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixes framework support for Nuxt ^3.12 by correctly calling loadNuxtConfig() (#7375)
+- Add a default for `firebase init dataconnect:sdk` (#7406)

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -106,7 +106,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
       type: "input",
       default:
         newConnectorYaml.generate.kotlinSdk?.outputDir ||
-        `./../.dataconnect/generated/${newConnectorYaml.connectorId}/kotlin-sdk`,
+        `./../.dataconnect/generated/${newConnectorYaml.connectorId}/kotlin-sdk/src/main/kotlin/${newConnectorYaml.connectorId}`,
     });
     const pkg = await promptOnce({
       message: "What package name do you want to use for your Kotlin SDK?",

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -59,11 +59,12 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   }
 
   if (platforms.includes(IOS)) {
-    const defaultOutputDir = newConnectorYaml.generate.swiftSdk?.outputDir;
     const outputDir = await promptOnce({
       message: `What directory do you want to write your Swift SDK code to? (If not absolute, path will be relative to '${connectorInfo.directory}')`,
       type: "input",
-      default: defaultOutputDir,
+      default:
+        newConnectorYaml.generate.swiftSdk?.outputDir ||
+        `.../.dataconnect/generated/${newConnectorYaml.connectorId}/js-sdk`,
     });
     const swiftSdk = { outputDir };
     newConnectorYaml.generate.swiftSdk = swiftSdk;
@@ -72,7 +73,9 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
     const outputDir = await promptOnce({
       message: `What directory do you want to write your JavaScript SDK code to? (If not absolute, path will be relative to '${connectorInfo.directory}')`,
       type: "input",
-      default: newConnectorYaml.generate.javascriptSdk?.outputDir,
+      default:
+        newConnectorYaml.generate.javascriptSdk?.outputDir ||
+        `.../.dataconnect/generated/${newConnectorYaml.connectorId}/ios-sdk`,
     });
     const pkg = await promptOnce({
       message: "What package name do you want to use for your JavaScript SDK?",
@@ -101,7 +104,9 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
     const outputDir = await promptOnce({
       message: `What directory do you want to write your Kotlin SDK code to? (If not absolute, path will be relative to '${connectorInfo.directory}')`,
       type: "input",
-      default: newConnectorYaml.generate.kotlinSdk?.outputDir,
+      default:
+        newConnectorYaml.generate.kotlinSdk?.outputDir ||
+        `.../.dataconnect/generated/${newConnectorYaml.connectorId}/android-sdk`,
     });
     const pkg = await promptOnce({
       message: "What package name do you want to use for your Kotlin SDK?",

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -64,7 +64,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
       type: "input",
       default:
         newConnectorYaml.generate.swiftSdk?.outputDir ||
-        `.../.dataconnect/generated/${newConnectorYaml.connectorId}/js-sdk`,
+        `./../.dataconnect/generated/${newConnectorYaml.connectorId}/swift-sdk`,
     });
     const swiftSdk = { outputDir };
     newConnectorYaml.generate.swiftSdk = swiftSdk;
@@ -75,7 +75,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
       type: "input",
       default:
         newConnectorYaml.generate.javascriptSdk?.outputDir ||
-        `.../.dataconnect/generated/${newConnectorYaml.connectorId}/ios-sdk`,
+        `./../.dataconnect/generated/${newConnectorYaml.connectorId}/javascript-sdk`,
     });
     const pkg = await promptOnce({
       message: "What package name do you want to use for your JavaScript SDK?",
@@ -106,7 +106,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
       type: "input",
       default:
         newConnectorYaml.generate.kotlinSdk?.outputDir ||
-        `.../.dataconnect/generated/${newConnectorYaml.connectorId}/android-sdk`,
+        `./../.dataconnect/generated/${newConnectorYaml.connectorId}/kotlin-sdk`,
     });
     const pkg = await promptOnce({
       message: "What package name do you want to use for your Kotlin SDK?",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Provide a default output path within `.dataconnect` folder, so by default we don't check-in generated SDK.

The existing behavior going through `firebase init dataconnect:sdk` flow with the default option is horrendous bad...

<img width="801" alt="Screenshot 2024-07-01 at 8 01 54 PM" src="https://github.com/firebase/firebase-tools/assets/9068391/f98c407b-73c0-45dc-b7ec-2953dc313271">

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

<img width="1440" alt="Screenshot 2024-07-01 at 7 48 19 PM" src="https://github.com/firebase/firebase-tools/assets/9068391/9152b631-9c49-48d6-a5a8-d23d4a772bf7">
