### PR TITLE
fix: temporary change the PORT in Angular server.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix esbuild path used to bundle next.config.js on Windows (#7555)
+- Fix (Angular 17+) temporary change the PORT in Angular server.ts (#6651)

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -242,11 +242,23 @@ exports.handle = function(req,res) {
   });
 };\n`;
   } else if (serverOutputPath) {
-    bootstrapScript = `const app = ${
-      serverEntry?.endsWith(".mjs")
-        ? `import(\`./${serverOutputPath}/${serverEntry}\`)`
-        : `Promise.resolve(require('./${serverOutputPath}/${serverEntry}'))`
-    }.then(server => server.app());
+    bootstrapScript = `
+    const app = new Promise((resolve) => {
+      setTimeout(() => {
+        const port = process.env.PORT;
+        const socket = 'express.sock';
+        process.env.PORT = socket;
+        
+        ${
+          serverEntry?.endsWith(".mjs")
+            ? `import(\`./${serverOutputPath}/${serverEntry}\`)`
+            : `Promise.resolve(require('./${serverOutputPath}/${serverEntry}'))`
+        }.then(({ app }) => {
+          process.env.PORT = port;
+          resolve(app());
+        });
+      }, 0);
+    });
 exports.handle = (req,res) => app.then(it => it(req,res));\n`;
   } else {
     bootstrapScript = `exports.handle = (res, req) => req.sendStatus(404);\n`;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

There was a following change in main server file template in Angular 17:
```
// Webpack will replace 'require' with '__webpack_require__'
// '__non_webpack_require__' is a proxy to Node 'require'
// The below code is to ensure that the server is run only when not requiring the bundle.
declare const __non_webpack_require__: NodeRequire;
const mainModule = __non_webpack_require__.main;
const moduleFilename = mainModule && mainModule.filename || '';
if (moduleFilename === __filename || moduleFilename.includes('iisnode')) {
  run();
}
```

to

```
run();
```
The guard to call run function was removed. In the result, there is an issue when someone tries to deploy Angular 17+ app with SSR.

The solution fixes: https://github.com/firebase/firebase-tools/issues/6651.

### Scenarios Tested

Angular 17+:

- server.ts has got `run` call and SSR is enabled in angular.json - deployment was successful and SSR pages works (without fix SSR pages were failing)

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
