### PR TITLE
Pipe through app folder selection to init dataconnect:sdk

### DIFF
--- a/firebase-vscode/src/data-connect/sdk-generation.ts
+++ b/firebase-vscode/src/data-connect/sdk-generation.ts
@@ -3,7 +3,7 @@ import { Uri } from "vscode";
 import { firstWhere, firstWhereDefined } from "../utils/signal";
 import { currentOptions } from "../options";
 import { dataConnectConfigs, ResolvedConnectorYaml } from "./config";
-import { runCommand } from "./terminal";
+import { runCommand, setTerminalEnvVars } from "./terminal";
 import { ExtensionBrokerImpl } from "../extension-broker";
 import { DATA_CONNECT_EVENT_NAME } from "../analytics";
 import {
@@ -14,14 +14,18 @@ import { ConnectorYaml, Platform } from "../../../src/dataconnect/types";
 import * as yaml from "yaml";
 import * as fs from "fs-extra";
 import { getSettings } from "../utils/settings";
+import { FDC_APP_FOLDER } from "../../../src/init/features/dataconnect/sdk";
+
 export function registerFdcSdkGeneration(
   broker: ExtensionBrokerImpl,
   telemetryLogger: vscode.TelemetryLogger,
 ): vscode.Disposable {
   const settings = getSettings();
 
-  const initSdkCmd = vscode.commands.registerCommand("fdc.init-sdk", () => {
+  const initSdkCmd = vscode.commands.registerCommand("fdc.init-sdk", (args: { appFolder: string }) => {
     telemetryLogger.logUsage(DATA_CONNECT_EVENT_NAME.INIT_SDK_CLI);
+    // Lets do it from the right directory
+    setTerminalEnvVars(FDC_APP_FOLDER, args.appFolder);
     runCommand(`${settings.firebasePath} init dataconnect:sdk`);
   });
 
@@ -142,7 +146,7 @@ export function registerFdcSdkGeneration(
       vscode.window.showErrorMessage(
         "Could not determine platform for specified app folder. Configuring from command line.",
       );
-      vscode.commands.executeCommand("fdc.init-sdk");
+      vscode.commands.executeCommand("fdc.init-sdk", { appFolder });
     } else {
       // generate yaml
       const newConnectorYaml = generateSdkYaml(

--- a/firebase-vscode/src/data-connect/terminal.ts
+++ b/firebase-vscode/src/data-connect/terminal.ts
@@ -15,11 +15,10 @@ export function setTerminalEnvVars(envVar: string, value: string) {
   environmentVariables[envVar] = value;
 }
 
-export function runCommand(command: string, cwd?: string) {
+export function runCommand(command: string) {
   const terminalOptions: TerminalOptions = {
     name: "Data Connect Terminal",
     env: environmentVariables,
-    cwd,
   };
   const terminal = vscode.window.createTerminal(terminalOptions);
   terminal.show();

--- a/firebase-vscode/src/data-connect/terminal.ts
+++ b/firebase-vscode/src/data-connect/terminal.ts
@@ -11,16 +11,16 @@ const executionOptions: vscode.ShellExecutionOptions = {
   env: environmentVariables,
 };
 
-const terminalOptions: TerminalOptions = {
-  name: "Data Connect Terminal",
-  env: environmentVariables,
-};
-
 export function setTerminalEnvVars(envVar: string, value: string) {
   environmentVariables[envVar] = value;
 }
 
-export function runCommand(command: string) {
+export function runCommand(command: string, cwd?: string) {
+  const terminalOptions: TerminalOptions = {
+    name: "Data Connect Terminal",
+    env: environmentVariables,
+    cwd,
+  };
   const terminal = vscode.window.createTerminal(terminalOptions);
   terminal.show();
 

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -66,13 +66,12 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
 
   // First, lets check if we are in a app directory
   let targetPlatform: Platform = Platform.UNDETERMINED;
-  let appDir: string;
-  const cwdPlatformGuess = await getPlatformFromFolder(process.cwd());
+  let appDir = process.env[FDC_APP_FOLDER] || process.cwd();
+  const cwdPlatformGuess = await getPlatformFromFolder(appDir);
   if (cwdPlatformGuess !== Platform.UNDETERMINED) {
     // If we are, we'll use that directory
-    logSuccess(`Detected ${cwdPlatformGuess} app in current directory ${process.cwd()}`);
+    logSuccess(`Detected ${cwdPlatformGuess} app in directory ${appDir}`);
     targetPlatform = cwdPlatformGuess;
-    appDir = process.cwd();
   } else {
     // If we aren't, ask the user where their app is, and try to autodetect from there
     logBullet(`Couldn't automatically detect your app directory.`);

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -25,6 +25,7 @@ import { FirebaseError } from "../../../error";
 import { camelCase, snakeCase, upperFirst } from "lodash";
 import { logSuccess, logBullet } from "../../../utils";
 
+export const FDC_APP_FOLDER = "_FDC_APP_FOLDER";
 export type SDKInfo = {
   connectorYamlContents: string;
   connectorInfo: ConnectorInfo;
@@ -75,11 +76,13 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
   } else {
     // If we aren't, ask the user where their app is, and try to autodetect from there
     logBullet(`Couldn't automatically detect your app directory.`);
-    appDir = await promptForDirectory({
-      config,
-      message:
-        "Where is your app directory? Leave blank to set up a generated SDK in your current directory.",
-    });
+    appDir =
+      process.env[FDC_APP_FOLDER] ??
+      (await promptForDirectory({
+        config,
+        message:
+          "Where is your app directory? Leave blank to set up a generated SDK in your current directory.",
+      }));
     const platformGuess = await getPlatformFromFolder(appDir);
     if (platformGuess !== Platform.UNDETERMINED) {
       logSuccess(`Detected ${platformGuess} app in directory ${appDir}`);


### PR DESCRIPTION
### Description
Stop asking for app folder twice - just pipe through the selection made in the VSCode UI
