### PR TITLE
Add support for setting the encryption configuration of restored firestore databases

### DIFF
--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -18,7 +18,7 @@ export const command = new Command("firestore:databases:restore")
   .option(
     "-e, --encryption-type <encryptionType>",
     `Encryption method of the restored database; one of ${EncryptionType.CUSTOMER_MANAGED_ENCRYPTION}, ` +
-      `${EncryptionType.USE_BACKUP_ENCRYPTION}, ${EncryptionType.GOOGLE_DEFAULT_ENCRYPTION}`,
+      `${EncryptionType.USE_BACKUP_ENCRYPTION} (default), ${EncryptionType.GOOGLE_DEFAULT_ENCRYPTION}`,
   )
   .option(
     "-k, --kms-key-name <kmsKeyName>",

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -14,8 +14,14 @@ export const command = new Command("firestore:databases:restore")
   .description("Restore a Firestore database in your Firebase project.")
   .option("-d, --database <databaseID>", "ID of the database to restore into")
   .option("-b, --backup <backup>", "Backup from which to restore")
-  .option("-e, --encryption-type <encryptionType", "Encryption method of the restored database; one of CUSTOMER_MANAGED_ENCRYPTION, USE_BACKUP_ENCRYPTION, GOOGLE_DEFAULT_ENCRYPTION")
-  .option("-k, --kms-key-name <kmsKeyName>", "Resource ID of the Cloud KMS key to encrypt the restored database")
+  .option(
+    "-e, --encryption-type <encryptionType",
+    "Encryption method of the restored database; one of CUSTOMER_MANAGED_ENCRYPTION, USE_BACKUP_ENCRYPTION, GOOGLE_DEFAULT_ENCRYPTION",
+  )
+  .option(
+    "-k, --kms-key-name <kmsKeyName>",
+    "Resource ID of the Cloud KMS key to encrypt the restored database",
+  )
   .before(requirePermissions, ["datastore.backups.restoreDatabase"])
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (options: FirestoreOptions) => {
@@ -24,31 +30,28 @@ export const command = new Command("firestore:databases:restore")
     const helpCommandText = "See firebase firestore:databases:restore --help for more info";
 
     if (!options.database) {
-      logger.error(
-        `Missing required flag --database. ${helpCommandText}`,
-      );
+      logger.error(`Missing required flag --database. ${helpCommandText}`);
       return;
     }
     const databaseId = options.database;
 
     if (!options.backup) {
-      logger.error(
-        `Missing required flag --backup. ${helpCommandText}`,
-      );
+      logger.error(`Missing required flag --backup. ${helpCommandText}`);
       return;
     }
     const backupName = options.backup;
-    var encryptionConfig: types.EncryptionConfig | undefined = undefined
+
+    let encryptionConfig: types.EncryptionConfig | undefined = undefined;
     switch (options.encryptionType ?? "") {
       case "GOOGLE_DEFAULT_ENCRYPTION":
-        encryptionConfig = {useGoogleDefaultEncryption: {}}
+        encryptionConfig = { useGoogleDefaultEncryption: {} };
         break;
       case "USE_BACKUP_ENCRYPTION":
-        encryptionConfig = {useBackupEncryption: {}}
+        encryptionConfig = { useBackupEncryption: {} };
         break;
       case "CUSTOMER_MANAGED_ENCRYPTION":
         if (options.kmsKeyName) {
-          encryptionConfig = {kmsKeyName: options.kmsKeyName}
+          encryptionConfig = { kmsKeyName: options.kmsKeyName };
           break;
         } else {
           logger.error(
@@ -60,16 +63,15 @@ export const command = new Command("firestore:databases:restore")
         // No encryption config specified
         break;
       default:
-        logger.error(
-          `Invalid value for flag --encryption-type. ${helpCommandText}`,
-        );
+        logger.error(`Invalid value for flag --encryption-type. ${helpCommandText}`);
         return;
     }
+
     const databaseResp: types.DatabaseResp = await api.restoreDatabase(
       options.project,
       databaseId,
       backupName,
-      encryptionConfig
+      encryptionConfig,
     );
 
     if (options.json) {
@@ -80,8 +82,8 @@ export const command = new Command("firestore:databases:restore")
       );
       logger.info(
         "Please be sure to configure Firebase rules in your Firebase config file for\n" +
-        "the new database. By default, created databases will have closed rules that\n" +
-        "block any incoming third-party traffic.",
+          "the new database. By default, created databases will have closed rules that\n" +
+          "block any incoming third-party traffic.",
       );
       logger.info(
         `Once the restore is complete, your database may be viewed at ${printer.firebaseConsoleDatabaseUrl(options.project, databaseId)}`,

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -58,8 +58,7 @@ export const command = new Command("firestore:databases:restore")
           encryptionConfig = { kmsKeyName: getKmsKeyOrThrow(options.kmsKeyName) };
           break;
         default:
-          logger.error(`Invalid value for flag --encryption-type. ${helpCommandText}`);
-          return;
+          throw new FirebaseError(`Invalid value for flag --encryption-type. ${helpCommandText}`);
       }
 } else {
       throwIfKmsKeyNameIsSet(options.kmsKeyName);

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -7,7 +7,7 @@ import { logger } from "../logger";
 import { requirePermissions } from "../requirePermissions";
 import { Emulators } from "../emulator/types";
 import { warnEmulatorNotSupported } from "../emulator/commandUtils";
-import { FirestoreOptions } from "../firestore/options";
+import { EncryptionType, FirestoreOptions } from "../firestore/options";
 import { PrettyPrint } from "../firestore/pretty-print";
 import { FirebaseError } from "../error";
 
@@ -17,7 +17,8 @@ export const command = new Command("firestore:databases:restore")
   .option("-b, --backup <backup>", "Backup from which to restore")
   .option(
     "-e, --encryption-type <encryptionType>",
-    "Encryption method of the restored database; one of CUSTOMER_MANAGED_ENCRYPTION, USE_BACKUP_ENCRYPTION, GOOGLE_DEFAULT_ENCRYPTION",
+    `Encryption method of the restored database; one of ${EncryptionType.CUSTOMER_MANAGED_ENCRYPTION}, ` +
+      `${EncryptionType.USE_BACKUP_ENCRYPTION}, ${EncryptionType.GOOGLE_DEFAULT_ENCRYPTION}`,
   )
   .option(
     "-k, --kms-key-name <kmsKeyName>",
@@ -44,16 +45,16 @@ export const command = new Command("firestore:databases:restore")
 
     let encryptionConfig: types.EncryptionConfig | undefined = undefined;
     if (options.encryptionType !== undefined) {
-      switch (options.encryptionType ?? "") {
-        case "GOOGLE_DEFAULT_ENCRYPTION":
+      switch (options.encryptionType) {
+        case EncryptionType.GOOGLE_DEFAULT_ENCRYPTION:
           throwIfKmsKeyNameIsSet(options.kmsKeyName);
           encryptionConfig = { useGoogleDefaultEncryption: {} };
           break;
-        case "USE_BACKUP_ENCRYPTION":
+        case EncryptionType.USE_BACKUP_ENCRYPTION:
           throwIfKmsKeyNameIsSet(options.kmsKeyName);
           encryptionConfig = { useBackupEncryption: {} };
           break;
-        case "CUSTOMER_MANAGED_ENCRYPTION":
+        case EncryptionType.CUSTOMER_MANAGED_ENCRYPTION:
           encryptionConfig = { kmsKeyName: getKmsKeyOrThrow(options.kmsKeyName) };
           break;
         default:
@@ -91,7 +92,7 @@ export const command = new Command("firestore:databases:restore")
       if (kmsKeyName) {
         throw new FirebaseError(
           "--kms-key-name cannot be set when using an --encryption-type of " +
-            "GOOGLE_DEFAULT_ENCRYPTION or USE_BACKUP_ENCRYPTION.",
+            `${EncryptionType.GOOGLE_DEFAULT_ENCRYPTION} or ${EncryptionType.USE_BACKUP_ENCRYPTION}.`,
         );
       }
     }
@@ -101,7 +102,7 @@ export const command = new Command("firestore:databases:restore")
 
       throw new FirebaseError(
         "--kms-key-name must be provided when using an --encryption-type of " +
-          "CUSTOMER_MANAGED_ENCRYPTION.",
+          `${EncryptionType.CUSTOMER_MANAGED_ENCRYPTION}.`,
       );
     }
   });

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -19,10 +19,11 @@ export const command = new Command("firestore:databases:restore")
   .action(async (options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
+    const HELP_COMMAND = "See firebase firestore:databases:restore --help for more info";
 
     if (!options.database) {
       logger.error(
-        "Missing required flag --database. See firebase firestore:databases:restore --help for more info",
+        `Missing required flag --database. ${HELP_COMMAND}`,
       );
       return;
     }
@@ -30,7 +31,7 @@ export const command = new Command("firestore:databases:restore")
 
     if (!options.backup) {
       logger.error(
-        "Missing required flag --backup. See firebase firestore:databases:restore --help for more info",
+        `Missing required flag --backup. ${HELP_COMMAND}`,
       );
       return;
     }

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -15,7 +15,7 @@ export const command = new Command("firestore:databases:restore")
   .option("-d, --database <databaseID>", "ID of the database to restore into")
   .option("-b, --backup <backup>", "Backup from which to restore")
   .option(
-    "-e, --encryption-type <encryptionType",
+    "-e, --encryption-type <encryptionType>",
     "Encryption method of the restored database; one of CUSTOMER_MANAGED_ENCRYPTION, USE_BACKUP_ENCRYPTION, GOOGLE_DEFAULT_ENCRYPTION",
   )
   .option(

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -61,6 +61,8 @@ export const command = new Command("firestore:databases:restore")
           logger.error(`Invalid value for flag --encryption-type. ${helpCommandText}`);
           return;
       }
+} else {
+      throwIfKmsKeyNameIsSet(options.kmsKeyName);
     }
 
     const databaseResp: types.DatabaseResp = await api.restoreDatabase(
@@ -91,8 +93,8 @@ export const command = new Command("firestore:databases:restore")
     function throwIfKmsKeyNameIsSet(kmsKeyName: string | undefined): void {
       if (kmsKeyName) {
         throw new FirebaseError(
-          "--kms-key-name cannot be set when using an --encryption-type of " +
-            `${EncryptionType.GOOGLE_DEFAULT_ENCRYPTION} or ${EncryptionType.USE_BACKUP_ENCRYPTION}.`,
+          "--kms-key-name can only be set when specifying an --encryption-type " +
+            `of ${EncryptionType.CUSTOMER_MANAGED_ENCRYPTION}.`,
         );
       }
     }

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -42,6 +42,9 @@ export const command = new Command("firestore:databases:restore")
       case "GOOGLE_DEFAULT_ENCRYPTION":
         encryptionConfig = {useGoogleDefaultEncryption: {}}
         break;
+      case "USE_BACKUP_ENCRYPTION":
+        encryptionConfig = {useBackupEncryption: {}}
+        break;
       case "":
         // No encryption config specified
         break;

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -29,7 +29,7 @@ export const command = new Command("firestore:databases:restore")
   .action(async (options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
-    const helpCommandText = "See firebase firestore:databases:restore --help for more info";
+    const helpCommandText = "See firebase firestore:databases:restore --help for more info.";
 
     if (!options.database) {
       logger.error(`Missing required flag --database. ${helpCommandText}`);
@@ -60,7 +60,7 @@ export const command = new Command("firestore:databases:restore")
         default:
           throw new FirebaseError(`Invalid value for flag --encryption-type. ${helpCommandText}`);
       }
-} else {
+    } else {
       throwIfKmsKeyNameIsSet(options.kmsKeyName);
     }
 
@@ -102,8 +102,8 @@ export const command = new Command("firestore:databases:restore")
       if (kmsKeyName) return kmsKeyName;
 
       throw new FirebaseError(
-        "--kms-key-name must be provided when using an --encryption-type of " +
-          `${EncryptionType.CUSTOMER_MANAGED_ENCRYPTION}.`,
+        "--kms-key-name must be provided when specifying an --encryption-type " +
+          `of ${EncryptionType.CUSTOMER_MANAGED_ENCRYPTION}.`,
       );
     }
   });

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -55,6 +55,7 @@ export const command = new Command("firestore:databases:restore")
       options.project,
       databaseId,
       backupName,
+      encryptionConfig
     );
 
     if (options.json) {
@@ -65,8 +66,8 @@ export const command = new Command("firestore:databases:restore")
       );
       logger.info(
         "Please be sure to configure Firebase rules in your Firebase config file for\n" +
-          "the new database. By default, created databases will have closed rules that\n" +
-          "block any incoming third-party traffic.",
+        "the new database. By default, created databases will have closed rules that\n" +
+        "block any incoming third-party traffic.",
       );
       logger.info(
         `Once the restore is complete, your database may be viewed at ${printer.firebaseConsoleDatabaseUrl(options.project, databaseId)}`,

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -42,29 +42,28 @@ export const command = new Command("firestore:databases:restore")
     const backupName = options.backup;
 
     let encryptionConfig: types.EncryptionConfig | undefined = undefined;
-    switch (options.encryptionType ?? "") {
-      case "GOOGLE_DEFAULT_ENCRYPTION":
-        encryptionConfig = { useGoogleDefaultEncryption: {} };
-        break;
-      case "USE_BACKUP_ENCRYPTION":
-        encryptionConfig = { useBackupEncryption: {} };
-        break;
-      case "CUSTOMER_MANAGED_ENCRYPTION":
-        if (options.kmsKeyName) {
-          encryptionConfig = { kmsKeyName: options.kmsKeyName };
+    if (options.encryptionType !== undefined) {
+      switch (options.encryptionType ?? "") {
+        case "GOOGLE_DEFAULT_ENCRYPTION":
+          encryptionConfig = { useGoogleDefaultEncryption: {} };
           break;
-        } else {
-          logger.error(
-            `If --encryption-type is CUSTOMER_MANAGED_ENCRYPTION, --kms-key-name must be provided. ${helpCommandText}`,
-          );
+        case "USE_BACKUP_ENCRYPTION":
+          encryptionConfig = { useBackupEncryption: {} };
+          break;
+        case "CUSTOMER_MANAGED_ENCRYPTION":
+          if (options.kmsKeyName) {
+            encryptionConfig = { kmsKeyName: options.kmsKeyName };
+            break;
+          } else {
+            logger.error(
+              `If --encryption-type is CUSTOMER_MANAGED_ENCRYPTION, --kms-key-name must be provided. ${helpCommandText}`,
+            );
+            return;
+          }
+        default:
+          logger.error(`Invalid value for flag --encryption-type. ${helpCommandText}`);
           return;
-        }
-      case "":
-        // No encryption config specified
-        break;
-      default:
-        logger.error(`Invalid value for flag --encryption-type. ${helpCommandText}`);
-        return;
+      }
     }
 
     const databaseResp: types.DatabaseResp = await api.restoreDatabase(

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -20,11 +20,11 @@ export const command = new Command("firestore:databases:restore")
   .action(async (options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
-    const HELP_COMMAND = "See firebase firestore:databases:restore --help for more info";
+    const helpCommandText = "See firebase firestore:databases:restore --help for more info";
 
     if (!options.database) {
       logger.error(
-        `Missing required flag --database. ${HELP_COMMAND}`,
+        `Missing required flag --database. ${helpCommandText}`,
       );
       return;
     }
@@ -32,7 +32,7 @@ export const command = new Command("firestore:databases:restore")
 
     if (!options.backup) {
       logger.error(
-        `Missing required flag --backup. ${HELP_COMMAND}`,
+        `Missing required flag --backup. ${helpCommandText}`,
       );
       return;
     }
@@ -50,7 +50,7 @@ export const command = new Command("firestore:databases:restore")
         break;
       default:
         logger.error(
-          `Invalid value for flag --encryption-type. ${HELP_COMMAND}`,
+          `Invalid value for flag --encryption-type. ${helpCommandText}`,
         );
         return;
     }

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -15,6 +15,7 @@ export const command = new Command("firestore:databases:restore")
   .option("-d, --database <databaseID>", "ID of the database to restore into")
   .option("-b, --backup <backup>", "Backup from which to restore")
   .option("-e, --encryption-type <encryptionType", "Encryption method of the restored database; one of CUSTOMER_MANAGED_ENCRYPTION, USE_BACKUP_ENCRYPTION, GOOGLE_DEFAULT_ENCRYPTION")
+  .option("-k, --kms-key-name <kmsKeyName>", "Resource ID of the Cloud KMS key to encrypt the restored database")
   .before(requirePermissions, ["datastore.backups.restoreDatabase"])
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (options: FirestoreOptions) => {
@@ -45,6 +46,16 @@ export const command = new Command("firestore:databases:restore")
       case "USE_BACKUP_ENCRYPTION":
         encryptionConfig = {useBackupEncryption: {}}
         break;
+      case "CUSTOMER_MANAGED_ENCRYPTION":
+        if (options.kmsKeyName) {
+          encryptionConfig = {kmsKeyName: options.kmsKeyName}
+          break;
+        } else {
+          logger.error(
+            `If --encryption-type is CUSTOMER_MANAGED_ENCRYPTION, --kms-key-name must be provided. ${helpCommandText}`,
+          );
+          return;
+        }
       case "":
         // No encryption config specified
         break;

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -44,24 +44,23 @@ export const command = new Command("firestore:databases:restore")
     const backupName = options.backup;
 
     let encryptionConfig: types.EncryptionConfig | undefined = undefined;
-    if (options.encryptionType !== undefined) {
-      switch (options.encryptionType) {
-        case EncryptionType.GOOGLE_DEFAULT_ENCRYPTION:
-          throwIfKmsKeyNameIsSet(options.kmsKeyName);
-          encryptionConfig = { useGoogleDefaultEncryption: {} };
-          break;
-        case EncryptionType.USE_BACKUP_ENCRYPTION:
-          throwIfKmsKeyNameIsSet(options.kmsKeyName);
-          encryptionConfig = { useBackupEncryption: {} };
-          break;
-        case EncryptionType.CUSTOMER_MANAGED_ENCRYPTION:
-          encryptionConfig = { kmsKeyName: getKmsKeyOrThrow(options.kmsKeyName) };
-          break;
-        default:
-          throw new FirebaseError(`Invalid value for flag --encryption-type. ${helpCommandText}`);
-      }
-    } else {
-      throwIfKmsKeyNameIsSet(options.kmsKeyName);
+    switch (options.encryptionType) {
+      case EncryptionType.GOOGLE_DEFAULT_ENCRYPTION:
+        throwIfKmsKeyNameIsSet(options.kmsKeyName);
+        encryptionConfig = { useGoogleDefaultEncryption: {} };
+        break;
+      case EncryptionType.USE_BACKUP_ENCRYPTION:
+        throwIfKmsKeyNameIsSet(options.kmsKeyName);
+        encryptionConfig = { useBackupEncryption: {} };
+        break;
+      case EncryptionType.CUSTOMER_MANAGED_ENCRYPTION:
+        encryptionConfig = { kmsKeyName: getKmsKeyOrThrow(options.kmsKeyName) };
+        break;
+      case undefined:
+        throwIfKmsKeyNameIsSet(options.kmsKeyName);
+        break;
+      default:
+        throw new FirebaseError(`Invalid value for flag --encryption-type. ${helpCommandText}`);
     }
 
     const databaseResp: types.DatabaseResp = await api.restoreDatabase(

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -14,6 +14,7 @@ export const command = new Command("firestore:databases:restore")
   .description("Restore a Firestore database in your Firebase project.")
   .option("-d, --database <databaseID>", "ID of the database to restore into")
   .option("-b, --backup <backup>", "Backup from which to restore")
+  .option("-e, --encryption-type <encryptionType", "Encryption method of the restored database; one of CUSTOMER_MANAGED_ENCRYPTION, USE_BACKUP_ENCRYPTION, GOOGLE_DEFAULT_ENCRYPTION")
   .before(requirePermissions, ["datastore.backups.restoreDatabase"])
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (options: FirestoreOptions) => {
@@ -36,7 +37,20 @@ export const command = new Command("firestore:databases:restore")
       return;
     }
     const backupName = options.backup;
-
+    var encryptionConfig: types.EncryptionConfig | undefined = undefined
+    switch (options.encryptionType ?? "") {
+      case "GOOGLE_DEFAULT_ENCRYPTION":
+        encryptionConfig = {useGoogleDefaultEncryption: {}}
+        break;
+      case "":
+        // No encryption config specified
+        break;
+      default:
+        logger.error(
+          `Invalid value for flag --encryption-type. ${HELP_COMMAND}`,
+        );
+        return;
+    }
     const databaseResp: types.DatabaseResp = await api.restoreDatabase(
       options.project,
       databaseId,

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -154,3 +154,8 @@ export enum RecurrenceType {
   DAILY = "DAILY",
   WEEKLY = "WEEKLY",
 }
+
+type UseGoogleDefaultEncryption = {useGoogleDefaultEncryption: Object}
+type UseBackupEncryption = {useBackupEncryption: Object}
+type UseCustomerManagedEncryption = {kmsKeyName: string}
+export type EncryptionConfig = UseCustomerManagedEncryption | UseBackupEncryption | UseGoogleDefaultEncryption

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -155,7 +155,10 @@ export enum RecurrenceType {
   WEEKLY = "WEEKLY",
 }
 
-type UseGoogleDefaultEncryption = {useGoogleDefaultEncryption: Object}
-type UseBackupEncryption = {useBackupEncryption: Object}
-type UseCustomerManagedEncryption = {kmsKeyName: string}
-export type EncryptionConfig = UseCustomerManagedEncryption | UseBackupEncryption | UseGoogleDefaultEncryption
+type UseGoogleDefaultEncryption = { useGoogleDefaultEncryption: Record<string, never> };
+type UseBackupEncryption = { useBackupEncryption: Record<string, never> };
+type UseCustomerManagedEncryption = { kmsKeyName: string };
+export type EncryptionConfig =
+  | UseCustomerManagedEncryption
+  | UseBackupEncryption
+  | UseGoogleDefaultEncryption;

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -711,11 +711,13 @@ export class FirestoreApi {
     project: string,
     databaseId: string,
     backupName: string,
+    encryptionConfig?: types.EncryptionConfig
   ): Promise<types.DatabaseResp> {
     const url = `/projects/${project}/databases:restore`;
     const payload: types.RestoreDatabaseReq = {
       databaseId,
       backup: backupName,
+      ...encryptionConfig
     };
     const options = { queryParams: { databaseId: databaseId } };
     const res = await this.apiClient.post<

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -706,18 +706,19 @@ export class FirestoreApi {
    * @param project the Firebase project id.
    * @param databaseId the ID of the Firestore Database to be restored into
    * @param backupName Name of the backup from which to restore
+   * @param encryptionConfig the encryption configuration of the restored database
    */
   async restoreDatabase(
     project: string,
     databaseId: string,
     backupName: string,
-    encryptionConfig?: types.EncryptionConfig
+    encryptionConfig?: types.EncryptionConfig,
   ): Promise<types.DatabaseResp> {
     const url = `/projects/${project}/databases:restore`;
     const payload: types.RestoreDatabaseReq = {
       databaseId,
       backup: backupName,
-      ...encryptionConfig
+      ...encryptionConfig,
     };
     const options = { queryParams: { databaseId: databaseId } };
     const res = await this.apiClient.post<

--- a/src/firestore/options.ts
+++ b/src/firestore/options.ts
@@ -29,9 +29,12 @@ export interface FirestoreOptions extends Options {
   backup?: string;
 
   // CMEK
-  encryptionType?:
-    | "CUSTOMER_MANAGED_ENCRYPTION"
-    | "USE_BACKUP_ENCRYPTION"
-    | "GOOGLE_DEFAULT_ENCRYPTION";
+  encryptionType?: EncryptionType;
   kmsKeyName?: string;
+}
+
+export enum EncryptionType {
+  CUSTOMER_MANAGED_ENCRYPTION = "CUSTOMER_MANAGED_ENCRYPTION",
+  USE_BACKUP_ENCRYPTION = "USE_BACKUP_ENCRYPTION",
+  GOOGLE_DEFAULT_ENCRYPTION = "GOOGLE_DEFAULT_ENCRYPTION",
 }

--- a/src/firestore/options.ts
+++ b/src/firestore/options.ts
@@ -29,6 +29,9 @@ export interface FirestoreOptions extends Options {
   backup?: string;
 
   // CMEK
-  encryptionType?: "CUSTOMER_MANAGED_ENCRYPTION" | "USE_BACKUP_ENCRYPTION" | "GOOGLE_DEFAULT_ENCRYPTION";
+  encryptionType?:
+    | "CUSTOMER_MANAGED_ENCRYPTION"
+    | "USE_BACKUP_ENCRYPTION"
+    | "GOOGLE_DEFAULT_ENCRYPTION";
   kmsKeyName?: string;
 }

--- a/src/firestore/options.ts
+++ b/src/firestore/options.ts
@@ -27,4 +27,7 @@ export interface FirestoreOptions extends Options {
 
   // backups
   backup?: string;
+
+  // CMEK
+  encryptionType?: "GOOGLE_DEFAULT_ENCRYPTION";
 }

--- a/src/firestore/options.ts
+++ b/src/firestore/options.ts
@@ -29,6 +29,6 @@ export interface FirestoreOptions extends Options {
   backup?: string;
 
   // CMEK
-  encryptionType?: "USE_BACKUP_ENCRYPTION" | "GOOGLE_DEFAULT_ENCRYPTION";
-  encryptionType?: "GOOGLE_DEFAULT_ENCRYPTION";
+  encryptionType?: "CUSTOMER_MANAGED_ENCRYPTION" | "USE_BACKUP_ENCRYPTION" | "GOOGLE_DEFAULT_ENCRYPTION";
+  kmsKeyName?: string;
 }

--- a/src/firestore/options.ts
+++ b/src/firestore/options.ts
@@ -29,5 +29,6 @@ export interface FirestoreOptions extends Options {
   backup?: string;
 
   // CMEK
+  encryptionType?: "USE_BACKUP_ENCRYPTION" | "GOOGLE_DEFAULT_ENCRYPTION";
   encryptionType?: "GOOGLE_DEFAULT_ENCRYPTION";
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

 2758 passing (24s)
-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Add support for setting the encryption configuration of the new database in `firebase:databases:restore`.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Success scenarios
- Restore without new args
   - This is equivalent to using USE_BACKUP_ENCRYPTION
- Restore with GOOGLE_DEFAULT_ENCRYPTION using -e
- Restore with GOOGLE_DEFAULT_ENCRYPTION using --encryption-type
- Restore with USE_BACKUP_ENCRYPTION using -e
- Restore with USE_BACKUP_ENCRYPTION using --encryption-type
- Restore with CUSTOMER_MANAGED_ENCRYPTION using -e and -k
- Restore with CUSTOMER_MANAGED_ENCRYPTION using --encryption-type and --kms-key-name

Failure scenarios
- --encryption-type provided without a value
  - firebase firestore:databases:restore -d database -b backup -e
  - `error: option '-e, --encryption-type <encryptionType>' argument missing`
- --encryption type provided with an invalid value
  - firebase firestore:databases:restore -d database -b backup -e NOT_AN_OPTION
  - `Error: Invalid value for flag --encryption-type. See firebase firestore:databases:restore --help for more info.`
- --kms-key-name provided without a value
  - firebase firestore:databases:restore -d database -b backup -k
  - `error: option '-k, --kms-key-name <kmsKeyName>' argument missing`
- --kms-key-name provided without an --encryption-type 
  - firebase firestore:databases:restore -d database -b backup -k key
  - `Error: --kms-key-name can only be set when specifying an --encryption-type of CUSTOMER_MANAGED_ENCRYPTION.` 
- --kms-key-name provided with --encryption-type of GOOGLE_DEFAULT_ENCRYPTION
  - firebase firestore:databases:restore -d database -b backup -e GOOGLE_DEFAULT_ENCRYPTION -k key
  - `Error: --kms-key-name can only be set when specifying an --encryption-type of CUSTOMER_MANAGED_ENCRYPTION.`
- --kms-key-name provided with --encryption-type of USE_BACKUP_ENCRYPTION
  - firebase firestore:databases:restore -d database -b backup -e USE_BACKUP_ENCRYPTION -k key
  - `Error: --kms-key-name can only be set when specifying an --encryption-type of CUSTOMER_MANAGED_ENCRYPTION.`
- no --kms-key-name provided with --encryption type of CUSTOMER_MANAGED_ENCRYPTION
  - firebase firestore:databases:restore -d database -b backup -e CUSTOMER_MANAGED_ENCRYPTION
  - `Error: --kms-key-name must be provided when specifying an --encryption-type of CUSTOMER_MANAGED_ENCRYPTION.`  


### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
- `firebase firestore:databases:restore -d database -b backup`
- `firebase firestore:databases:restore -d database -b backup -e GOOGLE_DEFAULT_ENCRYPTION`
- `firebase firestore:databases:restore -d database -b backup --debug --encryption-type USE_BACKUP_ENCRYPTION`
- `firebase firestore:databases:restore -d database -b backup --debug -e CUSTOMER_MANAGED_ENCRYPTION -k key`