### PR TITLE
Modernize `use.ts` and stop requiring auth for use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- `firebase use <project> --alias <alias>` no longer requires `firebase login`. (#7624)

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -71,7 +71,7 @@ export const command = new Command("use [alias_or_project_id]")
       const resolvedProject = options.rc.resolveAlias(newActive);
       validateProjectId(resolvedProject);
       if (!Constants.isDemoProject(resolvedProject)) {
-        project = await getFirebaseProject(resolvedProject) 
+        project = await getFirebaseProject(resolvedProject);
       }
       if (aliasOpt) {
         // firebase use [project] --alias [alias]


### PR DESCRIPTION
### Description
Modernized 'use.ts' to use async/await, and make `firebase use` work when not logged in. In cases where users don't actually have access to the project, they'll hit normal auth errors later when they execute commands, which is fine.
