### PR TITLE
Use v3.0.3 of the Crashlytics buildtools jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Added code generation of React hooks for Data Connect
 - Genkit init improvements around gcloud login and flow input values.
+- Fixes symbol generation when uploading Unity 6 symbols to Crashlytics.

--- a/src/crashlytics/buildToolsJarHelper.ts
+++ b/src/crashlytics/buildToolsJarHelper.ts
@@ -13,7 +13,7 @@ const JAR_CACHE_DIR =
   process.env.FIREBASE_CRASHLYTICS_BUILDTOOLS_PATH ||
   path.join(os.homedir(), ".cache", "firebase", "crashlytics", "buildtools");
 
-const JAR_VERSION = "3.0.2";
+const JAR_VERSION = "3.0.3";
 const JAR_URL = `https://dl.google.com/android/maven2/com/google/firebase/firebase-crashlytics-buildtools/${JAR_VERSION}/firebase-crashlytics-buildtools-${JAR_VERSION}.jar`;
 
 /**


### PR DESCRIPTION
This fixes an issue with Unity 6 symbols, see #7867.