### PR TITLE
Fix issue where tester.groups can be undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Fixes symbol generation when uploading Unity 6 symbols to Crashlytics.
 - Fixed SSR issues in Angular 19 by adding support for default and reqHandler exports. (#8145)
 - Added Angular 19 as supported version. (#8145)
+- Fixed appdistribution:testers:list raising an error when a tester is not part of any group. (#8191)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 - Fixes symbol generation when uploading Unity 6 symbols to Crashlytics.
 - Fixed SSR issues in Angular 19 by adding support for default and reqHandler exports. (#8145)
 - Added Angular 19 as supported version. (#8145)
-- Fixed appdistribution:testers:list raising an error when a tester is not part of any group. (#8191)
+- Fixed `appdistribution:testers:list` raising an error when a tester is not part of any group. (#8191)

--- a/src/appdistribution/types.ts
+++ b/src/appdistribution/types.ts
@@ -76,7 +76,7 @@ export interface ListTestersResponse {
 export interface Tester {
   name: string;
   displayName?: string;
-  groups: string[];
+  groups?: string[];
   lastActivityTime: Date;
 }
 

--- a/src/commands/appdistribution-testers-list.ts
+++ b/src/commands/appdistribution-testers-list.ts
@@ -47,7 +47,7 @@ function printTestersTable(testers: Tester[]): void {
 
   for (const tester of testers) {
     const name = tester.name.split("/").pop();
-    const groups = (tester.groups || [])
+    const groups = (tester.groups ?? [])
       .map((grp) => grp.split("/").pop())
       .sort()
       .join(";");

--- a/src/commands/appdistribution-testers-list.ts
+++ b/src/commands/appdistribution-testers-list.ts
@@ -47,7 +47,7 @@ function printTestersTable(testers: Tester[]): void {
 
   for (const tester of testers) {
     const name = tester.name.split("/").pop();
-    const groups = tester.groups
+    const groups = (tester.groups || [])
       .map((grp) => grp.split("/").pop())
       .sort()
       .join(";");


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #8191 

Checking API explorer in https://firebase.google.com/docs/reference/app-distribution/rest/v1/projects.testers/list. Executing the method returns a JSON response of:

```json
{
  "testers": [
    {
      "name": "projects/PROJECT_NUMBER/testers/tester_0@google.com",
      "groups": [
        "projects/PROJECT_NUMBER/groups/qa",
        "projects/PROJECT_NUMBER/groups/developers"
      ],
      "lastActivityTime": "2024-11-14T13:10:19.256962Z"
    },
    {
      "name": "projects/PROJECT_NUMBER/testers/tester_1@gmail.com",
      "lastActivityTime": "2025-01-30T14:03:28.146030Z"
    }
  ]
}
```

It looks like testers not part of any groups return a [Tester](https://firebase.google.com/docs/reference/app-distribution/rest/v1/projects.testers#Tester) object that does not have a `groups` field

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Run `firebase appdistribution:testers:list --project PROJECT_ID`
```
$ firebase appdistribution:testers:list --project PROJECT_ID
(node:29657) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
✔ Preparing the list of your App Distribution testers
┌───────────────────────────┬──────────────┬──────────────────────────────────────────────────────────────┬───────────────┐
│ Name                      │ Display Name │ Last Activity Time                                           │ Groups        │
├───────────────────────────┼──────────────┼──────────────────────────────────────────────────────────────┼───────────────┤
│ tester_0@google.com │              │ Thu Nov 14 2024 21:10:19 GMT+0800 (Philippine Standard Time) │ developers;qa │
├───────────────────────────┼──────────────┼──────────────────────────────────────────────────────────────┼───────────────┤
│ tester_1@gmail.com      │              │ Thu Jan 30 2025 22:03:28 GMT+0800 (Philippine Standard Time) │               │
└───────────────────────────┴──────────────┴──────────────────────────────────────────────────────────────┴───────────────┘
✔  Testers listed successfully
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
