### PR TITLE
Pin clean-publish to 5.0.0

### DIFF
--- a/scripts/clean-install.sh
+++ b/scripts/clean-install.sh
@@ -10,9 +10,9 @@ function cleanup() {
 trap cleanup EXIT
 
 rm -rf ./clean || true
-echo "Running clean-publish --without-publish, as we would before publishing to npm..."
-npx --yes clean-publish --without-publish --before-script ./scripts/clean-shrinkwrap.sh --temp-dir clean
-echo "Ran clean-publish --without-publish."
+echo "Running clean-publish@5.0.0 --without-publish, as we would before publishing to npm..."
+npx --yes clean-publish@5.0.0 --without-publish --before-script ./scripts/clean-shrinkwrap.sh --temp-dir clean
+echo "Ran clean-publish@5.0.0 --without-publish."
 echo "Packaging cleaned firebase-tools..."
 cd ./clean
 PACKED=$(npm pack --pack-destination ./ | tail -n 1)


### PR DESCRIPTION
### Description
Previously, this always used the latest version of clean-publish. This currently resolves to 5.1.0 which seems to include expected breaking changes. Pinning back to 5.0.0 to avoid these issues.
### Scenarios Tested
Ran clean-install.sh locally and verified that it passed