### PR TITLE
Always pass in credentials to FDC emulator

### DIFF
--- a/src/emulator/dataconnectEmulator.ts
+++ b/src/emulator/dataconnectEmulator.ts
@@ -29,8 +29,8 @@ import { PostgresServer, TRUNCATE_TABLES_SQL } from "./dataconnect/pgliteServer"
 import { cleanShutdown } from "./controller";
 import { connectableHostname } from "../utils";
 import { Account } from "../types/auth";
-import { getCredentialsEnvironment } from "./env";
 import { ensure } from "../ensureApiEnabled";
+import { getCredentialPathAsync } from "../defaultCredentials";
 
 export interface DataConnectEmulatorArgs {
   projectId: string;
@@ -358,12 +358,15 @@ export class DataConnectEmulator implements EmulatorInstance {
     account?: Account,
     extraEnv: Record<string, string> = {},
   ): Promise<NodeJS.ProcessEnv> {
-    const credsEnv = await getCredentialsEnvironment(
-      account,
-      EmulatorLogger.forEmulator(Emulators.DATACONNECT),
-      "dataconnect",
-      true,
-    );
+    const credsEnv: Record<string, string> = {};
+    if (account) {
+      // If Firebase CLI is logged in, always pass in the credentials to FDC emulator.
+      const defaultCredPath = await getCredentialPathAsync(account);
+      if (defaultCredPath) {
+        logger.log("DEBUG", `Setting GAC to ${defaultCredPath}`);
+        credsEnv.GOOGLE_APPLICATION_CREDENTIALS = defaultCredPath;
+      }
+    }
     return { ...process.env, ...extraEnv, ...credsEnv };
   }
 }

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -70,7 +70,14 @@ export async function getCredentialsEnvironment(
 ): Promise<Record<string, string>> {
   // Provide default application credentials when appropriate
   const credentialEnv: Record<string, string> = {};
-  if (account) {
+  if (await hasDefaultCredentials()) {
+    !silent &&
+      logger.logLabeled(
+        "WARN",
+        logLabel,
+        `Application Default Credentials detected. Non-emulated services will access production using these credentials. Be careful!`,
+      );
+  } else if (account) {
     const defaultCredPath = await getCredentialPathAsync(account);
     if (defaultCredPath) {
       logger.log("DEBUG", `Setting GAC to ${defaultCredPath}`);

--- a/src/emulator/env.ts
+++ b/src/emulator/env.ts
@@ -70,14 +70,7 @@ export async function getCredentialsEnvironment(
 ): Promise<Record<string, string>> {
   // Provide default application credentials when appropriate
   const credentialEnv: Record<string, string> = {};
-  if (await hasDefaultCredentials()) {
-    !silent &&
-      logger.logLabeled(
-        "WARN",
-        logLabel,
-        `Application Default Credentials detected. Non-emulated services will access production using these credentials. Be careful!`,
-      );
-  } else if (account) {
+  if (account) {
     const defaultCredPath = await getCredentialPathAsync(account);
     if (defaultCredPath) {
       logger.log("DEBUG", `Setting GAC to ${defaultCredPath}`);


### PR DESCRIPTION
I ran into a bug when gcloud application default credentials expired, but `firebase login` isn't supplied into the FDC emulator.

`firebase deploy` fails with permission issues from the emulator.
