### PR TITLE
update vscode to 0.14.0

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## NEXT
 
-## 0.13.2
+## 0.14.0
 
+- Updated internal `firebase-tools` dependency to 13.32.0
 - [Fixed] Graphql Language Server support for Windows
 
 ## 0.13.1

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "0.13.1",
+      "version": "0.14.0",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
- Updated internal `firebase-tools` dependency to 13.32.0
- [Fixed] Graphql Language Server support for Windows