### PR TITLE
Fix relative dataDir issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Updated `cross-env` and `cross-spawn` dependencies to avoid vulnerable versions. (#7979)
+- Fixed an issue with the Data Connect emulator where `dataDir` and `--export` were relative to the current directory insead of `firebase.json`.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -33673,7 +33673,7 @@
       "optional": true,
       "requires": {
         "install-artifact-from-github": "^1.3.1",
-        "nan": "^2.22.0",
+        "nan": "^2.17.0",
         "node-gyp": "^9.3.0"
       }
     },

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -114,9 +114,12 @@ export class DataConnectEmulator implements EmulatorInstance {
           `FIREBASE_DATACONNECT_POSTGRESQL_STRING is set to ${clc.bold(connStr)} - using that instead of starting a new database`,
         );
       } else if (pgHost && pgPort) {
-        const dataDirectory = this.args.config.get("emulators.dataconnect.dataDir");
+        let dataDirectory = this.args.config.get("emulators.dataconnect.dataDir");
+        if (dataDirectory) {
+          dataDirectory = this.args.config.path(dataDirectory);
+        }
         const postgresDumpPath = this.args.importPath
-          ? path.join(this.args.importPath, "postgres.tar.gz")
+          ? path.join(this.args.config.path(this.args.importPath), "postgres.tar.gz")
           : undefined;
         this.postgresServer = new PostgresServer({
           dataDirectory,
@@ -205,7 +208,9 @@ export class DataConnectEmulator implements EmulatorInstance {
 
   async exportData(exportPath: string): Promise<void> {
     if (this.postgresServer) {
-      await this.postgresServer.exportData(path.join(exportPath, "postgres.tar.gz"));
+      await this.postgresServer.exportData(
+        path.join(this.args.config.path(exportPath), "postgres.tar.gz"),
+      );
     } else {
       throw new FirebaseError(
         "The Data Connect emulator is currently connected to a separate Postgres instance. Export is not supported.",


### PR DESCRIPTION
### Description

Resolve dataDir and other paths relative to firebase.json instead of cwd. Fixes b/384546990

### Scenarios Tested
Pulled down the web data connect codelab, and added a dataDir to firebase.json. Confirmed that it runs successfully from the directory with firebase.json, and also from ./app
