### PR TITLE
Cleaning up logging in dataconnect:sql:setup

### DIFF
--- a/src/commands/dataconnect-sql-grant.ts
+++ b/src/commands/dataconnect-sql-grant.ts
@@ -7,7 +7,7 @@ import { pickService } from "../dataconnect/fileUtils";
 import { grantRoleToUserInSchema } from "../dataconnect/schemaMigration";
 import { requireAuth } from "../requireAuth";
 import { FirebaseError } from "../error";
-import { fdcSqlRoleMap } from "../gcp/cloudsql/permissions_setup";
+import { fdcSqlRoleMap } from "../gcp/cloudsql/permissionsSetup";
 
 const allowedRoles = Object.keys(fdcSqlRoleMap);
 

--- a/src/commands/dataconnect-sql-setup.ts
+++ b/src/commands/dataconnect-sql-setup.ts
@@ -6,7 +6,7 @@ import { FirebaseError } from "../error";
 import { requireAuth } from "../requireAuth";
 import { requirePermissions } from "../requirePermissions";
 import { ensureApis } from "../dataconnect/ensureApis";
-import { setupSQLPermissions, getSchemaMetadata } from "../gcp/cloudsql/permissions_setup";
+import { setupSQLPermissions, getSchemaMetadata } from "../gcp/cloudsql/permissionsSetup";
 import { DEFAULT_SCHEMA } from "../gcp/cloudsql/permissions";
 import { getIdentifiers, ensureServiceIsConnectedToCloudSql } from "../dataconnect/schemaMigration";
 import { getIAMUser } from "../gcp/cloudsql/connect";

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -17,7 +17,7 @@ import {
   setupSQLPermissions,
   getSchemaMetadata,
   SchemaSetupStatus,
-} from "../gcp/cloudsql/permissions_setup";
+} from "../gcp/cloudsql/permissionsSetup";
 import { DEFAULT_SCHEMA, firebaseowner } from "../gcp/cloudsql/permissions";
 import { promptOnce, confirm } from "../prompt";
 import { logger } from "../logger";
@@ -27,7 +27,6 @@ import { FirebaseError } from "../error";
 import { logLabeledBullet, logLabeledWarning, logLabeledSuccess } from "../utils";
 import { iamUserIsCSQLAdmin } from "../gcp/cloudsql/cloudsqladmin";
 import * as cloudSqlAdminClient from "../gcp/cloudsql/cloudsqladmin";
-
 import * as errors from "./errors";
 
 async function setupSchemaIfNecessary(
@@ -49,7 +48,7 @@ async function setupSchemaIfNecessary(
       /* silent=*/ true,
     );
   } else {
-    logger.info(
+    logger.debug(
       `Detected schema "${schemaInfo.name}" is setup in ${schemaInfo.setupStatus} mode. Skipping Setup.`,
     );
   }

--- a/src/gcp/cloudsql/permissionsSetup.ts
+++ b/src/gcp/cloudsql/permissionsSetup.ts
@@ -1,3 +1,5 @@
+import * as clc from "colorette";
+
 import { Options } from "../../options";
 import {
   firebaseowner,
@@ -8,18 +10,17 @@ import {
   readerRolePermissions,
   defaultPermissions,
   FIREBASE_SUPER_USER,
-  CLOUDSQL_SUPER_USER,
 } from "./permissions";
 import { iamUserIsCSQLAdmin } from "./cloudsqladmin";
 import { setupIAMUsers } from "./connect";
 import { logger } from "../../logger";
 import { confirm } from "../../prompt";
-import * as clc from "colorette";
 import { FirebaseError } from "../../error";
 import { needProjectNumber } from "../../projectUtils";
 import { executeSqlCmdsAsIamUser, executeSqlCmdsAsSuperUser, getIAMUser } from "./connect";
 import { concat } from "lodash";
 import { getDataConnectP4SA, toDatabaseUser } from "./connect";
+import * as utils from "../../utils";
 
 export type TableMetadata = {
   name: string;
@@ -104,9 +105,10 @@ export async function setupSQLPermissions(
   options: Options,
   silent: boolean = false,
 ): Promise<SchemaSetupStatus.BrownField | SchemaSetupStatus.GreenField> {
+  const logFn = silent ? logger.debug : (message: string) => {return utils.logLabeledBullet('dataconnect', message)};
   const schema = schemaInfo.name;
   // Step 0: Check current user can run setup and upsert IAM / P4SA users
-  logger.info(
+  logFn(
     `Detected schema "${schema}" setup status is ${schemaInfo.setupStatus}. Running setup...`,
   );
 
@@ -121,14 +123,14 @@ export async function setupSQLPermissions(
   let runGreenfieldSetup = false;
   if (schemaInfo.setupStatus === SchemaSetupStatus.GreenField) {
     runGreenfieldSetup = true;
-    logger.info(
+    logFn(
       `Database ${databaseId} has already been setup as greenfield project. Rerunning setup to repair any missing permissions.`,
     );
   }
 
   if (schemaInfo.tables.length === 0) {
     runGreenfieldSetup = true;
-    logger.info(`Found no tables in schema "${schema}", assuming greenfield project.`);
+    logFn(`Found no tables in schema "${schema}", assuming greenfield project.`);
   }
 
   // We need to setup the database
@@ -148,7 +150,7 @@ export async function setupSQLPermissions(
       /** transaction=*/ true,
     );
 
-    logger.info(clc.green("Database setup complete."));
+    logFn(clc.green("Database setup complete."));
     return SchemaSetupStatus.GreenField;
   }
 
@@ -158,7 +160,7 @@ export async function setupSQLPermissions(
     );
   }
   const currentTablesOwners = [...new Set(schemaInfo.tables.map((t) => t.owner))];
-  logger.info(
+  logFn(
     `We found some existing object owners [${currentTablesOwners.join(", ")}] in your cloudsql "${schema}" schema.`,
   );
 
@@ -173,22 +175,22 @@ export async function setupSQLPermissions(
 
   if (shouldSetupGreenfield) {
     await setupBrownfieldAsGreenfield(instanceId, databaseId, schemaInfo, options, silent);
-    logger.info(clc.green("Database setup complete."));
-    logger.info(
+    logger.info(clc.green("Database setup complete.")); // If we do set up, always at least show this line.
+    logFn(
       clc.yellow(
         "IMPORTANT: please uncomment 'schemaValidation: \"COMPATIBLE\"' in your dataconnect.yaml file to avoid dropping any existing tables by mistake.",
       ),
     );
     return SchemaSetupStatus.GreenField;
   } else {
-    logger.info(
+    logFn(
       clc.yellow(
         "Setting up database in brownfield mode.\n" +
           `Note: SQL migrations can't be done through ${clc.bold("firebase dataconnect:sql:migrate")} in this mode.`,
       ),
     );
     await brownfieldSqlSetup(instanceId, databaseId, schemaInfo, options, silent);
-    logger.info(clc.green("Brownfield database setup complete."));
+    logFn(clc.green("Brownfield database setup complete."));
     return SchemaSetupStatus.BrownField;
   }
 }
@@ -326,13 +328,6 @@ export async function getSchemaMetadata(
   };
 }
 
-function filterTableOwners(schemaInfo: SchemaMetadata, databaseId: string) {
-  return [...new Set(schemaInfo.tables.map((t) => t.owner))].filter(
-    (owner) =>
-      owner !== CLOUDSQL_SUPER_USER && owner !== firebaseowner(databaseId, schemaInfo.name),
-  );
-}
-
 export async function setupBrownfieldAsGreenfield(
   instanceId: string,
   databaseId: string,
@@ -343,13 +338,15 @@ export async function setupBrownfieldAsGreenfield(
   const schema = schemaInfo.name;
 
   const firebaseOwnerRole = firebaseowner(databaseId, schema);
-  const uniqueTablesOwners = filterTableOwners(schemaInfo, databaseId);
+  const nonFirebasetablesOwners = [...new Set(schemaInfo.tables.map((t) => t.owner))].filter(
+    (owner) => owner !== firebaseOwnerRole,
+  );
 
   // Grant roles to firebase superuser to avoid missing permissions on tables
-  const grantOwnersToSuperuserCmds = uniqueTablesOwners.map(
+  const grantOwnersToSuperuserCmds = nonFirebasetablesOwners.map(
     (owner) => `GRANT "${owner}" TO "${FIREBASE_SUPER_USER}"`,
   );
-  const revokeOwnersFromSuperuserCmds = uniqueTablesOwners.map(
+  const revokeOwnersFromSuperuserCmds = nonFirebasetablesOwners.map(
     (owner) => `REVOKE "${owner}" FROM "${FIREBASE_SUPER_USER}"`,
   );
 
@@ -357,7 +354,7 @@ export async function setupBrownfieldAsGreenfield(
   const greenfieldSetupCmds = await greenFieldSchemaSetup(instanceId, databaseId, schema, options);
 
   // Step 2: Grant non firebase owners the writer role before changing the table owners.
-  const grantCmds = uniqueTablesOwners.map(
+  const grantCmds = nonFirebasetablesOwners.map(
     (owner) => `GRANT "${firebasewriter(databaseId, schema)}" TO "${owner}"`,
   );
 
@@ -394,8 +391,8 @@ export async function brownfieldSqlSetup(
 ) {
   const schema = schemaInfo.name;
 
-  // Step 1: Grant firebasesuperuser access to the original owner.
-  const uniqueTablesOwners = filterTableOwners(schemaInfo, databaseId);
+  // Step 1: Grant firebasesuperuser access to the original owner
+  const uniqueTablesOwners = [...new Set(schemaInfo.tables.map((t) => t.owner))];
   const grantOwnersToFirebasesuperuser = uniqueTablesOwners.map(
     (owner) => `GRANT "${owner}" TO "${FIREBASE_SUPER_USER}"`,
   );

--- a/src/gcp/cloudsql/permissionsSetup.ts
+++ b/src/gcp/cloudsql/permissionsSetup.ts
@@ -105,12 +105,14 @@ export async function setupSQLPermissions(
   options: Options,
   silent: boolean = false,
 ): Promise<SchemaSetupStatus.BrownField | SchemaSetupStatus.GreenField> {
-  const logFn = silent ? logger.debug : (message: string) => {return utils.logLabeledBullet('dataconnect', message)};
+  const logFn = silent
+    ? logger.debug
+    : (message: string) => {
+        return utils.logLabeledBullet("dataconnect", message);
+      };
   const schema = schemaInfo.name;
   // Step 0: Check current user can run setup and upsert IAM / P4SA users
-  logFn(
-    `Detected schema "${schema}" setup status is ${schemaInfo.setupStatus}. Running setup...`,
-  );
+  logFn(`Detected schema "${schema}" setup status is ${schemaInfo.setupStatus}. Running setup...`);
 
   const userIsCSQLAdmin = await iamUserIsCSQLAdmin(options);
   if (!userIsCSQLAdmin) {

--- a/src/track.ts
+++ b/src/track.ts
@@ -319,7 +319,7 @@ function session(propertyName: GA4Property): AnalyticsSession | undefined {
   const validateOnly = !!process.env.FIREBASE_CLI_MP_VALIDATE;
   if (!usageEnabled() && propertyName !== "vscode") {
     if (validateOnly) {
-      logger.warn("Google Analytics is DISABLED. To enable, (re)login and opt in to collection.");
+      logger.debug("Google Analytics is DISABLED. To enable, (re)login and opt in to collection.");
     }
     return;
   }
@@ -352,7 +352,7 @@ function isDebugMode(): boolean {
   if (account?.user.email.endsWith("@google.com")) {
     try {
       require("../tsconfig.json");
-      logger.info(
+      logger.debug(
         `Using Google Analytics in DEBUG mode. Emulators (+ UI) events will be shown in GA Debug View only.`,
       );
       return true;


### PR DESCRIPTION
### Description
A couple logging clean ups:
- Respect the silent flag as much as possible in permissionsSetup
- Move Google Analytics logs to debug level
- Move some default case logs for SQL set up to debug level
- Rename file to use camelcase.

### Scenarios Tested
<img width="948" alt="Screenshot 2025-03-27 at 2 46 20 PM" src="https://github.com/user-attachments/assets/b819d32c-340e-43c9-869f-f9bbd6c7450c" />
