### PR TITLE
Improved defaults for init dataconnect:sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Added support for Customer-managed encryption keys (CMEK) on Firestore databases. (#7479)
+- Improved default values for 'init dataconnect:sdk'.

--- a/src/dataconnect/types.ts
+++ b/src/dataconnect/types.ts
@@ -134,16 +134,17 @@ export interface Generate {
 
 export interface JavascriptSDK {
   outputDir: string;
-  package?: string;
+  package: string;
   packageJSONDir?: string;
 }
+
 export interface SwiftSDK {
-  // Optional for Swift becasue XCode makes you import files.
-  outputDir?: string;
+  outputDir: string;
+  package: string;
 }
 export interface KotlinSDK {
   outputDir: string;
-  package?: string;
+  package: string;
 }
 
 export enum Platform {

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -26,16 +26,6 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   await actuate(sdkInfo, setup.projectId);
 }
 
-// generate:
-// swiftSdk:
-// outputDir: ./../gensdk/default-connector/swift-sdk
-// package: "DefaultConnector"
-// javascriptSdk:
-// outputDir: ./../gensdk/default-connector/javascript-sdk
-// package: "@firebasegen/default-connector"
-// kotlinSdk:
-// outputDir: ./../gensdk/default-connector/kotlin-sdk
-// package: connectors.default_connector
 async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
   const serviceCfgs = readFirebaseJson(config);
   const serviceInfos = await Promise.all(


### PR DESCRIPTION
### Description
- Improved defaults for init dataconnect:sdk
- Make package required for all platforms.
- Stop prompting for package name - instead, just always follow platform standard patterns using the connector ID.
- Reprompt if you choose no platforms.
- 
### Scenarios Tested
Tested all 3 platforms, confirmed that the appropriate 
<img width="492" alt="Screenshot 2024-07-29 at 6 23 53 PM" src="https://github.com/user-attachments/assets/fb1ac560-1057-4958-b9c2-0ad26529d2ff">
Tested the reprompting to ensure that it works as expected.
<img width="1571" alt="Screenshot 2024-07-29 at 6 26 25 PM" src="https://github.com/user-attachments/assets/aeadb511-e9bb-4b70-a2a9-f4fbb685605a">

