### PR TITLE
fix(functions,emulators): loadTriggers() with top level await

### DIFF
--- a/src/deploy/functions/runtimes/node/triggerParser.js
+++ b/src/deploy/functions/runtimes/node/triggerParser.js
@@ -21,7 +21,7 @@ async function loadModule(packageDir) {
   try {
     return require(packageDir);
   } catch (e) {
-    if (e.code === "ERR_REQUIRE_ESM") {
+    if (e.code === "ERR_REQUIRE_ESM" && e.code !== "ERR_REQUIRE_ASYNC_MODULE") {
       const modulePath = require.resolve(packageDir);
       // Resolve module path to file:// URL. Required for windows support.
       const moduleURL = url.pathToFileURL(modulePath).href;

--- a/src/emulator/functionsEmulatorRuntime.ts
+++ b/src/emulator/functionsEmulatorRuntime.ts
@@ -909,7 +909,7 @@ async function loadTriggers(): Promise<any> {
   try {
     triggerModule = require(process.cwd());
   } catch (err: any) {
-    if (err.code !== "ERR_REQUIRE_ESM") {
+    if (err.code !== "ERR_REQUIRE_ESM" && err.code !== "ERR_REQUIRE_ASYNC_MODULE") {
       // Try to run diagnostics to see what could've gone wrong before rethrowing the error.
       await moduleResolutionDetective(err);
       throw err;


### PR DESCRIPTION
### Description

Context: ESM functions with firestore triggers
The expected behavior of `loadTriggers()` is to
try and `require()` the function entrypoint,
falling back to dynamic `import()` when node raises a ERR_REQUIRE_ESM error. But node may also raise an ERR_REQUIRE_ASYNC_MODULE error when the module has top level awaits

This commit simply makes it so ERR_REQUIRE_ASYNC_MODULE also falls back to `import()`

### Scenarios Tested

Tested on our (private) repo

Let me know if tests need to be added/updated :)