### PR TITLE
App Hosting emulator - package manager detection

### DIFF
--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -17,10 +17,10 @@ export class AppHostingEmulator implements EmulatorInstance {
 
   async start(): Promise<void> {
     this.logger.logLabeled("INFO", Emulators.APPHOSTING, "starting apphosting emulator");
+
     const { hostname, port } = await apphostingStart(this.args.options);
     this.args.options.host = hostname;
     this.args.options.port = port;
-    this.logger.logLabeled("INFO", Emulators.APPHOSTING, "apphosting emulator started");
   }
 
   connect(): Promise<void> {

--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -18,7 +18,7 @@ export class AppHostingEmulator implements EmulatorInstance {
   async start(): Promise<void> {
     this.logger.logLabeled("INFO", Emulators.APPHOSTING, "starting apphosting emulator");
 
-    const { hostname, port } = await apphostingStart(this.args.options);
+    const { hostname, port } = await apphostingStart();
     this.args.options.host = hostname;
     this.args.options.port = port;
   }

--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -16,12 +16,11 @@ export class AppHostingEmulator implements EmulatorInstance {
   constructor(private args: AppHostingEmulatorArgs) {}
 
   async start(): Promise<void> {
-    this.args.options.host = this.args.host;
-    this.args.options.port = this.args.port;
-
     this.logger.logLabeled("INFO", Emulators.APPHOSTING, "starting apphosting emulator");
-    const { port } = await apphostingStart(this.args.options);
-    this.logger.logLabeled("INFO", Emulators.APPHOSTING, `serving on port ${port}`);
+    const { hostname, port } = await apphostingStart(this.args.options);
+    this.args.options.host = hostname;
+    this.args.options.port = port;
+    this.logger.logLabeled("INFO", Emulators.APPHOSTING, "apphosting emulator started");
   }
 
   connect(): Promise<void> {
@@ -37,8 +36,8 @@ export class AppHostingEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     return {
       name: Emulators.APPHOSTING,
-      host: this.args.host!,
-      port: this.args.port!,
+      host: this.args.options.host!,
+      port: this.args.options.port!,
     };
   }
 

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -19,15 +19,13 @@ describe("serve", () => {
   });
 
   describe("start", () => {
-    it("should only select an available port to serve", async () => {
-      checkListenableStub.onFirstCall().returns(false);
-      checkListenableStub.onSecondCall().returns(false);
-      checkListenableStub.onThirdCall().returns(true);
-
-      wrapSpawnStub.returns(Promise.resolve());
-
-      const res = await serve.start({ host: "127.0.0.1", port: 5000 });
-      expect(res.port).to.equal(5002);
-    });
+    // it("should only select an available port to serve", async () => {
+    //   checkListenableStub.onFirstCall().returns(false);
+    //   checkListenableStub.onSecondCall().returns(false);
+    //   checkListenableStub.onThirdCall().returns(true);
+    //   wrapSpawnStub.returns(Promise.resolve());
+    //   const res = await serve.start({ host: "127.0.0.1", port: 5000 });
+    //   expect(res.port).to.equal(5002);
+    // });
   });
 });

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -24,6 +24,18 @@ describe("serve", () => {
         "http://localhost:3002",
       );
     });
+
+    it("retrieves url from AngularJS output", () => {
+      expect(serve.getHostUrlFromString("  ➜  Local:   http://localhost:4200/")).to.equal(
+        "http://localhost:4200",
+      );
+    });
+
+    it("should not match https urls", () => {
+      expect(serve.getHostUrlFromString("  ➜  Local:   https://www.google.com")).to.equal(
+        undefined,
+      );
+    });
   });
 
   describe("start", () => {

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -18,6 +18,14 @@ describe("serve", () => {
     wrapSpawnStub.restore();
   });
 
+  describe("getHostUrlFromString", () => {
+    it("retrieves url from NextJS output", () => {
+      expect(serve.getHostUrlFromString("   - Local:        http://localhost:3002")).to.equal(
+        "http://localhost:3002",
+      );
+    });
+  });
+
   describe("start", () => {
     // it("should only select an available port to serve", async () => {
     //   checkListenableStub.onFirstCall().returns(false);

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -1,21 +1,17 @@
-import * as portUtils from "../portUtils";
 import * as sinon from "sinon";
-import * as spawn from "../../init/spawn";
+import * as sp from "cross-spawn";
 import { expect } from "chai";
 import * as serve from "./serve";
 
 describe("serve", () => {
-  let checkListenableStub: sinon.SinonStub;
-  let wrapSpawnStub: sinon.SinonStub;
+  let spawnStub: sinon.SinonStub;
 
   beforeEach(() => {
-    checkListenableStub = sinon.stub(portUtils, "checkListenable");
-    wrapSpawnStub = sinon.stub(spawn, "wrapSpawn");
+    spawnStub = sinon.stub(sp, "spawn");
   });
 
   afterEach(() => {
-    checkListenableStub.restore();
-    wrapSpawnStub.restore();
+    spawnStub.restore();
   });
 
   describe("getHostUrlFromString", () => {
@@ -36,16 +32,5 @@ describe("serve", () => {
         undefined,
       );
     });
-  });
-
-  describe("start", () => {
-    // it("should only select an available port to serve", async () => {
-    //   checkListenableStub.onFirstCall().returns(false);
-    //   checkListenableStub.onSecondCall().returns(false);
-    //   checkListenableStub.onThirdCall().returns(true);
-    //   wrapSpawnStub.returns(Promise.resolve());
-    //   const res = await serve.start({ host: "127.0.0.1", port: 5000 });
-    //   expect(res.port).to.equal(5002);
-    // });
   });
 });

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -4,19 +4,23 @@ import * as spawn from "../../init/spawn";
 import { expect } from "chai";
 import * as serve from "./serve";
 import { DEFAULT_PORTS } from "../constants";
+import * as utils from "./utils";
 
 describe("serve", () => {
   let checkListenableStub: sinon.SinonStub;
   let wrapSpawnStub: sinon.SinonStub;
+  let discoverPackageManagerStub: sinon.SinonStub;
 
   beforeEach(() => {
     checkListenableStub = sinon.stub(portUtils, "checkListenable");
     wrapSpawnStub = sinon.stub(spawn, "wrapSpawn");
+    discoverPackageManagerStub = sinon.stub(utils, "discoverPackageManager");
   });
 
   afterEach(() => {
     checkListenableStub.restore();
     wrapSpawnStub.restore();
+    discoverPackageManagerStub.restore();
   });
 
   describe("start", () => {
@@ -24,8 +28,6 @@ describe("serve", () => {
       checkListenableStub.onFirstCall().returns(false);
       checkListenableStub.onSecondCall().returns(false);
       checkListenableStub.onThirdCall().returns(true);
-
-      wrapSpawnStub.returns(Promise.resolve());
 
       const res = await serve.start();
       expect(res.port).to.equal(DEFAULT_PORTS.apphosting + 2);

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -10,8 +10,8 @@ import { discoverPackageManager } from "./utils";
  * Spins up a project locally by running the project's dev command.
  */
 
-export async function start(options: any): Promise<{ hostname: string; port: number }> {
-  const hostUrl = await serve(options);
+export async function start(): Promise<{ hostname: string; port: number }> {
+  const hostUrl = await serve();
 
   const { hostname, port } = new URL(hostUrl);
   return { hostname, port: +port };
@@ -20,7 +20,7 @@ export async function start(options: any): Promise<{ hostname: string; port: num
 /**
  * Exported for unit testing
  */
-export async function serve(options: any): Promise<string> {
+export async function serve(): Promise<string> {
   const rootDir = process.cwd();
   const packageManager = await discoverPackageManager(rootDir);
 
@@ -36,8 +36,8 @@ export async function serve(options: any): Promise<string> {
 
     serve.stdout.on("data", (data: any) => {
       process.stdout.write(data);
-      const match = data.toString().match(/(http:\/\/.*:\d+)/);
-      if (match) resolve(match[1]);
+      const url = getHostUrlFromString(data.toString());
+      if (url) resolve(url);
     });
     serve.stderr.on("data", (data: any) => {
       process.stderr.write(data);
@@ -46,4 +46,14 @@ export async function serve(options: any): Promise<string> {
   });
 
   return await hostUrl;
+}
+
+/**
+ * Exported for unit testing
+ */
+export function getHostUrlFromString(data: string): string | undefined {
+  const match = data.match(/(http:\/\/.*:\d+)/);
+  if (match) {
+    return match[1];
+  }
 }

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -5,8 +5,7 @@
 import { isIPv4 } from "net";
 import { checkListenable } from "../portUtils";
 import { wrapSpawn } from "../../init/spawn";
-import { pathExists } from "fs-extra";
-import { join } from "path";
+import {discover} from "./utils";
 
 /**
  * Spins up a project locally by running the project's dev command.
@@ -35,22 +34,13 @@ function availablePort(host: string, port: number): Promise<boolean> {
  * Exported for unit testing
  */
 export async function serve(options: any, port: string) {
-  // TODO: update to support other package managers and frameworks other than NextJS
-  await wrapSpawn("npm", ["run", "dev", "--", "-H", options.host, "-p", port], process.cwd());
-}
+  const { packageManager, framework } = await discover();
 
-async function discoverPackageManager(rootdir: string): Promise<SupportedPackageManager> {
-  if (await pathExists(join(rootdir, "pnpm-lock.yaml"))) {
-    return SupportedPackageManager.pnpm;
-  } else if (await pathExists(join(rootdir, "yarn.lock"))) {
-    return SupportedPackageManager.yarn;
-  } else {
-    return SupportedPackageManager.npm;
+  if (!framework) {
+    console.log(`unable to find framework`)
+    // TODO: Default to standard command that our buildpacks use
   }
-}
 
-enum SupportedPackageManager {
-  npm = 1,
-  yarn,
-  pnpm,
+  //["run", "dev", "--", "-H", options.host, "-p", port]
+  await wrapSpawn(packageManager, devArgs, process.cwd());
 }

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -17,10 +17,7 @@ export async function start(): Promise<{ hostname: string; port: number }> {
   return { hostname, port: +port };
 }
 
-/**
- * Exported for unit testing
- */
-export async function serve(): Promise<string> {
+async function serve(): Promise<string> {
   const rootDir = process.cwd();
   const packageManager = await discoverPackageManager(rootDir);
 

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -26,7 +26,7 @@ export async function serve(options: any): Promise<string> {
 
   /**
    *  TODO: Should add a timeout here. If the hostUrl cannot be retrieved
-   *  the user is probably using an unsupported framework.
+   *  in a timely manner, user is probably using an unsupported framework.
    * */
 
   const hostUrl = new Promise<string>((resolve, reject) => {

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -5,6 +5,8 @@
 import { isIPv4 } from "net";
 import { checkListenable } from "../portUtils";
 import { wrapSpawn } from "../../init/spawn";
+import { pathExists } from "fs-extra";
+import { join } from "path";
 
 /**
  * Spins up a project locally by running the project's dev command.
@@ -35,4 +37,20 @@ function availablePort(host: string, port: number): Promise<boolean> {
 export async function serve(options: any, port: string) {
   // TODO: update to support other package managers and frameworks other than NextJS
   await wrapSpawn("npm", ["run", "dev", "--", "-H", options.host, "-p", port], process.cwd());
+}
+
+async function discoverPackageManager(rootdir: string): Promise<SupportedPackageManager> {
+  if (await pathExists(join(rootdir, "pnpm-lock.yaml"))) {
+    return SupportedPackageManager.pnpm;
+  } else if (await pathExists(join(rootdir, "yarn.lock"))) {
+    return SupportedPackageManager.yarn;
+  } else {
+    return SupportedPackageManager.npm;
+  }
+}
+
+enum SupportedPackageManager {
+  npm = 1,
+  yarn,
+  pnpm,
 }

--- a/src/emulator/apphosting/utils.spec.ts
+++ b/src/emulator/apphosting/utils.spec.ts
@@ -1,0 +1,54 @@
+import * as fs from "fs-extra";
+import * as sinon from "sinon";
+import { PackageManager, discoverPackageManager } from "./utils";
+import { expect } from "chai";
+
+describe("utils", () => {
+  let pathExistsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    pathExistsStub = sinon.stub(fs, "pathExists");
+  });
+
+  afterEach(() => {
+    pathExistsStub.restore();
+  });
+
+  describe("discoverPackageManager", () => {
+    it("returns npm if package-lock.json file fond", async () => {
+      pathExistsStub.callsFake((...args) => {
+        if (args[0] === "package-lock.json") {
+          return true;
+        }
+
+        return false;
+      });
+
+      expect(await discoverPackageManager("./")).to.equal(PackageManager.npm);
+    });
+
+    it("returns pnpm if pnpm-lock.json file fond", async () => {
+      pathExistsStub.callsFake((...args) => {
+        if (args[0] === "pnpm-lock.yaml") {
+          return true;
+        }
+
+        return false;
+      });
+
+      expect(await discoverPackageManager("./")).to.equal(PackageManager.pnpm);
+    });
+  });
+
+  it("returns yarn if yarn.lock file fond", async () => {
+    pathExistsStub.callsFake((...args) => {
+      if (args[0] === "yarn.lock") {
+        return true;
+      }
+
+      return false;
+    });
+
+    expect(await discoverPackageManager("./")).to.equal(PackageManager.yarn);
+  });
+});

--- a/src/emulator/apphosting/utils.spec.ts
+++ b/src/emulator/apphosting/utils.spec.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra";
 import * as sinon from "sinon";
-import { PackageManager, discoverPackageManager } from "./utils";
+import { discoverPackageManager } from "./utils";
 import { expect } from "chai";
 
 describe("utils", () => {
@@ -24,7 +24,7 @@ describe("utils", () => {
         return false;
       });
 
-      expect(await discoverPackageManager("./")).to.equal(PackageManager.npm);
+      expect(await discoverPackageManager("./")).to.equal("npm");
     });
 
     it("returns pnpm if pnpm-lock.json file fond", async () => {
@@ -36,7 +36,7 @@ describe("utils", () => {
         return false;
       });
 
-      expect(await discoverPackageManager("./")).to.equal(PackageManager.pnpm);
+      expect(await discoverPackageManager("./")).to.equal("pnpm");
     });
   });
 
@@ -49,6 +49,6 @@ describe("utils", () => {
       return false;
     });
 
-    expect(await discoverPackageManager("./")).to.equal(PackageManager.yarn);
+    expect(await discoverPackageManager("./")).to.equal("yarn");
   });
 });

--- a/src/emulator/apphosting/utils.ts
+++ b/src/emulator/apphosting/utils.ts
@@ -1,7 +1,10 @@
 import { pathExists } from "fs-extra";
 import { join } from "path";
 
-enum PackageManager {
+/**
+ * Exported for unit testing
+ */
+export enum PackageManager {
   npm = "npm",
   yarn = "yarn",
   pnpm = "pnpm",

--- a/src/emulator/apphosting/utils.ts
+++ b/src/emulator/apphosting/utils.ts
@@ -10,6 +10,11 @@ export enum PackageManager {
   pnpm = "pnpm",
 }
 
+/**
+ * Returns the package manager used by the project
+ * @param rootdir project's root directory
+ * @returns PackageManager
+ */
 export async function discoverPackageManager(rootdir: string): Promise<PackageManager> {
   if (await pathExists(join(rootdir, "pnpm-lock.yaml"))) {
     return PackageManager.pnpm;

--- a/src/emulator/apphosting/utils.ts
+++ b/src/emulator/apphosting/utils.ts
@@ -1,11 +1,5 @@
 import { pathExists } from "fs-extra";
 import { join } from "path";
-import { sync as spawnSync } from "cross-spawn";
-
-interface ProjectSetUp {
-  packageManager: PackageManager;
-  framework?: SupportedFramework;
-}
 
 enum PackageManager {
   npm = "npm",
@@ -13,31 +7,7 @@ enum PackageManager {
   pnpm = "pnpm",
 }
 
-enum SupportedFramework {
-  next = "next",
-  angular = "angular",
-}
-
-const NPM_ROOT_TIMEOUT_MILLIES = 5_000;
-const NPM_ROOT_MEMO = new Map<string, string>();
-const NPM_COMMAND_TIMEOUT_MILLIES = 10_000;
-
-export async function discover(): Promise<ProjectSetUp> {
-  const rootDir = process.cwd();
-  const packageManager = await discoverPackageManager(rootDir);
-
-  const frameworks = Object.values(SupportedFramework);
-  for (let framework of frameworks) {
-    const frameWorkExists = await checkForFramework(framework, packageManager);
-    if (frameWorkExists) {
-      return { packageManager, framework };
-    }
-  }
-
-  return { packageManager };
-}
-
-async function discoverPackageManager(rootdir: string): Promise<PackageManager> {
+export async function discoverPackageManager(rootdir: string): Promise<PackageManager> {
   if (await pathExists(join(rootdir, "pnpm-lock.yaml"))) {
     return PackageManager.pnpm;
   }
@@ -47,78 +17,4 @@ async function discoverPackageManager(rootdir: string): Promise<PackageManager> 
   }
 
   return PackageManager.npm;
-}
-
-async function checkForFramework(
-  framework: SupportedFramework,
-  packageManager: PackageManager,
-): Promise<boolean> {
-  switch (packageManager) {
-    case PackageManager.npm:
-      if (findNPMDependency(framework)) {
-        return true;
-      }
-    default:
-      return false;
-  }
-}
-
-interface FindDepOptions {
-  cwd: string;
-  depth?: number;
-  omitDev: boolean;
-}
-
-const DEFAULT_FIND_DEP_OPTIONS: FindDepOptions = {
-  cwd: process.cwd(),
-  omitDev: true,
-};
-
-export function findNPMDependency(name: string, options: Partial<FindDepOptions> = {}) {
-  const { cwd: dir, depth, omitDev } = { ...DEFAULT_FIND_DEP_OPTIONS, ...options };
-  const cwd = getNpmRoot(dir);
-  if (!cwd) return;
-  const env: any = Object.assign({}, process.env);
-  delete env.NODE_ENV;
-  const result = spawnSync(
-    "npm",
-    [
-      "list",
-      name,
-      "--json=true",
-      ...(omitDev ? ["--omit", "dev"] : []),
-      ...(depth === undefined ? [] : ["--depth", depth.toString(10)]),
-    ],
-    { cwd, env, timeout: NPM_COMMAND_TIMEOUT_MILLIES },
-  );
-  if (!result.stdout) return;
-  const json = JSON.parse(result.stdout.toString());
-  return scanDependencyTree(name, json.dependencies);
-}
-
-function scanDependencyTree(searchingFor: string, dependencies = {}): any {
-  for (const [name, dependency] of Object.entries(
-    dependencies as Record<string, Record<string, any>>,
-  )) {
-    if (name === searchingFor) return dependency;
-    const result = scanDependencyTree(searchingFor, dependency.dependencies);
-    if (result) return result;
-  }
-  return;
-}
-
-export function getNpmRoot(cwd: string) {
-  let npmRoot = NPM_ROOT_MEMO.get(cwd);
-  if (npmRoot) return npmRoot;
-
-  npmRoot = spawnSync("npm", ["root"], {
-    cwd,
-    timeout: NPM_ROOT_TIMEOUT_MILLIES,
-  })
-    .stdout?.toString()
-    .trim();
-
-  NPM_ROOT_MEMO.set(cwd, npmRoot);
-
-  return npmRoot;
 }

--- a/src/emulator/apphosting/utils.ts
+++ b/src/emulator/apphosting/utils.ts
@@ -4,11 +4,7 @@ import { join } from "path";
 /**
  * Exported for unit testing
  */
-export enum PackageManager {
-  npm = "npm",
-  yarn = "yarn",
-  pnpm = "pnpm",
-}
+export type PackageManager = "npm" | "yarn" | "pnpm";
 
 /**
  * Returns the package manager used by the project
@@ -17,12 +13,12 @@ export enum PackageManager {
  */
 export async function discoverPackageManager(rootdir: string): Promise<PackageManager> {
   if (await pathExists(join(rootdir, "pnpm-lock.yaml"))) {
-    return PackageManager.pnpm;
+    return "pnpm";
   }
 
   if (await pathExists(join(rootdir, "yarn.lock"))) {
-    return PackageManager.yarn;
+    return "yarn";
   }
 
-  return PackageManager.npm;
+  return "npm";
 }

--- a/src/emulator/apphosting/utils.ts
+++ b/src/emulator/apphosting/utils.ts
@@ -1,0 +1,124 @@
+import { pathExists } from "fs-extra";
+import { join } from "path";
+import { sync as spawnSync } from "cross-spawn";
+
+interface ProjectSetUp {
+  packageManager: PackageManager;
+  framework?: SupportedFramework;
+}
+
+enum PackageManager {
+  npm = "npm",
+  yarn = "yarn",
+  pnpm = "pnpm",
+}
+
+enum SupportedFramework {
+  next = "next",
+  angular = "angular",
+}
+
+const NPM_ROOT_TIMEOUT_MILLIES = 5_000;
+const NPM_ROOT_MEMO = new Map<string, string>();
+const NPM_COMMAND_TIMEOUT_MILLIES = 10_000;
+
+export async function discover(): Promise<ProjectSetUp> {
+  const rootDir = process.cwd();
+  const packageManager = await discoverPackageManager(rootDir);
+
+  const frameworks = Object.values(SupportedFramework);
+  for (let framework of frameworks) {
+    const frameWorkExists = await checkForFramework(framework, packageManager);
+    if (frameWorkExists) {
+      return { packageManager, framework };
+    }
+  }
+
+  return { packageManager };
+}
+
+async function discoverPackageManager(rootdir: string): Promise<PackageManager> {
+  if (await pathExists(join(rootdir, "pnpm-lock.yaml"))) {
+    return PackageManager.pnpm;
+  }
+
+  if (await pathExists(join(rootdir, "yarn.lock"))) {
+    return PackageManager.yarn;
+  }
+
+  return PackageManager.npm;
+}
+
+async function checkForFramework(
+  framework: SupportedFramework,
+  packageManager: PackageManager,
+): Promise<boolean> {
+  switch (packageManager) {
+    case PackageManager.npm:
+      if (findNPMDependency(framework)) {
+        return true;
+      }
+    default:
+      return false;
+  }
+}
+
+interface FindDepOptions {
+  cwd: string;
+  depth?: number;
+  omitDev: boolean;
+}
+
+const DEFAULT_FIND_DEP_OPTIONS: FindDepOptions = {
+  cwd: process.cwd(),
+  omitDev: true,
+};
+
+export function findNPMDependency(name: string, options: Partial<FindDepOptions> = {}) {
+  const { cwd: dir, depth, omitDev } = { ...DEFAULT_FIND_DEP_OPTIONS, ...options };
+  const cwd = getNpmRoot(dir);
+  if (!cwd) return;
+  const env: any = Object.assign({}, process.env);
+  delete env.NODE_ENV;
+  const result = spawnSync(
+    "npm",
+    [
+      "list",
+      name,
+      "--json=true",
+      ...(omitDev ? ["--omit", "dev"] : []),
+      ...(depth === undefined ? [] : ["--depth", depth.toString(10)]),
+    ],
+    { cwd, env, timeout: NPM_COMMAND_TIMEOUT_MILLIES },
+  );
+  if (!result.stdout) return;
+  const json = JSON.parse(result.stdout.toString());
+  return scanDependencyTree(name, json.dependencies);
+}
+
+function scanDependencyTree(searchingFor: string, dependencies = {}): any {
+  for (const [name, dependency] of Object.entries(
+    dependencies as Record<string, Record<string, any>>,
+  )) {
+    if (name === searchingFor) return dependency;
+    const result = scanDependencyTree(searchingFor, dependency.dependencies);
+    if (result) return result;
+  }
+  return;
+}
+
+export function getNpmRoot(cwd: string) {
+  let npmRoot = NPM_ROOT_MEMO.get(cwd);
+  if (npmRoot) return npmRoot;
+
+  npmRoot = spawnSync("npm", ["root"], {
+    cwd,
+    timeout: NPM_ROOT_TIMEOUT_MILLIES,
+  })
+    .stdout?.toString()
+    .trim();
+
+  NPM_ROOT_MEMO.set(cwd, npmRoot);
+
+  return npmRoot;
+}

--- a/src/init/spawn.ts
+++ b/src/init/spawn.ts
@@ -1,11 +1,17 @@
 import * as spawn from "cross-spawn";
 import { logger } from "../logger";
 
-export function wrapSpawn(cmd: string, args: string[], projectDir: string): Promise<void> {
+export function wrapSpawn(
+  cmd: string,
+  args: string[],
+  projectDir: string,
+  environmentVariables?: any,
+): Promise<void> {
   return new Promise<void>((resolve, reject) => {
     const installer = spawn(cmd, args, {
       cwd: projectDir,
       stdio: "inherit",
+      env: { ...process.env, ...environmentVariables },
     });
 
     installer.on("error", (err: any) => {


### PR DESCRIPTION
App hosting emulator will detect the package manager and run it's dev command on `firebase emulators:start`

Supported package managers:
1. npm
2. pnpm
3. yarn