### PR TITLE
Add shortname option for kms-key-name to firestore:databases:create

### DIFF
--- a/src/commands/firestore-databases-create.ts
+++ b/src/commands/firestore-databases-create.ts
@@ -27,8 +27,10 @@ export const command = new Command("firestore:databases:create <database>")
   )
   // TODO(b/356137854): Remove allowlist only message once feature is public GA.
   .option(
-    "--kms-key-name <kmsKeyName>",
-    "The resource ID of a Cloud KMS key. If set, the database created will be a Customer-managed Encryption Key (CMEK) database encrypted with this key. This feature is allowlist only in initial launch.",
+    "-k, --kms-key-name <kmsKeyName>",
+    "The resource ID of a Cloud KMS key. If set, the database created will be a " +
+      "Customer-managed Encryption Key (CMEK) database encrypted with this key. " +
+      "This feature is allowlist only in initial launch.",
   )
   .before(requirePermissions, ["datastore.databases.create"])
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Adds support for using -k to specify --kms-key-name when creating a firestore database. This aligns with #7483.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- No key provided
- Key provided with `-k`
- Key provided with `--kms-key-name`

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

- ` firebase firestore:databases:create database --location nam5 -k key`
- ` firebase firestore:databases:create database --location nam5 --kms-key-name key`
- ` firebase firestore:databases:create database --location nam5`