### PR TITLE
Add appdist group and tester list commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Added support for Next.js 15. (#7588)
+- Added the appdistribution:group:list and appdistribution:testers:list commands.

--- a/src/appdistribution/client.spec.ts
+++ b/src/appdistribution/client.spec.ts
@@ -83,6 +83,90 @@ describe("distribution", () => {
       await expect(appDistributionClient.removeTesters(projectName, emails)).to.eventually.deep.eq(
         mockResponse,
       );
+
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("listTesters", () => {
+    it("should throw error if request fails", async () => {
+      nock(appDistributionOrigin())
+        .get(`/v1/${projectName}/testers`)
+        .reply(400, { error: { status: "FAILED_PRECONDITION" } });
+      await expect(appDistributionClient.listTesters(projectName)).to.be.rejectedWith(
+        FirebaseError,
+        "Client request failed to list testers",
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve with ListTestersResponse when request succeeds - no filter", async () => {
+      const testerListing = [
+        {
+          name: "tester_1",
+          displayName: "Tester 1",
+          groups: [],
+          lastActivityTime: new Date("2024-08-27T02:37:19.539865Z"),
+        },
+        {
+          name: "tester_2",
+          displayName: "Tester 2",
+          groups: [`${projectName}/groups/beta-team`, `${projectName}/groups/alpha-team`],
+          lastActivityTime: new Date("2024-08-26T02:37:19Z"),
+        },
+      ];
+
+      nock(appDistributionOrigin()).get(`/v1/${projectName}/testers`).reply(200, {
+        testers: testerListing,
+      });
+      await expect(appDistributionClient.listTesters(projectName)).to.eventually.deep.eq({
+        testers: [
+          {
+            name: "tester_1",
+            displayName: "Tester 1",
+            groups: [],
+            lastActivityTime: new Date("2024-08-27T02:37:19.539865Z"),
+          },
+          {
+            name: "tester_2",
+            displayName: "Tester 2",
+            groups: [`${projectName}/groups/beta-team`, `${projectName}/groups/alpha-team`],
+            lastActivityTime: new Date("2024-08-26T02:37:19Z"),
+          },
+        ],
+      });
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve when request succeeds - with filter", async () => {
+      const testerListing = [
+        {
+          name: "tester_2",
+          displayName: "Tester 2",
+          groups: [`${projectName}/groups/beta-team`],
+          lastActivityTime: new Date("2024-08-26T02:37:19Z"),
+        },
+      ];
+
+      const filterQuery = encodeURI(`groups=${projectName}/groups/beta-team`);
+
+      nock(appDistributionOrigin())
+        .get(`/v1/${projectName}/testers?filter=${filterQuery}`)
+        .reply(200, {
+          testers: testerListing,
+        });
+      await expect(
+        appDistributionClient.listTesters(projectName, "beta-team"),
+      ).to.eventually.deep.eq({
+        testers: [
+          {
+            name: "tester_2",
+            displayName: "Tester 2",
+            groups: [`${projectName}/groups/beta-team`],
+            lastActivityTime: new Date("2024-08-26T02:37:19Z"),
+          },
+        ],
+      });
       expect(nock.isDone()).to.be.true;
     });
   });
@@ -294,6 +378,43 @@ describe("distribution", () => {
       nock(appDistributionOrigin()).post(`/v1/${groupName}:batchLeave`).reply(200, {});
       await expect(appDistributionClient.removeTestersFromGroup(groupName, emails)).to.be.eventually
         .fulfilled;
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("listGroups", () => {
+    it("should throw error if request fails", async () => {
+      nock(appDistributionOrigin())
+        .get(`/v1/${projectName}/groups`)
+        .reply(400, { error: { status: "FAILED_PRECONDITION" } });
+      await expect(appDistributionClient.listGroups(projectName)).to.be.rejectedWith(
+        FirebaseError,
+        "Client failed to list groups",
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve with ListGroupsResponse when request succeeds", async () => {
+      const groupListing: Group[] = [
+        {
+          name: "group_1",
+          displayName: "Group 1",
+          testerCount: 5,
+          releaseCount: 2,
+          inviteLinkCount: 10,
+        },
+        {
+          name: "group_2",
+          displayName: "Group 2",
+        },
+      ];
+
+      nock(appDistributionOrigin()).get(`/v1/${projectName}/groups`).reply(200, {
+        groups: groupListing,
+      });
+      await expect(appDistributionClient.listGroups(projectName)).to.eventually.deep.eq({
+        groups: groupListing,
+      });
       expect(nock.isDone()).to.be.true;
     });
   });

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -1,15 +1,17 @@
 import { ReadStream } from "fs";
 
-import * as utils from "../utils";
-import * as operationPoller from "../operation-poller";
-import { Distribution } from "./distribution";
-import { FirebaseError } from "../error";
-import { Client } from "../apiv2";
 import { appDistributionOrigin } from "../api";
+import { Client, ClientResponse } from "../apiv2";
+import { FirebaseError } from "../error";
+import * as operationPoller from "../operation-poller";
+import * as utils from "../utils";
+import { Distribution } from "./distribution";
 import {
   AabInfo,
   BatchRemoveTestersResponse,
   Group,
+  ListGroupsResponse,
+  ListTestersResponse,
   LoginCredential,
   mapDeviceToExecution,
   ReleaseTest,
@@ -123,6 +125,46 @@ export class AppDistributionClient {
     utils.logSuccess("distributed to testers/groups successfully");
   }
 
+  async listTesters(projectName: string, groupName?: string): Promise<ListTestersResponse> {
+    const listTestersResponse: ListTestersResponse = {
+      testers: [],
+    };
+
+    const client = this.appDistroV1Client;
+
+    let pageToken: string | undefined;
+
+    const filter = groupName ? `groups=${projectName}/groups/${groupName}` : null;
+
+    do {
+      const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
+      if (filter != null) {
+        queryParams["filter"] = filter;
+      }
+
+      let apiResponse: ClientResponse<ListTestersResponse>;
+      try {
+        apiResponse = await client.get<ListTestersResponse>(`${projectName}/testers`, {
+          queryParams,
+        });
+      } catch (err) {
+        throw new FirebaseError(`Client request failed to list testers ${err}`);
+      }
+
+      for (const t of apiResponse.body.testers) {
+        listTestersResponse.testers.push({
+          name: t.name,
+          displayName: t.displayName,
+          groups: t.groups,
+          lastActivityTime: new Date(t.lastActivityTime),
+        });
+      }
+
+      pageToken = apiResponse.body.nextPageToken;
+    } while (pageToken);
+    return listTestersResponse;
+  }
+
   async addTesters(projectName: string, emails: string[]): Promise<void> {
     try {
       await this.appDistroV1Client.request({
@@ -152,6 +194,30 @@ export class AppDistributionClient {
       throw new FirebaseError(`Failed to remove testers ${err}`);
     }
     return apiResponse.body;
+  }
+
+  async listGroups(projectName: string): Promise<ListGroupsResponse> {
+    const listGroupsResponse: ListGroupsResponse = {
+      groups: [],
+    };
+
+    const client = this.appDistroV1Client;
+
+    let pageToken: string | undefined;
+
+    do {
+      const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
+      try {
+        const apiResponse = await client.get<ListGroupsResponse>(`${projectName}/groups`, {
+          queryParams,
+        });
+        listGroupsResponse.groups.push(...(apiResponse.body.groups || []));
+        pageToken = apiResponse.body.nextPageToken;
+      } catch (err) {
+        throw new FirebaseError(`Client failed to list groups ${err}`);
+      }
+    } while (pageToken);
+    return listGroupsResponse;
   }
 
   async createGroup(projectName: string, displayName: string, alias?: string): Promise<Group> {

--- a/src/appdistribution/types.ts
+++ b/src/appdistribution/types.ts
@@ -55,12 +55,29 @@ export interface BatchRemoveTestersResponse {
   emails: string[];
 }
 
+export interface ListGroupsResponse {
+  groups: Group[];
+  nextPageToken?: string;
+}
+
 export interface Group {
   name: string;
   displayName: string;
   testerCount?: number;
   releaseCount?: number;
   inviteLinkCount?: number;
+}
+
+export interface ListTestersResponse {
+  testers: Tester[];
+  nextPageToken?: string;
+}
+
+export interface Tester {
+  name: string;
+  displayName?: string;
+  groups: string[];
+  lastActivityTime: Date;
 }
 
 export interface CreateReleaseTestRequest {

--- a/src/commands/appdistribution-group-list.ts
+++ b/src/commands/appdistribution-group-list.ts
@@ -1,0 +1,61 @@
+import * as ora from "ora";
+import { AppDistributionClient } from "../appdistribution/client";
+import { getProjectName } from "../appdistribution/options-parser-util";
+import { Group, ListGroupsResponse } from "../appdistribution/types";
+import { Command } from "../command";
+import { FirebaseError } from "../error";
+import { logger } from "../logger";
+import { Options } from "../options";
+import { requireAuth } from "../requireAuth";
+import * as utils from "../utils";
+
+const Table = require("cli-table");
+
+export const command = new Command("appdistribution:group:list")
+  .description("list groups in project")
+  .before(requireAuth)
+  .action(async (options?: Options): Promise<ListGroupsResponse> => {
+    const projectName = await getProjectName(options);
+    const appDistroClient = new AppDistributionClient();
+    let groupsResponse: ListGroupsResponse;
+    const spinner = ora("Preparing the list of your App Distribution Groups").start();
+    try {
+      groupsResponse = await appDistroClient.listGroups(projectName);
+    } catch (err: any) {
+      spinner.fail();
+      throw new FirebaseError("Failed to list groups.", {
+        exit: 1,
+        original: err,
+      });
+    }
+    spinner.succeed();
+    const groups = groupsResponse.groups ?? [];
+    printGroupsTable(groups);
+    utils.logSuccess(`Groups listed successfully`);
+    return groupsResponse;
+  });
+
+/**
+ * Prints a table given a list of groups
+ */
+export function printGroupsTable(groups: Group[]): void {
+  const tableHead = ["Group", "Display Name", "Tester Count", "Release Count", "Invite Link Count"];
+
+  const table = new Table({
+    head: tableHead,
+    style: { head: ["green"] },
+  });
+
+  for (const group of groups) {
+    const name = group.name.split("/").pop();
+    table.push([
+      name,
+      group.displayName,
+      group.testerCount || 0,
+      group.releaseCount || 0,
+      group.inviteLinkCount || 0,
+    ]);
+  }
+
+  logger.info(table.toString());
+}

--- a/src/commands/appdistribution-testers-list.ts
+++ b/src/commands/appdistribution-testers-list.ts
@@ -1,0 +1,59 @@
+import * as ora from "ora";
+import { AppDistributionClient } from "../appdistribution/client";
+import { getProjectName } from "../appdistribution/options-parser-util";
+import { ListTestersResponse, Tester } from "../appdistribution/types";
+import { Command } from "../command";
+import { FirebaseError } from "../error";
+import { logger } from "../logger";
+import { Options } from "../options";
+import { requireAuth } from "../requireAuth";
+import * as utils from "../utils";
+
+const Table = require("cli-table");
+
+export const command = new Command("appdistribution:testers:list [group]")
+  .description("list testers in project")
+  .before(requireAuth)
+  .action(async (group: string | undefined, options: Options): Promise<ListTestersResponse> => {
+    const projectName = await getProjectName(options);
+    const appDistroClient = new AppDistributionClient();
+    let testersResponse: ListTestersResponse;
+    const spinner = ora("Preparing the list of your App Distribution testers").start();
+    try {
+      testersResponse = await appDistroClient.listTesters(projectName, group);
+    } catch (err: any) {
+      spinner.fail();
+      throw new FirebaseError("Failed to list testers.", {
+        exit: 1,
+        original: err,
+      });
+    }
+    spinner.succeed();
+    const testers = testersResponse.testers ?? [];
+    printTestersTable(testers);
+    utils.logSuccess(`Testers listed successfully`);
+    return testersResponse;
+  });
+
+/**
+ * Prints a table given a list of testers
+ */
+function printTestersTable(testers: Tester[]): void {
+  const tableHead = ["Name", "Display Name", "Last Activity Time", "Groups"];
+
+  const table = new Table({
+    head: tableHead,
+    style: { head: ["green"] },
+  });
+
+  for (const tester of testers) {
+    const name = tester.name.split("/").pop();
+    const groups = tester.groups
+      .map((grp) => grp.split("/").pop())
+      .sort()
+      .join(";");
+    table.push([name, tester.displayName ?? "", tester.lastActivityTime, groups]);
+  }
+
+  logger.info(table.toString());
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -22,9 +22,11 @@ export function load(client: any): any {
   client.appdistribution = {};
   client.appdistribution.distribute = loadCommand("appdistribution-distribute");
   client.appdistribution.testers = {};
+  client.appdistribution.testers.list = loadCommand("appdistribution-testers-list");
   client.appdistribution.testers.add = loadCommand("appdistribution-testers-add");
   client.appdistribution.testers.delete = loadCommand("appdistribution-testers-remove");
   client.appdistribution.group = {};
+  client.appdistribution.group.list = loadCommand("appdistribution-group-list");
   client.appdistribution.group.create = loadCommand("appdistribution-group-create");
   client.appdistribution.group.delete = loadCommand("appdistribution-group-delete");
   client.apps = {};


### PR DESCRIPTION
### Description

Adds the following CLI commands for App Distribution:

- `firebase appdistribution:testers:list`
- `firebase appdistribution:group:list`

### Scenarios Tested

- List all testers
- List all testers in a group
- List all groups

### Sample Commands

List all AppDist testers:

```
firebase appdistribution:testers:list --project my-project
```

List all AppDist testers in the `alpha-team` group:

```
firebase appdistribution:testers:list alpha-team --project my-project
```

List all AppDist groups:

```
firebase appdistribution:group:list --project my-project 
```

List all AppDist groups, providing JSON as output:

```
firebase appdistribution:group:list --project my-project --json
```
