### PR TITLE
Improve robustness of function discovery for python

### DIFF
--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -195,7 +195,12 @@ export class Delegate implements runtimes.RuntimeDelegate {
       });
       const killProcess = await this.serveAdmin(adminPort, envs);
       try {
-        discovered = await discovery.detectFromPort(adminPort, this.projectId, this.runtime);
+        discovered = await discovery.detectFromPort(
+          adminPort,
+          this.projectId,
+          this.runtime,
+          500 /* initialDelay, python startup is slow */,
+        );
       } finally {
         await killProcess();
       }


### PR DESCRIPTION
Anecdotally, python function discovery is flakey. We propose 2 change in this PR:

1. For python discovery, add a small initial delay for python's admin server to boot.

2. Add a request timeout to retry call to retrieve trigger information. Previously, the default timeout would've been set to OS-level TCP timeout, which in my laptop was between 20~30s.

Before the change, I was able to reliably trigger the flake ~1/10 trigger parsing session. With these changes, I'm haven't been able to trigger the flake (N=~50, YMMV).