### PR TITLE
Fix order of emulator list at Init

### DIFF
--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -45,12 +45,12 @@ export const IMPORT_EXPORT_EMULATORS = [
 ];
 
 export const ALL_SERVICE_EMULATORS = [
+  ...(experiments.isEnabled("emulatorapphosting") ? [Emulators.APPHOSTING] : []),
   Emulators.AUTH,
   Emulators.FUNCTIONS,
   Emulators.FIRESTORE,
   Emulators.DATABASE,
   Emulators.HOSTING,
-  ...(experiments.isEnabled("emulatorapphosting") ? [Emulators.APPHOSTING] : []),
   Emulators.PUBSUB,
   Emulators.STORAGE,
   Emulators.EVENTARC,


### PR DESCRIPTION
Moves the app hosting emulator up to order alphabetically
