### PR TITLE
Include the error message as well as error code in the error message

### DIFF
--- a/firebase-vscode/src/data-connect/service.ts
+++ b/firebase-vscode/src/data-connect/service.ts
@@ -16,6 +16,7 @@ import { firebaseRC } from "../core/config";
 import {
   dataconnectDataplaneClient,
   executeGraphQL,
+  DATACONNECT_API_VERSION,
 } from "../../../src/dataconnect/dataplaneClient";
 import {
   ExecuteGraphqlRequest,
@@ -246,8 +247,7 @@ export class DataConnectService {
       }
       const client = new Client({
         urlPrefix: endpoint,
-        apiVersion: "v1beta",
-        auth: true,
+        apiVersion: DATACONNECT_API_VERSION,
       });
       const resp = await executeGraphQL(client, servicePath, prodBody);
       return this.handleEmulatorResponse(resp);

--- a/firebase-vscode/src/data-connect/service.ts
+++ b/firebase-vscode/src/data-connect/service.ts
@@ -23,7 +23,7 @@ import {
   ExecuteGraphqlResponseError,
   Impersonation,
 } from "../dataconnect/types";
-import { Client, ClientResponse } from "../apiv2";
+import { Client, ClientResponse } from "../../../src/apiv2";
 import { InstanceType } from "./code-lens-provider";
 import { pluginLogger } from "../logger-wrapper";
 import { DataConnectToolkit } from "./toolkit";
@@ -38,12 +38,13 @@ export class DataConnectService {
     private emulatorsController: EmulatorsController,
   ) {}
 
-  async servicePath(path: string): Promise<string | undefined> {
+  async servicePath(
+    path: string
+  ): Promise<string | undefined> {
     const dataConnectConfigsValue = await firstWhereDefined(dataConnectConfigs);
     // TODO: avoid calling this here and in getApiServicePathByPath
     const serviceId =
-      dataConnectConfigsValue?.tryReadValue?.findEnclosingServiceForPath(path)
-        ?.value.serviceId;
+      dataConnectConfigsValue?.tryReadValue?.findEnclosingServiceForPath(path)?.value.serviceId;
     const projectId = firebaseRC.value?.tryReadValue?.projects?.default;
 
     if (serviceId === undefined || projectId === undefined) {
@@ -88,7 +89,7 @@ export class DataConnectService {
       const errorResponse =
         response as ClientResponse<ExecuteGraphqlResponseError>;
       throw new DataConnectError(
-        `Prod Request failed with status ${response.status}: message ${errorResponse?.body?.error?.message}`,
+        `Prod Request failed with status ${response.status}\nMessage ${errorResponse?.body?.error?.message}`,
       );
     }
     const successResponse = response as ClientResponse<ExecuteGraphqlResponse>;
@@ -104,7 +105,7 @@ export class DataConnectService {
       const errorResponse =
         response as ClientResponse<ExecuteGraphqlResponseError>;
       throw new DataConnectError(
-        `Prod Request failed with status ${response.status}: message ${errorResponse?.body?.error?.message}`,
+        `Prod Request failed with status ${response.status}\nMessage ${errorResponse?.body?.error?.message}`,
       );
     }
     const successResponse = response as ClientResponse<ExecuteGraphqlResponse>;
@@ -264,9 +265,9 @@ function parseVariableString(variables: string): Record<string, any> {
   }
   try {
     return JSON.parse(variables);
-  } catch (e: any) {
+  } catch(e: any) {
     throw new Error(
-      "Unable to parse variables as JSON. Double check that that there are no unmatched braces or quotes, or unqouted keys in the variables pane.",
+      "Unable to parse variables as JSON. Double check that that there are no unmatched braces or quotes, or unqouted keys in the variables pane."
     );
   }
 }

--- a/firebase-vscode/src/data-connect/service.ts
+++ b/firebase-vscode/src/data-connect/service.ts
@@ -105,7 +105,7 @@ export class DataConnectService {
       const errorResponse =
         response as ClientResponse<ExecuteGraphqlResponseError>;
       throw new DataConnectError(
-        `Prod Request failed with status ${response.status}\nMessage ${errorResponse?.body?.error?.message}`,
+        `Emulator Request failed with status ${response.status}\nMessage ${errorResponse?.body?.error?.message}`,
       );
     }
     const successResponse = response as ClientResponse<ExecuteGraphqlResponse>;

--- a/src/dataconnect/dataplaneClient.ts
+++ b/src/dataconnect/dataplaneClient.ts
@@ -12,7 +12,11 @@ export function dataconnectDataplaneClient(): Client {
   });
 }
 
-export async function executeGraphQL(client: Client, servicePath: string, body: types.ExecuteGraphqlRequest): Promise<ClientResponse<types.ExecuteGraphqlResponse | types.ExecuteGraphqlResponseError>> {
+export async function executeGraphQL(
+  client: Client,
+  servicePath: string,
+  body: types.ExecuteGraphqlRequest,
+): Promise<ClientResponse<types.ExecuteGraphqlResponse | types.ExecuteGraphqlResponseError>> {
   const res = await client.post<
     types.ExecuteGraphqlRequest,
     types.ExecuteGraphqlResponse | types.ExecuteGraphqlResponseError

--- a/src/dataconnect/dataplaneClient.ts
+++ b/src/dataconnect/dataplaneClient.ts
@@ -1,18 +1,19 @@
 import { dataconnectOrigin } from "../api";
-import { Client } from "../apiv2";
+import { Client, ClientResponse } from "../apiv2";
 import * as types from "./types";
 
-const DATACONNECT_API_VERSION = "v1beta";
+export const DATACONNECT_API_VERSION = "v1beta";
 
-const dataconnectDataplaneClient = () =>
-  new Client({
+export function dataconnectDataplaneClient(): Client {
+  return new Client({
     urlPrefix: dataconnectOrigin(),
     apiVersion: DATACONNECT_API_VERSION,
     auth: true,
   });
+}
 
-export async function executeGraphQL(servicePath: string, body: types.ExecuteGraphqlRequest) {
-  const res = await dataconnectDataplaneClient().post<
+export async function executeGraphQL(client: Client, servicePath: string, body: types.ExecuteGraphqlRequest): Promise<ClientResponse<types.ExecuteGraphqlResponse | types.ExecuteGraphqlResponseError>> {
+  const res = await client.post<
     types.ExecuteGraphqlRequest,
     types.ExecuteGraphqlResponse | types.ExecuteGraphqlResponseError
   >(`${servicePath}:executeGraphql`, body, { resolveOnHTTPError: true });


### PR DESCRIPTION
Tested here. Having the error message makes it so much easy to tell what happened.

We can polish up additional error handling later.

To prod:
<img width="1679" alt="Screenshot 2024-09-27 at 11 19 18 AM" src="https://github.com/user-attachments/assets/16c8f45f-9684-432f-a976-e99b6f81c38b">

To emulator:
<img width="1679" alt="Screenshot 2024-09-27 at 11 23 33 AM" src="https://github.com/user-attachments/assets/375ec50a-8dac-451e-9fdd-55d3330430b8">
