### PR TITLE
Provide full DocumentNode when validating operations

### DIFF
--- a/firebase-vscode/src/data-connect/code-lens-provider.ts
+++ b/firebase-vscode/src/data-connect/code-lens-provider.ts
@@ -103,7 +103,7 @@ export class OperationCodeLensProvider extends ComputedCodeLensProvider {
               title: `$(play) Run (local)`,
               command: "firebase.dataConnect.executeOperation",
               tooltip: "Execute the operation (⌘+enter or Ctrl+Enter)",
-              arguments: [x, operationLocation, InstanceType.LOCAL],
+              arguments: [x, documentNode, operationLocation, InstanceType.LOCAL],
             }),
           );
 
@@ -112,7 +112,7 @@ export class OperationCodeLensProvider extends ComputedCodeLensProvider {
               title: `$(play) Run (Production – Project: ${rc.projects.default})`,
               command: "firebase.dataConnect.executeOperation",
               tooltip: "Execute the operation (⌘+enter or Ctrl+Enter)",
-              arguments: [x, operationLocation, InstanceType.PRODUCTION],
+              arguments: [x, documentNode, operationLocation, InstanceType.PRODUCTION],
             }),
           );
         }


### PR DESCRIPTION
### Description
Ugly fix for a problem that @mbleigh found - currently, we don't provide the full document node when validating operations. This means that it will not have any definitions for Fragments, and will throw `unknown fragment` errors when they are used.

We definitely ought to clean this code up before merging for real - it currently sends redundant info thru the broker (OperationDefinitionNode is part of DocumentNode), and it still does not provide definitions from other GQL documents.

### Scenarios Tested
<img width="1311" alt="Screenshot 2025-04-07 at 3 30 35 PM" src="https://github.com/user-attachments/assets/ce549c8c-3fe8-4611-9af3-44d072ae0c7c" />
