### PR TITLE
Improve error message thrown when secret dataFile path does not exist

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -915,5 +915,12 @@ export function readSecretValue(prompt: string, dataFile?: string): Promise<stri
   if (dataFile && dataFile !== "-") {
     input = dataFile;
   }
-  return Promise.resolve(fs.readFileSync(input, "utf-8"));
+  try {
+    return Promise.resolve(fs.readFileSync(input, "utf-8"));
+  } catch (e: any) {
+    if (e.code === "ENOENT") {
+      throw new FirebaseError(`File not found: ${input}`, { original: e });
+    }
+    throw e;
+  }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

`firebase functions:secrets:set SECRET_API_KEY --data-file ./non-existent.json` throws 
```
Error: An unexpected error has occurred.
``` 

when file does not exist

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

`firebase functions:secrets:set SECRET_API_KEY --data-file ./secrets/test.jso` throws
```
Error: File not found: ./secrets/test.jso
``` 

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
