### PR TITLE
Skip Gen sdk prompt during `init dataconnect` if no platform is detected

### DIFF
--- a/firebase-vscode/src/data-connect/sdk-generation.ts
+++ b/firebase-vscode/src/data-connect/sdk-generation.ts
@@ -142,7 +142,7 @@ export function registerFdcSdkGeneration(
   ) {
     const platform = await getPlatformFromFolder(appFolder);
     // if app platform undetermined, run init command
-    if (platform === Platform.UNDETERMINED) {
+    if (platform === Platform.NONE || platform === Platform.MULTIPLE) {
       vscode.window.showErrorMessage(
         "Could not determine platform for specified app folder. Configuring from command line.",
       );

--- a/src/dataconnect/fileUtils.spec.ts
+++ b/src/dataconnect/fileUtils.spec.ts
@@ -15,19 +15,19 @@ describe("getPlatformFromFolder", () => {
       desc: "Empty folder",
       folderName: "test/",
       folderItems: {},
-      output: Platform.UNDETERMINED,
+      output: Platform.NONE,
     },
     {
       desc: "Empty folder, long path name",
       folderName: "root/abcd/test/",
       folderItems: {},
-      output: Platform.UNDETERMINED,
+      output: Platform.NONE,
     },
     {
       desc: "folder w/ no identifier",
       folderName: "test/",
       folderItems: { file1: "contents", randomfile2: "my android contents" },
-      output: Platform.UNDETERMINED,
+      output: Platform.NONE,
     },
     {
       desc: "Web identifier 1",
@@ -108,7 +108,7 @@ describe("getPlatformFromFolder", () => {
       folderItems: {
         "pubspec.mispelled": "my deps",
       },
-      output: Platform.UNDETERMINED,
+      output: Platform.NONE,
     },
     {
       desc: "multiple identifiers, returns undetermined",
@@ -118,7 +118,7 @@ describe("getPlatformFromFolder", () => {
         podfile: "cocoa pods yummy",
         "androidmanifest.xml": "file found second :(",
       },
-      output: Platform.UNDETERMINED,
+      output: Platform.MULTIPLE,
     },
   ];
   for (const c of cases) {

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -134,7 +134,9 @@ export async function getPlatformFromFolder(dirPath: string) {
       IOS_POSTFIX_INDICATORS.some((indicator) => cleanedFileName.endsWith(indicator));
     hasDart ||= DART_INDICATORS.some((indicator) => indicator === cleanedFileName);
   }
-  if (hasWeb && !hasAndroid && !hasIOS && !hasDart) {
+  if (!hasWeb && !hasAndroid && !hasIOS && !hasDart) {
+    return Platform.NONE;
+  } else if (hasWeb && !hasAndroid && !hasIOS && !hasDart) {
     return Platform.WEB;
   } else if (hasAndroid && !hasWeb && !hasIOS && !hasDart) {
     return Platform.ANDROID;
@@ -144,8 +146,8 @@ export async function getPlatformFromFolder(dirPath: string) {
     return Platform.DART;
   }
   // At this point, its not clear which platform the app directory is
-  // (either because we found no indicators, or indicators for multiple platforms)
-  return Platform.UNDETERMINED;
+  // because we found indicators for multiple platforms.
+  return Platform.MULTIPLE;
 }
 
 export async function directoryHasPackageJson(dirPath: string) {

--- a/src/dataconnect/types.ts
+++ b/src/dataconnect/types.ts
@@ -155,11 +155,12 @@ export interface DartSDK {
 }
 
 export enum Platform {
+  NONE = "NONE",
   ANDROID = "ANDROID",
   WEB = "WEB",
   IOS = "IOS",
   DART = "DART",
-  UNDETERMINED = "UNDETERMINED",
+  MULTIPLE = "MULTIPLE",
 }
 
 // Helper types && converters

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -73,17 +73,9 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   if (cwdPlatformGuess !== Platform.UNDETERMINED) {
     await sdk.doSetup(setup, config);
   } else {
-    const promptForSDKGeneration = await confirm({
-      message: `Would you like to configure generated SDKs now?`,
-      default: false,
-    });
-    if (promptForSDKGeneration) {
-      await sdk.doSetup(setup, config);
-    } else {
-      logBullet(
-        `If you'd like to generate an SDK for your new connector later, run ${clc.bold("firebase init dataconnect:sdk")}`,
-      );
-    }
+    logBullet(
+      `If you'd like to generate an SDK for your new connector later, run ${clc.bold("firebase init dataconnect:sdk")}`,
+    );
   }
 
   logger.info("");

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -70,7 +70,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   await actuate(setup, config, info);
 
   const cwdPlatformGuess = await getPlatformFromFolder(process.cwd());
-  if (cwdPlatformGuess !== Platform.UNDETERMINED) {
+  if (cwdPlatformGuess !== Platform.NONE) {
     await sdk.doSetup(setup, config);
   } else {
     logBullet(

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -74,7 +74,7 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
     await sdk.doSetup(setup, config);
   } else {
     logBullet(
-      `If you'd like to generate an SDK for your new connector later, run ${clc.bold("firebase init dataconnect:sdk")}`,
+      `If you'd like to add the generated SDK to your app your later, run ${clc.bold("firebase init dataconnect:sdk")}`,
     );
   }
 

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -67,15 +67,13 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
   // First, lets check if we are in an app directory
   let appDir = process.env[FDC_APP_FOLDER] || process.cwd();
   let targetPlatform = await getPlatformFromFolder(appDir);
-  if (targetPlatform === Platform.NONE) {
+  if (targetPlatform === Platform.NONE && !process.env[FDC_APP_FOLDER]?.length) {
     // If we aren't in an app directory, ask the user where their app is, and try to autodetect from there.
-    appDir =
-      process.env[FDC_APP_FOLDER] ||
-      (await promptForDirectory({
-        config,
-        message:
-          "Where is your app directory? Leave blank to set up a generated SDK in your current directory.",
-      }));
+    appDir = await promptForDirectory({
+      config,
+      message:
+        "Where is your app directory? Leave blank to set up a generated SDK in your current directory.",
+    });
     targetPlatform = await getPlatformFromFolder(appDir);
   }
   if (targetPlatform === Platform.NONE || targetPlatform === Platform.MULTIPLE) {

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -64,43 +64,40 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
     );
   }
 
-  // First, lets check if we are in a app directory
-  let targetPlatform: Platform = Platform.UNDETERMINED;
+  // First, lets check if we are in an app directory
   let appDir = process.env[FDC_APP_FOLDER] || process.cwd();
-  const cwdPlatformGuess = await getPlatformFromFolder(appDir);
-  if (cwdPlatformGuess !== Platform.UNDETERMINED) {
-    // If we are, we'll use that directory
-    logSuccess(`Detected ${cwdPlatformGuess} app in directory ${appDir}`);
-    targetPlatform = cwdPlatformGuess;
-  } else {
-    // If we aren't, ask the user where their app is, and try to autodetect from there
-    logBullet(`Couldn't automatically detect your app directory.`);
+  let targetPlatform = await getPlatformFromFolder(appDir);
+  if (targetPlatform === Platform.NONE) {
+    // If we aren't in an app directory, ask the user where their app is, and try to autodetect from there.
     appDir =
-      process.env[FDC_APP_FOLDER] ??
+      process.env[FDC_APP_FOLDER] ||
       (await promptForDirectory({
         config,
         message:
           "Where is your app directory? Leave blank to set up a generated SDK in your current directory.",
       }));
-    const platformGuess = await getPlatformFromFolder(appDir);
-    if (platformGuess !== Platform.UNDETERMINED) {
-      logSuccess(`Detected ${platformGuess} app in directory ${appDir}`);
-      targetPlatform = platformGuess;
+    targetPlatform = await getPlatformFromFolder(appDir);
+  }
+  if (targetPlatform === Platform.NONE || targetPlatform === Platform.MULTIPLE) {
+    if (targetPlatform === Platform.NONE) {
+      logBullet(`Couldn't automatically detect app your in directory ${appDir}.`);
     } else {
-      // If we still can't autodetect, just ask the user
-      logBullet("Couldn't automatically detect your app's platform.");
-      const platforms = [
-        { name: "iOS (Swift)", value: Platform.IOS },
-        { name: "Web (JavaScript)", value: Platform.WEB },
-        { name: "Android (Kotlin)", value: Platform.ANDROID },
-        { name: "Flutter (Dart)", value: Platform.DART },
-      ];
-      targetPlatform = await promptOnce({
-        message: "Which platform do you want to set up a generated SDK for?",
-        type: "list",
-        choices: platforms,
-      });
+      logSuccess(`Detected multiple app platforms in directory ${appDir}`);
+      // Can only setup one platform at a time, just ask the user
     }
+    const platforms = [
+      { name: "iOS (Swift)", value: Platform.IOS },
+      { name: "Web (JavaScript)", value: Platform.WEB },
+      { name: "Android (Kotlin)", value: Platform.ANDROID },
+      { name: "Flutter (Dart)", value: Platform.DART },
+    ];
+    targetPlatform = await promptOnce({
+      message: "Which platform do you want to set up a generated SDK for?",
+      type: "list",
+      choices: platforms,
+    });
+  } else {
+    logSuccess(`Detected ${targetPlatform} app in directory ${appDir}`);
   }
 
   const connectorInfo: ConnectorInfo = await promptOnce({


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Chatting with Charlotte. If we are adding "Answer No to Generated SDK question" to instructions. This question provides negative value. Print instruction would work well.

1. `firebase init dataconnect` would only configure SDK if some app sis detected.
2. Improved sdk init logging. Call out whether none or multiple platforms are detected.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
