### PR TITLE
Secrets set now handles test vs production secrets

### DIFF
--- a/src/apphosting/config.ts
+++ b/src/apphosting/config.ts
@@ -135,7 +135,7 @@ export function upsertEnv(document: yaml.Document, env: Env): void {
  * If env does not exist, offers to add it.
  * If secretName is not a valid env var name, prompts for an env var name.
  */
-export async function maybeAddSecretToYaml(secretName: string): Promise<void> {
+export async function maybeAddSecretToYaml(secretName: string, fileName: string = APPHOSTING_BASE_YAML_FILE): Promise<void> {
   // We must go through the exports object for stubbing to work in tests.
   const dynamicDispatch = exports as {
     discoverBackendRoot: typeof discoverBackendRoot;
@@ -149,7 +149,7 @@ export async function maybeAddSecretToYaml(secretName: string): Promise<void> {
   let path: string | undefined;
   let projectYaml: yaml.Document;
   if (backendRoot) {
-    path = join(backendRoot, APPHOSTING_BASE_YAML_FILE);
+    path = join(backendRoot, fileName);
     projectYaml = dynamicDispatch.load(path);
   } else {
     projectYaml = new yaml.Document();
@@ -159,7 +159,7 @@ export async function maybeAddSecretToYaml(secretName: string): Promise<void> {
     return;
   }
   const addToYaml = await prompt.confirm({
-    message: "Would you like to add this secret to apphosting.yaml?",
+    message: `Would you like to add this secret to ${fileName}?`,
     default: true,
   });
   if (!addToYaml) {
@@ -168,10 +168,10 @@ export async function maybeAddSecretToYaml(secretName: string): Promise<void> {
   if (!path) {
     path = await prompt.promptOnce({
       message:
-        "It looks like you don't have an apphosting.yaml yet. Where would you like to store it?",
+        `It looks like you don't have an ${fileName} yet. Where would you like to store it?`,
       default: process.cwd(),
     });
-    path = join(path, APPHOSTING_BASE_YAML_FILE);
+    path = join(path, fileName);
   }
   const envName = await dialogs.envVarForSecret(secretName);
   dynamicDispatch.upsertEnv(projectYaml, {

--- a/src/apphosting/config.ts
+++ b/src/apphosting/config.ts
@@ -58,7 +58,9 @@ const SECRET_CONFIG = "Secret";
 const EXPORTABLE_CONFIG = [SECRET_CONFIG];
 
 function foundProjectFile(dir: string): boolean {
-  return fs.listFiles(dir).some((file) => [APPHOSTING_BASE_YAML_FILE, APPHOSTING_EMULATORS_YAML_FILE].includes(file));
+  return fs
+    .listFiles(dir)
+    .some((file) => [APPHOSTING_BASE_YAML_FILE, APPHOSTING_EMULATORS_YAML_FILE].includes(file));
 }
 /**
  * Returns the absolute path for an app hosting backend root.
@@ -158,7 +160,10 @@ export function upsertEnv(document: yaml.Document, env: Env): void {
  * If env does not exist, offers to add it.
  * If secretName is not a valid env var name, prompts for an env var name.
  */
-export async function maybeAddSecretToYaml(secretName: string, fileName: string = APPHOSTING_BASE_YAML_FILE): Promise<void> {
+export async function maybeAddSecretToYaml(
+  secretName: string,
+  fileName: string = APPHOSTING_BASE_YAML_FILE,
+): Promise<void> {
   // We must go through the exports object for stubbing to work in tests.
   const dynamicDispatch = exports as {
     discoverBackendRoot: typeof discoverBackendRoot;
@@ -190,13 +195,15 @@ export async function maybeAddSecretToYaml(secretName: string, fileName: string 
   }
   if (!path) {
     path = await prompt.promptOnce({
-      message:
-        `It looks like you don't have an ${fileName} yet. Where would you like to store it?`,
+      message: `It looks like you don't have an ${fileName} yet. Where would you like to store it?`,
       default: process.cwd(),
     });
     path = join(path, fileName);
   }
-  const envName = await dialogs.envVarForSecret(secretName, /* removeTestPrefix */ fileName === APPHOSTING_EMULATORS_YAML_FILE);
+  const envName = await dialogs.envVarForSecret(
+    secretName,
+    /* removeTestPrefix */ fileName === APPHOSTING_EMULATORS_YAML_FILE,
+  );
   dynamicDispatch.upsertEnv(projectYaml, {
     variable: envName,
     secret: secretName,

--- a/src/apphosting/secrets/dialogs.spec.ts
+++ b/src/apphosting/secrets/dialogs.spec.ts
@@ -465,5 +465,15 @@ describe("dialogs", () => {
         /Key X_GOOGLE_SECRET starts with a reserved prefix/,
       );
     });
+
+    it("can trim test prefixes", async () => {
+      prompt.promptOnce.resolves("SECRET");
+
+      await expect(dialogs.envVarForSecret("test-secret")).to.eventually.equal("SECRET");
+      expect(prompt.promptOnce).to.have.been.calledWithMatch({
+        message: "What environment variable name would you like to use?",
+        default: "SECRET",
+      });
+    });
   });
 });

--- a/src/apphosting/secrets/dialogs.ts
+++ b/src/apphosting/secrets/dialogs.ts
@@ -207,7 +207,10 @@ function toUpperSnakeCase(key: string): string {
     .toUpperCase();
 }
 
-export async function envVarForSecret(secret: string, trimTestPrefix: boolean = false): Promise<string> {
+export async function envVarForSecret(
+  secret: string,
+  trimTestPrefix: boolean = false,
+): Promise<string> {
   let upper = toUpperSnakeCase(secret);
   if (trimTestPrefix) {
     // Remove TEST_ or TEST

--- a/src/apphosting/secrets/dialogs.ts
+++ b/src/apphosting/secrets/dialogs.ts
@@ -207,8 +207,16 @@ function toUpperSnakeCase(key: string): string {
     .toUpperCase();
 }
 
-export async function envVarForSecret(secret: string): Promise<string> {
-  const upper = toUpperSnakeCase(secret);
+export async function envVarForSecret(secret: string, trimTestPrefix: boolean = false): Promise<string> {
+  let upper = toUpperSnakeCase(secret);
+  if (trimTestPrefix) {
+    // Remove TEST_ or TEST
+    if (upper.startsWith("TEST_")) {
+      upper = upper.substring("TEST_".length);
+    } else if (upper.startsWith("TEST")) {
+      upper = upper.substring("TEST".length);
+    }
+  }
   if (upper === secret) {
     try {
       env.validateKey(secret);

--- a/src/commands/apphosting-secrets-set.ts
+++ b/src/commands/apphosting-secrets-set.ts
@@ -76,7 +76,8 @@ export const command = new Command("apphosting:secrets:set <secretName>")
       const emailList = await prompt.promptOnce({
         type: "input",
         name: "emails",
-        message: "Please enter a comma separated list of user or groups who should have access to this secret:",
+        message:
+          "Please enter a comma separated list of user or groups who should have access to this secret:",
       });
       await secrets.grantEmailsSecretAccess(projectId, [secretName], emailList.split(","));
       await config.maybeAddSecretToYaml(secretName, config.APPHOSTING_EMULATORS_YAML_FILE);
@@ -99,8 +100,8 @@ export const command = new Command("apphosting:secrets:set <secretName>")
     await config.maybeAddSecretToYaml(secretName, config.APPHOSTING_BASE_YAML_FILE);
     utils.logBullet(
       "To grant additional users access to this secret run " +
-      clc.bold(`firebase apphosting:secrets:grantaccess ${secretName} --email [email list]`) + 
-      ".\nTo grant additional backends access to this secret run " +
-      clc.bold(`firebase apphosting:secrets:grantaccess ${secretName} --backend [backend ID]`)
+        clc.bold(`firebase apphosting:secrets:grantaccess ${secretName} --email [email list]`) +
+        ".\nTo grant additional backends access to this secret run " +
+        clc.bold(`firebase apphosting:secrets:grantaccess ${secretName} --backend [backend ID]`),
     );
   });

--- a/src/commands/apphosting-secrets-set.ts
+++ b/src/commands/apphosting-secrets-set.ts
@@ -76,10 +76,10 @@ export const command = new Command("apphosting:secrets:set <secretName>")
       const emailList = await prompt.promptOnce({
         type: "input",
         name: "emails",
-        message: "Please enter a comma separated list of user or groups who should ahve access to this secret:",
+        message: "Please enter a comma separated list of user or groups who should have access to this secret:",
       });
       await secrets.grantEmailsSecretAccess(projectId, [secretName], emailList.split(","));
-      await config.maybeAddSecretToYaml(secretName, "apphosting.emulator.yaml");
+      await config.maybeAddSecretToYaml(secretName, config.APPHOSTING_EMULATORS_YAML_FILE);
       return;
     }
 
@@ -96,5 +96,11 @@ export const command = new Command("apphosting:secrets:set <secretName>")
       await secrets.grantSecretAccess(projectId, projectNumber, secretName, accounts);
     }
 
-    await config.maybeAddSecretToYaml(secretName);
+    await config.maybeAddSecretToYaml(secretName, config.APPHOSTING_BASE_YAML_FILE);
+    utils.logBullet(
+      "To grant additional users access to this secret run " +
+      clc.bold(`firebase apphosting:secrets:grantaccess ${secretName} --email [email list]`) + 
+      ".\nTo grant additional backends access to this secret run " +
+      clc.bold(`firebase apphosting:secrets:grantaccess ${secretName} --backend [backend ID]`)
+    );
   });


### PR DESCRIPTION
apphosting:secrets:set now asks if the secret is test-only and can update apphosting.emulator.yaml instead for these cases (as well as granting individuals or groups access).

1. When adding a new secret, prompts if this secret is for local development only.
2. If only local development, asks for a list of users or groups to grant access.
3. If local only, tries to add the secret to apphosting.emulator.yaml instead of apphosting.emulators.yaml
4. If local only, tries stripping any "test-" prefix off of suggested key names to help with user flows where people will want something like `stripe-key` and `test-stripe-key` to both point to `STRIPE_KEY` in apphosting.yaml and apphosting.emulator.yaml respectively
5. Fixes a slight bug where we found a project root with X file and try to insert the variable in Y file (e.g. apphosting.local.yaml exists, but we're adding to apphosting.yaml)
6. Prints guidance on how to grant access to a secret in further commands