### PR TITLE
Revert the minimum Functions SDK version and add logging for extensions features using v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Released version 1.3.9 of the Data Connect emulator, which includes SDK support for `Any` scalar type and `OrderDirection`, support for `first` to lookup operations, and breaking changes for iOS generated SDKs. PLease see documentation for more details.
+- Revert the minimum Functions SDK version and add logging for extensions features using v5.1.0 (#7731).

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -9,7 +9,7 @@ import fetch from "node-fetch";
 import { FirebaseError } from "../../../../error";
 import { getRuntimeChoice } from "./parseRuntimeAndValidateSDK";
 import { logger } from "../../../../logger";
-import { logLabeledSuccess, logLabeledWarning, randomInt } from "../../../../utils";
+import { logLabeledBullet, logLabeledSuccess, logLabeledWarning, randomInt } from "../../../../utils";
 import * as backend from "../../backend";
 import * as build from "../../build";
 import * as discovery from "../discovery";
@@ -20,7 +20,11 @@ import * as versioning from "./versioning";
 import * as parseTriggers from "./parseTriggers";
 import { fileExistsSync } from "../../../../fsutils";
 
-const MIN_FUNCTIONS_SDK_VERSION = "5.1.0";
+// The versions of the Firebase Functions SDK that added support for the container contract.
+const MIN_FUNCTIONS_SDK_VERSION = "3.20.0";
+
+// The version of the Firebase Functions SDK that added support for the extensions annotation in the container contract.
+const MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES = "5.1.0";
 
 /**
  *
@@ -259,6 +263,15 @@ export class Delegate {
           `Please update firebase-functions SDK to >=${MIN_FUNCTIONS_SDK_VERSION}`,
       );
       return parseTriggers.discoverBuild(this.projectId, this.sourceDir, this.runtime, config, env);
+    }
+    // Perform a check for the minimum SDK version that added annotation support for the `Build.extensions` property
+    // and log to the user explaining why they need to upgrade their version.
+    if (semver.lt(this.sdkVersion, MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES)) {
+      logLabeledBullet(
+        "functions",
+        `You are using a version of firebase-functions SDK (${this.sdkVersion}) that does not have support for the newest Firebase Extensions features. ` +
+          `Please update firebase-functions SDK to >=${MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES} to use them correctly`,
+      );
     }
     let discovered = await discovery.detectFromYaml(this.sourceDir, this.projectId, this.runtime);
     if (!discovered) {

--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -9,7 +9,12 @@ import fetch from "node-fetch";
 import { FirebaseError } from "../../../../error";
 import { getRuntimeChoice } from "./parseRuntimeAndValidateSDK";
 import { logger } from "../../../../logger";
-import { logLabeledBullet, logLabeledSuccess, logLabeledWarning, randomInt } from "../../../../utils";
+import {
+  logLabeledBullet,
+  logLabeledSuccess,
+  logLabeledWarning,
+  randomInt,
+} from "../../../../utils";
 import * as backend from "../../backend";
 import * as build from "../../build";
 import * as discovery from "../discovery";


### PR DESCRIPTION
Revert the min functions SDK version for proper functions trigger parsing using the container contract

Add a log for using SDK version under v5.1.0 with the new extensions features