### PR TITLE
Update VSCode 0.13.0

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## NEXT
 
-- Updated internal 'firebase-tools` dependency to 13.30.0
+## 0.13.0
+
+- Updated internal `firebase-tools` dependency to 13.30.0
 - [Added] Added `extraEnv` setting to help extension development.
 - [Added] Make Run Local button always present
 

--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+- Updated internal 'firebase-tools` dependency to 13.30.0
 - [Added] Added `extraEnv` setting to help extension development.
 - [Added] Make Run Local button always present
 

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "0.12.2",
+      "version": "0.13.0",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",
@@ -54,7 +54,7 @@
         "string-replace-loader": "^3.1.0",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.3",
-        "wdio-vscode-service": "6.1.2",
+        "wdio-vscode-service": "^6.1.1",
         "webpack": "^5.75.0",
         "webpack-cli": "^5.0.1",
         "webpack-merge": "^5.8.0"

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "engines": {
     "vscode": "^1.69.0"
   },
@@ -87,7 +87,7 @@
           "default": "./exportedData",
           "markdownDescription": "%ext.config.emulators.exportPath%"
         },
-        "firebase.emulators.exportOnExit": {
+        "firebase.emulators.exportOnExit":{
           "type": "boolean",
           "default": false,
           "markdownDescription": "%ext.config.emulators.exportOnExit%"
@@ -267,7 +267,7 @@
     "string-replace-loader": "^3.1.0",
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.3",
-    "wdio-vscode-service": "6.1.2",
+    "wdio-vscode-service": "^6.1.1",
     "webpack": "^5.75.0",
     "webpack-cli": "^5.0.1",
     "webpack-merge": "^5.8.0"


### PR DESCRIPTION
Update VSCode to ver. 0.13.0

- Updated internal `firebase-tools` dependency to 13.30.0
- [Added] Added `extraEnv` setting to help extension development.
- [Added] Make Run Local button always present