### PR TITLE
Add private flag for disabling eager check for decomissioned CF3 runtimes

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -3,6 +3,7 @@ import * as clc from "colorette";
 import * as args from "./args";
 import * as backend from "./backend";
 import * as build from "./build";
+import * as experiments from "../../experiments";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
 import * as functionsConfig from "../../functionsConfig";
 import * as functionsEnv from "../../functions/env";
@@ -477,7 +478,9 @@ export async function loadCodebases(
     }
     const runtimeDelegate = await runtimes.getRuntimeDelegate(delegateContext);
     logger.debug(`Validating ${runtimeDelegate.language} source`);
-    supported.guardVersionSupport(runtimeDelegate.runtime);
+    if (!experiments.isEnabled("bypassfunctionsdeprecationcheck")) {
+      supported.guardVersionSupport(runtimeDelegate.runtime);
+    }
     await runtimeDelegate.validate();
     logger.debug(`Building ${runtimeDelegate.language} source`);
     await runtimeDelegate.build();

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -72,6 +72,14 @@ export const ALL_EXPERIMENTS = experiments({
     public: true,
     default: true,
   },
+  bypassfunctionsdeprecationcheck: {
+    shortDescription: "Bypass Functions check for old runtimes",
+    fullDescription: "Bypasses the local check for whether a functions runtime is " +
+      "decommissioned. This does not, by itself, allow you to deploy a function with a " +
+      "decommissioned runtime, as there are server-side checks as well.",
+    public: false,
+    default: false,
+  },
 
   // Emulator experiments
   emulatoruisnapshot: {


### PR DESCRIPTION
Usage:

```
firebase experiments:enable bypassfunctionsdeprecationcheck
```

This will merely turn off local checking. Server-side checking will still be enforced and exceptions will be highly scrutinized.