### PR TITLE
Fixed .graphqlrc path generation for Windows devices

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## NEXT
 
+## 0.13.2
+
+- [Fixed] Graphql Language Server support for Windows
+
 ## 0.13.1
 
 - Updated internal `firebase-tools` dependency to 13.31.2

--- a/firebase-vscode/src/data-connect/language-client.ts
+++ b/firebase-vscode/src/data-connect/language-client.ts
@@ -95,13 +95,29 @@ export function setupLanguageClient(
     // TODO: Expand to multiple services
     const config = configs.values[0];
     const generatedPath = ".dataconnect";
-    const schemaPaths = [
+
+    let schemaPaths = [
       `../${config.relativeSchemaPath}/**/*.gql`,
       `../${config.relativePath}/${generatedPath}/**/*.gql`,
     ];
-    const documentPaths = config.relativeConnectorPaths.map(
+    let documentPaths = config.relativeConnectorPaths.map(
       (connectorPath) => `../${connectorPath}/**/*.gql`,
     );
+
+    if (process.platform === "win32") {
+      // TODO: figure out why relative paths are absolute on windows
+      schemaPaths = [
+        `${config.relativeSchemaPath}/**/*.gql`,
+        `${config.relativePath}/${generatedPath}/**/*.gql`,
+      ];
+      documentPaths = config.relativeConnectorPaths.map(
+        (connectorPath) => `${connectorPath}/**/*.gql`,
+      );
+
+      // clean up windows \\ url scheme 
+      schemaPaths = schemaPaths.map((path) => path.replace(/\\/g, "/"));
+      documentPaths = documentPaths.map((path) => path.replace(/\\/g, "/"));
+    }
 
     const yamlJson = JSON.stringify({
       schema: schemaPaths,

--- a/firebase-vscode/src/data-connect/language-client.ts
+++ b/firebase-vscode/src/data-connect/language-client.ts
@@ -95,28 +95,24 @@ export function setupLanguageClient(
     // TODO: Expand to multiple services
     const config = configs.values[0];
     const generatedPath = ".dataconnect";
-
+    path.join(config.relativeSchemaPath, "**", "*.gql");
     let schemaPaths = [
-      `../${config.relativeSchemaPath}/**/*.gql`,
-      `../${config.relativePath}/${generatedPath}/**/*.gql`,
+      path.join(config.relativeSchemaPath, "**", "*.gql"),
+      path.join(config.relativePath, generatedPath, "**", "*.gql"),
     ];
-    let documentPaths = config.relativeConnectorPaths.map(
-      (connectorPath) => `../${connectorPath}/**/*.gql`,
+    let documentPaths = config.relativeConnectorPaths.map((connectorPath) =>
+      path.join(connectorPath, "**", "*.gql"),
     );
 
-    if (process.platform === "win32") {
-      // TODO: figure out why relative paths are absolute on windows
-      schemaPaths = [
-        `${config.relativeSchemaPath}/**/*.gql`,
-        `${config.relativePath}/${generatedPath}/**/*.gql`,
-      ];
-      documentPaths = config.relativeConnectorPaths.map(
-        (connectorPath) => `${connectorPath}/**/*.gql`,
+    // make non windows paths relative
+    // TODO: figure out why relative paths are absolute on windows
+    if (process.platform !== "win32") {
+      schemaPaths = schemaPaths.map((schemaPath) =>
+        path.join("..", schemaPath),
       );
-
-      // clean up windows \\ url scheme 
-      schemaPaths = schemaPaths.map((path) => path.replace(/\\/g, "/"));
-      documentPaths = documentPaths.map((path) => path.replace(/\\/g, "/"));
+      documentPaths = documentPaths.map((documentPath) =>
+        path.join("..", documentPath),
+      );
     }
 
     const yamlJson = JSON.stringify({


### PR DESCRIPTION
Fix generation of paths to schema and operation files. Fixes GQL Language server support for Windows devices. 

Fixes #8177 

Verified on Windows VM. 