### PR TITLE
Add --dry-run to deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added `firebase deploy --dry-run`, which validates your changes and builds your code without making any production changes.

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -93,7 +93,8 @@ export const command = new Command("deploy")
   .option("--except <targets>", 'deploy to all targets except specified (e.g. "database")')
   .option(
     "--dry-run",
-    "Perform a dry run of your deployment. Validates your changes and builds your code without deploying any changes to your project",
+    "Perform a dry run of your deployment. Validates your changes and builds your code without deploying any changes to your project. " + 
+    "In order to provide better validation, this may still enable APIs on the target project.",
   )
   .before(requireConfig)
   .before((options) => {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -93,8 +93,8 @@ export const command = new Command("deploy")
   .option("--except <targets>", 'deploy to all targets except specified (e.g. "database")')
   .option(
     "--dry-run",
-    "Perform a dry run of your deployment. Validates your changes and builds your code without deploying any changes to your project. " + 
-    "In order to provide better validation, this may still enable APIs on the target project.",
+    "Perform a dry run of your deployment. Validates your changes and builds your code without deploying any changes to your project. " +
+      "In order to provide better validation, this may still enable APIs on the target project.",
   )
   .before(requireConfig)
   .before((options) => {

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -91,6 +91,10 @@ export const command = new Command("deploy")
       '(e.g. "--only dataconnect:serviceId,dataconnect:serviceId:connectorId,dataconnect:serviceId:schema"). ',
   )
   .option("--except <targets>", 'deploy to all targets except specified (e.g. "database")')
+  .option(
+    "--dry-run",
+    "Perform a dry run of your deployment. Validates your changes and builds your code without deploying any changes to your project",
+  )
   .before(requireConfig)
   .before((options) => {
     options.filteredTargets = filterTargets(options, VALID_DEPLOY_TARGETS);

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -42,7 +42,7 @@ export async function provisionCloudSql(args: {
     const why = getUpdateReason(existingInstance, enableGoogleMlIntegration);
     if (why) {
       const cta = dryRun
-        ? `It will be updated on you next deploy.`
+        ? `It will be updated on your next deploy.`
         : `Updating instance. This may take a few minutes...`;
       silent ||
         utils.logLabeledBullet(

--- a/src/deploy/database/prepare.ts
+++ b/src/deploy/database/prepare.ts
@@ -5,10 +5,10 @@ import { FirebaseError } from "../../error";
 import { parseBoltRules } from "../../parseBoltRules";
 import * as rtdb from "../../rtdb";
 import * as utils from "../../utils";
-import { Options } from "../../options";
 import * as dbRulesConfig from "../../database/rulesConfig";
+import { DeployOptions } from "..";
 
-export function prepare(context: any, options: Options): Promise<any> {
+export function prepare(context: any, options: DeployOptions): Promise<any> {
   const rulesConfig = dbRulesConfig.getRulesConfig(context.projectId, options);
   const next = Promise.resolve();
 

--- a/src/deploy/dataconnect/deploy.ts
+++ b/src/deploy/dataconnect/deploy.ts
@@ -1,4 +1,4 @@
-import { Options } from "../../options";
+import { DeployOptions } from "../";
 import * as client from "../../dataconnect/client";
 import * as utils from "../../utils";
 import { Service, ServiceInfo, requiresVector } from "../../dataconnect/types";
@@ -22,7 +22,7 @@ export default async function (
       filters?: ResourceFilter[];
     };
   },
-  options: Options,
+  options: DeployOptions,
 ): Promise<void> {
   const projectId = needProjectId(options);
   const serviceInfos = context.dataconnect.serviceInfos as ServiceInfo[];
@@ -96,6 +96,7 @@ export default async function (
           return Promise.resolve();
         }
         const enableGoogleMlIntegration = requiresVector(s.deploymentMetadata);
+        utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
         return provisionCloudSql({
           projectId,
           locationId: parseServiceName(s.serviceName).location,

--- a/src/deploy/dataconnect/deploy.ts
+++ b/src/deploy/dataconnect/deploy.ts
@@ -80,8 +80,6 @@ export default async function (
   }
 
   // Provision CloudSQL resources
-  utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
-
   await Promise.all(
     serviceInfos
       .filter((si) => {

--- a/src/deploy/dataconnect/prepare.ts
+++ b/src/deploy/dataconnect/prepare.ts
@@ -60,35 +60,34 @@ export default async function (context: any, options: DeployOptions): Promise<vo
   utils.logLabeledBullet("dataconnect", `Successfully prepared schema and connectors`);
   if (options.dryRun) {
     utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
-    return;
-  }
-  await Promise.all(
-    serviceInfos
-      .filter((si) => {
-        return !filters || filters?.some((f) => si.dataConnectYaml.serviceId === f.serviceId);
-      })
-      .map(async (s) => {
-        const instanceId = s.schema.primaryDatasource.postgresql?.cloudSql.instance
-          .split("/")
-          .pop();
-        const databaseId = s.schema.primaryDatasource.postgresql?.database;
-        if (!instanceId || !databaseId) {
-          return Promise.resolve();
-        }
-        const enableGoogleMlIntegration = requiresVector(s.deploymentMetadata);
-        utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
+    await Promise.all(
+      serviceInfos
+        .filter((si) => {
+          return !filters || filters?.some((f) => si.dataConnectYaml.serviceId === f.serviceId);
+        })
+        .map(async (s) => {
+          const instanceId = s.schema.primaryDatasource.postgresql?.cloudSql.instance
+            .split("/")
+            .pop();
+          const databaseId = s.schema.primaryDatasource.postgresql?.database;
+          if (!instanceId || !databaseId) {
+            return Promise.resolve();
+          }
+          const enableGoogleMlIntegration = requiresVector(s.deploymentMetadata);
+          utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
 
-        return provisionCloudSql({
-          projectId,
-          locationId: parseServiceName(s.serviceName).location,
-          instanceId,
-          databaseId,
-          enableGoogleMlIntegration,
-          waitForCreation: true,
-          dryRun: options.dryRun,
-        });
-      }),
-  );
+          return provisionCloudSql({
+            projectId,
+            locationId: parseServiceName(s.serviceName).location,
+            instanceId,
+            databaseId,
+            enableGoogleMlIntegration,
+            waitForCreation: true,
+            dryRun: options.dryRun,
+          });
+        }),
+    );
+  }
   logger.debug(JSON.stringify(context.dataconnect, null, 2));
   return;
 }

--- a/src/deploy/dataconnect/prepare.ts
+++ b/src/deploy/dataconnect/prepare.ts
@@ -61,7 +61,10 @@ export default async function (context: any, options: DeployOptions): Promise<vo
   utils.logLabeledBullet("dataconnect", `Successfully prepared schema and connectors`);
   if (options.dryRun) {
     for (const si of serviceInfos) {
-      await diffSchema(si.schema, si.dataConnectYaml.schema.datasource.postgresql?.schemaValidation)
+      await diffSchema(
+        si.schema,
+        si.dataConnectYaml.schema.datasource.postgresql?.schemaValidation,
+      );
     }
     utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
     await Promise.all(

--- a/src/deploy/dataconnect/prepare.ts
+++ b/src/deploy/dataconnect/prepare.ts
@@ -1,6 +1,6 @@
 import * as clc from "colorette";
 
-import { Options } from "../../options";
+import { DeployOptions } from "../";
 import { load } from "../../dataconnect/load";
 import { readFirebaseJson } from "../../dataconnect/fileUtils";
 import { logger } from "../../logger";
@@ -11,14 +11,17 @@ import { build } from "../../dataconnect/build";
 import { ensureApis } from "../../dataconnect/ensureApis";
 import { requireTosAcceptance } from "../../requireTosAcceptance";
 import { DATA_CONNECT_TOS_ID } from "../../gcp/firedata";
+import { provisionCloudSql } from "../../dataconnect/provisionCloudSql";
+import { parseServiceName } from "../../dataconnect/names";
 import { FirebaseError } from "../../error";
+import { requiresVector } from "../../dataconnect/types";
 
 /**
  * Prepares for a Firebase DataConnect deployment by loading schemas and connectors from file.
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-export default async function (context: any, options: Options): Promise<void> {
+export default async function (context: any, options: DeployOptions): Promise<void> {
   const projectId = needProjectId(options);
   await ensureApis(projectId);
   await requireTosAcceptance(DATA_CONNECT_TOS_ID)(options);
@@ -55,6 +58,37 @@ export default async function (context: any, options: Options): Promise<void> {
     filters,
   };
   utils.logLabeledBullet("dataconnect", `Successfully prepared schema and connectors`);
+  if (options.dryRun) {
+    utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
+    return;
+  }
+  await Promise.all(
+    serviceInfos
+      .filter((si) => {
+        return !filters || filters?.some((f) => si.dataConnectYaml.serviceId === f.serviceId);
+      })
+      .map(async (s) => {
+        const instanceId = s.schema.primaryDatasource.postgresql?.cloudSql.instance
+          .split("/")
+          .pop();
+        const databaseId = s.schema.primaryDatasource.postgresql?.database;
+        if (!instanceId || !databaseId) {
+          return Promise.resolve();
+        }
+        const enableGoogleMlIntegration = requiresVector(s.deploymentMetadata);
+        utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");
+
+        return provisionCloudSql({
+          projectId,
+          locationId: parseServiceName(s.serviceName).location,
+          instanceId,
+          databaseId,
+          enableGoogleMlIntegration,
+          waitForCreation: true,
+          dryRun: options.dryRun,
+        });
+      }),
+  );
   logger.debug(JSON.stringify(context.dataconnect, null, 2));
   return;
 }

--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -122,8 +122,10 @@ async function prepareHelper(
   if (payload.instancesToDelete.length) {
     logger.info(deploymentSummary.deletesSummary(payload.instancesToDelete));
     if (options.dryRun) {
-      logger.info("On your next deploy, these you will be asked if you want to delete these instances.")
-      logger.info("If you deploy --force, they will be deleted.")
+      logger.info(
+        "On your next deploy, these you will be asked if you want to delete these instances.",
+      );
+      logger.info("If you deploy --force, they will be deleted.");
     }
     if (
       !options.dryRun &&
@@ -145,8 +147,10 @@ async function prepareHelper(
   await requirePermissions(options, permissionsNeeded);
   if (options.dryRun) {
     const appDevTos = await getAppDeveloperTOSStatus(projectId);
-    if  (!appDevTos.lastAcceptedVersion) {
-      logger.info("On your next deploy, you will be asked to accept the Firebase Extensions App Developer Terms of Service")
+    if (!appDevTos.lastAcceptedVersion) {
+      logger.info(
+        "On your next deploy, you will be asked to accept the Firebase Extensions App Developer Terms of Service",
+      );
     }
   } else {
     await acceptLatestAppDeveloperTOS(

--- a/src/deploy/firestore/prepare.ts
+++ b/src/deploy/firestore/prepare.ts
@@ -5,6 +5,8 @@ import { RulesDeploy, RulesetServiceType } from "../../rulesDeploy";
 import * as utils from "../../utils";
 import { Options } from "../../options";
 import * as fsConfig from "../../firestore/fsConfig";
+import { logger } from "../../logger";
+import { DeployOptions } from "..";
 
 export interface RulesContext {
   databaseId: string;
@@ -69,7 +71,7 @@ function prepareIndexes(
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-export default async function (context: any, options: any): Promise<void> {
+export default async function (context: any, options: DeployOptions): Promise<void> {
   if (options.only) {
     const targets = options.only.split(",");
 
@@ -117,5 +119,18 @@ export default async function (context: any, options: any): Promise<void> {
 
   if (context.firestore.rules.length > 0) {
     await rulesDeploy.compile();
+  }
+
+  const rulesContext: RulesContext[] = context?.firestore?.rules;
+  for (const ruleContext of rulesContext) {
+    const databaseId = ruleContext.databaseId;
+    const rulesFile = ruleContext.rulesFile;
+    if (!rulesFile) {
+      logger.error(
+        `Invalid firestore config for ${databaseId} database: ${JSON.stringify(
+          options.config.src.firestore,
+        )}`,
+      );
+    }
   }
 }

--- a/src/deploy/firestore/release.ts
+++ b/src/deploy/firestore/release.ts
@@ -1,6 +1,4 @@
 import { RulesDeploy, RulesetServiceType } from "../../rulesDeploy";
-import { logger } from "../../logger";
-import { Options } from "../../options";
 import { RulesContext } from "./prepare";
 
 /**
@@ -8,7 +6,7 @@ import { RulesContext } from "./prepare";
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-export default async function (context: any, options: Options): Promise<void> {
+export default async function (context: any /** , options: DeployOptions*/): Promise<void> {
   const rulesDeploy: RulesDeploy = context?.firestore?.rulesDeploy;
   if (!context.firestoreRules || !rulesDeploy) {
     return;
@@ -19,15 +17,9 @@ export default async function (context: any, options: Options): Promise<void> {
     rulesContext.map(async (ruleContext: RulesContext): Promise<void> => {
       const databaseId = ruleContext.databaseId;
       const rulesFile = ruleContext.rulesFile;
-      if (!rulesFile) {
-        logger.error(
-          `Invalid firestore config for ${databaseId} database: ${JSON.stringify(
-            options.config.src.firestore,
-          )}`,
-        );
-        return;
+      if (rulesFile) {
+        return rulesDeploy.release(rulesFile, RulesetServiceType.CLOUD_FIRESTORE, databaseId);
       }
-      return rulesDeploy.release(rulesFile, RulesetServiceType.CLOUD_FIRESTORE, databaseId);
     }),
   );
 }

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -14,8 +14,6 @@ import * as utils from "../../utils";
 
 import { getIamPolicy, setIamPolicy } from "../../gcp/resourceManager";
 import { Service, serviceForEndpoint } from "./services";
-import { options } from "cjson";
-import * as deepEqualUnordered from 'deep-equal-in-any-order';
 
 const PERMISSION = "cloudfunctions.functions.setIamPolicy";
 export const SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE = "roles/iam.serviceAccountTokenCreator";
@@ -230,10 +228,11 @@ export async function ensureServiceAgentRoles(
   // set the updated policy
   try {
     if (dryRun) {
-        logger.info(`On your next deploy, the following required roles will be granted: ${
-          requiredBindings.map(b => `${b.members.join(", ")}: ${bold(b.role)}`);
-        }`)
-      }
+      logger.info(
+        `On your next deploy, the following required roles will be granted: ${requiredBindings.map(
+          (b) => `${b.members.join(", ")}: ${bold(b.role)}`,
+        )}`,
+      );
     } else {
       await setIamPolicy(projectNumber, policy, "bindings");
     }

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -14,6 +14,8 @@ import * as utils from "../../utils";
 
 import { getIamPolicy, setIamPolicy } from "../../gcp/resourceManager";
 import { Service, serviceForEndpoint } from "./services";
+import { options } from "cjson";
+import * as deepEqualUnordered from 'deep-equal-in-any-order';
 
 const PERMISSION = "cloudfunctions.functions.setIamPolicy";
 export const SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE = "roles/iam.serviceAccountTokenCreator";
@@ -178,6 +180,7 @@ export async function ensureServiceAgentRoles(
   projectNumber: string,
   want: backend.Backend,
   have: backend.Backend,
+  dryRun?: boolean,
 ): Promise<void> {
   // find new services
   const wantServices = backend.allEndpoints(want).reduce(reduceEventsToServices, []);
@@ -226,7 +229,14 @@ export async function ensureServiceAgentRoles(
 
   // set the updated policy
   try {
-    await setIamPolicy(projectNumber, policy, "bindings");
+    if (dryRun) {
+        logger.info(`On your next deploy, the following required roles will be granted: ${
+          requiredBindings.map(b => `${b.members.join(", ")}: ${bold(b.role)}`);
+        }`)
+      }
+    } else {
+      await setIamPolicy(projectNumber, policy, "bindings");
+    }
   } catch (err: any) {
     iam.printManualIamConfig(requiredBindings, projectId, "functions");
     throw new FirebaseError(

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -277,13 +277,9 @@ export async function prepare(
   // ===Phase 7. Finalize preparation by "fixing" all extraneous environment issues like IAM policies.
   // We limit the scope endpoints being deployed.
   await backend.checkAvailability(context, matchingBackend);
-  // TODO: CheckServiceAgentRoles when dryRun = true
-  options.dryRun ||
-    (await ensureServiceAgentRoles(projectId, projectNumber, matchingBackend, haveBackend));
   await validate.secretsAreValid(projectId, matchingBackend);
-  // TODO: CheckSecretAccess when dryRun = true
-  options.dryRun || (await ensure.secretAccess(projectId, matchingBackend, haveBackend));
-
+  await ensureServiceAgentRoles(projectId, projectNumber, matchingBackend, haveBackend, options.dryRun);
+  await ensure.secretAccess(projectId, matchingBackend, haveBackend, options.dryRun);
   /**
    * ===Phase 8 Generates the hashes for each of the functions now that secret versions have been resolved.
    * This must be called after `await validate.secretsAreValid`.

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -278,7 +278,13 @@ export async function prepare(
   // We limit the scope endpoints being deployed.
   await backend.checkAvailability(context, matchingBackend);
   await validate.secretsAreValid(projectId, matchingBackend);
-  await ensureServiceAgentRoles(projectId, projectNumber, matchingBackend, haveBackend, options.dryRun);
+  await ensureServiceAgentRoles(
+    projectId,
+    projectNumber,
+    matchingBackend,
+    haveBackend,
+    options.dryRun,
+  );
   await ensure.secretAccess(projectId, matchingBackend, haveBackend, options.dryRun);
   /**
    * ===Phase 8 Generates the hashes for each of the functions now that secret versions have been resolved.

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -103,7 +103,10 @@ export async function addPinnedFunctionsToOnlyString(
 /**
  *  Prepare creates versions for each Hosting site to be deployed.
  */
-export async function prepare(context: Context, options: HostingOptions & DeployOptions): Promise<void> {
+export async function prepare(
+  context: Context,
+  options: HostingOptions & DeployOptions,
+): Promise<void> {
   handlePublicDirectoryFlag(options);
 
   const configs = config.hostingConfig(options);

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -32,7 +32,7 @@ function handlePublicDirectoryFlag(options: HostingOptions & DeployOptions): voi
  * normal boilerplate), and the only string might need to be updated with
  * addPinnedFunctionsToOnlyString.
  */
-export function hasPinnedFunctions(options: HostingOptions & Options): boolean {
+export function hasPinnedFunctions(options: HostingOptions & DeployOptions): boolean {
   handlePublicDirectoryFlag(options);
   for (const c of config.hostingConfig(options)) {
     for (const r of c.rewrites || []) {
@@ -52,7 +52,7 @@ export function hasPinnedFunctions(options: HostingOptions & Options): boolean {
  */
 export async function addPinnedFunctionsToOnlyString(
   context: Context,
-  options: HostingOptions & Options,
+  options: HostingOptions & DeployOptions,
 ): Promise<boolean> {
   if (!options.only) {
     return false;
@@ -103,7 +103,7 @@ export async function addPinnedFunctionsToOnlyString(
 /**
  *  Prepare creates versions for each Hosting site to be deployed.
  */
-export async function prepare(context: Context, options: HostingOptions & Options): Promise<void> {
+export async function prepare(context: Context, options: HostingOptions & DeployOptions): Promise<void> {
   handlePublicDirectoryFlag(options);
 
   const configs = config.hostingConfig(options);

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -4,7 +4,7 @@ import * as config from "../../hosting/config";
 import * as deploymentTool from "../../deploymentTool";
 import * as clc from "colorette";
 import { Context } from "./context";
-import { Options } from "../../options";
+import { DeployOptions } from "../";
 import { HostingOptions } from "../../hosting/options";
 import { assertExhaustive, zipIn } from "../../functional";
 import { trackGA4 } from "../../track";
@@ -14,7 +14,7 @@ import * as backend from "../functions/backend";
 import { ensureTargeted } from "../../functions/ensureTargeted";
 import { generateSSRCodebaseId } from "../../frameworks";
 
-function handlePublicDirectoryFlag(options: HostingOptions & Options): void {
+function handlePublicDirectoryFlag(options: HostingOptions & DeployOptions): void {
   // Allow the public directory to be overridden by the --public flag
   if (options.public) {
     if (Array.isArray(options.config.get("hosting"))) {

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -36,7 +36,7 @@ const TARGETS = {
   dataconnect: DataConnectTarget,
 };
 
-export type DeployOptions = Options & { dryRun: boolean };
+export type DeployOptions = Options & { dryRun?: boolean };
 
 type Chain = ((context: any, options: any, payload: any) => Promise<unknown>)[];
 
@@ -53,7 +53,7 @@ const chain = async function (fns: Chain, context: any, options: any, payload: a
  */
 export const deploy = async function (
   targetNames: (keyof typeof TARGETS)[],
-  options: Options & { dryRun: boolean },
+  options: DeployOptions,
   customContext = {},
 ) {
   const projectId = needProjectId(options);

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -122,7 +122,7 @@ export const deploy = async function (
 
   await chain(predeploys, context, options, payload);
   await chain(prepares, context, options, payload);
-  if (!options.dr) await chain(deploys, context, options, payload);
+  await chain(deploys, context, options, payload);
   await chain(releases, context, options, payload);
   await chain(postdeploys, context, options, payload);
 

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -140,6 +140,7 @@ export const deploy = async function (
   }
   await trackGA4("product_deploy", analyticsParams, duration);
 
+  const successMessage = options.dryRun ? "Dry run complete!" : "Deploy complete!"
   logger.info();
   logSuccess(bold(underline("Deploy complete!")));
   logger.info();

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -140,9 +140,9 @@ export const deploy = async function (
   }
   await trackGA4("product_deploy", analyticsParams, duration);
 
-  const successMessage = options.dryRun ? "Dry run complete!" : "Deploy complete!"
+  const successMessage = options.dryRun ? "Dry run complete!" : "Deploy complete!";
   logger.info();
-  logSuccess(bold(underline("Deploy complete!")));
+  logSuccess(bold(underline(successMessage)));
   logger.info();
 
   const deployedHosting = includes(targetNames, "hosting");

--- a/src/deploy/remoteconfig/prepare.ts
+++ b/src/deploy/remoteconfig/prepare.ts
@@ -2,9 +2,9 @@ import { needProjectNumber } from "../../projectUtils";
 import { loadCJSON } from "../../loadCJSON";
 import { getEtag } from "./functions";
 import { validateInputRemoteConfigTemplate } from "./functions";
-import { Options } from "../../options";
+import { DeployOptions } from "../";
 
-export default async function (context: any, options: Options): Promise<void> {
+export default async function (context: any, options: DeployOptions): Promise<void> {
   if (!context) {
     return;
   }

--- a/src/deploy/storage/prepare.ts
+++ b/src/deploy/storage/prepare.ts
@@ -2,15 +2,15 @@ import * as _ from "lodash";
 
 import * as gcp from "../../gcp";
 import { RulesDeploy, RulesetServiceType } from "../../rulesDeploy";
-import { Options } from "../../options";
 import { FirebaseError } from "../../error";
+import { DeployOptions } from "..";
 
 /**
  * Prepares for a Firebase Storage deployment.
  * @param context The deploy context.
  * @param options The CLI options object.
  */
-export default async function (context: any, options: Options): Promise<void> {
+export default async function (context: any, options: DeployOptions): Promise<void> {
   let rulesConfig = options.config.get("storage");
   if (!rulesConfig) {
     return;

--- a/src/gcp/secretManager.ts
+++ b/src/gcp/secretManager.ts
@@ -445,7 +445,7 @@ export async function checkServiceAgentRole(
   secret: Pick<Secret, "projectId" | "name">,
   serviceAccountEmails: string[],
   role: string,
-): Promise<iam.Binding[]>{
+): Promise<iam.Binding[]> {
   const policy = await module.exports.getIamPolicy(secret);
   const bindings: iam.Binding[] = policy.bindings || [];
   let binding = bindings.find((b) => b.role === role);

--- a/src/gcp/secretManager.ts
+++ b/src/gcp/secretManager.ts
@@ -427,6 +427,25 @@ export async function ensureServiceAgentRole(
   serviceAccountEmails: string[],
   role: string,
 ): Promise<void> {
+  const bindings = await checkServiceAgentRole(secret, serviceAccountEmails, role);
+
+  await module.exports.setIamPolicy(secret, bindings);
+
+  // SecretManager would like us to _always_ inform users when we grant access to one of their secrets.
+  // As a safeguard against forgetting to do so, we log it here.
+  logLabeledSuccess(
+    "secretmanager",
+    `Granted ${role} on projects/${secret.projectId}/secrets/${
+      secret.name
+    } to ${serviceAccountEmails.join(", ")}`,
+  );
+}
+
+export async function checkServiceAgentRole(
+  secret: Pick<Secret, "projectId" | "name">,
+  serviceAccountEmails: string[],
+  role: string,
+): Promise<iam.Binding[]>{
   const policy = await module.exports.getIamPolicy(secret);
   const bindings: iam.Binding[] = policy.bindings || [];
   let binding = bindings.find((b) => b.role === role);
@@ -443,18 +462,8 @@ export async function ensureServiceAgentRole(
     }
   }
 
-  if (shouldShortCircuit) return;
-
-  await module.exports.setIamPolicy(secret, bindings);
-
-  // SecretManager would like us to _always_ inform users when we grant access to one of their secrets.
-  // As a safeguard against forgetting to do so, we log it here.
-  logLabeledSuccess(
-    "secretmanager",
-    `Granted ${role} on projects/${secret.projectId}/secrets/${
-      secret.name
-    } to ${serviceAccountEmails.join(", ")}`,
-  );
+  if (shouldShortCircuit) return [];
+  return bindings;
 }
 
 export const FIREBASE_MANAGED = "firebase-managed";

--- a/src/gcp/secretManager.ts
+++ b/src/gcp/secretManager.ts
@@ -428,8 +428,9 @@ export async function ensureServiceAgentRole(
   role: string,
 ): Promise<void> {
   const bindings = await checkServiceAgentRole(secret, serviceAccountEmails, role);
-
-  await module.exports.setIamPolicy(secret, bindings);
+  if (bindings.length) {
+    await module.exports.setIamPolicy(secret, bindings);
+  }
 
   // SecretManager would like us to _always_ inform users when we grant access to one of their secrets.
   // As a safeguard against forgetting to do so, we log it here.


### PR DESCRIPTION
### Description
Adds a new `--dry-run` flag to `firebase deploy`. `firebase deploy --dry-run` will run any validations or build steps, and then report information about what change would have been made, without making any changes to your project.

Under the hood, this means that we only run the prepare step, and skip release/deploy. I reviewed `prepare.ts` for each product to ensure they don't make any production changes, and moved some validation from later stages to prepare where it belongs.
