### PR TITLE
Don't surface insecure operations errors in VSCode.

### DIFF
--- a/firebase-vscode/src/data-connect/core-compiler.ts
+++ b/firebase-vscode/src/data-connect/core-compiler.ts
@@ -48,6 +48,10 @@ function convertGQLErrorToDiagnostic(
   const perFileDiagnostics: Record<string, Diagnostic[]> = {};
   const dcPath = configs.values[0].path;
   for (const error of gqlErrors) {
+    if (error.warningLevel)  {
+      // Don't surface connector evolution or insecure operation issues for now; we need to be able to compare with a deployed source for these to have meaning.
+      continue;
+    }
     const absFilePath = `${dcPath}/${error.extensions["file"]}`;
     const perFileDiagnostic = perFileDiagnostics[absFilePath] || [];
     perFileDiagnostic.push({

--- a/firebase-vscode/src/data-connect/core-compiler.ts
+++ b/firebase-vscode/src/data-connect/core-compiler.ts
@@ -48,7 +48,7 @@ function convertGQLErrorToDiagnostic(
   const perFileDiagnostics: Record<string, Diagnostic[]> = {};
   const dcPath = configs.values[0].path;
   for (const error of gqlErrors) {
-    if (error.warningLevel)  {
+    if (error.extensions["warningLevel"])  {
       // Don't surface connector evolution or insecure operation issues for now; we need to be able to compare with a deployed source for these to have meaning.
       continue;
     }

--- a/firebase-vscode/src/data-connect/core-compiler.ts
+++ b/firebase-vscode/src/data-connect/core-compiler.ts
@@ -48,8 +48,8 @@ function convertGQLErrorToDiagnostic(
   const perFileDiagnostics: Record<string, Diagnostic[]> = {};
   const dcPath = configs.values[0].path;
   for (const error of gqlErrors) {
-    if (error.extensions["warningLevel"])  {
-      // Don't surface connector evolution or insecure operation issues for now; we need to be able to compare with a deployed source for these to have meaning.
+    if (error.message.includes("INSECURE")) {
+      // Don't surface insecure operation issues for now; we need to be able to compare with a deployed source for these to be accurately presented.
       continue;
     }
     const absFilePath = `${dcPath}/${error.extensions["file"]}`;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Currently, VSCode is flagging insecure operation errors in the editor. However, these errors are not currently accurate since the connector source isn't being compared against a deployed source, and can't differentiate between existing insecure operations and new insecure operations. This PR suppresses insecure operation issues in VSCode for now.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
