### PR TITLE
Point Docker script at the right registry

### DIFF
--- a/scripts/publish/firebase-docker-image/cloudbuild.yaml
+++ b/scripts/publish/firebase-docker-image/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
     entrypoint: "sh"
     args:
       - "-c"
-      - "docker build -t us-central1-docker.pkg.dev/$PROJECT_ID/us/firebase:$(cat /workspace/version_number.txt) -t us-central1-docker.pkg.dev/$PROJECT_ID/us/firebase:latest -f ./Dockerfile ."
+      - "docker build -t us-docker.pkg.dev/$PROJECT_ID/us/firebase:$(cat /workspace/version_number.txt) -t us-docker.pkg.dev/$PROJECT_ID/us/firebase:latest -f ./Dockerfile ."
 
 images:
-  - "us-central1-docker.pkg.dev/$PROJECT_ID/us/firebase"
+  - "us-docker.pkg.dev/$PROJECT_ID/us/firebase"


### PR DESCRIPTION
### Description
Recently added this to the release script, and noticed it was pointing at the wrong repo on the last release. I manually reran the script for the last release, but this should fix it going forward
