### PR TITLE
feat: Add support for running functions emulator per codebase

### DIFF
--- a/src/deploy/functions/functionsDeployHelper.ts
+++ b/src/deploy/functions/functionsDeployHelper.ts
@@ -56,7 +56,7 @@ export function endpointMatchesFilter(endpoint: backend.Endpoint, filter: Endpoi
 /**
  * Returns list of filters after parsing selector.
  */
-export function parseFunctionSelector(selector: string): EndpointFilter[] {
+export function parseFunctionSelector(selector: string, strict: boolean): EndpointFilter[] {
   const fragments = selector.split(":");
   if (fragments.length < 2) {
     // This is a plain selector w/o codebase prefix (e.g. "abc" not "abc:efg") .
@@ -67,10 +67,13 @@ export function parseFunctionSelector(selector: string): EndpointFilter[] {
     //
     // We decide here to create filter for both conditions. This sounds sloppy, but it's only troublesome if there is
     // conflict between a codebase name as function id in the default codebase.
-    return [
-      { codebase: fragments[0] },
-      { codebase: DEFAULT_CODEBASE, idChunks: fragments[0].split(/[-.]/) },
-    ];
+    //
+    // In strict mode, 'default' codebase is not optional and we always assume it is a codebase fragment.
+    const filters: EndpointFilter[] = [{ codebase: fragments[0] }];
+    if (!strict) {
+      filters.push({ codebase: DEFAULT_CODEBASE, idChunks: fragments[0].split(/[-.]/) });
+    }
+    return filters;
   }
   return [
     {
@@ -98,11 +101,16 @@ export function parseFunctionSelector(selector: string): EndpointFilter[] {
  *     2) Grouped functions w/ "abc" prefix in the default codebase?
  *     3) All functions in the "abc" codebase?
  *
- *   Current implementation creates filters that match against all conditions.
+ *   The default implementation creates filters that match against all conditions.
+ *
+ *   In "strict" mode, we always assume the only filter follows the format functions:[codebase]:[fn].
  *
  *   If no filter exists, we return undefined which the caller should interpret as "match all functions".
  */
-export function getEndpointFilters(options: { only?: string }): EndpointFilter[] | undefined {
+export function getEndpointFilters(
+  options: { only?: string },
+  strict = true,
+): EndpointFilter[] | undefined {
   if (!options.only) {
     return undefined;
   }
@@ -113,7 +121,7 @@ export function getEndpointFilters(options: { only?: string }): EndpointFilter[]
     if (selector.startsWith("functions:")) {
       selector = selector.replace("functions:", "");
       if (selector.length > 0) {
-        filters.push(...parseFunctionSelector(selector));
+        filters.push(...parseFunctionSelector(selector, strict));
       }
     }
   }

--- a/src/emulator/controller.spec.ts
+++ b/src/emulator/controller.spec.ts
@@ -1,7 +1,11 @@
 import { Emulators } from "./types";
 import { EmulatorRegistry } from "./registry";
 import { expect } from "chai";
+import * as controller from "./controller";
 import { FakeEmulator } from "./testing/fakeEmulator";
+import { EmulatorOptions } from "./controller";
+import { ValidatedConfig } from "../functions/projectConfig";
+import { Config } from "../config";
 
 describe("EmulatorController", () => {
   afterEach(async () => {
@@ -19,4 +23,88 @@ describe("EmulatorController", () => {
     expect(EmulatorRegistry.isRunning(name)).to.be.true;
     expect(EmulatorRegistry.getInfo(name)!.port).to.eql(fake.getInfo().port);
   });
-}).timeout(2000);
+
+  describe("prepareFunctionsBackends", () => {
+    const baseOptions = {
+      project: "demo-project",
+      projectDir: "/path/to/project",
+      config: new Config({}, { projectDir: "/path/to/project", cwd: "/path/to/project" }),
+      nonInteractive: true,
+    } as unknown as EmulatorOptions;
+
+    const functionsConfig = [
+      { source: "functions-a", codebase: "codebasea" },
+      { source: "functions-b", codebase: "codebaseb" },
+      { source: "functions-default" },
+    ] as ValidatedConfig;
+
+    it("should include all codebases without only flag", () => {
+      const options = { ...baseOptions };
+      const backends = controller.prepareFunctionsBackends(
+        options,
+        functionsConfig,
+        "/project/dir",
+      );
+      expect(backends.length).to.equal(3);
+      expect(backends.map((b) => b.codebase)).to.have.members([
+        "codebasea",
+        "codebaseb",
+        undefined,
+      ]);
+    });
+
+    it("should include only specified codebases", () => {
+      const options = { ...baseOptions, only: "functions:codebasea" };
+      const backends = controller.prepareFunctionsBackends(
+        options,
+        functionsConfig,
+        "/project/dir",
+      );
+      expect(backends.length).to.equal(1);
+      expect(backends[0].codebase).to.equal("codebasea");
+    });
+
+    it("should include all specified codebases", () => {
+      const options = { ...baseOptions, only: "functions:codebasea,functions:codebaseb" };
+      const backends = controller.prepareFunctionsBackends(
+        options,
+        functionsConfig,
+        "/project/dir",
+      );
+      expect(backends.length).to.equal(2);
+      expect(backends.map((b) => b.codebase)).to.have.members(["codebasea", "codebaseb"]);
+    });
+
+    it("should include default codebase", () => {
+      const options = { ...baseOptions, only: "functions:default" };
+      const backends = controller.prepareFunctionsBackends(
+        options,
+        functionsConfig,
+        "/project/dir",
+      );
+      expect(backends.length).to.equal(1);
+      expect(backends[0].codebase).to.equal(undefined);
+    });
+
+    it("should ignore non-functions filters", () => {
+      const options = { ...baseOptions, only: "hosting,functions:codebasea" };
+      const backends = controller.prepareFunctionsBackends(
+        options,
+        functionsConfig,
+        "/project/dir",
+      );
+      expect(backends.length).to.equal(1);
+      expect(backends[0].codebase).to.equal("codebasea");
+    });
+
+    it("should include all codebases given --only functions", () => {
+      const options = { ...baseOptions, only: "functions" };
+      const backends = controller.prepareFunctionsBackends(
+        options,
+        functionsConfig,
+        "/project/dir",
+      );
+      expect(backends.length).to.equal(3);
+    });
+  });
+});


### PR DESCRIPTION
Functions emulator now only loads function codebases that are specified by the `--only` flag, e.g.

Given the following function configuration in `firebase.json`:

```json
{
  "functions": [
    {
      "source": "js",
      "codebase": "javascript"
    },
    {
      "source": "ts",
      "codebase": "typescript",
      "predeploy": "npm --prefix \"$RESOURCE_DIR\" run build"
    }
  ],
}
```

You can start the emulator to only start the `typescript` codebase by using the `--only` flag like this:

```sh
$ firebase emulators:start  --only functions:typescript
i  emulators: Starting emulators: functions
i  functions: Skipping codebase javascript due to --only filter

✔  functions: Loaded functions definitions from source: helloTS.
```

Fixes https://github.com/firebase/firebase-tools/issues/4878