### PR TITLE
Fix more issues with prepared statements and extended query protocol

### DIFF
--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -43,8 +43,8 @@ export class PostgresServer {
         async onAuthenticated() {
           // Every time we see a new authentication exchange, we need to throw away previously prepared statements -
           // Clients may not know of these statements, and may attempt to reuse the same name.
-          await db.query("DEALLOCATE ALL")
-        }
+          await db.query("DEALLOCATE ALL");
+        },
       });
 
       const extendedQueryPatch: PGliteExtendedQueryPatch = new PGliteExtendedQueryPatch(connection);
@@ -52,9 +52,9 @@ export class PostgresServer {
       socket.on("end", () => {
         logger.debug("Postgres client disconnected");
       });
-      socket.on("error", (err)=> {
+      socket.on("error", (err) => {
         server.emit("error", err);
-      })
+      });
     });
     const listeningPromise = new Promise<void>((resolve) => {
       server.listen(port, host, () => {
@@ -128,7 +128,7 @@ export class PGliteExtendedQueryPatch {
       }
       // Filter out incorrect `ReadyForQuery` messages during the extended query protocol
       if (this.isExtendedQuery && message[0] === BackendMessageCode.ReadyForQuery) {
-        logger.debug('Filtered out a ReadyForQuery.')
+        logger.debug("Filtered out a ReadyForQuery.");
         continue;
       }
       yield message;

--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -39,6 +39,12 @@ export class PostgresServer {
           // pglite wrongly sends.
           return extendedQueryPatch.filterResponse(data, result);
         },
+
+        async onAuthenticated() {
+          // Every time we see a new authentication exchange, we need to throw away previously prepared statements -
+          // Clients may not know of these statements, and may attempt to reuse the same name.
+          await db.query("DEALLOCATE ALL")
+        }
       });
 
       const extendedQueryPatch: PGliteExtendedQueryPatch = new PGliteExtendedQueryPatch(connection);
@@ -46,6 +52,9 @@ export class PostgresServer {
       socket.on("end", () => {
         logger.debug("Postgres client disconnected");
       });
+      socket.on("error", (err)=> {
+        server.emit("error", err);
+      })
     });
     const listeningPromise = new Promise<void>((resolve) => {
       server.listen(port, host, () => {
@@ -98,6 +107,7 @@ export class PGliteExtendedQueryPatch {
       FrontendMessageCode.Bind,
       FrontendMessageCode.Close,
     ];
+
     if (pipelineStartMessages.includes(message[0])) {
       this.isExtendedQuery = true;
     }
@@ -112,8 +122,13 @@ export class PGliteExtendedQueryPatch {
 
     // A PGlite response can contain multiple messages
     for await (const message of getMessages(response)) {
+      // If a prepared statement leads to an error message, we need to end the pipeline.
+      if (message[0] === BackendMessageCode.ErrorMessage) {
+        this.isExtendedQuery = false;
+      }
       // Filter out incorrect `ReadyForQuery` messages during the extended query protocol
       if (this.isExtendedQuery && message[0] === BackendMessageCode.ReadyForQuery) {
+        logger.debug('Filtered out a ReadyForQuery.')
         continue;
       }
       yield message;

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -17,6 +17,7 @@ import { logger } from "../logger";
 import { load } from "../dataconnect/load";
 import { Config } from "../config";
 import { PostgresServer } from "./dataconnect/pgliteServer";
+import { cleanShutdown } from "./controller";
 
 export interface DataConnectEmulatorArgs {
   projectId: string;
@@ -122,7 +123,7 @@ export class DataConnectEmulator implements EmulatorInstance {
               `Postgres threw an unexpected error, shutting down the Data Connect emulator: ${err}`,
             );
           }
-          this.stop();
+          void cleanShutdown();
         });
         this.logger.logLabeled(
           "INFO",


### PR DESCRIPTION
### Description
Bug bash (and Tyler's demoing) uncovered more problems with our handling of extended query protocol and prepared statements:. Fixes b/369172372

- If we're in the midst of a pipeline and the PGLite sends a ErrorMessage, we need to end the pipeline.
- We previously were holding onto prepared statements indefinitely. This lead to issues where the emulator tries to re-prepare statements with the same name. Now, we `DEALLOCATE ALL`  after a new client is authenticated.
- Correctly pipe through socket errors so that we stop orphaning emulators.

### Scenarios Tested
I was using the web quickstart app to repro the original issue.  I confirmed that the movies app works after this change.