### PR TITLE
Update --only option description to include function codebases

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -84,7 +84,9 @@ export const command = new Command("deploy")
     'only deploy to specified, comma-separated targets (e.g. "hosting,storage"). For functions, ' +
       'can specify filters with colons to scope function deploys to only those functions (e.g. "--only functions:func1,functions:func2"). ' +
       "When filtering based on export groups (the exported module object keys), use dots to specify group names " +
-      '(e.g. "--only functions:group1.subgroup1,functions:group2)"' +
+      '(e.g. "--only functions:group1.subgroup1,functions:group2"). ' +
+      "When filtering based on codebases, use colons to specify codebase names " +
+      '(e.g. "--only functions:codebase1:func1,functions:codebase2:group1.subgroup1"). ' +
       "For data connect, can specify filters with colons to deploy only a service, connector, or schema" +
       '(e.g. "--only dataconnect:serviceId,dataconnect:serviceId:connectorId,dataconnect:serviceId:schema"). ',
   )


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Update the `--only` options description for `firebase deploy` to include info on how to deploy using specific codebases.  

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Ran `firebase deploy --help`:
```
$ firebase deploy --help
Usage: firebase deploy [options]

deploy code and assets to your Firebase project

Options:
  -f, --force              delete Cloud Functions missing from the current working directory and bypass interactive prompts
  -p, --public <path>      override the Hosting public directory specified in firebase.json
  -m, --message <message>  an optional message describing this deploy
  --only <targets>         only deploy to specified, comma-separated targets (e.g. "hosting,storage"). For functions, can specify filters with colons to scope function 
                           deploys to only those functions (e.g. "--only functions:func1,functions:func2"). When filtering based on export groups (the exported module object 
                           keys), use dots to specify group names (e.g. "--only functions:group1.subgroup1,functions:group2"). When filtering based on codebases, use colons 
                           to specify codebase names (e.g. "--only functions:codebase1:func1,functions:codebase2:group1.subgroup1"). For data connect, can specify filters 
                           with colons to deploy only a service, connector, or schema(e.g. "--only 
                           dataconnect:serviceId,dataconnect:serviceId:connectorId,dataconnect:serviceId:schema"). 
  --except <targets>       deploy to all targets except specified (e.g. "database")
  -h, --help               output usage information
  ```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase deploy --help`