### PR TITLE
Fix issue where content-type headers were not sent to event functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Added default value for `emulators.dataconnect.dataDir` to `init dataconnect`.
 - Fixed an issue where `firebase` would error out instead of displaying help text.
+- Fixed an issue where emulator returned error when emulating alerts functions written in python (#8019)

--- a/src/emulator/eventarcEmulator.ts
+++ b/src/emulator/eventarcEmulator.ts
@@ -189,6 +189,7 @@ export class EventarcEmulator implements EmulatorInstance {
       .request<CloudEvent<any>, NodeJS.ReadableStream>({
         method: "POST",
         path: `/functions/projects/${trigger.projectId}/triggers/${trigger.triggerName}`,
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(event),
         responseType: "stream",
         resolveOnHTTPError: true,


### PR DESCRIPTION
This issue only affected python functions because Flask by default will return status=415 when making POST request with JSON body without content-type header. Express server wrapping Nodejs functions, on the other hand, is more loosey-goosey when it comes to validating incoming request headers.

Fixes https://github.com/firebase/firebase-tools/issues/7998