### PR TITLE
Fixing an issue where old access_tokens would be used intead of requesting new ones

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -110,13 +110,10 @@ export function getAllAccounts(): Account[] {
  * @param options options object.
  * @param account account to make active.
  */
-export function setActiveAccount(options: any, account: Account) {
+export async function setActiveAccount(options: any, account: Account) {
   if (account.tokens.refresh_token) {
     setRefreshToken(account.tokens.refresh_token);
-  }
-
-  if (account.tokens.access_token) {
-    setAccessToken(account.tokens.access_token);
+    setAccessToken(await apiv2.getAccessToken());
   }
 
   options.user = account.user;

--- a/src/command.ts
+++ b/src/command.ts
@@ -319,7 +319,7 @@ export class Command {
     const activeAccount = selectAccount(account, projectRoot);
 
     if (activeAccount) {
-      setActiveAccount(options, activeAccount);
+      await setActiveAccount(options, activeAccount);
     }
 
     this.applyRC(options);

--- a/src/init/features/account.ts
+++ b/src/init/features/account.ts
@@ -73,7 +73,7 @@ export async function doSetup(setup: any, config: any, options: any): Promise<vo
   }
 
   // Set the global auth state
-  setActiveAccount(options, account);
+  await setActiveAccount(options, account);
 
   // Set the project default user
   if (config.projectDir) {

--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -51,7 +51,10 @@ async function autoAuth(options: Options, authScopes: string[]): Promise<void | 
   }
   if (process.env.MONOSPACE_ENV && token && clientEmail) {
     // Within monospace, this a OAuth token for the user, so we make it the active user.
-    setActiveAccount(options, { user: { email: clientEmail }, tokens: { access_token: token } });
+    await setActiveAccount(options, {
+      user: { email: clientEmail },
+      tokens: { access_token: token },
+    });
     setGlobalDefaultAccount({ user: { email: clientEmail }, tokens: { access_token: token } });
 
     // project is also selected in monospace auth flow
@@ -107,6 +110,6 @@ export async function requireAuth(options: any): Promise<string | void> {
     throw new FirebaseError(AUTH_ERROR_MESSAGE);
   }
 
-  setActiveAccount(options, { user, tokens });
+  await setActiveAccount(options, { user, tokens });
   return user.email;
 }


### PR DESCRIPTION
### Description
Fixes #7429 - fixies an issue where we would always reuse access_tokens instead of using our refresh tokens to request new ones.

There is probably some more work to be done here in the future - if I'm understanding things correctly, very long running VSCode sessions may get stuck with an old access_token still. We probably want to do some actual expiry checking and grab new tokens based on that.