### PR TITLE
Emulators:exec should rethrow errors from emulator startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes an issue where `emulators:exec` would return a 0 error code when emulators failed to start. (#7974)

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -468,8 +468,9 @@ export async function emulatorExec(script: string, options: any): Promise<void> 
     await sendVSCodeMessage({ message: VSCODE_MESSAGE.EMULATORS_STARTED });
     exitCode = await runScript(script, extraEnv);
     await controller.onExit(options);
-  } catch {
+  } catch (err: unknown) {
     await sendVSCodeMessage({ message: VSCODE_MESSAGE.EMULATORS_START_ERRORED });
+    throw err;
   } finally {
     await controller.cleanShutdown();
   }


### PR DESCRIPTION
### Description
Stop swallowing errors from emulator startup during `emulators:exec`. Fixes #7974 7974

### Scenarios Tested
 JAVA_HOME=/does/not/exist firebase emulators:exec "exit 0" correctly exits with code 1.

