### PR TITLE
Fix storage-integeration-test

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -89,6 +89,10 @@ jobs:
           distribution: temurin
 
       - uses: actions/checkout@v4
+      - uses: actions/setup-chrome
+        with:
+          install-dependencies: true
+          install-chromedriver: true
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
@@ -184,6 +188,10 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
+      - uses: actions/setup-chrome
+        with:
+          install-dependencies: true
+          install-chromedriver: true
       - name: Cache firebase emulators
         uses: actions/cache@v3
         with:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -89,7 +89,8 @@ jobs:
           distribution: temurin
 
       - uses: actions/checkout@v4
-      - uses: browser-actions/setup-chrome
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1.7.2
         with:
           install-dependencies: true
           install-chromedriver: true
@@ -188,7 +189,8 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
-      - uses: browser-actions/setup-chrome
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1.7.2
         with:
           install-dependencies: true
           install-chromedriver: true

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -89,7 +89,7 @@ jobs:
           distribution: temurin
 
       - uses: actions/checkout@v4
-      - uses: actions/setup-chrome
+      - uses: browser-actions/setup-chrome
         with:
           install-dependencies: true
           install-chromedriver: true
@@ -188,7 +188,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
           cache-dependency-path: npm-shrinkwrap.json
-      - uses: actions/setup-chrome
+      - uses: browser-actions/setup-chrome
         with:
           install-dependencies: true
           install-chromedriver: true

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -151,7 +151,7 @@ jobs:
   integration:
     needs: unit
     if: contains(fromJSON('["push", "merge_group"]'), github.event_name)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
       FIREBASE_EMULATORS_PATH: ${{ github.workspace }}/emulator-cache

--- a/scripts/storage-emulator-integration/run.sh
+++ b/scripts/storage-emulator-integration/run.sh
@@ -12,10 +12,19 @@ firebase setup:emulators:storage
 
 mocha scripts/storage-emulator-integration/internal/tests.ts
 
+# Brief sleep between tests to make sure emulators shut down fully.
+sleep 5
+
 mocha scripts/storage-emulator-integration/rules/*.test.ts
+
+sleep 5
 
 mocha scripts/storage-emulator-integration/import/tests.ts
 
+sleep 5
+
 mocha scripts/storage-emulator-integration/multiple-targets/tests.ts
+
+sleep 5
 
 mocha scripts/storage-emulator-integration/conformance/*.test.ts


### PR DESCRIPTION
### Description
storage-integration-test started failing (like https://github.com/firebase/firebase-tools/actions/runs/12471094954/job/34807608158) with errors like:
```
  Error: Failed to launch the browser process!
[1223/182035.329646:FATAL:zygote_host_impl_linux.cc(127)] No usable sandbox! Update your kernel or see https://chromium.googlesource.com/chromium/src/+/main/docs/linux/suid_sandbox_development.md for more information on developing with the SUID sandbox. If you want to live dangerously and need an immediate workaround, you can try using --no-sandbox.
```
It seems like puppeteer can't start up headless Chrome - so let's see if we can fix that.
