### PR TITLE
Set Data Connect emulator env var for admin SDK too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fixed a bug where the Admin SDK would not automatically connect to the Data Connect emulator. (#8379)
+- Fixed a bug where the Admin SDK would not automatically connect to the Data Connect emulator when run in the Functions emulator. (#8379)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed a bug where the Admin SDK would not automatically connect to the Data Connect emulator. (#8379)

--- a/src/emulator/constants.ts
+++ b/src/emulator/constants.ts
@@ -79,6 +79,9 @@ export class Constants {
   // Environment variable to discover the Data Connect emulator.
   static FIREBASE_DATACONNECT_EMULATOR_HOST = "FIREBASE_DATA_CONNECT_EMULATOR_HOST";
 
+  // Alternative (deprecated) env var for Data Connect Emulator.
+  static FIREBASE_DATACONNECT_ENV_ALT = "DATA_CONNECT_EMULATOR_HOST";
+
   // Environment variable to override SDK/CLI to point at the Firebase Auth emulator.
   static FIREBASE_AUTH_EMULATOR_HOST = "FIREBASE_AUTH_EMULATOR_HOST";
 

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -46,6 +46,7 @@ export function setEnvVarsForEmulators(
         break;
       case Emulators.DATACONNECT:
         env[Constants.FIREBASE_DATACONNECT_EMULATOR_HOST] = `http://${host}`;
+        env[Constants.FIREBASE_DATACONNECT_ENV_ALT] = `http://${host}`;
         // Originally, there was a typo in this env var name. To avoid breaking folks unecessarily,
         // we'll keep setting this.
         env["FIREBASE_DATACONNECT_EMULATOR_HOST"] = host;


### PR DESCRIPTION
### Description
Fixes #8379.
Admin checks DATA_CONNECT_EMUALTOR_HOST: https://github.com/firebase/firebase-admin-node/blob/a46086b61f58f07426a6ca103e00385ae216691d/src/data-connect/data-connect-api-client-internal.ts#L220 
Web SDK checks https://github.com/firebase/firebase-js-sdk/blob/61f0102ac85e4fd6c54506df93b1f1899e3ef110/packages/data-connect/src/api/DataConnect.ts#L65

We'll address that discrepancy in future releases, but continue setting both here to make sure this stays working for as many  users as possible.
