### PR TITLE
Improved handling when `emulators:export` cannot read the metadata file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Removed outdated dependency on `rimraf`.
 - Fixed an issue where the Extensions emulator would fail silently if started with a non-existant project without the `demo-` prefix. (#7779)
 - Bumped the Firebase Data Connect local toolkit version to v1.5.1, which adds compatible mode schema migration support to the emulator and fixes an issue with the Timestamp type in Swift codegen. (#7837)
+- Improved handling when `emulators:export` cannot read the metadata file.

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -70,9 +70,9 @@ export class HubExport {
     try {
       mdString = fs.readFileSync(metadataPath, "utf8").toString();
       return JSON.parse(mdString) as ExportMetadata;
-    } catch(err: any) {
+    } catch (err: any) {
       // JSON parse errors are unreadable. Throw the original.
-      throw new FirebaseError(`Unable to parse metadata file ${metadataPath}: ${mdString});
+      throw new FirebaseError(`Unable to parse metadata file ${metadataPath}: ${mdString}`);
     }
   }
 

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -66,8 +66,14 @@ export class HubExport {
     if (!fs.existsSync(metadataPath)) {
       return undefined;
     }
-
-    return JSON.parse(fs.readFileSync(metadataPath, "utf8").toString()) as ExportMetadata;
+    let mdString: string = "";
+    try {
+      mdString = fs.readFileSync(metadataPath, "utf8").toString();
+      return JSON.parse(mdString) as ExportMetadata;
+    } catch(err: any) {
+      // JSON parse errors are unreadable. Throw the original.
+      throw new FirebaseError(`Unable to parse metadata file ${metadataPath}: ${mdString});
+    }
   }
 
   public async exportAll(): Promise<void> {


### PR DESCRIPTION
### Description
Improved handling when `emulators:export` cannot read the metadata file - errors here weren't valid JSON, so this was giving an unclear JSON.parse error.
