### PR TITLE
Cleaning up some leftovers from #7836

### DIFF
--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -80,14 +80,6 @@
         }
       }
     },
-    "keybindings": [
-      {
-        "command": "firebase.dataConnect.executeOperationAtCursor",
-        "key": "ctrl+enter",
-        "mac": "cmd+enter",
-        "when": "editorLangId == gql || editorLangId == graphql"
-      }
-    ],
     "viewsContainers": {
       "activitybar": [
         {

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -1,4 +1,5 @@
 import * as childProcess from "child_process";
+import * as pg from "pg";
 import { EventEmitter } from "events";
 import * as clc from "colorette";
 import * as path from "path";
@@ -17,7 +18,7 @@ import { EmulatorRegistry } from "./registry";
 import { logger } from "../logger";
 import { load } from "../dataconnect/load";
 import { Config } from "../config";
-import { PostgresServer } from "./dataconnect/pgliteServer";
+import { PostgresServer, TRUNCATE_TABLES_SQL } from "./dataconnect/pgliteServer";
 import { cleanShutdown } from "./controller";
 import { connectableHostname } from "../utils";
 
@@ -180,6 +181,9 @@ export class DataConnectEmulator implements EmulatorInstance {
   async clearData(): Promise<void> {
     if (this.postgresServer) {
       await this.postgresServer.clearDb();
+    } else {
+      const conn = new pg.Client(dataConnectLocalConnString());
+      await conn.query(TRUNCATE_TABLES_SQL);
     }
   }
 

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -184,6 +184,7 @@ export class DataConnectEmulator implements EmulatorInstance {
     } else {
       const conn = new pg.Client(dataConnectLocalConnString());
       await conn.query(TRUNCATE_TABLES_SQL);
+      await conn.end()
     }
   }
 

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -184,7 +184,7 @@ export class DataConnectEmulator implements EmulatorInstance {
     } else {
       const conn = new pg.Client(dataConnectLocalConnString());
       await conn.query(TRUNCATE_TABLES_SQL);
-      await conn.end()
+      await conn.end();
     }
   }
 

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -37,7 +37,12 @@ export const DOWNLOADABLE_EMULATORS = [
   Emulators.DATACONNECT,
 ];
 
-export type ImportExportEmulators = Emulators.FIRESTORE | Emulators.DATABASE | Emulators.AUTH;
+export type ImportExportEmulators =
+  | Emulators.FIRESTORE
+  | Emulators.DATABASE
+  | Emulators.AUTH
+  | Emulators.STORAGE
+  | Emulators.DATACONNECT;
 export const IMPORT_EXPORT_EMULATORS = [
   Emulators.FIRESTORE,
   Emulators.DATABASE,


### PR DESCRIPTION
### Description
Fixes a few small things that I meant to include in #7836:
- ClearData now works for non-pglite instances
- ImportExportEmualtors now includes all the emulators that support import/export
- (sorta unreleated, but noticed it while working) Removed a keybinding for a command that no longer exists.

