### PR TITLE
Add App Hosting as an option for firebase init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Added emulator support for SDK defined extensions.
 - Fixed various trigger handling issues in the Functions emualtor, including an issue where Eventarc functions would not be emulated correctly after a reload.
 - Added support for generating Dart SDKs for Data Connect connectors.
+- Added App Hosting as an option for firebase init. (#7803)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -87,6 +87,12 @@ let choices: {
     checked: false,
     hidden: true,
   },
+  {
+    value: "apphosting",
+    name: "App Hosting: Configure an apphosting.yaml file for App Hosting",
+    checked: false,
+    hidden: false,
+  },
 ];
 
 if (isEnabled("genkit")) {

--- a/src/init/features/apphosting.ts
+++ b/src/init/features/apphosting.ts
@@ -1,0 +1,16 @@
+import * as clc from "colorette";
+import * as utils from "../../utils";
+import { Options } from "../../options";
+import { Config } from "../../config";
+import { readTemplateSync } from "../../templates";
+
+const APPHOSTING_YAML_TEMPLATE = readTemplateSync("init/apphosting/apphosting.yaml");
+
+/**
+ * Set up an apphosting.yaml file for a new App Hosting project.
+ */
+export async function doSetup(setup: any, config: Config, options: Options): Promise<void> {
+  const path = `apphosting.yaml`;
+  utils.logBullet("Writing default settings to " + clc.bold("apphosting.yaml") + "...");
+  await config.askWriteProjectFile(path, APPHOSTING_YAML_TEMPLATE);
+}

--- a/src/init/features/apphosting.ts
+++ b/src/init/features/apphosting.ts
@@ -1,6 +1,5 @@
 import * as clc from "colorette";
 import * as utils from "../../utils";
-import { Options } from "../../options";
 import { Config } from "../../config";
 import { readTemplateSync } from "../../templates";
 
@@ -9,7 +8,7 @@ const APPHOSTING_YAML_TEMPLATE = readTemplateSync("init/apphosting/apphosting.ya
 /**
  * Set up an apphosting.yaml file for a new App Hosting project.
  */
-export async function doSetup(setup: any, config: Config, options: Options): Promise<void> {
+export async function doSetup(setup: any, config: Config): Promise<void> {
   const path = `apphosting.yaml`;
   utils.logBullet("Writing default settings to " + clc.bold("apphosting.yaml") + "...");
   await config.askWriteProjectFile(path, APPHOSTING_YAML_TEMPLATE);

--- a/src/init/features/apphosting.ts
+++ b/src/init/features/apphosting.ts
@@ -9,7 +9,6 @@ const APPHOSTING_YAML_TEMPLATE = readTemplateSync("init/apphosting/apphosting.ya
  * Set up an apphosting.yaml file for a new App Hosting project.
  */
 export async function doSetup(setup: any, config: Config): Promise<void> {
-  const path = `apphosting.yaml`;
   utils.logBullet("Writing default settings to " + clc.bold("apphosting.yaml") + "...");
-  await config.askWriteProjectFile(path, APPHOSTING_YAML_TEMPLATE);
+  await config.askWriteProjectFile("apphosting.yaml", APPHOSTING_YAML_TEMPLATE);
 }

--- a/src/init/features/index.ts
+++ b/src/init/features/index.ts
@@ -12,5 +12,5 @@ export { doSetup as remoteconfig } from "./remoteconfig";
 export { initGitHub as hostingGithub } from "./hosting/github";
 export { doSetup as dataconnect } from "./dataconnect";
 export { doSetup as dataconnectSdk } from "./dataconnect/sdk";
-export { doSetup as apphosting } from "../../apphosting";
+export { doSetup as apphosting } from "./apphosting";
 export { doSetup as genkit } from "./genkit";

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -32,6 +32,7 @@ const featureFns = new Map<string, (setup: any, config: any, options?: any) => P
   ["remoteconfig", features.remoteconfig],
   ["hosting:github", features.hostingGithub],
   ["genkit", features.genkit],
+  ["apphosting", features.apphosting],
 ]);
 
 export async function init(setup: Setup, config: any, options: any): Promise<any> {

--- a/templates/init/apphosting/apphosting.yaml
+++ b/templates/init/apphosting/apphosting.yaml
@@ -1,0 +1,23 @@
+# Settings for Backend (on Cloud Run).
+# See https://firebase.google.com/docs/app-hosting/configure#cloud-run
+runConfig:
+  minInstances: 0
+  # maxInstances: 100
+  # concurrency: 80
+  # cpu: 1
+  # memoryMiB: 512
+
+# Environment variables and secrets.
+# env:
+  # Configure environment variables.
+  # See https://firebase.google.com/docs/app-hosting/configure#user-defined-environment
+  # - variable: MESSAGE
+  #   value: Hello world!
+  #   availability:
+  #     - BUILD
+  #     - RUNTIME
+
+  # Grant access to secrets in Cloud Secret Manager.
+  # See https://firebase.google.com/docs/app-hosting/configure#secret-parameters
+  # - variable: MY_SECRET
+  #   secret: mySecretRef


### PR DESCRIPTION
Today, all `firebase init apphosting` does is write an apphosting.yaml file with default settings to the app directory.