### PR TITLE
Let users create paid CSQl instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed an issue in the extensions emulator where parameter default values would not be substitued into resource definitions.
 - Keep artifact registry dry run off for policy changes #8419
+- Allowed users to create paid Cloud SQL instances for Data Connect when the free trial has already been used.

--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -3,7 +3,6 @@ import * as clc from "colorette";
 import { queryTimeSeries, CmQuery } from "../gcp/cloudmonitoring";
 import { listInstances } from "../gcp/cloudsql/cloudsqladmin";
 import * as utils from "../utils";
-import { confirm } from "../prompt";
 
 export function freeTrialTermsLink(): string {
   return "https://firebase.google.com/pricing";

--- a/src/dataconnect/freeTrial.ts
+++ b/src/dataconnect/freeTrial.ts
@@ -1,7 +1,9 @@
+import * as clc from "colorette";
+
 import { queryTimeSeries, CmQuery } from "../gcp/cloudmonitoring";
 import { listInstances } from "../gcp/cloudsql/cloudsqladmin";
 import * as utils from "../utils";
-import * as clc from "colorette";
+import { confirm } from "../prompt";
 
 export function freeTrialTermsLink(): string {
   return "https://firebase.google.com/pricing";

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -7,21 +7,13 @@ import { logger } from "../logger";
 
 const GOOGLE_ML_INTEGRATION_ROLE = "roles/aiplatform.user";
 
-import {
-  getFreeTrialInstanceId,
-  freeTrialTermsLink,
-  printFreeTrialUnavailable,
-  isFreeTrialError,
-  checkFreeTrialInstanceUsed,
-} from "./freeTrial";
-import { FirebaseError } from "../error";
+import { freeTrialTermsLink, checkFreeTrialInstanceUsed } from "./freeTrial";
 
 export async function provisionCloudSql(args: {
   projectId: string;
   location: string;
   instanceId: string;
   databaseId: string;
-  configYamlPath: string;
   enableGoogleMlIntegration: boolean;
   waitForCreation: boolean;
   silent?: boolean;
@@ -33,7 +25,6 @@ export async function provisionCloudSql(args: {
     location,
     instanceId,
     databaseId,
-    configYamlPath,
     enableGoogleMlIntegration,
     waitForCreation,
     silent,
@@ -74,13 +65,15 @@ export async function provisionCloudSql(args: {
     const cta = dryRun ? "It will be created on your next deploy" : "Creating it now.";
     const freeTrialUsed = await checkFreeTrialInstanceUsed(projectId);
     silent ||
-    utils.logLabeledBullet(
-      "dataconnect",
-      `CloudSQL instance '${instanceId}' not found.` +
-        cta +
-        freeTrialUsed ? "" : `\nThis instance is provided under the terms of the Data Connect no-cost trial ${freeTrialTermsLink()}` +
-        dryRun ? `\nMonitor the progress at ${cloudSqlAdminClient.instanceConsoleLink(projectId, instanceId)}`: "",
-    );
+      utils.logLabeledBullet(
+        "dataconnect",
+        `CloudSQL instance '${instanceId}' not found.` + cta + freeTrialUsed
+          ? ""
+          : `\nThis instance is provided under the terms of the Data Connect no-cost trial ${freeTrialTermsLink()}` +
+              dryRun
+            ? `\nMonitor the progress at ${cloudSqlAdminClient.instanceConsoleLink(projectId, instanceId)}`
+            : "",
+      );
 
     if (!dryRun) {
       const newInstance = await promiseWithSpinner(
@@ -92,8 +85,7 @@ export async function provisionCloudSql(args: {
             enableGoogleMlIntegration,
             waitForCreation,
             freeTrial: !freeTrialUsed,
-            }
-          ),
+          }),
         "Creating your instance...",
       );
       if (newInstance) {

--- a/src/deploy/dataconnect/deploy.ts
+++ b/src/deploy/dataconnect/deploy.ts
@@ -94,7 +94,7 @@ export default async function (
           const enableGoogleMlIntegration = requiresVector(s.deploymentMetadata);
           return provisionCloudSql({
             projectId,
-            locationId: parseServiceName(s.serviceName).location,
+            location: parseServiceName(s.serviceName).location,
             instanceId,
             databaseId,
             configYamlPath: join(s.sourceDirectory, "dataconnect.yaml"),

--- a/src/deploy/dataconnect/deploy.ts
+++ b/src/deploy/dataconnect/deploy.ts
@@ -8,7 +8,6 @@ import { parseServiceName } from "../../dataconnect/names";
 import { ResourceFilter } from "../../dataconnect/filters";
 import { vertexAIOrigin } from "../../api";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
-import { join } from "node:path";
 import { confirm } from "../../prompt";
 
 /**
@@ -97,7 +96,6 @@ export default async function (
             location: parseServiceName(s.serviceName).location,
             instanceId,
             databaseId,
-            configYamlPath: join(s.sourceDirectory, "dataconnect.yaml"),
             enableGoogleMlIntegration,
             waitForCreation: true,
           });

--- a/src/deploy/dataconnect/prepare.ts
+++ b/src/deploy/dataconnect/prepare.ts
@@ -17,7 +17,6 @@ import { parseServiceName } from "../../dataconnect/names";
 import { FirebaseError } from "../../error";
 import { requiresVector } from "../../dataconnect/types";
 import { diffSchema } from "../../dataconnect/schemaMigration";
-import { join } from "node:path";
 import { upgradeInstructions } from "../../dataconnect/freeTrial";
 
 /**
@@ -93,7 +92,6 @@ export default async function (context: any, options: DeployOptions): Promise<vo
               location: parseServiceName(s.serviceName).location,
               instanceId,
               databaseId,
-              configYamlPath: join(s.sourceDirectory, "dataconnect.yaml"),
               enableGoogleMlIntegration,
               waitForCreation: true,
               dryRun: options.dryRun,

--- a/src/deploy/dataconnect/prepare.ts
+++ b/src/deploy/dataconnect/prepare.ts
@@ -90,7 +90,7 @@ export default async function (context: any, options: DeployOptions): Promise<vo
             const enableGoogleMlIntegration = requiresVector(s.deploymentMetadata);
             return provisionCloudSql({
               projectId,
-              locationId: parseServiceName(s.serviceName).location,
+              location: parseServiceName(s.serviceName).location,
               instanceId,
               databaseId,
               configYamlPath: join(s.sourceDirectory, "dataconnect.yaml"),

--- a/src/gcp/cloudsql/cloudsqladmin.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.ts
@@ -58,16 +58,14 @@ export function instanceConsoleLink(projectId: string, instanceId: string) {
   return `https://console.cloud.google.com/sql/instances/${instanceId}/overview?project=${projectId}`;
 }
 
-export async function createInstance(
-  args: {
-    projectId: string,
-    location: string,
-    instanceId: string,
-    enableGoogleMlIntegration: boolean,
-    waitForCreation: boolean,
-    freeTrial: boolean,
-  }
-): Promise<Instance | undefined> {
+export async function createInstance(args: {
+  projectId: string;
+  location: string;
+  instanceId: string;
+  enableGoogleMlIntegration: boolean;
+  waitForCreation: boolean;
+  freeTrial: boolean;
+}): Promise<Instance | undefined> {
   const databaseFlags = [{ name: "cloudsql.iam_authentication", value: "on" }];
   if (args.enableGoogleMlIntegration) {
     databaseFlags.push({ name: "cloudsql.enable_google_ml_integration", value: "on" });

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -123,13 +123,15 @@ async function askQuestions(setup: Setup, isBillingEnabled: boolean): Promise<Re
     info.cloudSqlInstanceId === "" ||
     info.locationId === "" ||
     info.cloudSqlDatabase === "";
-  const shouldConfigureBackend = isBillingEnabled && requiredConfigUnset
-    && await confirm({
-        message: `Would you like to configure your backend resources now?`,
-        // For Blaze Projects, configure Cloud SQL by default.
-        // TODO: For Spark projects, allow them to configure Cloud SQL but deploy as unlinked Postgres.
-        default: true,
-      });
+  const shouldConfigureBackend =
+    isBillingEnabled &&
+    requiredConfigUnset &&
+    (await confirm({
+      message: `Would you like to configure your backend resources now?`,
+      // For Blaze Projects, configure Cloud SQL by default.
+      // TODO: For Spark projects, allow them to configure Cloud SQL but deploy as unlinked Postgres.
+      default: true,
+    }));
   if (shouldConfigureBackend) {
     info = await promptForService(info);
     info = await promptForCloudSQL(setup, info);
@@ -166,7 +168,6 @@ export async function actuate(setup: Setup, config: Config, info: RequiredInfo) 
       location: info.locationId,
       instanceId: info.cloudSqlInstanceId,
       databaseId: info.cloudSqlDatabase,
-      configYamlPath: join(config.get("dataconnect.source"), "dataconnect.yaml"),
       enableGoogleMlIntegration: false,
       waitForCreation: false,
     });


### PR DESCRIPTION
### Description
Allow users to create paid CSQL instances when the free trial has already been used.

### Scenarios Tested
Ran firebase init on a project that already had used the free trial:
<img width="826" alt="Screenshot 2025-04-15 at 12 09 44 PM" src="https://github.com/user-attachments/assets/ddacc6a4-328d-4dad-911b-d83675dd4edc" />
Verified that the created instance has the `nt` label value:
<img width="636" alt="Screenshot 2025-04-15 at 12 10 21 PM" src="https://github.com/user-attachments/assets/3e27a0e6-aac7-47b8-8fa3-632bb2453b57" />
TODO once instance provisioning completes - deploy a schema that uses vectors and confirm that it can enable Google ML extension.
