### PR TITLE
Don't check TOS for robots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fixed an issue where the prompt to create apphosting.emulator.yaml did not work with backends that are not at the project.root (#8412)
-- Fixed an issue where Terms of Service acceptance would be checked for non-human users. 
+- Fixed an issue where Terms of Service acceptance would be checked for non-human users.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixed an issue where the prompt to create apphosting.emulator.yaml did not work with backends that are not at the project.root (#8412)
+- Fixed an issue where Terms of Service acceptance would be checked for non-human users. 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,6 +5,7 @@ import * as jwt from "jsonwebtoken";
 import * as opn from "open";
 import * as portfinder from "portfinder";
 import * as url from "url";
+import { GetApplicationDefault } from "google-auth-library";
 
 import * as apiv2 from "./apiv2";
 import { configstore } from "./configstore";
@@ -39,6 +40,7 @@ import {
 } from "./types/auth";
 import { readTemplate } from "./templates";
 import { refreshAuth } from "./requireAuth";
+import { Options } from "./options";
 
 portfinder.setBasePort(9005);
 
@@ -768,4 +770,11 @@ export function addAdditionalAccount(account: Account): void {
   const additionalAccounts = getAdditionalAccounts();
   additionalAccounts.push(account);
   configstore.set("additionalAccounts", additionalAccounts);
+}
+
+export async function isHuman(options: Options) {
+  if (loggedIn()) {
+    return true;
+  }
+  const adc =  await auth.getApplicationDefault();
 }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -771,10 +771,3 @@ export function addAdditionalAccount(account: Account): void {
   additionalAccounts.push(account);
   configstore.set("additionalAccounts", additionalAccounts);
 }
-
-export async function isHuman(options: Options) {
-  if (loggedIn()) {
-    return true;
-  }
-  const adc =  await auth.getApplicationDefault();
-}

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,7 +5,6 @@ import * as jwt from "jsonwebtoken";
 import * as opn from "open";
 import * as portfinder from "portfinder";
 import * as url from "url";
-import { GetApplicationDefault } from "google-auth-library";
 
 import * as apiv2 from "./apiv2";
 import { configstore } from "./configstore";
@@ -40,7 +39,6 @@ import {
 } from "./types/auth";
 import { readTemplate } from "./templates";
 import { refreshAuth } from "./requireAuth";
-import { Options } from "./options";
 
 portfinder.setBasePort(9005);
 

--- a/src/requireTosAcceptance.spec.ts
+++ b/src/requireTosAcceptance.spec.ts
@@ -88,7 +88,7 @@ describe("requireTosAcceptance", () => {
       .get("/v1/accessmanagement/tos:getStatus")
       .reply(200, SAMPLE_RESPONSE);
     loggedInStub.returns(false);
-    
+
     await requireTosAcceptance(APPHOSTING_TOS_ID)(SAMPLE_OPTIONS);
 
     expect(nock.isDone()).to.be.true;

--- a/src/requireTosAcceptance.spec.ts
+++ b/src/requireTosAcceptance.spec.ts
@@ -84,9 +84,6 @@ describe("requireTosAcceptance", () => {
   });
 
   it("should resolve to if not a human", async () => {
-    nock("https://mobilesdk-pa.googleapis.com")
-      .get("/v1/accessmanagement/tos:getStatus")
-      .reply(200, SAMPLE_RESPONSE);
     loggedInStub.returns(false);
 
     await requireTosAcceptance(APPHOSTING_TOS_ID)(SAMPLE_OPTIONS);

--- a/src/requireTosAcceptance.spec.ts
+++ b/src/requireTosAcceptance.spec.ts
@@ -1,9 +1,11 @@
 import * as nock from "nock";
+import * as sinon from "sinon";
 import { APPHOSTING_TOS_ID, APP_CHECK_TOS_ID } from "./gcp/firedata";
 import { requireTosAcceptance } from "./requireTosAcceptance";
 import { Options } from "./options";
 import { RC } from "./rc";
 import { expect } from "chai";
+import * as auth from "./auth";
 
 const SAMPLE_OPTIONS: Options = {
   cwd: "/",
@@ -47,17 +49,21 @@ const SAMPLE_RESPONSE = {
 };
 
 describe("requireTosAcceptance", () => {
-  before(() => {
+  let loggedInStub: sinon.SinonStub;
+  beforeEach(() => {
     nock.disableNetConnect();
+    loggedInStub = sinon.stub(auth, "loggedIn");
   });
-  after(() => {
+  afterEach(() => {
     nock.enableNetConnect();
+    loggedInStub.restore();
   });
 
   it("should resolve for accepted terms of service", async () => {
     nock("https://mobilesdk-pa.googleapis.com")
       .get("/v1/accessmanagement/tos:getStatus")
       .reply(200, SAMPLE_RESPONSE);
+    loggedInStub.returns(true);
 
     await requireTosAcceptance(APP_CHECK_TOS_ID)(SAMPLE_OPTIONS);
 
@@ -68,10 +74,22 @@ describe("requireTosAcceptance", () => {
     nock("https://mobilesdk-pa.googleapis.com")
       .get("/v1/accessmanagement/tos:getStatus")
       .reply(200, SAMPLE_RESPONSE);
+    loggedInStub.returns(true);
 
     await expect(requireTosAcceptance(APPHOSTING_TOS_ID)(SAMPLE_OPTIONS)).to.be.rejectedWith(
       "Terms of Service",
     );
+
+    expect(nock.isDone()).to.be.true;
+  });
+
+  it("should resolve to if not a human", async () => {
+    nock("https://mobilesdk-pa.googleapis.com")
+      .get("/v1/accessmanagement/tos:getStatus")
+      .reply(200, SAMPLE_RESPONSE);
+    loggedInStub.returns(false);
+    
+    await requireTosAcceptance(APPHOSTING_TOS_ID)(SAMPLE_OPTIONS);
 
     expect(nock.isDone()).to.be.true;
   });

--- a/src/requireTosAcceptance.ts
+++ b/src/requireTosAcceptance.ts
@@ -9,6 +9,7 @@ import {
   isProductTosAccepted,
 } from "./gcp/firedata";
 import { consoleOrigin } from "./api";
+import { hasDefaultCredentials } from "./defaultCredentials";
 
 const consoleLandingPage = new Map<TosId, string>([
   [APPHOSTING_TOS_ID, `${consoleOrigin()}/project/_/apphosting`],
@@ -27,10 +28,13 @@ const consoleLandingPage = new Map<TosId, string>([
  * generic ToS error messages.
  */
 export function requireTosAcceptance(tosId: TosId): (options: Options) => Promise<void> {
-  return () => requireTos(tosId);
+  return (options: Options) => requireTos(options, tosId);
 }
 
-async function requireTos(tosId: TosId): Promise<void> {
+async function requireTos(options: Options, tosId: TosId): Promise<void> {
+  if (await hasDefaultCredentials()) {
+    return;
+  }
   const res = await getTosStatus();
   if (isProductTosAccepted(res, tosId)) {
     return;

--- a/src/requireTosAcceptance.ts
+++ b/src/requireTosAcceptance.ts
@@ -9,7 +9,7 @@ import {
   isProductTosAccepted,
 } from "./gcp/firedata";
 import { consoleOrigin } from "./api";
-import { hasDefaultCredentials } from "./defaultCredentials";
+import { loggedIn } from "./auth";
 
 const consoleLandingPage = new Map<TosId, string>([
   [APPHOSTING_TOS_ID, `${consoleOrigin()}/project/_/apphosting`],
@@ -28,11 +28,13 @@ const consoleLandingPage = new Map<TosId, string>([
  * generic ToS error messages.
  */
 export function requireTosAcceptance(tosId: TosId): (options: Options) => Promise<void> {
-  return (options: Options) => requireTos(options, tosId);
+  return () => requireTos(tosId);
 }
 
-async function requireTos(options: Options, tosId: TosId): Promise<void> {
-  if (await hasDefaultCredentials()) {
+async function requireTos(tosId: TosId): Promise<void> {
+  // If they are not logged in, they either cannot make calls, or are using a service account.
+  // Either way, no need to check TOS.
+  if (!loggedIn()) {
     return;
   }
   const res = await getTosStatus();


### PR DESCRIPTION
### Description
Looks like we overlooked this case when implementing TOS checks. Service accounts cannot accept TOS, so we shouldn't try to check it. Additionally, the TOS check API is a private API, so it won't be available unless the quota project is a Google owned project. When logged in, this is no issue (since the OAuth token has Google owned quota project), but it is a problem when using service accounts.

This should fix part of #6310 (the service account bits, not the --token issues)
