### PR TITLE
Remove AbortController polyfill as it is no longer needed and use native fetch where possible

### DIFF
--- a/src/apiv2.spec.ts
+++ b/src/apiv2.spec.ts
@@ -1,7 +1,6 @@
 import { createServer, Server } from "http";
 import { expect } from "chai";
 import * as nock from "nock";
-import AbortController from "abort-controller";
 const proxySetup = require("proxy");
 
 import { Client, CLI_OAUTH_PROJECT_NUMBER } from "./apiv2";

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -1,12 +1,9 @@
-import { AbortSignal } from "abort-controller";
 import { URL, URLSearchParams } from "url";
 import { Readable } from "stream";
 import { ProxyAgent } from "proxy-agent";
 import * as retry from "retry";
-import AbortController from "abort-controller";
 import fetch, { HeadersInit, Response, RequestInit, Headers } from "node-fetch";
 import util from "util";
-
 import * as auth from "./auth";
 import { FirebaseError } from "./error";
 import { isFirebaseMcp, detectAIAgent } from "./env";
@@ -386,12 +383,7 @@ export class Client {
     }
 
     if (options.signal) {
-      const signal = options.signal as any;
-      signal.reason = "";
-      signal.throwIfAborted = () => {
-        throw new FirebaseError("Aborted");
-      };
-      fetchOptions.signal = signal;
+      fetchOptions.signal = options.signal as RequestInit["signal"];
     }
 
     let reqTimeout: NodeJS.Timeout | undefined;
@@ -400,12 +392,7 @@ export class Client {
       reqTimeout = setTimeout(() => {
         controller.abort();
       }, options.timeout);
-      const signal = controller.signal as any;
-      signal.reason = "";
-      signal.throwIfAborted = () => {
-        throw new FirebaseError("Aborted");
-      };
-      fetchOptions.signal = signal;
+      fetchOptions.signal = controller.signal as RequestInit["signal"];
     }
 
     if (typeof options.body === "string" || isStream(options.body)) {

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -1,5 +1,4 @@
 import { size } from "lodash";
-import AbortController from "abort-controller";
 import * as clc from "colorette";
 import * as crypto from "crypto";
 import * as fs from "fs";

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -1,8 +1,6 @@
 import { URLSearchParams } from "url";
 import { decode as decodeJwt, sign as signJwt, JwtHeader } from "jsonwebtoken";
 import * as express from "express";
-import fetch from "node-fetch";
-import AbortController from "abort-controller";
 import { ExegesisContext } from "exegesis-express";
 import {
   toUnixTimestamp,

--- a/src/emulator/taskQueue.ts
+++ b/src/emulator/taskQueue.ts
@@ -1,9 +1,6 @@
-import AbortController from "abort-controller";
 import { EmulatorLogger } from "./emulatorLogger";
 import { RetryConfig, Task, TaskQueueConfig } from "./tasksEmulator";
 import { Emulators } from "./types";
-import { FirebaseError } from "../error";
-import fetch from "node-fetch";
 
 class Node<T> {
   public data: T;
@@ -294,16 +291,11 @@ export class TaskQueue {
         headers["X-CloudTasks-TaskPreviousResponse"] = `${emulatedTask.metadata.previousResponse}`;
       }
       const controller = new AbortController();
-      const signal = controller.signal as any;
-      signal.reason = "";
-      signal.throwIfAborted = () => {
-        throw new FirebaseError("Aborted");
-      };
       const request = fetch(emulatedTask.task.httpRequest.url, {
         method: "POST",
         headers: headers,
         body: JSON.stringify(emulatedTask.task.httpRequest.body),
-        signal: signal,
+        signal: controller.signal,
       });
 
       const dispatchDeadline = emulatedTask.task.dispatchDeadline;

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -2,7 +2,6 @@ import * as fs from "fs";
 import * as ora from "ora";
 import * as readline from "readline";
 import * as tmp from "tmp";
-import AbortController from "abort-controller";
 
 import { Client } from "./apiv2";
 import { realtimeOriginOrEmulatorOrCustomUrl } from "./database/api";


### PR DESCRIPTION
### Description

This PR removes a redundant `AbortController` polyfill, since it's supported natively in Node.js since v14.18, and Firebase minimum target is 18. It also removes fetch polyfill where it's not needed anymore, however I had to leave it be in one place because of usage of custom HTTP agents, which native fetch doesn't support yet. node-fetch-native supports proxies but not custom http agents based on what I know.

### Scenarios Tested

I've run `npm test`, and a bunch of unrelated tests started failing (assertions). Will see what I can do. Linting passes though