### PR TITLE
 Remove --location from apphosting:backends:get and return the first backend if multiple are found.

### DIFF
--- a/src/commands/apphosting-backends-get.ts
+++ b/src/commands/apphosting-backends-get.ts
@@ -8,25 +8,15 @@ import { printBackendsTable } from "./apphosting-backends-list";
 
 export const command = new Command("apphosting:backends:get <backend>")
   .description("print info about a Firebase App Hosting backend")
-  .option("-l, --location <location>", "backend location")
   .before(apphosting.ensureApiEnabled)
   .action(async (backend: string, options: Options) => {
     const projectId = needProjectId(options);
-    if (options.location !== undefined) {
-      logWarning("--location is being removed in the next major release.");
-    }
-    const location = (options.location as string) ?? "-";
 
     let backendsList: apphosting.Backend[] = [];
     try {
-      if (location !== "-") {
-        const backendInRegion = await apphosting.getBackend(projectId, location, backend);
-        backendsList.push(backendInRegion);
-      } else {
-        const resp = await apphosting.listBackends(projectId, "-");
-        const allBackends = resp.backends || [];
-        backendsList = allBackends.filter((bkd) => bkd.name.split("/").pop() === backend);
-      }
+      const resp = await apphosting.listBackends(projectId, "-");
+      const allBackends = resp.backends || [];
+      backendsList = allBackends.filter((bkd) => bkd.name.split("/").pop() === backend);
     } catch (err: unknown) {
       throw new FirebaseError(
         `Failed to get backend: ${backend}. Please check the parameters you have provided.`,
@@ -37,6 +27,13 @@ export const command = new Command("apphosting:backends:get <backend>")
       logWarning(`Backend "${backend}" not found`);
       return;
     }
-    printBackendsTable(backendsList);
+    if (backendsList.length > 1) {
+      logWarning(
+        `Detected multiple backends with the same ${backend} ID. This is not allowed until we can support more locations.\n` +
+          `Please delete and recreate any backends that share an ID with another backend. ` +
+          `Use apphosting:backends:list to see all backends.\n Returning the following backend:`,
+      );
+    }
+    printBackendsTable(backendsList.slice(0, 1));
     return backendsList[0];
   });


### PR DESCRIPTION
### Description

Remove `--location` from apphosting:backends:get and return the first backend in the list if multiple are found. We will also warn the user and tell them to delete the duplicate backends.

### Scenarios Tested

`firebase apphosting:backends:get friendlybugs-codelab` where multiple backends named friendlybugs-codelab exist
`firebase apphosting:backends:get friendlybugs-codelab-chicken` where the backend does not exit
`firebase apphosting:backends:get chickenbugs` where only one backend with this name exists.
`firebase apphosting:backends:get chickenbugs --location europ-west4` returns "unknown option '--location'"
