### PR TITLE
Provide default values for namespace and database for v2 Firestore triggers in extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where the Extensions emulator did not provide fall back values for v2 Firestore event triggers. (#8390)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1098,11 +1098,11 @@ export class FunctionsEmulator implements EmulatorInstance {
     logger.debug("Found a v2 firestore trigger.");
     const database = eventTrigger.eventFilters?.database;
     if (!database) {
-      throw new FirebaseError("A database must be supplied.");
+      throw new FirebaseError(`A database must be supplied for event trigger ${key}`);
     }
     const namespace = eventTrigger.eventFilters?.namespace;
     if (!namespace) {
-      throw new FirebaseError("A namespace must be supplied.");
+      throw new FirebaseError(`A namespace must be supplied for event trigger ${key}`);
     }
     let doc;
     let match;
@@ -1140,7 +1140,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     if (!EmulatorRegistry.isRunning(Emulators.FIRESTORE)) {
       return Promise.resolve(false);
     }
-
+    console.log(eventTrigger);
     const { bundle, path } =
       signature === "cloudevent"
         ? this.getV2FirestoreAttributes(projectId, key, eventTrigger)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1140,7 +1140,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     if (!EmulatorRegistry.isRunning(Emulators.FIRESTORE)) {
       return Promise.resolve(false);
     }
-    console.log(eventTrigger);
     const { bundle, path } =
       signature === "cloudevent"
         ? this.getV2FirestoreAttributes(projectId, key, eventTrigger)

--- a/src/extensions/emulator/triggerHelper.ts
+++ b/src/extensions/emulator/triggerHelper.ts
@@ -138,6 +138,11 @@ export function functionResourceToEmulatedTriggerDefintion(
             eventFilterPathPatterns[filter.attribute] = filter.value;
           }
         }
+        if (properties.eventTrigger.eventType.includes("google.cloud.firestore")) {
+          // Fall back to '(default)' if unset, to match https://github.com/firebase/firebase-functions/blob/e3f9772a530860f7469434a91d344e3faa371765/src/v2/providers/firestore.ts#L511
+          eventFilters["database"] = eventFilters["database"] ?? "(default)";
+          eventFilters["namespace"] = eventFilters["namespace"] ?? "(default)";
+        }
         etd.eventTrigger.eventFilters = eventFilters;
         etd.eventTrigger.eventFilterPathPatterns = eventFilterPathPatterns;
       }


### PR DESCRIPTION
### Description
If omitted from the resource definition, we should still use fallback values for these triggers (to match the behavior of firebase-functions).

Fixes #8390.

### Scenarios Tested
Successfully emulated the v2.0.1 of the typesense extension (following the repro provided at https://github.com/tharropoulos/firebase-reprod) 
