### PR TITLE
(Functions)The redeploy option is undefined, but an error message is displayed asking to use the redeploy option.

### DIFF
--- a/src/commands/functions-secrets-set.ts
+++ b/src/commands/functions-secrets-set.ts
@@ -36,6 +36,8 @@ export const command = new Command("functions:secrets:set <KEY>")
     "--data-file <dataFile>",
     'File path from which to read secret data. Set to "-" to read the secret data from stdin.',
   )
+  .option("--redeploy", 'Redeploy if there are functions that depend on the secret manager to be set.', null)
+  .option("--no-redeploy", 'If there are functions that depend on the secret manager being set, the redeployment will not be executed.')
   .action(async (unvalidatedKey: string, options: Options) => {
     const projectId = needProjectId(options);
     const projectNumber = await needProjectNumber(options);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Overriding the secrets used in functions will result in the following warning message.
However, the redeploy option does not exist and there is no way to ignore the confirmation and set it to No.

```
Error: Missing required options (redeploy) while running in non-interactive mode:
- redeploy Do you want to re-deploy the functions and destroy the stale version of secret FOO?
```

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

The following commands were executed.

```bash
# my expect is show prompt.
$ firebase functions:secrets:set --data-file /tmp/aaa FOO
...
Error: Missing required options (redeploy) while running in non-interactive mode:
- redeploy Do you want to re-deploy the functions and destroy the stale version of secret FOO?
# actual show prompt.
# my expect is not run redeploy
$ firebase functions:secrets:set --data-file /tmp/aaa --no-redeploy FOO
# actual not run redeploy.
# my expect is run redeploy
$ firebase functions:secrets:set --data-file /tmp/aaa --redeploy FOO
# actual run redeploy
```

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

```bash
$ firebase functions:secrets:set --data-file /tmp/aaa FOO
$ firebase functions:secrets:set --data-file /tmp/aaa --no-redeploy FOO
$ firebase functions:secrets:set --data-file /tmp/aaa --redeploy FOO
```

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
