### PR TITLE
temporarily remove extensions deploy from functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Released Firestore Emulator v 1.19.8 which adds support for `FindNearest.distanceResultField` and `FindNearest.distanceThreshold` parameters.
+- Temporarily removing extensions from functions deploy because it was causing unexpected extension deletions.

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -45,8 +45,8 @@ import { generateServiceIdentity } from "../../gcp/serviceusage";
 import { applyBackendHashToBackends } from "./cache/applyHash";
 import { allEndpoints, Backend } from "./backend";
 import { assertExhaustive } from "../../functional";
-import { prepareDynamicExtensions } from "../extensions/prepare";
-import { Context as ExtContext, Payload as ExtPayload } from "../extensions/args";
+// import { prepareDynamicExtensions } from "../extensions/prepare";
+// import { Context as ExtContext, Payload as ExtPayload } from "../extensions/args";
 
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
 
@@ -101,13 +101,13 @@ export async function prepare(
   );
 
   // == Phase 1.5 Prepare extensions found in codebases if any
-  if (Object.values(wantBuilds).some((b) => b.extensions)) {
-    const extContext: ExtContext = {};
-    const extPayload: ExtPayload = {};
-    await prepareDynamicExtensions(extContext, options, extPayload, wantBuilds);
-    context.extensions = extContext;
-    payload.extensions = extPayload;
-  }
+  // if (Object.values(wantBuilds).some((b) => b.extensions)) {
+  //   const extContext: ExtContext = {};
+  //   const extPayload: ExtPayload = {};
+  //   await prepareDynamicExtensions(extContext, options, extPayload, wantBuilds);
+  //   context.extensions = extContext;
+  //   payload.extensions = extPayload;
+  // }
 
   // == Phase 2. Resolve build to backend.
   const codebaseUsesEnvs: string[] = [];


### PR DESCRIPTION
Temporarily remove extensions deploy from functions.
This is causing issues with unexpected deletion of extensions during functions deploy.
