### PR TITLE
Fixing an issue with --import and dataDir at the same time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Changes default CF3 runtime to nodejs22 (#8037)
+- Fixed an issue where `--import` would error for the Data Connect emulator if `dataDir` was also set.

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -28,7 +28,7 @@ import { LoggingEmulator } from "./loggingEmulator";
 import * as dbRulesConfig from "../database/rulesConfig";
 import { EmulatorLogger, Verbosity } from "./emulatorLogger";
 import { EmulatorHubClient } from "./hubClient";
-import { confirm } from "../prompt";
+import { confirm, promptOnce } from "../prompt";
 import {
   FLAG_EXPORT_ON_EXIT_NAME,
   JAVA_DEPRECATION_WARNING,
@@ -893,6 +893,26 @@ export async function startAll(
         importDirAbsPath,
         exportMetadata.dataconnect.path,
       );
+      const dataDirectory = options.config.get("emulators.dataconnect.dataDir");
+      if (exportMetadataFilePath && dataDirectory) {
+        EmulatorLogger.forEmulator(Emulators.DATACONNECT).logLabeled(
+          "WARN",
+          "dataconnect",
+          "'firebase.json#emulators.dataconnect.dataDir' is set and `--import` flag was passed. " +
+            "This will overwrite any data saved from previous runs.",
+        );
+        if (
+          !options.nonInteractive &&
+          !(await promptOnce({
+            type: "confirm",
+            message: `Do you wish to continue and overwrite data in ${dataDirectory}?`,
+            default: false,
+          }))
+        ) {
+          await cleanShutdown();
+          return { deprecationNotices: [] };
+        }
+      }
 
       EmulatorLogger.forEmulator(Emulators.DATACONNECT).logLabeled(
         "BULLET",

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -9,7 +9,7 @@ import {
 } from "./types";
 import { Constants } from "./constants";
 
-import { FirebaseError } from "../error";
+import { FirebaseError, hasMessage } from "../error";
 import * as childProcess from "child_process";
 import * as utils from "../utils";
 import { EmulatorLogger } from "./emulatorLogger";
@@ -655,7 +655,6 @@ export async function start(
 }
 
 export function isIncomaptibleArchError(err: unknown): boolean {
-  const hasMessage = (e: any): e is { message: string } => !!e?.message;
   return (
     hasMessage(err) &&
     /Unknown system error/.test(err.message ?? "") &&

--- a/src/error.ts
+++ b/src/error.ts
@@ -121,3 +121,8 @@ export function isBillingError(e: {
     );
   });
 }
+
+/**
+ * Checks whether an unknown object (such as an error) has a message field
+ */
+export const hasMessage = (e: any): e is { message: string } => !!e?.message;


### PR DESCRIPTION
### Description
When 'dataDir' and `--import` are used at the same time, the emulator would fail with 'Database already exists'. Now, we warn that data will be overwritten, prompt if we're in interactive mode, and then overwrite the dataDir.

### Scenarios Tested
Manually tested the following cases and verified that they work as expected:
- Interactive, both are set, accept prompt
- Interactive, both are set, decline prompt
- Noninteractive, both are set
- Only --import is set
- Only dataDir is set

