### PR TITLE
Provide default param values to extensions emulator when reading resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue in the extensions emulator where parameter default values would not be substitued into resource definitions.

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -21,6 +21,7 @@ import { EmulatorRegistry } from "./registry";
 import { EmulatorInfo, EmulatorInstance, Emulators } from "./types";
 import { Build } from "../deploy/functions/build";
 import { extractExtensionsFromBuilds } from "../extensions/runtimes/common";
+import { populateDefaultParams } from "../extensions/paramHelper";
 
 export interface ExtensionEmulatorArgs {
   options: Options;
@@ -267,7 +268,8 @@ export class ExtensionsEmulator implements EmulatorInstance {
     // TODO: This should find package.json, then use that as functionsDir.
     const functionsDir = path.join(extensionDir, "functions");
     // TODO(b/213335255): For local extensions, this should include extensionSpec instead of extensionVersion
-    const env = Object.assign(this.autoPopulatedParams(instance), instance.params);
+    const params = populateDefaultParams(instance.params, await planner.getExtensionSpec(instance));
+    const env = Object.assign(this.autoPopulatedParams(instance), params);
 
     const { extensionTriggers, runtime, nonSecretEnv, secretEnvVariables } =
       await getExtensionFunctionInfo(instance, env);

--- a/src/extensions/paramHelper.ts
+++ b/src/extensions/paramHelper.ts
@@ -225,3 +225,16 @@ export function isSystemParam(paramName: string): boolean {
   const regex = /^firebaseextensions\.[a-zA-Z0-9\.]*\//;
   return regex.test(paramName);
 }
+
+// Populate default values for missing params.
+// This is only needed when emulating extensions - when deploying, this is handled in the back end.
+export function populateDefaultParams(
+  params: Record<string, string>,
+  spec: ExtensionSpec,
+): Record<string, string> {
+  const ret = { ...params };
+  for (const p of spec.params) {
+    ret[p.param] = ret[p.param] ?? p.default;
+  }
+  return ret;
+}

--- a/src/responseToError.ts
+++ b/src/responseToError.ts
@@ -6,7 +6,6 @@ export function responseToError(response: any, body: any, url?: string): Firebas
   if (response.statusCode < 400) {
     return;
   }
-
   if (typeof body === "string") {
     if (response.statusCode === 404) {
       body = {


### PR DESCRIPTION

### Description
Fixed an issue where we didn't provide default param values when reading resources before emulating extensions. This was causing problems for Invertase while updating to v2 Firestore triggers.

### Scenarios Tested
Confirmed that I can successfully emulate https://github.com/firebase/extensions/tree/736196bd27653673461f235c190480bb94273008/firestore-shorten-urls-bitly without having all params defined in .env files.

