### PR TITLE
Restore the "genkit-action" label as a booelan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Annotate onCallGenkit functions to allow for future Firebase Console annotations (#8135)

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -42,9 +42,6 @@ export interface HttpsTriggered {
 
 /** API agnostic version of a Firebase callable function. */
 export type CallableTrigger = {
-  // NOTE: This is currently unused because GCF 2nd gen labels do not support
-  // the characterset that may be in a genkit action name.
-  // This should be set as a Cloud Run attribute once we move to Cloud Run Functions.
   genkitAction?: string;
 };
 

--- a/src/gcp/cloudfunctionsv2.spec.ts
+++ b/src/gcp/cloudfunctionsv2.spec.ts
@@ -221,6 +221,23 @@ describe("cloudfunctionsv2", () => {
           [BLOCKING_LABEL]: "before-sign-in",
         },
       });
+
+      expect(
+        cloudfunctionsv2.functionFromEndpoint({
+          ...ENDPOINT,
+          platform: "gcfv2",
+          callableTrigger: {
+            genkitAction: "flows/flow",
+          },
+        }),
+      ).to.deep.equal({
+        ...CLOUD_FUNCTION_V2,
+        labels: {
+          ...CLOUD_FUNCTION_V2.labels,
+          "deployment-callable": "true",
+          "genkit-action": "flows/flow",
+        },
+      });
     });
 
     it("should copy trival fields", () => {
@@ -634,6 +651,29 @@ describe("cloudfunctionsv2", () => {
         platform: "gcfv2",
         uri: GCF_URL,
         labels: { "deployment-blocking": "before-sign-in" },
+      });
+    });
+
+    it("should translate genkit callables", () => {
+      expect(
+        cloudfunctionsv2.endpointFromFunction({
+          ...HAVE_CLOUD_FUNCTION_V2,
+          labels: {
+            "deployment-callable": "true",
+            "genkit-action": "flows/flow",
+          },
+        }),
+      ).to.deep.equal({
+        ...ENDPOINT,
+        callableTrigger: {
+          genkitAction: "flows/flow",
+        },
+        platform: "gcfv2",
+        uri: GCF_URL,
+        labels: {
+          "deployment-callable": "true",
+          "genkit-action": "flows/flow",
+        },
       });
     });
 

--- a/src/gcp/cloudfunctionsv2.spec.ts
+++ b/src/gcp/cloudfunctionsv2.spec.ts
@@ -235,7 +235,7 @@ describe("cloudfunctionsv2", () => {
         labels: {
           ...CLOUD_FUNCTION_V2.labels,
           "deployment-callable": "true",
-          "genkit-action": "flows/flow",
+          "genkit-action": "true",
         },
       });
     });
@@ -651,29 +651,6 @@ describe("cloudfunctionsv2", () => {
         platform: "gcfv2",
         uri: GCF_URL,
         labels: { "deployment-blocking": "before-sign-in" },
-      });
-    });
-
-    it("should translate genkit callables", () => {
-      expect(
-        cloudfunctionsv2.endpointFromFunction({
-          ...HAVE_CLOUD_FUNCTION_V2,
-          labels: {
-            "deployment-callable": "true",
-            "genkit-action": "flows/flow",
-          },
-        }),
-      ).to.deep.equal({
-        ...ENDPOINT,
-        callableTrigger: {
-          genkitAction: "flows/flow",
-        },
-        platform: "gcfv2",
-        uri: GCF_URL,
-        labels: {
-          "deployment-callable": "true",
-          "genkit-action": "flows/flow",
-        },
       });
     });
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -609,6 +609,9 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
     gcfFunction.labels = { ...gcfFunction.labels, "deployment-taskqueue": "true" };
   } else if (backend.isCallableTriggered(endpoint)) {
     gcfFunction.labels = { ...gcfFunction.labels, "deployment-callable": "true" };
+    if (endpoint.callableTrigger.genkitAction) {
+      gcfFunction.labels["genkit-action"] = endpoint.callableTrigger.genkitAction;
+    }
   } else if (backend.isBlockingTriggered(endpoint)) {
     gcfFunction.labels = {
       ...gcfFunction.labels,
@@ -654,6 +657,9 @@ export function endpointFromFunction(gcfFunction: OutputCloudFunction): backend.
     trigger = {
       callableTrigger: {},
     };
+    if (gcfFunction.labels["genkit-action"]) {
+      trigger.callableTrigger.genkitAction = gcfFunction.labels["genkit-action"];
+    }
   } else if (gcfFunction.labels?.[BLOCKING_LABEL]) {
     trigger = {
       blockingTrigger: {

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -610,7 +610,7 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
   } else if (backend.isCallableTriggered(endpoint)) {
     gcfFunction.labels = { ...gcfFunction.labels, "deployment-callable": "true" };
     if (endpoint.callableTrigger.genkitAction) {
-      gcfFunction.labels["genkit-action"] = endpoint.callableTrigger.genkitAction;
+      gcfFunction.labels["genkit-action"] = "true";
     }
   } else if (backend.isBlockingTriggered(endpoint)) {
     gcfFunction.labels = {
@@ -657,9 +657,6 @@ export function endpointFromFunction(gcfFunction: OutputCloudFunction): backend.
     trigger = {
       callableTrigger: {},
     };
-    if (gcfFunction.labels["genkit-action"]) {
-      trigger.callableTrigger.genkitAction = gcfFunction.labels["genkit-action"];
-    }
   } else if (gcfFunction.labels?.[BLOCKING_LABEL]) {
     trigger = {
       blockingTrigger: {


### PR DESCRIPTION
This doesn't give us everything we wanted (allowing the Firebase console to describe what the Genkit action is) but still lets us annotate the console with the genkit icon/that this is a genkit callable.