### PR TITLE
set current user without waiting for webview load

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+- [Fixed] User auth will now load without requiring extension sidebar to open
+
 ## 1.0.0
 
 - [Breaking] Updated minimum VSCode version requirement to 1.69.0 to ensure node 20 is used

--- a/firebase-vscode/src/core/user.ts
+++ b/firebase-vscode/src/core/user.ts
@@ -43,14 +43,20 @@ export function registerUser(
     },
   );
 
+  const getInitialData = async () => {
+    isLoadingUser.value = true;
+    currentUser.value = await checkLogin();
+    isLoadingUser.value = false;
+  };
+
+  getInitialData();
+
   const notifyUserChangedSub = effect(() => {
     broker.send("notifyUserChanged", { user: currentUser.value });
   });
 
   const getInitialDataSub = broker.on("getInitialData", async () => {
-    isLoadingUser.value = true;
-    currentUser.value = await checkLogin();
-    isLoadingUser.value = false;
+    await getInitialData();
   });
 
   const isLoadingSub = effect(() => {


### PR DESCRIPTION
Tested w/ local and prod executions, and calls to Gemini endpoints.