### PR TITLE
Remove globs from default Firestore rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed an issue where the prompt to create apphosting.emulator.yaml did not work with backends that are not at the project.root (#8412)
 - Fixed an issue where Terms of Service acceptance would be checked for non-human users.
+- Changed default security rules from `firebase init` to be more secure.

--- a/src/init/features/database.ts
+++ b/src/init/features/database.ts
@@ -33,7 +33,7 @@ interface DatabaseSetupConfig {
 }
 
 const DEFAULT_RULES = JSON.stringify(
-  { rules: { ".read": "auth != null", ".write": "auth != null" } },
+  { rules: { some_path: { ".read": "auth != null", ".write": "auth != null" } } },
   null,
   2,
 );

--- a/templates/init/firestore/firestore.rules
+++ b/templates/init/firestore/firestore.rules
@@ -1,16 +1,14 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      // This rule allows anyone with your database reference to view, edit,
-      // and delete all data in your database. It is useful for getting
-      // started, but it is configured to expire after 30 days because it
-      // leaves your app open to attackers. At that time, all client
-      // requests to your database will be denied.
-      //
-      // Make sure to write security rules for your app before that time, or
-      // else all client requests to your database will be denied until you
-      // update your rules.
-      allow read, write: if request.time < timestamp.date({{IN_30_DAYS}});
-    }
+    // This rule allows anyone with your database reference to view, edit,
+    // and delete all data in your database. It is useful for getting
+    // started, but it is configured to expire after 30 days because it
+    // leaves your app open to attackers. At that time, all client
+    // requests to your database will be denied.
+    //
+    // Make sure to write security rules for your app before that time, or
+    // else all client requests to your database will be denied until you
+    // update your rules.
+    allow read, write: if request.time < timestamp.date({{IN_30_DAYS}});
   }
 }

--- a/templates/init/firestore/firestore.rules
+++ b/templates/init/firestore/firestore.rules
@@ -1,14 +1,13 @@
+rules_version = '2';
+
 service cloud.firestore {
   match /databases/{database}/documents {
-    // This rule allows anyone with your database reference to view, edit,
-    // and delete all data in your database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or
-    // else all client requests to your database will be denied until you
-    // update your rules.
-    allow read, write: if request.time < timestamp.date({{IN_30_DAYS}});
+    // Security rules are closed by default - if you don't have a rule that grants access,
+    // clients will not be able to read or write to that location in Firestore.
+    // Below is an example of how to open up a collection to only authenticated users
+    // For more help developing your security rules, see https://firebase.google.com/docs/rules/basics
+    match /some_collection/{document} {
+      allow read, write: if request.auth != null;
+    }
   }
 }

--- a/templates/init/storage/storage.rules
+++ b/templates/init/storage/storage.rules
@@ -1,12 +1,13 @@
 rules_version = '2';
 
-// Craft rules based on data in your Firestore database
-// allow write: if firestore.get(
-//    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
+// Security rules are closed by default - if you don't have a rule that grants access,
+// clients will not be able to read or write to that location in Storafe.
+// Below is an example of how to open up a folder to only authenticated users
+// For more help developing your security rules, see https://firebase.google.com/docs/rules/basics
 service firebase.storage {
   match /b/{bucket}/o {
-    match /{allPaths=**} {
-      allow read, write: if false;
+    match /some_folder/{fileName} {
+      allow read, write: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
### Description
Remove globs from default Firestore rules. The replacement rules are sourced from our docs, and are effectively closed to all reads/writes
