### PR TITLE
[MCP] Exposing RemoteConfig  `get_template` operation as MCP tool

### DIFF
--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -7,6 +7,7 @@ import { directoryTools } from "./directory/index.js";
 import { coreTools } from "./core/index.js";
 import { storageTools } from "./storage/index.js";
 import { messagingTools } from "./messaging/index.js";
+import { remoteConfigTools } from "./remoteconfig/index.js";
 
 /** availableTools returns the list of MCP tools available given the server flags */
 export function availableTools(fixedRoot: boolean, activeFeatures?: ServerFeature[]): ServerTool[] {
@@ -31,6 +32,7 @@ const tools: Record<ServerFeature, ServerTool[]> = {
   dataconnect: addPrefixToToolName("dataconnect_", dataconnectTools),
   storage: addPrefixToToolName("storage_", storageTools),
   messaging: addPrefixToToolName("messaging_", messagingTools),
+  remoteconfig: addPrefixToToolName("remoteconfig_", remoteConfigTools),
 };
 
 function addPrefixToToolName(prefix: string, tools: ServerTool[]): ServerTool[] {

--- a/src/mcp/tools/remoteconfig/get_template.ts
+++ b/src/mcp/tools/remoteconfig/get_template.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { tool } from "../../tool.js";
+import { mcpError, toContent } from "../../util.js";
+import { getTemplate } from "../../../remoteconfig/get.js";
+
+export const get_rc_template = tool(
+  {
+    name: "get_template",
+    description: "Retrieves a remote config template for the project",
+    inputSchema: z.object({
+      versionNumber: z.string().optional(),
+    }),
+    annotations: {
+      title: "Get remote config template",
+      readOnlyHint: true,
+    },
+    _meta: {
+      requiresAuth: true,
+      requiresProject: true,
+    },
+  },
+  async ({ versionNumber }, { projectId }) => {
+    if (projectId === undefined) {
+      return mcpError(`No projectId specified in the get_template tool`);
+    }
+    return toContent(await getTemplate(projectId!, versionNumber));
+  },
+);

--- a/src/mcp/tools/remoteconfig/get_template.ts
+++ b/src/mcp/tools/remoteconfig/get_template.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { tool } from "../../tool.js";
-import { mcpError, toContent } from "../../util.js";
+import { toContent } from "../../util.js";
 import { getTemplate } from "../../../remoteconfig/get.js";
 
 export const get_rc_template = tool(
@@ -20,9 +20,6 @@ export const get_rc_template = tool(
     },
   },
   async ({ versionNumber }, { projectId }) => {
-    if (projectId === undefined) {
-      return mcpError(`No projectId specified in the get_template tool`);
-    }
     return toContent(await getTemplate(projectId!, versionNumber));
   },
 );

--- a/src/mcp/tools/remoteconfig/index.ts
+++ b/src/mcp/tools/remoteconfig/index.ts
@@ -1,0 +1,4 @@
+import { ServerTool } from "../../tool.js";
+import { get_rc_template } from "./get_template.js";
+
+export const remoteConfigTools: ServerTool[] = [get_rc_template];

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -4,5 +4,6 @@ export const SERVER_FEATURES = [
   "dataconnect",
   "auth",
   "messaging",
+  "remoteconfig",
 ] as const;
 export type ServerFeature = (typeof SERVER_FEATURES)[number];

--- a/src/mcp/util.ts
+++ b/src/mcp/util.ts
@@ -8,6 +8,7 @@ import {
   dataconnectOrigin,
   firestoreOrigin,
   messagingApiOrigin,
+  remoteConfigApiOrigin,
   storageOrigin,
 } from "../api";
 import { check } from "../ensureApiEnabled";
@@ -69,6 +70,7 @@ const SERVER_FEATURE_APIS: Record<ServerFeature, string> = {
   dataconnect: dataconnectOrigin(),
   auth: authManagementOrigin(),
   messaging: messagingApiOrigin(),
+  remoteconfig: remoteConfigApiOrigin(),
 };
 /**
  * Detects whether an MCP feature is active in the current project root. Relies first on


### PR DESCRIPTION
Created a new MCP tool for remote config to get the template

- Added MCP tool `get_template` to get the remote config template. User can also pass versionNumber to get a specific version of the template.
