### PR TITLE
Update to upload-artifact@v4

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -117,7 +117,7 @@ jobs:
           run: npm run test:e2e
           working-directory: firebase-vscode
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: screenshots


### PR DESCRIPTION
### Description

Updating upload-artifact to v4, as v3 is deprecated (https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) and starting to cause test failures.

