### PR TITLE
Fixing VSCE build by removing uneeded steps

### DIFF
--- a/firebase-vscode/webpack.common.js
+++ b/firebase-vscode/webpack.common.js
@@ -191,19 +191,20 @@ const extensionConfig = {
           from: "../schema",
           to: "./schema",
         },
+        // TODO(hlshen): Sanity check if these should be fixed or removed. AFIACT, they exist for functions and hosting deploys, which are not relevant anymore.
         // Copy uncompiled JS files called at runtime by
         // firebase-tools/src/parseTriggers.ts
-        {
-          from: "*.js",
-          to: "./",
-          context: "../src/deploy/functions/runtimes/node",
-        },
-        // Copy cross-env-shell.js used to run predeploy scripts
-        // to ensure they work in Windows
-        {
-          from: "../node_modules/cross-env/dist",
-          to: "./cross-env/dist",
-        },
+        // {
+        //   from: "*.js",
+        //   to: "./",
+        //   context: "../src/deploy/functions/runtimes/node",
+        // },
+        // // Copy cross-env-shell.js used to run predeploy scripts
+        // // to ensure they work in Windows
+        // {
+        //   from: "../node_modules/cross-env/dist",
+        //   to: "./cross-env/dist",
+        // },
       ],
     }),
   ],


### PR DESCRIPTION
### Description
Currently, all VSCE tests are failing on CI/CD because `npm run build` returns a non zero exit code. AFAICT, the root cause are these webpack hacks that were put in place to support functions/hosting deploy (back when those were part of the extension).

### Scenarios Tested
Before this change, `npm run build` returns 1. After, it returns 0, and I am able to run the extension locally.
