### PR TITLE
Make the functions emulator work in Studio

### DIFF
--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -88,29 +88,28 @@ export async function getCredentialsEnvironment(
   return credentialEnv;
 }
 
-export function maybeUsePortForwarding(emulatorInfos: EmulatorInfo[]): EmulatorInfo[] {
+export function maybeUsePortForwarding(i: EmulatorInfo): EmulatorInfo {
   const portForwardingHost = process.env.WEB_HOST;
   if (portForwardingHost) {
-    for (const info of emulatorInfos) {
-      if (info.host.includes(portForwardingHost)) {
-        // Don't double apply this.
-        // TODO: Just deep copy everything each time.
-        continue;
-      }
-      const url = `${info.port}-${portForwardingHost}`;
-      info.host = url;
-      info.listen = info.listen?.map((l) => {
-        l.address = url;
-        l.port = 443;
-        return l;
-      });
-      info.port = 443;
-      const fsInfo = info as FirestoreEmulatorInfo;
-      if (fsInfo.webSocketPort) {
-        fsInfo.webSocketHost = `${fsInfo.webSocketPort}-${portForwardingHost}`;
-        fsInfo.webSocketPort = 443;
-      }
+    const info = { ...i };
+    if (info.host.includes(portForwardingHost)) {
+      // Never double apply this. Added as a safety check against sloppy usage.
+      return info;
     }
+    const url = `${info.port}-${portForwardingHost}`;
+    info.host = url;
+    info.listen = info.listen?.map((l) => {
+      l.address = url;
+      l.port = 443;
+      return l;
+    });
+    info.port = 443;
+    const fsInfo = info as FirestoreEmulatorInfo;
+    if (fsInfo.webSocketPort) {
+      fsInfo.webSocketHost = `${fsInfo.webSocketPort}-${portForwardingHost}`;
+      fsInfo.webSocketPort = 443;
+    }
+    return info;
   }
-  return emulatorInfos;
+  return i;
 }

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -15,7 +15,6 @@ export function setEnvVarsForEmulators(
   env: Record<string, string | undefined>,
   emulators: EmulatorInfo[],
 ): void {
-  maybeUsePortForwarding(emulators);
   for (const emu of emulators) {
     const host = formatHost(emu);
     switch (emu.name) {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -59,7 +59,7 @@ import * as functionsEnv from "../functions/env";
 import { AUTH_BLOCKING_EVENTS, BEFORE_CREATE_EVENT } from "../functions/events/v1";
 import { BlockingFunctionsConfig } from "../gcp/identityPlatform";
 import { resolveBackend } from "../deploy/functions/build";
-import { getCredentialsEnvironment, maybeUsePortForwarding, setEnvVarsForEmulators } from "./env";
+import { getCredentialsEnvironment, setEnvVarsForEmulators } from "./env";
 import { runWithVirtualEnv } from "../functions/python";
 import { Runtime } from "../deploy/functions/runtimes/supported";
 import { ExtensionsEmulator } from "./extensionsEmulator";
@@ -1427,7 +1427,6 @@ export class FunctionsEmulator implements EmulatorInstance {
     if (this.args.remoteEmulators) {
       emulatorInfos = emulatorInfos.concat(Object.values(this.args.remoteEmulators));
     }
-    maybeUsePortForwarding(emulatorInfos);
     setEnvVarsForEmulators(envs, emulatorInfos);
 
     if (this.debugMode) {

--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -13,6 +13,7 @@ import { ExpressBasedEmulator } from "./ExpressBasedEmulator";
 import { PortName } from "./portUtils";
 import { DataConnectEmulator } from "./dataconnectEmulator";
 import { isVSCodeExtension } from "../vsCodeUtils";
+import { maybeUsePortForwarding } from "./env";
 
 // We use the CLI version from package.json
 const pkg = require("../../package.json");
@@ -82,10 +83,10 @@ export class EmulatorHub extends ExpressBasedEmulator {
   getRunningEmulatorsMapping(): GetEmulatorsResponse {
     const emulators: GetEmulatorsResponse = {};
     for (const info of EmulatorRegistry.listRunningWithInfo()) {
-      emulators[info.name] = {
+      emulators[info.name] = maybeUsePortForwarding({
         listen: this.args.listenForEmulator[info.name],
         ...info,
-      };
+      });
     }
     return emulators;
   }

--- a/src/emulator/ui.ts
+++ b/src/emulator/ui.ts
@@ -10,7 +10,6 @@ import { AnalyticsSession, emulatorSession } from "../track";
 import { ExpressBasedEmulator } from "./ExpressBasedEmulator";
 import { ALL_EXPERIMENTS, ExperimentName, isEnabled } from "../experiments";
 import { EmulatorHub, GetEmulatorsResponse } from "./hub";
-import { maybeUsePortForwarding } from "./env";
 
 export interface EmulatorUIOptions {
   listen: ListenSpec[];
@@ -62,7 +61,6 @@ export class EmulatorUI extends ExpressBasedEmulator {
       "/api/config",
       this.jsonHandler(() => {
         const emulatorInfos = (hub! as EmulatorHub).getRunningEmulatorsMapping();
-        maybeUsePortForwarding(Object.values(emulatorInfos));
         const json: EmulatorConfigInfo = {
           projectId,
           experiments: enabledExperiments ?? [],


### PR DESCRIPTION
### Description
Cleaning up some issues introduced in #8443.

Within Firebase Studio, any calls coming from the browser need to use the port forwarding hosts. However, calls coming from inside the VM can safely just use localhost. This change should keep the emulator UI using port forwarding, but let the functions emulator use localhost.

### Scenarios Tested
Tested on Studio with `npx firebase/firebase-tools#jh-fns-studio`, and confirmed that calls from within functions are working and calls from the emulator UI are routed to the right host.
