### PR TITLE
App Hosting Emulator: Instead of removing startCommandOverride config, mark it as deprecated

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -371,6 +371,9 @@
                         },
                         "startCommand": {
                             "type": "string"
+                        },
+                        "startCommandOverride": {
+                            "type": "string"
                         }
                     },
                     "type": "object"

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -952,10 +952,18 @@ export async function startAll(
 
   if (listenForEmulator.apphosting) {
     const apphostingAddr = legacyGetFirstAddr(Emulators.APPHOSTING);
+    if (apphostingConfig?.startCommandOverride) {
+      const apphostingLogger = EmulatorLogger.forEmulator(Emulators.APPHOSTING);
+      apphostingLogger.logLabeled(
+        "WARN",
+        Emulators.APPHOSTING,
+        "The `firebase.json#emulators.apphosting.startCommandOverride` config is deprecated, please use `firebase.json#emulators.apphosting.startCommand` to set a custom start command instead",
+      );
+    }
     const apphostingEmulator = new AppHostingEmulator({
       host: apphostingAddr.host,
       port: apphostingAddr.port,
-      startCommand: apphostingConfig?.startCommand,
+      startCommand: apphostingConfig?.startCommand || apphostingConfig?.startCommandOverride,
       rootDirectory: apphostingConfig?.rootDirectory,
       options,
     });

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -207,6 +207,10 @@ export type EmulatorsConfig = {
     host?: string;
     port?: number;
     startCommand?: string;
+    /**
+     * @deprecated
+     */
+    startCommandOverride?: string;
     rootDirectory?: string;
   };
   pubsub?: {


### PR DESCRIPTION
Re-adds the `startCommandOverride` App Hosting Emulator config so that current user setups are not broken when they upgrade the CLI. Instead this config is marked as deprecated and a warning is logged when `startCommandOverride` is used.