### PR TITLE
Update the Firestore init() flow to handle non-default databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Added support for non-default Firestore databases in `firebase init`. (#7655)
 - Update supported range for Angular framework. (#7418)
 - Fix (Angular 17+) temporary change the PORT in Angular server.ts (#6651)

--- a/src/firestore/checkDatabaseType.ts
+++ b/src/firestore/checkDatabaseType.ts
@@ -1,26 +1,42 @@
 import { firestoreOrigin } from "../api";
 import { Client } from "../apiv2";
 import { logger } from "../logger";
+import { FirebaseError } from "../error";
 
 /**
  * Determine the Firestore database type for a given project. One of:
  *   - DATABASE_TYPE_UNSPECIFIED (unspecified)
  *   - DATASTORE_MODE(Datastore legacy)
  *   - FIRESTORE_NATIVE (Firestore native mode)
+ *   - DATABASE_DOES_NOT_EXIST (Database does not exist on specified project)
  *
  * @param projectId the Firebase project ID.
+ * @param databaseId the Firestore database ID.
  */
 export async function checkDatabaseType(
   projectId: string,
-): Promise<"DATASTORE_MODE" | "FIRESTORE_NATIVE" | "DATABASE_TYPE_UNSPECIFIED" | undefined> {
+  databaseId: string = "(default)",
+): Promise<
+  | "DATASTORE_MODE"
+  | "FIRESTORE_NATIVE"
+  | "DATABASE_TYPE_UNSPECIFIED"
+  | "DATABASE_DOES_NOT_EXIST"
+  | undefined
+> {
   try {
     const client = new Client({ urlPrefix: firestoreOrigin(), apiVersion: "v1" });
     const resp = await client.get<{
       type?: "DATASTORE_MODE" | "FIRESTORE_NATIVE" | "DATABASE_TYPE_UNSPECIFIED";
-    }>(`/projects/${projectId}/databases/(default)`);
+    }>(`/projects/${projectId}/databases/${databaseId}`);
     return resp.body.type;
   } catch (err: any) {
-    logger.debug("error getting database type", err);
+    logger.debug("error getting database type: ", err);
+    if (err instanceof FirebaseError) {
+      if (err.status == 404) {
+        logger.info(`${databaseId} does not exist in project ${projectId}.`);
+        return "DATABASE_DOES_NOT_EXIST";
+      }
+    }
     return undefined;
   }
 }

--- a/src/firestore/checkDatabaseType.ts
+++ b/src/firestore/checkDatabaseType.ts
@@ -32,7 +32,7 @@ export async function checkDatabaseType(
   } catch (err: any) {
     logger.debug("error getting database type: ", err);
     if (err instanceof FirebaseError) {
-      if (err.status == 404) {
+      if (err.status === 404) {
         logger.info(`${databaseId} does not exist in project ${projectId}.`);
         return "DATABASE_DOES_NOT_EXIST";
       }

--- a/src/init/features/firestore/indexes.ts
+++ b/src/init/features/firestore/indexes.ts
@@ -52,15 +52,15 @@ export function initIndexes(setup: any, config: any): Promise<any> {
         return config.writeProjectFile(setup.config.firestore.indexes, INDEXES_TEMPLATE);
       }
 
-      return getIndexesFromConsole(setup.projectId).then((contents: any) => {
+      return getIndexesFromConsole(setup.projectId, setup.databaseId).then((contents: any) => {
         return config.writeProjectFile(setup.config.firestore.indexes, contents);
       });
     });
 }
 
-function getIndexesFromConsole(projectId: any): Promise<any> {
-  const indexesPromise = indexes.listIndexes(projectId);
-  const fieldOverridesPromise = indexes.listFieldOverrides(projectId);
+function getIndexesFromConsole(projectId: any, databaseId: any): Promise<any> {
+  const indexesPromise = indexes.listIndexes(projectId, databaseId);
+  const fieldOverridesPromise = indexes.listFieldOverrides(projectId, databaseId);
 
   return Promise.all([indexesPromise, fieldOverridesPromise])
     .then((res) => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Update the Firestore init() flow to handle non-default databases, by allowing the user to input the name of the database they want to initialize. 

This is a catch for older projects created in Cloud, which have a (default) non-Firestore Native database in their projects before they add Firebase. New projects shouldn't be affected by this change.

The only other thought I had was maybe it would be better to have input of database name during init *by default* but defaulting to (default) with option to enter your own without first hitting a 404. 

### Scenarios Tested

Projects created with older (default) database, deleting that and creating a new Firestore database with a different name.

### Sample Commands

Nothing new, just additional ask for database name if (default) doesnt exist, which would fail out without reason previously.
