### PR TITLE
Fix load  when datasource is undefined

### DIFF
--- a/src/dataconnect/types.ts
+++ b/src/dataconnect/types.ts
@@ -184,7 +184,7 @@ export function toDatasource(
   locationId: string,
   ds: DatasourceYaml,
 ): Datasource {
-  if (ds.postgresql) {
+  if (ds?.postgresql) {
     return {
       postgresql: {
         database: ds.postgresql.database,


### PR DESCRIPTION
### Description
Fix a 'cannot read properties of undefined' error when datasource is not set. Load gets used in some places where this is not relevant (ie `dataconnect:sdk;generate`), so we shouldn't error if this is missing, but rather handle missing fields at the call site when necessary.
Thanks for catching this Denver! 
