### PR TITLE
Add a CMEK warning, and only suggest lowercase csql ids

### DIFF
--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -69,6 +69,7 @@ export async function provisionCloudSql(args: {
     if (err.status !== 404) {
       throw err;
     }
+    cmekWarning();
     const cta = dryRun ? "It will be created on your next deploy" : "Creating it now.";
     silent ||
       utils.logLabeledBullet(
@@ -181,4 +182,11 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
   }
 
   return reason;
+}
+
+function cmekWarning() {
+  const message = "The no-cost Cloud SQL trial instance does not support customer managed encryption keys.\n" +
+  "If you'd like to use a CMEK to encrypt your data, first create a CMEK encrypted instance (https://cloud.google.com/sql/docs/postgres/configure-cmek#createcmekinstance).\n" +
+  "Then, edit your `dataconnect.yaml` file to use the encrypted instance and redeploy.";
+  utils.logLabeledWarning("dataconnect", message);
 }

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -185,8 +185,9 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
 }
 
 function cmekWarning() {
-  const message = "The no-cost Cloud SQL trial instance does not support customer managed encryption keys.\n" +
-  "If you'd like to use a CMEK to encrypt your data, first create a CMEK encrypted instance (https://cloud.google.com/sql/docs/postgres/configure-cmek#createcmekinstance).\n" +
-  "Then, edit your `dataconnect.yaml` file to use the encrypted instance and redeploy.";
+  const message =
+    "The no-cost Cloud SQL trial instance does not support customer managed encryption keys.\n" +
+    "If you'd like to use a CMEK to encrypt your data, first create a CMEK encrypted instance (https://cloud.google.com/sql/docs/postgres/configure-cmek#createcmekinstance).\n" +
+    "Then, edit your `dataconnect.yaml` file to use the encrypted instance and redeploy.";
   utils.logLabeledWarning("dataconnect", message);
 }

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -144,7 +144,8 @@ async function askQuestions(setup: Setup, isBillingEnabled: boolean): Promise<Re
     // Ensure that the suggested name is DNS compatible
     const defaultServiceId = toDNSCompatibleId(basename(process.cwd()));
     info.serviceId = info.serviceId || defaultServiceId;
-    info.cloudSqlInstanceId = info.cloudSqlInstanceId || `${info.serviceId.toLowerCase() || "app"}-fdc`;
+    info.cloudSqlInstanceId =
+      info.cloudSqlInstanceId || `${info.serviceId.toLowerCase() || "app"}-fdc`;
     info.locationId = info.locationId || `us-central1`;
     info.cloudSqlDatabase = info.cloudSqlDatabase || `fdcdb`;
   }

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -144,7 +144,7 @@ async function askQuestions(setup: Setup, isBillingEnabled: boolean): Promise<Re
     // Ensure that the suggested name is DNS compatible
     const defaultServiceId = toDNSCompatibleId(basename(process.cwd()));
     info.serviceId = info.serviceId || defaultServiceId;
-    info.cloudSqlInstanceId = info.cloudSqlInstanceId || `${info.serviceId || "app"}-fdc`;
+    info.cloudSqlInstanceId = info.cloudSqlInstanceId || `${info.serviceId.toLowerCase() || "app"}-fdc`;
     info.locationId = info.locationId || `us-central1`;
     info.cloudSqlDatabase = info.cloudSqlDatabase || `fdcdb`;
   }
@@ -370,7 +370,7 @@ async function promptForCloudSQL(setup: Setup, info: RequiredInfo): Promise<Requ
     info.cloudSqlInstanceId = await promptOnce({
       message: `What ID would you like to use for your new CloudSQL instance?`,
       type: "input",
-      default: `${info.serviceId || "app"}-fdc`,
+      default: `${info.serviceId.toLowerCase() || "app"}-fdc`,
     });
   }
   if (info.locationId === "") {


### PR DESCRIPTION

### Description
As requested, warn about CMEK during instance creation and link to docs on creating a CMEK encrypted instance.
I also noticed an issue where we'd suggest instance IDs based on service ID - service IDs can include capital letters, and CSQL instance IDs cannot.
