### PR TITLE
Change how FDC determines whether creating a CSQL free trial is allowed.

### DIFF
--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -11,6 +11,7 @@ const FREE_TRIAL_METRIC = "sqladmin.googleapis.com/fdc_lifetime_free_trial_per_p
 
 // Checks whether there is already a free trial instance on a project.
 export async function checkFreeTrialInstanceUsed(projectId: string): Promise<boolean> {
+  // TODO: Catch error instead of checking for metric? Some test projects have been allow-listed for unlimited free trials.
   const past7d = new Date();
   past7d.setDate(past7d.getDate() - 7);
   const query: CmQuery = {
@@ -42,11 +43,11 @@ export function printFreeTrialUnavailable(
 ): void {
   if (!instanceId) {
     utils.logLabeledError(
-      "data connect",
+      "dataconnect",
       "The CloudSQL free trial has already been used on this project.",
     );
     utils.logLabeledError(
-      "data connect",
+      "dataconnect",
       `You may create or use a paid CloudSQL instance by visiting https://console.cloud.google.com/sql/instances`,
     );
     return;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Currently, the CLI determines whether it can create a CSQL free trial instance by querying for the presence of the free trial metric. However, some projects (mostly internal testing projects) have been allowlisted to have unlimited free trial instances, and creating a CSQL instance via the CLI fails for these projects if they previously had a free trial instance.

This PR updates the provisioning logic use the backend error for determining whether a free trial instance can be created, instead of just the presence of the free trial metric.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

- [x] `firebase deploy` for a non-allowlisted project that previously had a free trial instance
- [x] `firebase deploy` for an allowlisted project that previously had a free trial instance

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
