### PR TITLE
Added `--output` option to `firestore:indexes` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Added default value for `emulators.dataconnect.dataDir` to `init dataconnect`.
 - Fixed an issue where `firebase` would error out instead of displaying help text.
+- Added `--output` option to `firestore:indexes` which writes indexes to a file.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Add `--output` option to `firestore:indexes` command

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Given the ff files:

<details>
  <summary>firebase.json</summary>

```json
{
  "firestore": [
    {
      "database": "(default)",
      "rules": "firestore.rules",
      "indexes": "firestore.indexes.json"
    },
    {
      "database": "non-default",
      "rules": "firestore-non-default.rules",
      "indexes": "firestore-indexes-non-default.indexes.json"
    }
  ]
}
```

</details>

<details>
  <summary>firestore-indexes-non-default.indexes.json</summary>

```json
{
  "indexes": [],
  "fieldOverrides": []
}
```

</details>

<details>
  <summary>firestore.indexes.json</summary>
  
```json
{
  "indexes": [],
  "fieldOverrides": []
}
```
</details>

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase firestore:indexes --output` Updates `firestore.indexes.json`

```json
{
  "indexes": [
    {
      "collectionGroup": "messagespaces",
      "queryScope": "COLLECTION",
      "fields": [
        {
          "fieldPath": "userIds",
          "arrayConfig": "CONTAINS"
        },
        {
          "fieldPath": "updatedAt",
          "order": "ASCENDING"
        }
      ]
    }
  ],
  "fieldOverrides": []
}
```

`firebase firestore:indexes --output --database non-default` Updates `firestore-indexes-non-default.indexes.json`

```json
{
  "indexes": [
    {
      "collectionGroup": "random-collection",
      "queryScope": "COLLECTION_GROUP",
      "fields": [
        {
          "fieldPath": "a",
          "order": "ASCENDING"
        },
        {
          "fieldPath": "b",
          "order": "DESCENDING"
        }
      ]
    }
  ],
  "fieldOverrides": []
}
```
