### PR TITLE
Update to data connect emulator 1.4.0 and only use a single connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-- Released version 1.3.9 of the Data Connect emulator, which includes SDK support for `Any` scalar type and `OrderDirection`, support for `first` to lookup operations, and breaking changes for iOS generated SDKs. PLease see documentation for more details.
+- Released version 1.4.0 of the Data Connect emulator, which includes SDK support for `Any` scalar type and `OrderDirection`, support for `first` to lookup operations, and breaking changes for iOS generated SDKs. PLease see documentation for more details.
 - Revert the minimum Functions SDK version and add logging for extensions features using v5.1.0 (#7731).

--- a/src/emulator/dataconnect/pg-gateway/connection.ts
+++ b/src/emulator/dataconnect/pg-gateway/connection.ts
@@ -203,6 +203,9 @@ export default class PostgresConnection {
           for await (const msg of getMessages(responseMessage)) {
             if (msg[0] !== BackendMessageCode.NoticeMessage) {
               logger.debug('Backend message', getBackendMessageName(msg[0]!));
+              if (msg[0] === BackendMessageCode.ErrorMessage) {
+                logger.debug(new TextDecoder().decode(msg));
+              }
             }
           }
           await writer.write(responseMessage);

--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -39,12 +39,6 @@ export class PostgresServer {
           // pglite wrongly sends.
           return extendedQueryPatch.filterResponse(data, result);
         },
-
-        async onAuthenticated() {
-          // Every time we see a new authentication exchange, we need to throw away previously prepared statements -
-          // Clients may not know of these statements, and may attempt to reuse the same name.
-          await db.query("DEALLOCATE ALL");
-        },
       });
 
       const extendedQueryPatch: PGliteExtendedQueryPatch = new PGliteExtendedQueryPatch(connection);

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -245,6 +245,7 @@ export class DataConnectEmulator implements EmulatorInstance {
           connectionString: connectionString.toString(),
           database,
           serviceId,
+          maxOpenConnections: 1, // PGlite only supports a single open connection at a time - otherwise, prepared statements will misbehave.
         });
         this.logger.logLabeled(
           "DEBUG",
@@ -278,6 +279,8 @@ type ConfigureEmulatorRequest = {
   // populated, then any database specified in the connection_string will be
   // overwritten.
   database?: string;
+  // The max number of simultaneous Postgres connections the emulator may open
+  maxOpenConnections?: number;
 };
 
 type GetInfoResponse = {

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -56,24 +56,23 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedSize: 66786933,
     expectedChecksum: "a9025b3e53fdeafd2969ccb3ba1e1d38",
   },
-
   dataconnect:
     process.platform === "darwin"
       ? {
-          version: "1.3.9",
-          expectedSize: 25064192,
-          expectedChecksum: "87b403487c33ca79e404b1c05b728a55",
+          version: "1.4.0",
+          expectedSize: 25105152,
+          expectedChecksum: "a1dc95f1ead2370d559b7df05b30e60e",
         }
       : process.platform === "win32"
         ? {
-            version: "1.3.9",
-            expectedSize: 25489920,
-            expectedChecksum: "067fe58e401af23fd49b5cbc01a015d0",
+            version: "1.4.0",
+            expectedSize: 25529344,
+            expectedChecksum: "92f7da686e00a36680460b0379863493",
           }
         : {
-            version: "1.3.9",
-            expectedSize: 24977560,
-            expectedChecksum: "ec26bcdf2c616801fade7d48ce3dbb9c",
+            version: "1.4.0",
+            expectedSize: 25018520,
+            expectedChecksum: "dc7d26bf1be7ea2e1a40e1f8092d167a",
           },
 };
 


### PR DESCRIPTION
### Description
Update to data connect emulator 1.4.0 and set it to only use a single connection at a time to avoid issues with prepared statements.

### Scenarios Tested
Tested out the quickstart web app and no longer able to reproduce the issues we ran into.