### PR TITLE
Fix issue where rules/indexes file path become undefined during init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed issue where `firebase init firestore` would raise an error due to rules/indexes file path being undefined. (#8518)

--- a/src/init/features/firestore/indexes.ts
+++ b/src/init/features/firestore/indexes.ts
@@ -25,6 +25,7 @@ export async function initIndexes(setup: any, config: any): Promise<any> {
       message: "What file should be used for Firestore indexes?",
       default: "firestore.indexes.json",
     }));
+  setup.config.firestore.indexes = filename;
 
   if (fsutils.fileExistsSync(filename)) {
     const msg =

--- a/src/init/features/firestore/rules.ts
+++ b/src/init/features/firestore/rules.ts
@@ -24,6 +24,7 @@ export async function initRules(setup: any, config: any): Promise<any> {
       message: "What file should be used for Firestore Rules?",
       default: DEFAULT_RULES_FILE,
     }));
+  setup.config.firestore.rules = filename;
 
   if (fsutils.fileExistsSync(filename)) {
     const msg =


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #8518 

From what I can gather, we never set the value of `setup.config.firestore.rules` or `setup.config.firestore.indexes` after prompting. We initially remove the values during `doSetup` in https://github.com/firebase/firebase-tools/blob/65ed08d97e5009abc50eb013c85db6326f520537/src/init/features/firestore/index.ts#L70-L78

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

```
$ firebase init firestore --project PROJECT_ID

     ######## #### ########  ######## ########     ###     ######  ########
     ##        ##  ##     ## ##       ##     ##  ##   ##  ##       ##
     ######    ##  ########  ######   ########  #########  ######  ######
     ##        ##  ##    ##  ##       ##     ## ##     ##       ## ##
     ##       #### ##     ## ######## ########  ##     ##  ######  ########

You're about to initialize a Firebase project in this directory:

  /Users/<PATH>/8518


=== Project Setup

First, let's associate this project directory with a Firebase project.
You can create multiple project aliases by running firebase use --add, 
but for now we'll just set up a default project.

i  Using project PROJECT_ID (PROJECT_NAME)

=== Firestore Setup

Firestore Security Rules allow you to define how and when to allow
requests. You can keep these rules in your project directory
and publish them with firebase deploy.

✔ What file should be used for Firestore Rules? firestore.rules

Firestore indexes allow you to perform complex queries while
maintaining performance that scales with the size of the result
set. You can keep index definitions in your project directory
and publish them with firebase deploy.

✔ What file should be used for Firestore indexes? firestore.indexes.json

i  Writing configuration info to firebase.json...
i  Writing project information to .firebaserc...
i  Writing gitignore file to .gitignore...

```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase init firestore --project PROJECT_ID`
