### PR TITLE
Fix invalid option names in Firestore backup schedule commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@
 - Released version firebase-tools-ui@1.13.0, which adds Emulator UI support for firealerts events.
 - Improved errors when an incorrect service ID is passed to `firebase deploy --only dataconnect:serviceId`.
 - Fixed display of errors in Firestore commands when using JSON or noninteractive modes. (#7482)
+- Fixed an issue where  Firestore backup schedule commands had invalid short option names. (#7481)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@
 - Released version firebase-tools-ui@1.13.0, which adds Emulator UI support for firealerts events.
 - Improved errors when an incorrect service ID is passed to `firebase deploy --only dataconnect:serviceId`.
 - Fixed display of errors in Firestore commands when using JSON or noninteractive modes. (#7482)
-- Fixed an issue where  Firestore backup schedule commands had invalid short option names. (#7481)
+- Fixed an issue where Firestore backup schedule commands had invalid short option names. (#7481)

--- a/src/commands/firestore-backups-schedules-create.ts
+++ b/src/commands/firestore-backups-schedules-create.ts
@@ -20,7 +20,7 @@ import { FirebaseError } from "../error";
 export const command = new Command("firestore:backups:schedules:create")
   .description("Create a backup schedule under your Cloud Firestore database.")
   .option(
-    "-db, --database <databaseId>",
+    "-d, --database <databaseId>",
     "Database under which you want to create a schedule. Defaults to the (default) database",
   )
   .option("-rt, --retention <duration>", "duration string (e.g. 12h or 30d) for backup retention")

--- a/src/commands/firestore-backups-schedules-create.ts
+++ b/src/commands/firestore-backups-schedules-create.ts
@@ -23,10 +23,10 @@ export const command = new Command("firestore:backups:schedules:create")
     "-d, --database <databaseId>",
     "Database under which you want to create a schedule. Defaults to the (default) database",
   )
-  .option("-rt, --retention <duration>", "duration string (e.g. 12h or 30d) for backup retention")
-  .option("-rc, --recurrence <recurrence>", "Recurrence settings; either DAILY or WEEKLY")
+  .option("--retention <duration>", "duration string (e.g. 12h or 30d) for backup retention")
+  .option("--recurrence <recurrence>", "Recurrence settings; either DAILY or WEEKLY")
   .option(
-    "-dw, --day-of-week <dayOfWeek>",
+    "--day-of-week <dayOfWeek>",
     "On which day of the week to perform backups; one of MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, or SUNDAY",
   )
   .before(requirePermissions, ["datastore.backupSchedules.create"])

--- a/src/commands/firestore-backups-schedules-list.ts
+++ b/src/commands/firestore-backups-schedules-list.ts
@@ -10,7 +10,7 @@ import { PrettyPrint } from "../firestore/pretty-print";
 export const command = new Command("firestore:backups:schedules:list")
   .description("List backup schedules under your Cloud Firestore database.")
   .option(
-    "-db, --database <databaseId>",
+    "-d, --database <databaseId>",
     "Database whose schedules you wish to list. Defaults to the (default) database.",
   )
   .before(requirePermissions, ["datastore.backupSchedules.list"])

--- a/src/commands/firestore-backups-schedules-update.ts
+++ b/src/commands/firestore-backups-schedules-update.ts
@@ -13,7 +13,7 @@ import { FirebaseError } from "../error";
 
 export const command = new Command("firestore:backups:schedules:update <backupSchedule>")
   .description("Update a backup schedule under your Cloud Firestore database.")
-  .option("-rt, --retention <duration>", "duration string (e.g. 12h or 30d) for backup retention")
+  .option("--retention <duration>", "duration string (e.g. 12h or 30d) for backup retention")
   .before(requirePermissions, ["datastore.backupSchedules.update"])
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (backupScheduleName: string, options: FirestoreOptions) => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Some firestore commands were incorrectly using two characters in their short option name. When passing two characters on the command line, only the first is actually parsed and checked, resulting in either unknown args or mismatched args.

Note: This is the same PR as #7473, but not using a fork.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
Success scenarios
- Create backup schedule with retention and recurrence
- Create backup schedule retention, recurrence and database (via -d)
- Create backup schedule retention, recurrence and database (via --database)
- List backup schedules with no arguments
- List backup schedules with -d
- List backup schedules with --database
- Update backup schedule with retention

Failure scenarios
- Create backup schedule without any args
- Create backup schedule without retention 
- Create backup schedule with --retention but no value
- Create backup schedule without recurrence
- Create backup schedule with recurrence but no value
- Create backup schedule with recurrence but invalid value
- Create backup schedule with -d but no value
- Create backup schedule with --database but no value
- List backup schedule with -d but no value
- List backup schedule with --database but no value
- Update backup schedule with no arguments
- Update backup schedule without retention
- Update backup schedule with retention but no value

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

```
firebase firestore:backups:schedules:create --retention 2w --recurrence DAILY
firebase firestore:backups:schedules:create --retention 2w --recurrence DAILY -d named-database
firebase firestore:backups:schedules:create --retention 2w --recurrence DAILY --database named-database

firebase firestore:backups:schedules:list
firebase firestore:backups:schedules:list -d named-database
firebase firestore:backups:schedules:list --database named-database

firebase firestore:backups:schedules:update schedule --retention 2w
```