### PR TITLE
Adds environment variable for FDC emulator.

### DIFF
--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -76,6 +76,9 @@ export class Constants {
   // Environment variable to override SDK/CLI to point at the Realtime Database emulator.
   static FIREBASE_DATABASE_EMULATOR_HOST = "FIREBASE_DATABASE_EMULATOR_HOST";
 
+  // Environment variable to discover the Data Connect emulator.
+  static FIREBASE_DATACONNECT_EMULATOR_HOST = "FIREBASE_DATACONNECT_EMULATOR_HOST";
+
   // Environment variable to override SDK/CLI to point at the Firebase Auth emulator.
   static FIREBASE_AUTH_EMULATOR_HOST = "FIREBASE_AUTH_EMULATOR_HOST";
 

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -41,6 +41,8 @@ export function setEnvVarsForEmulators(
       case Emulators.TASKS:
         env[Constants.CLOUD_TASKS_EMULATOR_HOST] = host;
         break;
+      case Emulators.DATACONNECT:
+        env[Constants.FIREBASE_DATACONNECT_EMULATOR_HOST] = host;
     }
   }
 }


### PR DESCRIPTION
Does this seem correct? We'd also then need to add the autoconfiguration logic to firebase-admin, but setting the env var should be a good start, right?