### PR TITLE
Override `nan` to support node 22 (and earlier)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14637,9 +14637,10 @@
       }
     },
     "node_modules/nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/nanoid": {
@@ -31852,9 +31853,9 @@
       }
     },
     "nan": {
-      "version": "2.17.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-      "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.22.0.tgz",
+      "integrity": "sha512-nbajikzWTMwsW+eSsNm3QwlOs7het9gGJU5dDZzRTQGk03vyBOauxgI4VakDzE0PtsGTmXPsXTbbjVhRwR5mpw==",
       "optional": true
     },
     "nanoid": {
@@ -33672,7 +33673,7 @@
       "optional": true,
       "requires": {
         "install-artifact-from-github": "^1.3.1",
-        "nan": "^2.17.0",
+        "nan": "^2.22.0",
         "node-gyp": "^9.3.0"
       }
     },


### PR DESCRIPTION
### Description

Overrides `nan` (node native interfaces) to its current 2.22.0. This adds support for node 22 for any native V8 interfaces and fixes a remaining 6.x ajv compilation issue due to the angular tools.

Pay particular attention to the `npm-shrinkwrap` diffs -- you can see the nan upgrade happening in exactly two places.

Fixes #8096 

### Scenarios Tested

All tests not requiring a local firebase project. Also, this compiles on nixos with the sandbox (which builds all from source including extensions -- it's a very strict build which also runs the tests.) 

### Sample Commands

n/a
