### PR TITLE
Remove --location from apphosting:backends:create and prompt for primary region

### DIFF
--- a/src/apphosting/backend.ts~
+++ b/src/apphosting/backend.ts~
@@ -88,9 +88,6 @@ export async function doSetup(
   // possible to reduce the likelihood that the subsequent Cloud Build fails. See b/336862200.
   await ensureAppHostingComputeServiceAccount(projectId, serviceAccount);
 
-  // TODO(https://github.com/firebase/firebase-tools/issues/8283): The "primary region"
-  // is still "locations" in the V1 API. This will change in the V2 API and we may need to update
-  // the variables and API methods we're calling under the hood when fetching "primary region".
   const location = await promptLocation(
     projectId,
     "Select a primary region to host your backend:\n",

--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -6,7 +6,6 @@ import { doSetup } from "../apphosting/backend";
 import { ensureApiEnabled } from "../gcp/apphosting";
 import { APPHOSTING_TOS_ID } from "../gcp/firedata";
 import { requireTosAcceptance } from "../requireTosAcceptance";
-import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:backends:create")
   .description("create a Firebase App Hosting backend")
@@ -14,7 +13,6 @@ export const command = new Command("apphosting:backends:create")
     "-a, --app <webAppId>",
     "specify an existing Firebase web app's ID to associate your App Hosting backend with",
   )
-  .option("-l, --location <location>", "specify the location of the backend")
   .option(
     "-s, --service-account <serviceAccount>",
     "specify the service account used to run the server",
@@ -24,21 +22,9 @@ export const command = new Command("apphosting:backends:create")
   .before(requireInteractive)
   .before(requireTosAcceptance(APPHOSTING_TOS_ID))
   .action(async (options: Options) => {
-    if (options.location !== undefined) {
-      logWarning(
-        "--location is being removed in the next major release. " +
-          "The CLI will prompt for a Primary Region where appropriate.",
-      );
-    }
     const projectId = needProjectId(options);
     const webAppId = options.app;
-    const location = options.location as string;
     const serviceAccount = options.serviceAccount;
 
-    await doSetup(
-      projectId,
-      webAppId as string | null,
-      location as string | null,
-      serviceAccount as string | null,
-    );
+    await doSetup(projectId, webAppId as string | null, serviceAccount as string | null);
   });


### PR DESCRIPTION
### Description

Remove --location from apphosting:backends:create and prompt for primary region

### Scenarios Tested

`firebase apphosting:backends:create`

`firebase apphosting:backends:create --location asia-east1` should return error
