### PR TITLE
Support nodejs22 in CF3

### DIFF
--- a/src/deploy/functions/runtimes/supported/types.ts
+++ b/src/deploy/functions/runtimes/supported/types.ts
@@ -85,7 +85,7 @@ export const RUNTIMES = runtimes({
   },
   nodejs22: {
     friendly: "Node.js 22",
-    status: "beta",
+    status: "GA",
     deprecationDate: "2027-04-30",
     decommissionDate: "2027-10-31",
   },

--- a/templates/init/functions/javascript/package.lint.json
+++ b/templates/init/functions/javascript/package.lint.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "main": "index.js",
   "dependencies": {

--- a/templates/init/functions/javascript/package.nolint.json
+++ b/templates/init/functions/javascript/package.nolint.json
@@ -9,7 +9,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "main": "index.js",
   "dependencies": {

--- a/templates/init/functions/typescript/package.lint.json
+++ b/templates/init/functions/typescript/package.lint.json
@@ -11,7 +11,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "main": "lib/index.js",
   "dependencies": {

--- a/templates/init/functions/typescript/package.nolint.json
+++ b/templates/init/functions/typescript/package.nolint.json
@@ -10,7 +10,7 @@
     "logs": "firebase functions:log"
   },
   "engines": {
-    "node": "18"
+    "node": "22"
   },
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
nodejs22 is not GA in GCF per https://cloud.google.com/static/functions/docs/concepts/execution-environment#node.js