### PR TITLE
Remove --location from apphosting:rollouts:create and error when more than one backend is found.

### DIFF
--- a/src/commands/apphosting-rollouts-create.ts
+++ b/src/commands/apphosting-rollouts-create.ts
@@ -4,11 +4,9 @@ import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
 import { FirebaseError } from "../error";
 import { createRollout } from "../apphosting/rollout";
-import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:rollouts:create <backendId>")
   .description("create a rollout using a build for an App Hosting backend")
-  .option("-l, --location <location>", "specify the region of the backend")
   .option(
     "-b, --git-branch <gitBranch>",
     "repository branch to deploy (mutually exclusive with -g)",
@@ -18,10 +16,6 @@ export const command = new Command("apphosting:rollouts:create <backendId>")
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);
-    if (options.location !== undefined) {
-      logWarning("--location is being removed in the next major release.");
-    }
-    const location = (options.location as string) ?? "-";
 
     const branch = options.gitBranch as string | undefined;
     const commit = options.gitCommit as string | undefined;
@@ -31,5 +25,5 @@ export const command = new Command("apphosting:rollouts:create <backendId>")
       );
     }
 
-    await createRollout(backendId, projectId, location, branch, commit, options.force);
+    await createRollout(backendId, projectId, branch, commit, options.force);
   });


### PR DESCRIPTION
### Description

Remove --location from apphosting:rollouts:create and error when more than one backend is found.

### Scenarios Tested

`firebase apphosting:rollouts:create chickenbugs` where chickenbugs is the only backend with the name => should succeed
`firebase apphosting:rollouts:create chicken` where there are multiple backends with this name => should error
`firebase apphosting:rollouts:create chicken --location us-central1` => should complain about unknown option --location

