### PR TITLE
update to 0.14.1

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+## 0.14.1
+
+- Updated internal `firebase-tools` dependency to 13.33.0
 - Updated introspection endpoint to V1
 - Allow unused variables in GraphQL queries and mutations.
 

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
Update VSCode to ver 0.14.1

- Updated internal `firebase-tools` dependency to 13.33.0
- Updated introspection endpoint to V1
- Allow unused variables in GraphQL queries and mutations.