### PR TITLE
Add extraEnv setting to vscode

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+- Added `extraEnv` setting to help extension development.
+
 ## 0.12.2
 
 - Updated internal `firebase-tools` dependency to 13.29.3

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -96,6 +96,11 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "%ext.config.debug%"
+        },
+        "firebase.extraEnv": {
+          "type": "object",
+          "default": {},
+          "markdownDescription": "%ext.config.extraEnv%"
         }
       }
     },

--- a/firebase-vscode/package.nls.json
+++ b/firebase-vscode/package.nls.json
@@ -8,6 +8,7 @@
   "ext.config.idx.viewMetricNotice": "Show data collection notice on next startup (IDX Only)",
   "ext.config.emulators.importPath": "Path to import emulator data from",
   "ext.config.emulators.exportPath": "Path to export emulator data to",
-  "ext.config.emulators.exportOnExit": "If true, data will be exported to exportPath when the emulator shuts down"
+  "ext.config.emulators.exportOnExit": "If true, data will be exported to exportPath when the emulator shuts down",
   "ext.config.debug": "When true, add the --debug flag to any commands run by the extension",
+  "ext.config.extraEnv": "Extra environment variables to provide during deploy or emulation. Useful during extension development to enable experiments or hit non-production environments."
 }

--- a/firebase-vscode/src/core/webhook.ts
+++ b/firebase-vscode/src/core/webhook.ts
@@ -16,7 +16,7 @@ export async function registerWebhooks() {
   const port = await findOpenPort(DEFAULT_PORT);
 
   if (port !== DEFAULT_PORT) {
-    setTerminalEnvVars("VSCODE_WEBHOOK_PORT", port.toString());
+    setTerminalEnvVars({"VSCODE_WEBHOOK_PORT": port.toString()});
   }
   
   server.listen(port, () => {

--- a/firebase-vscode/src/data-connect/sdk-generation.ts
+++ b/firebase-vscode/src/data-connect/sdk-generation.ts
@@ -40,7 +40,9 @@ export function registerFdcSdkGeneration(
     (args: { appFolder: string }) => {
       analyticsLogger.logger.logUsage(DATA_CONNECT_EVENT_NAME.INIT_SDK_CLI);
       // Lets do it from the right directory
-      setTerminalEnvVars(FDC_APP_FOLDER, args.appFolder);
+      const e: Record<string, string> = {}
+      e[FDC_APP_FOLDER] = args.appFolder;
+      setTerminalEnvVars(e);
       runCommand(`${settings.firebasePath} init dataconnect:sdk`);
     },
   );

--- a/firebase-vscode/src/data-connect/terminal.ts
+++ b/firebase-vscode/src/data-connect/terminal.ts
@@ -1,4 +1,4 @@
-import { TelemetryLogger, TerminalOptions } from "vscode";
+import { TerminalOptions } from "vscode";
 import { ExtensionBrokerImpl } from "../extension-broker";
 import vscode, { Disposable } from "vscode";
 import { checkLogin } from "../core/user";
@@ -6,18 +6,19 @@ import { DATA_CONNECT_EVENT_NAME, AnalyticsLogger } from "../analytics";
 import { getSettings } from "../utils/settings";
 import { currentProjectId } from "../core/project";
 
-const environmentVariables: Record<string, string> = {};
+let environmentVariables: Record<string, string> = {};
 
 const executionOptions: vscode.ShellExecutionOptions = {
   env: environmentVariables,
 };
 
-export function setTerminalEnvVars(envVar: string, value: string) {
-  environmentVariables[envVar] = value;
+export function setTerminalEnvVars(env: Record<string, string>) {
+  environmentVariables = {...environmentVariables, ...env};
 }
 
 export function runCommand(command: string) {
   const settings = getSettings();
+  setTerminalEnvVars(settings.extraEnv ?? {});
   const terminalOptions: TerminalOptions = {
     name: "Data Connect Terminal",
     env: environmentVariables,
@@ -43,6 +44,7 @@ export function runTerminalTask(
   presentationOptions: vscode.TaskPresentationOptions = { focus: true },
 ): Promise<string> {
   const settings = getSettings();
+  setTerminalEnvVars(settings.extraEnv ?? {});
   const type = "firebase-" + Date.now();
   return new Promise(async (resolve, reject) => {
     vscode.tasks.onDidEndTaskProcess(async (e) => {

--- a/firebase-vscode/src/data-connect/toolkit.ts
+++ b/firebase-vscode/src/data-connect/toolkit.ts
@@ -1,9 +1,8 @@
 import * as vscode from "vscode";
 import { ExtensionBrokerImpl } from "../extension-broker";
-import { effect, signal } from "@preact/signals-core";
+import { effect } from "@preact/signals-core";
 import { firebaseRC } from "../core/config";
 import { dataConnectConfigs, firebaseConfig } from "./config";
-import { runEmulatorIssuesStream } from "./emulator-stream";
 import { runDataConnectCompiler } from "./core-compiler";
 import { DataConnectToolkitController } from "../../../src/emulator/dataconnectToolkitController";
 import { DataConnectEmulatorArgs } from "../emulator/dataconnectEmulator";
@@ -11,6 +10,7 @@ import { Config } from "../config";
 import { RC } from "../rc";
 import { findOpenPort } from "../utils/port_utils";
 import { pluginLogger } from "../logger-wrapper";
+import { getSettings } from "../utils/settings";
 
 const DEFAULT_PORT = 50001;
 /** FDC-specific emulator logic; Toolkit and emulator */
@@ -37,6 +37,7 @@ export class DataConnectToolkit implements vscode.Disposable {
   // special function to start FDC emulator with special flags & port
   async startFDCToolkit(configDir: string, config: Config, RC: RC) {
     const port = await findOpenPort(DEFAULT_PORT);
+    const settings = getSettings();
     const toolkitArgs: DataConnectEmulatorArgs = {
       projectId: "toolkit",
       listen: [{ address: "localhost", port, family: "IPv4" }],
@@ -46,6 +47,7 @@ export class DataConnectToolkit implements vscode.Disposable {
       autoconnectToPostgres: false,
       enable_output_generated_sdk: true,
       enable_output_schema_extensions: true,
+      extraEnv: settings.extraEnv,
     };
     pluginLogger.info(`Starting Data Connect toolkit on port ${port}`);
     return DataConnectToolkitController.start(toolkitArgs);

--- a/firebase-vscode/src/utils/env.ts
+++ b/firebase-vscode/src/utils/env.ts
@@ -1,3 +1,2 @@
 // Set by the `package.json` file
 export const isTest = !!process.env.TEST;
-export const isDebug = !!process.env.DEBUG;

--- a/firebase-vscode/src/utils/settings.ts
+++ b/firebase-vscode/src/utils/settings.ts
@@ -11,6 +11,7 @@ export interface Settings {
   readonly exportPath: string;
   readonly exportOnExit: boolean;
   readonly debug: boolean;
+  readonly extraEnv: Record<string, string>;
 }
 
 // TODO: Temporary fallback for bashing, this should probably point to the global firebase binary on the system
@@ -45,6 +46,7 @@ export function getSettings(): Settings {
     exportPath: config.get<string>("emulators.exportPath", "./exportedData"),
     exportOnExit: config.get<boolean>("emulators.exportOnExit", false),
     debug: config.get<boolean>("debug", false),
+    extraEnv: config.get<Record<string,string>>("extraEnv", {}),
   };
 }
 

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -41,6 +41,7 @@ export interface DataConnectEmulatorArgs {
   enable_output_generated_sdk: boolean;
   importPath?: string;
   debug?: boolean;
+  extraEnv?: Record<string, string>;
 }
 
 export interface DataConnectGenerateArgs {
@@ -91,13 +92,17 @@ export class DataConnectEmulator implements EmulatorInstance {
     } catch (err: any) {
       this.logger.log("DEBUG", `'fdc build' failed with error: ${err.message}`);
     }
-    await start(Emulators.DATACONNECT, {
-      auto_download: this.args.auto_download,
-      listen: listenSpecsToString(this.args.listen),
-      config_dir: resolvedConfigDir,
-      enable_output_schema_extensions: this.args.enable_output_schema_extensions,
-      enable_output_generated_sdk: this.args.enable_output_generated_sdk,
-    });
+    await start(
+      Emulators.DATACONNECT,
+      {
+        auto_download: this.args.auto_download,
+        listen: listenSpecsToString(this.args.listen),
+        config_dir: resolvedConfigDir,
+        enable_output_schema_extensions: this.args.enable_output_schema_extensions,
+        enable_output_generated_sdk: this.args.enable_output_generated_sdk,
+      },
+      this.args.extraEnv,
+    );
 
     this.usingExistingEmulator = false;
     if (this.args.autoconnectToPostgres) {


### PR DESCRIPTION
### Description
Adds `extraEnv` to settings. This setting is a map of env vars that will be provided (in addition the base process.env) whenever we run a command. We can use these to hit non-prod APIs or to enable emulator experiments

### Scenarios Tested
Tested this out by setting FIREBASE_DATACONNECT_URL = https://staging-firebasedataconnect.sandbox.googleapis.com and confirmed that deploy hits the staging API.
