### PR TITLE
FDC Emulator Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-- Fixed issue where react-based web apps were crashing when users initialize Data Connect.
-- Updated the Firebase Dat Connect local toolkit to v.1.8.0, which:
+- Fixed issue where `firebase init dataconnect` would crash on React-based web apps.
+- Updated the Firebase Data Connect local toolkit to v.1.8.1, which:
   - Fixed issue where users who are using a version lower than 11.3.0 of `firebase` get a "missing import" error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
-- Data Connect: Fixed issue where react-based web apps were crashing when users initialize Data Connect.
-- Data Connect: Fixed issue where users who are using a version lower than 11.3.0 of `firebase` get a "missing import" error.
+- Fixed issue where react-based web apps were crashing when users initialize Data Connect.
+- Updated the Firebase Dat Connect local toolkit to v.1.8.0, which:
+    - Fixed issue where users who are using a version lower than 11.3.0 of `firebase` get a "missing import" error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Fixed issue where react-based web apps were crashing when users initialize Data Connect.
 - Updated the Firebase Dat Connect local toolkit to v.1.8.0, which:
-    - Fixed issue where users who are using a version lower than 11.3.0 of `firebase` get a "missing import" error.
+  - Fixed issue where users who are using a version lower than 11.3.0 of `firebase` get a "missing import" error.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Data Connect: Fixed issue where react-based web apps were crashing when users initialize Data Connect.
+- Data Connect: Fixed issue where users who are using a version lower than 11.3.0 of `firebase` get a "missing import" error.

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -57,22 +57,22 @@ const EMULATOR_UPDATE_DETAILS: { [s in DownloadableEmulators]: EmulatorUpdateDet
     expectedChecksum: "a9025b3e53fdeafd2969ccb3ba1e1d38",
   },
   dataconnect:
-    process.platform === "darwin"
+    process.platform === "darwin" // macos
       ? {
-          version: "1.8.0",
+          version: "1.8.1",
           expectedSize: 25469696,
-          expectedChecksum: "d20a4240b4290a262caff3d0d3a85a4f",
+          expectedChecksum: "dc8b5c38838ebe667e2e93c51c14578a",
         }
-      : process.platform === "win32"
+      : process.platform === "win32" // windows
         ? {
-            version: "1.8.0",
-            expectedSize: 25903616,
-            expectedChecksum: "dda0350259449493ecc5cc24187ce752",
+            version: "1.8.1",
+            expectedSize: 25904128,
+            expectedChecksum: "4ba969a49ade413c3f68f5bb0287af22",
           }
         : {
-            version: "1.8.0",
+            version: "1.8.1", // linux
             expectedSize: 25383064,
-            expectedChecksum: "54a19e336f4118854c4c2d4eeeccb506",
+            expectedChecksum: "1117c1c3cc0fca725dd7a869c1d2e90f",
           },
 };
 

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -136,10 +136,8 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
           },
         ],
       );
-      if (additionalFrameworks.fdcFrameworks) {
-        for (const framework of additionalFrameworks.fdcFrameworks) {
-          newConnectorYaml!.generate!.javascriptSdk![framework] = true;
-        }
+      for (const framework of additionalFrameworks.fdcFrameworks) {
+        newConnectorYaml!.generate!.javascriptSdk![framework] = true;
       }
     }
   }

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -116,24 +116,30 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
   );
   if (targetPlatform === Platform.WEB) {
     const unusedFrameworks = SUPPORTED_FRAMEWORKS.filter(
-      (framework) => newConnectorYaml!.generate?.javascriptSdk![framework],
+      (framework) => !newConnectorYaml!.generate?.javascriptSdk![framework],
     );
     if (unusedFrameworks.length > 0) {
-      const additionalFrameworks: { features: (keyof SupportedFrameworks)[] } = await prompt(
+      const additionalFrameworks: { fdcFrameworks: (keyof SupportedFrameworks)[] } = await prompt(
         setup,
         [
           {
             type: "checkbox",
-            name: "features",
+            name: "fdcFrameworks",
             message:
               "Which framework would you like to generate SDKs for? " +
               "Press Space to select features, then Enter to confirm your choices.",
-            choices: unusedFrameworks,
+            choices: unusedFrameworks.map((frameworkStr) => ({
+              value: frameworkStr,
+              name: frameworkStr,
+              checked: false,
+            })),
           },
         ],
       );
-      for (const framework of additionalFrameworks.features) {
-        newConnectorYaml!.generate!.javascriptSdk![framework] = true;
+      if (additionalFrameworks.fdcFrameworks) {
+        for (const framework of additionalFrameworks.fdcFrameworks) {
+          newConnectorYaml!.generate!.javascriptSdk![framework] = true;
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes:
* Issue where react web app users get a crash when calling `firebase init dataconnect` due to misconfiguration of `prompt`
* Issue where web developers using versions lower than 11.3.0 of firebase get a missing export error.