### PR TITLE
Remove --location from apphosting:backends:get and return the first backend if multiple are found.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,0 @@
-- Fixed an issue where `--import` path was incorrectly resolved for the Data Connect emulator. (#8219)
-- Updated the Firebase Data Connect local toolkit to v1.8.2 which fixes an issue with a missing `FirebaseError` import. (#8232)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Enforce webframeworks enablement only on webframeworks sites (#8168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Add initial delay when loading python functions (#8239)
 - Enforce webframeworks enablement only on webframeworks sites (#8168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixed an issue where `--import` path was incorrectly resolved for the Data Connect emulator. (#8219)
+- Updated the Firebase Data Connect local toolkit to v1.8.2 which fixes an issue with a missing `FirebaseError` import. (#8232)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Add initial delay when loading python functions (#8239)
 - Enforce webframeworks enablement only on webframeworks sites (#8168)
+- Fix issue where `apps:init` throws an error upon app creation

--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## NEXT
 
+## 0.13.1
+
+- Updated internal `firebase-tools` dependency to 13.31.2
+
 ## 0.13.0
 
 - Updated internal `firebase-tools` dependency to 13.30.0

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "0.13.0",
+      "version": "0.13.1",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "engines": {
     "vscode": "^1.69.0"
   },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-tools",
-  "version": "13.31.1",
+  "version": "13.31.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-tools",
-      "version": "13.31.1",
+      "version": "13.31.2",
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.2.16",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -241,8 +241,8 @@
       "integrity": "sha512-ofDhTmJqoAkmkJP0duwUaCxDBMxPlc+AWYwgs3rKKZeJBb0d+tchEXHXevD5bYbbRfXtnwM+Vye2XYHhA4nWAA==",
       "dev": true,
       "dependencies": {
-        "ajv": "8.11.0",
-        "ajv-formats": "2.1.1",
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
         "jsonc-parser": "3.1.0",
         "rxjs": "6.6.7",
         "source-map": "0.7.4"
@@ -261,45 +261,14 @@
         }
       }
     },
-    "node_modules/@angular-devkit/core/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-      "dev": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@angular-devkit/core/node_modules/ajv-formats": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@angular-devkit/core/node_modules/rxjs": {
       "version": "6.6.7",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
       "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
       "dev": true,
       "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
         "tslib": "^1.9.0"
       },
       "engines": {
@@ -2475,7 +2444,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
@@ -21084,31 +21053,14 @@
         "source-map": "0.7.4"
       },
       "dependencies": {
-        "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "json-schema-traverse": "^1.0.0",
-            "require-from-string": "^2.0.2",
-            "uri-js": "^4.2.2"
-          }
-        },
-        "ajv-formats": {
-          "version": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
-          "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-          "dev": true,
-          "requires": {
-            "ajv": "^8.17.1"
-          }
-        },
         "rxjs": {
           "version": "6.6.7",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
           "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
           "dev": true,
           "requires": {
+            "ajv": "^8.17.1",
+            "ajv-formats": "3.0.1",
             "tslib": "^1.9.0"
           }
         },
@@ -24925,7 +24877,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.0.0"
+        "ajv": "^8.17.1"
       }
     },
     "ansi-align": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-tools",
-  "version": "13.31.1",
+  "version": "13.31.2",
   "description": "Command-Line Interface for Firebase",
   "main": "./lib/index.js",
   "bin": {

--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -6,6 +6,7 @@ import { doSetup } from "../apphosting/backend";
 import { ensureApiEnabled } from "../gcp/apphosting";
 import { APPHOSTING_TOS_ID } from "../gcp/firedata";
 import { requireTosAcceptance } from "../requireTosAcceptance";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:backends:create")
   .description("create a Firebase App Hosting backend")
@@ -13,7 +14,7 @@ export const command = new Command("apphosting:backends:create")
     "-a, --app <webAppId>",
     "specify an existing Firebase web app's ID to associate your App Hosting backend with",
   )
-  .option("-l, --location <location>", "specify the location of the backend", "")
+  .option("-l, --location <location>", "specify the location of the backend")
   .option(
     "-s, --service-account <serviceAccount>",
     "specify the service account used to run the server",
@@ -23,9 +24,15 @@ export const command = new Command("apphosting:backends:create")
   .before(requireInteractive)
   .before(requireTosAcceptance(APPHOSTING_TOS_ID))
   .action(async (options: Options) => {
+    if (options.location !== undefined) {
+      logWarning(
+        "--location is being removed in the next major release. " +
+          "The CLI will prompt for a Primary Region where appropriate.",
+      );
+    }
     const projectId = needProjectId(options);
     const webAppId = options.app;
-    const location = options.location;
+    const location = options.location as string;
     const serviceAccount = options.serviceAccount;
 
     await doSetup(

--- a/src/commands/apphosting-backends-delete.ts
+++ b/src/commands/apphosting-backends-delete.ts
@@ -15,12 +15,15 @@ import * as ora from "ora";
 
 export const command = new Command("apphosting:backends:delete <backend>")
   .description("delete a Firebase App Hosting backend")
-  .option("-l, --location <location>", "specify the location of the backend", "-")
+  .option("-l, --location <location>", "specify the location of the backend")
   .withForce()
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
-    let location = options.location as string;
+    if (options.location !== undefined) {
+      utils.logWarning("--location is being removed in the next major release.");
+    }
+    let location = (options.location as string) ?? "-";
     let backend: apphosting.Backend;
     if (location === "-" || location === "") {
       backend = await getBackendForAmbiguousLocation(

--- a/src/commands/apphosting-backends-get.ts
+++ b/src/commands/apphosting-backends-get.ts
@@ -8,11 +8,14 @@ import { printBackendsTable } from "./apphosting-backends-list";
 
 export const command = new Command("apphosting:backends:get <backend>")
   .description("print info about a Firebase App Hosting backend")
-  .option("-l, --location <location>", "backend location", "-")
+  .option("-l, --location <location>", "backend location")
   .before(apphosting.ensureApiEnabled)
   .action(async (backend: string, options: Options) => {
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    const location = (options.location as string) ?? "-";
 
     let backendsList: apphosting.Backend[] = [];
     try {

--- a/src/commands/apphosting-backends-list.ts
+++ b/src/commands/apphosting-backends-list.ts
@@ -6,16 +6,20 @@ import { needProjectId } from "../projectUtils";
 import { Options } from "../options";
 import * as apphosting from "../gcp/apphosting";
 import * as Table from "cli-table3";
+import { logWarning } from "../utils";
 
 const TABLE_HEAD = ["Backend", "Repository", "URL", "Location", "Updated Date"];
 
 export const command = new Command("apphosting:backends:list")
   .description("list Firebase App Hosting backends")
-  .option("-l, --location <location>", "list backends in the specified location", "-")
+  .option("-l, --location <location>", "list backends in the specified location")
   .before(apphosting.ensureApiEnabled)
   .action(async (options: Options) => {
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    const location = (options.location as string) ?? "-";
     let backendRes: apphosting.ListBackendsResponse;
     try {
       backendRes = await apphosting.listBackends(projectId, location);

--- a/src/commands/apphosting-builds-create.ts
+++ b/src/commands/apphosting-builds-create.ts
@@ -3,16 +3,20 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:builds:create <backendId>")
   .description("create a build for an App Hosting backend")
-  .option("-l, --location <location>", "specify the region of the backend", "us-central1")
+  .option("-l, --location <location>", "specify the region of the backend")
   .option("-i, --id <buildId>", "id of the build (defaults to autogenerating a random id)", "")
   .option("-b, --branch <branch>", "repository branch to deploy (defaults to 'main')", "main")
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    const location = (options.location as string) ?? "us-central1";
     const buildId =
       (options.buildId as string) ||
       (await apphosting.getNextRolloutId(projectId, location, backendId));

--- a/src/commands/apphosting-builds-get.ts
+++ b/src/commands/apphosting-builds-get.ts
@@ -3,12 +3,17 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:builds:get <backendId> <buildId>")
   .description("get a build for an App Hosting backend")
-  .option("-l, --location <location>", "specify the region of the backend", "us-central1")
+  .option("-l, --location <location>", "specify the region of the backend")
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, buildId: string, options: Options) => {
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    options.location = options.location ?? "us-central";
     const projectId = needProjectId(options);
     const location = options.location as string;
     const build = await apphosting.getBuild(projectId, location, backendId, buildId);

--- a/src/commands/apphosting-rollouts-create.ts
+++ b/src/commands/apphosting-rollouts-create.ts
@@ -4,10 +4,11 @@ import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
 import { FirebaseError } from "../error";
 import { createRollout } from "../apphosting/rollout";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:rollouts:create <backendId>")
   .description("create a rollout using a build for an App Hosting backend")
-  .option("-l, --location <location>", "specify the region of the backend", "-")
+  .option("-l, --location <location>", "specify the region of the backend")
   .option(
     "-b, --git-branch <gitBranch>",
     "repository branch to deploy (mutually exclusive with -g)",
@@ -17,7 +18,10 @@ export const command = new Command("apphosting:rollouts:create <backendId>")
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    const location = (options.location as string) ?? "-";
 
     const branch = options.gitBranch as string | undefined;
     const commit = options.gitCommit as string | undefined;

--- a/src/commands/apphosting-rollouts-list.ts
+++ b/src/commands/apphosting-rollouts-list.ts
@@ -3,18 +3,21 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:rollouts:list <backendId>")
   .description("list rollouts of an App Hosting backend")
   .option(
     "-l, --location <location>",
     "region of the rollouts (defaults to listing rollouts from all regions)",
-    "-",
   )
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    const location = (options.location as string) ?? "-";
     const rollouts = await apphosting.listRollouts(projectId, location, backendId);
     if (rollouts.unreachable) {
       logger.error(

--- a/src/commands/apps-init.ts
+++ b/src/commands/apps-init.ts
@@ -92,7 +92,7 @@ export const command = new Command("apps:init [platform] [appId]")
       } catch (e) {
         if ((e as Error).message.includes("associated with this Firebase project")) {
           const projectId = needProjectId(options);
-          await sdkInit(platform, { ...options, project: projectId });
+          await sdkInit(detectedPlatform, { ...options, project: projectId });
         } else {
           throw e;
         }

--- a/src/dataconnect/graphqlError.ts
+++ b/src/dataconnect/graphqlError.ts
@@ -2,13 +2,29 @@ import { GraphqlError } from "./types";
 import * as Table from "cli-table3";
 
 export function prettify(err: GraphqlError): string {
-  const message = err.message;
+  let message = err.message;
   let header = err.extensions?.file ?? "";
   if (err.locations && err.locations.length) {
     const line = err.locations[0]?.line ?? "";
     if (line) {
       header += `:${line}`;
     }
+  }
+
+  if (err.path && err.path.length) {
+    let pathStr = "On ";
+    for (let i = 0; i < err.path.length; i++) {
+      if (typeof err.path[i] === "string") {
+        if (i === 0) {
+          pathStr += err.path[i];
+        } else {
+          pathStr = `${pathStr}.${err.path[i]}`;
+        }
+      } else {
+        pathStr = `${pathStr}[${err.path[i]}]`;
+      }
+    }
+    message = `${pathStr}: ${message}`;
   }
   return header.length ? `${header}: ${message}` : message;
 }

--- a/src/dataconnect/types.ts
+++ b/src/dataconnect/types.ts
@@ -81,6 +81,7 @@ export interface Workaround {
 
 export interface GraphqlError {
   message: string;
+  path?: (string | number)[];
   locations?: {
     line: number;
     column: number;

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -195,7 +195,12 @@ export class Delegate implements runtimes.RuntimeDelegate {
       });
       const killProcess = await this.serveAdmin(adminPort, envs);
       try {
-        discovered = await discovery.detectFromPort(adminPort, this.projectId, this.runtime);
+        discovered = await discovery.detectFromPort(
+          adminPort,
+          this.projectId,
+          this.runtime,
+          500 /* initialDelay, python startup is slow */,
+        );
       } finally {
         await killProcess();
       }

--- a/src/deploy/hosting/deploy.spec.ts
+++ b/src/deploy/hosting/deploy.spec.ts
@@ -1,0 +1,122 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { setEnabled } from "../../experiments";
+import { FirebaseConfig } from "../../firebaseConfig";
+import * as frameworks from "../../frameworks";
+import * as config from "../../hosting/config";
+import { HostingOptions } from "../../hosting/options";
+import { Options } from "../../options";
+import { matchesHostingTarget, prepareFrameworksIfNeeded } from "../index";
+
+describe("hosting prepare", () => {
+  let frameworksStub: sinon.SinonStubbedInstance<typeof frameworks>;
+  let classicSiteConfig: config.HostingResolved;
+  let webFrameworkSiteConfig: config.HostingResolved;
+  let firebaseJson: FirebaseConfig;
+  let options: HostingOptions & Options;
+
+  beforeEach(() => {
+    frameworksStub = sinon.stub(frameworks);
+
+    // We're intentionally using pointer references so that editing site
+    // edits the results of hostingConfig() and changes firebase.json
+    classicSiteConfig = {
+      site: "classic",
+      target: "classic",
+      public: ".",
+    };
+    webFrameworkSiteConfig = {
+      site: "webframework",
+      target: "webframework",
+      source: "src",
+    };
+    firebaseJson = {
+      hosting: [classicSiteConfig, webFrameworkSiteConfig],
+    };
+    options = {
+      cwd: ".",
+      configPath: ".",
+      only: "hosting",
+      except: "",
+      filteredTargets: ["HOSTING"],
+      force: false,
+      json: false,
+      nonInteractive: false,
+      interactive: true,
+      debug: false,
+      projectId: "project",
+      config: {
+        src: firebaseJson,
+        get: (key: string) => {
+          if (key === "hosting") {
+            return firebaseJson.hosting;
+          }
+          return null;
+        },
+      } as any,
+      rc: null as any,
+
+      // Forces caching behavior of hostingConfig call
+      normalizedHostingConfig: [classicSiteConfig, webFrameworkSiteConfig],
+    };
+  });
+
+  afterEach(() => {
+    sinon.verifyAndRestore();
+  });
+
+  describe("matchesHostingTarget", () => {
+    it("should correctly identify if a hosting target should be included in deployment", () => {
+      const cases = [
+        { only: "hosting:site1", target: "site1", expected: true },
+        { only: "hosting:site12", target: "site1", expected: false },
+        { only: "hosting:", target: "", expected: true },
+        { only: "functions:fn1", target: "site1", expected: true },
+        { only: "hosting:site1,hosting:site2", target: "site1", expected: true },
+        { only: undefined, target: "site1", expected: true },
+        { only: "hosting:site1,functions:fn1", target: "site1", expected: true },
+      ];
+
+      cases.forEach(({ only, target, expected }) => {
+        expect(matchesHostingTarget(only, target)).to.equal(expected);
+      });
+    });
+  });
+
+  it("deploys classic site without webframeworks disabled", async () => {
+    setEnabled("webframeworks", false);
+    options.only = "hosting:classic";
+    await expect(prepareFrameworksIfNeeded(["hosting"], options, {})).to.not.be.rejected;
+  });
+
+  it("fails webframework deploy with webframeworks disabled", async () => {
+    setEnabled("webframeworks", false);
+    options.only = "hosting:webframework";
+    await expect(prepareFrameworksIfNeeded(["hosting"], options, {})).to.be.rejectedWith(
+      /Cannot deploy a web framework from source because the experiment.+webframeworks.+is not enabled/,
+    );
+  });
+
+  it("deploys webframework site with webframeworks enabled", async () => {
+    setEnabled("webframeworks", true);
+    options.only = "hosting:webframework";
+    await expect(prepareFrameworksIfNeeded(["hosting"], options, {})).to.not.be.rejected;
+    expect(frameworksStub.prepareFrameworks).to.have.been.calledOnceWith("deploy", ["hosting"]);
+  });
+
+  it("deploys classic site with webframeworks enabled", async () => {
+    setEnabled("webframeworks", true);
+    options.only = "hosting:classic";
+    await expect(prepareFrameworksIfNeeded(["hosting"], options, {})).to.not.be.rejected;
+    expect(frameworksStub.prepareFrameworks).to.not.have.been.called;
+  });
+
+  it("fails when at least one site has webframeworks enabled and the experiment is disabled", async () => {
+    setEnabled("webframeworks", false);
+    options.only = "hosting";
+    await expect(prepareFrameworksIfNeeded(["hosting"], options, {})).to.be.rejectedWith(
+      /Cannot deploy a web framework from source because the experiment.+webframeworks.+is not enabled/,
+    );
+  });
+});

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -85,9 +85,14 @@ function availablePort(host: string, port: number): Promise<boolean> {
   });
 }
 
-function getEmulatorEnvs(): Record<string, string> {
+/**
+ * Exported for unit tests
+ */
+export function getEmulatorEnvs(): Record<string, string> {
   const envs: Record<string, string> = {};
-  const emulatorInfos = EmulatorRegistry.listRunningWithInfo();
+  const emulatorInfos = EmulatorRegistry.listRunningWithInfo().filter(
+    (emulator) => emulator.name !== Emulators.APPHOSTING, // No need to set envs for the apphosting emulator itself.
+  );
   setEnvVarsForEmulators(envs, emulatorInfos);
 
   return envs;

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -59,20 +59,20 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
   dataconnect:
     process.platform === "darwin" // macos
       ? {
-          version: "1.8.1",
-          expectedSize: 25469696,
-          expectedChecksum: "dc8b5c38838ebe667e2e93c51c14578a",
+          version: "1.8.2",
+          expectedSize: 25506560,
+          expectedChecksum: "2db676cb9d30b289897ffb7e5aa1ef63",
         }
       : process.platform === "win32" // windows
         ? {
-            version: "1.8.1",
-            expectedSize: 25904128,
-            expectedChecksum: "4ba969a49ade413c3f68f5bb0287af22",
+            version: "1.8.2",
+            expectedSize: 25936384,
+            expectedChecksum: "08e6ca0ad20893b565fb57effd687eb8",
           }
         : {
-            version: "1.8.1", // linux
-            expectedSize: 25383064,
-            expectedChecksum: "1117c1c3cc0fca725dd7a869c1d2e90f",
+            version: "1.8.2", // linux
+            expectedSize: 25415832,
+            expectedChecksum: "24e0eb78acb619ed91f6d268dd18df05",
           },
 };
 

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -19,7 +19,7 @@ import { Schema, Service, File, Platform } from "../../../dataconnect/types";
 import { parseCloudSQLInstanceName, parseServiceName } from "../../../dataconnect/names";
 import { logger } from "../../../logger";
 import { readTemplateSync } from "../../../templates";
-import { logBullet } from "../../../utils";
+import { logBullet, envOverride } from "../../../utils";
 import { checkBillingEnabled } from "../../../gcp/cloudbilling";
 import * as sdk from "./sdk";
 import { getPlatformFromFolder } from "../../../dataconnect/fileUtils";
@@ -29,6 +29,11 @@ const CONNECTOR_YAML_TEMPLATE = readTemplateSync("init/dataconnect/connector.yam
 const SCHEMA_TEMPLATE = readTemplateSync("init/dataconnect/schema.gql");
 const QUERIES_TEMPLATE = readTemplateSync("init/dataconnect/queries.gql");
 const MUTATIONS_TEMPLATE = readTemplateSync("init/dataconnect/mutations.gql");
+
+// serviceEnvVar is used by Firebase Console to specify which service to import.
+// It should be in the form <location>/<serviceId>
+// It must be an existing service - if set to anything else, we'll ignore it.
+const serviceEnvVar = () => envOverride("FDC_SERVICE", "");
 
 export interface RequiredInfo {
   serviceId: string;
@@ -282,21 +287,34 @@ async function promptForExistingServices(
     }),
   );
   if (existingServicesAndSchemas.length) {
-    const choices: { name: string; value: { service: Service; schema?: Schema } | undefined }[] =
-      existingServicesAndSchemas.map((s) => {
-        const serviceName = parseServiceName(s.service.name);
-        return {
-          name: `${serviceName.location}/${serviceName.serviceId}`,
-          value: s,
-        };
-      });
-    choices.push({ name: "Create a new service", value: undefined });
-    const choice: { service: Service; schema?: Schema } | undefined = await promptOnce({
-      message:
-        "Your project already has existing services. Which would you like to set up local files for?",
-      type: "list",
-      choices,
+    let choice: { service: Service; schema?: Schema } | undefined;
+    const [serviceLocationFromEnvVar, serviceIdFromEnvVar] = serviceEnvVar().split("/");
+    const serviceFromEnvVar = existingServicesAndSchemas.find((s) => {
+      const serviceName = parseServiceName(s.service.name);
+      return (
+        serviceName.serviceId === serviceIdFromEnvVar &&
+        serviceName.location === serviceLocationFromEnvVar
+      );
     });
+    if (serviceFromEnvVar) {
+      choice = serviceFromEnvVar;
+    } else {
+      const choices: { name: string; value: { service: Service; schema?: Schema } | undefined }[] =
+        existingServicesAndSchemas.map((s) => {
+          const serviceName = parseServiceName(s.service.name);
+          return {
+            name: `${serviceName.location}/${serviceName.serviceId}`,
+            value: s,
+          };
+        });
+      choices.push({ name: "Create a new service", value: undefined });
+      choice = await promptOnce({
+        message:
+          "Your project already has existing services. Which would you like to set up local files for?",
+        type: "list",
+        choices,
+      });
+    }
     if (choice) {
       const serviceName = parseServiceName(choice.service.name);
       info.serviceId = serviceName.serviceId;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Remove --location from apphosting:backends:get and return the first backend if multiple are found.

### Scenarios Tested

`firebase apphosting:backends:get chickenbugs` where there is only one backend named `chickenbugs`

`firebase apphosting:backends:get friendlybugs-codelab` where there are two backends named `friendlybugs-codelab`.

`firebase apphosting:backends:get friendlybugs-codelab --location="-"` which should result in unknown option error.

### Sample Commands

Removing `--location` from apphosting:backends:get
