### PR TITLE
Fix deploy with multiple target/site in firebase.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix webframeworks deployments when using multiple hosting sites in `firebase.json`. (#8314)

--- a/src/deploy/index.spec.ts
+++ b/src/deploy/index.spec.ts
@@ -16,6 +16,43 @@ describe("Deploy", () => {
       };
     });
 
+    describe("with no hosting config", () => {
+      beforeEach(() => {
+        options.config.get.withArgs("hosting").returns(null);
+      });
+
+      it("should return false when config is null", () => {
+        expect(isDeployingWebFramework(options)).to.be.false;
+      });
+    });
+
+    describe("with only hosting specified", () => {
+      describe("with mixed configs", () => {
+        beforeEach(() => {
+          options.config.get.withArgs("hosting").returns([
+            { source: "src", target: "prod" },
+            { source: "src", target: "staging" },
+            { target: "static", public: "public" },
+          ]);
+        });
+
+        it("should return true when only 'hosting' is specified", () => {
+          options.only = "hosting";
+          expect(isDeployingWebFramework(options)).to.be.true;
+        });
+
+        it("should return true when targeting a web framework site", () => {
+          options.only = "hosting:prod";
+          expect(isDeployingWebFramework(options)).to.be.true;
+        });
+
+        it("should return false when targeting a static site", () => {
+          options.only = "hosting:static";
+          expect(isDeployingWebFramework(options)).to.be.false;
+        });
+      });
+    });
+
     describe("with site in config", () => {
       describe("single web framework", () => {
         beforeEach(() => {

--- a/src/deploy/index.spec.ts
+++ b/src/deploy/index.spec.ts
@@ -16,198 +16,129 @@ describe("Deploy", () => {
       };
     });
 
-    describe("with no hosting config", () => {
-      beforeEach(() => {
-        options.config.get.withArgs("hosting").returns(null);
+    for (const key of ["site", "target"]) {
+      describe(`with ${key} in config`, () => {
+        describe("with a single web framework", () => {
+          beforeEach(() => {
+            options.config.get
+              .withArgs("hosting")
+              .returns([{ source: "src", [key]: "webframework" }]);
+          });
+
+          describe("without 'only' option", () => {
+            it("should return true if a web framework is in config", () => {
+              expect(isDeployingWebFramework(options)).to.be.true;
+            });
+          });
+
+          describe("with 'only' option", () => {
+            it(`should return false if 'only' option does not match the ${key}`, () => {
+              options.only = "hosting:othersite";
+              expect(isDeployingWebFramework(options)).to.be.false;
+            });
+
+            it(`should return true if 'only' option matches the ${key}`, () => {
+              options.only = `hosting:webframework`;
+              expect(isDeployingWebFramework(options)).to.be.true;
+            });
+
+            it("should return false if 'only' option matches a function, not a web framework", () => {
+              options.only = "functions:webframework";
+              expect(isDeployingWebFramework(options)).to.be.false;
+            });
+          });
+        });
+
+        describe("with both a web framework and a non-web framework", () => {
+          beforeEach(() => {
+            options.config.get.withArgs("hosting").returns([
+              { source: "src", [key]: "webframework" },
+              { public: "public", [key]: "public" },
+            ]);
+          });
+
+          describe("without 'only' option", () => {
+            it("should return true if a web framework is in config", () => {
+              expect(isDeployingWebFramework(options)).to.be.true;
+            });
+          });
+
+          describe("with 'only' option", () => {
+            it(`should return false if 'only' option does not match the web framework ${key}`, () => {
+              options.only = "hosting:othersite";
+              expect(isDeployingWebFramework(options)).to.be.false;
+            });
+
+            it(`should return true if 'only' option matches the web framework ${key}`, () => {
+              options.only = `hosting:webframework`;
+              expect(isDeployingWebFramework(options)).to.be.true;
+            });
+
+            it(`should return false if 'only' option matches a non-web framework ${key}`, () => {
+              options.only = "hosting:public";
+              expect(isDeployingWebFramework(options)).to.be.false;
+            });
+
+            it("should return false if 'only' option matches a function, not a web framework", () => {
+              options.only = "functions:webframework";
+              expect(isDeployingWebFramework(options)).to.be.false;
+            });
+          });
+        });
+
+        describe("with more than one web framework in config", () => {
+          beforeEach(() => {
+            options.config.get.withArgs("hosting").returns([
+              { source: "src", [key]: "prod" },
+              { source: "src", [key]: "staging" },
+              { public: "public", [key]: "static" },
+            ]);
+          });
+
+          it("should return true when only 'hosting' is specified", () => {
+            options.only = "hosting";
+            expect(isDeployingWebFramework(options)).to.be.true;
+          });
+
+          it("should return true when targeting a web framework site", () => {
+            options.only = "hosting:prod";
+            expect(isDeployingWebFramework(options)).to.be.true;
+
+            // verify if it also works for the other site
+            options.only = "hosting:staging";
+            expect(isDeployingWebFramework(options)).to.be.true;
+          });
+
+          it("should return false when targeting a non-web framework site", () => {
+            options.only = "hosting:static";
+            expect(isDeployingWebFramework(options)).to.be.false;
+          });
+        });
       });
 
-      it("should return false when config is null", () => {
-        expect(isDeployingWebFramework(options)).to.be.false;
-      });
-    });
-
-    describe("with only hosting specified", () => {
-      describe("with mixed configs", () => {
+      describe("with no web framework in config", () => {
         beforeEach(() => {
-          options.config.get.withArgs("hosting").returns([
-            { source: "src", target: "prod" },
-            { source: "src", target: "staging" },
-            { target: "static", public: "public" },
-          ]);
+          options.config.get.withArgs("hosting").returns([{ [key]: "public", public: "public" }]);
         });
 
-        it("should return true when only 'hosting' is specified", () => {
-          options.only = "hosting";
-          expect(isDeployingWebFramework(options)).to.be.true;
+        describe("without 'only' option", () => {
+          it("should return false if no web framework is in config", () => {
+            expect(isDeployingWebFramework(options)).to.be.false;
+          });
         });
 
-        it("should return true when targeting a web framework site", () => {
-          options.only = "hosting:prod";
-          expect(isDeployingWebFramework(options)).to.be.true;
+        describe("with 'only' option", () => {
+          it("should return false regardless of 'only' option", () => {
+            options.only = "hosting:webframework";
+            expect(isDeployingWebFramework(options)).to.be.false;
+          });
         });
 
-        it("should return false when targeting a static site", () => {
-          options.only = "hosting:static";
+        it("should return false when config is null", () => {
+          options.config.get.withArgs("hosting").returns(null);
           expect(isDeployingWebFramework(options)).to.be.false;
         });
       });
-    });
-
-    describe("with site in config", () => {
-      describe("single web framework", () => {
-        beforeEach(() => {
-          options.config.get.withArgs("hosting").returns([{ source: "src", site: "webframework" }]);
-        });
-
-        describe("without 'only' option", () => {
-          it("should return true if a web framework is in config", () => {
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-        });
-
-        describe("with 'only' option", () => {
-          it("should return false if 'only' option does not match the site", () => {
-            options.only = "hosting:othersite";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-
-          it("should return true if 'only' option matches the site", () => {
-            options.only = "hosting:webframework";
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-
-          it("should return false if 'only' option matches a function, not a web framework", () => {
-            options.only = "functions:webframework";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-        });
-      });
-
-      describe("with both a web framework and a non-web framework", () => {
-        beforeEach(() => {
-          options.config.get.withArgs("hosting").returns([
-            { source: "src", site: "webframework" },
-            { site: "public", public: "public" },
-          ]);
-        });
-
-        describe("without 'only' option", () => {
-          it("should return true if a web framework is in config", () => {
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-        });
-
-        describe("with 'only' option", () => {
-          it("should return false if 'only' option does not match the web framework site", () => {
-            options.only = "hosting:othersite";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-
-          it("should return true if 'only' option matches the web framework site", () => {
-            options.only = "hosting:webframework";
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-
-          it("should return false if 'only' option matches a non-web framework site", () => {
-            options.only = "hosting:public";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-
-          it("should return false if 'only' option matches a function, not a web framework", () => {
-            options.only = "functions:webframework";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-        });
-      });
-    });
-
-    describe("with target in config", () => {
-      describe("single web framework", () => {
-        beforeEach(() => {
-          options.config.get
-            .withArgs("hosting")
-            .returns([{ source: "src", target: "webframework" }]);
-        });
-
-        describe("without 'only' option", () => {
-          it("should return true if a web framework is in config", () => {
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-        });
-
-        describe("with 'only' option", () => {
-          it("should return false if 'only' option does not match the target", () => {
-            options.only = "hosting:othertarget";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-
-          it("should return true if 'only' option matches the target", () => {
-            options.only = "hosting:webframework";
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-
-          it("should return false if 'only' option matches a function, not a web framework", () => {
-            options.only = "functions:webframework";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-        });
-      });
-
-      describe("with both a web framework and a non-web framework", () => {
-        beforeEach(() => {
-          options.config.get.withArgs("hosting").returns([
-            { source: "src", target: "webframework" },
-            { target: "public", public: "public" },
-          ]);
-        });
-
-        describe("without 'only' option", () => {
-          it("should return true if a web framework is in config", () => {
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-        });
-
-        describe("with 'only' option", () => {
-          it("should return false if 'only' option does not match the web framework target", () => {
-            options.only = "hosting:othertarget";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-
-          it("should return true if 'only' option matches the web framework target", () => {
-            options.only = "hosting:webframework";
-            expect(isDeployingWebFramework(options)).to.be.true;
-          });
-
-          it("should return false if 'only' option matches a non-web framework target", () => {
-            options.only = "hosting:public";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-
-          it("should return false if 'only' option matches a function, not a web framework", () => {
-            options.only = "functions:webframework";
-            expect(isDeployingWebFramework(options)).to.be.false;
-          });
-        });
-      });
-    });
-
-    describe("with no web framework in config", () => {
-      beforeEach(() => {
-        options.config.get.withArgs("hosting").returns([{ site: "public", public: "public" }]);
-      });
-
-      describe("without 'only' option", () => {
-        it("should return false if no web framework is in config", () => {
-          expect(isDeployingWebFramework(options)).to.be.false;
-        });
-      });
-
-      describe("with 'only' option", () => {
-        it("should return false regardless of 'only' option", () => {
-          options.only = "hosting:webframework";
-          expect(isDeployingWebFramework(options)).to.be.false;
-        });
-      });
-    });
+    }
   });
 });

--- a/src/deploy/index.ts
+++ b/src/deploy/index.ts
@@ -52,28 +52,27 @@ export const isDeployingWebFramework = (options: DeployOptions): boolean => {
   if (!config) return false;
 
   const normalizedConfig = Array.isArray(config) ? config : [config];
+  const webFrameworksInConfig = normalizedConfig.filter((c) => c?.source);
 
-  // If we're deploying a specific site/target
-  if (options.only) {
-    return options.only.split(",").some((it) => {
-      const [target, site] = it.split(":");
-      if (target !== "hosting") return false;
+  // If no webframeworks are in config, a web framework is not being deployed
+  if (webFrameworksInConfig.length === 0) return false;
 
-      // If no site specified, check if any config has source
-      if (!site) {
-        return normalizedConfig.some((c) => c?.source);
-      }
+  // If a web framework is present in config and no --only flag is present, a web framework is being deployed
+  if (!options.only) return true;
 
-      // Find the specific config being deployed
-      const targetConfig = normalizedConfig.find((c) => [c.site, c.target].includes(site));
+  // If we're deploying a specific site/target when a web framework is present in config, check if the target is a web framework
+  return options.only.split(",").some((it) => {
+    const [target, site] = it.split(":");
 
-      // Only return true if this specific config has source
-      return Boolean(targetConfig?.source);
-    });
-  }
+    // If not deploying to Firebase Hosting, skip
+    if (target !== "hosting") return false;
 
-  // If no --only flag, check if any config has source
-  return normalizedConfig.some((c) => c?.source);
+    // If no site specified but we're deploying to Firebase Hosting, a webframework is being deployed
+    if (!site) return true;
+
+    // If a site is specified, check if it's a web framework
+    return webFrameworksInConfig.some((c) => [c.site, c.target].includes(site));
+  });
 };
 
 /**


### PR DESCRIPTION
### Description

Fixes #8274 when using firebase.json with an array of sites/targets. Like the following:
```
{
  "hosting": [
    {
      "target": "static",
      "public": "public"
    },
    {
      "target": "prod",
      "source": ".",
      "ignore": [
        "firebase.json",
        "**/.*",
        "**/node_modules/**"
      ],
      "frameworksBackend": {
        "region": "europe-west1"
      }
    },
    {
      "target": "staging",
      "source": ".",
      "ignore": [
        "firebase.json",
        "**/.*",
        "**/node_modules/**"
      ],
      "frameworksBackend": {
        "region": "europe-west1"
      }
    }
  ]
}
```


### Scenarios Tested
- firebase.js deploy
- firebase.js deploy --only hosting
- firebase.js deploy --only hosting:static
- firebase.js deploy --only hosting:prod
- firebase.js deploy --only hosting:staging
- firebase.js deploy --only hosting:prod,hosting:static

- Also tested using `site` in firebase.json instead of `target`.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
