### PR TITLE
Fix broken default command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Added default value for `emulators.dataconnect.dataDir` to `init dataconnect`.
+- Fixed an issue where `firebase` would error out instead of displaying help text.

--- a/src/bin/firebase.ts
+++ b/src/bin/firebase.ts
@@ -33,7 +33,7 @@ import * as fsutils from "../fsutils";
 import * as utils from "../utils";
 import * as winston from "winston";
 
-let args = process.argv.slice(2);
+const args = process.argv.slice(2);
 let cmd: CommanderStatic;
 
 function findAvailableLogFile(): string {
@@ -161,11 +161,10 @@ process.on("uncaughtException", (err) => {
 });
 
 if (!handlePreviewToggles(args)) {
-  cmd = client.cli.parse(process.argv);
-
-  // determine if there are any non-option arguments. if not, display help
-  args = args.filter((arg) => !arg.includes("-"));
+  // determine if there are any arguments. if not, display help
   if (!args.length) {
     client.cli.help();
+  } else {
+    cmd = client.cli.parse(process.argv);
   }
 }


### PR DESCRIPTION
### Description
Fixes an issue where `firebase` would error out instead of printing help text. 

The root cause here was updating from commander 4 -> 5. That included a [fix for a bug](https://github.com/tj/commander.js/pull/1062) that we were implicitly relying on.

### Scenarios Tested
`firebase` correctly prints help text.
`firebase --version` correctly prints the version.
`firebase notacommand` correctly prints an error message and suggests closely named commands.
