### PR TITLE
Re-enable single builds by default

### DIFF
--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -40,7 +40,7 @@ export const ALL_EXPERIMENTS = experiments({
       "of deploys. This has been made an experiment due to backend bugs that are " +
       "temporarily causing failures in some regions with this optimization enabled",
     public: true,
-    default: false,
+    default: true,
   },
   deletegcfartifacts: {
     shortDescription: `Add the ${bold(


### PR DESCRIPTION
GCF single builds has been fully rolled out. We are re-enabling single builds by default. Fixes https://github.com/firebase/firebase-tools/issues/7268