### PR TITLE
Upgrade superstatic in package.json to 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Updates `superstatic` to `9.1.0` in package.json.

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "sql-formatter": "^15.3.0",
     "stream-chain": "^2.2.4",
     "stream-json": "^1.7.3",
-    "superstatic": "^9.0.3",
+    "superstatic": "^9.1.0",
     "tar": "^6.1.11",
     "tcp-port-used": "^1.0.2",
     "tmp": "^0.2.3",


### PR DESCRIPTION


### Description

Follow up to https://github.com/firebase/firebase-tools/pull/7941 to also upgrade `superstatic` in the package.json. https://github.com/firebase/firebase-tools/pull/7941#issuecomment-2488945873

### Scenarios Tested



### Sample Commands

npm install uses superstatic@9.1.0
