### PR TITLE
Fix issue where prompt would print boolean if false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-* Fix issue with prompt when Data Connect prompts user for framework generation.
+- Fixed issue with prompt when Data Connect prompts user for framework generation.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+* Fix issue with prompt when Data Connect prompts user for framework generation.

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -127,7 +127,7 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
             type: "checkbox",
             name: "fdcFrameworks",
             message:
-              `Which ${hasFrameworkEnabled && "additional "}frameworks would you like to generate SDKs for? ` +
+              `Which ${hasFrameworkEnabled ? "additional " : ""}frameworks would you like to generate SDKs for? ` +
               "Press Space to select features, then Enter to confirm your choices.",
             choices: unusedFrameworks.map((frameworkStr) => ({
               value: frameworkStr,


### PR DESCRIPTION
When no frameworks are detected, `Which falseframeworks` prints out. Instead, we should just print `Which frameworks`
Before:
```
? Which falseframeworks would you like to generate SDKs for? Press Space to select features, then Enter to confirm your choices. (Press <space> to select, <a> to toggle all, <i> to invert selection, and <enter> to proceed)
❯◯ react
 ◯ angular
```
After:
```
? Which frameworks would you like to generate SDKs for? Press Space to select features, then Enter to confirm your choices. (Press <space> to select, <a> to toggle all, <i> to invert selection, and <enter> to proceed)
❯◯ react
 ◯ angular
```