### PR TITLE
add debug log for socket timeout

### DIFF
--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -263,6 +263,8 @@ export class RuntimeWorker {
     const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
     const timeout = new Promise<never>((resolve, reject) => {
       setTimeout(() => {
+        this.logDebug("Reached socked ready timeout");
+        
         reject(new FirebaseError("Failed to load function."));
       }, 30_000);
     });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Adds some debug output for the `Failed to load function.` error triggered by a timeout waiting for socket ready. 

I ran into this error in my CI with no extra information in logs, even with `--debug`, and needed to search through the code to find this instance where it is thrown with no additional info. I think it would be helpful to give some context on what failed. I am happy to tweak the text/means of logging as suggested.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
