### PR TITLE
Always include the default template the data connect

### DIFF
--- a/src/init/features/dataconnect/index.spec.ts
+++ b/src/init/features/dataconnect/index.spec.ts
@@ -35,15 +35,21 @@ describe("init dataconnect", () => {
       expectCSQLProvisioning: boolean;
     }[] = [
       {
-        desc: "should default to dataconnect directory",
+        desc: "empty project should generate template",
         requiredInfo: mockRequiredInfo(),
         config: mockConfig(),
         expectedSource: "dataconnect",
-        expectedFiles: ["dataconnect/dataconnect.yaml"],
+        expectedFiles: [
+          "dataconnect/dataconnect.yaml",
+          "dataconnect/schema/schema.gql",
+          "dataconnect/connector/connector.yaml",
+          "dataconnect/connector/queries.gql",
+          "dataconnect/connector/mutations.gql",
+        ],
         expectCSQLProvisioning: false,
       },
       {
-        desc: "should use existing directory if there is one in firebase.json",
+        desc: "exiting project should use existing directory",
         requiredInfo: mockRequiredInfo(),
         config: mockConfig({ dataconnect: { source: "not-dataconnect" } }),
         expectedSource: "not-dataconnect",
@@ -97,7 +103,13 @@ describe("init dataconnect", () => {
         }),
         config: mockConfig({}),
         expectedSource: "dataconnect",
-        expectedFiles: ["dataconnect/dataconnect.yaml"],
+        expectedFiles: [
+          "dataconnect/dataconnect.yaml",
+          "dataconnect/schema/schema.gql",
+          "dataconnect/connector/connector.yaml",
+          "dataconnect/connector/queries.gql",
+          "dataconnect/connector/mutations.gql",
+        ],
         expectCSQLProvisioning: true,
       },
     ];

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -173,7 +173,8 @@ async function writeFiles(config: Config, info: RequiredInfo) {
   });
   // If we are starting from a fresh project without data connect,
   if (!config.get("dataconnect.source")) {
-    // If the existing service is empty (no schema / connector GQL), include the template.
+    // Make sure to add add some GQL files.
+    // Use the template if the existing service is empty (no schema / connector GQL).
     if (!info.schemaGql.length && !info.connectors.flatMap((r) => r.files).length) {
       info.schemaGql = [defaultSchema];
       info.connectors = [defaultConnector];

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -171,6 +171,14 @@ async function writeFiles(config: Config, info: RequiredInfo) {
     ...info,
     connectorDirs: info.connectors.map((c) => c.path),
   });
+  // If we are starting from a fresh project without data connect,
+  if (!config.get("dataconnect.source")) {
+    // If the existing service is empty (no schema / connector GQL), include the template.
+    if (!info.schemaGql.length && !info.connectors.flatMap((r) => r.files).length) {
+      info.schemaGql = [defaultSchema];
+      info.connectors = [defaultConnector];
+    }
+  }
 
   config.set("dataconnect", { source: dir });
   await config.askWriteProjectFile(


### PR DESCRIPTION
Pick up new empty service from console.

From an empty folder
<img width="1212" alt="Screenshot 2024-10-08 at 1 36 05 PM" src="https://github.com/user-attachments/assets/eb65e451-0d63-4e3b-b322-1e71381344a7">


From a Firebase project already has `dataconnect`.
<img width="1212" alt="Screenshot 2024-10-08 at 1 37 14 PM" src="https://github.com/user-attachments/assets/b3108b21-2188-4f85-ba99-7fe8c5c4ff79">
