### PR TITLE
Consider app/src/main/kotlin in preference to app/src/main/java

### DIFF
--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -147,11 +147,16 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
   }
 
   if (targetPlatform === Platform.ANDROID) {
-    // app/src/main/java is a common practice for Andorid, but not explicitly required.
-    // If it is present, we'll use it. Otherwise, we fall back to the app directory.
-    const baseDir = fs.existsSync(path.join(appDir, "app/src/main/java"))
-      ? path.join(appDir, "app/src/main/java")
-      : path.join(appDir, "generated");
+    // app/src/main/kotlin and app/src/main/java are conventional for Android,
+    // but not required or enforced. If one of them is present (preferring the
+    // "kotlin" directory), use it. Otherwise, fall back to the app directory.
+    let baseDir = path.join(appDir, "generated");
+    for (const candidateSubdir of ["app/src/main/java", "app/src/main/kotlin"]) {
+      const candidateDir = path.join(appDir, candidateSubdir);
+      if (fs.existsSync(candidateDir)) {
+        baseDir = candidateDir;
+      }
+    }
 
     const outputDir =
       newConnectorYaml.generate.kotlinSdk?.outputDir ||


### PR DESCRIPTION
This is a follow-up to https://github.com/firebase/firebase-tools/pull/7522 and https://github.com/firebase/firebase-tools/pull/7531 which considers `app/src/main/kotlin` in addition to `app/src/main/java` for the output directory of generated data connect Kotlin code.