### PR TITLE
fix esbuild path used to bundle next.config.js on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix esbuild path used to bundle next.config.js on Windows (#7555)

--- a/src/frameworks/next/utils.spec.ts
+++ b/src/frameworks/next/utils.spec.ts
@@ -573,17 +573,20 @@ describe("Next.js utils", () => {
 
     it("should warn if global esbuild version does not match required version", () => {
       const mockBinaryPath = "/path/to/.bin/esbuild";
+      const mockGlobalVersion = "1.2.3";
       execSyncStub
         .withArgs("npx which esbuild", { encoding: "utf8" })
         .returns(mockBinaryPath + "\n");
-      execSyncStub.withArgs("esbuild --version", { encoding: "utf8" }).returns("0.18.0\n");
+      execSyncStub
+        .withArgs(`${mockBinaryPath} --version`, { encoding: "utf8" })
+        .returns(`${mockGlobalVersion}\n`);
 
       const consoleWarnStub = sinon.stub(console, "warn");
 
       findEsbuildPath();
       expect(
         consoleWarnStub.calledWith(
-          `Warning: Global esbuild version (0.18.0) does not match the required version (${ESBUILD_VERSION}).`,
+          `Warning: Global esbuild version (${mockGlobalVersion}) does not match the required version (${ESBUILD_VERSION}).`,
         ),
       ).to.be.true;
 

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -498,7 +498,11 @@ export async function whichNextConfigFile(dir: string): Promise<NextConfigFileNa
  */
 export function findEsbuildPath(): string | null {
   try {
-    const esbuildBinPath = execSync("npx which esbuild", { encoding: "utf8" }).trim();
+    const esbuildBinPath = execSync("npx which esbuild", { encoding: "utf8" })?.trim();
+    if (!esbuildBinPath) {
+      return null;
+    }
+
     const globalVersion = getGlobalEsbuildVersion(esbuildBinPath);
     if (globalVersion && !satisfies(globalVersion, ESBUILD_VERSION)) {
       console.warn(

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -521,7 +521,11 @@ export function findEsbuildPath(): string | null {
  */
 export function getGlobalEsbuildVersion(binPath: string): string | null {
   try {
-    const versionOutput = execSync(`${binPath} --version`, { encoding: "utf8" }).trim();
+    const versionOutput = execSync(`${binPath} --version`, { encoding: "utf8" })?.trim();
+    if (!versionOutput) {
+      return null;
+    }
+
     const versionMatch = versionOutput.match(/(\d+\.\d+\.\d+)/);
     return versionMatch ? versionMatch[0] : null;
   } catch (error) {

--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -499,7 +499,7 @@ export async function whichNextConfigFile(dir: string): Promise<NextConfigFileNa
 export function findEsbuildPath(): string | null {
   try {
     const esbuildBinPath = execSync("npx which esbuild", { encoding: "utf8" }).trim();
-    const globalVersion = getGlobalEsbuildVersion();
+    const globalVersion = getGlobalEsbuildVersion(esbuildBinPath);
     if (globalVersion && !satisfies(globalVersion, ESBUILD_VERSION)) {
       console.warn(
         `Warning: Global esbuild version (${globalVersion}) does not match the required version (${ESBUILD_VERSION}).`,
@@ -515,9 +515,9 @@ export function findEsbuildPath(): string | null {
 /**
  * Helper function to get the global esbuild version
  */
-export function getGlobalEsbuildVersion(): string | null {
+export function getGlobalEsbuildVersion(binPath: string): string | null {
   try {
-    const versionOutput = execSync("esbuild --version", { encoding: "utf8" }).trim();
+    const versionOutput = execSync(`${binPath} --version`, { encoding: "utf8" }).trim();
     const versionMatch = versionOutput.match(/(\d+\.\d+\.\d+)/);
     return versionMatch ? versionMatch[0] : null;
   } catch (error) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

use path from npx which to run esbuild, Fixes #7549

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

`firebase deploy` on Windows

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
