### PR TITLE
replace strip-ansi with stripVTControlCharacters from node:util

### DIFF
--- a/firebase-vscode/src/logger-wrapper.ts
+++ b/firebase-vscode/src/logger-wrapper.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as os from "os";
 import { transports, format } from "winston";
 import Transport from "winston-transport";
-import stripAnsi from "strip-ansi";
+import { stripVTControlCharacters } from "node:util";
 import { SPLAT } from "triple-beam";
 import { logger as cliLogger } from "../../src/logger";
 import { setupLoggers, tryStringify } from "../../src/utils";
@@ -61,7 +61,7 @@ export function logSetup() {
           const segments = [info.message, ...(info[SPLAT] || [])].map(
             tryStringify,
           );
-          return `[${info.level}] ${stripAnsi(segments.join(" "))}`;
+          return `[${info.level}] ${stripVTControlCharacters(segments.join(" "))}`;
         }),
       }),
     );
@@ -81,7 +81,7 @@ class VSCodeOutputTransport extends Transport {
       this.emit("logged", info);
     });
     const segments = [info.message, ...(info[SPLAT] || [])].map(tryStringify);
-    const text = `[${info.level}] ${stripAnsi(segments.join(" "))}`;
+    const text = `[${info.level}] ${stripVTControlCharacters(segments.join(" "))}`;
 
     if (info.level !== "debug") {
       // info or greater: write to output window

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -63,7 +63,6 @@
         "sql-formatter": "^15.3.0",
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
-        "strip-ansi": "^6.0.1",
         "superstatic": "^9.0.3",
         "tar": "^6.1.11",
         "tcp-port-used": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "sql-formatter": "^15.3.0",
     "stream-chain": "^2.2.4",
     "stream-json": "^1.7.3",
-    "strip-ansi": "^6.0.1",
     "superstatic": "^9.0.3",
     "tar": "^6.1.11",
     "tcp-port-used": "^1.0.2",

--- a/src/bin/firebase.ts
+++ b/src/bin/firebase.ts
@@ -21,7 +21,7 @@ marked.use(markedTerminal() as any);
 import { Command } from "commander";
 import { join } from "node:path";
 import { SPLAT } from "triple-beam";
-const stripAnsi = require("strip-ansi");
+import { stripVTControlCharacters } from "node:util";
 import * as fs from "node:fs";
 
 import { configstore } from "../configstore";
@@ -77,7 +77,7 @@ logger.add(
     filename: logFilename,
     format: winston.format.printf((info) => {
       const segments = [info.message, ...(info[SPLAT] || [])].map(utils.tryStringify);
-      return `[${info.level}] ${stripAnsi(segments.join(" "))}`;
+      return `[${info.level}] ${stripVTControlCharacters(segments.join(" "))}`;
     }),
   }),
 );

--- a/src/emulator/loggingEmulator.ts
+++ b/src/emulator/loggingEmulator.ts
@@ -5,7 +5,7 @@ import * as WebSocket from "ws";
 import { LogEntry } from "winston";
 import * as TransportStream from "winston-transport";
 import { logger } from "../logger";
-const stripAnsi = require("strip-ansi");
+import { stripVTControlCharacters } from "node:util";
 
 export interface LoggingEmulatorArgs {
   port?: number;
@@ -145,7 +145,7 @@ class WebSocketTransport extends TransportStream {
       bundle.message = bundle.data.metadata.message;
     }
 
-    bundle.message = stripAnsi(bundle.message);
+    bundle.message = stripVTControlCharacters(bundle.message);
 
     this.history.push(bundle);
     this.connections.forEach((ws) => {

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -3,7 +3,7 @@ import { spawn } from "cross-spawn";
 import { existsSync } from "fs";
 import { copy, pathExists } from "fs-extra";
 import { join } from "path";
-const stripAnsi = require("strip-ansi");
+import { stripVTControlCharacters } from "node:util";
 import { FrameworkType, SupportLevel } from "../interfaces";
 import { promptOnce } from "../../prompt";
 import {
@@ -120,7 +120,7 @@ export async function getDevModeHandle(dir: string) {
     const serve = spawn(cli, [], { cwd: dir });
     serve.stdout.on("data", (data: any) => {
       process.stdout.write(data);
-      const dataWithoutAnsiCodes = stripAnsi(data.toString());
+      const dataWithoutAnsiCodes = stripVTControlCharacters(data.toString());
       const match = dataWithoutAnsiCodes.match(/(http:\/\/.+:\d+)/);
       if (match) resolve(match[1]);
     });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ import { Readable } from "stream";
 import * as winston from "winston";
 import { SPLAT } from "triple-beam";
 import { AssertionError } from "assert";
-const stripAnsi = require("strip-ansi");
+import { stripVTControlCharacters } from "node:util";
 import { getPortPromise as getPort } from "portfinder";
 
 import { configstore } from "./configstore";
@@ -508,7 +508,7 @@ export function setupLoggers() {
         level: "debug",
         format: winston.format.printf((info) => {
           const segments = [info.message, ...(info[SPLAT] || [])].map(tryStringify);
-          return `${stripAnsi(segments.join(" "))}`;
+          return `${stripVTControlCharacters(segments.join(" "))}`;
         }),
       }),
     );


### PR DESCRIPTION
### Description

This PR removes the dependency on `strip-ansi` and uses `stripVTControlCharacters` from `node:util` instead which is a built-in replacement.
