### PR TITLE
Put an existing connector in ./connector if it is the only one.

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -263,7 +263,7 @@ async function promptForService(setup: Setup, info: RequiredInfo): Promise<Requi
               const id = c.name.split("/").pop()!;
               return {
                 id,
-                path: `./${id}`,
+                path: connectors.length === 1 ? "./connector" : `./${id}`,
                 files: c.source.files || [],
               };
             });


### PR DESCRIPTION
### Description

To provide more consistency with a fresh init template and make the path
more predictable, mostly for documentation references.

### Scenarios Tested

TBD

### Sample Commands

`firebase init dataconnect` with an existing service with an already deployed connector.
