### PR TITLE
Remove protocol from DATA_CONNECT_EMULATOR_HOST.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixed a bug where the Admin SDK fails with ENOTFOUND when automatically connecting to the Data Connect emulator when run in the Functions emulator. (#8379)
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,1 @@
 - Fixed a bug where the Admin SDK fails with ENOTFOUND when automatically connecting to the Data Connect emulator when run in the Functions emulator. (#8379)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed a bug where the Admin SDK fails with ENOTFOUND when automatically connecting to the Data Connect emulator when run in the Functions emulator. (#8379)

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -45,10 +45,14 @@ export function setEnvVarsForEmulators(
         env[Constants.CLOUD_TASKS_EMULATOR_HOST] = host;
         break;
       case Emulators.DATACONNECT:
-        env[Constants.FIREBASE_DATACONNECT_EMULATOR_HOST] = host;
+        // Right now, the JS SDK requires a protocol within the env var.
+        // https://github.com/firebase/firebase-js-sdk/blob/88a8055808bdbd1c75011a94d11062460027d931/packages/data-connect/src/api/DataConnect.ts#L74
+        env[Constants.FIREBASE_DATACONNECT_EMULATOR_HOST] = `http://${host}`;
+        // The alternative env var, right now only read by the Node.js Admin SDK, does not work if a protocol is appended.
+        // https://github.com/firebase/firebase-admin-node/blob/a46086b61f58f07426a6ca103e00385ae216691d/src/data-connect/data-connect-api-client-internal.ts#L220
         env[Constants.FIREBASE_DATACONNECT_ENV_ALT] = host;
-        // Originally, there was a typo in this env var name. To avoid breaking folks unecessarily,
-        // we'll keep setting this.
+        // A previous CLI release set the following env var as well but it is missing an underscore between `DATA` and `CONNECT`.
+        // We'll keep setting this for customers who depends on this misspelled name. Its value is also kept protocol-less.
         env["FIREBASE_DATACONNECT_EMULATOR_HOST"] = host;
     }
   }

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -45,8 +45,8 @@ export function setEnvVarsForEmulators(
         env[Constants.CLOUD_TASKS_EMULATOR_HOST] = host;
         break;
       case Emulators.DATACONNECT:
-        env[Constants.FIREBASE_DATACONNECT_EMULATOR_HOST] = `http://${host}`;
-        env[Constants.FIREBASE_DATACONNECT_ENV_ALT] = `http://${host}`;
+        env[Constants.FIREBASE_DATACONNECT_EMULATOR_HOST] = host;
+        env[Constants.FIREBASE_DATACONNECT_ENV_ALT] = host;
         // Originally, there was a typo in this env var name. To avoid breaking folks unecessarily,
         // we'll keep setting this.
         env["FIREBASE_DATACONNECT_EMULATOR_HOST"] = host;


### PR DESCRIPTION
### Description

The protocol should never be set according to go/emulator-suite-admin-sdk and setting it breaks the Node.js Admin SDK.

Symptoms include error messages like `getaddrinfo ENOTFOUND http` because it's trying to resolve the word `http` via DNS.

The other environment variable `FIREBASE_DATA_CONNECT_EMULATOR_HOST` is consumed by the JS SDK, which requires a protocol right now. We've decided not to remove the protocol for now to avoid breaking the JS SDK (e.g. when used within the Functions emulator where this env var is automatically set).

### Scenarios Tested

Not tested

### Sample Commands

N/A
