### PR TITLE
Remove label annotations for genkit functions; they break

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -42,6 +42,9 @@ export interface HttpsTriggered {
 
 /** API agnostic version of a Firebase callable function. */
 export type CallableTrigger = {
+  // NOTE: This is currently unused because GCF 2nd gen labels do not support
+  // the characterset that may be in a genkit action name.
+  // This should be set as a Cloud Run attribute once we move to Cloud Run Functions.
   genkitAction?: string;
 };
 

--- a/src/gcp/cloudfunctionsv2.spec.ts
+++ b/src/gcp/cloudfunctionsv2.spec.ts
@@ -221,23 +221,6 @@ describe("cloudfunctionsv2", () => {
           [BLOCKING_LABEL]: "before-sign-in",
         },
       });
-
-      expect(
-        cloudfunctionsv2.functionFromEndpoint({
-          ...ENDPOINT,
-          platform: "gcfv2",
-          callableTrigger: {
-            genkitAction: "flows/flow",
-          },
-        }),
-      ).to.deep.equal({
-        ...CLOUD_FUNCTION_V2,
-        labels: {
-          ...CLOUD_FUNCTION_V2.labels,
-          "deployment-callable": "true",
-          "genkit-action": "flows/flow",
-        },
-      });
     });
 
     it("should copy trival fields", () => {
@@ -651,29 +634,6 @@ describe("cloudfunctionsv2", () => {
         platform: "gcfv2",
         uri: GCF_URL,
         labels: { "deployment-blocking": "before-sign-in" },
-      });
-    });
-
-    it("should translate genkit callables", () => {
-      expect(
-        cloudfunctionsv2.endpointFromFunction({
-          ...HAVE_CLOUD_FUNCTION_V2,
-          labels: {
-            "deployment-callable": "true",
-            "genkit-action": "flows/flow",
-          },
-        }),
-      ).to.deep.equal({
-        ...ENDPOINT,
-        callableTrigger: {
-          genkitAction: "flows/flow",
-        },
-        platform: "gcfv2",
-        uri: GCF_URL,
-        labels: {
-          "deployment-callable": "true",
-          "genkit-action": "flows/flow",
-        },
       });
     });
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -609,9 +609,6 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
     gcfFunction.labels = { ...gcfFunction.labels, "deployment-taskqueue": "true" };
   } else if (backend.isCallableTriggered(endpoint)) {
     gcfFunction.labels = { ...gcfFunction.labels, "deployment-callable": "true" };
-    if (endpoint.callableTrigger.genkitAction) {
-      gcfFunction.labels["genkit-action"] = endpoint.callableTrigger.genkitAction;
-    }
   } else if (backend.isBlockingTriggered(endpoint)) {
     gcfFunction.labels = {
       ...gcfFunction.labels,
@@ -657,9 +654,6 @@ export function endpointFromFunction(gcfFunction: OutputCloudFunction): backend.
     trigger = {
       callableTrigger: {},
     };
-    if (gcfFunction.labels["genkit-action"]) {
-      trigger.callableTrigger.genkitAction = gcfFunction.labels["genkit-action"];
-    }
   } else if (gcfFunction.labels?.[BLOCKING_LABEL]) {
     trigger = {
       blockingTrigger: {


### PR DESCRIPTION
Ran into an error testing out `onCallGenkit`. Turns out that Run labels can only have [a-z0-9_-]. We need both capital letters and slashes. Run annotations supports that, but they are unavailable until after a migration to CRF.