### PR TITLE
Removing LocalConnectionString

### DIFF
--- a/firebase-vscode/src/core/config.ts
+++ b/firebase-vscode/src/core/config.ts
@@ -81,10 +81,6 @@ export async function updateFirebaseRCProject(values: {
     );
   }
 
-  if (values.fdcPostgresConnectionString) {
-    rc.setDataconnect(values.fdcPostgresConnectionString);
-  }
-
   rc.save();
 }
 

--- a/src/commands/setup-emulators-dataconnect.ts
+++ b/src/commands/setup-emulators-dataconnect.ts
@@ -1,8 +1,6 @@
 import { Command } from "../command";
 import { Emulators } from "../emulator/types";
 import { Options } from "../options";
-import { DEFAULT_POSTGRES_CONNECTION } from "../init/features/emulators";
-import { promptOnce } from "../prompt";
 import { logger } from "../logger";
 import { downloadIfNecessary } from "../emulator/downloadableEmulators";
 

--- a/src/commands/setup-emulators-dataconnect.ts
+++ b/src/commands/setup-emulators-dataconnect.ts
@@ -18,19 +18,5 @@ export const command = new Command(`setup:emulators:${NAME}`)
       );
       return;
     }
-
-    if (!options.nonInteractive) {
-      const dataconnectEmulatorConfig = options.rc.getDataconnect();
-      const defaultConnectionString =
-        dataconnectEmulatorConfig?.postgres?.localConnectionString ?? DEFAULT_POSTGRES_CONNECTION;
-      // TODO: Download Postgres
-      const localConnectionString = await promptOnce({
-        type: "input",
-        name: "localConnectionString",
-        message: `What is the connection string of the local Postgres instance you would like to use with the Data Connect emulator?`,
-        default: defaultConnectionString,
-      });
-      options.rc.setDataconnect(localConnectionString);
-    }
     logger.info("Setup complete!");
   });

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -90,8 +90,14 @@ export class DataConnectEmulator implements EmulatorInstance {
       enable_output_generated_sdk: this.args.enable_output_generated_sdk,
     });
     this.usingExistingEmulator = false;
-    if (this.args.autoconnectToPostgres) {
-      // TODO: Skip starting our own PG server if localConnectString is set
+    if (dataConnectLocalConnString()) {
+      this.logger.logLabeled(
+        "INFO",
+        "Data Connect",
+        `FIREBASE_DATACONNECT_POSTGRESQL_STRING is set to ${dataConnectLocalConnString()}`,
+      );
+    }
+    if (this.args.autoconnectToPostgres && !dataConnectLocalConnString()) {
       if (isEnabled("fdcpglite")) {
         const pgServer = new PostgresServer(dbId, "postgres");
         const server = await pgServer.createPGServer(

--- a/src/init/features/dataconnect/index.spec.ts
+++ b/src/init/features/dataconnect/index.spec.ts
@@ -6,7 +6,7 @@ import { Config } from "../../../config";
 import { RCData } from "../../../rc";
 import * as provison from "../../../dataconnect/provisionCloudSql";
 
-const MOCK_RC: RCData = { projects: {}, targets: {}, etags: {}, dataconnectEmulatorConfig: {} };
+const MOCK_RC: RCData = { projects: {}, targets: {}, etags: {} };
 
 describe("init dataconnect", () => {
   describe.skip("askQuestions", () => {

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -15,7 +15,6 @@ import {
   listConnectors,
 } from "../../../dataconnect/client";
 import { Schema, Service, File } from "../../../dataconnect/types";
-import { DEFAULT_POSTGRES_CONNECTION } from "../emulators";
 import { parseCloudSQLInstanceName, parseServiceName } from "../../../dataconnect/names";
 import { logger } from "../../../logger";
 import { readTemplateSync } from "../../../templates";
@@ -91,19 +90,6 @@ async function askQuestions(setup: Setup, config: Config): Promise<RequiredInfo>
   if (info.cloudSqlDatabase === "") {
     info = await promptForDatabase(setup, config, info);
   }
-
-  // TODO: Remove this in favor of a better way of setting local connection string.
-  const defaultConnectionString =
-    setup.rcfile.dataconnectEmulatorConfig?.postgres?.localConnectionString ??
-    DEFAULT_POSTGRES_CONNECTION;
-  // TODO: Download Postgres
-  const localConnectionString = await promptOnce({
-    type: "input",
-    name: "localConnectionString",
-    message: `What is the connection string of the local Postgres instance you would like to use with the Data Connect emulator?`,
-    default: defaultConnectionString,
-  });
-  setup.rcfile.dataconnectEmulatorConfig = { postgres: { localConnectionString } };
 
   info.shouldProvisionCSQL = !!(
     setup.projectId &&

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -11,9 +11,6 @@ interface EmulatorsInitSelections {
   download?: boolean;
 }
 
-// postgresql://localhost:5432 is a default out of the box value for most installations of Postgres
-export const DEFAULT_POSTGRES_CONNECTION = "postgresql://localhost:5432?sslmode=disable";
-
 export async function doSetup(setup: Setup, config: any) {
   const choices = ALL_SERVICE_EMULATORS.map((e) => {
     return {

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -1,7 +1,6 @@
 import * as clc from "colorette";
-import * as _ from "lodash";
 import * as utils from "../../utils";
-import { prompt, promptOnce } from "../../prompt";
+import { prompt } from "../../prompt";
 import { Emulators, ALL_SERVICE_EMULATORS, isDownloadableEmulator } from "../../emulator/types";
 import { Constants } from "../../emulator/constants";
 import { downloadIfNecessary } from "../../emulator/downloadableEmulators";
@@ -94,20 +93,6 @@ export async function doSetup(setup: Setup, config: any) {
       }
     }
 
-    if (selections.emulators.includes(Emulators.DATACONNECT)) {
-      const defaultConnectionString =
-        setup.rcfile.dataconnectEmulatorConfig?.postgres?.localConnectionString ??
-        DEFAULT_POSTGRES_CONNECTION;
-      // TODO: Download Postgres
-      const localConnectionString = await promptOnce({
-        type: "input",
-        name: "localConnectionString",
-        message: `What is the connection string of the local Postgres instance you would like to use with the Data Connect emulator?`,
-        default: defaultConnectionString,
-      });
-      setup.rcfile.dataconnectEmulatorConfig = { postgres: { localConnectionString } };
-    }
-
     await prompt(selections, [
       {
         name: "download",
@@ -130,7 +115,7 @@ export async function doSetup(setup: Setup, config: any) {
       }
     }
 
-    if (_.get(setup, "config.emulators.ui.enabled")) {
+    if (setup?.config?.emulators?.ui?.enabled) {
       downloadIfNecessary(Emulators.UI);
     }
   }

--- a/src/init/features/functions.spec.ts
+++ b/src/init/features/functions.spec.ts
@@ -24,7 +24,7 @@ function createExistingTestSetupAndConfig(): { setup: Setup; config: Config } {
       config: {
         functions: [cbconfig],
       },
-      rcfile: { projects: {}, targets: {}, etags: {}, dataconnectEmulatorConfig: {} },
+      rcfile: { projects: {}, targets: {}, etags: {} },
       featureArg: true,
     },
     config: new Config({ functions: [cbconfig] }, { projectDir: "test", cwd: "test" }),

--- a/src/rc.spec.ts
+++ b/src/rc.spec.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import { RC, loadRC, RCData } from "./rc";
 import { CONFLICT_RC_DIR, FIREBASE_JSON_PATH, INVALID_RC_DIR } from "./test/fixtures/fbrc";
 
-const EMPTY_DATA: RCData = { projects: {}, targets: {}, etags: {}, dataconnectEmulatorConfig: {} };
+const EMPTY_DATA: RCData = { projects: {}, targets: {}, etags: {} };
 
 describe("RC", () => {
   describe(".load", () => {

--- a/src/rc.ts
+++ b/src/rc.ts
@@ -58,7 +58,7 @@ export class RC {
 
   constructor(rcpath?: string, data?: Partial<RCData>) {
     this.path = rcpath;
-    this.data = { projects: {}, targets: {}, etags: {}, dataconnectEmulatorConfig: {}, ...data };
+    this.data = { projects: {}, targets: {}, etags: {}, ...data };
   }
 
   private set(key: string | string[], value: any): void {

--- a/src/rc.ts
+++ b/src/rc.ts
@@ -37,11 +37,6 @@ export interface RCData {
   etags: {
     [projectId: string]: Record<EtagResourceType, Record<string, string>>;
   };
-  dataconnectEmulatorConfig: {
-    postgres?: {
-      localConnectionString: string;
-    };
-  };
 }
 
 export class RC {
@@ -232,15 +227,6 @@ export class RC {
       this.data.etags[projectId] = {} as Record<EtagResourceType, Record<string, string>>;
     }
     this.data.etags[projectId][resourceType] = etagData;
-    this.save();
-  }
-
-  getDataconnect() {
-    return this.data.dataconnectEmulatorConfig ?? {};
-  }
-
-  setDataconnect(localConnectionString: string) {
-    this.data.dataconnectEmulatorConfig = { postgres: { localConnectionString } };
     this.save();
   }
 


### PR DESCRIPTION
### Description
In the new wonderful world of pglite, localconnectionstring is confusing and not very useful for 95% of users.
This PR:

- Removes LocalConnectionString from .firebaserc
- Keeps the FIREBASE_DATACONNECT_POSTGRESQL_STRING env var override for the rare cases we do want this.
-  Gets rid of these questions from init flows.

