### PR TITLE
Optionally enable telemetry collection during Genkit init

### DIFF
--- a/src/init/features/genkit/index.ts
+++ b/src/init/features/genkit/index.ts
@@ -381,7 +381,21 @@ export async function genkitSetup(
       default: true,
     }))
   ) {
-    generateSampleFile(modelOptions[model].plugin, plugins, projectDir, genkitInfo.templateVersion);
+
+    logger.info("Telemetry data can be used to monitor and gain insights into your AI features. There may be a cost associated with using this feature. See https://firebase.google.com/docs/genkit/observability/telemetry-collection.");
+    const enableTelemetry =
+      options.nonInteractive || 
+      (await confirm({
+        message: "Would like you to enable telemetry collection?",
+        default: true
+      }));
+
+    generateSampleFile(
+      modelOptions[model].plugin,
+      plugins,
+      projectDir,
+      genkitInfo.templateVersion,
+      enableTelemetry);
   }
 }
 
@@ -506,6 +520,7 @@ function generateSampleFile(
   configPlugins: string[],
   projectDir: string,
   templateVersion: string,
+  enableTelemetry: boolean,
 ): void {
   let modelImport = "";
   if (modelPlugin && pluginToInfo[modelPlugin].model) {
@@ -533,6 +548,7 @@ function generateSampleFile(
           ? pluginToInfo[modelPlugin].model || pluginToInfo[modelPlugin].modelStr || ""
           : "'' /* TODO: Set a model. */",
       ),
+    enableTelemetry,
   );
   logLabeledBullet("genkit", "Generating sample file");
   try {
@@ -621,16 +637,24 @@ async function updatePackageJson(nonInteractive: boolean, projectDir: string): P
   }
 }
 
-function renderConfig(pluginNames: string[], template: string): string {
+function renderConfig(pluginNames: string[], template: string, enableTelemetry: boolean): string {
   const imports = pluginNames
-    .map((pluginName) => generateImportStatement(pluginToInfo[pluginName].imports, pluginName))
-    .join("\n");
+    .map((pluginName) => generateImportStatement(pluginToInfo[pluginName].imports, pluginName));
+  if (enableTelemetry) {
+    imports.push(generateImportStatement("enableFirebaseTelemetry", "@genkit-ai/firebase"));
+  }
+  const telemetryBlock = enableTelemetry
+    ? "\n// Collect telemetry data to enable production monitoring.\n" +
+       "// See https://firebase.google.com/docs/genkit/observability/telemetry-collection.\n" +
+       "enableFirebaseTelemetry();\n"
+    : "";
   const plugins =
     pluginNames.map((pluginName) => `    ${pluginToInfo[pluginName].init},`).join("\n") ||
     "    /* Add your plugins here. */";
   return template
-    .replace("$GENKIT_CONFIG_IMPORTS", imports)
-    .replace("$GENKIT_CONFIG_PLUGINS", plugins);
+    .replace("$GENKIT_CONFIG_IMPORTS", imports.join("\n"))
+    .replace("$GENKIT_CONFIG_PLUGINS", plugins)
+    .replace("$GENKIT_ENABLE_TELEMETRY", telemetryBlock);
 }
 
 function generateImportStatement(imports: string, name: string): string {

--- a/src/init/features/genkit/index.ts
+++ b/src/init/features/genkit/index.ts
@@ -381,13 +381,14 @@ export async function genkitSetup(
       default: true,
     }))
   ) {
-
-    logger.info("Telemetry data can be used to monitor and gain insights into your AI features. There may be a cost associated with using this feature. See https://firebase.google.com/docs/genkit/observability/telemetry-collection.");
+    logger.info(
+      "Telemetry data can be used to monitor and gain insights into your AI features. There may be a cost associated with using this feature. See https://firebase.google.com/docs/genkit/observability/telemetry-collection.",
+    );
     const enableTelemetry =
-      options.nonInteractive || 
+      options.nonInteractive ||
       (await confirm({
         message: "Would like you to enable telemetry collection?",
-        default: true
+        default: true,
       }));
 
     generateSampleFile(
@@ -395,7 +396,8 @@ export async function genkitSetup(
       plugins,
       projectDir,
       genkitInfo.templateVersion,
-      enableTelemetry);
+      enableTelemetry,
+    );
   }
 }
 
@@ -638,15 +640,16 @@ async function updatePackageJson(nonInteractive: boolean, projectDir: string): P
 }
 
 function renderConfig(pluginNames: string[], template: string, enableTelemetry: boolean): string {
-  const imports = pluginNames
-    .map((pluginName) => generateImportStatement(pluginToInfo[pluginName].imports, pluginName));
+  const imports = pluginNames.map((pluginName) =>
+    generateImportStatement(pluginToInfo[pluginName].imports, pluginName),
+  );
   if (enableTelemetry) {
     imports.push(generateImportStatement("enableFirebaseTelemetry", "@genkit-ai/firebase"));
   }
   const telemetryBlock = enableTelemetry
     ? "\n// Collect telemetry data to enable production monitoring.\n" +
-       "// See https://firebase.google.com/docs/genkit/observability/telemetry-collection.\n" +
-       "enableFirebaseTelemetry();\n"
+      "// See https://firebase.google.com/docs/genkit/observability/telemetry-collection.\n" +
+      "enableFirebaseTelemetry();\n"
     : "";
   const plugins =
     pluginNames.map((pluginName) => `    ${pluginToInfo[pluginName].init},`).join("\n") ||

--- a/templates/genkit/firebase.1.0.0.template
+++ b/templates/genkit/firebase.1.0.0.template
@@ -20,7 +20,7 @@ const ai = genkit({
 $GENKIT_CONFIG_PLUGINS
   ],
 });
-
+$GENKIT_ENABLE_TELEMETRY
 // Define a simple flow that prompts an LLM to generate menu suggestions.
 const menuSuggestionFlow = ai.defineFlow({
     name: "menuSuggestionFlow",


### PR DESCRIPTION
### Description

When running `firebase init genkit`, prompt user to add telemetry collection to the generated sample file.

### Scenarios Tested

Tested creating the Genkit sample file with and without the new option enabled.

### Sample Commands

firebase init genkit
