### PR TITLE
upgrade superstatic to 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Updates `superstatic` to `9.1.0` (#7929).

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -11971,6 +11971,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -17716,26 +17722,37 @@
       }
     },
     "node_modules/router": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/router/-/router-1.3.5.tgz",
-      "integrity": "sha512-kozCJZUhuSJ5VcLhSb3F8fsmGXy+8HaDbKCAerR1G6tq3mnMZFMuSohbFvGv1c5oMFipijDjRZuuN/Sq5nMf3g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.0.0.tgz",
+      "integrity": "sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==",
+      "license": "MIT",
       "dependencies": {
         "array-flatten": "3.0.0",
-        "debug": "2.6.9",
+        "is-promise": "4.0.0",
         "methods": "~1.1.2",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "^8.0.0",
         "setprototypeof": "1.2.0",
         "utils-merge": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.10"
       }
     },
     "node_modules/router/node_modules/array-flatten": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
+      "license": "MIT"
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/run-async": {
       "version": "2.4.1",
@@ -18801,9 +18818,10 @@
       "dev": true
     },
     "node_modules/superstatic": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.0.3.tgz",
-      "integrity": "sha512-e/tmW0bsnQ/33ivK6y3CapJT0Ovy4pk/ohNPGhIAGU2oasoNLRQ1cv6enua09NU9w6Y0H/fBu07cjzuiWvLXxw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.1.0.tgz",
+      "integrity": "sha512-1PcxGREb5My6iX/DL9x+3+XFY5lM2nOiPBQV45RwbpM5bHGsStz+Lduts7y8W+xo68pHa7F8atTF52+dwfwxcw==",
+      "license": "MIT",
       "dependencies": {
         "basic-auth-connect": "^1.0.0",
         "commander": "^10.0.0",
@@ -18821,14 +18839,14 @@
         "on-finished": "^2.2.0",
         "on-headers": "^1.0.0",
         "path-to-regexp": "^1.8.0",
-        "router": "^1.3.1",
+        "router": "^2.0.0",
         "update-notifier-cjs": "^5.1.6"
       },
       "bin": {
         "superstatic": "lib/bin/server.js"
       },
       "engines": {
-        "node": "^14.18.0 || >=16.4.0"
+        "node": "18 || 20 || 22"
       },
       "optionalDependencies": {
         "re2": "^1.17.7"
@@ -29947,6 +29965,11 @@
       "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
       "dev": true
     },
+    "is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
+    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
@@ -34195,15 +34218,15 @@
       }
     },
     "router": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/router/-/router-1.3.5.tgz",
-      "integrity": "sha512-kozCJZUhuSJ5VcLhSb3F8fsmGXy+8HaDbKCAerR1G6tq3mnMZFMuSohbFvGv1c5oMFipijDjRZuuN/Sq5nMf3g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.0.0.tgz",
+      "integrity": "sha512-dIM5zVoG8xhC6rnSN8uoAgFARwTE7BQs8YwHEvK0VCmfxQXMaOuA1uiR1IPwsW7JyK5iTt7Od/TC9StasS2NPQ==",
       "requires": {
         "array-flatten": "3.0.0",
-        "debug": "2.6.9",
+        "is-promise": "4.0.0",
         "methods": "~1.1.2",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "^8.0.0",
         "setprototypeof": "1.2.0",
         "utils-merge": "1.0.1"
       },
@@ -34212,6 +34235,11 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
           "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA=="
+        },
+        "path-to-regexp": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+          "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="
         }
       }
     },
@@ -35053,9 +35081,9 @@
       }
     },
     "superstatic": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.0.3.tgz",
-      "integrity": "sha512-e/tmW0bsnQ/33ivK6y3CapJT0Ovy4pk/ohNPGhIAGU2oasoNLRQ1cv6enua09NU9w6Y0H/fBu07cjzuiWvLXxw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/superstatic/-/superstatic-9.1.0.tgz",
+      "integrity": "sha512-1PcxGREb5My6iX/DL9x+3+XFY5lM2nOiPBQV45RwbpM5bHGsStz+Lduts7y8W+xo68pHa7F8atTF52+dwfwxcw==",
       "requires": {
         "basic-auth-connect": "^1.0.0",
         "commander": "^10.0.0",
@@ -35074,7 +35102,7 @@
         "on-headers": "^1.0.0",
         "path-to-regexp": "^1.8.0",
         "re2": "^1.17.7",
-        "router": "^1.3.1",
+        "router": "^2.0.0",
         "update-notifier-cjs": "^5.1.6"
       },
       "dependencies": {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Updates superstatic to v9.1.0.

Fixes #7929
Fixes #7173


### Scenarios Tested

A basic website still worked well with this version. Works on node 22 as well!