### PR TITLE
Reorder `firebase init dataconnect` prompts for better local onboarding flow.

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -132,7 +132,14 @@ async function askQuestions(setup: Setup): Promise<RequiredInfo> {
       }))
     );
   } else {
-    // TODO(rosalyntan): Enter defaults.
+    info.serviceId = info.serviceId !== "" ? info.serviceId : basename(process.cwd());
+    info.cloudSqlInstanceId =
+      info.cloudSqlInstanceId !== "" ? info.cloudSqlInstanceId : `${info.serviceId || "app"}-fdc`;
+    info.locationId = info.locationId !== "" ? info.locationId : `us-central1`;
+    info.cloudSqlDatabase = info.cloudSqlDatabase !== "" ? info.cloudSqlDatabase : `fdcdb`;
+    logBullet(
+      `Setting placeholder values in dataconnect.yaml. You can edit these before you deploy to use different IDs or regions.`,
+    );
   }
   return info;
 }

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -105,17 +105,17 @@ async function askQuestions(setup: Setup): Promise<RequiredInfo> {
   };
   const isBillingEnabled = setup.projectId ? await checkBillingEnabled(setup.projectId) : false;
   if (setup.projectId) {
-    isBillingEnabled ? ensureApis(setup.projectId) : ensureSparkApis(setup.projectId);
+    isBillingEnabled ? await ensureApis(setup.projectId) : await ensureSparkApis(setup.projectId);
   }
 
   info = await checkExistingInstances(setup, info, isBillingEnabled);
 
   const shouldConfigureBackend = isBillingEnabled
-    ? isBillingEnabled
-    : await confirm({
-        message: `Would you like to configure and provision your backend resources now?`,
+    ? await confirm({
+        message: `Would you like to configure your backend resources now?`,
         default: false,
-      });
+      })
+    : false;
 
   if (shouldConfigureBackend) {
     info = await promptForService(info);
@@ -138,7 +138,7 @@ async function askQuestions(setup: Setup): Promise<RequiredInfo> {
     info.locationId = info.locationId !== "" ? info.locationId : `us-central1`;
     info.cloudSqlDatabase = info.cloudSqlDatabase !== "" ? info.cloudSqlDatabase : `fdcdb`;
     logBullet(
-      `Setting placeholder values in dataconnect.yaml. You can edit these before you deploy to use different IDs or regions.`,
+      `Setting placeholder values in dataconnect.yaml. You can edit these before you deploy to specify different IDs or regions.`,
     );
   }
   return info;

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -267,15 +267,16 @@ async function checkExistingInstances(
     }),
   );
   if (existingServicesAndSchemas.length) {
-    const choices: { name: string; value: any }[] = existingServicesAndSchemas.map((s) => {
-      const serviceName = parseServiceName(s.service.name);
-      return {
-        name: `${serviceName.location}/${serviceName.serviceId}`,
-        value: s,
-      };
-    });
+    const choices: { name: string; value: { service: Service; schema?: Schema } | undefined }[] =
+      existingServicesAndSchemas.map((s) => {
+        const serviceName = parseServiceName(s.service.name);
+        return {
+          name: `${serviceName.location}/${serviceName.serviceId}`,
+          value: s,
+        };
+      });
     choices.push({ name: "Create a new service", value: undefined });
-    const choice: { service: Service; schema: Schema } = await promptOnce({
+    const choice: { service: Service; schema?: Schema } | undefined = await promptOnce({
       message:
         "Your project already has existing services. Which would you like to set up local files for?",
       type: "list",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

- If there are existing services / instances, use those for setting up local files
    - Until b/368609569 is fixed, this is only for projects with billing. After, should work regardless of billing state
- If there are no existing services / instances:
    - If no billing:
        - Set up local files with defaults
    - If yes billing:
        - Ask if they want to configure backend resource, otherwise set up local files with defaults

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- [x] project with no billing
- [x] project with billing with existing services
- [x] project with billing with no services, (y) for configuring backend resources
- [x] project with billing with no services, (n) for configuring backend resources

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

project with billing with existing services:
<img width="783" alt="Screenshot 2024-09-25 at 9 40 59 PM" src="https://github.com/user-attachments/assets/81e7d7b1-ce41-496b-9a41-52602bf4dc54">

project with billing with no services, (n) for configuring backend resources:
<img width="878" alt="Screenshot 2024-09-25 at 9 39 15 PM" src="https://github.com/user-attachments/assets/13bf1fb9-a3b5-4600-9917-5ce4bbae5d23">
