### PR TITLE
Fixing some warnings due to union types

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -14,6 +14,7 @@
         "@google-cloud/pubsub": "^4.5.0",
         "abort-controller": "^3.0.0",
         "ajv": "^8.17.1",
+        "ajv-formats": "3.0.1",
         "archiver": "^7.0.0",
         "async-lock": "1.4.1",
         "body-parser": "^1.19.0",
@@ -166,7 +167,7 @@
         "swagger2openapi": "^7.0.8",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.4",
-        "typescript-json-schema": "^0.50.1",
+        "typescript-json-schema": "^0.65.1",
         "vite": "^4.2.1"
       },
       "engines": {
@@ -275,6 +276,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/@angular-devkit/core/node_modules/rxjs": {
@@ -5122,9 +5140,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -9032,6 +9050,22 @@
         "npm": ">5.0.0"
       }
     },
+    "node_modules/exegesis/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/express": {
       "version": "4.19.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
@@ -12461,15 +12495,6 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
-    "node_modules/json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "dependencies": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -12509,15 +12534,6 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/jsonpath": {
@@ -16083,6 +16099,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/path-equal": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.5.tgz",
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==",
+      "dev": true
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -17784,6 +17806,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -19610,36 +19641,36 @@
       }
     },
     "node_modules/typescript-json-schema": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.50.1.tgz",
-      "integrity": "sha512-GCof/SDoiTDl0qzPonNEV4CHyCsZEIIf+mZtlrjoD8vURCcEzEfa2deRuxYid8Znp/e27eDR7Cjg8jgGrimBCA==",
+      "version": "0.65.1",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.65.1.tgz",
+      "integrity": "sha512-tuGH7ff2jPaUYi6as3lHyHcKpSmXIqN7/mu50x3HlYn0EHzLpmt3nplZ7EuhUkO0eqDRc9GqWNkfjgBPIS9kxg==",
       "dev": true,
       "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@types/node": "^14.14.33",
-        "glob": "^7.1.6",
-        "json-stable-stringify": "^1.0.1",
-        "ts-node": "^9.1.1",
-        "typescript": "~4.2.3",
-        "yargs": "^16.2.0"
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^18.11.9",
+        "glob": "^7.1.7",
+        "path-equal": "^1.2.5",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "~5.5.0",
+        "yargs": "^17.1.1"
       },
       "bin": {
         "typescript-json-schema": "bin/typescript-json-schema"
       }
     },
-    "node_modules/typescript-json-schema/node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
-    },
-    "node_modules/typescript-json-schema/node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+    "node_modules/typescript-json-schema/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
       "engines": {
-        "node": ">=0.3.1"
+        "node": ">=12"
       }
     },
     "node_modules/typescript-json-schema/node_modules/glob": {
@@ -19663,43 +19694,53 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/typescript-json-schema/node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
-      "dev": true,
-      "dependencies": {
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.7"
-      }
-    },
     "node_modules/typescript-json-schema/node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-json-schema/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript-json-schema/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/typescript-json-schema/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/uc.micro": {
@@ -21057,6 +21098,15 @@
             "json-schema-traverse": "^1.0.0",
             "require-from-string": "^2.0.2",
             "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-formats": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^8.0.0"
           }
         },
         "rxjs": {
@@ -24877,9 +24927,9 @@
       }
     },
     "ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
         "ajv": "^8.0.0"
       }
@@ -27679,6 +27729,16 @@
         "qs": "^6.6.0",
         "raw-body": "^2.3.3",
         "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "ajv-formats": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+          "requires": {
+            "ajv": "^8.0.0"
+          }
+        }
       }
     },
     "exegesis-express": {
@@ -30262,15 +30322,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "~0.0.0"
-      }
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -30303,12 +30354,6 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
     },
     "jsonpath": {
       "version": "1.1.1",
@@ -32925,6 +32970,12 @@
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
+    "path-equal": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/path-equal/-/path-equal-1.2.5.tgz",
+      "integrity": "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g==",
+      "dev": true
+    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -34171,6 +34222,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -35601,31 +35658,31 @@
       "dev": true
     },
     "typescript-json-schema": {
-      "version": "0.50.1",
-      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.50.1.tgz",
-      "integrity": "sha512-GCof/SDoiTDl0qzPonNEV4CHyCsZEIIf+mZtlrjoD8vURCcEzEfa2deRuxYid8Znp/e27eDR7Cjg8jgGrimBCA==",
+      "version": "0.65.1",
+      "resolved": "https://registry.npmjs.org/typescript-json-schema/-/typescript-json-schema-0.65.1.tgz",
+      "integrity": "sha512-tuGH7ff2jPaUYi6as3lHyHcKpSmXIqN7/mu50x3HlYn0EHzLpmt3nplZ7EuhUkO0eqDRc9GqWNkfjgBPIS9kxg==",
       "dev": true,
       "requires": {
-        "@types/json-schema": "^7.0.7",
-        "@types/node": "^14.14.33",
-        "glob": "^7.1.6",
-        "json-stable-stringify": "^1.0.1",
-        "ts-node": "^9.1.1",
-        "typescript": "~4.2.3",
-        "yargs": "^16.2.0"
+        "@types/json-schema": "^7.0.9",
+        "@types/node": "^18.11.9",
+        "glob": "^7.1.7",
+        "path-equal": "^1.2.5",
+        "safe-stable-stringify": "^2.2.0",
+        "ts-node": "^10.9.1",
+        "typescript": "~5.5.0",
+        "yargs": "^17.1.1"
       },
       "dependencies": {
-        "@types/node": {
-          "version": "14.18.63",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-          "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-          "dev": true
-        },
-        "diff": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-          "dev": true
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
         },
         "glob": {
           "version": "7.2.3",
@@ -35641,24 +35698,37 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "ts-node": {
-          "version": "9.1.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-          "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+        "typescript": {
+          "version": "5.5.4",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
+          "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+          "dev": true
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "dev": true,
           "requires": {
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.17",
-            "yn": "3.1.1"
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
           }
         },
-        "typescript": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-          "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@google-cloud/pubsub": "^4.5.0",
     "abort-controller": "^3.0.0",
     "ajv": "^8.17.1",
+    "ajv-formats": "3.0.1",
     "archiver": "^7.0.0",
     "async-lock": "1.4.1",
     "body-parser": "^1.19.0",
@@ -253,7 +254,7 @@
     "swagger2openapi": "^7.0.8",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",
-    "typescript-json-schema": "^0.50.1",
+    "typescript-json-schema": "^0.65.1",
     "vite": "^4.2.1"
   }
 }

--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -2,8 +2,125 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
     "definitions": {
+        "DataConnectSingle": {
+            "additionalProperties": false,
+            "properties": {
+                "postdeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "predeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "source": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "source"
+            ],
+            "type": "object"
+        },
+        "DatabaseSingle": {
+            "additionalProperties": false,
+            "properties": {
+                "postdeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "predeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "rules": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "rules"
+            ],
+            "type": "object"
+        },
         "ExtensionsConfig": {
             "additionalProperties": false,
+            "type": "object"
+        },
+        "FirestoreSingle": {
+            "additionalProperties": false,
+            "properties": {
+                "database": {
+                    "type": "string"
+                },
+                "indexes": {
+                    "type": "string"
+                },
+                "postdeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "predeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "rules": {
+                    "type": "string"
+                }
+            },
             "type": "object"
         },
         "FrameworksBackendOptions": {
@@ -23,9 +140,7 @@
                 "cpu": {
                     "anyOf": [
                         {
-                            "enum": [
-                                "gcf_gen1"
-                            ],
+                            "const": "gcf_gen1",
                             "type": "string"
                         },
                         {
@@ -48,10 +163,8 @@
                     "type": "string"
                 },
                 "invoker": {
+                    "const": "public",
                     "description": "Invoker to set access control on https functions.",
-                    "enum": [
-                        "public"
-                    ],
                     "type": "string"
                 },
                 "labels": {
@@ -122,8 +235,746 @@
             },
             "type": "object"
         },
+        "FunctionConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "codebase": {
+                    "type": "string"
+                },
+                "ignore": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "postdeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "predeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "runtime": {
+                    "enum": [
+                        "nodejs10",
+                        "nodejs12",
+                        "nodejs14",
+                        "nodejs16",
+                        "nodejs18",
+                        "nodejs20",
+                        "nodejs22",
+                        "python310",
+                        "python311",
+                        "python312"
+                    ],
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
+        "HostingHeaders": {
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "glob": {
+                            "type": "string"
+                        },
+                        "headers": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "value"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": [
+                        "glob",
+                        "headers"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "headers": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "value"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "headers",
+                        "source"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "headers": {
+                            "items": {
+                                "additionalProperties": false,
+                                "properties": {
+                                    "key": {
+                                        "type": "string"
+                                    },
+                                    "value": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "key",
+                                    "value"
+                                ],
+                                "type": "object"
+                            },
+                            "type": "array"
+                        },
+                        "regex": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "headers",
+                        "regex"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "HostingRedirects": {
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "destination": {
+                            "type": "string"
+                        },
+                        "glob": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "destination",
+                        "glob"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "destination": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "destination",
+                        "source"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "destination": {
+                            "type": "string"
+                        },
+                        "regex": {
+                            "type": "string"
+                        },
+                        "type": {
+                            "type": "number"
+                        }
+                    },
+                    "required": [
+                        "destination",
+                        "regex"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "HostingRewrites": {
+            "anyOf": [
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "destination": {
+                            "type": "string"
+                        },
+                        "glob": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "destination",
+                        "glob"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "function": {
+                            "type": "string"
+                        },
+                        "glob": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "function",
+                        "glob"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "function": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "functionId": {
+                                    "type": "string"
+                                },
+                                "pinTag": {
+                                    "type": "boolean"
+                                },
+                                "region": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "functionId"
+                            ],
+                            "type": "object"
+                        },
+                        "glob": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "function",
+                        "glob"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "glob": {
+                            "type": "string"
+                        },
+                        "run": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "pinTag": {
+                                    "type": "boolean"
+                                },
+                                "region": {
+                                    "type": "string"
+                                },
+                                "serviceId": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "serviceId"
+                            ],
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "glob",
+                        "run"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "dynamicLinks": {
+                            "type": "boolean"
+                        },
+                        "glob": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "dynamicLinks",
+                        "glob"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "destination": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "destination",
+                        "source"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "function": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "function",
+                        "source"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "function": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "functionId": {
+                                    "type": "string"
+                                },
+                                "pinTag": {
+                                    "type": "boolean"
+                                },
+                                "region": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "functionId"
+                            ],
+                            "type": "object"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "function",
+                        "source"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "run": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "pinTag": {
+                                    "type": "boolean"
+                                },
+                                "region": {
+                                    "type": "string"
+                                },
+                                "serviceId": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "serviceId"
+                            ],
+                            "type": "object"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "run",
+                        "source"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "dynamicLinks": {
+                            "type": "boolean"
+                        },
+                        "source": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "dynamicLinks",
+                        "source"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "destination": {
+                            "type": "string"
+                        },
+                        "regex": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "destination",
+                        "regex"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "function": {
+                            "type": "string"
+                        },
+                        "regex": {
+                            "type": "string"
+                        },
+                        "region": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "function",
+                        "regex"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "function": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "functionId": {
+                                    "type": "string"
+                                },
+                                "pinTag": {
+                                    "type": "boolean"
+                                },
+                                "region": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "functionId"
+                            ],
+                            "type": "object"
+                        },
+                        "regex": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "function",
+                        "regex"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "regex": {
+                            "type": "string"
+                        },
+                        "run": {
+                            "additionalProperties": false,
+                            "properties": {
+                                "pinTag": {
+                                    "type": "boolean"
+                                },
+                                "region": {
+                                    "type": "string"
+                                },
+                                "serviceId": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "serviceId"
+                            ],
+                            "type": "object"
+                        }
+                    },
+                    "required": [
+                        "regex",
+                        "run"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "dynamicLinks": {
+                            "type": "boolean"
+                        },
+                        "regex": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "dynamicLinks",
+                        "regex"
+                    ],
+                    "type": "object"
+                }
+            ]
+        },
+        "HostingSingle": {
+            "additionalProperties": false,
+            "properties": {
+                "appAssociation": {
+                    "enum": [
+                        "AUTO",
+                        "NONE"
+                    ],
+                    "type": "string"
+                },
+                "cleanUrls": {
+                    "type": "boolean"
+                },
+                "frameworksBackend": {
+                    "$ref": "#/definitions/FrameworksBackendOptions"
+                },
+                "headers": {
+                    "items": {
+                        "$ref": "#/definitions/HostingHeaders"
+                    },
+                    "type": "array"
+                },
+                "i18n": {
+                    "additionalProperties": false,
+                    "properties": {
+                        "root": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "root"
+                    ],
+                    "type": "object"
+                },
+                "ignore": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "postdeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "predeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "public": {
+                    "type": "string"
+                },
+                "redirects": {
+                    "items": {
+                        "$ref": "#/definitions/HostingRedirects"
+                    },
+                    "type": "array"
+                },
+                "rewrites": {
+                    "items": {
+                        "$ref": "#/definitions/HostingRewrites"
+                    },
+                    "type": "array"
+                },
+                "site": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "string"
+                },
+                "trailingSlash": {
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
         "Record<string,string>": {
             "additionalProperties": false,
+            "type": "object"
+        },
+        "RemoteConfigConfig": {
+            "additionalProperties": false,
+            "properties": {
+                "postdeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "predeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "template": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "template"
+            ],
+            "type": "object"
+        },
+        "StorageSingle": {
+            "additionalProperties": false,
+            "properties": {
+                "postdeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "predeploy": {
+                    "anyOf": [
+                        {
+                            "items": {
+                                "type": "string"
+                            },
+                            "type": "array"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "rules": {
+                    "type": "string"
+                },
+                "target": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "rules"
+            ],
             "type": "object"
         }
     },
@@ -135,42 +986,7 @@
         "database": {
             "anyOf": [
                 {
-                    "additionalProperties": false,
-                    "properties": {
-                        "postdeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "predeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "rules": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "rules"
-                    ],
-                    "type": "object"
+                    "$ref": "#/definitions/DatabaseSingle"
                 },
                 {
                     "items": {
@@ -274,81 +1090,11 @@
         "dataconnect": {
             "anyOf": [
                 {
-                    "additionalProperties": false,
-                    "properties": {
-                        "postdeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "predeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "source": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "source"
-                    ],
-                    "type": "object"
+                    "$ref": "#/definitions/DataConnectSingle"
                 },
                 {
                     "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                            "postdeploy": {
-                                "anyOf": [
-                                    {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ]
-                            },
-                            "predeploy": {
-                                "anyOf": [
-                                    {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ]
-                            },
-                            "source": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "source"
-                        ],
-                        "type": "object"
+                        "$ref": "#/definitions/DataConnectSingle"
                     },
                     "type": "array"
                 }
@@ -436,8 +1182,7 @@
                     "type": "object"
                 },
                 "extensions": {
-                    "properties": {
-                    },
+                    "properties": {},
                     "type": "object"
                 },
                 "firestore": {
@@ -569,45 +1314,7 @@
         "firestore": {
             "anyOf": [
                 {
-                    "additionalProperties": false,
-                    "properties": {
-                        "database": {
-                            "type": "string"
-                        },
-                        "indexes": {
-                            "type": "string"
-                        },
-                        "postdeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "predeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "rules": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/FirestoreSingle"
                 },
                 {
                     "items": {
@@ -715,127 +1422,11 @@
         "functions": {
             "anyOf": [
                 {
-                    "additionalProperties": false,
-                    "properties": {
-                        "codebase": {
-                            "type": "string"
-                        },
-                        "ignore": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "postdeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "predeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "runtime": {
-                            "enum": [
-                                "nodejs10",
-                                "nodejs12",
-                                "nodejs14",
-                                "nodejs16",
-                                "nodejs18",
-                                "nodejs20",
-                                "nodejs22",
-                                "nodejs6",
-                                "nodejs8",
-                                "python310",
-                                "python311",
-                                "python312"
-                            ],
-                            "type": "string"
-                        },
-                        "source": {
-                            "type": "string"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/FunctionConfig"
                 },
                 {
                     "items": {
-                        "additionalProperties": false,
-                        "properties": {
-                            "codebase": {
-                                "type": "string"
-                            },
-                            "ignore": {
-                                "items": {
-                                    "type": "string"
-                                },
-                                "type": "array"
-                            },
-                            "postdeploy": {
-                                "anyOf": [
-                                    {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ]
-                            },
-                            "predeploy": {
-                                "anyOf": [
-                                    {
-                                        "items": {
-                                            "type": "string"
-                                        },
-                                        "type": "array"
-                                    },
-                                    {
-                                        "type": "string"
-                                    }
-                                ]
-                            },
-                            "runtime": {
-                                "enum": [
-                                    "nodejs10",
-                                    "nodejs12",
-                                    "nodejs14",
-                                    "nodejs16",
-                                    "nodejs18",
-                                    "nodejs20",
-                                    "nodejs22",
-                                    "nodejs6",
-                                    "nodejs8",
-                                    "python310",
-                                    "python311",
-                                    "python312"
-                                ],
-                                "type": "string"
-                            },
-                            "source": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object"
+                        "$ref": "#/definitions/FunctionConfig"
                     },
                     "type": "array"
                 }
@@ -844,595 +1435,7 @@
         "hosting": {
             "anyOf": [
                 {
-                    "additionalProperties": false,
-                    "properties": {
-                        "appAssociation": {
-                            "enum": [
-                                "AUTO",
-                                "NONE"
-                            ],
-                            "type": "string"
-                        },
-                        "cleanUrls": {
-                            "type": "boolean"
-                        },
-                        "frameworksBackend": {
-                            "$ref": "#/definitions/FrameworksBackendOptions"
-                        },
-                        "headers": {
-                            "items": {
-                                "anyOf": [
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "glob": {
-                                                "type": "string"
-                                            },
-                                            "headers": {
-                                                "items": {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "value"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                "type": "array"
-                                            }
-                                        },
-                                        "required": [
-                                            "glob",
-                                            "headers"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "headers": {
-                                                "items": {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "value"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                "type": "array"
-                                            },
-                                            "source": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "headers",
-                                            "source"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "headers": {
-                                                "items": {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "key": {
-                                                            "type": "string"
-                                                        },
-                                                        "value": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "key",
-                                                        "value"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                "type": "array"
-                                            },
-                                            "regex": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "headers",
-                                            "regex"
-                                        ],
-                                        "type": "object"
-                                    }
-                                ]
-                            },
-                            "type": "array"
-                        },
-                        "i18n": {
-                            "additionalProperties": false,
-                            "properties": {
-                                "root": {
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "root"
-                            ],
-                            "type": "object"
-                        },
-                        "ignore": {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        "postdeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "predeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "public": {
-                            "type": "string"
-                        },
-                        "redirects": {
-                            "items": {
-                                "anyOf": [
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "destination": {
-                                                "type": "string"
-                                            },
-                                            "glob": {
-                                                "type": "string"
-                                            },
-                                            "type": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "required": [
-                                            "destination",
-                                            "glob"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "destination": {
-                                                "type": "string"
-                                            },
-                                            "source": {
-                                                "type": "string"
-                                            },
-                                            "type": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "required": [
-                                            "destination",
-                                            "source"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "destination": {
-                                                "type": "string"
-                                            },
-                                            "regex": {
-                                                "type": "string"
-                                            },
-                                            "type": {
-                                                "type": "number"
-                                            }
-                                        },
-                                        "required": [
-                                            "destination",
-                                            "regex"
-                                        ],
-                                        "type": "object"
-                                    }
-                                ]
-                            },
-                            "type": "array"
-                        },
-                        "rewrites": {
-                            "items": {
-                                "anyOf": [
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "destination": {
-                                                "type": "string"
-                                            },
-                                            "glob": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "destination",
-                                            "glob"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "function": {
-                                                "type": "string"
-                                            },
-                                            "glob": {
-                                                "type": "string"
-                                            },
-                                            "region": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "function",
-                                            "glob"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "function": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "functionId": {
-                                                        "type": "string"
-                                                    },
-                                                    "pinTag": {
-                                                        "type": "boolean"
-                                                    },
-                                                    "region": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "functionId"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "glob": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "function",
-                                            "glob"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "glob": {
-                                                "type": "string"
-                                            },
-                                            "run": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "pinTag": {
-                                                        "type": "boolean"
-                                                    },
-                                                    "region": {
-                                                        "type": "string"
-                                                    },
-                                                    "serviceId": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "serviceId"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "required": [
-                                            "glob",
-                                            "run"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "dynamicLinks": {
-                                                "type": "boolean"
-                                            },
-                                            "glob": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "dynamicLinks",
-                                            "glob"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "destination": {
-                                                "type": "string"
-                                            },
-                                            "source": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "destination",
-                                            "source"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "function": {
-                                                "type": "string"
-                                            },
-                                            "region": {
-                                                "type": "string"
-                                            },
-                                            "source": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "function",
-                                            "source"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "function": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "functionId": {
-                                                        "type": "string"
-                                                    },
-                                                    "pinTag": {
-                                                        "type": "boolean"
-                                                    },
-                                                    "region": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "functionId"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "source": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "function",
-                                            "source"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "run": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "pinTag": {
-                                                        "type": "boolean"
-                                                    },
-                                                    "region": {
-                                                        "type": "string"
-                                                    },
-                                                    "serviceId": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "serviceId"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "source": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "run",
-                                            "source"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "dynamicLinks": {
-                                                "type": "boolean"
-                                            },
-                                            "source": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "dynamicLinks",
-                                            "source"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "destination": {
-                                                "type": "string"
-                                            },
-                                            "regex": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "destination",
-                                            "regex"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "function": {
-                                                "type": "string"
-                                            },
-                                            "regex": {
-                                                "type": "string"
-                                            },
-                                            "region": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "function",
-                                            "regex"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "function": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "functionId": {
-                                                        "type": "string"
-                                                    },
-                                                    "pinTag": {
-                                                        "type": "boolean"
-                                                    },
-                                                    "region": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "functionId"
-                                                ],
-                                                "type": "object"
-                                            },
-                                            "regex": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "function",
-                                            "regex"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "regex": {
-                                                "type": "string"
-                                            },
-                                            "run": {
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "pinTag": {
-                                                        "type": "boolean"
-                                                    },
-                                                    "region": {
-                                                        "type": "string"
-                                                    },
-                                                    "serviceId": {
-                                                        "type": "string"
-                                                    }
-                                                },
-                                                "required": [
-                                                    "serviceId"
-                                                ],
-                                                "type": "object"
-                                            }
-                                        },
-                                        "required": [
-                                            "regex",
-                                            "run"
-                                        ],
-                                        "type": "object"
-                                    },
-                                    {
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "dynamicLinks": {
-                                                "type": "boolean"
-                                            },
-                                            "regex": {
-                                                "type": "string"
-                                            }
-                                        },
-                                        "required": [
-                                            "dynamicLinks",
-                                            "regex"
-                                        ],
-                                        "type": "object"
-                                    }
-                                ]
-                            },
-                            "type": "array"
-                        },
-                        "site": {
-                            "type": "string"
-                        },
-                        "source": {
-                            "type": "string"
-                        },
-                        "target": {
-                            "type": "string"
-                        },
-                        "trailingSlash": {
-                            "type": "boolean"
-                        }
-                    },
-                    "type": "object"
+                    "$ref": "#/definitions/HostingSingle"
                 },
                 {
                     "items": {
@@ -1455,104 +1458,7 @@
                                     },
                                     "headers": {
                                         "items": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "headers": {
-                                                            "items": {
-                                                                "additionalProperties": false,
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "value": {
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "value"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "glob",
-                                                        "headers"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "headers": {
-                                                            "items": {
-                                                                "additionalProperties": false,
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "value": {
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "value"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "headers",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "headers": {
-                                                            "items": {
-                                                                "additionalProperties": false,
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "value": {
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "value"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "headers",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                }
-                                            ]
+                                            "$ref": "#/definitions/HostingHeaders"
                                         },
                                         "type": "array"
                                     },
@@ -1605,411 +1511,13 @@
                                     },
                                     "redirects": {
                                         "items": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": {
-                                                            "type": "number"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": {
-                                                            "type": "number"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": {
-                                                            "type": "number"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                }
-                                            ]
+                                            "$ref": "#/definitions/HostingRedirects"
                                         },
                                         "type": "array"
                                     },
                                     "rewrites": {
                                         "items": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "type": "string"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "region": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "functionId": {
-                                                                    "type": "string"
-                                                                },
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "functionId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "run": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                },
-                                                                "serviceId": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "serviceId"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "glob",
-                                                        "run"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "dynamicLinks": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "dynamicLinks",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "type": "string"
-                                                        },
-                                                        "region": {
-                                                            "type": "string"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "functionId": {
-                                                                    "type": "string"
-                                                                },
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "functionId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "run": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                },
-                                                                "serviceId": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "serviceId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "run",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "dynamicLinks": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "dynamicLinks",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "type": "string"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        },
-                                                        "region": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "functionId": {
-                                                                    "type": "string"
-                                                                },
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "functionId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "regex": {
-                                                            "type": "string"
-                                                        },
-                                                        "run": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                },
-                                                                "serviceId": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "serviceId"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "regex",
-                                                        "run"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "dynamicLinks": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "dynamicLinks",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                }
-                                            ]
+                                            "$ref": "#/definitions/HostingRewrites"
                                         },
                                         "type": "array"
                                     },
@@ -2049,104 +1557,7 @@
                                     },
                                     "headers": {
                                         "items": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "headers": {
-                                                            "items": {
-                                                                "additionalProperties": false,
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "value": {
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "value"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "glob",
-                                                        "headers"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "headers": {
-                                                            "items": {
-                                                                "additionalProperties": false,
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "value": {
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "value"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "headers",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "headers": {
-                                                            "items": {
-                                                                "additionalProperties": false,
-                                                                "properties": {
-                                                                    "key": {
-                                                                        "type": "string"
-                                                                    },
-                                                                    "value": {
-                                                                        "type": "string"
-                                                                    }
-                                                                },
-                                                                "required": [
-                                                                    "key",
-                                                                    "value"
-                                                                ],
-                                                                "type": "object"
-                                                            },
-                                                            "type": "array"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "headers",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                }
-                                            ]
+                                            "$ref": "#/definitions/HostingHeaders"
                                         },
                                         "type": "array"
                                     },
@@ -2199,411 +1610,13 @@
                                     },
                                     "redirects": {
                                         "items": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": {
-                                                            "type": "number"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": {
-                                                            "type": "number"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        },
-                                                        "type": {
-                                                            "type": "number"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                }
-                                            ]
+                                            "$ref": "#/definitions/HostingRedirects"
                                         },
                                         "type": "array"
                                     },
                                     "rewrites": {
                                         "items": {
-                                            "anyOf": [
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "type": "string"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "region": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "functionId": {
-                                                                    "type": "string"
-                                                                },
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "functionId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "glob": {
-                                                            "type": "string"
-                                                        },
-                                                        "run": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                },
-                                                                "serviceId": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "serviceId"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "glob",
-                                                        "run"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "dynamicLinks": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "glob": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "dynamicLinks",
-                                                        "glob"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "type": "string"
-                                                        },
-                                                        "region": {
-                                                            "type": "string"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "functionId": {
-                                                                    "type": "string"
-                                                                },
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "functionId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "run": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                },
-                                                                "serviceId": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "serviceId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "run",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "dynamicLinks": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "source": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "dynamicLinks",
-                                                        "source"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "destination": {
-                                                            "type": "string"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "destination",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "type": "string"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        },
-                                                        "region": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "function": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "functionId": {
-                                                                    "type": "string"
-                                                                },
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "functionId"
-                                                            ],
-                                                            "type": "object"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "function",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "regex": {
-                                                            "type": "string"
-                                                        },
-                                                        "run": {
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "pinTag": {
-                                                                    "type": "boolean"
-                                                                },
-                                                                "region": {
-                                                                    "type": "string"
-                                                                },
-                                                                "serviceId": {
-                                                                    "type": "string"
-                                                                }
-                                                            },
-                                                            "required": [
-                                                                "serviceId"
-                                                            ],
-                                                            "type": "object"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "regex",
-                                                        "run"
-                                                    ],
-                                                    "type": "object"
-                                                },
-                                                {
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "dynamicLinks": {
-                                                            "type": "boolean"
-                                                        },
-                                                        "regex": {
-                                                            "type": "string"
-                                                        }
-                                                    },
-                                                    "required": [
-                                                        "dynamicLinks",
-                                                        "regex"
-                                                    ],
-                                                    "type": "object"
-                                                }
-                                            ]
+                                            "$ref": "#/definitions/HostingRewrites"
                                         },
                                         "type": "array"
                                     },
@@ -2632,85 +1645,12 @@
             ]
         },
         "remoteconfig": {
-            "additionalProperties": false,
-            "properties": {
-                "postdeploy": {
-                    "anyOf": [
-                        {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                "predeploy": {
-                    "anyOf": [
-                        {
-                            "items": {
-                                "type": "string"
-                            },
-                            "type": "array"
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                },
-                "template": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "template"
-            ],
-            "type": "object"
+            "$ref": "#/definitions/RemoteConfigConfig"
         },
         "storage": {
             "anyOf": [
                 {
-                    "additionalProperties": false,
-                    "properties": {
-                        "postdeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "predeploy": {
-                            "anyOf": [
-                                {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                },
-                                {
-                                    "type": "string"
-                                }
-                            ]
-                        },
-                        "rules": {
-                            "type": "string"
-                        },
-                        "target": {
-                            "type": "string"
-                        }
-                    },
-                    "required": [
-                        "rules"
-                    ],
-                    "type": "object"
+                    "$ref": "#/definitions/StorageSingle"
                 },
                 {
                     "items": {

--- a/src/firebaseConfigValidate.ts
+++ b/src/firebaseConfigValidate.ts
@@ -2,11 +2,11 @@
 import { ValidateFunction, ErrorObject } from "ajv";
 import * as fs from "fs";
 import * as path from "path";
+import { Ajv } from "ajv";
+import addFormats from "ajv-formats";
 
-const Ajv = require("ajv");
-const addFormats = require("ajv-formats");
-
-const ajv = new Ajv();
+// We need to allow union types becuase typescript-json-schema generates them sometimes.
+const ajv = new Ajv({ allowUnionTypes: true });
 addFormats(ajv);
 let _VALIDATOR: ValidateFunction | undefined = undefined;
 


### PR DESCRIPTION
### Description
Fixing up some issues from the recent 'ajv' upgrade - namely:
- AllowUnionTypes:true - typescript-json-schema can generate these, so we need to allow them.
- Actually depend on ajv-formats - this slipped past our no-undeclared-imports check because it was a require before.

### Scenarios Tested
Before:
<img width="957" alt="Screenshot 2025-01-08 at 10 01 13 AM" src="https://github.com/user-attachments/assets/5bcbf61b-d6c9-44f4-b5f5-3dc43d7e7068" />
After:
<img width="892" alt="Screenshot 2025-01-08 at 10 01 20 AM" src="https://github.com/user-attachments/assets/40f14054-5af4-47ac-a6ef-3f2df43512d8" />

