### PR TITLE
Set extraEnv in vscode process

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Added] Added rerun execution button in variables context
 - [Added] Provide default required variables during execution
+- [Fixed] Fixed an issue where nvironment variables provided in `extraEnv` were not respected in some cases
 
 ## 0.14.2
 

--- a/firebase-vscode/src/data-connect/service.ts
+++ b/firebase-vscode/src/data-connect/service.ts
@@ -4,7 +4,6 @@ import {
   IntrospectionQuery,
   getIntrospectionQuery,
 } from "graphql";
-import { assertExecutionResult } from "../../common/graphql";
 import { DataConnectError } from "../../common/error";
 import { AuthService } from "../auth/service";
 import { UserMockKind } from "../../common/messaging/protocol";
@@ -15,6 +14,7 @@ import { dataConnectConfigs } from "../data-connect/config";
 import { firebaseRC } from "../core/config";
 import {
   dataconnectDataplaneClient,
+  dataconnectOrigin,
   executeGraphQL,
   DATACONNECT_API_VERSION,
 } from "../../../src/dataconnect/dataplaneClient";
@@ -236,6 +236,7 @@ export class DataConnectService {
     });
     if (params.instance === InstanceType.PRODUCTION) {
       const client = dataconnectDataplaneClient();
+      pluginLogger.info(`ExecuteGraphQL (${dataconnectOrigin()}) request: ${JSON.stringify(prodBody, undefined, 4)}`);
       const resp = await executeGraphQL(client, servicePath, prodBody);
       return this.handleProdResponse(resp);
     } else {

--- a/firebase-vscode/src/utils/settings.ts
+++ b/firebase-vscode/src/utils/settings.ts
@@ -33,6 +33,9 @@ export function getSettings(): Settings {
     firebaseBinaryKind = "firepit-global";
   }
 
+  const extraEnv = config.get<Record<string,string>>("extraEnv", {})
+  process.env = { ...process.env, ...extraEnv };
+  
   return {
     firebasePath,
     firebaseBinaryKind,
@@ -46,7 +49,7 @@ export function getSettings(): Settings {
     exportPath: config.get<string>("emulators.exportPath", "./exportedData"),
     exportOnExit: config.get<boolean>("emulators.exportOnExit", false),
     debug: config.get<boolean>("debug", false),
-    extraEnv: config.get<Record<string,string>>("extraEnv", {}),
+    extraEnv,
   };
 }
 

--- a/src/dataconnect/dataplaneClient.ts
+++ b/src/dataconnect/dataplaneClient.ts
@@ -1,4 +1,5 @@
 import { dataconnectOrigin } from "../api";
+export { dataconnectOrigin } from "../api"
 import { Client, ClientResponse } from "../apiv2";
 import * as types from "./types";
 
@@ -11,7 +12,6 @@ export function dataconnectDataplaneClient(): Client {
     auth: true,
   });
 }
-
 export async function executeGraphQL(
   client: Client,
   servicePath: string,

--- a/src/dataconnect/dataplaneClient.ts
+++ b/src/dataconnect/dataplaneClient.ts
@@ -1,5 +1,5 @@
 import { dataconnectOrigin } from "../api";
-export { dataconnectOrigin } from "../api"
+export { dataconnectOrigin } from "../api";
 import { Client, ClientResponse } from "../apiv2";
 import * as types from "./types";
 


### PR DESCRIPTION
### Description
Fixes an issue where extraEnv wasn't actually set for code executed as part of the extension. 

Also, added some logging to help debug where prod requests are going.

### Scenarios Tested
Verified that when I set the DATA_CONNECT_URL env var to staging, Run (production) sends requests to staging.