### PR TITLE
Fix issue where accounts:lookup is case-sensitive for emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug where functions:artifacts:setpolicy command's --none option didn't work as expected (#8330)
+- Fix bug in Auth emulator where accounts:lookup is case-sensitive for emails (#8344)

--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -300,7 +300,8 @@ function lookup(
       tryAddUser(state.getUserByLocalId(localId));
     }
     for (const email of reqBody.email ?? []) {
-      tryAddUser(state.getUserByEmail(email));
+      const canonicalizedEmail = canonicalizeEmailAddress(email);
+      tryAddUser(state.getUserByEmail(canonicalizedEmail));
     }
     for (const phoneNumber of reqBody.phoneNumber ?? []) {
       tryAddUser(state.getUserByPhoneNumber(phoneNumber));


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #8344

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Verified that when connected to the Auth emulator, the 2 code snippets below output the same UserRecord 

1. All lowercase email
```js
const admin = require('firebase-admin');

admin.initializeApp({
    projectId: "demo-project"
})

process.env.FIREBASE_AUTH_EMULATOR_HOST = "127.0.0.1:9099"

async function main() {
    try {
        const matchingCase = 'email@example.com';
        const user = await admin.auth().getUserByEmail(matchingCase); // Throws auth/user-not-found
        console.log(user);
    } catch (e) {
        console.error(e); 
    }
}

main()
```

2. Random uppercases in email
```js
const admin = require('firebase-admin');

admin.initializeApp({
    projectId: "demo-project"
})

process.env.FIREBASE_AUTH_EMULATOR_HOST = "127.0.0.1:9099"

async function main() {
    try {
        const nonMatchingCase = 'EmAiL@eXaMpLe.com';
        const user = await admin.auth().getUserByEmail(nonMatchingCase); // Throws auth/user-not-found
        console.log(user);
    } catch (e) {
        console.error(e); 
    }
}

main()
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

### Notes

AFAICT, all emails in the emulator are lowercased on signUp https://github.com/firebase/firebase-tools/blob/ee2e8b5de9f621ad53d851a244be80e28c2afe05/src/emulator/auth/operations.ts#L204-L207. Verified this manually as well.

`canonicalizeEmailAddress` converts the string to all lower-case
https://github.com/firebase/firebase-tools/blob/ee2e8b5de9f621ad53d851a244be80e28c2afe05/src/emulator/auth/utils.ts#L69-L71
