### PR TITLE
Small improvements to FDC init and JSON Schema. #1014

### DIFF
--- a/schema/connector-yaml.json
+++ b/schema/connector-yaml.json
@@ -43,6 +43,16 @@
           "description": "Path to the directory where generated files should be written to."
         }
       }
+    },
+    "llmTools": {
+      "additionalProperties": true,
+      "type": "object",
+      "properties": {
+        "outputFile": {
+          "type": "string",
+          "description": "Path where the JSON LLM tool definitions file should be generated."
+        }
+      }
     }
   },
   "properties": {
@@ -53,32 +63,52 @@
     "authMode": {
       "type": "string",
       "description": "The authentication strategy to use for this connector"
-
     },
     "generate": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "javascriptSdk": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/javascriptSdk"
-          },
+          "oneOf": [
+            { "$ref": "#/definitions/javascriptSdk" },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/javascriptSdk"
+              }
+            }
+          ],
           "description": "Configuration for a generated Javascript SDK"
         },
         "kotlinSdk": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/kotlinSdk"
-          },
+          "oneOf": [
+            { "$ref": "#/definitions/kotlinSdk" },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/kotlinSdk"
+              }
+            }
+          ],
           "description": "Configuration for a generated Kotlin SDK"
         },
         "swiftSdk": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/swiftSdk"
-          },
+          "oneOf": [
+            { "$ref": "#/definitions/swiftSdk" },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/swiftSdk"
+              }
+            }
+          ],
           "description": "Configuration for a generated Swift SDK"
+        },
+        "llmTools": {
+          "oneOf": [
+            { "$ref": "#/definitions/llmTools" },
+            { "type": "array", "items": { "$ref": "#/definitions/llmTools" } }
+          ]
         }
       }
     }

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -114,7 +114,7 @@ async function askQuestions(setup: Setup, config: Config): Promise<RequiredInfo>
     (info.isNewInstance || info.isNewDatabase) &&
     (await confirm({
       message:
-        "Would you like to provision your CloudSQL instance and database now? This will take a few minutes.",
+        `Would you like to provision your Cloud SQL instance and database now?${info.isNewInstance ? " This will take several minutes." : ""}.",
       default: true,
     }))
   );
@@ -283,7 +283,7 @@ async function promptForService(setup: Setup, info: RequiredInfo): Promise<Requi
     info.serviceId = await promptOnce({
       message: "What ID would you like to use for this service?",
       type: "input",
-      default: "my-service",
+      default: "app",
     });
   }
   return info;
@@ -318,7 +318,7 @@ async function promptForCloudSQLInstance(setup: Setup, info: RequiredInfo): Prom
     info.cloudSqlInstanceId = await promptOnce({
       message: `What ID would you like to use for your new CloudSQL instance?`,
       type: "input",
-      default: `fdc-sql`,
+      default: `${info.serviceId || "app"}-fdc`,
     });
   }
   if (info.locationId === "") {

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -113,8 +113,7 @@ async function askQuestions(setup: Setup, config: Config): Promise<RequiredInfo>
     setup.projectId &&
     (info.isNewInstance || info.isNewDatabase) &&
     (await confirm({
-      message:
-        `Would you like to provision your Cloud SQL instance and database now?${info.isNewInstance ? " This will take several minutes." : ""}.",
+      message: `Would you like to provision your Cloud SQL instance and database now?${info.isNewInstance ? " This will take several minutes." : ""}.`,
       default: true,
     }))
   );


### PR DESCRIPTION
1. Fixes the JSON schema for connectors to allow either list or single for generators, and adds llmTools support.
1. Changes default service id (no my-).
1. Elides "this will take a few minutes" when not creating an instance.