### PR TITLE
Add in requireAuth to AppHosting CLI commands

### DIFF
--- a/src/commands/apphosting-backends-create.ts
+++ b/src/commands/apphosting-backends-create.ts
@@ -1,6 +1,7 @@
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import requireInteractive from "../requireInteractive";
 import { doSetup } from "../apphosting/backend";
 import { ensureApiEnabled } from "../gcp/apphosting";
@@ -18,6 +19,7 @@ export const command = new Command("apphosting:backends:create")
     "specify the service account used to run the server",
     "",
   )
+  .before(requireAuth)
   .before(ensureApiEnabled)
   .before(requireInteractive)
   .before(requireTosAcceptance(APPHOSTING_TOS_ID))

--- a/src/commands/apphosting-backends-delete.ts
+++ b/src/commands/apphosting-backends-delete.ts
@@ -1,6 +1,7 @@
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import { FirebaseError, getError } from "../error";
 import { promptOnce } from "../prompt";
 import * as utils from "../utils";
@@ -12,6 +13,7 @@ import * as ora from "ora";
 export const command = new Command("apphosting:backends:delete <backend>")
   .description("delete a Firebase App Hosting backend")
   .withForce()
+  .before(requireAuth)
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/apphosting-backends-get.ts
+++ b/src/commands/apphosting-backends-get.ts
@@ -1,6 +1,7 @@
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import { FirebaseError, getError } from "../error";
 import { logWarning } from "../utils";
 import * as apphosting from "../gcp/apphosting";
@@ -8,6 +9,7 @@ import { printBackendsTable } from "./apphosting-backends-list";
 
 export const command = new Command("apphosting:backends:get <backend>")
   .description("print info about a Firebase App Hosting backend")
+  .before(requireAuth)
   .before(apphosting.ensureApiEnabled)
   .action(async (backend: string, options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/apphosting-backends-list.ts
+++ b/src/commands/apphosting-backends-list.ts
@@ -3,6 +3,7 @@ import { datetimeString } from "../utils";
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import { Options } from "../options";
 import * as apphosting from "../gcp/apphosting";
 import * as Table from "cli-table3";
@@ -11,6 +12,7 @@ const TABLE_HEAD = ["Backend", "Repository", "URL", "Primary Region", "Updated D
 
 export const command = new Command("apphosting:backends:list")
   .description("list Firebase App Hosting backends")
+  .before(requireAuth)
   .before(apphosting.ensureApiEnabled)
   .action(async (options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/apphosting-builds-create.ts
+++ b/src/commands/apphosting-builds-create.ts
@@ -3,6 +3,7 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:builds:create <backendId>")
@@ -10,6 +11,7 @@ export const command = new Command("apphosting:builds:create <backendId>")
   .option("-l, --location <location>", "specify the region of the backend")
   .option("-i, --id <buildId>", "id of the build (defaults to autogenerating a random id)", "")
   .option("-b, --branch <branch>", "repository branch to deploy (defaults to 'main')", "main")
+  .before(requireAuth)
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/apphosting-builds-get.ts
+++ b/src/commands/apphosting-builds-get.ts
@@ -3,11 +3,13 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:builds:get <backendId> <buildId>")
   .description("get a build for an App Hosting backend")
   .option("-l, --location <location>", "specify the region of the backend")
+  .before(requireAuth)
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, buildId: string, options: Options) => {
     if (options.location !== undefined) {

--- a/src/commands/apphosting-rollouts-create.ts
+++ b/src/commands/apphosting-rollouts-create.ts
@@ -2,6 +2,7 @@ import * as apphosting from "../gcp/apphosting";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import { FirebaseError } from "../error";
 import { createRollout } from "../apphosting/rollout";
 
@@ -13,6 +14,7 @@ export const command = new Command("apphosting:rollouts:create <backendId>")
   )
   .option("-g, --git-commit <gitCommit>", "git commit to deploy (mutually exclusive with -b)")
   .withForce("Skip confirmation before creating rollout")
+  .before(requireAuth)
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/apphosting-rollouts-list.ts
+++ b/src/commands/apphosting-rollouts-list.ts
@@ -3,6 +3,7 @@ import { logger } from "../logger";
 import { Command } from "../command";
 import { Options } from "../options";
 import { needProjectId } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
 import { logWarning } from "../utils";
 
 export const command = new Command("apphosting:rollouts:list <backendId>")
@@ -11,6 +12,7 @@ export const command = new Command("apphosting:rollouts:list <backendId>")
     "-l, --location <location>",
     "region of the rollouts (defaults to listing rollouts from all regions)",
   )
+  .before(requireAuth)
   .before(apphosting.ensureApiEnabled)
   .action(async (backendId: string, options: Options) => {
     if (options.location !== undefined) {


### PR DESCRIPTION
Add in requireAuth to AppHosting CLI commands to reliably fetch and use ADC when invoking commands through the CLI