### PR TITLE
Fix another extended query protocol issue

### DIFF
--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -97,7 +97,12 @@ export class PGliteExtendedQueryPatch {
 
   async *filterResponse(message: Uint8Array, response: Uint8Array) {
     // 'Parse' indicates the start of an extended query
-    if (message[0] === FrontendMessageCode.Parse || message[0] === FrontendMessageCode.Bind) {
+    const pipelineStartMessages: number[] = [
+      FrontendMessageCode.Parse,
+      FrontendMessageCode.Bind,
+      FrontendMessageCode.Close,
+    ];
+    if (pipelineStartMessages.includes(message[0])) {
       this.isExtendedQuery = true;
     }
 


### PR DESCRIPTION
### Description
PGLite responds with an extra ReadyForQuery message after Close messages (similar to the previous issue we saw with Parse/Bind). This filters out those extras so that clients don't choke on them.
### Scenarios Tested
Previously, if you executed the same query 2x in a row in the emualtor, it would break with "Unexpected query response 'Z'". Now, it doesn't!

