### PR TITLE
Added check to see if projectId is valid

### DIFF
--- a/src/commands/firestore-indexes-list.ts
+++ b/src/commands/firestore-indexes-list.ts
@@ -8,6 +8,7 @@ import { Emulators } from "../emulator/types";
 import { warnEmulatorNotSupported } from "../emulator/commandUtils";
 import { FirestoreOptions } from "../firestore/options";
 import { PrettyPrint } from "../firestore/pretty-print";
+import { needProjectId } from "../projectUtils";
 
 export const command = new Command("firestore:indexes")
   .description("List indexes in your project's Cloud Firestore database.")
@@ -27,8 +28,9 @@ export const command = new Command("firestore:indexes")
     const printer = new PrettyPrint();
 
     const databaseId = options.database ?? "(default)";
-    const indexes = await indexApi.listIndexes(options.project, databaseId);
-    const fieldOverrides = await indexApi.listFieldOverrides(options.project, databaseId);
+    const projectId = needProjectId(options);
+    const indexes = await indexApi.listIndexes(projectId, databaseId);
+    const fieldOverrides = await indexApi.listFieldOverrides(projectId, databaseId);
 
     const indexSpec = indexApi.makeIndexSpec(indexes, fieldOverrides);
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Validate if project id is being passed for `firebase firestore:indexes` command. Running `firebase firestore:indexes` in a non-firebase project folder results in:
```
$ firebase firestore:indexes

Error: Request to https://firestore.googleapis.com/v1/projects/undefined/databases/(default)/collectionGroups/-/indexes had HTTP Error: 403, Permission denied: Consumer 'project:undefined' has been suspended.
```

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Run `firebase firestore:indexes` on a non-firebase project folder
```
firebase firestore:indexes
Using Google Analytics in DEBUG mode. Emulators (+ UI) events will be shown in GA Debug View only.

Error: No currently active project.
To run this command, you need to specify a project. You have two options:
- Run this command with --project <alias_or_project_id>.
- Set an active project by running firebase use --add, then rerun this command.
To list all the Firebase projects to which you have access, run firebase projects:list.
To learn about active projects for the CLI, visit https://firebase.google.com/docs/cli#project_aliases
```


### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase firestore:indexes`
