### PR TITLE
Add support for apphosting.emulator.yaml

### DIFF
--- a/src/apphosting/config.ts
+++ b/src/apphosting/config.ts
@@ -14,8 +14,19 @@ import { logger } from "../logger";
 import { updateOrCreateGitignore } from "../utils";
 import { getOrPromptProject } from "../management/projects";
 
+// Common config across all environments
 export const APPHOSTING_BASE_YAML_FILE = "apphosting.yaml";
+
+// Modern version of local configuration that is intended to be safe to commit.
+// In order to ensure safety, values that are secret environment variables in
+// apphosting.yaml cannot be made plaintext in apphosting.emulators.yaml
+export const APPHOSTING_EMULATORS_YAML_FILE = "apphosting.emulator.yaml";
+
+// Legacy/undocumented version of local configuration that is allowed to store
+// values that are secrets in preceeding files as plaintext. It is not safe
+// to commit to SCM
 export const APPHOSTING_LOCAL_YAML_FILE = "apphosting.local.yaml";
+
 export const APPHOSTING_YAML_FILE_REGEX = /^apphosting(\.[a-z0-9_]+)?\.yaml$/;
 
 export interface RunConfig {

--- a/src/apphosting/yaml.ts
+++ b/src/apphosting/yaml.ts
@@ -59,7 +59,7 @@ export class AppHostingYamlConfig {
         .map(([key]) => key);
       if (wereSecrets.some((key) => other.env[key]?.value)) {
         throw new FirebaseError(
-          `Cannot convert secret to plaintext in ${other.filename ? other.filename : "apphosting yaml"}`,
+          `Cannot convert secret to plaintext in ${other.filename ?? "apphosting yaml"}`,
         );
       }
     }

--- a/src/emulator/apphosting/config.ts
+++ b/src/emulator/apphosting/config.ts
@@ -8,8 +8,11 @@ import {
 import { AppHostingYamlConfig } from "../../apphosting/yaml";
 
 /**
- * Loads in apphosting.yaml & apphosting.local.yaml, giving
- * apphosting.local.yaml precedence if present.
+ * Loads in apphosting.yaml, apphosting.emulator.yaml & apphosting.local.yaml as an
+ * overriding union. In order to keep apphosting.emulator.yaml safe to commit,
+ * users cannot change a secret environment variable to plaintext.
+ * apphosting.local.yaml can, however, for reverse compatibility, though its existence
+ * will be downplayed and tooling will not assist in creating or managing it.
  */
 export async function getLocalAppHostingConfiguration(
   backendDir: string,
@@ -27,7 +30,7 @@ export async function getLocalAppHostingConfiguration(
   const localFilePath = fileNameToPathMap[APPHOSTING_LOCAL_YAML_FILE];
 
   if (baseFilePath) {
-    // N.B. merging from into helps tests stay hermetic. I previously ran into a test bug where
+    // N.B. merging from empty helps tests stay hermetic. I previously ran into a test bug where
     // using the returned value as the base caused the test stub to be modified and tests would succeed
     // independently but would fail as part of a suite.
     const baseFile = await AppHostingYamlConfig.loadFromFile(baseFilePath);

--- a/src/emulator/apphosting/config.ts
+++ b/src/emulator/apphosting/config.ts
@@ -1,6 +1,7 @@
 import { basename } from "path";
 import {
   APPHOSTING_BASE_YAML_FILE,
+  APPHOSTING_EMULATORS_YAML_FILE,
   APPHOSTING_LOCAL_YAML_FILE,
   listAppHostingFilesInPath,
 } from "../../apphosting/config";
@@ -15,27 +16,33 @@ export async function getLocalAppHostingConfiguration(
 ): Promise<AppHostingYamlConfig> {
   const appHostingConfigPaths = listAppHostingFilesInPath(backendDir);
   // generate a map to make it easier to interface between file name and it's path
-  const fileNameToPathMap: Map<string, string> = new Map();
-  for (const path of appHostingConfigPaths) {
-    const fileName = basename(path);
-    fileNameToPathMap.set(fileName, path);
+  const fileNameToPathMap = Object.fromEntries(
+    appHostingConfigPaths.map((path) => [basename(path), path]),
+  );
+
+  const output = AppHostingYamlConfig.empty();
+
+  const baseFilePath = fileNameToPathMap[APPHOSTING_BASE_YAML_FILE];
+  const emulatorsFilePath = fileNameToPathMap[APPHOSTING_EMULATORS_YAML_FILE];
+  const localFilePath = fileNameToPathMap[APPHOSTING_LOCAL_YAML_FILE];
+
+  if (baseFilePath) {
+    // N.B. merging from into helps tests stay hermetic. I previously ran into a test bug where
+    // using the returned value as the base caused the test stub to be modified and tests would succeed
+    // independently but would fail as part of a suite.
+    const baseFile = await AppHostingYamlConfig.loadFromFile(baseFilePath);
+    output.merge(baseFile, /* allowSecretsToBecomePlaintext= */ false);
   }
 
-  const baseFilePath = fileNameToPathMap.get(APPHOSTING_BASE_YAML_FILE);
-  const localFilePath = fileNameToPathMap.get(APPHOSTING_LOCAL_YAML_FILE);
-
-  // apphosting.local.yaml or apphosting.yaml are not required to run the emulator
-  if (!baseFilePath && !localFilePath) {
-    return AppHostingYamlConfig.empty();
+  if (emulatorsFilePath) {
+    const emulatorsConfig = await AppHostingYamlConfig.loadFromFile(emulatorsFilePath);
+    output.merge(emulatorsConfig, /* allowSecretsToBecomePlaintext= */ false);
   }
 
-  // If one of them exists ...
-  if (!baseFilePath || !localFilePath) {
-    return await AppHostingYamlConfig.loadFromFile((baseFilePath || localFilePath)!);
+  if (localFilePath) {
+    const localYamlConfig = await AppHostingYamlConfig.loadFromFile(localFilePath);
+    output.merge(localYamlConfig, /* allowSecretsToBecomePlaintext= */ true);
   }
 
-  const localYamlConfig = await AppHostingYamlConfig.loadFromFile(localFilePath);
-  const baseConfig = await AppHostingYamlConfig.loadFromFile(baseFilePath);
-  baseConfig.merge(localYamlConfig);
-  return baseConfig;
+  return output;
 }


### PR DESCRIPTION
The App Hosting emulator can now load values from apphosting.emulator.yaml. This file is designed to be safe to commit, and therefore cannot convert a secret value to a plaintext value.