### PR TITLE
Extend supported version range to include Vite 6

### DIFF
--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -17,7 +17,7 @@ import {
 export const name = "Vite";
 export const support = SupportLevel.Experimental;
 export const type = FrameworkType.Toolchain;
-export const supportedRange = "3 - 5";
+export const supportedRange = "3 - 6";
 
 export const DEFAULT_BUILD_SCRIPT = ["vite build", "tsc && vite build"];
 


### PR DESCRIPTION
### Description

Added support for Vite 6.

The Vite documentation also mentions using the latest version of Vite, and I have determined that using Vite 6 is acceptable.
https://github.com/firebase/firebase-tools/blob/master/src/frameworks/docs/vite.md#before-you-begin

### Scenarios Tested

Run `firebase init hosting` and selected `Vite` as the web framework.
After running `firebase emulators:start`, verified that the vite application starts successfully at http://localhost:3000/.

Please let us know if any additional tests are required.

### Sample Commands

firebase init hosting
