### PR TITLE
Implement getBackend to auto-pick backends with duplicate names.

### DIFF
--- a/src/apphosting/backend.ts
+++ b/src/apphosting/backend.ts
@@ -17,7 +17,7 @@ import { Backend, BackendOutputOnlyFields, API_VERSION } from "../gcp/apphosting
 import { addServiceAccountToRoles } from "../gcp/resourceManager";
 import * as iam from "../gcp/iam";
 import { FirebaseError, getErrStatus, getError } from "../error";
-import { promptOnce } from "../prompt";
+import { promptOnce, confirm } from "../prompt";
 import { DEFAULT_LOCATION } from "./constants";
 import { ensure } from "../ensureApiEnabled";
 import * as deploymentTool from "../deploymentTool";
@@ -473,4 +473,52 @@ export async function getBackendForAmbiguousLocation(
     choices: [...backendsByLocation.keys()],
   });
   return backendsByLocation.get(location)!;
+}
+
+/**
+ * Fetches a backend from the server. If there are multiple backends with the name, it will fetch the first
+ * in the list and warn the user that there are other backends with the same name that need to be deleted. If
+ * the force option is specified nad multiple backends have the same name, it throws an error.
+ */
+export async function getBackend(
+  projectId: string,
+  backendId: string,
+  force?: boolean,
+): Promise<apphosting.Backend> {
+  // TODO: call apphosting.getBackend() once all duplicate named backends have been deleted.
+  let { unreachable, backends } = await apphosting.listBackends(projectId, "-");
+  backends = backends.filter(
+    (backend) => apphosting.parseBackendName(backend.name).id === backendId,
+  );
+  if (backends.length > 0) {
+    if (backends.length > 1) {
+      logWarning(
+	`You have multiple backends with the same ${backendId} ID. This is no longer supported. ` +
+	  "Please delete and recreate any backends that share an ID with another backend."
+      )
+      if (force) {
+	throw new FirebaseError(
+	  `Force cannot be used when multiple backends share the same ID`,
+	);
+      };
+      const options = {force: force,  nonInteractive: false };
+      const confirmed = await confirm({
+	...options,
+	message: `Using backend ${backends[0].name} continue?`,
+      });
+      if (!confirmed) {
+	throw new FirebaseError("Command aborted.");
+      }
+    }
+    return backends[0];
+  }
+  if (unreachable && unreachable.length !== 0) {
+    logWarning(
+      `Backends with the following primary regions are unreachable: ${unreachable}.\n` +
+	"If your backend is in one of these regions, please try again later."
+    );
+  };
+  throw new FirebaseError(
+    `No backend named ${backendId} found.`,
+  );
 }

--- a/src/apphosting/rollout.ts
+++ b/src/apphosting/rollout.ts
@@ -13,7 +13,7 @@ import * as poller from "../operation-poller";
 import { logBullet, sleep } from "../utils";
 import { apphostingOrigin, consoleOrigin } from "../api";
 import { DeepOmit } from "../metaprogramming";
-import { getBackendForAmbiguousLocation, getBackendForLocation } from "./backend";
+import { getBackendForAmbiguousLocation, getBackendForLocation, getBackend } from "./backend";
 
 const apphostingPollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
   apiOrigin: apphostingOrigin(),
@@ -38,10 +38,9 @@ export async function createRollout(
 ): Promise<void> {
   let backend: apphosting.Backend;
   if (location === "-" || location === "") {
-    backend = await getBackendForAmbiguousLocation(
+    backend = await getBackend(
       projectId,
       backendId,
-      "Please select the location of the backend you'd like to roll out:",
       force,
     );
     location = apphosting.parseBackendName(backend.name).location;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Implement getBackend to be called instead of getBackendForAmbiguousLocation. We will no longer support backends with the same ID. 
<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
