### PR TITLE
Can grant access to emails (user, group, SA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix bug in Auth emulator where accounts:lookup is case-sensitive for emails (#8344)
+- firebase apphosting:secrets:grantAccess can now grant access to emails and can grant multiple secrets at once (#8357)

--- a/src/apphosting/secrets/index.spec.ts
+++ b/src/apphosting/secrets/index.spec.ts
@@ -11,6 +11,7 @@ import * as utilsImport from "../../utils";
 import * as promptImport from "../../prompt";
 
 import { Secret } from "../yaml";
+import { FirebaseError } from "../../error";
 
 describe("secrets", () => {
   let gcsm: sinon.SinonStubbedInstance<typeof gcsmImport>;
@@ -256,6 +257,71 @@ describe("secrets", () => {
 
       expect(gcsm.getIamPolicy).to.be.calledWithMatch(secret);
       expect(gcsm.setIamPolicy).to.be.calledWithMatch(secret, newBindings);
+    });
+  });
+
+  describe("grantEmailsSecretAccess", () => {
+    const secret = {
+      projectId: "projectId",
+      name: "secret",
+    };
+    const existingPolicy: iam.Policy = {
+      version: 1,
+      etag: "tag",
+      bindings: [
+        {
+          role: "roles/viewer",
+          members: ["serviceAccount:existingSA"],
+        },
+      ],
+    };
+
+    it("should brute force its way to success", async () => {
+      gcsm.getIamPolicy.resolves(existingPolicy);
+      gcsm.setIamPolicy
+        .onFirstCall()
+        .rejects(
+          new FirebaseError(
+            'Principal mygroup@mydomain.com is of type "group". The principal should appear as "group:mygroup@mydomain.com"',
+          ),
+        );
+      gcsm.setIamPolicy.onSecondCall().resolves();
+
+      await secrets.grantEmailsSecretAccess(secret.projectId, secret.name, [
+        "user@mydomain.com",
+        "mygroup@mydomain.com",
+      ]);
+
+      expect(gcsm.getIamPolicy).to.be.calledWithMatch(secret);
+      expect(gcsm.setIamPolicy.firstCall).to.be.calledWithMatch(secret, [
+        {
+          role: "roles/viewer",
+          members: ["serviceAccount:existingSA"],
+        },
+        {
+          role: "roles/secretmanager.secretAccessor",
+          members: ["user:user@mydomain.com", "user:mygroup@mydomain.com"],
+        },
+      ]);
+      expect(gcsm.setIamPolicy.secondCall).to.be.calledWithMatch(secret, [
+        {
+          role: "roles/viewer",
+          members: ["serviceAccount:existingSA"],
+        },
+        {
+          role: "roles/secretmanager.secretAccessor",
+          members: ["user:user@mydomain.com", "group:mygroup@mydomain.com"],
+        },
+      ]);
+    });
+
+    it("Should fail if the error is not specifically a principal type error", async () => {
+      gcsm.getIamPolicy.resolves(existingPolicy);
+      gcsm.setIamPolicy.rejects(new FirebaseError("Some other error"));
+
+      await expect(
+        secrets.grantEmailsSecretAccess(secret.projectId, secret.name, ["user@mydomain.com"]),
+      ).to.eventually.be.rejectedWith(/Failed to set IAM bindings/);
     });
   });
 

--- a/src/apphosting/secrets/index.spec.ts
+++ b/src/apphosting/secrets/index.spec.ts
@@ -268,7 +268,7 @@ describe("secrets", () => {
     const secret2 = {
       projectId: "projectId",
       name: "secret2",
-    }
+    };
     const existingPolicy: iam.Policy = {
       version: 1,
       etag: "tag",
@@ -291,10 +291,11 @@ describe("secrets", () => {
         );
       gcsm.setIamPolicy.onSecondCall().resolves();
 
-      await secrets.grantEmailsSecretAccess(secret.projectId, [secret.name], [
-        "user@mydomain.com",
-        "mygroup@mydomain.com",
-      ]);
+      await secrets.grantEmailsSecretAccess(
+        secret.projectId,
+        [secret.name],
+        ["user@mydomain.com", "mygroup@mydomain.com"],
+      );
 
       expect(gcsm.getIamPolicy).to.be.calledWithMatch(secret);
       expect(gcsm.setIamPolicy.firstCall).to.be.calledWithMatch(secret, [
@@ -331,10 +332,11 @@ describe("secrets", () => {
       gcsm.setIamPolicy.onSecondCall().resolves();
       gcsm.setIamPolicy.onThirdCall().resolves();
 
-      await secrets.grantEmailsSecretAccess(secret.projectId, [secret.name, secret2.name], [
-        "user@mydomain.com",
-        "mygroup@mydomain.com",
-      ]);
+      await secrets.grantEmailsSecretAccess(
+        secret.projectId,
+        [secret.name, secret2.name],
+        ["user@mydomain.com", "mygroup@mydomain.com"],
+      );
 
       expect(gcsm.getIamPolicy).to.be.calledWithMatch(secret);
       expect(gcsm.setIamPolicy).to.be.calledThrice;

--- a/src/apphosting/secrets/index.ts
+++ b/src/apphosting/secrets/index.ts
@@ -103,7 +103,8 @@ export async function grantSecretAccess(
     await gcsm.setIamPolicy({ projectId, name: secretName }, updatedBindings);
   } catch (err: unknown) {
     throw new FirebaseError(
-      `Failed to set IAM bindings ${JSON.stringify(newBindings)} on secret: ${secretName}. Ensure you have the permissions to do so and try again.`,
+      `Failed to set IAM bindings ${JSON.stringify(newBindings)} on secret: ${secretName}. Ensure you have the permissions to do so and try again. ` +
+        "For more information visit https://cloud.google.com/secret-manager/docs/manage-access-to-secrets#required-roles",
       { original: getError(err) },
     );
   }
@@ -112,7 +113,7 @@ export async function grantSecretAccess(
 }
 
 /**
- * Grants the following users or grouips access to the provided secret.
+ * Grants the following users or groups access to the provided secret.
  */
 export async function grantEmailsSecretAccess(
   projectId: string,
@@ -133,7 +134,8 @@ export async function grantEmailsSecretAccess(
       existingBindings = (await gcsm.getIamPolicy({ projectId, name: secretName })).bindings || [];
     } catch (err: unknown) {
       throw new FirebaseError(
-        `Failed to get IAM bindings on secret: ${secretName}. Ensure you have the permissions to do so and try again.`,
+        `Failed to get IAM bindings on secret: ${secretName}. Ensure you have the permissions to do so and try again. ` +
+          "For more information visit https://cloud.google.com/secret-manager/docs/manage-access-to-secrets#required-roles",
         { original: getError(err) },
       );
     }

--- a/src/apphosting/secrets/index.ts
+++ b/src/apphosting/secrets/index.ts
@@ -116,56 +116,59 @@ export async function grantSecretAccess(
  */
 export async function grantEmailsSecretAccess(
   projectId: string,
-  secretName: string,
+  secretNames: string[],
   emails: string[],
 ): Promise<void> {
-  let existingBindings;
-  try {
-    existingBindings = (await gcsm.getIamPolicy({ projectId, name: secretName })).bindings || [];
-  } catch (err: unknown) {
-    throw new FirebaseError(
-      `Failed to get IAM bindings on secret: ${secretName}. Ensure you have the permissions to do so and try again.`,
-      { original: getError(err) },
-    );
-  }
-
   // This feels like a hack, but it's actually sorta taking advantage of an escalation of privilege in Google IAM.
   // The correct way to determine if an email address is a user or group is to use the Google Admin API
   // (GET e.g. admin.googleapis.com/admin/directory/v1/users/<email> or GET admin.googleapis.com/admin/driectory/v1/groups/<email>)
   // but that would require us to have admin permissions on GMail for example. Fortunately, IAM seems to give us well formed errors
   // that dictate what type of role the email address should have been bound with. This seems... like a design mistake. If they knew
   // already, why not just accept the value without leaking its type?
+  // Note: we keep typeGuesses outside of the loop so that we learn the type of principal an email is once across all secrets.
   const typeGuesses = Object.fromEntries(emails.map((email) => [email, "user"]));
-  do {
+  for (const secretName of secretNames) {
+    let existingBindings;
     try {
-      const newBindings: iam.Binding[] = [
-        {
-          role: "roles/secretmanager.secretAccessor",
-          members: Object.entries(typeGuesses).map(([email, type]) => `${type}:${email}`),
-        },
-      ];
-      const updatedBindings = existingBindings.concat(newBindings);
-      await gcsm.setIamPolicy({ projectId, name: secretName }, updatedBindings);
-      break;
-    } catch (err: any) {
-      if (!(err instanceof FirebaseError)) {
-        throw new FirebaseError(`Unexpected error updating IAM bindings on secret: ${secretName}`, {
-          original: getError(err),
-        });
-      }
-      const match = /Principal (.*) is of type "([^"]+)"/.exec(err.message);
-      if (!match) {
-        throw new FirebaseError(
-          `Failed to set IAM bindings on secret: ${secretName}. Ensure you have the permissions to do so and try again.`,
-          { original: getError(err) },
-        );
-      }
-      typeGuesses[match[1]] = match[2];
-      continue;
+      existingBindings = (await gcsm.getIamPolicy({ projectId, name: secretName })).bindings || [];
+    } catch (err: unknown) {
+      throw new FirebaseError(
+        `Failed to get IAM bindings on secret: ${secretName}. Ensure you have the permissions to do so and try again.`,
+        { original: getError(err) },
+      );
     }
-  } while (true);
 
-  utils.logSuccess(`Successfully set IAM bindings on secret ${secretName}.\n`);
+    do {
+      try {
+        const newBindings: iam.Binding[] = [
+          {
+            role: "roles/secretmanager.secretAccessor",
+            members: Object.entries(typeGuesses).map(([email, type]) => `${type}:${email}`),
+          },
+        ];
+        const updatedBindings = existingBindings.concat(newBindings);
+        await gcsm.setIamPolicy({ projectId, name: secretName }, updatedBindings);
+        break;
+      } catch (err: any) {
+        if (!(err instanceof FirebaseError)) {
+          throw new FirebaseError(`Unexpected error updating IAM bindings on secret: ${secretName}`, {
+            original: getError(err),
+          });
+        }
+        const match = /Principal (.*) is of type "([^"]+)"/.exec(err.message);
+        if (!match) {
+          throw new FirebaseError(
+            `Failed to set IAM bindings on secret: ${secretName}. Ensure you have the permissions to do so and try again.`,
+            { original: getError(err) },
+          );
+        }
+        typeGuesses[match[1]] = match[2];
+        continue;
+      }
+    } while (true);
+
+    utils.logSuccess(`Successfully set IAM bindings on secret ${secretName}.\n`);
+  }
 }
 
 /**

--- a/src/apphosting/secrets/index.ts
+++ b/src/apphosting/secrets/index.ts
@@ -151,9 +151,12 @@ export async function grantEmailsSecretAccess(
         break;
       } catch (err: any) {
         if (!(err instanceof FirebaseError)) {
-          throw new FirebaseError(`Unexpected error updating IAM bindings on secret: ${secretName}`, {
-            original: getError(err),
-          });
+          throw new FirebaseError(
+            `Unexpected error updating IAM bindings on secret: ${secretName}`,
+            {
+              original: getError(err),
+            },
+          );
         }
         const match = /Principal (.*) is of type "([^"]+)"/.exec(err.message);
         if (!match) {

--- a/src/commands/apphosting-secrets-grantaccess.ts
+++ b/src/commands/apphosting-secrets-grantaccess.ts
@@ -10,7 +10,9 @@ import * as secrets from "../apphosting/secrets";
 import { getBackendForAmbiguousLocation } from "../apphosting/backend";
 
 export const command = new Command("apphosting:secrets:grantaccess <secretNames>")
-  .description("grant service accounts permissions to the provided secret(s). Can pass one or more secrets, separated by a comma")
+  .description(
+    "grant service accounts permissions to the provided secret(s). Can pass one or more secrets, separated by a comma",
+  )
   .option("-l, --location <location>", "backend location", "-")
   .option("-b, --backend <backend>", "backend name")
   .option("-u, --emails <emails>", "comma delmited list user or group emails")
@@ -71,5 +73,9 @@ export const command = new Command("apphosting:secrets:grantaccess <secretNames>
 
     const accounts = secrets.toMulti(secrets.serviceAccountsForBackend(projectNumber, backend));
 
-    await Promise.all(secretList.map((secretName) => secrets.grantSecretAccess(projectId, projectNumber, secretName, accounts)));
+    await Promise.all(
+      secretList.map((secretName) =>
+        secrets.grantSecretAccess(projectId, projectNumber, secretName, accounts),
+      ),
+    );
   });

--- a/src/commands/apphosting-secrets-grantaccess.ts
+++ b/src/commands/apphosting-secrets-grantaccess.ts
@@ -11,11 +11,11 @@ import { getBackendForAmbiguousLocation } from "../apphosting/backend";
 
 export const command = new Command("apphosting:secrets:grantaccess <secretNames>")
   .description(
-    "grant service accounts permissions to the provided secret(s). Can pass one or more secrets, separated by a comma",
+    "grant service accounts, users, or groups permissions to the provided secret(s). Can pass one or more secrets, separated by a comma",
   )
   .option("-l, --location <location>", "backend location", "-")
   .option("-b, --backend <backend>", "backend name")
-  .option("-u, --emails <emails>", "comma delmited list user or group emails")
+  .option("-e, --emails <emails>", "comma delimited list of user or group emails")
   .before(requireAuth)
   .before(secretManager.ensureApi)
   .before(apphosting.ensureApiEnabled)
@@ -73,7 +73,7 @@ export const command = new Command("apphosting:secrets:grantaccess <secretNames>
 
     const accounts = secrets.toMulti(secrets.serviceAccountsForBackend(projectNumber, backend));
 
-    await Promise.all(
+    await Promise.allSettled(
       secretList.map((secretName) =>
         secrets.grantSecretAccess(projectId, projectNumber, secretName, accounts),
       ),


### PR DESCRIPTION
Part of the new work to encourage the use of test secrets in the emulator.

Unfortunately there is no general API to figure out whether an email address is a service account, user, or group. Fortunately, IAM will return an error with a clear message on what type of principal the secret was on error so we can brute force our way to success ¯\_(ツ)_/¯