### PR TITLE
Fixed an issue where expired auth tokens would be used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,0 @@
-- Switched Data Connect emulator to use an in memory PGLite database instead of requiring a separate Postgres installation. Deprecated 'dataconnectEmulator`in`.firebaserc`.
-- Released version 1.4.2 of the Data Connect emulator, which includes SDK support for `Any` scalar type and `OrderDirection`, support for `first` to lookup operations, and breaking changes for iOS generated SDKs. PLease see documentation for more details (#7744).
-- Revert the minimum Functions SDK version and add logging for extensions features using v5.1.0 (#7731).
-- Added compatibility mode support for Firebase Data Connect schema migrations, where application schema updates are allowed if the database schema is in a compatible state. (#7746)
-- Improved `firebase init dataconnect` to better support local-first onboarding. (#7733)
-- Added support for the `--watch` option in `firebase dataconnect:sdk:generate`. (#7719)
-- Minor fix in the Firebase Data Connect GraphQL query template. (#7736)

--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## NEXT
 
+- [Fixed] Fixed an issue where commands would be executed against directory default project instead of the currently selected project.
+- [Fixed] Fixed an issue where expired auth tokens would be used.
+
+## 0.10.0
+
 - [Added] UI overhaul.
 - [Added] Added View Docs button to see generated documentation for your schema and connectors.
 - [Fixed] Improved detection for emulator start up and shut down.

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -128,7 +128,8 @@ export function setAccessToken(token = ""): void {
  */
 export async function getAccessToken(): Promise<string> {
   const valid = auth.haveValidTokens(refreshToken, []);
-  if (accessToken && valid) {
+  const usingADC = !auth.loggedIn();
+  if (accessToken && (valid || usingADC)) {
     return accessToken;
   }
   const data = await auth.getAccessToken(refreshToken, []);

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -127,7 +127,8 @@ export function setAccessToken(token = ""): void {
  * @returns An access token
  */
 export async function getAccessToken(): Promise<string> {
-  if (accessToken) {
+  const valid = auth.haveValidTokens(refreshToken, []);
+  if (accessToken && valid) {
     return accessToken;
   }
   const data = await auth.getAccessToken(refreshToken, []);
@@ -462,6 +463,16 @@ export class Client {
         this.logResponse(res, body, options);
 
         if (res.status >= 400) {
+          if (res.status === 401 && this.opts.auth) {
+            // If we get a 401, access token is expired or otherwise invalid.
+            // Throw it away and get a new one. We check for validity before using
+            // tokens, so this should not happen.
+            logger.debug(
+              "Got a 401 Unauthenticated error for a call that required authentication. Refreshing tokens.",
+            );
+            setAccessToken();
+            setAccessToken(await getAccessToken());
+          }
           if (options.retryCodes?.includes(res.status)) {
             const err = responseToError({ statusCode: res.status }, body) || undefined;
             if (operation.retry(err)) {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -560,6 +560,10 @@ export function findAccountByEmail(email: string): Account | undefined {
   return getAllAccounts().find((a) => a.user.email === email);
 }
 
+export function loggedIn() {
+  return !!lastAccessToken;
+}
+
 export function haveValidTokens(refreshToken: string, authScopes: string[]) {
   if (!lastAccessToken?.access_token) {
     const tokens = configstore.get("tokens");
@@ -576,7 +580,13 @@ export function haveValidTokens(refreshToken: string, authScopes: string[]) {
   // tokens if they have a _long_ time before the server rejects them.
   const isExpired = (lastAccessToken?.expires_at || 0) < Date.now() + FIFTEEN_MINUTES_IN_MS;
   const valid = hasTokens && hasSameScopes && !isExpired;
-  logger.debug(`Checked if tokens are valid: ${valid}, expires at: ${lastAccessToken?.expires_at}`);
+  if (hasTokens) {
+    logger.debug(
+      `Checked if tokens are valid: ${valid}, expires at: ${lastAccessToken?.expires_at}`,
+    );
+  } else {
+    logger.debug("No OAuth tokens found");
+  }
   return valid;
 }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -560,7 +560,7 @@ export function findAccountByEmail(email: string): Account | undefined {
   return getAllAccounts().find((a) => a.user.email === email);
 }
 
-function haveValidTokens(refreshToken: string, authScopes: string[]) {
+export function haveValidTokens(refreshToken: string, authScopes: string[]) {
   if (!lastAccessToken?.access_token) {
     const tokens = configstore.get("tokens");
     if (refreshToken === tokens?.refresh_token) {
@@ -575,8 +575,9 @@ function haveValidTokens(refreshToken: string, authScopes: string[]) {
   // To avoid token expiration in the middle of a long process we only hand out
   // tokens if they have a _long_ time before the server rejects them.
   const isExpired = (lastAccessToken?.expires_at || 0) < Date.now() + FIFTEEN_MINUTES_IN_MS;
-
-  return hasTokens && hasSameScopes && !isExpired;
+  const valid = hasTokens && hasSameScopes && !isExpired;
+  logger.debug(`Checked if tokens are valid: ${valid}, expires at: ${lastAccessToken?.expires_at}`);
+  return valid;
 }
 
 function deleteAccount(account: Account) {


### PR DESCRIPTION
### Description
Previously, getAuthToken never checked expiry, because it was never relevant for short lived commands. Now that VSCode uses this same path, we saw lots of expired auth token issues.

I also added a second line of defense here and get new auth tokens whenever we get a 401 error. This is mostly irrelevant within the CLI (since 401's will generally end the process), but may help VSCE repair itself. With the new validity check, this probably should never be hit. 

### Scenarios Tested
I was getting 401s when executing queries against prod in VSCE - this fixed that. I also tested out a bunch of CLI commands from various auth states: valid tokens, expired tokens, and using application default credentials
