### PR TITLE
[MCP] Add a list_dataconnect_services MCP tool

### DIFF
--- a/src/mcp/tools/dataconnect/index.ts
+++ b/src/mcp/tools/dataconnect/index.ts
@@ -1,0 +1,5 @@
+import type { ServerTool } from "../../tool.js";
+
+import { list_dataconnect_services } from "./list_dataconnect_services.js";
+
+export const dataconnectTools: ServerTool[] = [list_dataconnect_services];

--- a/src/mcp/tools/dataconnect/list_dataconnect_services.ts
+++ b/src/mcp/tools/dataconnect/list_dataconnect_services.ts
@@ -7,7 +7,7 @@ import * as client from "../../../dataconnect/client";
 export const list_dataconnect_services = tool(
   {
     name: "list_dataconnect_services",
-    description: "List the Firebase Data Connect Services Deploy.",
+    description: "List the Firebase Data Connect services available in the current project.",
     inputSchema: z.object({}),
     annotations: {
       title: "List the Firebase Data Connect Services that's available in the backend",

--- a/src/mcp/tools/dataconnect/list_dataconnect_services.ts
+++ b/src/mcp/tools/dataconnect/list_dataconnect_services.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+import { tool } from "../../tool.js";
+import { mcpError, toContent } from "../../util.js";
+import { AppPlatform, getAppConfig, listFirebaseApps } from "../../../management/apps.js";
+import * as client from "../../../dataconnect/client";
+
+export const list_dataconnect_services = tool(
+  {
+    name: "list_dataconnect_services",
+    description: "List the Firebase Data Connect Services Deploy.",
+    inputSchema: z.object({}),
+    annotations: {
+      title: "List the Firebase Data Connect Services that's available in the backend",
+      readOnlyHint: true,
+    },
+    _meta: {
+      requiresProject: true,
+    },
+  },
+  async (_, { projectId }) => {
+    if (!projectId) return mcpError("No current project detected.");
+    const services = await client.listAllServices(projectId);
+    return toContent(services, { format: "yaml" });
+  },
+);

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -1,12 +1,13 @@
 import { ServerTool } from "../tool.js";
 import { ServerFeature } from "../types.js";
 import { authTools } from "./auth/index.js";
+import { dataconnectTools } from "./dataconnect/index.js";
 import { projectTools } from "./project/index.js";
 
 export const tools: Record<ServerFeature, ServerTool[]> = {
   project: projectTools,
   firestore: [],
   auth: authTools,
-  dataconnect: [],
+  dataconnect: dataconnectTools,
   storage: [],
 };


### PR DESCRIPTION
### Description

Add the first FDC tool.

`list_dataconnect_services` talks to the backend API and returns the list of services available.

### Scenarios Tested

![image](https://github.com/user-attachments/assets/557837f2-95a5-4cea-a025-cf9930ad57e4)

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->