### PR TITLE
update vscode to 1.2.0

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,8 @@
-## NEXT
+## Next
 
+## 1.2.0
+
+- Updated internal `firebase-tools` dependency to 14.2.0
 - [Fixed] Fragments now properly validate for execution
 
 ## 1.1.0

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
- Updated internal `firebase-tools` dependency to 14.2.0
- [Fixed] Fragments now properly validate for execution