### PR TITLE
Write the default connector into a directory named `connector`.

### DIFF
--- a/src/init/features/dataconnect/index.spec.ts
+++ b/src/init/features/dataconnect/index.spec.ts
@@ -56,6 +56,7 @@ describe("init dataconnect", () => {
           connectors: [
             {
               id: "my-connector",
+              path: "hello",
               files: [
                 {
                   path: "queries.gql",
@@ -70,8 +71,8 @@ describe("init dataconnect", () => {
         expectedFiles: [
           "dataconnect/dataconnect.yaml",
           "dataconnect/schema/schema.gql",
-          "dataconnect/my-connector/connector.yaml",
-          "dataconnect/my-connector/queries.gql",
+          "dataconnect/hello/connector.yaml",
+          "dataconnect/hello/queries.gql",
         ],
         expectCSQLProvisioning: false,
       },

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -175,7 +175,7 @@ async function writeConnectorFiles(
     subbedConnectorYaml,
   );
   for (const f of connectorInfo.files) {
-    await config.askWriteProjectFile(join(dir, connectorInfo.id, f.path), f.content);
+    await config.askWriteProjectFile(join(dir, connectorInfo.path, f.path), f.content);
   }
 }
 

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -164,13 +164,14 @@ async function writeConnectorFiles(
   config: Config,
   connectorInfo: {
     id: string;
+    path: string;
     files: File[];
   },
 ) {
   const subbedConnectorYaml = subConnectorYamlValues({ connectorId: connectorInfo.id });
   const dir: string = config.get("dataconnect.source") || "dataconnect";
   await config.askWriteProjectFile(
-    join(dir, connectorInfo.id, "connector.yaml"),
+    join(dir, connectorInfo.path, "connector.yaml"),
     subbedConnectorYaml,
   );
   for (const f of connectorInfo.files) {

--- a/templates/init/dataconnect/connector.yaml
+++ b/templates/init/dataconnect/connector.yaml
@@ -1,5 +1,5 @@
-connectorId: "__connectorId__"
-authMode: "PUBLIC" 
+connectorId: __connectorId__
+authMode: "PUBLIC"
 ## ## Here's an example of how to add generated SDKs.
 ## ## You'll need to replace the outputDirs with ones pointing to where you want the generated code in your app.
 # generate:

--- a/templates/init/dataconnect/dataconnect.yaml
+++ b/templates/init/dataconnect/dataconnect.yaml
@@ -1,11 +1,11 @@
 specVersion: "v1alpha"
-serviceId: "__serviceId__"
-location: "__location__"
+serviceId: __serviceId__
+location: __location__
 schema:
   source: "./schema"
   datasource:
     postgresql:
-      database: "__cloudSqlDatabase__"
+      database: __cloudSqlDatabase__
       cloudSql:
-        instanceId: "__cloudSqlInstanceId__"
-connectorDirs: [__connectorIds__]
+        instanceId: __cloudSqlInstanceId__
+connectorDirs: __connectorDirs__


### PR DESCRIPTION
### Description

This writes `dataconnect/connector/queries.gql` instead of `dataconnect/default/queries.gql` for
clarity.

The connector ID is still `default` (unchanged).

### Scenarios Tested

TODO

### Sample Commands

`firebase init dataconnect`
