### PR TITLE
fix queue id validation to match the error message guide

### DIFF
--- a/src/emulator/tasksEmulator.ts
+++ b/src/emulator/tasksEmulator.ts
@@ -186,11 +186,11 @@ export class TasksEmulator implements EmulatorInstance {
     if (typeof queueId !== "string") {
       return false;
     }
-  
+
     if (queueId.length < 1 || queueId.length > 62) {
       return false;
     }
-  
+
     const regex = /^[A-Za-z][A-Za-z0-9_-]*[A-Za-z0-9]$/;
     return regex.test(queueId);
   }

--- a/src/emulator/tasksEmulator.ts
+++ b/src/emulator/tasksEmulator.ts
@@ -186,12 +186,12 @@ export class TasksEmulator implements EmulatorInstance {
     if (typeof queueId !== "string") {
       return false;
     }
-
-    if (queueId.length > 100) {
+  
+    if (queueId.length < 1 || queueId.length > 62) {
       return false;
     }
-
-    const regex = /^[A-Za-z0-9-]+$/;
+  
+    const regex = /^[A-Za-z][A-Za-z0-9_-]*[A-Za-z0-9]$/;
     return regex.test(queueId);
   }
   createHubServer(): express.Application {


### PR DESCRIPTION
### Description

The PR https://github.com/firebase/firebase-tools/pull/7916 is confusing, because it implements an error message that don't respect itself. This PR should fix the validation to match the error message.