### PR TITLE
Fix issue where the VS Code extension outputs a false positive warning message

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## NEXT
 
 - [Fixed] Fixed an issue where Add data and Read data would generate operations in the wrong folder
+- [Fixed] Fixed an issue where firebase version check produced false positives on Windows (#7910)
 
 ## 0.10.6
 

--- a/firebase-vscode/src/extension.ts
+++ b/firebase-vscode/src/extension.ts
@@ -89,9 +89,15 @@ async function checkCLIInstallation(): Promise<void> {
       "latest"
     ];
     const env = { ...process.env, VSCODE_CWD: "" };
-    const versionRes = spawnSync("firebase", ["--version"], { env });
+    const versionRes = spawnSync("firebase", ["--version"], {
+      env,
+      shell: process.platform === "win32",
+    });
     const currentVersion = semver.valid(versionRes.stdout?.toString());
-    const npmVersionRes = spawnSync("npm", ["--version"]);
+    const npmVersionRes = spawnSync("npm", ["--version"], {
+      env,
+      shell: process.platform === "win32",
+    });
     const npmVersion = semver.valid(npmVersionRes.stdout?.toString());
     if (!currentVersion) {
       message = `The Firebase CLI is not installed (or not available on $PATH). If you would like to install it, run ${


### PR DESCRIPTION


<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #7910. On Windows machines, spawnSync returns an error when shell:true isn't passed, which results in `versionRes` being null, as well as `npmVersionRes` being null

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
