### PR TITLE
Add support for importing nonempty services with 'firebase init dataconnect'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- `firebase init dataconnect` now can pull down deployed GQL files.

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -230,7 +230,6 @@ async function promptForService(setup: Setup, info: RequiredInfo): Promise<Requi
             info.cloudSqlInstanceId = instanceName.instanceId;
           }
           if (choice.schema.source.files) {
-            console.log(choice.schema.source.files.length);
             info.schemaGql = choice.schema.source.files;
           }
           info.cloudSqlDatabase = choice.schema.primaryDatasource.postgresql?.database ?? "";

--- a/templates/init/dataconnect/dataconnect.yaml
+++ b/templates/init/dataconnect/dataconnect.yaml
@@ -8,4 +8,4 @@ schema:
       database: "__cloudSqlDatabase__"
       cloudSql:
         instanceId: "__cloudSqlInstanceId__"
-connectorDirs: ["./__connectorId__"]
+connectorDirs: [__connectorIds__]


### PR DESCRIPTION
### Description
Allows users to import any service with 'firebase init dataconnect'

Limitations:
This does not replace source control. The files created by `init` will deploy an equivalent 

### Scenarios Tested
Deployed a service with multiple connectors, and verified that we can successfully init with it
<img width="1165" alt="Screenshot 2024-07-11 at 4 11 24 PM" src="https://github.com/user-attachments/assets/b519fc47-456d-4da1-8816-4b6f59d649d3">
I also verified that the normal, no new service flow still looks good.
