### PR TITLE
Pass down functions.ignore values in firebase.json to functions emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Pass down `functions.ignore` values in `firebase.json` to functions emulator so that supposedly ignored directories/files will not trigger reload. (#7414)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -517,6 +517,7 @@ export async function startAll(
         // TODO(b/213335255): predefinedTriggers and nodeMajorVersion are here to support ext:dev:emulators:* commands.
         // Ideally, we should handle that case via ExtensionEmulator.
         predefinedTriggers: options.extDevTriggers as ParsedTriggerDefinition[] | undefined,
+        ignore: cfg.ignore,
       });
     }
   }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -94,6 +94,7 @@ export interface EmulatableBackend {
   extension?: Extension; // Only present for published extensions
   extensionVersion?: ExtensionVersion; // Only present for published extensions
   extensionSpec?: ExtensionSpec; // Only present for local extensions
+  ignore?: string[];
 }
 
 /**
@@ -460,6 +461,7 @@ export class FunctionsEmulator implements EmulatorInstance {
           /(^|[\/\\])\../, // Ignore files which begin the a period
           /.+\.log/, // Ignore files which have a .log extension
           /.+?[\\\/]venv[\\\/].+?/, // Ignore site-packages in venv
+          ...(backend.ignore?.map((i) => `**/${i}`) ?? []),
         ],
         persistent: true,
       });


### PR DESCRIPTION
Pass down `functions.ignore` values in `firebase.json` to functions emulator so that supposedly ignored directories/files will not trigger reload.