### PR TITLE
Add function test package-locks to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/node_modules/*
 src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package.json
 src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions/package-lock.json
+scripts/functions-deploy-tests/**/package-lock.json
+scripts/functions-discover-tests/**/**/package-lock.json
 
 /.vscode
 node_modules


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

If you run "npm run build", it adds a bunch of untracked package-lock files to your local directory.  These should be in the .gitignore.

	scripts/functions-deploy-tests/functions/package-lock.json
	scripts/functions-discover-tests/fixtures/bundled/dist/package-lock.json
	scripts/functions-discover-tests/fixtures/bundled/package-lock.json
	scripts/functions-discover-tests/fixtures/codebases/v1/package-lock.json
	scripts/functions-discover-tests/fixtures/codebases/v2/package-lock.json
	scripts/functions-discover-tests/fixtures/esm/functions/package-lock.json
	scripts/functions-discover-tests/fixtures/pnpm/functions/package-lock.json
	scripts/functions-discover-tests/fixtures/simple/functions/package-lock.json
	scripts/functions-discover-tests/fixtures/yarn-workspaces/package-lock.json
	scripts/functions-discover-tests/fixtures/yarn-workspaces/packages/a-test-pkg/package-lock.json

### Scenarios Tested


### Sample Commands

