### PR TITLE
Remove --location from apphosting:backends:list

### DIFF
--- a/src/commands/apphosting-backends-list.ts
+++ b/src/commands/apphosting-backends-list.ts
@@ -6,23 +6,17 @@ import { needProjectId } from "../projectUtils";
 import { Options } from "../options";
 import * as apphosting from "../gcp/apphosting";
 import * as Table from "cli-table3";
-import { logWarning } from "../utils";
 
 const TABLE_HEAD = ["Backend", "Repository", "URL", "Primary Region", "Updated Date"];
 
 export const command = new Command("apphosting:backends:list")
   .description("list Firebase App Hosting backends")
-  .option("-l, --location <location>", "list backends in the specified location")
   .before(apphosting.ensureApiEnabled)
   .action(async (options: Options) => {
-    if (options.location !== undefined) {
-      logWarning("--location is being removed in the next major release.");
-    }
     const projectId = needProjectId(options);
-    const location = (options.location as string) ?? "-";
     let backendRes: apphosting.ListBackendsResponse;
     try {
-      backendRes = await apphosting.listBackends(projectId, location);
+      backendRes = await apphosting.listBackends(projectId, /* location= */ "-");
     } catch (err: unknown) {
       throw new FirebaseError(
         `Unable to list backends present for project: ${projectId}. Please check the parameters you have provided.`,


### PR DESCRIPTION
### Description

Remove --location from apphosting:backends:list

### Scenarios Tested

`firebase apphosting:backends:list` should work as normal
`firebase apphosting:backends:list --location europe-west4` => should error about unknown option