### PR TITLE
Fdc grant cmds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Update supported range for Angular framework. (#7418)
 - Fix (Angular 17+) temporary change the PORT in Angular server.ts. (#6651)
 - Improved handling of Spark projects in `firebase init dataconnect`. (#7666)
+- Add dataconnect SQL grant command `firebase dataconnect:sql:grant -R <role> -E email`. (#7656)

--- a/src/commands/dataconnect-sql-grant.ts
+++ b/src/commands/dataconnect-sql-grant.ts
@@ -1,0 +1,30 @@
+import { Command } from "../command";
+import { Options } from "../options";
+import { needProjectId } from "../projectUtils";
+import { ensureApis } from "../dataconnect/ensureApis";
+import { requirePermissions } from "../requirePermissions";
+import { pickService } from "../dataconnect/fileUtils";
+import { grantRoleToUserInSchema } from "../dataconnect/schemaMigration";
+import { requireAuth } from "../requireAuth";
+import { checkSQLRoleIsGranted, firebaseowner, firebasewriter, firebasereader, iamUserIsCSQLAdmin } from "../gcp/cloudsql/permissions"
+import { FirebaseError } from "../error";
+
+export const command = new Command("dataconnect:sql:grant [serviceId]")
+  .description(
+    "Grants the SQL role <role> to the provided user or service account <email>.",
+  )
+  .option("-R, --role <role>", "The SQL role to grant. One of: owner, writer, or reader.")
+  .option("-E, --email <email>", "The email of the user or service account we would like to grant the role to.")
+  .before(requirePermissions, [
+    "firebasedataconnect.services.list",
+  ])
+  .before(requireAuth)
+  .before(iamUserIsCSQLAdmin)
+  .action(async (serviceId: string, options: Options) => {
+    const projectId = needProjectId(options);
+    await ensureApis(projectId);
+    const serviceInfo = await pickService(projectId, options.config, serviceId);
+
+    await grantRoleToUserInSchema(options, serviceInfo.schema);
+    return { projectId, serviceId };
+  });

--- a/src/commands/dataconnect-sql-grant.ts
+++ b/src/commands/dataconnect-sql-grant.ts
@@ -6,20 +6,16 @@ import { requirePermissions } from "../requirePermissions";
 import { pickService } from "../dataconnect/fileUtils";
 import { grantRoleToUserInSchema } from "../dataconnect/schemaMigration";
 import { requireAuth } from "../requireAuth";
-import { checkSQLRoleIsGranted, firebaseowner, firebasewriter, firebasereader, iamUserIsCSQLAdmin } from "../gcp/cloudsql/permissions"
-import { FirebaseError } from "../error";
 
 export const command = new Command("dataconnect:sql:grant [serviceId]")
-  .description(
-    "Grants the SQL role <role> to the provided user or service account <email>.",
-  )
+  .description("Grants the SQL role <role> to the provided user or service account <email>.")
   .option("-R, --role <role>", "The SQL role to grant. One of: owner, writer, or reader.")
-  .option("-E, --email <email>", "The email of the user or service account we would like to grant the role to.")
-  .before(requirePermissions, [
-    "firebasedataconnect.services.list",
-  ])
+  .option(
+    "-E, --email <email>",
+    "The email of the user or service account we would like to grant the role to.",
+  )
+  .before(requirePermissions, ["firebasedataconnect.services.list"])
   .before(requireAuth)
-  .before(iamUserIsCSQLAdmin)
   .action(async (serviceId: string, options: Options) => {
     const projectId = needProjectId(options);
     await ensureApis(projectId);

--- a/src/commands/dataconnect-sql-grant.ts
+++ b/src/commands/dataconnect-sql-grant.ts
@@ -6,6 +6,10 @@ import { requirePermissions } from "../requirePermissions";
 import { pickService } from "../dataconnect/fileUtils";
 import { grantRoleToUserInSchema } from "../dataconnect/schemaMigration";
 import { requireAuth } from "../requireAuth";
+import { FirebaseError } from "../error";
+import { fdcSqlRoleMap } from "../gcp/cloudsql/permissions";
+
+const allowedRoles = Object.keys(fdcSqlRoleMap);
 
 export const command = new Command("dataconnect:sql:grant [serviceId]")
   .description("Grants the SQL role <role> to the provided user or service account <email>.")
@@ -17,6 +21,23 @@ export const command = new Command("dataconnect:sql:grant [serviceId]")
   .before(requirePermissions, ["firebasedataconnect.services.list"])
   .before(requireAuth)
   .action(async (serviceId: string, options: Options) => {
+    const role = options.role as string;
+    const email = options.email as string;
+    if (!role) {
+      throw new FirebaseError(
+        "-R, --role <role> is required. Run the command with -h for more info.",
+      );
+    }
+    if (!email) {
+      throw new FirebaseError(
+        "-E, --email <email> is required. Run the command with -h for more info.",
+      );
+    }
+
+    if (!allowedRoles.includes(role.toLowerCase())) {
+      throw new FirebaseError(`Role should be one of ${allowedRoles.join(" | ")}.`);
+    }
+
     const projectId = needProjectId(options);
     await ensureApis(projectId);
     const serviceInfo = await pickService(projectId, options.config, serviceId);

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -212,6 +212,7 @@ export function load(client: any): any {
   client.dataconnect.sql = {};
   client.dataconnect.sql.diff = loadCommand("dataconnect-sql-diff");
   client.dataconnect.sql.migrate = loadCommand("dataconnect-sql-migrate");
+  client.dataconnect.sql.grant = loadCommand("dataconnect-sql-grant");
   client.dataconnect.sdk = {};
   client.dataconnect.sdk.generate = loadCommand("dataconnect-sdk-generate");
   client.target = loadCommand("target");

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -12,7 +12,7 @@ import { FirebaseError } from "../../error";
 import { Options } from "../../options";
 import { FBToolsAuthClient } from "./fbToolsAuthClient";
 import { setupSQLPermissions, firebaseowner, firebasewriter } from "./permissions";
- 
+
 export async function execute(
   sqlStatements: string[],
   opts: {

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -12,7 +12,7 @@ import { FirebaseError } from "../../error";
 import { Options } from "../../options";
 import { FBToolsAuthClient } from "./fbToolsAuthClient";
 import { setupSQLPermissions, firebaseowner, firebasewriter } from "./permissions";
-
+ 
 export async function execute(
   sqlStatements: string[],
   opts: {

--- a/src/gcp/cloudsql/permissions.ts
+++ b/src/gcp/cloudsql/permissions.ts
@@ -18,6 +18,12 @@ export function firebasewriter(databaseId: string) {
   return `firebasewriter_${databaseId}_public`;
 }
 
+export const fdcSqlRoleMap = {
+  owner: firebaseowner,
+  writer: firebasewriter,
+  reader: firebasereader,
+};
+
 // Returns true if "grantedRole" is granted to "granteeRole" and false otherwise.
 // Throw an error if commands fails due to another reason like connection issues.
 export async function checkSQLRoleIsGranted(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Add `firebase dataconnect:sql:grant -R <role> -E <email>` command. The command grants the corresponding role in the FDC sql instance.

### Scenarios Tested

Not passing -R or --role -> `Error: -R, --role <role> is required. Run the command with -h for more info.`
Note passing -E or --email -> `Error: -E, --email <email> is required. Run the command with -h for more info.`
passing non existing role -> `Error: Role should be one of owner | writer | reader.`

<img width="1185" alt="Screenshot 2024-09-17 at 7 09 15 PM" src="https://github.com/user-attachments/assets/ef7aaa1c-be87-47c0-9526-e4c8f5cea2e5">

### Sample Commands

```
firebase dataconnect:sql:grant -E email@gmail.com -R writer
firebase dataconnect:sql:grant --email email@gmail.com --role reader
firebase dataconnect:sql:grant --email email@gmail.com --R owner
```
