### PR TITLE
Hide secondary init commands from multiselect menu

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -24,7 +24,12 @@ function isOutside(from: string, to: string): boolean {
   return !!/^\.\./.exec(path.relative(from, to));
 }
 
-const choices = [
+const choices: {
+  value: string;
+  name: string;
+  checked: boolean;
+  hidden?: boolean;
+}[] = [
   {
     value: "database",
     name: "Realtime Database: Configure a security rules file for Realtime Database and (optionally) provision default instance",
@@ -47,8 +52,9 @@ const choices = [
   },
   {
     value: "hosting:github",
-    name: " └── Hosting: Set up GitHub Action deploys",
+    name: "Hosting: Set up GitHub Action deploys",
     checked: false,
+    hidden: true,
   },
   {
     value: "storage",
@@ -70,6 +76,17 @@ const choices = [
     name: "Extensions: Set up an empty Extensions manifest",
     checked: false,
   },
+  {
+    value: "dataconnect",
+    name: "Data Connect: Set up a Firebase Data Connect service",
+    checked: false,
+  },
+  {
+    value: "dataconnect:sdk",
+    name: "Data Connect: Set up a generated SDK for your Firebase Data Connect service",
+    checked: false,
+    hidden: true,
+  },
 ];
 
 if (isEnabled("genkit")) {
@@ -79,17 +96,6 @@ if (isEnabled("genkit")) {
     checked: false,
   });
 }
-
-choices.push({
-  value: "dataconnect",
-  name: "Data Connect: Set up a Firebase Data Connect service",
-  checked: false,
-});
-choices.push({
-  value: "dataconnect:sdk",
-  name: " └── Data Connect: Set up a generated SDK for your Firebase Data Connect service",
-  checked: false,
-});
 
 const featureNames = choices.map((choice) => choice.value);
 
@@ -196,7 +202,7 @@ export function initAction(feature: string, options: Options): Promise<void> {
           message:
             "Which Firebase features do you want to set up for this directory? " +
             "Press Space to select features, then Enter to confirm your choices.",
-          choices: choices,
+          choices: choices.filter((c) => !c.hidden),
         },
       ]);
     })


### PR DESCRIPTION
### Description
Small change requested by tscrowe: These secondary options for hosting and data connect were confusing for some users. Now, we don;t show them in the multiselect list presented during `firebase init`, but `firebase init dataconnect:sdk` and `firebase init hosting:github` still work.

### Scenarios Tested
Ran all 3 commands and verified the behavior:

<img width="769" alt="Screenshot 2024-07-25 at 11 21 53 AM" src="https://github.com/user-attachments/assets/c5c9eb67-2103-42d9-93b0-f90a8ca432dd">
<img width="1230" alt="Screenshot 2024-07-25 at 11 21 29 AM" src="https://github.com/user-attachments/assets/34a5829c-39a0-4710-ad8c-dd8ac81f3081">
