### PR TITLE
Update VSCode to 0.12.2

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+## 0.12.2
+
+- Updated internal `firebase-tools` dependency to 13.29.3
 - [Fixed] Fixed a bug where results panel would break on API error
 
 ## 0.12.1

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "0.12.1",
+      "version": "0.12.2",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
Update VSCode to ver. 0.12.2.

Changelog:
- Updated internal `firebase-tools` dependency to 13.29.3
- [Fixed] Fixed a bug where results panel would break on API error