### PR TITLE
Fix errors showing as success in Firestore commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Adds support for firealerts events in Eventarc emulator. (#7355)
 - Released version firebase-tools-ui@1.13.0, which adds Emulator UI support for firealerts events.
 - Improved errors when an incorrect service ID is passed to `firebase deploy --only dataconnect:serviceId`.
+- Fixed display of errors in Firestore commands when using JSON or noninteractive modes. (#7482)

--- a/src/commands/firestore-backups-schedules-create.ts
+++ b/src/commands/firestore-backups-schedules-create.ts
@@ -15,6 +15,7 @@ import { Emulators } from "../emulator/types";
 import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 import { FirestoreOptions } from "../firestore/options";
 import { PrettyPrint } from "../firestore/pretty-print";
+import { FirebaseError } from "../error";
 
 export const command = new Command("firestore:backups:schedules:create")
   .description("Create a backup schedule under your Cloud Firestore database.")
@@ -32,47 +33,39 @@ export const command = new Command("firestore:backups:schedules:create")
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (options: FirestoreOptions) => {
     const printer = new PrettyPrint();
+    const helpCommandText = "See firebase firestore:backups:schedules:create --help for more info.";
 
     const databaseId = options.database || "(default)";
 
     if (!options.retention) {
-      logger.error(
-        "Missing required flag --retention. See firebase firestore:backups:schedules:create --help for more info",
-      );
-      return;
+      throw new FirebaseError(`Missing required flag --retention. ${helpCommandText}`);
     }
     const retention = calculateRetention(options.retention);
 
     if (!options.recurrence) {
-      logger.error(
-        "Missing required flag --recurrence. See firebase firestore:backups:schedules:create --help for more info",
-      );
-      return;
+      throw new FirebaseError(`Missing required flag --recurrence. ${helpCommandText}`);
     }
     const recurrenceType: types.RecurrenceType = options.recurrence;
     if (
       recurrenceType !== types.RecurrenceType.DAILY &&
       recurrenceType !== types.RecurrenceType.WEEKLY
     ) {
-      logger.error(
-        "Invalid value for flag --recurrence. See firebase firestore:backups:schedules:create --help for more info",
-      );
-      return;
+      throw new FirebaseError(`Invalid value for flag --recurrence. ${helpCommandText}`);
     }
     let dailyRecurrence: Record<string, never> | undefined;
     let weeklyRecurrence: WeeklyRecurrence | undefined;
     if (options.recurrence === types.RecurrenceType.DAILY) {
       dailyRecurrence = {};
       if (options.dayOfWeek) {
-        logger.error("--day-of-week should not be provided if --recurrence is DAILY");
-        return;
+        throw new FirebaseError(
+          `--day-of-week should not be provided if --recurrence is DAILY. ${helpCommandText}`,
+        );
       }
     } else if (options.recurrence === types.RecurrenceType.WEEKLY) {
       if (!options.dayOfWeek) {
-        logger.error(
-          "If --recurrence is WEEKLY, --day-of-week must be provided. See firebase firestore:backups:schedules:create --help for more info",
+        throw new FirebaseError(
+          `If --recurrence is WEEKLY, --day-of-week must be provided. ${helpCommandText}`,
         );
-        return;
       }
       const day: DayOfWeek = options.dayOfWeek;
       weeklyRecurrence = {

--- a/src/commands/firestore-backups-schedules-update.ts
+++ b/src/commands/firestore-backups-schedules-update.ts
@@ -9,6 +9,7 @@ import { Emulators } from "../emulator/types";
 import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 import { FirestoreOptions } from "../firestore/options";
 import { PrettyPrint } from "../firestore/pretty-print";
+import { FirebaseError } from "../error";
 
 export const command = new Command("firestore:backups:schedules:update <backupSchedule>")
   .description("Update a backup schedule under your Cloud Firestore database.")
@@ -17,12 +18,10 @@ export const command = new Command("firestore:backups:schedules:update <backupSc
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (backupScheduleName: string, options: FirestoreOptions) => {
     const printer = new PrettyPrint();
+    const helpCommandText = "See firebase firestore:backups:schedules:update --help for more info.";
 
     if (!options.retention) {
-      logger.error(
-        "Missing required flag --retention. See firebase firestore:backups:schedules:update --help for more info",
-      );
-      return;
+      throw new FirebaseError(`Missing required flag --retention. ${helpCommandText}`);
     }
     const retention = calculateRetention(options.retention);
 

--- a/src/commands/firestore-databases-create.ts
+++ b/src/commands/firestore-databases-create.ts
@@ -9,6 +9,7 @@ import { Emulators } from "../emulator/types";
 import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 import { FirestoreOptions } from "../firestore/options";
 import { PrettyPrint } from "../firestore/pretty-print";
+import { FirebaseError } from "../error";
 
 export const command = new Command("firestore:databases:create <database>")
   .description("Create a database in your Firebase project.")
@@ -29,11 +30,10 @@ export const command = new Command("firestore:databases:create <database>")
   .action(async (database: string, options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
+    const helpCommandText = "See firebase firestore:databases:create --help for more info.";
+
     if (!options.location) {
-      logger.error(
-        "Missing required flag --location. See firebase firestore:databases:create --help for more info.",
-      );
-      return;
+      throw new FirebaseError(`Missing required flag --location. ${helpCommandText}`);
     }
     // Type is always Firestore Native since Firebase does not support Datastore Mode
     const type: types.DatabaseType = types.DatabaseType.FIRESTORE_NATIVE;
@@ -42,10 +42,7 @@ export const command = new Command("firestore:databases:create <database>")
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.ENABLED &&
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.DISABLED
     ) {
-      logger.error(
-        "Invalid value for flag --delete-protection. See firebase firestore:databases:create --help for more info.",
-      );
-      return;
+      throw new FirebaseError(`Invalid value for flag --delete-protection. ${helpCommandText}`);
     }
     const deleteProtectionState: types.DatabaseDeleteProtectionState =
       options.deleteProtection === types.DatabaseDeleteProtectionStateOption.ENABLED
@@ -57,10 +54,9 @@ export const command = new Command("firestore:databases:create <database>")
       options.pointInTimeRecovery !== types.PointInTimeRecoveryEnablementOption.ENABLED &&
       options.pointInTimeRecovery !== types.PointInTimeRecoveryEnablementOption.DISABLED
     ) {
-      logger.error(
-        "Invalid value for flag --point-in-time-recovery. See firebase firestore:databases:create --help for more info.",
+      throw new FirebaseError(
+        `Invalid value for flag --point-in-time-recovery. ${helpCommandText}`,
       );
-      return;
     }
     const pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement =
       options.pointInTimeRecovery === types.PointInTimeRecoveryEnablementOption.ENABLED

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -9,6 +9,7 @@ import { Emulators } from "../emulator/types";
 import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 import { FirestoreOptions } from "../firestore/options";
 import { PrettyPrint } from "../firestore/pretty-print";
+import { FirebaseError } from "../error";
 
 export const command = new Command("firestore:databases:restore")
   .description("Restore a Firestore database in your Firebase project.")
@@ -22,18 +23,12 @@ export const command = new Command("firestore:databases:restore")
     const helpCommandText = "See firebase firestore:databases:restore --help for more info";
 
     if (!options.database) {
-      logger.error(
-        `Missing required flag --database. ${helpCommandText}`,
-      );
-      return;
+      throw new FirebaseError(`Missing required flag --database. ${helpCommandText}`);
     }
     const databaseId = options.database;
 
     if (!options.backup) {
-      logger.error(
-        `Missing required flag --backup. ${helpCommandText}`,
-      );
-      return;
+      throw new FirebaseError(`Missing required flag --backup. ${helpCommandText}`);
     }
     const backupName = options.backup;
 

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -19,10 +19,11 @@ export const command = new Command("firestore:databases:restore")
   .action(async (options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
+    const HELP_COMMAND = "See firebase firestore:databases:restore --help for more info";
 
     if (!options.database) {
       logger.error(
-        "Missing required flag --database. See firebase firestore:databases:restore --help for more info",
+        `Missing required flag --database. ${HELP_COMMAND}`,
       );
       return;
     }
@@ -30,7 +31,7 @@ export const command = new Command("firestore:databases:restore")
 
     if (!options.backup) {
       logger.error(
-        "Missing required flag --backup. See firebase firestore:databases:restore --help for more info",
+        `Missing required flag --backup. ${HELP_COMMAND}`,
       );
       return;
     }

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -19,11 +19,11 @@ export const command = new Command("firestore:databases:restore")
   .action(async (options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
-    const HELP_COMMAND = "See firebase firestore:databases:restore --help for more info";
+    const helpCommandText = "See firebase firestore:databases:restore --help for more info";
 
     if (!options.database) {
       logger.error(
-        `Missing required flag --database. ${HELP_COMMAND}`,
+        `Missing required flag --database. ${helpCommandText}`,
       );
       return;
     }
@@ -31,7 +31,7 @@ export const command = new Command("firestore:databases:restore")
 
     if (!options.backup) {
       logger.error(
-        `Missing required flag --backup. ${HELP_COMMAND}`,
+        `Missing required flag --backup. ${helpCommandText}`,
       );
       return;
     }

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -20,7 +20,7 @@ export const command = new Command("firestore:databases:restore")
   .action(async (options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
-    const helpCommandText = "See firebase firestore:databases:restore --help for more info";
+    const helpCommandText = "See firebase firestore:databases:restore --help for more info.";
 
     if (!options.database) {
       throw new FirebaseError(`Missing required flag --database. ${helpCommandText}`);

--- a/src/commands/firestore-databases-update.ts
+++ b/src/commands/firestore-databases-update.ts
@@ -9,6 +9,7 @@ import { Emulators } from "../emulator/types";
 import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 import { FirestoreOptions } from "../firestore/options";
 import { PrettyPrint } from "../firestore/pretty-print";
+import { FirebaseError } from "../error";
 
 export const command = new Command("firestore:databases:update <database>")
   .description(
@@ -28,22 +29,17 @@ export const command = new Command("firestore:databases:update <database>")
   .action(async (database: string, options: FirestoreOptions) => {
     const api = new fsi.FirestoreApi();
     const printer = new PrettyPrint();
+    const helpCommandText = "See firebase firestore:databases:update --help for more info.";
 
     if (!options.deleteProtection && !options.pointInTimeRecovery) {
-      logger.error(
-        "Missing properties to update. See firebase firestore:databases:update --help for more info.",
-      );
-      return;
+      throw new FirebaseError(`Missing properties to update. ${helpCommandText}`);
     }
     if (
       options.deleteProtection &&
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.ENABLED &&
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.DISABLED
     ) {
-      logger.error(
-        "Invalid value for flag --delete-protection. See firebase firestore:databases:update --help for more info.",
-      );
-      return;
+      throw new FirebaseError(`Invalid value for flag --delete-protection. ${helpCommandText}`);
     }
     let deleteProtectionState: types.DatabaseDeleteProtectionState | undefined;
     if (options.deleteProtection === types.DatabaseDeleteProtectionStateOption.ENABLED) {
@@ -57,10 +53,9 @@ export const command = new Command("firestore:databases:update <database>")
       options.pointInTimeRecovery !== types.PointInTimeRecoveryEnablementOption.ENABLED &&
       options.pointInTimeRecovery !== types.PointInTimeRecoveryEnablementOption.DISABLED
     ) {
-      logger.error(
-        "Invalid value for flag --point-in-time-recovery. See firebase firestore:databases:update --help for more info.",
+      throw new FirebaseError(
+        `Invalid value for flag --point-in-time-recovery. ${helpCommandText}`,
       );
-      return;
     }
     let pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement | undefined;
     if (options.pointInTimeRecovery === types.PointInTimeRecoveryEnablementOption.ENABLED) {

--- a/src/commands/firestore-delete.ts
+++ b/src/commands/firestore-delete.ts
@@ -10,7 +10,7 @@ import { requirePermissions } from "../requirePermissions";
 import * as utils from "../utils";
 import { FirestoreOptions } from "../firestore/options";
 
-function confirmationMessage(deleteOp: FirestoreDelete, options: FirestoreOptions) {
+function confirmationMessage(deleteOp: FirestoreDelete, options: FirestoreOptions): string {
   if (options.allCollections) {
     return (
       "You are about to delete " +


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
Firestore commands often log and then return. This works fine for normal commands, but when using `--json` mode it will print `success` to the terminal even though it early exited with an error. Replacing these logs with FirebaseErrors.

Before change:
```
$ firebase firestore:databases:restore --json
{
  "status": "success"
}
```

After change:
```
$ firebase firestore:databases:restore --json
{
  "status": "error",
  "error": "Missing required flag --database. See firebase firestore:databases:restore --help for more info"
}
```

Note: This is the same PR as #7474 but not using a fork.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

All failure scenarios tested for the changed commands.

<details>
  <summary>Click to see all test output</summary>
  
  firestore:backups:schedules:create
  ```shell
$ firebase firestore:backups:schedules:create --json
{
  "status": "error",
  "error": "Missing required flag --retention. See firebase firestore:backups:schedules:create --help for more info."
}
Having trouble? Try firebase [command] --help

$ firebase firestore:backups:schedules:create --json --retention
error: option '-rt, --retention <duration>' argument missing

# retention
$ firebase firestore:backups:schedules:create --json --retention 1s
{
  "status": "error",
  "error": "\"retention\" flag must be a duration string (e.g. 24h, 2w, or 7d)"
}
Having trouble? Try firebase [command] --help

$ firebase firestore:backups:schedules:create --json --retention 2w
{
  "status": "error",
  "error": "Missing required flag --recurrence. See firebase firestore:backups:schedules:create --help for more info."
}
Having trouble? Try firebase [command] --help

# recurrence
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence
error: option '-rc, --recurrence <recurrence>' argument missing

$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence M
{
  "status": "error",
  "error": "Invalid value for flag --recurrence. See firebase firestore:backups:schedules:create --help for more info."
}
Having trouble? Try firebase [command] --help

$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence WEEKLY
{
  "status": "error",
  "error": "If --recurrence is WEEKLY, --day-of-week must be provided. See firebase firestore:backups:schedules:create --help for more info."
}
Having trouble? Try firebase [command] --help

# day-of-week
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence WEEKLY --day-of-week
error: option '-dw, --day-of-week <dayOfWeek>' argument missing

$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence WEEKLY --day-of-week MON
{
  "status": "error",
  "error": "HTTP Error: 400, Invalid value at 'backup_schedule.weekly_recurrence.day' (type.googleapis.com/google.type.DayOfWeek), \"MON\""
}
Having trouble? Try firebase [command] --help

$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence DAILY --day-of-week MONDAY
{
  "status": "error",
  "error": "--day-of-week should not be provided if --recurrence is DAILY. See firebase firestore:backups:schedules:create --help for more info."
}
Having trouble? Try firebase [command] --help

# Success
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence DAILY
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence WEEKLY --day-of-week MONDAY
  ```
  firestore:backups:schedules:update
  ```shell
$ firebase firestore:backups:schedules:update --json
error: missing required argument 'backupSchedule'

$ firebase firestore:backups:schedules:update schedule --json
{
  "status": "error",
  "error": "Missing required flag --retention. See firebase firestore:backups:schedules:update --help for more info."
}
Having trouble? Try firebase [command] --help

# retention
$ firebase firestore:backups:schedules:update schedule --json --retention
error: option '-rt, --retention <duration>' argument missing

# Success
$ firebase firestore:backups:schedules:update schedule --json --retention 2w
  ```

  firestore:databases:create
  ```shell
$ firebase firestore:databases:create --json
error: missing required argument 'database'

$ firebase firestore:databases:create database --json
{
  "status": "error",
  "error": "Missing required flag --location. See firebase firestore:databases:create --help for more info."
}
Having trouble? Try firebase [command] --help

# location
$ firebase firestore:databases:create database --json --location
error: option '--location <locationId>' argument missing

# delete-protection
$ firebase firestore:databases:create database --json --location us --delete-protection
error: option '--delete-protection <deleteProtectionState>' argument missing

$ firebase firestore:databases:create database --json --location us --delete-protection unknown
{
  "status": "error",
  "error": "Invalid value for flag --delete-protection. See firebase firestore:databases:create --help for more info."
}
Having trouble? Try firebase [command] --help

# point-in-time-recovery
$ firebase firestore:databases:create database --json --location us --delete-protection ENABLED --point-in-time-recovery
error: option '--point-in-time-recovery <enablement>' argument missing

$ firebase firestore:databases:create database --json --location us --delete-protection ENABLED --point-in-time-recovery unknown
{
  "status": "error",
  "error": "Invalid value for flag --point-in-time-recovery. See firebase firestore:databases:create --help for more info."
}
Having trouble? Try firebase [command] --help

# Success
$ firebase firestore:databases:create database --json --location us --delete-protection ENABLED --point-in-time-recovery ENABLED
  ```

  firestore:databases:restore
  ```shell
$ firebase firestore:databases:restore --json
{
  "status": "error",
  "error": "Missing required flag --database. See firebase firestore:databases:restore --help for more info."
}
Having trouble? Try firebase [command] --help

# database
$ firebase firestore:databases:restore --json --database
error: option '-d, --database <databaseID>' argument missing

$ firebase firestore:databases:restore --json --database database
{
  "status": "error",
  "error": "Missing required flag --backup. See firebase firestore:databases:restore --help for more info."
}
Having trouble? Try firebase [command] --help

# backup
$ firebase firestore:databases:restore --json --database database --backup
error: option '-b, --backup <backup>' argument missing

# Success
$ firebase firestore:databases:restore --json --database database --backup backup
  ```
 
  firestore:databases:update
  ```shell

$ firebase firestore:databases:update --json
error: missing required argument 'database'

$ firebase firestore:databases:update database --json
{
  "status": "error",
  "error": "Missing properties to update. See firebase firestore:databases:update --help for more info."
}
Having trouble? Try firebase [command] --help

# delete-protection
$ firebase firestore:databases:update database --json --delete-protection
error: option '--delete-protection <deleteProtectionState>' argument missing

$ firebase firestore:databases:update database --json --delete-protection unknown
{
  "status": "error",
  "error": "Invalid value for flag --delete-protection. See firebase firestore:databases:update --help for more info."
}
Having trouble? Try firebase [command] --help

# point-in-time-recovery
$ firebase firestore:databases:update database --json --point-in-time-recovery
error: option '--point-in-time-recovery <enablement>' argument missing

$ firebase firestore:databases:update database --json --point-in-time-recovery unknown
{
  "status": "error",
  "error": "Invalid value for flag --point-in-time-recovery. See firebase firestore:databases:update --help for more info."
}
Having trouble? Try firebase [command] --help

# Success
$ firebase firestore:databases:update database --json --point-in-time-recovery ENABLED
$ firebase firestore:databases:update database --json --delete-protection ENABLED
  ```
</details>

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
No changes to commands, only error output.

```
$ firebase firestore:backups:schedules:create --json
$ firebase firestore:backups:schedules:create --json --retention
$ firebase firestore:backups:schedules:create --json --retention 1s
$ firebase firestore:backups:schedules:create --json --retention 2w
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence M
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence WEEKLY
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence WEEKLY --day-of-week
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence WEEKLY --day-of-week MON
$ firebase firestore:backups:schedules:create --json --retention 2w --recurrence DAILY --day-of-week MONDAY

$ firebase firestore:backups:schedules:update --json
$ firebase firestore:backups:schedules:update schedule --json
$ firebase firestore:backups:schedules:update schedule --json --retention

$ firebase firestore:databases:create --json
$ firebase firestore:databases:create database --json
$ firebase firestore:databases:create database --json --location
$ firebase firestore:databases:create database --json --location us --delete-protection
$ firebase firestore:databases:create database --json --location us --delete-protection unknown
$ firebase firestore:databases:create database --json --location us --delete-protection ENABLED --point-in-time-recovery
$ firebase firestore:databases:create database --json --location us --delete-protection ENABLED --point-in-time-recovery unknown

$ firebase firestore:databases:restore --json
$ firebase firestore:databases:restore --json --database
$ firebase firestore:databases:restore --json --database database
$ firebase firestore:databases:restore --json --database database --backup

$ firebase firestore:databases:update --json
$ firebase firestore:databases:update database --json
$ firebase firestore:databases:update database --json --delete-protection
$ firebase firestore:databases:update database --json --delete-protection unknown
$ firebase firestore:databases:update database --json --point-in-time-recovery
$ firebase firestore:databases:update database --json --point-in-time-recovery unknown
```