### PR TITLE
bump min vscode version to 0.19.0 

### DIFF
--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -60,7 +60,7 @@
         "webpack-merge": "^5.8.0"
       },
       "engines": {
-        "vscode": "^1.69.0"
+        "vscode": "^1.90.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -6,7 +6,7 @@
   "description": "Firebase Data Connect for VSCode",
   "version": "0.14.2",
   "engines": {
-    "vscode": "^1.69.0"
+    "vscode": "^1.90.0"
   },
   "repository": "https://github.com/firebase/firebase-tools",
   "sideEffects": false,


### PR DESCRIPTION
CLI is removing support for node < 20. Bumping up minimum VSCode version to match.