### PR TITLE
Retry on more failures during functions discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+Improve resiliancy of functions startup during deploy and emulators (#8234)
+

--- a/src/deploy/functions/runtimes/discovery/index.spec.ts
+++ b/src/deploy/functions/runtimes/discovery/index.spec.ts
@@ -101,7 +101,15 @@ describe("detectFromPort", () => {
       code: "ECONNREFUSED",
     });
 
-    nock("http://127.0.0.1:8080").get("/__/functions.yaml").reply(200, YAML_TEXT);
+    nock("http://127.0.0.1:8080")
+      .get("/__/functions.yaml")
+      .once()
+      .reply(408, "Request Timeout")
+
+    nock("http://127.0.0.1:8080")
+      .get("/__/functions.yaml")
+      .once()
+      .reply(200, YAML_TEXT);
 
     const parsed = await discovery.detectFromPort(8080, "project", "nodejs16");
     expect(parsed).to.deep.equal(BUILD);

--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -87,10 +87,13 @@ export async function detectFromPort(
   while (true) {
     try {
       res = await Promise.race([fetch(`http://127.0.0.1:${port}/__/functions.yaml`), timedOut]);
-      break;
+      // Retry on HTTP timed out errors
+      if (res.status !== 408) {
+        break;
+      }
     } catch (err: any) {
       // Allow us to wait until the server is listening.
-      if (err?.code === "ECONNREFUSED") {
+      if (["ECONNREFUSED", "ECONNRESET", "ETIMEDOUT"].includes(err?.code)) {
         continue;
       }
       throw err;


### PR DESCRIPTION
Hopefully will improve Python reliability by broadening the set of circumstances in which we retry discovery of a codebase's desired configuration.