### PR TITLE
Keep artifact registry dry run off for policy changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Keep artifact registry dry run off for policy changes #8419

--- a/src/functions/artifacts.ts
+++ b/src/functions/artifacts.ts
@@ -173,6 +173,7 @@ export async function setCleanupPolicy(
       ...repository.cleanupPolicies,
       ...generateCleanupPolicy(daysToKeep),
     },
+    cleanupPolicyDryRun: false,
     labels,
   };
   await exports.updateRepository(update);

--- a/src/gcp/artifactregistry.ts
+++ b/src/gcp/artifactregistry.ts
@@ -23,6 +23,7 @@ export interface Repository {
   createTime: string;
   updateTime: string;
   cleanupPolicies?: Record<string, CleanupPolicy | undefined>;
+  cleanupPolicyDryRun?: boolean;
   labels?: Record<string, string>;
 }
 
@@ -84,7 +85,7 @@ export async function getRepository(repoPath: string): Promise<Repository> {
  * Update an Artifact Registry repository.
  */
 export async function updateRepository(repo: RepositoryInput): Promise<Repository> {
-  const updateMask = proto.fieldMasks(repo, "cleanupPolicies", "labels");
+  const updateMask = proto.fieldMasks(repo, "cleanupPolicies", "cleanupPolicyDryRun", "labels");
   if (updateMask.length === 0) {
     const res = await client.get<Repository>(repo.name!);
     return res.body;


### PR DESCRIPTION
Fixes #8418 

It seems that the [Repository resource](https://cloud.google.com/artifact-registry/docs/reference/rest/v1/projects.locations.repositories#resource:-repository) has the field `cleanupPolicyDryRun` set to `true` by default on the GCF repos. This change fixes forces that field to be `false` when using the `firebase functions:artifacts:setpolicy` command.