### PR TITLE
Use correct import path for data connect emulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixed an issue where `--import` path was incorrectly resolved for the Data Connecgt emulator. (#8219)
+- Fixed an issue where `--import` path was incorrectly resolved for the Data Connect emulator. (#8219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where `--import` path was incorrectly resolved for the Data Connecgt emulator. (#8219)

--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -88,7 +88,12 @@ export class PostgresServer {
   }
 
   async getDb(): Promise<PGlite> {
+
     if (!this.db) {
+      // Fisrt, ensure that the data directory exists - PGLite tries to do this but doesn't do so recursively
+      if (this.dataDirectory && !fs.existsSync(this.dataDirectory)) {
+        fs.mkdirSync(this.dataDirectory, {recursive: true})
+      }
       // Not all schemas will need vector installed, but we don't have an good way
       // to swap extensions after starting PGLite, so we always include it.
       const vector = (await dynamicImport("@electric-sql/pglite/vector")).vector;

--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -88,11 +88,10 @@ export class PostgresServer {
   }
 
   async getDb(): Promise<PGlite> {
-
     if (!this.db) {
       // Fisrt, ensure that the data directory exists - PGLite tries to do this but doesn't do so recursively
       if (this.dataDirectory && !fs.existsSync(this.dataDirectory)) {
-        fs.mkdirSync(this.dataDirectory, {recursive: true})
+        fs.mkdirSync(this.dataDirectory, { recursive: true });
       }
       // Not all schemas will need vector installed, but we don't have an good way
       // to swap extensions after starting PGLite, so we always include it.

--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -89,7 +89,7 @@ export class PostgresServer {
 
   async getDb(): Promise<PGlite> {
     if (!this.db) {
-      // Fisrt, ensure that the data directory exists - PGLite tries to do this but doesn't do so recursively
+      // First, ensure that the data directory exists - PGLite tries to do this but doesn't do so recursively
       if (this.dataDirectory && !fs.existsSync(this.dataDirectory)) {
         fs.mkdirSync(this.dataDirectory, { recursive: true });
       }

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -72,9 +72,7 @@ export class DataConnectEmulator implements EmulatorInstance {
   async start(): Promise<void> {
     let resolvedConfigDir;
     try {
-      resolvedConfigDir = this.args.config.path(this.args.configDir);
-
-      const info = await DataConnectEmulator.build({ configDir: resolvedConfigDir });
+      const info = await DataConnectEmulator.build({ configDir: this.args.configDir });
       if (requiresVector(info.metadata)) {
         if (Constants.isDemoProject(this.args.projectId)) {
           this.logger.logLabeled(

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -123,7 +123,7 @@ export class DataConnectEmulator implements EmulatorInstance {
           dataDirectory = this.args.config.path(dataDirectory);
         }
         const postgresDumpPath = this.args.importPath
-          ? path.join(this.args.config.path(this.args.importPath), "postgres.tar.gz")
+          ? path.join(this.args.importPath, "postgres.tar.gz")
           : undefined;
         this.postgresServer = new PostgresServer({
           dataDirectory,

--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -72,7 +72,8 @@ export class DataConnectEmulator implements EmulatorInstance {
   async start(): Promise<void> {
     let resolvedConfigDir;
     try {
-      const info = await DataConnectEmulator.build({ configDir: this.args.configDir });
+      resolvedConfigDir = this.args.config.path(this.args.configDir);
+      const info = await DataConnectEmulator.build({ configDir: resolvedConfigDir });
       if (requiresVector(info.metadata)) {
         if (Constants.isDemoProject(this.args.projectId)) {
           this.logger.logLabeled(


### PR DESCRIPTION
### Description
Fixes #8219 - for all other emulators, we resolve the import path at the call site, so we should do the same here.
