### PR TITLE
App Hosting Emulator bug - apphosting emulator info is not complete when env vars for emulators are set

### DIFF
--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -39,8 +39,8 @@ export class AppHostingEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     return {
       name: Emulators.APPHOSTING,
-      host: this.args.options.host ?? this.args.host,
-      port: this.args.options.port ?? this.args.port,
+      host: this.args.options.host,
+      port: this.args.options.port,
     };
   }
 

--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -39,8 +39,8 @@ export class AppHostingEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     return {
       name: Emulators.APPHOSTING,
-      host: this.args.options.host,
-      port: this.args.options.port,
+      host: this.args.options.host!,
+      port: this.args.options.port!,
     };
   }
 

--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -39,8 +39,8 @@ export class AppHostingEmulator implements EmulatorInstance {
   getInfo(): EmulatorInfo {
     return {
       name: Emulators.APPHOSTING,
-      host: this.args.options.host!,
-      port: this.args.options.port!,
+      host: this.args.options.host ?? this.args.host,
+      port: this.args.options.port ?? this.args.port,
     };
   }
 

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -83,8 +83,8 @@ describe("serve", () => {
     });
   });
 
-  describe("getEmulatorEnvs", async () => {
-    it("should omit apphosting emulator", async () => {
+  describe("getEmulatorEnvs", () => {
+    it("should omit apphosting emulator", () => {
       listRunningWithInfoStub.returns([{ name: "apphosting" }, { name: "functions" }]);
       serve.getEmulatorEnvs();
 

--- a/src/emulator/apphosting/serve.spec.ts
+++ b/src/emulator/apphosting/serve.spec.ts
@@ -8,6 +8,8 @@ import * as utils from "./developmentServer";
 import * as configsImport from "./config";
 import * as projectPathImport from "../../projectPath";
 import { AppHostingYamlConfig } from "../../apphosting/yaml";
+import * as emulatorRegistry from "../registry";
+import * as emulatorEnvs from "../env";
 
 describe("serve", () => {
   let checkListenableStub: sinon.SinonStub;
@@ -16,6 +18,8 @@ describe("serve", () => {
   let detectStartCommandStub: sinon.SinonStub;
   let configsStub: sinon.SinonStubbedInstance<typeof configsImport>;
   let resolveProjectPathStub: sinon.SinonStub;
+  let listRunningWithInfoStub: sinon.SinonStub;
+  let setEnvVarsForEmulatorsStub: sinon.SinonStub;
 
   beforeEach(() => {
     checkListenableStub = sinon.stub(portUtils, "checkListenable");
@@ -24,6 +28,9 @@ describe("serve", () => {
     detectStartCommandStub = sinon.stub(utils, "detectStartCommand");
     configsStub = sinon.stub(configsImport);
     resolveProjectPathStub = sinon.stub(projectPathImport, "resolveProjectPath");
+
+    listRunningWithInfoStub = sinon.stub(emulatorRegistry.EmulatorRegistry, "listRunningWithInfo");
+    setEnvVarsForEmulatorsStub = sinon.stub(emulatorEnvs, "setEnvVarsForEmulators");
 
     resolveProjectPathStub.returns("");
     detectStartCommandStub.returns("npm run dev");
@@ -37,6 +44,10 @@ describe("serve", () => {
   });
 
   describe("start", () => {
+    beforeEach(() => {
+      listRunningWithInfoStub.returns([]);
+    });
+
     it("should use user-provided port if one is defined", async () => {
       checkListenableStub.onFirstCall().returns(true);
       configsStub.getLocalAppHostingConfiguration.returns(
@@ -69,6 +80,15 @@ describe("serve", () => {
 
       expect(spawnWithCommandStringStub).to.be.called;
       expect(spawnWithCommandStringStub.getCall(0).args[0]).to.eq(startCommand);
+    });
+  });
+
+  describe("getEmulatorEnvs", async () => {
+    it("should omit apphosting emulator", async () => {
+      listRunningWithInfoStub.returns([{ name: "apphosting" }, { name: "functions" }]);
+      serve.getEmulatorEnvs();
+
+      expect(setEnvVarsForEmulatorsStub).to.be.calledWith({}, [{ name: "functions" }]);
     });
   });
 });

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -90,9 +90,8 @@ function availablePort(host: string, port: number): Promise<boolean> {
  */
 export function getEmulatorEnvs(): Record<string, string> {
   const envs: Record<string, string> = {};
-  // No need to set envs for the apphosting emulator itself.
   const emulatorInfos = EmulatorRegistry.listRunningWithInfo().filter(
-    (emulator) => emulator.name !== "apphosting",
+    (emulator) => emulator.name !== Emulators.APPHOSTING, // No need to set envs for the apphosting emulator itself.
   );
   setEnvVarsForEmulators(envs, emulatorInfos);
 

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -85,9 +85,15 @@ function availablePort(host: string, port: number): Promise<boolean> {
   });
 }
 
-function getEmulatorEnvs(): Record<string, string> {
+/**
+ * Exported for unit tests
+ */
+export function getEmulatorEnvs(): Record<string, string> {
   const envs: Record<string, string> = {};
-  const emulatorInfos = EmulatorRegistry.listRunningWithInfo();
+  // No need to set envs for the apphosting emulator itself.
+  const emulatorInfos = EmulatorRegistry.listRunningWithInfo().filter(
+    (emulator) => emulator.name !== "apphosting",
+  );
   setEnvVarsForEmulators(envs, emulatorInfos);
 
   return envs;


### PR DESCRIPTION
Fixes #8224.

The issue was that the App Hosting emulator info (port / host) is not ready when the environment variables for emulators are being set here: https://github.com/firebase/firebase-tools/blob/5b04f7d375bdd97d806253bb03d2a1988aeae567/src/emulator/apphosting/serve.ts#L60C8-L60C23. But we don't need to set the apphosting emulator's port/host (not needed for apphosting= emulator autoinit).