### PR TITLE
Dont require auth for demo projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-- Clean up prompt for setting up web frameworks for Data Connect developers.
+- Cleaned up prompt for setting up web frameworks during `init dataconnect`.
+- Fixed an issue were the Emualtor suite would check for auth when using `demo-` projects.

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -165,16 +165,18 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
     !controller.shouldStart(optionsWithConfig, Emulators.FUNCTIONS) &&
     !controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
 
-  try {
-    await requireAuth(options);
-  } catch (e: any) {
-    logger.debug(e);
-    utils.logLabeledWarning(
-      "emulators",
-      `You are not currently authenticated so some features may not work correctly. Please run ${clc.bold(
-        "firebase login",
-      )} to authenticate the CLI.`,
-    );
+  if (!Constants.isDemoProject(options.project)) {
+    try {
+      await requireAuth(options);
+    } catch (e: any) {
+      logger.debug(e);
+      utils.logLabeledWarning(
+        "emulators",
+        `You are not currently authenticated so some features may not work correctly. Please run ${clc.bold(
+          "firebase login",
+        )} to authenticate the CLI.`,
+      );
+    }
   }
 
   if (canStartWithoutConfig && !options.config) {

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -125,6 +125,7 @@ export async function prepareFrameworks(
   emulators: EmulatorInfo[] = [],
 ): Promise<void> {
   const project = needProjectId(context || options);
+  const isDemoProject = Constants.isDemoProject(project);
   const projectRoot = resolveProjectPath(options, ".");
   const account = getProjectDefaultAccount(projectRoot);
   // options.site is not present when emulated. We could call requireHostingSite but IAM permissions haven't
@@ -140,6 +141,9 @@ export async function prepareFrameworks(
   // think this breaks any other situation because we don't need a site during
   // emulation unless we have multiple sites, in which case we're guaranteed to
   // either have site or target set.
+  if (isDemoProject) {
+    options.site = project
+  }
   if (!options.site) {
     try {
       await requireHostingSite(options);
@@ -207,7 +211,6 @@ export async function prepareFrameworks(
     });
     let firebaseConfig = null;
     if (usesFirebaseJsSdk) {
-      const isDemoProject = Constants.isDemoProject(project);
 
       const sites = isDemoProject ? listDemoSites(project) : await listSites(project);
       const selectedSite = sites.find((it) => it.name && it.name.split("/").pop() === site);

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -142,7 +142,7 @@ export async function prepareFrameworks(
   // emulation unless we have multiple sites, in which case we're guaranteed to
   // either have site or target set.
   if (isDemoProject) {
-    options.site = project
+    options.site = project;
   }
   if (!options.site) {
     try {
@@ -211,7 +211,6 @@ export async function prepareFrameworks(
     });
     let firebaseConfig = null;
     if (usesFirebaseJsSdk) {
-
       const sites = isDemoProject ? listDemoSites(project) : await listSites(project);
       const selectedSite = sites.find((it) => it.name && it.name.split("/").pop() === site);
       if (selectedSite) {

--- a/src/hosting/api.ts
+++ b/src/hosting/api.ts
@@ -6,6 +6,7 @@ import { DEFAULT_DURATION } from "../hosting/expireUtils";
 import { getAuthDomains, updateAuthDomains } from "../gcp/auth";
 import * as proto from "../gcp/proto";
 import { getHostnameFromUrl } from "../utils";
+import { Constants } from "../emulator/constants";
 
 const ONE_WEEK_MS = 604800000; // 7 * 24 * 60 * 60 * 1000
 
@@ -761,6 +762,9 @@ export async function getDeploymentDomain(
   siteId: string,
   hostingChannel?: string | undefined,
 ): Promise<string | null> {
+  if (Constants.isDemoProject(projectId)) {
+    return null;
+  }
   if (hostingChannel) {
     const channel = await getChannel(projectId, siteId, hostingChannel);
 


### PR DESCRIPTION
### Description
If using a `demo-` project, we should not require auth. Doing so is pointless since we should not make any prod calls (and if we do, they will hit a nonexistant project and fail)

Also fixed a place where we'd make a prod call for 'demo-' projects when emulating webframeworks. This call would always fail and we'd use a fallback value, so instead we'll skip the call and just use the fallback