### PR TITLE
Have 'firebase firestore:delete' retry on bandwidth RESOURCE_EXHAUSTED errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Add support for deploying new blocking triggers. (#6384)
+- Have the firestore:delete command retry on bandwidth exceeded errors. (#7845)

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -153,7 +153,11 @@ export async function deleteDocuments(
   });
   const data = { writes };
 
-  const res = await apiClient.post<any, { writeResults: any[] }>(url, data);
+  const res = await apiClient.post<any, { writeResults: any[] }>(
+    url,
+    data,
+    {retries: 10, retryCodes: [ 429, 409, 503 ], retryMaxTimeout: 20 * 1000}
+  );
   return res.body.writeResults.length;
 }
 

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -153,11 +153,7 @@ export async function deleteDocuments(
   });
   const data = { writes };
 
-  const res = await apiClient.post<any, { writeResults: any[] }>(
-    url,
-    data,
-    {retries: 10, retryCodes: [ 429, 409, 503 ], retryMaxTimeout: 20 * 1000}
-  );
+  const res = await apiClient.post<any, { writeResults: any[] }>(url, data, {retries: 10, retryCodes: [ 429, 409, 503 ], retryMaxTimeout: 20 * 1000});
   return res.body.writeResults.length;
 }
 

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -153,7 +153,11 @@ export async function deleteDocuments(
   });
   const data = { writes };
 
-  const res = await apiClient.post<any, { writeResults: any[] }>(url, data, {retries: 10, retryCodes: [ 429, 409, 503 ], retryMaxTimeout: 20 * 1000});
+  const res = await apiClient.post<any, { writeResults: any[] }>(url, data, {
+    retries: 10,
+    retryCodes: [429, 409, 503],
+    retryMaxTimeout: 20 * 1000,
+  });
   return res.body.writeResults.length;
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Have 'firebase firestore:delete' retry on bandwidth RESOURCE_EXHAUSTED errors

Fixes https://github.com/firebase/firebase-tools/issues/7845

### Scenarios Tested

Tested on a locally setup database with several thousands 1MB Documents.

### Sample Commands

`firebase firestore:delete -r "large-collection" --debug`
