### PR TITLE
Remove support for node 18

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -46,7 +46,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "18"
           - "20"
           - "22"
     steps:
@@ -73,7 +72,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "18"
           - "20"
 
     env:
@@ -132,7 +130,6 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "18"
           - "20"
           - "22"
     steps:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -170,7 +170,7 @@
         "vite": "^4.2.1"
       },
       "engines": {
-        "node": ">=18.0.0 || >=20.0.0 || >=22.0.0"
+        "node": ">=20.0.0 || >=22.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "preferGlobal": true,
   "engines": {
-    "node": ">=18.0.0 || >=20.0.0 || >=22.0.0"
+    "node": ">=20.0.0 || >=22.0.0"
   },
   "author": "Firebase (https://firebase.google.com/)",
   "license": "MIT",


### PR DESCRIPTION
### Description
Node 18 has been in maintenance mode and is nearing end of long term support. We will drop support for it in firebase-tools@14.0.0
