### PR TITLE
Change type from number to integer for the emulator ports.

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -364,7 +364,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         },
                         "startCommandOverride": {
                             "type": "string"
@@ -379,7 +379,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -391,7 +391,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -403,13 +403,13 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         },
                         "postgresHost": {
                             "type": "string"
                         },
                         "postgresPort": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -421,7 +421,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -438,10 +438,10 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         },
                         "websocketPort": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -453,7 +453,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -465,7 +465,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -477,7 +477,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -489,7 +489,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -501,7 +501,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -516,7 +516,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -528,7 +528,7 @@
                             "type": "string"
                         },
                         "port": {
-                            "type": "number"
+                            "type": "integer"
                         }
                     },
                     "type": "object"
@@ -545,7 +545,7 @@
                         "port": {
                             "type": [
                                 "string",
-                                "number"
+                                "integer"
                             ]
                         }
                     },
@@ -2756,4 +2756,3 @@
     },
     "type": "object"
 }
-


### PR DESCRIPTION
### Description

Changed the firebase-config.json Schema file. The ports of the emulators are changed from number to integer. Main reason for this is when using the schema in a generator like jsonschema2pojo, the generator will generate java.lang.Double as field instead of java.lang.Integer. As ports can only be integers, this setup better reflects the field.

