### PR TITLE
fix dot env files in windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed a Data Connect emulator issue where prepared statements would be persisted after terminated connections.
 - Added a warning when deploying a Genkit function without a secret as this is likely a bug (#8138)
+- Fixed `.env.*` files for web frameworks in Windows (#8086)

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -48,7 +48,7 @@ import {
   FrameworkContext,
   FrameworksOptions,
 } from "./interfaces";
-import { logWarning } from "../utils";
+import { IS_WINDOWS, logWarning } from "../utils";
 import { ensureTargeted } from "../functions/ensureTargeted";
 import { isDeepStrictEqual } from "util";
 import { resolveProjectPath } from "../projectPath";
@@ -525,7 +525,7 @@ ${
 }`.trimStart(),
       );
 
-      const envs = await glob(getProjectPath(".env.*"));
+      const envs = await glob(getProjectPath(".env.*"), { windowsPathsNoEscape: IS_WINDOWS });
 
       await Promise.all(envs.map((path) => copyFile(path, join(functionsDist, basename(path)))));
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #8076 by telling glob to use Windows path delimiters on Windows.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Tested with an `.env.production` file on Windows

### Sample Commands

firebase deploy

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
