### PR TITLE
Split up emulator hub message to better match how its used

### DIFF
--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -125,12 +125,13 @@ function printEmulatorOverview(options: any): void {
     ) as ExtensionsEmulator;
     extensionsTable = extensionsEmulatorInstance.extensionsInfoTable();
   }
+  const hubInfo = EmulatorRegistry.getInfo(Emulators.HUB);
   logger.info(`\n${successMessageTable}
 
 ${emulatorsTable}
 ${
-  EmulatorRegistry.isRunning(Emulators.HUB)
-    ? clc.blackBright("  Emulator Hub running at ") + EmulatorRegistry.url(Emulators.HUB).host
+  hubInfo
+    ? clc.blackBright(`  Emulator Hub host: ${hubInfo.host} port: ${hubInfo.port}`)
     : clc.blackBright("  Emulator Hub not running.")
 }
 ${clc.blackBright("  Other reserved ports:")} ${reservedPortsString}


### PR DESCRIPTION
### Description
This log line was misleading to some users, and it mainly used across 2 env vars (one for host, one for port).
