### PR TITLE
Update firebase functions template to latest major version of the Functions SDK.

### DIFF
--- a/templates/init/functions/javascript/index.js
+++ b/templates/init/functions/javascript/index.js
@@ -7,7 +7,7 @@
  * See a full list of supported triggers at https://firebase.google.com/docs/functions
  */
 
-const {onRequest} = require("firebase-functions/v2/https");
+const {onRequest} = require("firebase-functions/https");
 const logger = require("firebase-functions/logger");
 
 // Create and deploy your first functions

--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -15,7 +15,7 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^12.1.0",
-    "firebase-functions": "^5.0.0"
+    "firebase-functions": "^6.0.0"
   },
   "devDependencies": {
     "eslint": "^8.15.0",

--- a/templates/init/functions/javascript/package.nolint.json
+++ b/templates/init/functions/javascript/package.nolint.json
@@ -14,7 +14,7 @@
   "main": "index.js",
   "dependencies": {
     "firebase-admin": "^12.1.0",
-    "firebase-functions": "^5.0.0"
+    "firebase-functions": "^6.0.0"
   },
   "devDependencies": {
     "firebase-functions-test": "^3.1.0"

--- a/templates/init/functions/typescript/index.ts
+++ b/templates/init/functions/typescript/index.ts
@@ -7,7 +7,7 @@
  * See a full list of supported triggers at https://firebase.google.com/docs/functions
  */
 
-import {onRequest} from "firebase-functions/v2/https";
+import {onRequest} from "firebase-functions/https";
 import * as logger from "firebase-functions/logger";
 
 // Start writing functions

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -16,7 +16,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^12.1.0",
-    "firebase-functions": "^5.0.0"
+    "firebase-functions": "^6.0.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.12.0",

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -15,7 +15,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "firebase-admin": "^12.1.0",
-    "firebase-functions": "^5.0.0"
+    "firebase-functions": "^6.0.0"
   },
   "devDependencies": {
     "typescript": "^4.9.0",


### PR DESCRIPTION
The template also includes a change to omit use of `v2` in require paths. `v2` is assumed in the latest Functions SDK. 