### PR TITLE
Update error message for existing Cloud SQL instance.

### DIFF
--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -1,5 +1,6 @@
 import { listInstances } from "../gcp/cloudsql/cloudsqladmin";
 import * as utils from "../utils";
+import * as clc from "colorette";
 
 export function freeTrialTermsLink(): string {
   return "https://firebase.google.com/pricing";
@@ -21,8 +22,9 @@ export function printFreeTrialUnavailable(
     `Project '${projectId} already has a CloudSQL instance '${instanceId}' on the Firebase Data Connect no-cost trial.`,
   );
   const reuseHint =
-    `To use a different database in the same instance, change the instanceId to "${instanceId}" in` +
-    `${configYamlPath}. Also, update the database field (i.e. the database name in the instance) and location as needed.`;
+    `To use a different database in the same instance, ${clc.bold(`change the instanceId to "${instanceId}"`)} in ` +
+    `${clc.green(configYamlPath)}. (Also, update the ${clc.blue("database")} field (i.e. DB name in the instance) ` +
+    `and ${clc.blue("location")} as needed.)`;
   utils.logLabeledBullet("dataconnect", reuseHint);
   utils.logLabeledBullet(
     "dataconnect",

--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -22,7 +22,7 @@ export function printFreeTrialUnavailable(
   );
   const reuseHint =
     `To use a different database in the same instance, change the instanceId to "${instanceId}" in` +
-    `${configYamlPath}. Also, update the database field (i.e. the database name in the instance) as needed.`;
+    `${configYamlPath}. Also, update the database field (i.e. the database name in the instance) and location as needed.`;
   utils.logLabeledBullet("dataconnect", reuseHint);
   utils.logLabeledBullet(
     "dataconnect",

--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -11,11 +11,15 @@ export async function checkForFreeTrialInstance(projectId: string): Promise<stri
   return instances.find((i) => i.settings.userLabels?.["firebase-data-connect"] === "ft")?.name;
 }
 
-export function printFreeTrialUnavailable(projectId: string, instanceId: string) {
+export function printFreeTrialUnavailable(
+  projectId: string,
+  instanceId: string,
+  configYamlPath: string,
+) {
   const message =
-    `Project '${projectId}' already has a CloudSQL instance '${instanceId}' on the Firebase Data Connect free trial. ` +
-    "The free trial only includes one CloudSQL instance. " +
-    `Consider using a separate database on ${instanceId}, or creating a new CloudSQL instance at ` +
-    "https://console.cloud.google.com/sql/instances";
+    `Project '${projectId} already has a CloudSQL instance '${instanceId}' on the Firebase Data Connect no-cost trial.` +
+    `To use a different database in the same instance, change the instanceId to "${instanceId}" in` +
+    `${configYamlPath}. Also, update the database field (i.e. the database name in the instance) as needed.` +
+    `(Or you may create a new (paid) CloudSQL instance at https://console.cloud.google.com/sql/instances )`;
   utils.logLabeledError("dataconnect", message);
 }

--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -24,7 +24,7 @@ export function printFreeTrialUnavailable(
     `To use a different database in the same instance, change the instanceId to "${instanceId}" in` +
     `${configYamlPath}. Also, update the database field (i.e. the database name in the instance) as needed.`;
   utils.logLabeledBullet("dataconnect", reuseHint);
-  utils.logLabeledError(
+  utils.logLabeledBullet(
     "dataconnect",
     `Or you may create a new (paid) CloudSQL instance at https://console.cloud.google.com/sql/instances`,
   );

--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -22,7 +22,7 @@ export function printFreeTrialUnavailable(
     `Project '${projectId} already has a CloudSQL instance '${instanceId}' on the Firebase Data Connect no-cost trial.`,
   );
   const reuseHint =
-    `To use a different database in the same instance, ${clc.bold(`change the instanceId to "${instanceId}"`)} in ` +
+    `To use a different database in the same instance, ${clc.bold(`change the ${clc.blue("instanceId")} to "${instanceId}"`)} in ` +
     `${clc.green(configYamlPath)}. (Also, update the ${clc.blue("database")} field (i.e. DB name in the instance) ` +
     `and ${clc.blue("location")} as needed.)`;
   utils.logLabeledBullet("dataconnect", reuseHint);

--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -16,10 +16,16 @@ export function printFreeTrialUnavailable(
   instanceId: string,
   configYamlPath: string,
 ) {
-  const message =
-    `Project '${projectId} already has a CloudSQL instance '${instanceId}' on the Firebase Data Connect no-cost trial.` +
+  utils.logLabeledError(
+    "dataconnect",
+    `Project '${projectId} already has a CloudSQL instance '${instanceId}' on the Firebase Data Connect no-cost trial.`,
+  );
+  const reuseHint =
     `To use a different database in the same instance, change the instanceId to "${instanceId}" in` +
-    `${configYamlPath}. Also, update the database field (i.e. the database name in the instance) as needed.` +
-    `(Or you may create a new (paid) CloudSQL instance at https://console.cloud.google.com/sql/instances )`;
-  utils.logLabeledError("dataconnect", message);
+    `${configYamlPath}. Also, update the database field (i.e. the database name in the instance) as needed.`;
+  utils.logLabeledBullet("dataconnect", reuseHint);
+  utils.logLabeledError(
+    "dataconnect",
+    `Or you may create a new (paid) CloudSQL instance at https://console.cloud.google.com/sql/instances`,
+  );
 }

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -79,7 +79,7 @@ export async function provisionCloudSql(args: {
         "dataconnect",
         `CloudSQL instance '${instanceId}' not found.` +
           cta +
-          `\nThis instance is provided under the terms of the Data Connect free trial ${freeTrialTermsLink()}` +
+          `\nThis instance is provided under the terms of the Data Connect no-cost trial ${freeTrialTermsLink()}` +
           `\nMonitor the progress at ${cloudSqlAdminClient.instanceConsoleLink(projectId, instanceId)}`,
       );
     if (!dryRun) {

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -19,6 +19,7 @@ export async function provisionCloudSql(args: {
   locationId: string;
   instanceId: string;
   databaseId: string;
+  configYamlPath: string;
   enableGoogleMlIntegration: boolean;
   waitForCreation: boolean;
   silent?: boolean;
@@ -30,6 +31,7 @@ export async function provisionCloudSql(args: {
     locationId,
     instanceId,
     databaseId,
+    configYamlPath,
     enableGoogleMlIntegration,
     waitForCreation,
     silent,
@@ -68,8 +70,8 @@ export async function provisionCloudSql(args: {
     }
     const freeTrialInstanceId = await checkForFreeTrialInstance(projectId);
     if (freeTrialInstanceId) {
-      printFreeTrialUnavailable(projectId, freeTrialInstanceId);
-      throw new FirebaseError("Free trial unavailable.");
+      printFreeTrialUnavailable(projectId, freeTrialInstanceId, configYamlPath);
+      throw new FirebaseError("Cannot create another no-cost trial Cloud SQL instance.");
     }
     const cta = dryRun ? "It will be created on your next deploy" : "Creating it now.";
     silent ||

--- a/src/deploy/dataconnect/deploy.ts
+++ b/src/deploy/dataconnect/deploy.ts
@@ -8,6 +8,7 @@ import { parseServiceName } from "../../dataconnect/names";
 import { ResourceFilter } from "../../dataconnect/filters";
 import { vertexAIOrigin } from "../../api";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
+import { join } from "node:path";
 
 /**
  * Checks for and creates a Firebase DataConnect service, if needed.
@@ -101,6 +102,7 @@ export default async function (
             locationId: parseServiceName(s.serviceName).location,
             instanceId,
             databaseId,
+            configYamlPath: join(s.sourceDirectory, "dataconnect.yaml"),
             enableGoogleMlIntegration,
             waitForCreation: true,
           });

--- a/src/deploy/dataconnect/prepare.ts
+++ b/src/deploy/dataconnect/prepare.ts
@@ -16,6 +16,7 @@ import { parseServiceName } from "../../dataconnect/names";
 import { FirebaseError } from "../../error";
 import { requiresVector } from "../../dataconnect/types";
 import { diffSchema } from "../../dataconnect/schemaMigration";
+import { join } from "node:path";
 
 /**
  * Prepares for a Firebase DataConnect deployment by loading schemas and connectors from file.
@@ -86,6 +87,7 @@ export default async function (context: any, options: DeployOptions): Promise<vo
               locationId: parseServiceName(s.serviceName).location,
               instanceId,
               databaseId,
+              configYamlPath: join(s.sourceDirectory, "dataconnect.yaml"),
               enableGoogleMlIntegration,
               waitForCreation: true,
               dryRun: options.dryRun,

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -137,6 +137,7 @@ export async function actuate(setup: Setup, config: Config, info: RequiredInfo) 
       locationId: info.locationId,
       instanceId: info.cloudSqlInstanceId,
       databaseId: info.cloudSqlDatabase,
+      configYamlPath: join(config.get("dataconnect.source"), "dataconnect.yaml"),
       enableGoogleMlIntegration: false,
       waitForCreation: false,
     });


### PR DESCRIPTION
### Description

This makes the error message a bit more actionable.

### Scenarios Tested

`firebase deploy --only dataconnect` (snipped to only the error part)

![image](https://github.com/user-attachments/assets/e43eaaf7-dc7a-4729-8a07-18ad692b45af)

`firebase init dataconnect` and choose a different DB name than the existing one, and then choose to provision now:

![image](https://github.com/user-attachments/assets/7fbc4a46-ac31-4999-8f7c-58b6f6b834bc)



### Sample Commands

```bash
firebase init dataconnect # Choose to provision now
firebase deploy --only dataconnect
```
