### PR TITLE
When no project is detected, add an "open folder" button.

### DIFF
--- a/firebase-vscode/common/messaging/protocol.ts
+++ b/firebase-vscode/common/messaging/protocol.ts
@@ -51,6 +51,9 @@ export interface WebviewToExtensionParamsMap {
   /** Calls the `firebase init` CLI */
   runFirebaseInit: void;
 
+  /** Calls VScode's `openFolder` command */
+  openFolder: void;
+
   /** Calls the `firebase init` CLI */
   runStartEmulators: void;
 

--- a/firebase-vscode/src/core/index.ts
+++ b/firebase-vscode/src/core/index.ts
@@ -12,6 +12,7 @@ import { registerQuickstart } from "./quickstart";
 import { registerOptions } from "../options";
 import { upsertFile } from "../data-connect/file-utils";
 import { registerWebhooks } from "./webhook";
+import { setupExecuteCommandMockable } from "../utils/test_hooks";
 
 export async function registerCore(
   broker: ExtensionBrokerImpl,
@@ -41,6 +42,14 @@ export async function registerCore(
 
   const sub3 = broker.on("openLink", async ({ href }) => {
     vscode.env.openExternal(vscode.Uri.parse(href));
+  });
+
+  const executeCommand = setupExecuteCommandMockable(context);
+
+  context.subscriptions.push({
+    dispose: broker.on("openFolder", () => {
+      return executeCommand.call("workbench.action.files.openFolder");
+    }),
   });
 
   const sub4 = broker.on("runFirebaseInit", async () => {

--- a/firebase-vscode/src/test/integration/empty/sidebar.ts
+++ b/firebase-vscode/src/test/integration/empty/sidebar.ts
@@ -1,5 +1,6 @@
 import { browser } from "@wdio/globals";
 import { FirebaseSidebar } from "../../utils/page_objects/sidebar";
+import { getCommandsSpyCalls, spyCommands } from "../mock";
 
 it("Supports opening empty projects", async function () {
   const workbench = await browser.getWorkbench();
@@ -9,5 +10,25 @@ it("Supports opening empty projects", async function () {
 
   await sidebar.runInFirebaseViewContext(async (firebase) => {
     await firebase.connectProjectLinkElement.waitForDisplayed();
+  });
+});
+
+it("Supports `open folder` button", async () => {
+  const workbench = await browser.getWorkbench();
+  const sidebar = new FirebaseSidebar(workbench);
+
+  await sidebar.open();
+
+  await spyCommands();
+
+  await sidebar.runInFirebaseViewContext(async (firebase) => {
+    await firebase.openFolderElement.waitForDisplayed();
+    await firebase.openFolderElement.click();
+
+    const calls = await getCommandsSpyCalls();
+
+    console.log("calls", calls);
+
+    expect(calls).toEqual([["workbench.action.files.openFolder"]]);
   });
 });

--- a/firebase-vscode/src/test/integration/mock.ts
+++ b/firebase-vscode/src/test/integration/mock.ts
@@ -11,27 +11,36 @@ export async function e2eSpy(key: string): Promise<void> {
 }
 
 export function getE2eSpyCalls(
-  key: "deploy"
+  key: "deploy",
 ): Promise<Array<Parameters<typeof cliDeploy>>>;
+export function getE2eSpyCalls(key: "executeCommand"): Promise<Array<[string]>>;
 export async function getE2eSpyCalls(key: string): Promise<Array<Array<any>>> {
   return callBrowserSpyCommand(
     key,
     // We don't mock anything, just read the call list.
-    { spy: undefined }
+    { spy: undefined },
   );
 }
 
 async function callBrowserSpyCommand(
   key: string,
-  args: { spy: boolean | undefined }
+  args: { spy: boolean | undefined },
 ): Promise<Array<Array<any>>> {
   const result = await browser.executeWorkbench(
     (vs: typeof vscode, key, args) => {
       return vs.commands.executeCommand(key, args);
     },
     `fdc-graphql.spy.${key}`,
-    args
+    args,
   );
 
   return result as Array<Array<any>>;
+}
+
+export async function spyCommands() {
+  await e2eSpy("executeCommand");
+}
+
+export async function getCommandsSpyCalls() {
+  return getE2eSpyCalls("executeCommand");
 }

--- a/firebase-vscode/src/test/utils/page_objects/execution.ts
+++ b/firebase-vscode/src/test/utils/page_objects/execution.ts
@@ -1,5 +1,5 @@
 import { Workbench } from "wdio-vscode-service";
-import { findWebviewWithTitle, runInFrame } from "../webviews";
+import { runWebviewWithTitle, runInFrame } from "../webviews";
 
 export class ExecutionPanel {
   constructor(readonly workbench: Workbench) {
@@ -10,7 +10,7 @@ export class ExecutionPanel {
 
   async open(): Promise<void> {
     await this.workbench.executeCommand(
-      "data-connect-execution-configuration.focus"
+      "data-connect-execution-configuration.focus",
     );
   }
 
@@ -22,14 +22,12 @@ export class ExecutionPanel {
     });
   }
 
-  async runInConfigurationContext<R>(
-    cb: (configs: ConfigurationView) => Promise<R>
-  ): Promise<R> {
-    const [a, b] = await findWebviewWithTitle("Configuration");
-
-    return runInFrame(a, () =>
-      runInFrame(b, () => cb(new ConfigurationView(this.workbench)))
-    );
+  async runInConfigurationContext(
+    cb: (configs: ConfigurationView) => Promise<void>,
+  ): Promise<void> {
+    await runWebviewWithTitle("Configuration", async () => {
+      cb(new ConfigurationView(this.workbench));
+    });
   }
 }
 

--- a/firebase-vscode/src/test/utils/page_objects/sidebar.ts
+++ b/firebase-vscode/src/test/utils/page_objects/sidebar.ts
@@ -1,5 +1,5 @@
 import { Workbench } from "wdio-vscode-service";
-import { findWebviewWithTitle, runInFrame } from "../webviews";
+import { runWebviewWithTitle, runInFrame } from "../webviews";
 import * as vscode from "vscode";
 
 export class FirebaseSidebar {
@@ -8,7 +8,7 @@ export class FirebaseSidebar {
   async open() {
     await browser.executeWorkbench((vs: typeof vscode) => {
       return vs.commands.executeCommand(
-        "firebase.dataConnect.explorerView.focus"
+        "firebase.dataConnect.explorerView.focus",
       );
     });
   }
@@ -46,14 +46,12 @@ export class FirebaseSidebar {
   }
 
   /** Runs the callback in the context of the Firebase view, within the sidebar */
-  async runInFirebaseViewContext<R>(
-    cb: (firebase: FirebaseView) => Promise<R>
-  ): Promise<R> {
-    const [a, b] = await findWebviewWithTitle("Config");
-
-    return runInFrame(a, () =>
-      runInFrame(b, () => cb(new FirebaseView(this.workbench)))
-    );
+  async runInFirebaseViewContext(
+    cb: (firebase: FirebaseView) => Promise<void>,
+  ): Promise<void> {
+    await runWebviewWithTitle("Config", async () => {
+      await cb(new FirebaseView(this.workbench));
+    });
   }
 }
 
@@ -66,5 +64,9 @@ export class FirebaseView {
 
   get connectProjectLinkElement() {
     return $("vscode-link=Connect a Firebase project");
+  }
+
+  get openFolderElement() {
+    return $("vscode-button=Open folder");
   }
 }

--- a/firebase-vscode/webviews/SidebarApp.tsx
+++ b/firebase-vscode/webviews/SidebarApp.tsx
@@ -55,6 +55,13 @@ function Welcome() {
       >
         Run firebase init
       </VSCodeButton>
+      <Spacer size="small"></Spacer>
+      <VSCodeButton
+        appearance="secondary"
+        onClick={() => broker.send("openFolder")}
+      >
+        Open folder
+      </VSCodeButton>
     </>
   );
 }
@@ -72,7 +79,9 @@ function EmulatorsPanel() {
       return (
         <>
           <Spacer size="medium"></Spacer>
-          <label>Emulator start-up may take a while. In case of error, click reset.</label>
+          <label>
+            Emulator start-up may take a while. In case of error, click reset.
+          </label>
           <VSCodeProgressRing></VSCodeProgressRing>
           <Spacer size="medium"></Spacer>
           <VSCodeButton


### PR DESCRIPTION
### Description

The new button relies on the VSCode's built-in open command.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
