### PR TITLE
Update to 1.1.0

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+## 1.1.0
+
+- Updated internal `firebase-tools` dependency to 14.1.0
 - [Fixed] User auth will now load without requiring extension sidebar to open
 
 ## 1.0.0

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
Update extension ver to 1.1.0

- Updated internal `firebase-tools` dependency to 14.1.0
- [Fixed] User auth will now load without requiring extension sidebar to open