### PR TITLE
Print cloudfunctions.net URL instead of run.app URL for 2nd Gen function

### DIFF
--- a/src/deploy/functions/backend.spec.ts
+++ b/src/deploy/functions/backend.spec.ts
@@ -53,6 +53,7 @@ describe("Backend", () => {
     },
   };
   const RUN_URI = "https://id-nonce-region-project.run.app";
+  const GCF_URL = "https://region-project.cloudfunctions.net/id";
   const HAVE_CLOUD_FUNCTION_V2: gcfV2.OutputCloudFunction = {
     ...CLOUD_FUNCTION_V2,
     serviceConfig: {
@@ -61,6 +62,7 @@ describe("Backend", () => {
       availableCpu: "1",
       maxInstanceRequestConcurrency: 80,
     },
+    url: GCF_URL,
     state: "ACTIVE",
     updateTime: new Date(),
   };

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -394,7 +394,7 @@ export class Fabricator {
         });
     }
 
-    endpoint.uri = resultFunction.serviceConfig?.uri;
+    endpoint.uri = resultFunction.url;
     const serviceName = resultFunction.serviceConfig?.service;
     endpoint.runServiceId = utils.last(serviceName?.split("/"));
     if (!serviceName) {

--- a/src/gcp/cloudfunctionsv2.spec.ts
+++ b/src/gcp/cloudfunctionsv2.spec.ts
@@ -49,12 +49,14 @@ describe("cloudfunctionsv2", () => {
   };
 
   const RUN_URI = "https://id-nonce-region-project.run.app";
+  const GCF_URL = "https://region-project.cloudfunctions.net/id";
   const HAVE_CLOUD_FUNCTION_V2: cloudfunctionsv2.OutputCloudFunction = {
     ...CLOUD_FUNCTION_V2,
     serviceConfig: {
       service: "service",
       uri: RUN_URI,
     },
+    url: GCF_URL,
     state: "ACTIVE",
     updateTime: new Date(),
   };
@@ -408,7 +410,7 @@ describe("cloudfunctionsv2", () => {
         ...ENDPOINT,
         httpsTrigger: {},
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
       });
     });
 
@@ -425,7 +427,7 @@ describe("cloudfunctionsv2", () => {
         ...ENDPOINT,
         httpsTrigger: {},
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
         runServiceId: "service-id",
       });
     });
@@ -596,7 +598,7 @@ describe("cloudfunctionsv2", () => {
         ...ENDPOINT,
         taskQueueTrigger: {},
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
         labels: { "deployment-taskqueue": "true" },
       });
     });
@@ -613,7 +615,7 @@ describe("cloudfunctionsv2", () => {
           eventType: events.v1.BEFORE_CREATE_EVENT,
         },
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
         labels: { "deployment-blocking": "before-create" },
       });
     });
@@ -630,7 +632,7 @@ describe("cloudfunctionsv2", () => {
           eventType: events.v1.BEFORE_SIGN_IN_EVENT,
         },
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
         labels: { "deployment-blocking": "before-sign-in" },
       });
     });
@@ -668,7 +670,7 @@ describe("cloudfunctionsv2", () => {
         ...ENDPOINT,
         platform: "gcfv2",
         httpsTrigger: {},
-        uri: RUN_URI,
+        uri: GCF_URL,
         ...extraFields,
         serviceAccount: "inlined@google.com",
         vpc,
@@ -703,7 +705,7 @@ describe("cloudfunctionsv2", () => {
       ).to.deep.equal({
         ...ENDPOINT,
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
         httpsTrigger: {},
         ...extraFields,
       });
@@ -721,7 +723,7 @@ describe("cloudfunctionsv2", () => {
       ).to.deep.equal({
         ...ENDPOINT,
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
         httpsTrigger: {},
         labels: {
           ...ENDPOINT.labels,
@@ -744,7 +746,7 @@ describe("cloudfunctionsv2", () => {
       ).to.deep.equal({
         ...ENDPOINT,
         platform: "gcfv2",
-        uri: RUN_URI,
+        uri: GCF_URL,
         httpsTrigger: {},
         labels: {
           ...ENDPOINT.labels,

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -166,6 +166,7 @@ export type OutputCloudFunction = CloudFunctionBase & {
   state: FunctionState;
   updateTime: Date;
   serviceConfig?: RequireKeys<ServiceConfig, "service" | "uri">;
+  url: string;
 };
 
 export type InputCloudFunction = CloudFunctionBase & {
@@ -781,6 +782,7 @@ export function endpointFromFunction(gcfFunction: OutputCloudFunction): backend.
       endpoint.runServiceId = utils.last(serviceName.split("/"));
     }
   }
+  proto.renameIfPresent(endpoint, gcfFunction, "uri", "url");
   endpoint.codebase = gcfFunction.labels?.[CODEBASE_LABEL] || projectConfig.DEFAULT_CODEBASE;
   if (gcfFunction.labels?.[HASH_LABEL]) {
     endpoint.hash = gcfFunction.labels[HASH_LABEL];


### PR DESCRIPTION
On successful deploy of 2nd Gen HTTP functions, we will now print the cloudfunctions.net URL instead of run.app URL:

```
$ firebase deploy
...
Function URL (helloUrl(us-central1)): https://us-central1-danielylee-xplore.cloudfunctions.net/helloUrl
```