### PR TITLE
Updated to Data connect emulator 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Fixed various trigger handling issues in the Functions emualtor, including an issue where Eventarc functions would not be emulated correctly after a reload.
 - Added support for generating Dart SDKs for Data Connect connectors.
 - Commands now correctly default to 'default' alias when there is more than one alias listed. (#7624)
+- Updated Data Connect emulator to v1.15.0, which includes bug fixes for `insertMany` and improved error handling .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 - Fixed various trigger handling issues in the Functions emualtor, including an issue where Eventarc functions would not be emulated correctly after a reload.
 - Added support for generating Dart SDKs for Data Connect connectors.
 - Commands now correctly default to 'default' alias when there is more than one alias listed. (#7624)
-- Updated Data Connect emulator to v1.15.0, which includes bug fixes for `insertMany` and improved error handling .
+- Updated Data Connect emulator to v1.15.0, which includes bug fixes for `insertMany` and improved error handling.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -59,20 +59,20 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
   dataconnect:
     process.platform === "darwin"
       ? {
-          version: "1.4.4",
-          expectedSize: 25142016,
-          expectedChecksum: "9b071275feaba21e04bbb0db842f945d",
+          version: "1.5.0",
+          expectedSize: 25215744,
+          expectedChecksum: "670ad771cf36b07c52a71f580df89994",
         }
       : process.platform === "win32"
         ? {
-            version: "1.4.4",
-            expectedSize: 25567744,
-            expectedChecksum: "d23bf88b04a09d666ae927a107317611",
+            version: "1.5.0",
+            expectedSize: 25643520,
+            expectedChecksum: "b565e4609f08eb2299b7bec7e0cac0dc",
           }
         : {
-            version: "1.4.4",
-            expectedSize: 25055384,
-            expectedChecksum: "9c04a6c4738088305eb1a7b2a5d34df4",
+            version: "1.5.0",
+            expectedSize: 25129112,
+            expectedChecksum: "9a08671b89f557d096c075f6a5ac87db",
           },
 };
 


### PR DESCRIPTION


### Description
Updated to Data connect emulator 1.5.0

Full emulator changelog: 
- [changed] Improve error messages of unsupported directives on GQL
- [fixed] Surface GQL errors next on the field lines.
- [changed] Mutations w/o `@transaction` execute all steps and surface partial errors.
- [added] Generate a Readme for Swift generated code documenting the connector Swift API.
- [fixed] In `@auth(expr:)` expressions, UUIDs are now converted to strings in the FDC canonical format (32 lower-case hex digits with no delimiters or curly braces).
- [fixed] Generate schema extensions even when the connectors are invalid.
- [fixed] `_insertMany` now correctly applies column `@default` values.
- [internal] Remove confusing logs from `packageJsonDir` when package.json is missing.