### PR TITLE
Fixing bug where Extensions API is required for functions deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Updated `ws` to 7.5.10 to remediate CVE-2024-37890. (#7398)
+- Fixed the issue with firebase functions deploy requiring Extensions API. (https://github.com/firebase/firebase-functions/issues/1596)

--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -8,7 +8,10 @@ import { logger } from "../../logger";
 import { Context, Payload } from "./args";
 import { FirebaseError } from "../../error";
 import { requirePermissions } from "../../requirePermissions";
-import { ensureExtensionsApiEnabled } from "../../extensions/extensionsHelper";
+import {
+  checkExtensionsApiEnabled,
+  ensureExtensionsApiEnabled,
+} from "../../extensions/extensionsHelper";
 import { ensureSecretManagerApiEnabled } from "../../extensions/secretsUtils";
 import { checkSpecForSecrets } from "./secrets";
 import { displayWarningsForDeploy, outOfBandChangesWarning } from "../../extensions/warnings";
@@ -151,7 +154,10 @@ export async function prepareDynamicExtensions(
 ) {
   const filters = getEndpointFilters(options);
   const extensions = extractExtensionsFromBuilds(builds, filters);
-  if (Object.keys(extensions).length === 0) {
+  const isApiEnabled = await checkExtensionsApiEnabled(options);
+  if (Object.keys(extensions).length === 0 && !isApiEnabled) {
+    // Assume if we have no extensions defined and the API is not enabled
+    // there is nothing to delete.
     return;
   }
   const projectId = needProjectId(options);
@@ -162,9 +168,7 @@ export async function prepareDynamicExtensions(
   // This is only a primary call if we are not including extensions
   const isPrimaryCall = !!options.only && !options.only.split(",").includes("extensions");
 
-  if (isPrimaryCall) {
-    await ensureExtensionsApiEnabled(options);
-  }
+  await ensureExtensionsApiEnabled(options);
   await requirePermissions(options, ["firebaseextensions.instances.list"]);
 
   const dynamicWant = await planner.wantDynamic({

--- a/src/deploy/extensions/release.ts
+++ b/src/deploy/extensions/release.ts
@@ -10,6 +10,14 @@ import { saveEtags } from "../../extensions/etags";
 import { trackGA4 } from "../../track";
 
 export async function release(context: Context, options: Options, payload: Payload) {
+  if (
+    !payload.instancesToCreate &&
+    !payload.instancesToUpdate &&
+    !payload.instancesToConfigure &&
+    !payload.instancesToDelete
+  ) {
+    return;
+  }
   const projectId = needProjectId(options);
 
   const errorHandler = new ErrorHandler();

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -20,7 +20,7 @@ import { getExtensionRegistry } from "./resolveSource";
 import { FirebaseError } from "../error";
 import { diagnose } from "./diagnose";
 import { checkResponse } from "./askUserForParam";
-import { ensure } from "../ensureApiEnabled";
+import { ensure, check } from "../ensureApiEnabled";
 import { deleteObject, uploadObject } from "../gcp/storage";
 import { getProjectId } from "../projectUtils";
 import { createSource, getInstance } from "./extensionsApi";
@@ -505,6 +505,14 @@ async function promptForReleaseStage(args: {
     }
   }
   return stage;
+}
+
+export async function checkExtensionsApiEnabled(options: any): Promise<boolean> {
+  const projectId = getProjectId(options);
+  if (!projectId) {
+    return false;
+  }
+  return await check(projectId, extensionsOrigin(), "extensions", options.markdown);
 }
 
 export async function ensureExtensionsApiEnabled(options: any): Promise<void> {


### PR DESCRIPTION
Fixing bug where extensions API is required for functions deploy
(https://github.com/firebase/firebase-functions/issues/1596)
