### PR TITLE
fix(mcp): Make all input schemas valid for Gemini.

### DIFF
--- a/src/gcp/auth.ts
+++ b/src/gcp/auth.ts
@@ -138,7 +138,7 @@ export async function findUser(
     expression: [expression],
     limit: "1",
   });
-  if (res.body.userInfo.length === 0) {
+  if (!res.body.userInfo?.length) {
     throw new Error("No users found");
   }
   const modifiedUserInfo = res.body.userInfo.map((ui) => {

--- a/src/mcp/tools/auth/set_claims.ts
+++ b/src/mcp/tools/auth/set_claims.ts
@@ -7,19 +7,20 @@ export const set_claim = tool(
   {
     name: "set_claims",
     description:
-      "Sets custom claims on a specific user's account. Use to create trusted values associated with a user e.g. marking them as an admin. Claims are limited in size and should be succinct in name and value.",
+      "Sets custom claims on a specific user's account. Use to create trusted values associated with a user e.g. marking them as an admin. Claims are limited in size and should be succinct in name and value. Specify ONLY ONE OF `value` or `json_value` parameters.",
     inputSchema: z.object({
       uid: z.string().describe("the UID of the user to update"),
       claim: z.string().describe("the name (key) of the claim to update, e.g. 'admin'"),
       value: z
-        .union([
-          z.string(),
-          z.number(),
-          z.boolean(),
-          z.record(z.union([z.string(), z.number(), z.boolean()])),
-          z.array(z.union([z.string(), z.number(), z.boolean()])),
-        ])
-        .describe("the value of the custom claim"),
+        .union([z.string(), z.number(), z.boolean()])
+        .describe("set the value of the custom claim to the specified simple scalar value")
+        .optional(),
+      json_value: z
+        .string()
+        .optional()
+        .describe(
+          "set the claim to a complex JSON value like an object or an array. string must be parseable as valid JSON",
+        ),
     }),
     annotations: {
       title: "Set custom Firebase Auth claim",

--- a/src/mcp/tools/dataconnect/converter.ts
+++ b/src/mcp/tools/dataconnect/converter.ts
@@ -56,3 +56,13 @@ export function graphqlResponseToToolResponse(
     return mcpError(JSON.stringify(g, null, 2));
   }
 }
+
+export function parseVariables(unparsedVariables?: string): Record<string, any> {
+  try {
+    const variables = JSON.parse(unparsedVariables || "{}");
+    if (typeof variables !== "object") throw new Error("not an object");
+    return variables;
+  } catch (e) {
+    throw new Error("Provided variables string `" + unparsedVariables + "` is not valid JSON.");
+  }
+}

--- a/src/mcp/tools/dataconnect/execute_graphql_read.ts
+++ b/src/mcp/tools/dataconnect/execute_graphql_read.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import { tool } from "../../tool.js";
 import * as client from "../../../dataconnect/dataplaneClient.js";
 import { pickService } from "../../../dataconnect/fileUtils.js";
-import { graphqlResponseToToolResponse } from "./converter.js";
+import { graphqlResponseToToolResponse, parseVariables } from "./converter.js";
 
 export const execute_graphql_read = tool(
   {
@@ -17,7 +17,12 @@ export const execute_graphql_read = tool(
         .describe(
           "The Firebase Data Connect service ID to look for. If there is only one service defined in firebase.json, this can be omitted and that will be used.",
         ),
-      variables: z.record(z.string()).optional().describe("Variables for this operation."),
+      variables: z
+        .string()
+        .optional()
+        .describe(
+          "A stringified JSON object containing variables for the operation. MUST be valid JSON.",
+        ),
     }),
     annotations: {
       title: "Executes a arbitrary GraphQL query against a Data Connect service",
@@ -28,12 +33,12 @@ export const execute_graphql_read = tool(
       requiresAuth: true,
     },
   },
-  async ({ query, serviceId, variables }, { projectId, config }) => {
+  async ({ query, serviceId, variables: unparsedVariables }, { projectId, config }) => {
     const serviceInfo = await pickService(projectId!, config!, serviceId || undefined);
     const response = await client.executeGraphQLRead(
       client.dataconnectDataplaneClient(),
       serviceInfo.serviceName,
-      { name: "", query, variables },
+      { name: "", query, variables: parseVariables(unparsedVariables) },
     );
     return graphqlResponseToToolResponse(response.body);
   },

--- a/src/mcp/tools/dataconnect/execute_mutation.ts
+++ b/src/mcp/tools/dataconnect/execute_mutation.ts
@@ -4,7 +4,7 @@ import { tool } from "../../tool.js";
 import { mcpError } from "../../util.js";
 import * as client from "../../../dataconnect/dataplaneClient.js";
 import { pickService } from "../../../dataconnect/fileUtils.js";
-import { graphqlResponseToToolResponse } from "./converter.js";
+import { graphqlResponseToToolResponse, parseVariables } from "./converter.js";
 
 export const execute_mutation = tool(
   {
@@ -25,10 +25,10 @@ export const execute_mutation = tool(
           "The Firebase Data Connect connector ID to look for. If there is only one connector defined in dataconnect.yaml, this can be omitted and that will be used.",
         ),
       variables: z
-        .record(z.string())
+        .string()
         .optional()
         .describe(
-          "Variables for this operation. Use dataconnect_get_connector to find the expected variables for this query",
+          "A stringified JSON object containing the variables needed to execute the operation. The value MUST be able to be parsed as a JSON object.",
         ),
     }),
     annotations: {
@@ -40,7 +40,10 @@ export const execute_mutation = tool(
       requiresAuth: true,
     },
   },
-  async ({ operationName, serviceId, connectorId, variables }, { projectId, config }) => {
+  async (
+    { operationName, serviceId, connectorId, variables: unparsedVariables },
+    { projectId, config },
+  ) => {
     const serviceInfo = await pickService(projectId!, config!, serviceId || undefined);
     if (!connectorId) {
       if (serviceInfo.connectorInfo.length === 0) {
@@ -57,7 +60,7 @@ export const execute_mutation = tool(
     const response = await client.executeGraphQLMutation(
       client.dataconnectDataplaneClient(),
       connectorPath,
-      { operationName, variables },
+      { operationName, variables: parseVariables(unparsedVariables) },
     );
     return graphqlResponseToToolResponse(response.body);
   },


### PR DESCRIPTION
Gemini is currently not able to handle arbitrary key/value dictionaries, so I had to change some of the schemas around.
