### PR TITLE
Add OOB flow for VERIFY_AND_CHANGE_EMAIL

### DIFF
--- a/src/emulator/auth/handlers.ts
+++ b/src/emulator/auth/handlers.ts
@@ -143,6 +143,32 @@ export function registerHandlers(
           }
         }
       }
+      case "verifyAndChangeEmail": {
+        try {
+          const { newEmail } = setAccountInfoImpl(state, { oobCode });
+          if (continueUrl) {
+            return res.redirect(303, continueUrl);
+          } else {
+            return res.status(200).json({
+              authEmulator: { success: `The email has been successfully changed.`, newEmail },
+            });
+          }
+        } catch (e: any) {
+          if (
+            e instanceof NotImplementedError ||
+            (e instanceof BadRequestError && e.message === "INVALID_OOB_CODE")
+          ) {
+            return res.status(400).json({
+              authEmulator: {
+                error: `Your request to change your email has expired or the link has already been used.`,
+                instructions: `Try changing your email again.`,
+              },
+            });
+          } else {
+            throw e;
+          }
+        }
+      }
       case "signIn": {
         if (!continueUrl) {
           return res.status(400).json({

--- a/src/emulator/auth/oob.spec.ts
+++ b/src/emulator/auth/oob.spec.ts
@@ -76,6 +76,22 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
         expect(res.body.oobCode).to.be.a("string");
         expect(res.body.oobLink).to.be.a("string");
       });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .set("Authorization", "Bearer owner")
+      .send({
+        email: user.email,
+        newEmail: "bob@example.com",
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+        returnOobLink: true,
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.email).to.equal(user.email);
+        expect(res.body.oobCode).to.be.a("string");
+        expect(res.body.oobLink).to.be.a("string");
+      });
   });
 
   it("should return OOB code by idToken for OAuth 2 requests as well", async () => {
@@ -91,6 +107,23 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
         expect(res.body.oobCode).to.be.a("string");
         expect(res.body.oobLink).to.be.a("string");
       });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .set("Authorization", "Bearer owner")
+      .send({
+        email: user.email,
+        newEmail: "bob@example.com",
+        idToken,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+        returnOobLink: true,
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.email).to.equal(user.email);
+        expect(res.body.oobCode).to.be.a("string");
+        expect(res.body.oobLink).to.be.a("string");
+      });
   });
 
   it("should error when trying to verify email without idToken or email", async () => {
@@ -100,7 +133,7 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
       .query({ key: "fake-api-key" })
-      .send({ requestType: "VERIFY_EMAIL" })
+      .send({ idToken: "hoge", requestType: "VERIFY_EMAIL" })
       .then((res) => {
         expectStatusCode(400, res);
         expect(res.body.error).to.have.property("message").equal("INVALID_ID_TOKEN");
@@ -281,6 +314,7 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
   it("should return purpose of oobCodes via resetPassword endpoint", async () => {
     const user = { email: "alice@example.com", password: "notasecret" };
     const { idToken } = await registerUser(authApi(), user);
+    const newEmail = "bob@example.com";
 
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
@@ -297,11 +331,22 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
     await authApi()
       .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
       .query({ key: "fake-api-key" })
-      .send({ email: "bob@example.com", requestType: "EMAIL_SIGNIN" })
+      .send({ email: newEmail, requestType: "EMAIL_SIGNIN" })
+      .then((res) => expectStatusCode(200, res));
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({
+        email: user.email,
+        newEmail,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+        idToken,
+      })
       .then((res) => expectStatusCode(200, res));
 
     const oobs = await inspectOobs(authApi());
-    expect(oobs).to.have.length(3);
+    expect(oobs).to.have.length(4);
 
     for (const oob of oobs) {
       await authApi()
@@ -322,12 +367,15 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
           } else {
             expect(res.body.email).to.equal(oob.email);
           }
+          if (oob.requestType === "VERIFY_AND_CHANGE_EMAIL") {
+            expect(res.body.newEmail).to.equal(newEmail);
+          }
         });
     }
 
     // OOB codes are not consumed by the lookup above.
     const oobs2 = await inspectOobs(authApi());
-    expect(oobs2).to.have.length(3);
+    expect(oobs2).to.have.length(4);
   });
 
   it("should error on resetPassword if auth is disabled", async () => {
@@ -394,5 +442,190 @@ describeAuthEmulator("accounts:sendOobCode", ({ authApi, getClock }) => {
           .equals("identitytoolkit#GetOobConfirmationCodeResponse");
         expect(res.body).to.have.property("email").equals(user.email);
       });
+  });
+
+  it("should generate OOB code for verify and change email", async () => {
+    const user = { email: "alice@example.com", password: "notasecret" };
+    const { idToken, localId } = await registerUser(authApi(), user);
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({
+        email: user.email,
+        newEmail: "bob@example.com",
+        idToken,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+      })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body)
+          .to.have.property("kind")
+          .equals("identitytoolkit#GetOobConfirmationCodeResponse");
+        expect(res.body.email).to.equal(user.email);
+
+        // These fields should not be set since returnOobLink is not set.
+        expect(res.body).not.to.have.property("oobCode");
+        expect(res.body).not.to.have.property("oobLink");
+      });
+
+    const oobs = await inspectOobs(authApi());
+    expect(oobs).to.have.length(1);
+    expect(oobs[0].email).to.equal(user.email);
+    expect(oobs[0].requestType).to.equal("VERIFY_AND_CHANGE_EMAIL");
+
+    // The returned oobCode can be redeemed to verify and change the email.
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .query({ key: "fake-api-key" })
+      // OOB code is enough, no idToken needed.
+      .send({ oobCode: oobs[0].oobCode })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.localId).to.equal(localId);
+        expect(res.body.email).to.equal("bob@example.com");
+        expect(res.body.emailVerified).to.equal(true);
+      });
+
+    // oobCode is removed after redeemed.
+    const oobs2 = await inspectOobs(authApi());
+    expect(oobs2).to.have.length(0);
+  });
+
+  it("should error when trying to verify and change email without idToken or email or newEmail", async () => {
+    const user = { email: "alice@example.com", password: "notasecret" };
+    await registerUser(authApi(), user);
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({ newEmail: "bob@example.com", requestType: "VERIFY_AND_CHANGE_EMAIL" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("MISSING_ID_TOKEN");
+      });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({ email: user.email, requestType: "VERIFY_AND_CHANGE_EMAIL" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("MISSING_NEW_EMAIL");
+      });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .set("Authorization", "Bearer owner")
+      .send({
+        newEmail: "bob@example.com",
+        returnOobLink: true,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("MISSING_EMAIL");
+      });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .set("Authorization", "Bearer owner")
+      .send({
+        email: user.email,
+        returnOobLink: true,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("MISSING_NEW_EMAIL");
+      });
+
+    const oobs = await inspectOobs(authApi());
+    expect(oobs).to.have.length(0);
+  });
+
+  it("should error when trying to verify and change email without idToken if not returnOobLink", async () => {
+    const user = await registerUser(authApi(), {
+      email: "alice@example.com",
+      password: "notasecret",
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({
+        email: user.email,
+        newEmail: "bob@example.com",
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("MISSING_ID_TOKEN");
+      });
+
+    const oobs = await inspectOobs(authApi());
+    expect(oobs).to.have.length(0);
+  });
+
+  it("should error when trying to verify and change email not associated with any user", async () => {
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .set("Authorization", "Bearer owner")
+      .send({
+        email: "nosuchuser@example.com",
+        newEmail: "bob@example.com",
+        returnOobLink: true,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("USER_NOT_FOUND");
+      });
+
+    const oobs = await inspectOobs(authApi());
+    expect(oobs).to.have.length(0);
+  });
+
+  it("should error if newEmail is already associated to another user", async () => {
+    const user = {
+      email: "alice@example.com",
+      password: "notasecret",
+    };
+    const { idToken } = await registerUser(authApi(), user);
+    const anotherUser = await registerUser(authApi(), {
+      email: "bob@example.com",
+      password: "notasecret",
+    });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({
+        idToken,
+        email: user.email,
+        newEmail: anotherUser.email,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("EMAIL_EXISTS");
+      });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .set("Authorization", "Bearer owner")
+      .send({
+        email: user.email,
+        newEmail: anotherUser.email,
+        returnOobLink: true,
+        requestType: "VERIFY_AND_CHANGE_EMAIL",
+      })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equal("EMAIL_EXISTS");
+      });
+
+    const oobs = await inspectOobs(authApi());
+    expect(oobs).to.have.length(0);
   });
 });

--- a/src/emulator/auth/setAccountInfo.spec.ts
+++ b/src/emulator/auth/setAccountInfo.spec.ts
@@ -361,6 +361,79 @@ describeAuthEmulator("accounts:update", ({ authApi, getClock }) => {
       });
   });
 
+  it("should update email when OOB flow of VERIFY_AND_CHANGE_EMAIL is initiated", async () => {
+    const oldEmail = "alice@example.com";
+    const password = "notasecret";
+    const newEmail = "bob@example.com";
+    const { idToken } = await registerUser(authApi(), { email: oldEmail, password });
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, newEmail, requestType: "VERIFY_AND_CHANGE_EMAIL" })
+      .then((res) => {
+        expectStatusCode(200, res);
+      });
+
+    const oobs = await inspectOobs(authApi());
+    expect(oobs).to.have.length(1);
+    expect(oobs[0].email).to.equal(oldEmail);
+    expect(oobs[0].newEmail).to.equal(newEmail);
+    expect(oobs[0].requestType).to.equal("VERIFY_AND_CHANGE_EMAIL");
+
+    // The returned oobCode can be redeemed to verify and change the email.
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .query({ key: "fake-api-key" })
+      // OOB code is enough, no idToken needed.
+      .send({ oobCode: oobs[0].oobCode })
+      .then((res) => {
+        expectStatusCode(200, res);
+        expect(res.body.email).to.equal(newEmail);
+        expect(res.body.newEmail).to.equal(newEmail);
+        // Email is verified since this flow can only be initiated through a link sent to the user's email.
+        expect(res.body.emailVerified).to.equal(true);
+      });
+
+    // oobCode is removed after redeemed.
+    const oobs2 = await inspectOobs(authApi());
+    expect(oobs2).to.have.length(0);
+  });
+
+  it("should disallow changing an email if another user exists with the same email", async () => {
+    const user = { email: "alice@example.com", password: "notasecret" };
+    const anotherUser = { email: "bob@example.com", password: "notasecreteither" };
+
+    const { idToken } = await registerUser(authApi(), user);
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:sendOobCode")
+      .query({ key: "fake-api-key" })
+      .send({ idToken, newEmail: anotherUser.email, requestType: "VERIFY_AND_CHANGE_EMAIL" })
+      .then((res) => {
+        expectStatusCode(200, res);
+      });
+
+    const oobs = await inspectOobs(authApi());
+    expect(oobs).to.have.length(1);
+    expect(oobs[0].requestType).to.equal("VERIFY_AND_CHANGE_EMAIL");
+
+    await registerUser(authApi(), anotherUser);
+
+    await authApi()
+      .post("/identitytoolkit.googleapis.com/v1/accounts:update")
+      .send({ oobCode: oobs[0].oobCode })
+      .query({ key: "fake-api-key" })
+      .then((res) => {
+        expectStatusCode(400, res);
+        expect(res.body.error).to.have.property("message").equals("EMAIL_EXISTS");
+      });
+
+    // oobCode is removed after redeemed.
+    const oobs2 = await inspectOobs(authApi());
+    expect(oobs2).to.have.length(0);
+  });
+
   it("should update phoneNumber if specified", async () => {
     const phoneNumber = TEST_PHONE_NUMBER;
     const { localId, idToken } = await signInWithPhoneNumber(authApi(), phoneNumber);

--- a/src/emulator/auth/state.ts
+++ b/src/emulator/auth/state.ts
@@ -431,6 +431,7 @@ export abstract class ProjectState {
 
   createOob(
     email: string,
+    newEmail: string | undefined,
     requestType: OobRequestType,
     generateLink: (oobCode: string) => string,
   ): OobRecord {
@@ -439,6 +440,7 @@ export abstract class ProjectState {
 
     const oob: OobRecord = {
       email,
+      newEmail,
       requestType,
       oobCode,
       oobLink,
@@ -905,6 +907,7 @@ export type OobRequestType = NonNullable<
 
 export interface OobRecord {
   email: string;
+  newEmail?: string;
   oobLink: string;
   oobCode: string;
   requestType: OobRequestType;


### PR DESCRIPTION
### Description

Implement `VERIFY_AND_CHANGE_EMAIL` OOB flow to `accounts:sendOobCode` API in Firebase Emulator. This changes allows you to use `verifyBeforeUpdateEmail` in Firebase Javascript SDK, `generateVerifyAndChangeEmailLink` in Firebase Admin SDK and `accounts:sendOobCode` API with requestType `VERIFY_AND_CHANGE_EMAIL` as well.

Refs https://github.com/firebase/firebase-tools/issues/3424

### Scenarios Tested

- Tested the default handler for `verifyAndChangeEmail` mode by accessing the URL returned from `generateVerifyAndChangeEmailLink`
- Tested the custom email handler using `checkActionCode` and `applyActionCode` of `firebase/auth`