### PR TITLE
Support Firebase sutdio port forwarding in emulator suite

### DIFF
--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -88,7 +88,7 @@ export async function getCredentialsEnvironment(
   return credentialEnv;
 }
 
-export function maybeUseMonospacePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[]{
+export function maybeUseMonospacePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[] {
   const portForwardingHost = process.env.MONOSPACE_PORT_FORWARDING_HOST;
   if (process.env.MONOSPACE_ENV && portForwardingHost) {
     for (const info of emulatorInfos) {
@@ -99,7 +99,7 @@ export function maybeUseMonospacePortForwarding(emulatorInfos: EmulatorInfo[]): 
       }
       const url = `${info.port}-${portForwardingHost}`;
       info.host = url;
-      info.listen = info.listen?.map(l => {
+      info.listen = info.listen?.map((l) => {
         l.address = url;
         l.port = 80;
         return l;

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -109,7 +109,7 @@ export function maybeUseMonospacePortForwarding(emulatorInfos: EmulatorInfo[]): 
       if (fsInfo.webSocketPort) {
         fsInfo.webSocketHost = `${fsInfo.webSocketPort}-${portForwardingHost}`;
         fsInfo.webSocketPort = 80;
-      } 
+      }
     }
   }
   return emulatorInfos;

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -85,3 +85,19 @@ export async function getCredentialsEnvironment(
   }
   return credentialEnv;
 }
+
+export function maybeUseMonospacePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[]{
+  if (process.env.MONOSPACE_ENV && process.env.MONOSPACE_PORT_FORWARDING_HOST) {
+    for (const info of emulatorInfos) {
+      const url = `${info.port}-${process.env.MONOSPACE_PORT_FORWARDING_HOST}`;
+      info.host = url;
+      info.listen = info.listen?.map(l => {
+        l.address = url;
+        l.port = 80;
+        return l;
+      });
+      info.port = 80;
+    }
+  }
+  return emulatorInfos;
+}

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -15,7 +15,7 @@ export function setEnvVarsForEmulators(
   env: Record<string, string | undefined>,
   emulators: EmulatorInfo[],
 ): void {
-  maybeUseMonospacePortForwarding(emulators);
+  maybeUsePortForwarding(emulators);
   for (const emu of emulators) {
     const host = formatHost(emu);
     switch (emu.name) {
@@ -88,9 +88,9 @@ export async function getCredentialsEnvironment(
   return credentialEnv;
 }
 
-export function maybeUseMonospacePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[] {
-  const portForwardingHost = process.env.MONOSPACE_PORT_FORWARDING_HOST;
-  if (process.env.MONOSPACE_ENV && portForwardingHost) {
+export function maybeUsePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[] {
+  const portForwardingHost = process.env.FIREBASE_STUDIO_PORT_FORWARDING_HOST;
+  if (portForwardingHost) {
     for (const info of emulatorInfos) {
       if (info.host.includes(portForwardingHost)) {
         // Don't double apply this.

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -101,14 +101,14 @@ export function maybeUsePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorI
       info.host = url;
       info.listen = info.listen?.map((l) => {
         l.address = url;
-        l.port = 80;
+        l.port = 443;
         return l;
       });
-      info.port = 80;
+      info.port = 443;
       const fsInfo = info as FirestoreEmulatorInfo;
       if (fsInfo.webSocketPort) {
         fsInfo.webSocketHost = `${fsInfo.webSocketPort}-${portForwardingHost}`;
-        fsInfo.webSocketPort = 80;
+        fsInfo.webSocketPort = 443;
       }
     }
   }

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -14,6 +14,7 @@ export function setEnvVarsForEmulators(
   env: Record<string, string | undefined>,
   emulators: EmulatorInfo[],
 ): void {
+  maybeUseMonospacePortForwarding(emulators);
   for (const emu of emulators) {
     const host = formatHost(emu);
     switch (emu.name) {

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -90,6 +90,9 @@ export async function getCredentialsEnvironment(
 export function maybeUseMonospacePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[]{
   if (process.env.MONOSPACE_ENV && process.env.MONOSPACE_PORT_FORWARDING_HOST) {
     for (const info of emulatorInfos) {
+      if (info.host.includes(process.env.MONOSPACE_PORT_FORWARDING_HOST)) {
+        continue;
+      }
       const url = `${info.port}-${process.env.MONOSPACE_PORT_FORWARDING_HOST}`;
       info.host = url;
       info.listen = info.listen?.map(l => {

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -89,7 +89,7 @@ export async function getCredentialsEnvironment(
 }
 
 export function maybeUsePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[] {
-  const portForwardingHost = process.env.FIREBASE_STUDIO_PORT_FORWARDING_HOST;
+  const portForwardingHost = process.env.WEB_HOST;
   if (portForwardingHost) {
     for (const info of emulatorInfos) {
       if (info.host.includes(portForwardingHost)) {

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -85,16 +85,6 @@ export class FirestoreEmulator implements EmulatorInstance {
   getInfo(): FirestoreEmulatorInfo {
     let host = this.args.host || Constants.getDefaultHost();
     let port = this.args.port || Constants.getDefaultPort(Emulators.FIRESTORE);
-    try {
-      if (process.env["FIRESTORE_EMULATOR_HOST"]) {
-        const hostEnv = url.parse(process.env["FIRESTORE_EMULATOR_HOST"])
-        host = hostEnv.hostname ?? host;
-        port = parseInt(hostEnv.port ?? `${port}`);
-
-      }
-    } catch (err: any) {
-      utils.logLabeledBullet("firestore", "Couldn't read host/port from env var");
-    }
     const reservedPorts = this.args.websocket_port ? [this.args.websocket_port] : [];
 
     return {

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -9,7 +9,6 @@ import { EmulatorInfo, EmulatorInstance, Emulators, Severity } from "../emulator
 import { EmulatorRegistry } from "./registry";
 import { Constants } from "./constants";
 import { Issue } from "./types";
-import Uri from 'vscode';
 import * as url from 'url';
 
 export interface FirestoreEmulatorArgs {

--- a/src/emulator/firestoreEmulator.ts
+++ b/src/emulator/firestoreEmulator.ts
@@ -9,7 +9,6 @@ import { EmulatorInfo, EmulatorInstance, Emulators, Severity } from "../emulator
 import { EmulatorRegistry } from "./registry";
 import { Constants } from "./constants";
 import { Issue } from "./types";
-import * as url from 'url';
 
 export interface FirestoreEmulatorArgs {
   port?: number;
@@ -83,8 +82,8 @@ export class FirestoreEmulator implements EmulatorInstance {
   }
 
   getInfo(): FirestoreEmulatorInfo {
-    let host = this.args.host || Constants.getDefaultHost();
-    let port = this.args.port || Constants.getDefaultPort(Emulators.FIRESTORE);
+    const host = this.args.host || Constants.getDefaultHost();
+    const port = this.args.port || Constants.getDefaultPort(Emulators.FIRESTORE);
     const reservedPorts = this.args.websocket_port ? [this.args.websocket_port] : [];
 
     return {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -59,7 +59,7 @@ import * as functionsEnv from "../functions/env";
 import { AUTH_BLOCKING_EVENTS, BEFORE_CREATE_EVENT } from "../functions/events/v1";
 import { BlockingFunctionsConfig } from "../gcp/identityPlatform";
 import { resolveBackend } from "../deploy/functions/build";
-import { getCredentialsEnvironment, setEnvVarsForEmulators } from "./env";
+import { getCredentialsEnvironment, maybeUseMonospacePortForwarding, setEnvVarsForEmulators } from "./env";
 import { runWithVirtualEnv } from "../functions/python";
 import { Runtime } from "../deploy/functions/runtimes/supported";
 import { ExtensionsEmulator } from "./extensionsEmulator";
@@ -1427,6 +1427,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     if (this.args.remoteEmulators) {
       emulatorInfos = emulatorInfos.concat(Object.values(this.args.remoteEmulators));
     }
+    maybeUseMonospacePortForwarding(emulatorInfos);
     setEnvVarsForEmulators(envs, emulatorInfos);
 
     if (this.debugMode) {
@@ -1710,12 +1711,9 @@ export class FunctionsEmulator implements EmulatorInstance {
    * @param emulator
    */
   private getEmulatorInfo(emulator: Emulators): EmulatorInfo | undefined {
-    if (this.args.remoteEmulators) {
-      if (this.args.remoteEmulators[emulator]) {
+    if (this.args.remoteEmulators?.[emulator]) {
         return this.args.remoteEmulators[emulator];
-      }
     }
-
     return EmulatorRegistry.getInfo(emulator);
   }
 

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -59,7 +59,11 @@ import * as functionsEnv from "../functions/env";
 import { AUTH_BLOCKING_EVENTS, BEFORE_CREATE_EVENT } from "../functions/events/v1";
 import { BlockingFunctionsConfig } from "../gcp/identityPlatform";
 import { resolveBackend } from "../deploy/functions/build";
-import { getCredentialsEnvironment, maybeUseMonospacePortForwarding, setEnvVarsForEmulators } from "./env";
+import {
+  getCredentialsEnvironment,
+  maybeUseMonospacePortForwarding,
+  setEnvVarsForEmulators,
+} from "./env";
 import { runWithVirtualEnv } from "../functions/python";
 import { Runtime } from "../deploy/functions/runtimes/supported";
 import { ExtensionsEmulator } from "./extensionsEmulator";
@@ -1712,7 +1716,7 @@ export class FunctionsEmulator implements EmulatorInstance {
    */
   private getEmulatorInfo(emulator: Emulators): EmulatorInfo | undefined {
     if (this.args.remoteEmulators?.[emulator]) {
-        return this.args.remoteEmulators[emulator];
+      return this.args.remoteEmulators[emulator];
     }
     return EmulatorRegistry.getInfo(emulator);
   }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -59,11 +59,7 @@ import * as functionsEnv from "../functions/env";
 import { AUTH_BLOCKING_EVENTS, BEFORE_CREATE_EVENT } from "../functions/events/v1";
 import { BlockingFunctionsConfig } from "../gcp/identityPlatform";
 import { resolveBackend } from "../deploy/functions/build";
-import {
-  getCredentialsEnvironment,
-  maybeUseMonospacePortForwarding,
-  setEnvVarsForEmulators,
-} from "./env";
+import { getCredentialsEnvironment, maybeUsePortForwarding, setEnvVarsForEmulators } from "./env";
 import { runWithVirtualEnv } from "../functions/python";
 import { Runtime } from "../deploy/functions/runtimes/supported";
 import { ExtensionsEmulator } from "./extensionsEmulator";
@@ -1431,7 +1427,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     if (this.args.remoteEmulators) {
       emulatorInfos = emulatorInfos.concat(Object.values(this.args.remoteEmulators));
     }
-    maybeUseMonospacePortForwarding(emulatorInfos);
+    maybeUsePortForwarding(emulatorInfos);
     setEnvVarsForEmulators(envs, emulatorInfos);
 
     if (this.debugMode) {

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -29,7 +29,7 @@ export interface EmulatorHubArgs {
   listenForEmulator: Record<PortName, ListenSpec[]>;
 }
 
-export type GetEmulatorsResponse = Record<string, EmulatorInfo>;
+export type GetEmulatorsResponse = Partial<Record<Emulators, EmulatorInfo>>;
 
 export class EmulatorHub extends ExpressBasedEmulator {
   static CLI_VERSION = pkg.version;

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -79,7 +79,7 @@ export class EmulatorHub extends ExpressBasedEmulator {
     await this.writeLocatorFile();
   }
 
-  getRunningEmulatorsMapping(): any {
+  getRunningEmulatorsMapping(): GetEmulatorsResponse {
     const emulators: GetEmulatorsResponse = {};
     for (const info of EmulatorRegistry.listRunningWithInfo()) {
       emulators[info.name] = {

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -10,6 +10,7 @@ import { emulatorSession } from "../track";
 import { ExpressBasedEmulator } from "./ExpressBasedEmulator";
 import { ALL_EXPERIMENTS, ExperimentName, isEnabled } from "../experiments";
 import { EmulatorHub } from "./hub";
+import * as url from 'url';
 
 export interface EmulatorUIOptions {
   listen: ListenSpec[];
@@ -58,6 +59,20 @@ export class EmulatorUI extends ExpressBasedEmulator {
           experiments: [],
           ...(hub! as EmulatorHub).getRunningEmulatorsMapping(),
         };
+
+        if (json["firestore"]) {
+              try {
+                if (process.env["FIRESTORE_EMULATOR_HOST"]) {
+                  const hostEnv = url.parse(process.env["FIRESTORE_EMULATOR_HOST"])
+                  const host = hostEnv.hostname;
+                  const port = parseInt(hostEnv.port ?? `80`);
+
+          
+                }
+              } catch (err: any) {
+                console.log("Reading emulator host env var id not work")
+              }
+        }
 
         // Googlers: see go/firebase-emulator-ui-usage-collection-design?pli=1#heading=h.jwz7lj6r67z8
         // for more detail

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -61,12 +61,15 @@ export class EmulatorUI extends ExpressBasedEmulator {
         };
 
         if (json["firestore"]) {
+
+            console.log("Reading emulator host env var id not work")
               try {
                 if (process.env["FIRESTORE_EMULATOR_HOST"]) {
                   const hostEnv = url.parse(process.env["FIRESTORE_EMULATOR_HOST"])
                   const host = hostEnv.hostname;
                   const port = parseInt(hostEnv.port ?? `80`);
 
+                  json["firestore"] = {...json["firestore"], listen: { address: host, port}, host, port}
           
                 }
               } catch (err: any) {

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -48,6 +48,7 @@ export class EmulatorUI extends ExpressBasedEmulator {
     const downloadDetails = downloadableEmulators.getDownloadDetails(Emulators.UI);
     const webDir = path.join(downloadDetails.unzipDir!, "client");
 
+    let called = false
     // Exposes the host and port of various emulators to facilitate accessing
     // them using client SDKs. For features that involve multiple emulators or
     // hard to accomplish using client SDKs, consider adding an API below.
@@ -63,12 +64,14 @@ export class EmulatorUI extends ExpressBasedEmulator {
         if (json["firestore"]) {
               try {
                 if (process.env["FIRESTORE_EMULATOR_HOST"]) {
+                  console.log(process.env["FIRESTORE_EMULATOR_HOST"])
                   const hostEnv = url.parse(process.env["FIRESTORE_EMULATOR_HOST"])
                   const host = hostEnv.hostname;
                   const port = parseInt(hostEnv.port ?? `80`);
 
                   json["firestore"] = {...json["firestore"], listen: { address: host, port}, host, port}
-                  console.log(JSON.stringify(json, undefined, 4));
+                  !called && console.log(JSON.stringify(json, undefined, 4));
+                  called = true;
                 }
               } catch (err: any) {
                 console.log("Reading emulator host env var id not work")

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -61,8 +61,6 @@ export class EmulatorUI extends ExpressBasedEmulator {
         };
 
         if (json["firestore"]) {
-
-            console.log("Reading emulator host env var id not work")
               try {
                 if (process.env["FIRESTORE_EMULATOR_HOST"]) {
                   const hostEnv = url.parse(process.env["FIRESTORE_EMULATOR_HOST"])
@@ -70,7 +68,7 @@ export class EmulatorUI extends ExpressBasedEmulator {
                   const port = parseInt(hostEnv.port ?? `80`);
 
                   json["firestore"] = {...json["firestore"], listen: { address: host, port}, host, port}
-          
+                  console.log(JSON.stringify(json, undefined, 4));
                 }
               } catch (err: any) {
                 console.log("Reading emulator host env var id not work")

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -10,9 +10,7 @@ import { emulatorSession } from "../track";
 import { ExpressBasedEmulator } from "./ExpressBasedEmulator";
 import { ALL_EXPERIMENTS, ExperimentName, isEnabled } from "../experiments";
 import { EmulatorHub } from "./hub";
-import * as url from 'url';
-import { analytics } from "@angular-devkit/core";
-import { maybeUseMonosapcePortForwarding } from "./env";
+import { maybeUseMonospacePortForwarding } from "./env";
 
 export interface EmulatorUIOptions {
   listen: ListenSpec[];
@@ -59,7 +57,7 @@ export class EmulatorUI extends ExpressBasedEmulator {
       this.jsonHandler(() => {
 
         const emulatorInfos = (hub! as EmulatorHub).getRunningEmulatorsMapping();
-        maybeUseMonosapcePortForwarding(Object.values(emulatorInfos));
+        maybeUseMonospacePortForwarding(Object.values(emulatorInfos));
         const json = {
           projectId,
           experiments: enabledExperiments ?? [],

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -48,21 +48,20 @@ export class EmulatorUI extends ExpressBasedEmulator {
     const downloadDetails = downloadableEmulators.getDownloadDetails(Emulators.UI);
     const webDir = path.join(downloadDetails.unzipDir!, "client");
 
-    let called = false
+    let called = false;
     // Exposes the host and port of various emulators to facilitate accessing
     // them using client SDKs. For features that involve multiple emulators or
     // hard to accomplish using client SDKs, consider adding an API below
     app.get(
       "/api/config",
       this.jsonHandler(() => {
-
         const emulatorInfos = (hub! as EmulatorHub).getRunningEmulatorsMapping();
         maybeUseMonospacePortForwarding(Object.values(emulatorInfos));
         const json = {
           projectId,
           experiments: enabledExperiments ?? [],
           ...emulatorInfos,
-          analytics: emulatorGaSession
+          analytics: emulatorGaSession,
         };
         !called && console.log(JSON.stringify(json, undefined, 4));
         called = true;

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -12,6 +12,7 @@ import { ALL_EXPERIMENTS, ExperimentName, isEnabled } from "../experiments";
 import { EmulatorHub } from "./hub";
 import * as url from 'url';
 import { analytics } from "@angular-devkit/core";
+import { maybeUseMonosapcePortForwarding } from "./env";
 
 export interface EmulatorUIOptions {
   listen: ListenSpec[];
@@ -58,18 +59,7 @@ export class EmulatorUI extends ExpressBasedEmulator {
       this.jsonHandler(() => {
 
         const emulatorInfos = (hub! as EmulatorHub).getRunningEmulatorsMapping();
-        if (process.env.MONOSPACE_ENV && process.env.MONOSPACE_PORT_FORWARDING_HOST) {
-          for (const [name, info] of Object.entries(emulatorInfos)) {
-            const url = `${info.port}-${process.env.MONOSPACE_PORT_FORWARDING_HOST}`;
-            info.host = url;
-            info.listen = info.listen?.map(l => {
-              l.address = url;
-              l.port = 80;
-              return l;
-            });
-            info.port = 80;
-          }
-        }
+        maybeUseMonosapcePortForwarding(Object.values(emulatorInfos));
         const json = {
           projectId,
           experiments: enabledExperiments ?? [],


### PR DESCRIPTION
### Description
Did some rewiring to support Firebase Studios port forwarding logic. 

 In Firebase Studio, if you serve something on localhost:4000, it will be available on `4000-idx-<workspaceId>.<clusterId>.cloudworkstations.dev`. We need to provide this cloudworkstations.dev URL to the various emalators and SDKs so that corss emulator calls point to the right place.

Rough design:

- When this env var is set, we'll update the host/port for emulators to be `host: <originalHost>-<MONOSPACE_PORT_FORWARDING_HOST> port: 80`. We'll provide these new values in the env vars that the Functions/app hosting emulators use, and we'll provide these in the /api/configs endpoint that the emulator UI uses. 

Stuff that's still broken:
- CORS problems abound - haven't really dug into these yet, but pretty much every call across hosts fails.
- The UI has [some wonky logic](https://github.com/firebase/firebase-tools-ui/blob/master/src/components/common/EmulatorConfigProvider.tsx#L256) that forces the Websocket Host onto the same host as the HTTP host. In IDX, sicne they are on different ports, they are gonna be on different hosts.
- Probably more!

### Using it in Firebase Studio
If you want to test against this in Firebase Studio, the easiest way is probably to use NPX - in any firebase command, replace `firebase` with:
`npx -y firebase/firebase-tools#jh-idx-hax` - so for example:
```
npx -y firebase/firebase-tools#jh-idx-hax emulators:start
```