### PR TITLE
Update superstatic in package.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Updates `superstatic` to `9.1.0` in package.json.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -64,7 +64,7 @@
         "sql-formatter": "^15.3.0",
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
-        "superstatic": "^9.0.3",
+        "superstatic": "^9.1.0",
         "tar": "^6.1.11",
         "tcp-port-used": "^1.0.2",
         "tmp": "^0.2.3",

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "sql-formatter": "^15.3.0",
     "stream-chain": "^2.2.4",
     "stream-json": "^1.7.3",
-    "superstatic": "^9.0.3",
+    "superstatic": "^9.1.0",
     "tar": "^6.1.11",
     "tcp-port-used": "^1.0.2",
     "tmp": "^0.2.3",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

an update of #7975 - evidently npm-shrinkwrap isn't being shipped any longer, so the update there (which is what `npm update` does by default) won't fix this for older installs (that might just be updating firebase-tools)
