### PR TITLE
Throw away prepared statements on terminate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed a Data Connect emualtor issue where prepared stataements would be persisted after terminated connections.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "13.29.2",
       "license": "MIT",
       "dependencies": {
-        "@electric-sql/pglite": "^0.2.0",
+        "@electric-sql/pglite": "^0.2.16",
         "@google-cloud/cloud-sql-connector": "^1.3.3",
         "@google-cloud/pubsub": "^4.5.0",
         "abort-controller": "^3.0.0",
@@ -958,9 +958,9 @@
       }
     },
     "node_modules/@electric-sql/pglite": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0.tgz",
-      "integrity": "sha512-9ckSTnr9ChwY03lojiHM3HIOKFen72koxo44hb94Qz/L9fNejg1riwbfl2ROghA/z4ntCuyT+Zwl5pkbrSX3Aw=="
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.16.tgz",
+      "integrity": "sha512-dCSHpoOKuTxecaYhWDRp2yFTN3XWcMPMrBVl5yOR8VZEUprz4+R3iuU7BipmlsqBnBDO/6l9H/C2ZwJdunkWyw=="
     },
     "node_modules/@emmetio/abbreviation": {
       "version": "2.3.1",
@@ -21618,9 +21618,9 @@
       }
     },
     "@electric-sql/pglite": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.0.tgz",
-      "integrity": "sha512-9ckSTnr9ChwY03lojiHM3HIOKFen72koxo44hb94Qz/L9fNejg1riwbfl2ROghA/z4ntCuyT+Zwl5pkbrSX3Aw=="
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.16.tgz",
+      "integrity": "sha512-dCSHpoOKuTxecaYhWDRp2yFTN3XWcMPMrBVl5yOR8VZEUprz4+R3iuU7BipmlsqBnBDO/6l9H/C2ZwJdunkWyw=="
     },
     "@emmetio/abbreviation": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     ]
   },
   "dependencies": {
-    "@electric-sql/pglite": "^0.2.0",
+    "@electric-sql/pglite": "^0.2.16",
     "@google-cloud/cloud-sql-connector": "^1.3.3",
     "@google-cloud/pubsub": "^4.5.0",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
### Description
When we get a TERMINATE message from the frontend, we need to DEALLOCATE all currently prepared statements because the new client will not know about them. 

Also, bumps to the latest patch version of pglite.

Fixes part of #8133, specifically the `SQL Error: pq: prepared statement "1" already exists` errors

### Scenarios Tested
After an error that leads to a terminate message, future queries still work as normal.
