### PR TITLE
Modify console link to route to specific backend page

### DIFF
--- a/src/apphosting/backend.ts
+++ b/src/apphosting/backend.ts
@@ -161,7 +161,7 @@ export async function doSetup(
 
   const url = `https://${backend.uri}`;
   logBullet(
-    `You may also track this rollout at:\n\t${consoleOrigin()}/project/${projectId}/apphosting`,
+    `You may also track this rollout at:\n\t${consoleOrigin()}/project/${projectId}/apphosting/backends/${backendId}/locations/${location}`,
   );
   // TODO: Previous versions of this command printed the URL before the rollout started so that
   // if a user does exit they will know where to go later. Should this be re-added?


### PR DESCRIPTION
Direct users to a more specific link in the Firebase Console to the relevant backend's dashboard. 

This uses the new route that isn't live in console yet. Wait for it to be live before merging this PR.