### PR TITLE
Add createUser in getSchemaMetadata for now

### DIFF
--- a/src/gcp/cloudsql/permissions_setup.ts
+++ b/src/gcp/cloudsql/permissions_setup.ts
@@ -11,11 +11,12 @@ import {
 } from "./permissions";
 import { iamUserIsCSQLAdmin } from "./cloudsqladmin";
 import { setupIAMUsers } from "./connect";
+import * as cloudSqlAdminClient from "./cloudsqladmin";
 import { logger } from "../../logger";
 import { confirm } from "../../prompt";
 import * as clc from "colorette";
 import { FirebaseError } from "../../error";
-import { needProjectNumber } from "../../projectUtils";
+import { needProjectId, needProjectNumber } from "../../projectUtils";
 import { executeSqlCmdsAsIamUser, executeSqlCmdsAsSuperUser, getIAMUser } from "./connect";
 import { concat } from "lodash";
 import { getDataConnectP4SA, toDatabaseUser } from "./connect";
@@ -228,6 +229,11 @@ export async function getSchemaMetadata(
   schema: string,
   options: Options,
 ): Promise<SchemaMetadata> {
+  // Upsert user in case it doesn't exist
+  const { user, mode } = await getIAMUser(options);
+  const projectId = needProjectId(options);
+  await cloudSqlAdminClient.createUser(projectId, instanceId, mode, user);
+
   // Check if schema exists
   const checkSchemaExists = await executeSqlCmdsAsIamUser(
     options,


### PR DESCRIPTION
This will make sure we add the user before getting any metadata, it will cover adding the user in grant, setup, and migrate. 