### PR TITLE
Increase size limit for JSON uploads to storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug in Auth emulator where accounts:lookup is case-sensitive for emails (#8344)
+- Fixed an issue where the Storage emulator applied too low of a limit for files uploaded with Content-Type: application/json. (#8355)

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -64,7 +64,7 @@ export function createApp(
   app.use(
     express.json({
       type: ["application/json"],
-      limit: "130mb"
+      limit: "130mb",
     }),
   );
 

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -64,6 +64,7 @@ export function createApp(
   app.use(
     express.json({
       type: ["application/json"],
+      limit: "130mb"
     }),
   );
 


### PR DESCRIPTION
### Description
The Storage emulator was applying an artificially low limit on upload size when Content-Type: application/json was set. Fixes #8355