### PR TITLE
Migrate some API calls to resourcemanager.googleapis.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Migrated some API calls from `firebase.googleapis.com` to `resourcemanager.googleapis.com`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-- Migrates some API calls from `firebase.googleapis.com` to `resourcemanager.googleapis.com`.
+- Migrates some API calls from `firebase.googleapis.com` to `cloudresourcemanager.googleapis.com`.
 - Updates `superstatic` to `9.1.0` (#7929).

--- a/src/command.spec.ts
+++ b/src/command.spec.ts
@@ -99,7 +99,7 @@ describe("Command", () => {
     });
 
     it("should resolve a numeric --project flag into a project id", async () => {
-      nock("https://firebase.googleapis.com").get("/v1beta1/projects/12345678").reply(200, {
+      nock("https://cloudresourcemanager.googleapis.com").get("/v1/projects/12345678").reply(200, {
         projectNumber: "12345678",
         projectId: "resolved-project",
       });

--- a/src/command.ts
+++ b/src/command.ts
@@ -10,7 +10,7 @@ import { configstore } from "./configstore";
 import { detectProjectRoot } from "./detectProjectRoot";
 import { trackEmulator, trackGA4 } from "./track";
 import { selectAccount, setActiveAccount } from "./auth";
-import { getFirebaseProject } from "./management/projects";
+import { getProject } from "./management/projects";
 import { requireAuth } from "./requireAuth";
 import { Options } from "./options";
 
@@ -372,7 +372,7 @@ export class Command {
   }): Promise<void> {
     if (options.project?.match(/^\d+$/)) {
       await requireAuth(options);
-      const { projectId, projectNumber } = await getFirebaseProject(options.project);
+      const { projectId, projectNumber } = await getProject(options.project);
       options.projectId = projectId;
       options.projectNumber = projectNumber;
     } else {

--- a/src/commands/ext-dev-upload.ts
+++ b/src/commands/ext-dev-upload.ts
@@ -22,7 +22,7 @@ import * as utils from "../utils";
 import { Options } from "../options";
 import { getPublisherProfile } from "../extensions/publisherApi";
 import { getPublisherProjectFromName } from "../extensions/extensionsHelper";
-import { getFirebaseProject } from "../management/projects";
+import { getProject } from "../management/projects";
 
 // TODO(joehan): Go update @types/marked-terminal
 marked.use(markedTerminal() as any);
@@ -87,7 +87,7 @@ export async function uploadExtensionAction(
     throw err;
   }
   const projectNumber = `${getPublisherProjectFromName(profile.name)}`;
-  const { projectId } = await getFirebaseProject(projectNumber);
+  const { projectId } = await getProject(projectNumber);
   await acceptLatestPublisherTOS(options, projectNumber);
 
   let res;

--- a/src/commands/use.ts
+++ b/src/commands/use.ts
@@ -1,8 +1,7 @@
 import * as clc from "colorette";
 
 import { Command } from "../command";
-import { getFirebaseProject, listFirebaseProjects } from "../management/projects";
-import { FirebaseProjectMetadata } from "../types/project";
+import { getProject, listFirebaseProjects, ProjectInfo } from "../management/projects";
 import { logger } from "../logger";
 import { Options } from "../options";
 import { prompt } from "../prompt";
@@ -58,11 +57,11 @@ export const command = new Command("use [alias_or_project_id]")
 
     if (newActive) {
       // firebase use [alias_or_project]
-      let project: FirebaseProjectMetadata | undefined;
+      let project: ProjectInfo | undefined;
       const hasAlias = options.rc.hasProjectAlias(newActive);
       const resolvedProject = options.rc.resolveAlias(newActive);
       validateProjectId(resolvedProject);
-      return getFirebaseProject(resolvedProject)
+      return getProject(resolvedProject)
         .then((foundProject) => {
           project = foundProject;
         })

--- a/src/deploy/functions/ensure.ts
+++ b/src/deploy/functions/ensure.ts
@@ -1,19 +1,17 @@
 import * as clc from "colorette";
 
-import type { FirebaseProjectMetadata } from "../../types/project";
-
 import { ensure } from "../../ensureApiEnabled";
 import { FirebaseError, isBillingError } from "../../error";
 import { logLabeledBullet, logLabeledSuccess } from "../../utils";
 import { checkServiceAgentRole, ensureServiceAgentRole } from "../../gcp/secretManager";
-import { getFirebaseProject } from "../../management/projects";
+import { getProject, ProjectInfo } from "../../management/projects";
 import { assertExhaustive } from "../../functional";
 import { cloudbuildOrigin } from "../../api";
 import * as backend from "./backend";
 
 const FAQ_URL = "https://firebase.google.com/support/faq#functions-runtime";
 
-const metadataCallCache: Map<string, Promise<FirebaseProjectMetadata>> = new Map();
+const metadataCallCache: Map<string, Promise<ProjectInfo>> = new Map();
 
 /**
  *  By default:
@@ -23,7 +21,7 @@ const metadataCallCache: Map<string, Promise<FirebaseProjectMetadata>> = new Map
 export async function defaultServiceAccount(e: backend.Endpoint): Promise<string> {
   let metadataCall = metadataCallCache.get(e.project);
   if (!metadataCall) {
-    metadataCall = getFirebaseProject(e.project);
+    metadataCall = getProject(e.project);
     metadataCallCache.set(e.project, metadataCall);
   }
   const metadata = await metadataCall;

--- a/src/getProjectNumber.ts
+++ b/src/getProjectNumber.ts
@@ -1,4 +1,4 @@
-import { getFirebaseProject } from "./management/projects";
+import { getProject } from "./management/projects";
 import { needProjectId } from "./projectUtils";
 /**
  * Fetches the project number.
@@ -10,7 +10,7 @@ export async function getProjectNumber(options: any): Promise<string> {
     return options.projectNumber;
   }
   const projectId = needProjectId(options);
-  const metadata = await getFirebaseProject(projectId);
+  const metadata = await getProject(projectId);
   options.projectNumber = metadata.projectNumber;
   return options.projectNumber;
 }

--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -121,7 +121,6 @@ export async function doSetup(setup: any, config: any, options: any): Promise<vo
     // require a resource location:
     const rcProject: FirebaseProjectMetadata = await getFirebaseProject(projectFromRcFile);
     setup.projectId = rcProject.projectId;
-    // TODO: Handle this.
     setup.projectLocation = rcProject?.resources?.locationId;
     return;
   }

--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -24,20 +24,20 @@ const OPTION_ADD_FIREBASE = "Add Firebase to an existing Google Cloud Platform p
  * Used in init flows to keep information about the project - basically
  * a shorter version of {@link FirebaseProjectMetadata} with some additional fields.
  */
-export interface ProjectInfo {
+export interface InitProjectInfo {
   id: string; // maps to FirebaseProjectMetadata.projectId
   label?: string;
   instance?: string; // maps to FirebaseProjectMetadata.resources.realtimeDatabaseInstance
   location?: string; // maps to FirebaseProjectMetadata.resources.locationId
 }
 
-function toProjectInfo(projectMetaData: FirebaseProjectMetadata): ProjectInfo {
+function toInitProjectInfo(projectMetaData: FirebaseProjectMetadata): InitProjectInfo {
   const { projectId, displayName, resources } = projectMetaData;
   return {
     id: projectId,
     label: `${projectId}` + (displayName ? ` (${displayName})` : ""),
-    instance: _.get(resources, "realtimeDatabaseInstance"),
-    location: _.get(resources, "locationId"),
+    instance: resources?.realtimeDatabaseInstance,
+    location: resources?.locationId,
   };
 }
 
@@ -114,14 +114,15 @@ export async function doSetup(setup: any, config: any, options: any): Promise<vo
   logger.info(`but for now we'll just set up a default project.`);
   logger.info();
 
-  const projectFromRcFile = _.get(setup.rcfile, "projects.default");
+  const projectFromRcFile = setup.rcfile?.projects?.default;
   if (projectFromRcFile && !options.project) {
     utils.logBullet(`.firebaserc already has a default project, using ${projectFromRcFile}.`);
     // we still need to get project info in case user wants to init firestore or storage, which
     // require a resource location:
     const rcProject: FirebaseProjectMetadata = await getFirebaseProject(projectFromRcFile);
     setup.projectId = rcProject.projectId;
-    setup.projectLocation = _.get(rcProject, "resources.locationId");
+    // TODO: Handle this.
+    setup.projectLocation = rcProject?.resources?.locationId;
     return;
   }
 
@@ -137,7 +138,7 @@ export async function doSetup(setup: any, config: any, options: any): Promise<vo
     }
   }
 
-  const projectInfo = toProjectInfo(projectMetaData);
+  const projectInfo = toInitProjectInfo(projectMetaData);
   utils.logBullet(`Using project ${projectInfo.label}`);
   // write "default" alias and activate it immediately
   _.set(setup.rcfile, "projects.default", projectInfo.id);

--- a/src/management/projects.ts
+++ b/src/management/projects.ts
@@ -2,7 +2,7 @@ import * as clc from "colorette";
 import * as ora from "ora";
 
 import { Client } from "../apiv2";
-import { FirebaseError } from "../error";
+import { FirebaseError, getErrStatus } from "../error";
 import { pollOperation } from "../operation-poller";
 import { Question, promptOnce } from "../prompt";
 import * as api from "../api";
@@ -46,6 +46,11 @@ const firebaseAPIClient = new Client({
   urlPrefix: api.firebaseApiOrigin(),
   auth: true,
   apiVersion: "v1beta1",
+});
+
+const resourceManagerClient = new Client({
+  urlPrefix: api.resourceManagerOrigin(),
+  apiVersion: "v1",
 });
 
 export async function createFirebaseProjectAndLog(
@@ -230,13 +235,12 @@ export async function createCloudProject(
   options: { displayName?: string; parentResource?: ProjectParentResource },
 ): Promise<any> {
   try {
-    const client = new Client({ urlPrefix: api.resourceManagerOrigin(), apiVersion: "v1" });
     const data = {
       projectId,
       name: options.displayName || projectId,
       parent: options.parentResource,
     };
-    const response = await client.request<any, { name: string }>({
+    const response = await resourceManagerClient.request<any, { name: string }>({
       method: "POST",
       path: "/projects",
       body: data,
@@ -411,6 +415,19 @@ export async function getFirebaseProject(projectId: string): Promise<FirebasePro
     });
     return res.body;
   } catch (err: any) {
+    if (getErrStatus(err) === 404) {
+      try {
+        const info = await getProject(projectId);
+        // TODO: Update copy based on Rachel/Yvonne's feedback.
+        // TODO: Add link
+        // logger.info(`Project ${clc.bold(projectId)} is not a Firebase project.`);
+        // logger.info('It can only use products governed by the Google Cloud Platform terms of service.');
+        // logger.info('If you wish to use products governed by the Firebase terms of service, upgrade to a Firebase project <link here>');
+        return info;
+      } catch (err: any) {
+        logger.debug(`Unable to get project info from resourcemanager for ${projectId}: ${err}`);
+      }
+    }
     let message = err.message;
     if (err.original) {
       message += ` (original: ${err.original.message})`;
@@ -422,4 +439,22 @@ export async function getFirebaseProject(projectId: string): Promise<FirebasePro
       { exit: 2, original: err },
     );
   }
+}
+
+export interface ProjectInfo {
+  projectNumber: string;
+  projectId: string;
+  lifecycleState: string;
+  name: string;
+  createTime: string;
+  parent: { type: string; id: string };
+}
+
+/**
+ * Gets basic information about any Cloud project. Does not use Firebase TOS APIs, so this is safe for core app projects.
+ * @param projectId
+ */
+export async function getProject(projectId: string): Promise<ProjectInfo> {
+  const response = await resourceManagerClient.get<ProjectInfo>(`/projects/${projectId}`);
+  return response.body;
 }

--- a/src/management/projects.ts
+++ b/src/management/projects.ts
@@ -98,7 +98,9 @@ function logNewFirebaseProjectInfo(projectInfo: FirebaseProjectMetadata): void {
   logger.info("");
   logger.info("Project information:");
   logger.info(`   - Project ID: ${clc.bold(projectInfo.projectId)}`);
-  logger.info(`   - Project Name: ${clc.bold(projectInfo.displayName)}`);
+  if (projectInfo.displayName) {
+    logger.info(`   - Project Name: ${clc.bold(projectInfo.displayName)}`);
+  }
   logger.info("");
   logger.info("Firebase console is available at");
   logger.info(

--- a/src/management/projects.ts
+++ b/src/management/projects.ts
@@ -419,6 +419,9 @@ export async function getFirebaseProject(projectId: string): Promise<FirebasePro
   } catch (err: any) {
     if (getErrStatus(err) === 404) {
       try {
+        logger.debug(
+          `Couldn't get project info from firedata for ${projectId}, trying resource manager. Original error: ${err}`,
+        );
         const info = await getProject(projectId);
         // TODO: Update copy based on Rachel/Yvonne's feedback.
         // TODO: Add link

--- a/src/projectUtils.spec.ts
+++ b/src/projectUtils.spec.ts
@@ -37,7 +37,7 @@ describe("needProjectNumber", () => {
   let getProjectStub: sinon.SinonStub;
 
   beforeEach(() => {
-    getProjectStub = sinon.stub(projects, "getFirebaseProject").throws(new Error("stubbed"));
+    getProjectStub = sinon.stub(projects, "getProject").throws(new Error("stubbed"));
   });
 
   afterEach(() => {

--- a/src/projectUtils.ts
+++ b/src/projectUtils.ts
@@ -1,4 +1,4 @@
-import { getFirebaseProject } from "./management/projects";
+import { getProject } from "./management/projects";
 import { RC } from "./rc";
 
 import * as clc from "colorette";
@@ -86,7 +86,7 @@ export async function needProjectNumber(options: any): Promise<string> {
     return options.projectNumber;
   }
   const projectId = needProjectId(options);
-  const metadata = await getFirebaseProject(projectId);
+  const metadata = await getProject(projectId);
   options.projectNumber = metadata.projectNumber;
   return options.projectNumber;
 }

--- a/src/types/project/index.d.ts
+++ b/src/types/project/index.d.ts
@@ -13,7 +13,7 @@ export interface FirebaseProjectMetadata {
   name: string /* The fully qualified resource name of the Firebase project */;
   projectId: string;
   projectNumber: string;
-  displayName: string;
+  displayName?: string;
   resources?: DefaultProjectResources;
 }
 


### PR DESCRIPTION
### Description
Migrate some API calls from `firebase.googleapis.com` to `cloudresourcemanger.googleapis.com`. This addresses some issues with using the CLI with non-Firebase Cloud projects.

### Scenarios Tested
I tested a bunch of commands (including init and deploy for GCP TOS products), and verified that they work.

