### PR TITLE
Pick up project selection when running in IDX

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+- Automatically pick up IDX project selection.
+
 ## 0.5.4
 
 - Updated internal firebase-tools dependency to 13.15.1

--- a/firebase-vscode/src/cli.ts
+++ b/firebase-vscode/src/cli.ts
@@ -27,6 +27,7 @@ import {
 import * as commandUtils from "../../src/emulator/commandUtils";
 import { currentUser } from "./core/user";
 import { firstWhere } from "./utils/signal";
+import { currentProjectId } from "./core/project";
 export { Emulators };
 
 /**
@@ -46,7 +47,6 @@ export async function requireAuthWrapper(
 
   // helper to determine if VSCode options has the same account as global default
   function isUserMatching(account: Account, options: Options) {
-
     if (!options.user || !options.tokens) {
       return false;
     }
@@ -56,7 +56,7 @@ export async function requireAuthWrapper(
     return (
       account &&
       account.user.email === optionsUser.email &&
-      account.tokens.refresh_token === optionsTokens.refresh_token // Should check refresh token which is consistent, not access_token which is short lived. 
+      account.tokens.refresh_token === optionsTokens.refresh_token // Should check refresh token which is consistent, not access_token which is short lived.
     );
   }
 
@@ -86,7 +86,10 @@ export async function requireAuthWrapper(
     // - we are using tokens from configstore (aka those set by firebase login), AND
     // - we are calling CLI code that skips Command (where we normally call this)
     currentOptions.value = optsCopy;
-    setAccessToken(await getAccessToken()); 
+    if (optsCopy.projectId) {
+      currentProjectId.value = optsCopy.projectId;
+    }
+    setAccessToken(await getAccessToken());
     if (userEmail) {
       pluginLogger.debug("User found: ", userEmail);
 


### PR DESCRIPTION
### Description
Pick up project selection when running in IDX, and clean up currentProject.

### Scenarios Tested
Tested this in IDX and confirmed that we pick up the selected project without extra action from the user.
Tested this in local VSCode and confirmed that we still pick up the .firebaserc default project.
Would definitely appreciate extra testing here tho.