### PR TITLE
Use FUNCTIONS_DISCOVERY_TIMEOUT when waiting for sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Removed outdated dependency on `rimraf`.
 - Fixed an issue where the Extensions emulator would fail silently if started with a non-existant project without the `demo-` prefix. (#7779)
 - Bumped the Firebase Data Connect local toolkit version to v1.5.1, which adds compatible mode schema migration support to the emulator and fixes an issue with the Timestamp type in Swift codegen. (#7837)
+- Fixed an issue during functions discovery where `FUNCTIONS_DISCOVERY_TIMEOUT` wasn't respected. (#6285)

--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -15,6 +15,10 @@ export const readFileAsync = promisify(fs.readFile);
 
 const TIMEOUT_OVERRIDE_ENV_VAR = "FUNCTIONS_DISCOVERY_TIMEOUT";
 
+export function getFunctionDiscoveryTimeout(): number | undefined {
+  return +(process.env[TIMEOUT_OVERRIDE_ENV_VAR] || 0) * 1000; /* ms */
+}
+
 /**
  * Converts the YAML retrieved from discovery into a Build object for param interpolation.
  */
@@ -75,14 +79,9 @@ export async function detectFromPort(
 ): Promise<build.Build> {
   let res: Response;
   const timedOut = new Promise<never>((resolve, reject) => {
-    setTimeout(
-      () => {
-        reject(
-          new FirebaseError("User code failed to load. Cannot determine backend specification"),
-        );
-      },
-      +(process.env[TIMEOUT_OVERRIDE_ENV_VAR] || 0) * 1000 /* ms */ || timeout,
-    );
+    setTimeout(() => {
+      reject(new FirebaseError("User code failed to load. Cannot determine backend specification"));
+    }, getFunctionDiscoveryTimeout() || timeout);
   });
 
   while (true) {

--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -15,7 +15,7 @@ export const readFileAsync = promisify(fs.readFile);
 
 const TIMEOUT_OVERRIDE_ENV_VAR = "FUNCTIONS_DISCOVERY_TIMEOUT";
 
-export function getFunctionDiscoveryTimeout(): number | undefined {
+export function getFunctionDiscoveryTimeout(): number {
   return +(process.env[TIMEOUT_OVERRIDE_ENV_VAR] || 0) * 1000; /* ms */
 }
 

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -8,6 +8,7 @@ import { EventEmitter } from "events";
 import { EmulatorLogger, ExtensionLogInfo } from "./emulatorLogger";
 import { FirebaseError } from "../error";
 import { Serializable } from "child_process";
+import { getFunctionDiscoveryTimeout } from "../deploy/functions/runtimes/discovery";
 
 type LogListener = (el: EmulatorLog) => any;
 
@@ -264,7 +265,7 @@ export class RuntimeWorker {
     const timeout = new Promise<never>((resolve, reject) => {
       setTimeout(() => {
         reject(new FirebaseError("Failed to load function."));
-      }, 30_000);
+      }, getFunctionDiscoveryTimeout() ?? 30_000);
     });
     while (true) {
       try {

--- a/src/emulator/functionsRuntimeWorker.ts
+++ b/src/emulator/functionsRuntimeWorker.ts
@@ -265,7 +265,7 @@ export class RuntimeWorker {
     const timeout = new Promise<never>((resolve, reject) => {
       setTimeout(() => {
         reject(new FirebaseError("Failed to load function."));
-      }, getFunctionDiscoveryTimeout() ?? 30_000);
+      }, getFunctionDiscoveryTimeout() || 30_000);
     });
     while (true) {
       try {


### PR DESCRIPTION
### Description
Fixed an issue during functions discovery where `FUNCTIONS_DISCOVERY_TIMEOUT` wasn't respected. Thanks @ErlikC for finding this fix! 

Fixes #6285.
