### PR TITLE
Fix issue where publishTime is always 1970-01-01T00:00:00

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - `firebase init dataconnect` now can pull down deployed GQL files.
 - GitHub Action fixes for web frameworks (#6883)
+- Fixes issue where PubSub message `publishTime` is set to 1970-01-01T00:00:00 (#7441)

--- a/src/emulator/pubsubEmulator.ts
+++ b/src/emulator/pubsubEmulator.ts
@@ -192,7 +192,7 @@ export class PubsubEmulator implements EmulatorInstance {
     // Pubsub events from Pubsub Emulator include a date with nanoseconds.
     // Prod Pubsub doesn't publish timestamp at that level of precision. Timestamp with nanosecond precision also
     // are difficult to parse in languages other than Node.js (e.g. python).
-    const truncatedPublishTime = new Date(message.publishTime.getMilliseconds()).toISOString();
+    const truncatedPublishTime = new Date(message.publishTime.getTime()).toISOString();
     const data: MessagePublishedData = {
       message: {
         messageId: message.id,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #7441

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Using:

functions/index.js

```js
import { onRequest } from "firebase-functions/v2/https";
import { onMessagePublished } from "firebase-functions/v2/pubsub";
import { PubSub } from '@google-cloud/pubsub'

export const example = onMessagePublished(
    {
        topic: 'example',
        timeoutSeconds: 540,
        memory: '2GiB',
    },
    (event) => {
        console.log(`Publish time: ${event.data.message.publishTime}`);
    },
);

export const publishMessage = onRequest(async (req, res) => {
    const pubSubClient = new PubSub()

    const [messageId] = await pubSubClient.topic('example').publishMessage({
        data: Buffer.from(JSON.stringify({ generateRun: true })),
    })

    res.send(`Message ID ${messageId}`)
})
```
Steps:

1. Run `firebase emulators:start --project demo-project`
2. Open a new terminal and run `curl http://127.0.0.1:5001/demo-project/us-central1/publishMessage`, or open "http://127.0.0.1:5001/demo-project/us-central1/publishMessage" in a browser
3 Outputs:
```shell
i  emulators: Starting emulators: functions, pubsub
i  emulators: Detected demo project ID "demo-project", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  pubsub: Pub/Sub Emulator logging to pubsub-debug.log
i  ui: Emulator UI logging to ui-debug.log
i  functions: Watching "/Users/<user>/Desktop/firebase-tools/issues/7441/functions" for Cloud Functions...
⚠  functions: Your requested "node" version "18" doesn't match your global version "20". Using node@20 from host.
Serving at port 8820

✔  functions: Loaded functions definitions from source: example, publishMessage.
✔  functions[us-central1-example]: pubsub function initialized.
✔  functions[us-central1-publishMessage]: http function initialized (http://127.0.0.1:5001/demo-project/us-central1/publishMessage).

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://127.0.0.1:4000/               │
└─────────────────────────────────────────────────────────────┘

┌───────────┬────────────────┬─────────────────────────────────┐
│ Emulator  │ Host:Port      │ View in Emulator UI             │
├───────────┼────────────────┼─────────────────────────────────┤
│ Functions │ 127.0.0.1:5001 │ http://127.0.0.1:4000/functions │
├───────────┼────────────────┼─────────────────────────────────┤
│ Pub/Sub   │ 127.0.0.1:8085 │ n/a                             │
└───────────┴────────────────┴─────────────────────────────────┘
  Emulator Hub running at 127.0.0.1:4400
  Other reserved ports: 4500

Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
 
i  functions: Beginning execution of "us-central1-publishMessage"
i  functions: Finished "us-central1-publishMessage" in 85.38625ms
i  functions: Beginning execution of "us-central1-example"
>  Publish time: 2024-07-16T16:11:15.847Z
i  functions: Finished "us-central1-example" in 3.460125ms
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
