### PR TITLE
Enable execution id for 2nd gen functions log.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixed issue where `apps:init` fails to detect the output directory when it was run in a directory where `app` was the only module.
+- Set `LOG_EXECUTION_ID=true` by default for Cloud Functions (2nd gen) to improve debugging by displaying execution IDs in logs.

--- a/src/gcp/cloudfunctionsv2.spec.ts
+++ b/src/gcp/cloudfunctionsv2.spec.ts
@@ -825,14 +825,23 @@ describe("cloudfunctionsv2", () => {
         buildConfig: {
           ...CLOUD_FUNCTION_V2.buildConfig,
           environmentVariables: {},
-        }
+        },
       };
 
       const scope = nock(functionsV2Origin())
         .post("/v2/projects/project/locations/region/functions", (body) => {
-          expect(body.serviceConfig.environmentVariables).to.have.property("LOG_EXECUTION_ID", "true");
-          expect(body.serviceConfig.environmentVariables).to.have.property("FUNCTION_TARGET", "function");
-          expect(body.buildConfig.environmentVariables).to.have.property("GOOGLE_NODE_RUN_SCRIPTS", "");
+          expect(body.serviceConfig.environmentVariables).to.have.property(
+            "LOG_EXECUTION_ID",
+            "true",
+          );
+          expect(body.serviceConfig.environmentVariables).to.have.property(
+            "FUNCTION_TARGET",
+            "function",
+          );
+          expect(body.buildConfig.environmentVariables).to.have.property(
+            "GOOGLE_NODE_RUN_SCRIPTS",
+            "",
+          );
           return true;
         })
         .query({ functionId: "id" })
@@ -847,9 +856,18 @@ describe("cloudfunctionsv2", () => {
     it("should set default environment variables", async () => {
       const scope = nock(functionsV2Origin())
         .patch("/v2/projects/project/locations/region/functions/id", (body) => {
-          expect(body.serviceConfig.environmentVariables).to.have.property("LOG_EXECUTION_ID", "true");
-          expect(body.serviceConfig.environmentVariables).to.have.property("FUNCTION_TARGET", "function");
-          expect(body.buildConfig.environmentVariables).to.have.property("GOOGLE_NODE_RUN_SCRIPTS", "");
+          expect(body.serviceConfig.environmentVariables).to.have.property(
+            "LOG_EXECUTION_ID",
+            "true",
+          );
+          expect(body.serviceConfig.environmentVariables).to.have.property(
+            "FUNCTION_TARGET",
+            "function",
+          );
+          expect(body.buildConfig.environmentVariables).to.have.property(
+            "GOOGLE_NODE_RUN_SCRIPTS",
+            "",
+          );
           return true;
         })
         .query(true) // Accept any query parameters

--- a/src/gcp/cloudfunctionsv2.spec.ts
+++ b/src/gcp/cloudfunctionsv2.spec.ts
@@ -812,4 +812,51 @@ describe("cloudfunctionsv2", () => {
       expect(nock.isDone()).to.be.true;
     });
   });
+
+  describe("createFunction", () => {
+    it("should set default environment variables", async () => {
+      const testFunction = {
+        ...CLOUD_FUNCTION_V2,
+        name: "projects/project/locations/region/functions/id",
+        serviceConfig: {
+          ...CLOUD_FUNCTION_V2.serviceConfig,
+          environmentVariables: {},
+        },
+        buildConfig: {
+          ...CLOUD_FUNCTION_V2.buildConfig,
+          environmentVariables: {},
+        }
+      };
+
+      const scope = nock(functionsV2Origin())
+        .post("/v2/projects/project/locations/region/functions", (body) => {
+          expect(body.serviceConfig.environmentVariables).to.have.property("LOG_EXECUTION_ID", "true");
+          expect(body.serviceConfig.environmentVariables).to.have.property("FUNCTION_TARGET", "function");
+          expect(body.buildConfig.environmentVariables).to.have.property("GOOGLE_NODE_RUN_SCRIPTS", "");
+          return true;
+        })
+        .query({ functionId: "id" })
+        .reply(200, { name: "operations/123", done: true });
+
+      await cloudfunctionsv2.createFunction(testFunction);
+      expect(scope.isDone()).to.be.true;
+    });
+  });
+
+  describe("updateFunction", () => {
+    it("should set default environment variables", async () => {
+      const scope = nock(functionsV2Origin())
+        .patch("/v2/projects/project/locations/region/functions/id", (body) => {
+          expect(body.serviceConfig.environmentVariables).to.have.property("LOG_EXECUTION_ID", "true");
+          expect(body.serviceConfig.environmentVariables).to.have.property("FUNCTION_TARGET", "function");
+          expect(body.buildConfig.environmentVariables).to.have.property("GOOGLE_NODE_RUN_SCRIPTS", "");
+          return true;
+        })
+        .query(true) // Accept any query parameters
+        .reply(200, { name: "operations/123", done: true });
+
+      await cloudfunctionsv2.updateFunction(CLOUD_FUNCTION_V2);
+      expect(scope.isDone()).to.be.true;
+    });
+  });
 });

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -509,6 +509,12 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
     "ingressSettings",
     "timeoutSeconds",
   );
+  
+  // Add LOG_EXECUTION_ID=true by default for better debugging, unless user has explicitly set it
+  gcfFunction.serviceConfig.environmentVariables = {
+    LOG_EXECUTION_ID: "true",
+    ...gcfFunction.serviceConfig.environmentVariables,
+  };
   proto.renameIfPresent(
     gcfFunction.serviceConfig,
     endpoint,

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -333,6 +333,8 @@ export async function createFunction(cloudFunction: InputCloudFunction): Promise
   cloudFunction.serviceConfig.environmentVariables = {
     ...cloudFunction.serviceConfig.environmentVariables,
     FUNCTION_TARGET: cloudFunction.buildConfig.entryPoint.replaceAll("-", "."),
+    // Enable logging execution id by default for better debugging
+    LOG_EXECUTION_ID: "true",
   };
 
   try {
@@ -439,6 +441,8 @@ export async function updateFunction(cloudFunction: InputCloudFunction): Promise
   cloudFunction.serviceConfig.environmentVariables = {
     ...cloudFunction.serviceConfig.environmentVariables,
     FUNCTION_TARGET: cloudFunction.buildConfig.entryPoint.replaceAll("-", "."),
+    // Enable logging execution id by default for better debugging
+    LOG_EXECUTION_ID: "true",
   };
 
   try {
@@ -510,11 +514,6 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
     "timeoutSeconds",
   );
 
-  // Add LOG_EXECUTION_ID=true by default for better debugging, unless user has explicitly set it
-  gcfFunction.serviceConfig.environmentVariables = {
-    LOG_EXECUTION_ID: "true",
-    ...gcfFunction.serviceConfig.environmentVariables,
-  };
   proto.renameIfPresent(
     gcfFunction.serviceConfig,
     endpoint,

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -509,7 +509,7 @@ export function functionFromEndpoint(endpoint: backend.Endpoint): InputCloudFunc
     "ingressSettings",
     "timeoutSeconds",
   );
-  
+
   // Add LOG_EXECUTION_ID=true by default for better debugging, unless user has explicitly set it
   gcfFunction.serviceConfig.environmentVariables = {
     LOG_EXECUTION_ID: "true",


### PR DESCRIPTION
Functions Framework added support for logging execution id for every log entry emitted by 2nd Gen functions:

https://cloud.google.com/functions/docs/monitoring/logging#viewing_runtime_logs

We will enable this feature by default for all Firebase Functions customers, unless user has decided to expliclty opt-out of it by setting the env var to false.