### PR TITLE
Silence warning message when ADC is detected by data connect emulator

### DIFF
--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -362,6 +362,7 @@ export class DataConnectEmulator implements EmulatorInstance {
       account,
       EmulatorLogger.forEmulator(Emulators.DATACONNECT),
       "dataconnect",
+      true,
     );
     return { ...process.env, ...extraEnv, ...credsEnv };
   }

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -70,7 +70,7 @@ export async function getCredentialsEnvironment(
   // Provide default application credentials when appropriate
   const credentialEnv: Record<string, string> = {};
   if (await hasDefaultCredentials()) {
-    !silent ||
+    !silent &&
       logger.logLabeled(
         "WARN",
         logLabel,

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -70,11 +70,12 @@ export async function getCredentialsEnvironment(
   // Provide default application credentials when appropriate
   const credentialEnv: Record<string, string> = {};
   if (await hasDefaultCredentials()) {
-    !silent || logger.logLabeled(
-      "WARN",
-      logLabel,
-      `Application Default Credentials detected. Non-emulated services will access production using these credentials. Be careful!`,
-    );
+    !silent ||
+      logger.logLabeled(
+        "WARN",
+        logLabel,
+        `Application Default Credentials detected. Non-emulated services will access production using these credentials. Be careful!`,
+      );
   } else if (account) {
     const defaultCredPath = await getCredentialPathAsync(account);
     if (defaultCredPath) {

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -65,11 +65,12 @@ export async function getCredentialsEnvironment(
   account: Account | undefined,
   logger: EmulatorLogger,
   logLabel: string,
+  silent: boolean = false,
 ): Promise<Record<string, string>> {
   // Provide default application credentials when appropriate
   const credentialEnv: Record<string, string> = {};
   if (await hasDefaultCredentials()) {
-    logger.logLabeled(
+    !silent || logger.logLabeled(
       "WARN",
       logLabel,
       `Application Default Credentials detected. Non-emulated services will access production using these credentials. Be careful!`,


### PR DESCRIPTION
### Description
This warning is popping up during deploy (since the data connect emulator is used to compile sources and check for invalid connectors). Silence it since it is confusing in that context.
