### PR TITLE
Multiple fixes for the Data connect emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Fixed an issue where `clearData` with no tables would cause the Data Connect emulator to crash.
+- Fixed an issue where the Data Connect emulator would crash with `Error: Unreachable`.

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -884,6 +884,7 @@ export async function startAll(
       postgresListen: listenForEmulator["dataconnect.postgres"],
       enable_output_generated_sdk: true, // TODO: source from arguments
       enable_output_schema_extensions: true,
+      debug: options.debug,
     };
 
     if (exportMetadata.dataconnect) {

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -118,8 +118,6 @@ export class DataConnectEmulator implements EmulatorInstance {
           ? path.join(this.args.importPath, "postgres.tar.gz")
           : undefined;
         this.postgresServer = new PostgresServer({
-          database: dbId,
-          username: "fdc",
           dataDirectory,
           importPath: postgresDumpPath,
           debug: this.args.debug,


### PR DESCRIPTION
### Description
Fixes a number of issues causing the data connect emulator to be totally broken in 13.29.0

1 - No longer provide User and Database when starting pglite. If these are passed in and the corresponding roles/databases don't exist in dataDir/--import, the emulator will crash.

2 - The ClearData query would fail with a `null value in query string of EXECUTE statement` if there were no tables in the DB. This new SQL is safe in that case

3 - Actually pipe thru --debug all the way to the emulator - forgot this step in yesterdays PR 🤦 

Fixes #8062 8062

### Scenarios Tested
- From https://github.com/firebaseextended/codelab-dataconnect-web, start up the emulator and confirm that it does not crash. 
- Next, shut down the emulator and set a dataDir. Start up again and confirm it doesn't crash.
- Next, shut down and start up again with a populated data dir. Confirm that there is no crash.
- `curl -X  POST localhost:4400/dataconnect/clearData/`, confirm no crash.
- Add a type to your schema, add some data using VSCE, confirm it writes successfully.
- Shut down, restart, confirm data is still there.
- `curl -X  POST localhost:4400/dataconnect/clearData/`, confirm data is cleared
- Modify schema, confirm it migrates correctly
