### PR TITLE
Implement `schemaValidation` mode handling in `dataconnect:sql:migrate` and `deploy`

### DIFF
--- a/src/commands/dataconnect-sql-migrate.ts
+++ b/src/commands/dataconnect-sql-migrate.ts
@@ -34,6 +34,7 @@ export const command = new Command("dataconnect:sql:migrate [serviceId]")
       options,
       schema: serviceInfo.schema,
       validateOnly: true,
+      schemaValidation: serviceInfo.dataConnectYaml.schema.datasource.postgresql?.schemaValidation,
     });
     if (diffs.length) {
       logLabeledSuccess(

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -247,11 +247,7 @@ function diffsEqual(x: Diff[], y: Diff[]): boolean {
 }
 
 function setSchemaValidationMode(schema: Schema, schemaValidation: SchemaValidation) {
-  if (
-    experiments.isEnabled("fdccompatiblemode") &&
-    schema.primaryDatasource.postgresql &&
-    !schema.primaryDatasource.postgresql.schemaValidation
-  ) {
+  if (experiments.isEnabled("fdccompatiblemode") && schema.primaryDatasource.postgresql) {
     schema.primaryDatasource.postgresql.schemaValidation = schemaValidation;
   }
 }

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -514,7 +514,6 @@ function displaySchemaChanges(
   databaseId: string,
 ) {
   switch (error.violationType) {
-    
     case "INCOMPATIBLE_SCHEMA":
       {
         let message;

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -389,13 +389,14 @@ async function promptForSchemaMigration(
   if (!err) {
     return "none";
   }
+  if (validationMode === "STRICT_AFTER_COMPATIBLE" && (options.nonInteractive || options.force)) {
+    // If these are purely optional changes, do not execute them in non-interactive mode or with the `--force` flag.
+    return "none";
+  }
   displaySchemaChanges(err, validationMode, instanceName, databaseId);
   if (!options.nonInteractive) {
     if (validateOnly && options.force) {
-      // `firebase dataconnect:sql:migrate --force` performs all migrations unless these are purely optional changes.
-      if (validationMode === "STRICT_AFTER_COMPATIBLE") {
-        return "none";
-      }
+      // `firebase dataconnect:sql:migrate --force` performs all migrations.
       return "all";
     }
     // `firebase deploy` and `firebase dataconnect:sql:migrate` always prompt for any SQL migration changes.
@@ -419,10 +420,7 @@ async function promptForSchemaMigration(
       default: defaultValue,
     });
   }
-  if (validationMode === "STRICT_AFTER_COMPATIBLE") {
-    // Neither `firebase deploy --nonInteractive` nor `dataconnect:sql:migrate --nonInteractive` should not perform any optional changes.
-    return "none";
-  } else if (!validateOnly) {
+  if (!validateOnly) {
     // `firebase deploy --nonInteractive` performs no migrations
     throw new FirebaseError(
       "Command aborted. Your database schema is incompatible with your Data Connect schema. Run `firebase dataconnect:sql:migrate` to migrate your database schema",

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -514,6 +514,7 @@ function displaySchemaChanges(
   databaseId: string,
 ) {
   switch (error.violationType) {
+    
     case "INCOMPATIBLE_SCHEMA":
       {
         let message;

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -216,13 +216,14 @@ export async function migrateSchema(args: {
         );
 
         if (incompatible) {
-          diffs = await handleIncompatibleSchemaError({
+          const maybeDiffs = await handleIncompatibleSchemaError({
             options,
             databaseId,
             instanceId,
             incompatibleSchemaError: incompatible,
             choice: migrationMode,
           });
+          diffs = diffs.concat(maybeDiffs);
         }
       }
     }

--- a/src/deploy/dataconnect/release.ts
+++ b/src/deploy/dataconnect/release.ts
@@ -34,7 +34,10 @@ export default async function (
         })
       );
     })
-    .map((s) => s.schema);
+    .map((s) => ({
+      schema: s.schema,
+      validationMode: s.dataConnectYaml.schema.datasource.postgresql?.schemaValidation,
+    }));
 
   if (wantSchemas.length) {
     utils.logLabeledBullet("dataconnect", "Releasing Data Connect schemas...");
@@ -43,8 +46,9 @@ export default async function (
     for (const s of wantSchemas) {
       await migrateSchema({
         options,
-        schema: s,
+        schema: s.schema,
         validateOnly: false,
+        schemaValidation: s.validationMode,
       });
     }
     utils.logLabeledBullet("dataconnect", "Schemas released.");


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Updates `firebase dataconnect:sql:migrate` and `firebase deploy` per go/fdc-compat-mode-cli-api.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

**`schemaValidation` unset, both required and optional changes:**

- [x] `firebase deploy`
- [x] `firebase deploy --force`
- [x] `firebase deploy --non-interactive`
- [x] `firebase deploy --non-interactive --force`
- [x] `firebase dataconnect:sql:migrate`
- [x] `firebase dataconnect:sql:migrate --force`
- [x] `firebase dataconnect:sql:migrate --non-interactive`
- [x] `firebase dataconnect:sql:migrate --non-interactive --force`

**`schemaValidation` unset, only required changes:**

- [x] `firebase deploy`
- [x] `firebase deploy --force`
- [x] `firebase deploy --non-interactive`
- [x] `firebase deploy --non-interactive --force`
- [x] `firebase dataconnect:sql:migrate`
- [x] `firebase dataconnect:sql:migrate --force`
- [x] `firebase dataconnect:sql:migrate --non-interactive`
- [x] `firebase dataconnect:sql:migrate --non-interactive --force`

**`schemaValidation` unset, only optional changes:**

- [x] `firebase deploy`
- [x] `firebase deploy --force`
- [x] `firebase deploy --non-interactive`
- [x] `firebase deploy --non-interactive --force`
- [x] `firebase dataconnect:sql:migrate`
- [x] `firebase dataconnect:sql:migrate --force`
- [x] `firebase dataconnect:sql:migrate --non-interactive`
- [x] `firebase dataconnect:sql:migrate --non-interactive --force`

**`schemaValidation=COMPATIBLE`, both required and optional changes:**

- [x] `firebase deploy`
- [x] `firebase deploy --force`
- [x] `firebase deploy --non-interactive`
- [x] `firebase deploy --non-interactive --force`
- [x] `firebase dataconnect:sql:migrate`
- [x] `firebase dataconnect:sql:migrate --force`
- [x] `firebase dataconnect:sql:migrate --non-interactive`
- [x] `firebase dataconnect:sql:migrate --non-interactive --force`

**`schemaValidation=COMPATIBLE`, only optional changes:**

- [x] `firebase deploy`
- [x] `firebase deploy --force`
- [x] `firebase deploy --non-interactive`
- [x] `firebase deploy --non-interactive --force`
- [x] `firebase dataconnect:sql:migrate`
- [x] `firebase dataconnect:sql:migrate --force`
- [x] `firebase dataconnect:sql:migrate --non-interactive`
- [x] `firebase dataconnect:sql:migrate --non-interactive --force`

**`schemaValidation=STRICT`, both required and optional changes:**

- [x] `firebase deploy`
- [x] `firebase deploy --force`
- [x] `firebase deploy --non-interactive`
- [x] `firebase deploy --non-interactive --force`
- [x] `firebase dataconnect:sql:migrate`
- [x] `firebase dataconnect:sql:migrate --force`
- [x] `firebase dataconnect:sql:migrate --non-interactive`
- [x] `firebase dataconnect:sql:migrate --non-interactive --force`

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase deploy`, with `schemaValidation` unset, both required and optional changes, and default options selected:
<img width="569" alt="Screenshot 2024-09-13 at 6 42 25 PM" src="https://github.com/user-attachments/assets/5da54183-6c98-472d-beda-25c686e9f1f3">