### PR TITLE
[BREAKING(functions)] Update post-deploy function logic to stop aggressively deleting conatiners

### DIFF
--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -58,21 +58,6 @@ export const ALL_EXPERIMENTS = experiments({
     public: true,
   },
 
-  // permanent experiment
-  automaticallydeletegcfartifacts: {
-    shortDescription: "Control whether functions cleans up images after deploys",
-    fullDescription:
-      "To control costs, Firebase defaults to automatically deleting containers " +
-      "created during the build process. This has the side-effect of preventing " +
-      "users from rolling back to previous revisions using the Run API. To change " +
-      `this behavior, call ${bold("experiments:disable deletegcfartifactsondeploy")} ` +
-      `consider also calling ${bold("experiments:enable deletegcfartifacts")} ` +
-      `to enable the new command ${bold("functions:deletegcfartifacts")} which` +
-      "lets you clean up images manually",
-    public: true,
-    default: true,
-  },
-
   // Emulator experiments
   emulatoruisnapshot: {
     shortDescription: "Load pre-release versions of the emulator UI",

--- a/src/functions/artifacts.ts
+++ b/src/functions/artifacts.ts
@@ -1,4 +1,5 @@
 import * as artifactregistry from "../gcp/artifactregistry";
+import { logger } from "../logger";
 import { FirebaseError } from "../error";
 
 /**
@@ -35,6 +36,30 @@ export function makeRepoPath(
   repoName: string = GCF_REPO_ID,
 ): string {
   return `projects/${projectId}/locations/${location}/repositories/${repoName}`;
+}
+
+/**
+ * For testing purposes
+ * TODO: Consider using cache object stored in deploy context instead of using globals.
+ */
+export const getRepoCache = new Map<string, artifactregistry.Repository>();
+
+/**
+ * Returns AR repository (cached)
+ */
+export async function getRepo(
+  projectId: string,
+  location: string,
+  forceRefresh = false,
+  repoName: string = GCF_REPO_ID,
+): Promise<artifactregistry.Repository> {
+  const repoPath = makeRepoPath(projectId, location, repoName);
+  if (!forceRefresh && getRepoCache.has(repoPath)) {
+    return getRepoCache.get(repoPath)!;
+  }
+  const repo = await artifactregistry.getRepository(repoPath);
+  getRepoCache.set(repoPath, repo);
+  return repo;
 }
 
 /**
@@ -181,4 +206,103 @@ export function hasSameCleanupPolicy(
  */
 export function hasCleanupOptOut(repo: artifactregistry.Repository): boolean {
   return !!(repo.labels && repo.labels[OPT_OUT_LABEL_KEY] === "true");
+}
+
+/**
+ * Checks whether a clean up policy is required for Artifact Registry in given locations.
+ */
+export async function checkCleanupPolicy(
+  projectId: string,
+  locations: string[],
+): Promise<{ locationsToSetup: string[]; locationsWithErrors: string[] }> {
+  if (locations.length === 0) {
+    return { locationsToSetup: [], locationsWithErrors: [] };
+  }
+
+  const checkRepos = await Promise.allSettled(
+    locations.map(async (location) => {
+      try {
+        const repository = await exports.getRepo(projectId, location);
+        const hasPolicy = !!findExistingPolicy(repository);
+        const hasOptOut = hasCleanupOptOut(repository);
+        const hasOtherPolicies =
+          repository.cleanupPolicies &&
+          Object.keys(repository.cleanupPolicies).some((key) => key !== CLEANUP_POLICY_ID);
+
+        return {
+          location,
+          repository,
+          hasPolicy,
+          hasOptOut,
+          hasOtherPolicies,
+        };
+      } catch (err) {
+        logger.debug(`Failed to check artifact cleanup policy for region ${location}:`, err);
+        throw err;
+      }
+    }),
+  );
+
+  const locationsToSetup = [];
+  const locationsWithErrors = [];
+
+  for (let i = 0; i < checkRepos.length; i++) {
+    const result = checkRepos[i];
+    if (result.status === "fulfilled") {
+      if (!(result.value.hasPolicy || result.value.hasOptOut || result.value.hasOtherPolicies)) {
+        locationsToSetup.push(result.value.location);
+      }
+    } else {
+      locationsWithErrors.push(locations[i]);
+    }
+  }
+  return { locationsToSetup, locationsWithErrors };
+}
+
+/**
+ * Sets Artifact Registry cleanup policies for given locations.
+ */
+export async function setCleanupPolicies(
+  projectId: string,
+  locations: string[],
+  daysToKeep: number,
+): Promise<{ locationsWithPolicy: string[]; locationsWithErrors: string[] }> {
+  if (locations.length === 0) return { locationsWithPolicy: [], locationsWithErrors: [] };
+
+  const locationsWithPolicy: string[] = [];
+  const locationsWithErrors: string[] = [];
+
+  const setupRepos = await Promise.allSettled(
+    locations.map(async (location) => {
+      try {
+        logger.debug(`Setting up artifact cleanup policy for region ${location}`);
+        const repo = await exports.getRepo(projectId, location);
+        await exports.setCleanupPolicy(repo, daysToKeep);
+        return location;
+      } catch (err: unknown) {
+        throw new FirebaseError("Failed to set up artifact cleanup policy", {
+          original: err as Error,
+        });
+      }
+    }),
+  );
+
+  for (let i = 0; i < locations.length; i++) {
+    const location = locations[i];
+    const result = setupRepos[i];
+    if (result.status === "rejected") {
+      logger.debug(
+        `Failed to set up artifact cleanup policy for region ${location}:`,
+        result.reason,
+      );
+      locationsWithErrors.push(location);
+    } else {
+      locationsWithPolicy.push(location);
+    }
+  }
+
+  return {
+    locationsWithPolicy,
+    locationsWithErrors,
+  };
 }


### PR DESCRIPTION
Today, CLI attempts to clean up GCF artifacts (container images) in Artifact Registry post function deploys.

Historically, this post-deploy cleanup task had not been too reliable, and the resulting warning logs have confused developers.

We are trying a different approach - instead of trying to clean up the artifacts on every deploy, we'll make it easy for developers to set up a [Artifact Registry Cleanup Policy](https://cloud.google.com/artifact-registry/docs/repositories/cleanup-policy) on repository used by Cloud Run functions.

Cleanup policies are a managed service feature that automatically removes container images based on configurable rules, providing a more robust and transparent solution.

As suggested in this change, we'll automatically set up a clean up policy post-function deployment if we detect that a clean up policy doesn't exist yet.

We'll soon be updating the documentations to clarify what developers should do in order to avoid small monthly cost for Firebase Function's use of Artifact Registry.

Fixes https://github.com/firebase/firebase-tools/issues/4954, https://github.com/firebase/firebase-tools/issues/4954, https://github.com/firebase/firebase-tools/issues/8164, https://github.com/firebase/firebase-tools/issues/4757