### PR TITLE
Use published version of firebase-tools, and CHANGELOGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Switched Data Connect emulator to use an in memory PGLite database instead of requiring a separate Postgres installation. Deprecated 'dataconnectEmulator`in`.firebaserc`.
 - Released version 1.4.0 of the Data Connect emulator, which includes SDK support for `Any` scalar type and `OrderDirection`, support for `first` to lookup operations, and breaking changes for iOS generated SDKs. PLease see documentation for more details.
 - Revert the minimum Functions SDK version and add logging for extensions features using v5.1.0 (#7731).

--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## NEXT
 
+- [Added] UI overhaul.
+- [Added] Added View Docs button to see generated documentation for your schema and connectors.
+- [Fixed] Improved detection for emulator start up and shut down.
+- [Fixed] Improved error handling for variables pane.
+- [Added] Added Firebase path setting, to control which Firebase dbinary is used when executing commands.
+
 ## 0.9.1
 
 - Updated internal firebase-tools dependency to 13.19.0

--- a/firebase-vscode/src/utils/settings.ts
+++ b/firebase-vscode/src/utils/settings.ts
@@ -12,7 +12,7 @@ const FIREBASE_BINARY =
   // Allow defaults via env var. Useful when starting VS Code from command line or Monospace.
   process.env.FIREBASE_BINARY ||
   // TODO: Temporary fallback for bashing, this should probably point to the global firebase binary on the system
-  "npx -y firebase/firebase-tools";
+  "npx -y firebase-tools@latest";
 
 export function getSettings(): Settings {
   const config = workspace.value.getConfiguration("firebase");


### PR DESCRIPTION

### Description
Launch prep things - switching `npx` command to use published versions and added a changelog.