### PR TITLE
Code to create emulators.yaml uses backend root not project root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-fix: Prompt to create apphosting.emulator.yaml works with backends that are not at the project.root (#8412)
+- Fixed an issue where the prompt to create apphosting.emulator.yaml did not work with backends that are not at the project.root (#8412)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Upgraded `inquirer` library to address some visual bugs with prompting (#8389)
+fix: Prompt to create apphosting.emulator.yaml works with backends that are not at the project.root (#8412)

--- a/src/apphosting/config.ts
+++ b/src/apphosting/config.ts
@@ -218,11 +218,11 @@ export async function maybeAddSecretToYaml(
  */
 export async function maybeGenerateEmulatorYaml(
   projectId: string | undefined,
-  repoRoot: string,
+  backendRoot: string,
 ): Promise<Env[] | null> {
   // Even if the app is in /project/app, the user might have their apphosting.yaml file in /project/apphosting.yaml.
   // Walk up the tree to see if we find other local files so that we can put apphosting.emulator.yaml in the right place.
-  const basePath = dynamicDispatch.discoverBackendRoot(repoRoot) || repoRoot;
+  const basePath = dynamicDispatch.discoverBackendRoot(backendRoot) || backendRoot;
   if (fs.fileExistsSync(join(basePath, APPHOSTING_EMULATORS_YAML_FILE))) {
     logger.debug(
       "apphosting.emulator.yaml already exists, skipping generation and secrets access prompt",

--- a/src/emulator/initEmulators.ts
+++ b/src/emulator/initEmulators.ts
@@ -7,7 +7,6 @@ import { detectStartCommand } from "./apphosting/developmentServer";
 import { EmulatorLogger } from "./emulatorLogger";
 import { Emulators } from "./types";
 import { Env, maybeGenerateEmulatorYaml } from "../apphosting/config";
-import { detectProjectRoot } from "../detectProjectRoot";
 import { Config } from "../config";
 import { getProjectId } from "../projectUtils";
 import { grantEmailsSecretAccess } from "../apphosting/secrets";

--- a/src/emulator/initEmulators.ts
+++ b/src/emulator/initEmulators.ts
@@ -42,8 +42,7 @@ export const AdditionalInitFns: AdditionalInitFnsType = {
     const projectId = getProjectId(config.options);
     let env: Env[] | null = [];
     try {
-      const projectRoot = detectProjectRoot({ cwd: config.options.cwd }) ?? backendRoot;
-      env = await maybeGenerateEmulatorYaml(projectId, projectRoot);
+      env = await maybeGenerateEmulatorYaml(projectId, backendRoot);
     } catch (e) {
       logger.log("WARN", "failed to export app hosting configs");
     }


### PR DESCRIPTION
Quicker fix than I realized.

We may want to re-add some of the previous behavior to detect multiple environments and determine which to use as the base config. I was more focused on making breaking changes before the major release, but that was interesting/useful, esp if people only have apphosting[.environment].yaml and not a generic apphosting.yaml.

That might require more though though as we may want to consolidate backendRoot/apphosting.mybackend.yaml and /apphosting.yaml for mult-backend setups.