### PR TITLE
Add default value for `dataDir` in `init dataconnect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added default value for `emulators.dataconnect.dataDir` to `init dataconnect`.

--- a/src/emulator/initEmulators.ts
+++ b/src/emulator/initEmulators.ts
@@ -8,7 +8,7 @@ import { Emulators } from "./types";
 import { exportConfig } from "../apphosting/config";
 import { detectProjectRoot } from "../detectProjectRoot";
 
-type InitFn = () => Promise<Record<string, string> | null>;
+type InitFn = (currentConfig?: Record<string, any>) => Promise<Record<string, string> | null>;
 type AdditionalInitFnsType = Partial<Record<Emulators, InitFn>>;
 
 export const AdditionalInitFns: AdditionalInitFnsType = {
@@ -46,11 +46,12 @@ export const AdditionalInitFns: AdditionalInitFnsType = {
 
     return mapToObject(additionalConfigs);
   },
-  [Emulators.DATACONNECT]: async () => {
+  [Emulators.DATACONNECT]: async (currentConfig?: Record<string, any>) => {
+    const defaultDataConnectDir = currentConfig?.dataconnect?.source || "dataconnect";
     const dataDir = await promptOnce({
       name: "dataDir",
       type: "input",
-      default: "./postgresData",
+      default: `./${defaultDataConnectDir}/.dataconnect/pgliteData`,
       message:
         "Where do you want to store Postgres data from the Data Connect emulator? " +
         "If set, data will be saved between emulator runs. " +

--- a/src/emulator/initEmulators.ts
+++ b/src/emulator/initEmulators.ts
@@ -61,7 +61,7 @@ export const AdditionalInitFns: AdditionalInitFnsType = {
         message:
           "Do you want to persist Postgres data from the Data Connect emulator between runs? " +
           `Data will be saved to ${defaultDataDir}. ` +
-          `You can change this directory by editting 'firebase.json#emulators.dataconnect.dataDir'.`,
+          `You can change this directory by editing 'firebase.json#emulators.dataconnect.dataDir'.`,
       })
     ) {
       additionalConfig["dataDir"] = defaultDataDir;

--- a/src/emulator/initEmulators.ts
+++ b/src/emulator/initEmulators.ts
@@ -46,6 +46,18 @@ export const AdditionalInitFns: AdditionalInitFnsType = {
 
     return mapToObject(additionalConfigs);
   },
+  [Emulators.DATACONNECT] : async () => {
+    
+    const dataDir = await promptOnce({
+      name: "dataDir",
+      type: "input",
+      default: "./postgresData",
+      message: "Where do you want to store Postgres data from the Data Connect emulator? " +
+        "If set, data will be saved between emulator runs. " +
+        "Set this to blank if you do not want to persist Postgres data between runs.",
+    });
+    return { dataDir }
+  }
 };
 
 function mapToObject(map: Map<string, string>): Record<string, string> {

--- a/src/emulator/initEmulators.ts
+++ b/src/emulator/initEmulators.ts
@@ -46,18 +46,18 @@ export const AdditionalInitFns: AdditionalInitFnsType = {
 
     return mapToObject(additionalConfigs);
   },
-  [Emulators.DATACONNECT] : async () => {
-    
+  [Emulators.DATACONNECT]: async () => {
     const dataDir = await promptOnce({
       name: "dataDir",
       type: "input",
       default: "./postgresData",
-      message: "Where do you want to store Postgres data from the Data Connect emulator? " +
+      message:
+        "Where do you want to store Postgres data from the Data Connect emulator? " +
         "If set, data will be saved between emulator runs. " +
         "Set this to blank if you do not want to persist Postgres data between runs.",
     });
-    return { dataDir }
-  }
+    return { dataDir };
+  },
 };
 
 function mapToObject(map: Map<string, string>): Record<string, string> {

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -79,6 +79,8 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
     isBillingEnabled ? await ensureApis(setup.projectId) : await ensureSparkApis(setup.projectId);
   }
   const info = await askQuestions(setup, isBillingEnabled);
+  // Most users will want to perist data between emulator runs, so set this to a reasonable default.
+  config.set("emulators.dataconnect.dataDir", "./postgresData");
   await actuate(setup, config, info);
 
   const cwdPlatformGuess = await getPlatformFromFolder(process.cwd());

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -80,7 +80,10 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   }
   const info = await askQuestions(setup, isBillingEnabled);
   // Most users will want to perist data between emulator runs, so set this to a reasonable default.
-  config.set("emulators.dataconnect.dataDir", "./postgresData");
+
+  const dir: string = config.get("dataconnect.source", "dataconnect");
+  const dataDir = config.get("emulators.dataconnect.dataDir", `${dir}/.dataconnect/pgliteData`);
+  config.set("emulators.dataconnect.dataDir", dataDir);
   await actuate(setup, config, info);
 
   const cwdPlatformGuess = await getPlatformFromFolder(process.cwd());

--- a/src/init/features/emulators.ts
+++ b/src/init/features/emulators.ts
@@ -6,13 +6,14 @@ import { Constants } from "../../emulator/constants";
 import { downloadIfNecessary } from "../../emulator/downloadableEmulators";
 import { Setup } from "../index";
 import { AdditionalInitFns } from "../../emulator/initEmulators";
+import { Config } from "../../config";
 
 interface EmulatorsInitSelections {
   emulators?: Emulators[];
   download?: boolean;
 }
 
-export async function doSetup(setup: Setup, config: any) {
+export async function doSetup(setup: Setup, config: Config) {
   const choices = ALL_SERVICE_EMULATORS.map((e) => {
     return {
       value: e,
@@ -57,7 +58,7 @@ export async function doSetup(setup: Setup, config: any) {
 
     const additionalInitFn = AdditionalInitFns[selected];
     if (additionalInitFn) {
-      const additionalOptions = await additionalInitFn();
+      const additionalOptions = await additionalInitFn(config);
       if (additionalOptions) {
         setup.config.emulators[selected] = {
           ...setup.config.emulators[selected],


### PR DESCRIPTION


### Description
Add default value for `dataDir` in `init dataconnect`, and makes it configurable via `init emulators:dataconnect`.

I intentionally held this back until post Thanksgiving freeze so that this persistence behavior is opt in for now.

