### PR TITLE
Apphosting emulator: Support custom port

### DIFF
--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -18,6 +18,7 @@ export class AppHostingEmulator implements EmulatorInstance {
 
   async start(): Promise<void> {
     const { hostname, port } = await apphostingStart({
+      port: this.args.port,
       startCommand: this.args.startCommandOverride,
       rootDirectory: this.args.rootDirectory,
     });

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -32,10 +32,21 @@ describe("serve", () => {
   afterEach(() => {
     wrapSpawnStub.restore();
     detectStartCommandStub.restore();
+    checkListenableStub.restore();
     sinon.verifyAndRestore();
   });
 
   describe("start", () => {
+    it("should use user-provided port if one is defined", async () => {
+      checkListenableStub.onFirstCall().returns(true);
+      configsStub.getLocalAppHostingConfiguration.returns(
+        Promise.resolve(AppHostingYamlConfig.empty()),
+      );
+
+      const res = await serve.start({ port: 9999 });
+      expect(res.port).to.equal(9999);
+    });
+
     it("should only select an available port to serve", async () => {
       checkListenableStub.onFirstCall().returns(false);
       checkListenableStub.onSecondCall().returns(false);

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -14,6 +14,7 @@ import { getLocalAppHostingConfiguration } from "./config";
 import { resolveProjectPath } from "../../projectPath";
 
 interface StartOptions {
+  port?: number;
   startCommand?: string;
   rootDirectory?: string;
 }
@@ -28,7 +29,7 @@ interface StartOptions {
  */
 export async function start(options?: StartOptions): Promise<{ hostname: string; port: number }> {
   const hostname = DEFAULT_HOST;
-  let port = DEFAULT_PORTS.apphosting;
+  let port = options?.port ?? DEFAULT_PORTS.apphosting;
   while (!(await availablePort(hostname, port))) {
     port += 1;
   }


### PR DESCRIPTION
Allow apphosting emulator to start on custom port defined in the firebase.json config