### PR TITLE
App Hosting: Support multiple regions

### DIFF
--- a/src/apphosting/githubConnections.spec.ts
+++ b/src/apphosting/githubConnections.spec.ts
@@ -320,7 +320,7 @@ describe("githubConnections", () => {
         mockConn("apphosting-github-oauth"),
       ]);
 
-      const conns = await repo.listAppHostingConnections(projectId);
+      const conns = await repo.listAppHostingConnections(projectId, location);
       expect(conns).to.have.length(2);
       expect(conns.map((c) => extractId(c.name))).to.include.members([
         "apphosting-github-conn-baddcafe",

--- a/src/apphosting/githubConnections.ts
+++ b/src/apphosting/githubConnections.ts
@@ -98,7 +98,7 @@ export async function linkGitHubRepository(
   utils.logBullet(clc.bold(`${clc.yellow("===")} Import a GitHub repository`));
   // Fetch the sentinel Oauth connection first which is needed to create further GitHub connections.
   const oauthConn = await getOrCreateOauthConnection(projectId, location);
-  const existingConns = await listAppHostingConnections(projectId);
+  const existingConns = await listAppHostingConnections(projectId, location);
 
   if (existingConns.length === 0) {
     existingConns.push(
@@ -408,8 +408,9 @@ export async function getOrCreateRepository(
  */
 export async function listAppHostingConnections(
   projectId: string,
+  location: string,
 ): Promise<devConnect.Connection[]> {
-  const conns = await devConnect.listAllConnections(projectId, "-");
+  const conns = await devConnect.listAllConnections(projectId, location);
   return conns.filter(
     (conn) =>
       APPHOSTING_CONN_PATTERN.test(conn.name) &&


### PR DESCRIPTION
For the most part the CLI already has support for multiple regions, this is the only place I saw us doing a global query instead of region based query.