### PR TITLE
ensureServiceIsConnectedToCloudSql only need to call backend when schemaValidation==NONE

### DIFF
--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -568,7 +568,7 @@ async function ensureServiceIsConnectedToCloudSql(
     );
   }
   if (!postgresql || postgresql.schemaValidation !== "NONE") {
-    // Skip provisioning connectvity if it was already connected.
+    // Skip provisioning connectvity if it is already connected.
     return;
   }
   postgresql.schemaValidation = "STRICT";

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -543,6 +543,7 @@ async function ensureServiceIsConnectedToCloudSql(
         {
           postgresql: {
             database: databaseId,
+            schemaValidation: "NONE",
             cloudSql: {
               instance: instanceId,
             },
@@ -566,7 +567,8 @@ async function ensureServiceIsConnectedToCloudSql(
       `Switching connected Postgres database from ${postgresql?.database} to ${databaseId}`,
     );
   }
-  if (!postgresql || postgresql.schemaValidation === "STRICT") {
+  if (!postgresql || postgresql.schemaValidation !== "NONE") {
+    // Skip provisioning connectvity if it was already connected.
     return;
   }
   postgresql.schemaValidation = "STRICT";


### PR DESCRIPTION
[low priority] Minor tweak.

`postgresql.schemaValidation !== "NONE"` can be used to detect if backend has been linked to Cloud SQL.

We previously used `=== "STRICT"` because at that time only `NONE` and `STRICT` were valid, so it's equivalent to `!== "NONE"`.

We forgot to tweak this when adding compatible mode.