### PR TITLE
Properly escape log URL and print it at the end for `functions:log` command

### DIFF
--- a/src/commands/functions-log.ts
+++ b/src/commands/functions-log.ts
@@ -1,8 +1,9 @@
 import * as opn from "open";
-import * as qs from "querystring";
+import { URLSearchParams } from "url";
 
 import { Command } from "../command";
 import { FirebaseError } from "../error";
+import { logger } from "../logger";
 import * as cloudlogging from "../gcp/cloudlogging";
 import * as functionsLog from "../functions/functionslog";
 import { needProjectId } from "../projectUtils";
@@ -21,13 +22,14 @@ export const command = new Command("functions:log")
     try {
       const projectId = needProjectId(options);
       const apiFilter = functionsLog.getApiFilter(options.only);
+      const filterParams = new URLSearchParams(apiFilter);
+      const url = `https://console.developers.google.com/logs/viewer?advancedFilter=${filterParams.toString()}&project=${projectId}`;
+
       if (options.open) {
-        const url = `https://console.developers.google.com/logs/viewer?advancedFilter=${qs.escape(
-          apiFilter,
-        )}&project=${projectId}`;
         opn(url);
         return;
       }
+
       const entries = await cloudlogging.listEntries(
         projectId,
         apiFilter,
@@ -35,6 +37,7 @@ export const command = new Command("functions:log")
         "desc",
       );
       functionsLog.logEntries(entries);
+      logger.info(`\nSee full logs at: ${url}`)
       return entries;
     } catch (err: any) {
       throw new FirebaseError(`Failed to list log entries ${err.message}`, { exit: 1 });


### PR DESCRIPTION
At the end of `functions:log`, we print the URL where developers can view the full log as needed.

```
$  firebase functions:log
2025-02-12T18:37:01.212523Z I hellorawbody: {"structuredData":true,"message":"Hello logs!"}
2025-02-12T18:37:01.316128Z I hellorawbody:
2025-02-12T18:37:01.322816Z ? hellorawbody: RAW BODY IS undefined

2025-02-12T18:37:01.323878Z I hellorawbody: {"structuredData":true,"message":"Hello logs!"}
2025-02-12T18:37:01.427900Z W hellorawbody:
2025-02-12T18:37:01.494996Z W hellorawbody:

See full logs at: https://console.developers.google.com/logs/viewer?advancedFilter=resource.type=%22cloud_function%22+OR+%28resource.type%3D%22cloud_run_revision%22+AND+labels.%22goog-managed-by%22%3D%22cloudfunctions%22%29&project=<REDACTED>
```