### PR TITLE
Fall back to no platform detected flow in unclear cases

### DIFF
--- a/src/dataconnect/fileUtils.spec.ts
+++ b/src/dataconnect/fileUtils.spec.ts
@@ -86,14 +86,14 @@ describe("getPlatformFromFolder", () => {
       output: Platform.IOS,
     },
     {
-      desc: "multiple identifiers, returns first found",
+      desc: "multiple identifiers, returns undetermined",
       folderName: "test/",
       folderItems: {
         file1: "contents",
         podfile: "cocoa pods yummy",
         "androidmanifest.xml": "file found second :(",
       },
-      output: Platform.ANDROID,
+      output: Platform.UNDETERMINED,
     },
   ];
   for (const c of cases) {

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -125,11 +125,9 @@ export async function getPlatformFromFolder(dirPath: string) {
   let hasIOS = false;
   for (const fileName of fileNames) {
     const cleanedFileName = fileName.toLowerCase();
-    hasWeb = hasWeb || WEB_INDICATORS.some((indicator) => indicator === cleanedFileName);
-    hasAndroid =
-      hasAndroid || ANDROID_INDICATORS.some((indicator) => indicator === cleanedFileName);
-    hasIOS =
-      hasIOS ||
+    hasWeb ||= WEB_INDICATORS.some((indicator) => indicator === cleanedFileName);
+    hasAndroid ||= ANDROID_INDICATORS.some((indicator) => indicator === cleanedFileName);
+    hasIOS ||=
       IOS_INDICATORS.some((indicator) => indicator === cleanedFileName) ||
       IOS_POSTFIX_INDICATORS.some((indicator) => cleanedFileName.endsWith(indicator));
   }

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -113,23 +113,35 @@ const IOS_INDICATORS = ["info.plist", "podfile", "package.swift"];
 const ANDROID_INDICATORS = ["androidmanifest.xml", "build.gradle", "build.gradle.kts"];
 
 // endswith match
-const IOS_INDICATORS_2 = [".xcworkspace", ".xcodeproj"];
+const IOS_POSTFIX_INDICATORS = [".xcworkspace", ".xcodeproj"];
 
 // given a directory, determine the platform type
 export async function getPlatformFromFolder(dirPath: string) {
   // Check for file indicators
   const fileNames = await fs.readdir(dirPath);
 
+  let hasWeb = false;
+  let hasAndroid = false;
+  let hasIOS = false;
   for (const fileName of fileNames) {
     const cleanedFileName = fileName.toLowerCase();
-    if (WEB_INDICATORS.some((indicator) => indicator === cleanedFileName)) return Platform.WEB;
-    if (ANDROID_INDICATORS.some((indicator) => indicator === cleanedFileName))
-      return Platform.ANDROID;
-    if (IOS_INDICATORS.some((indicator) => indicator === cleanedFileName)) return Platform.IOS;
-    if (IOS_INDICATORS_2.some((indicator) => cleanedFileName.endsWith(indicator)))
-      return Platform.IOS;
+    hasWeb = hasWeb || WEB_INDICATORS.some((indicator) => indicator === cleanedFileName);
+    hasAndroid =
+      hasAndroid || ANDROID_INDICATORS.some((indicator) => indicator === cleanedFileName);
+    hasIOS =
+      hasIOS ||
+      IOS_INDICATORS.some((indicator) => indicator === cleanedFileName) ||
+      IOS_POSTFIX_INDICATORS.some((indicator) => cleanedFileName.endsWith(indicator));
   }
-
+  if (hasWeb && !hasAndroid && !hasIOS) {
+    return Platform.WEB;
+  } else if (hasAndroid && !hasWeb && !hasIOS) {
+    return Platform.ANDROID;
+  } else if (hasIOS && !hasWeb && !hasAndroid) {
+    return Platform.IOS;
+  }
+  // At this point, its not clear which platform the app directory is
+  // (either because we found no indicators, or indicators for multiple platforms)
   return Platform.UNDETERMINED;
 }
 


### PR DESCRIPTION
### Description
Slight behavior tweak that @yuchenshi pointed out. In cases where its not obvious what platform we're looking at, we should fall back to asking the user.