### PR TITLE
App Hosting: Remove incorrect log indicating branch does not exist when creating a backend

### DIFF
--- a/src/apphosting/githubConnections.ts
+++ b/src/apphosting/githubConnections.ts
@@ -471,9 +471,6 @@ export async function promptGitHubBranch(repoLink: devConnect.GitRepositoryLink)
     },
   });
 
-  utils.logWarning(
-    `The branch "${branch}" does not exist on "${extractRepoSlugFromUri(repoLink.cloneUri) ?? ""}". Please enter a valid branch for this repo.`,
-  );
   return branch;
 }
 


### PR DESCRIPTION
Remove incorrect apphosting:backends:create log that indicates branch does not exist when it does.

Since we make users to select amongst the list of branches we fetched for their repo, its not possible for them to select one that doesn't exist. Currently this log is shown every-time the user selects a branch.