### PR TITLE
Extra debug logs for update-notifier

### DIFF
--- a/src/bin/firebase.ts
+++ b/src/bin/firebase.ts
@@ -83,11 +83,13 @@ logger.add(
 );
 
 logger.debug("-".repeat(70));
-logger.debug("Command:      ", process.argv.join(" "));
-logger.debug("CLI Version:  ", pkg.version);
-logger.debug("Platform:     ", process.platform);
-logger.debug("Node Version: ", process.version);
-logger.debug("Time:         ", new Date().toString());
+logger.debug(`Command:           ${process.argv.join(" ")}`);
+logger.debug(`CLI Version:       ${pkg.version}`);
+logger.debug(`Platform:          ${process.platform}`);
+logger.debug(`Node Version:      ${process.version}`);
+logger.debug(`Time:              ${new Date().toString()}`);
+logger.debug(`Update Available?: ${updateNotifier.update ?? false}`)
+
 if (utils.envOverrides.length) {
   logger.debug("Env Overrides:", utils.envOverrides.join(", "));
 }


### PR DESCRIPTION
### Description
Adding some extra logging to sanity check update-notifier. These messages will show up at the very top of firebase-debug.log.

The notifier seems to still be working for me:
<img width="944" alt="Screenshot 2024-08-27 at 9 42 14 AM" src="https://github.com/user-attachments/assets/ffb26216-391c-4315-9b66-8933d0b95ff8">

However, it does have some logic that uses ConfigStore to limit checks to only 1x per week (https://github.com/ryanblock/update-notifier-cjs/blob/main/index.js#L93), and if it does not have write access to configstore, it will fail silently. Can you check that `~/.config/configstore/update-notifier-firebase-tools.json` is writable and has a reasonable lastCheckedTime?
