### PR TITLE
Update to firebase-tools-ui@1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,5 @@
 - Fixes issue where PubSub message `publishTime` is set to 1970-01-01T00:00:00 (#7441)
 - Display meaningful error message when cannot determine target. (#6594)
 - Adds support for firealerts events in Eventarc emulator. (#7355)
+- Released version firebase-tools-ui@1.13.0, which adds Emulator UI support for firealerts events.
 - Improved errors when an incorrect service ID is passed to `firebase deploy --only dataconnect:serviceId`.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -45,9 +45,9 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
   ui: experiments.isEnabled("emulatoruisnapshot")
     ? { version: "SNAPSHOT", expectedSize: -1, expectedChecksum: "" }
     : {
-        version: "1.12.1",
-        expectedSize: 3498269,
-        expectedChecksum: "a7f4398a00e5ca22abdcd78dc3877d00",
+        version: "1.13.0",
+        expectedSize: 3605485,
+        expectedChecksum: "ec0aa91592c56af9ff7df18168d58459",
       },
   pubsub: {
     version: "0.8.14",


### PR DESCRIPTION
### Description
Update to firebase-tools-ui@1.13.0

### Scenarios Tested
I followed http://go/firebase-emulator-ui-release (thanks @christhompsongoogle) and verified that the emulator UI starts up correctly.