### PR TITLE
Fix regex pattern used to verify Cloud Storage bucket name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed issue where Extensions deployment fails due to `*.firebasestorage.app` not being recognized as a valid Storage bucket name. (#8152)

--- a/src/extensions/provisioningHelper.ts
+++ b/src/extensions/provisioningHelper.ts
@@ -130,7 +130,7 @@ async function isStorageProvisioned(projectId: string): Promise<boolean> {
     // Bucket resource name looks like: projects/PROJECT_NUMBER/buckets/BUCKET_NAME
     // and we just need the BUCKET_NAME part.
     const bucketResourceNameTokens = bucketResourceName.split("/");
-    const pattern = "^" + projectId + "(.[[a-z0-9]+)*.appspot.com$";
+    const pattern = "^" + projectId + "(.[[a-z0-9]+)*.(appspot.com|firebasestorage.app)$";
     return new RegExp(pattern).test(bucketResourceNameTokens[bucketResourceNameTokens.length - 1]);
   });
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #8152 

From what I can gather, there are currently 2 formats being used for [Cloud Storage bucket names](https://firebase.google.com/docs/storage/faqs-storage-changes-announced-sept-2024#all-changes-default-storage-bucket). `PROJECT_ID.firebasestorage.app` for the new ones, `PROJECT_ID.appspot.com` for the old ones

Logging the `bucketResourceNameTokens` of new and old projects:
New:
```
--- bucketResourceNameTokens
[
  'projects',
  'PROJECT_ID',
  'buckets',
  'PROJECT_ID.firebasestorage.app'
]
```
Old:
```
--- bucketResourceNameTokens
[
  'projects',
  'PROJECT_ID',
  'buckets',
  'PROJECT_ID.appspot.com'
]
```


### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Using an old project with that has a `PROJECT_ID.appspot.com` Cloud Storage bucket name:

1. Run `firebase init extensions --project PROJECT_ID`
2. Run `firebase ext:install firebase/delete-user-data --project=PROJECT_ID`
    - Answer all prompts
    - In `extensions/delete-user-data.env`
```
...
CLOUD_STORAGE_BUCKET=PROJECT_ID.appspot.com
...
```
3. Run `firebase deploy`
```
=== Deploying to 'PROJECT_ID'...

i  deploying extensions
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: ensuring required API compute.googleapis.com is enabled...
✔  extensions: required API compute.googleapis.com is enabled
The following extension instances will be configured:
        delete-user-data (firebase/delete-user-data@0.1.23)

i  extensions: By installing an extension instance onto a Firebase project, you accept the Firebase Extensions User Terms of Service: https://firebase.google.com/terms/extensions/user
✔  extensions Successfully validated configure for delete-user-data
i  extensions: Configuring delete-user-data extension instance
✔  extensions Successfully configured delete-user-data
Using Google Analytics in DEBUG mode. Emulators (+ UI) events will be shown in GA Debug View only.

✔  Deploy complete!

```




Using a new project with that has a `PROJECT_ID.firebasestorage.app` Cloud Storage bucket name:

1. Run `firebase init extensions --project PROJECT_ID`
2. Run `firebase ext:install firebase/delete-user-data --project=PROJECT_ID`
    - Answer all prompts
    - In `extensions/delete-user-data.env`
```
...
CLOUD_STORAGE_BUCKET=PROJECT_ID.firebasestorage.app
...
```
3. Run `firebase deploy`
```
=== Deploying to 'PROJECT_ID'...

i  deploying extensions
i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  extensions: ensuring required API compute.googleapis.com is enabled...
✔  extensions: required API compute.googleapis.com is enabled
The following extension instances will be created:
        delete-user-data (firebase/delete-user-data@0.1.23)

i  extensions: By installing an extension instance onto a Firebase project, you accept the Firebase Extensions User Terms of Service: https://firebase.google.com/terms/extensions/user
✔  extensions Successfully validated create for delete-user-data
i  extensions: Creating delete-user-data extension instance
✔  extensions Successfully created delete-user-data

✔  Deploy complete!
```



### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
