### PR TITLE
Print warning about --location removal.

### DIFF
--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -6,6 +6,7 @@ import { doSetup } from "../apphosting/backend";
 import { ensureApiEnabled } from "../gcp/apphosting";
 import { APPHOSTING_TOS_ID } from "../gcp/firedata";
 import { requireTosAcceptance } from "../requireTosAcceptance";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:backends:create")
   .description("create a Firebase App Hosting backend")
@@ -13,7 +14,7 @@ export const command = new Command("apphosting:backends:create")
     "-a, --app <webAppId>",
     "specify an existing Firebase web app's ID to associate your App Hosting backend with",
   )
-  .option("-l, --location <location>", "specify the location of the backend", "")
+  .option("-l, --location <location>", "specify the location of the backend")
   .option(
     "-s, --service-account <serviceAccount>",
     "specify the service account used to run the server",
@@ -23,9 +24,15 @@ export const command = new Command("apphosting:backends:create")
   .before(requireInteractive)
   .before(requireTosAcceptance(APPHOSTING_TOS_ID))
   .action(async (options: Options) => {
+    if (options.location !== undefined) {
+      logWarning(
+        "--location is being removed in the next major release. " +
+          "The CLI will prompt for a Primary Region where appropriate.",
+      );
+    }
     const projectId = needProjectId(options);
     const webAppId = options.app;
-    const location = options.location;
+    const location = options.location as string;
     const serviceAccount = options.serviceAccount;
 
     await doSetup(

--- a/src/commands/apphosting-backends-delete.ts
+++ b/src/commands/apphosting-backends-delete.ts
@@ -15,12 +15,15 @@ import * as ora from "ora";
 
 export const command = new Command("apphosting:backends:delete <backend>")
   .description("delete a Firebase App Hosting backend")
-  .option("-l, --location <location>", "specify the location of the backend", "-")
+  .option("-l, --location <location>", "specify the location of the backend")
   .withForce()
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
-    let location = options.location as string;
+    if (options.location !== undefined) {
+      utils.logWarning("--location is being removed in the next major release.");
+    }
+    let location = (options.location as string) ?? "-";
     let backend: apphosting.Backend;
     if (location === "-" || location === "") {
       backend = await getBackendForAmbiguousLocation(

--- a/src/commands/apphosting-backends-get.ts
+++ b/src/commands/apphosting-backends-get.ts
@@ -8,11 +8,14 @@ import { printBackendsTable } from "./apphosting-backends-list";
 
 export const command = new Command("apphosting:backends:get <backend>")
   .description("print info about a Firebase App Hosting backend")
-  .option("-l, --location <location>", "backend location", "-")
+  .option("-l, --location <location>", "backend location")
   .before(apphosting.ensureApiEnabled)
   .action(async (backend: string, options: Options) => {
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    const location = (options.location as string) ?? "-";
 
     let backendsList: apphosting.Backend[] = [];
     try {

--- a/src/commands/apphosting-backends-list.ts
+++ b/src/commands/apphosting-backends-list.ts
@@ -6,16 +6,20 @@ import { needProjectId } from "../projectUtils";
 import { Options } from "../options";
 import * as apphosting from "../gcp/apphosting";
 import * as Table from "cli-table3";
+import { logWarning } from "../utils";
 
 const TABLE_HEAD = ["Backend", "Repository", "URL", "Location", "Updated Date"];
 
 export const command = new Command("apphosting:backends:list")
   .description("list Firebase App Hosting backends")
-  .option("-l, --location <location>", "list backends in the specified location", "-")
+  .option("-l, --location <location>", "list backends in the specified location")
   .before(apphosting.ensureApiEnabled)
   .action(async (options: Options) => {
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    const location = (options.location as string) ?? "-";
     let backendRes: apphosting.ListBackendsResponse;
     try {
       backendRes = await apphosting.listBackends(projectId, location);

--- a/src/commands/apphosting-builds-create.ts
+++ b/src/commands/apphosting-builds-create.ts
@@ -3,16 +3,20 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:builds:create <backendId>")
   .description("create a build for an App Hosting backend")
-  .option("-l, --location <location>", "specify the region of the backend", "us-central1")
+  .option("-l, --location <location>", "specify the region of the backend")
   .option("-i, --id <buildId>", "id of the build (defaults to autogenerating a random id)", "")
   .option("-b, --branch <branch>", "repository branch to deploy (defaults to 'main')", "main")
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    const location = (options.location as string) ?? "us-central1";
     const buildId =
       (options.buildId as string) ||
       (await apphosting.getNextRolloutId(projectId, location, backendId));

--- a/src/commands/apphosting-builds-get.ts
+++ b/src/commands/apphosting-builds-get.ts
@@ -3,12 +3,17 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:builds:get <backendId> <buildId>")
   .description("get a build for an App Hosting backend")
-  .option("-l, --location <location>", "specify the region of the backend", "us-central1")
+  .option("-l, --location <location>", "specify the region of the backend")
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, buildId: string, options: Options) => {
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    options.location = options.location ?? "us-central";
     const projectId = needProjectId(options);
     const location = options.location as string;
     const build = await apphosting.getBuild(projectId, location, backendId, buildId);

--- a/src/commands/apphosting-rollouts-create.ts
+++ b/src/commands/apphosting-rollouts-create.ts
@@ -4,10 +4,11 @@ import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
 import { FirebaseError } from "../error";
 import { createRollout } from "../apphosting/rollout";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:rollouts:create <backendId>")
   .description("create a rollout using a build for an App Hosting backend")
-  .option("-l, --location <location>", "specify the region of the backend", "-")
+  .option("-l, --location <location>", "specify the region of the backend")
   .option(
     "-b, --git-branch <gitBranch>",
     "repository branch to deploy (mutually exclusive with -g)",
@@ -17,7 +18,10 @@ export const command = new Command("apphosting:rollouts:create <backendId>")
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
+    const location = (options.location as string) ?? "-";
 
     const branch = options.gitBranch as string | undefined;
     const commit = options.gitCommit as string | undefined;

--- a/src/commands/apphosting-rollouts-list.ts
+++ b/src/commands/apphosting-rollouts-list.ts
@@ -3,18 +3,21 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:rollouts:list <backendId>")
   .description("list rollouts of an App Hosting backend")
   .option(
     "-l, --location <location>",
     "region of the rollouts (defaults to listing rollouts from all regions)",
-    "-",
   )
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
+    if (options.location !== undefined) {
+      logWarning("--location is being removed in the next major release.");
+    }
     const projectId = needProjectId(options);
-    const location = options.location as string;
+    const location = (options.location as string) ?? "-";
     const rollouts = await apphosting.listRollouts(projectId, location, backendId);
     if (rollouts.unreachable) {
       logger.error(


### PR DESCRIPTION
### Description
Print warning about --location removal in next major version

### Scenarios Tested
Tested the following commands with and without --location:
apphosting:backends:get, apphosting:backends:create, apphosting:backends:delete,
apphosting:backends:list, apphosting:builds:create, apphosting:rollouts:create , apphosting:builds:get
