### PR TITLE
Better error when incorrect project ID is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixed Flutter web apps that might require the --no-tree-shake-icons flag in order to build. (#7724)
+- Fixed an issue where the Extensions emulator would fail silently if started with a non-existant project without the `demo-` prefix. (#7779)

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -352,9 +352,21 @@ export async function startAll(
   // the Functions emulator needs to start.
   let extensionEmulator: ExtensionsEmulator | undefined = undefined;
   if (shouldStart(options, Emulators.EXTENSIONS)) {
-    const projectNumber = isDemoProject
-      ? Constants.FAKE_PROJECT_NUMBER
-      : await needProjectNumber(options);
+    let projectNumber = Constants.FAKE_PROJECT_NUMBER;
+    if (!isDemoProject) {
+      try {
+        projectNumber = await needProjectNumber(options);
+      } catch (err: any) {
+        EmulatorLogger.forEmulator(Emulators.EXTENSIONS).logLabeled(
+          "ERROR",
+          Emulators.EXTENSIONS,
+          `Unable to look up project number for ${options.project}.\n` +
+            " If this is a real project, ensure that you are logged in and have access to it.\n" +
+            " If this is a fake project, please use a project ID starting with 'demo-' to skip production calls.\n" +
+            " Continuing with a fake project number - secrets and other features that require production access may behave unexpectedly.",
+        );
+      }
+    }
     const aliases = getAliases(options, projectId);
     extensionEmulator = new ExtensionsEmulator({
       options,

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -119,9 +119,11 @@ export async function getFirebaseProjectParams(
   if (!projectId) {
     return {};
   }
+  console.log("we getting config");
   const body = emulatorMode
     ? await getProjectAdminSdkConfigOrCached(projectId)
     : await getFirebaseConfig({ project: projectId });
+  console.log("we getting params");
   const projectNumber =
     emulatorMode && Constants.isDemoProject(projectId)
       ? Constants.FAKE_PROJECT_NUMBER

--- a/src/extensions/extensionsHelper.ts
+++ b/src/extensions/extensionsHelper.ts
@@ -36,7 +36,7 @@ import * as refs from "./refs";
 import { EXTENSIONS_SPEC_FILE, readFile, getLocalExtensionSpec } from "./localHelper";
 import { confirm, promptOnce } from "../prompt";
 import { logger } from "../logger";
-import { envOverride, logLabeledWarning } from '../utils';
+import { envOverride, logLabeledError } from "../utils";
 import { getLocalChangelog } from "./change-log";
 import { getProjectNumber } from "../getProjectNumber";
 import { Constants } from "../emulator/constants";
@@ -126,10 +126,10 @@ export async function getFirebaseProjectParams(
   let projectNumber = Constants.FAKE_PROJECT_NUMBER;
   if (!Constants.isDemoProject(projectId)) {
     try {
-      projectNumber = await getProjectNumber({ projectId });;
+      projectNumber = await getProjectNumber({ projectId });
     } catch (err: any) {
-      logLabeledWarning(
-        "ERROR",
+      logLabeledError(
+        "extensions",
         `Unable to look up project number for ${projectId}.\n` +
           " If this is a real project, ensure that you are logged in and have access to it.\n" +
           " If this is a fake project, please use a project ID starting with 'demo-' to skip production calls.\n" +


### PR DESCRIPTION
### Description
Previously, if you used a fake project ID without the 'demo-' prefix, the emulator suite would crash without a clear message (see #7779). This PR handles those errors more cleanly.

Addresses a side issue we found while working on #7779, but doesn't seem to fix the main issue. Will keep at it.