### PR TITLE
Add support for Node 24

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -48,6 +48,7 @@ jobs:
         node-version:
           - "20"
           - "22"
+          - "24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -132,6 +133,7 @@ jobs:
         node-version:
           - "20"
           - "22"
+          - "24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -280,7 +282,6 @@ jobs:
       matrix:
         node-version:
           - "20"
-          - "22"
 
     steps:
       - uses: actions/checkout@v4
@@ -300,7 +301,6 @@ jobs:
       matrix:
         node-version:
           - "20"
-          - "22"
 
     steps:
       - uses: actions/checkout@v4
@@ -320,7 +320,6 @@ jobs:
       matrix:
         node-version:
           - "20"
-          - "22"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-- Changed artifact registry cleanup policy error to warn for CI/CD workloads #8513
+- Added Node 24 support.
+- Changed artifact registry cleanup policy error to warn for CI/CD workloads (#8513)
 - Enhance firebase init apphosting to support local source deploys. (#8479)
 - Fixed issue where `firebase init hosting:github` didn't correctly parse the repo input. (#8536)
 - Add GCP API client functions to support App Hosting deploy from source feature. (#8545)

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   ],
   "preferGlobal": true,
   "engines": {
-    "node": ">=20.0.0 || >=22.0.0"
+    "node": ">=20.0.0 || >=22.0.0 || >=24.0.0"
   },
   "author": "Firebase (https://firebase.google.com/)",
   "license": "MIT",


### PR DESCRIPTION
### Description
Adds Node 24 to our engines field and CI.

TODO: Merge https://github.com/firebase/superstatic/pull/493, release superstatic, update package.json to use new version of superstatic
