### PR TITLE
Added env var to magically import data connect service from console

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -30,10 +30,10 @@ const SCHEMA_TEMPLATE = readTemplateSync("init/dataconnect/schema.gql");
 const QUERIES_TEMPLATE = readTemplateSync("init/dataconnect/queries.gql");
 const MUTATIONS_TEMPLATE = readTemplateSync("init/dataconnect/mutations.gql");
 
-// SERVICE_ENV_VAR is used by Firebase Console to specify which service to import.
+// serviceEnvVar is used by Firebase Console to specify which service to import.
 // It should be in the form <location>/<serviceId>
 // It must be an existing service - if set to anything else, we'll ignore it.
-const SERVICE_ENV_VAR = () => envOverride("FDC_SERVICE", "");
+const serviceEnvVar = () => envOverride("FDC_SERVICE", "");
 
 export interface RequiredInfo {
   serviceId: string;
@@ -288,10 +288,13 @@ async function promptForExistingServices(
   );
   if (existingServicesAndSchemas.length) {
     let choice: { service: Service; schema?: Schema } | undefined;
-    const [ serviceLocationFromEnvVar, serviceIdFromEnvVar ] = SERVICE_ENV_VAR().split("/");
-    const serviceFromEnvVar = existingServicesAndSchemas.find(s => {
+    const [serviceLocationFromEnvVar, serviceIdFromEnvVar] = serviceEnvVar().split("/");
+    const serviceFromEnvVar = existingServicesAndSchemas.find((s) => {
       const serviceName = parseServiceName(s.service.name);
-      return serviceName.serviceId === serviceIdFromEnvVar && serviceName.location === serviceLocationFromEnvVar;
+      return (
+        serviceName.serviceId === serviceIdFromEnvVar &&
+        serviceName.location === serviceLocationFromEnvVar
+      );
     });
     if (serviceFromEnvVar) {
       choice = serviceFromEnvVar;

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -19,7 +19,7 @@ import { Schema, Service, File, Platform } from "../../../dataconnect/types";
 import { parseCloudSQLInstanceName, parseServiceName } from "../../../dataconnect/names";
 import { logger } from "../../../logger";
 import { readTemplateSync } from "../../../templates";
-import { logBullet, envOverride } from '../../../utils';
+import { logBullet, envOverride } from "../../../utils";
 import { checkBillingEnabled } from "../../../gcp/cloudbilling";
 import * as sdk from "./sdk";
 import { getPlatformFromFolder } from "../../../dataconnect/fileUtils";

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -30,9 +30,10 @@ const SCHEMA_TEMPLATE = readTemplateSync("init/dataconnect/schema.gql");
 const QUERIES_TEMPLATE = readTemplateSync("init/dataconnect/queries.gql");
 const MUTATIONS_TEMPLATE = readTemplateSync("init/dataconnect/mutations.gql");
 
-// SERVICE_ID_ENV_VAR is used by Firebase Console to specify which service to import.
+// SERVICE_ENV_VAR is used by Firebase Console to specify which service to import.
+// It should be in the form <location>/<serviceId>
 // It must be an existing service - if set to anything else, we'll ignore it.
-const SERVICE_ID_ENV_VAR = () => envOverride("FDC_SERVICE_ID", "");
+const SERVICE_ENV_VAR = () => envOverride("FDC_SERVICE", "");
 
 export interface RequiredInfo {
   serviceId: string;
@@ -287,10 +288,10 @@ async function promptForExistingServices(
   );
   if (existingServicesAndSchemas.length) {
     let choice: { service: Service; schema?: Schema } | undefined;
-    const serviceIdFromEnvVar = SERVICE_ID_ENV_VAR()
+    const [ serviceLocationFromEnvVar, serviceIdFromEnvVar ] = SERVICE_ENV_VAR().split("/");
     const serviceFromEnvVar = existingServicesAndSchemas.find(s => {
       const serviceName = parseServiceName(s.service.name);
-      return serviceName.serviceId === serviceIdFromEnvVar;
+      return serviceName.serviceId === serviceIdFromEnvVar && serviceName.location === serviceLocationFromEnvVar;
     });
     if (serviceFromEnvVar) {
       choice = serviceFromEnvVar;


### PR DESCRIPTION
### Description
Slightly hacky trick to make onboarding from console experience smoother - when `FDC_SERVICE_ID` is set to an existing service ID, we'll automatically assume you chose that one and proceed with `init`.
