### PR TITLE
Make $schema be just a string

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -129,7 +129,6 @@
     },
     "properties": {
         "$schema": {
-            "format": "uri",
             "type": "string"
         },
         "database": {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
You can specify `$schema` in your firebase.json like this:
```json
{
  "$schema": "./node_modules/firebase-tools/schema/firebase-config.json",
}
```

To just use the proper version of the locally installed schema, instead of grabbing it from the internet over HTTPS.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->
Using the specified `$schema` value in VS Code.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
