### PR TITLE
Add `storage/v1/`-prefixed cloud endpoint for object patch

### DIFF
--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -114,25 +114,31 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     },
   );
 
-  gcloudStorageAPI.patch("/b/:bucketId/o/:objectId", async (req, res) => {
-    let updatedMetadata: StoredFileMetadata;
-    try {
-      updatedMetadata = await adminStorageLayer.updateObjectMetadata({
-        bucketId: req.params.bucketId,
-        decodedObjectId: req.params.objectId,
-        metadata: req.body as IncomingMetadata,
-      });
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return sendObjectNotFound(req, res);
+  gcloudStorageAPI.patch(
+    [
+      "/b/:bucketId/o/:objectId", 
+      "/storage/v1/b/:bucketId/o/:objectId",
+    ],
+    async (req, res) => {
+      let updatedMetadata: StoredFileMetadata;
+      try {
+        updatedMetadata = await adminStorageLayer.updateObjectMetadata({
+          bucketId: req.params.bucketId,
+          decodedObjectId: req.params.objectId,
+          metadata: req.body as IncomingMetadata,
+        });
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return sendObjectNotFound(req, res);
+        }
+        if (err instanceof ForbiddenError) {
+          return res.sendStatus(403);
+        }
+        throw err;
       }
-      if (err instanceof ForbiddenError) {
-        return res.sendStatus(403);
-      }
-      throw err;
+      return res.json(new CloudStorageObjectMetadata(updatedMetadata));
     }
-    return res.json(new CloudStorageObjectMetadata(updatedMetadata));
-  });
+  );
 
   gcloudStorageAPI.get(["/b/:bucketId/o", "/storage/v1/b/:bucketId/o"], async (req, res) => {
     let listResponse: ListObjectsResponse;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Add the `/storage/v1/`-prefixed path to the object patch endpoint. This is already supported on other endpoints, but for some reason it's not available on the object patch one.
