### PR TITLE
Make emulator links clickable

### DIFF
--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -115,7 +115,7 @@ function printEmulatorOverview(options: any): void {
           uiLink = stylizeLink(url.toString());
         }
 
-        return [emulatorName, listen, uiLink];
+        return [emulatorName, `http://${listen}`, uiLink];
       })
       .map((col) => col.slice(0, head.length))
       .filter((v) => v),


### PR DESCRIPTION
Makes emulator links clickable from terminal by prepending the links with `http://`