### PR TITLE
Fixing init dataconnect on some empty schema cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Changes default CF3 runtime to nodejs22 (#8037)
 - Fixed an issue where `--import` would error for the Data Connect emulator if `dataDir` was also set.
+- Fixed an issue where `firebase init dataconnect` errored when importing a schema with no GQL files.

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -58,6 +58,9 @@ function validateConnectorYaml(unvalidated: any): ConnectorYaml {
 }
 
 export async function readGQLFiles(sourceDir: string): Promise<File[]> {
+  if (!fs.existsSync(sourceDir)) {
+    return [];
+  }
   const files = await fs.readdir(sourceDir);
   // TODO: Handle files in subdirectories such as `foo/a.gql` and `bar/baz/b.gql`.
   return files

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -198,7 +198,7 @@ async function writeFiles(config: Config, info: RequiredInfo) {
       await config.askWriteProjectFile(join(dir, "schema", f.path), f.content);
     }
   } else {
-    // Even if the schema is empty, lets give them an emty .gql file to get started.
+    // Even if the schema is empty, lets give them an empty .gql file to get started.
     fs.ensureFileSync(join(dir, "schema", "schema.gql"));
   }
 

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -1,5 +1,6 @@
 import { join, basename } from "path";
 import * as clc from "colorette";
+import { ensureDirSync } from "fs-extra";
 
 import { confirm, promptOnce } from "../../../prompt";
 import { Config } from "../../../config";
@@ -192,6 +193,9 @@ async function writeFiles(config: Config, info: RequiredInfo) {
     true,
   );
 
+  // Make sure we create a schema directory even if there are no files
+  // so that users know where to put them.
+  ensureDirSync(join(dir, "schema"));
   if (info.schemaGql.length) {
     for (const f of info.schemaGql) {
       await config.askWriteProjectFile(join(dir, "schema", f.path), f.content);

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -1,6 +1,6 @@
 import { join, basename } from "path";
 import * as clc from "colorette";
-import { ensureDirSync } from "fs-extra";
+import * as fs from "fs-extra";
 
 import { confirm, promptOnce } from "../../../prompt";
 import { Config } from "../../../config";
@@ -193,14 +193,15 @@ async function writeFiles(config: Config, info: RequiredInfo) {
     true,
   );
 
-  // Make sure we create a schema directory even if there are no files
-  // so that users know where to put them.
-  ensureDirSync(join(dir, "schema"));
   if (info.schemaGql.length) {
     for (const f of info.schemaGql) {
       await config.askWriteProjectFile(join(dir, "schema", f.path), f.content);
     }
+  } else {
+    // Even if the schema is empty, lets give them an emty .gql file to get started.
+    fs.ensureFileSync(join(dir, "schema", "schema.gql"));
   }
+
   for (const c of info.connectors) {
     await writeConnectorFiles(config, c);
   }


### PR DESCRIPTION
### Description
Fixes an issue where `firebase init dataconnect` would error out when importing services that have schemas with no GQL files. Thanks @maneesht for debugging this with me!

