### PR TITLE
Add View Docs button

### DIFF
--- a/firebase-vscode/common/messaging/protocol.ts
+++ b/firebase-vscode/common/messaging/protocol.ts
@@ -93,6 +93,9 @@ export interface WebviewToExtensionParamsMap {
   /** Configures generated SDK */
   "fdc.configure-sdk": void;
 
+
+  "fdc.open-docs": void;
+
   // Initialize "result" tab.
   getDataConnectResults: void;
 

--- a/firebase-vscode/src/data-connect/service.ts
+++ b/firebase-vscode/src/data-connect/service.ts
@@ -264,6 +264,10 @@ export class DataConnectService {
       return this.handleResponse(resp);
     }
   }
+
+  docsLink() {
+    return this.dataConnectToolkit.getGeneratedDocsURL();
+  }
 }
 
 function parseVariableString(variables: string): Record<string, any> {

--- a/firebase-vscode/src/data-connect/toolkit.ts
+++ b/firebase-vscode/src/data-connect/toolkit.ts
@@ -29,6 +29,9 @@ export class DataConnectToolkit implements vscode.Disposable {
           }
         }
       }),
+      broker.on("fdc.open-docs", () => {
+        vscode.commands.executeCommand("vscode.open", this.getGeneratedDocsURL());
+      })
     );
   }
 
@@ -59,6 +62,10 @@ export class DataConnectToolkit implements vscode.Disposable {
   getFDCToolkitURL() {
     //TODO source from ToolkitController
     return "http://localhost:12345";
+  }
+
+  getGeneratedDocsURL() {
+    return this.getFDCToolkitURL() + "/docs";
   }
 
   readonly isPostgresEnabled = signal(false);

--- a/firebase-vscode/webviews/data-connect/data-connect.entry.tsx
+++ b/firebase-vscode/webviews/data-connect/data-connect.entry.tsx
@@ -3,15 +3,12 @@ import { createRoot } from "react-dom/client";
 import {
   VSCodeButton,
   VSCodeProgressRing,
-  VSCodeTextField,
 } from "@vscode/webview-ui-toolkit/react";
 import { Spacer } from "../components/ui/Spacer";
 import styles from "../globals/index.scss";
-import { broker, useBroker, useBrokerListener } from "../globals/html-broker";
+import { broker, useBroker } from "../globals/html-broker";
 import { PanelSection } from "../components/ui/PanelSection";
 import { EmulatorPanel } from "../components/EmulatorPanel";
-import { computed } from "@preact/signals-core";
-import { Emulators } from "../emulator/types";
 
 // Prevent webpack from removing the `style` import above
 styles;
@@ -67,6 +64,13 @@ function DataConnect() {
         </p>
         <VSCodeButton onClick={() => broker.send("fdc.configure-sdk")}>
           Configure Generated SDK
+        </VSCodeButton>
+        <Spacer size="xlarge" />
+        <p>
+          View generated GQL reference docs for your schema
+        </p>
+        <VSCodeButton onClick={() => broker.send("fdc.open-docs")}>
+          View my docs
         </VSCodeButton>
       </PanelSection>
       <PanelSection title="Production" isLast={true}>


### PR DESCRIPTION
### Description
Adding a button to better expose the cool new docs feature:
<img width="554" alt="Screenshot 2024-09-13 at 1 34 50 PM" src="https://github.com/user-attachments/assets/f07f1870-59e9-4d35-9765-1432dba0c7c6">
Clicking it opens the docs in your default browser. We could move this into a Webview at some point, but this seems simpler for now.

### Scenarios Tested
Click the button, view the docs.
