### PR TITLE
[MCP] Exposing Remote Config Publish and Rollback template operations as MCP tools

### DIFF
--- a/src/mcp/tools/remoteconfig/index.ts
+++ b/src/mcp/tools/remoteconfig/index.ts
@@ -1,4 +1,10 @@
 import { ServerTool } from "../../tool.js";
 import { get_rc_template } from "./get_template.js";
+import { rollback_rc_template } from "./rollback_template.js";
+import { publish_rc_template } from "./publish_template.js";
 
-export const remoteConfigTools: ServerTool[] = [get_rc_template];
+export const remoteConfigTools: ServerTool[] = [
+  get_rc_template,
+  publish_rc_template,
+  rollback_rc_template,
+];

--- a/src/mcp/tools/remoteconfig/publish_template.ts
+++ b/src/mcp/tools/remoteconfig/publish_template.ts
@@ -1,0 +1,35 @@
+import { z } from "zod";
+import { tool } from "../../tool.js";
+import { mcpError, toContent } from "../../util.js";
+import { publishTemplate } from "../../../remoteconfig/publish.js";
+import { RemoteConfigTemplate } from "../../../remoteconfig/interfaces.js";
+
+export const publish_rc_template = tool(
+  {
+    name: "publish_template",
+    description: "Publishes a new remote config template for the project",
+    inputSchema: z.object({
+      template: z.object({}),
+      force: z.boolean().optional(),
+    }),
+    annotations: {
+      title: "Publish remote config template",
+      readOnlyHint: false,
+    },
+    _meta: {
+      requiresAuth: true,
+      requiresProject: true,
+    },
+  },
+  async ({ template, force }, { projectId }) => {
+    if (template === undefined) {
+      return mcpError(`No template specified in the publish requests`);
+    }
+    if (force === undefined) {
+      return toContent(await publishTemplate(projectId!, template as RemoteConfigTemplate));
+    }
+    return toContent(
+      await publishTemplate(projectId!, template as RemoteConfigTemplate, { force }),
+    );
+  },
+);

--- a/src/mcp/tools/remoteconfig/rollback_template.ts
+++ b/src/mcp/tools/remoteconfig/rollback_template.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+import { tool } from "../../tool.js";
+import { mcpError, toContent } from "../../util.js";
+import { rollbackTemplate } from "../../../remoteconfig/rollback.js";
+
+export const rollback_rc_template = tool(
+  {
+    name: "rollback_template",
+    description: "Rollback to a specific version of Remote Config template for a project",
+    inputSchema: z.object({
+      versionNumber: z.number().optional(),
+    }),
+    annotations: {
+      title: "Rollback remote config template",
+      readOnlyHint: false,
+    },
+    _meta: {
+      requiresAuth: true,
+      requiresProject: true,
+    },
+  },
+  async ({ versionNumber }, { projectId }) => {
+    if (versionNumber === undefined) {
+      return mcpError(`No version number specified in the rollback requests`);
+    }
+    return toContent(await rollbackTemplate(projectId!, versionNumber!));
+  },
+);

--- a/src/remoteconfig/publish.ts
+++ b/src/remoteconfig/publish.ts
@@ -1,0 +1,58 @@
+import { remoteConfigApiOrigin } from "../api";
+import { Client } from "../apiv2";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import { RemoteConfigTemplate } from "./interfaces";
+
+const TIMEOUT = 30000;
+
+const apiClient = new Client({
+  urlPrefix: remoteConfigApiOrigin(),
+  apiVersion: "v1",
+});
+
+/**
+ * Function to publish a new remote config template for a project
+ * This is added to support publish operation for RC MCP tooling
+ * @param projectId Input is the project ID string
+ * @param template The new template to be published
+ * @param options Takes in parameter `force` to force update the template
+ * @return {Promise} Returns a promise of a RemoteConfigTemplate
+ */
+export async function publishTemplate(
+  projectId: string,
+  template: RemoteConfigTemplate,
+  options?: { force: boolean },
+): Promise<RemoteConfigTemplate> {
+  try {
+    let ifMatch = template.etag;
+    if (options && options.force === true) {
+      // setting `If-Match = "*"` forces the Remote Config template to be updated
+      // and circumvent the ETag
+      ifMatch = "*";
+    }
+
+    const requestBody = {
+      conditions: template.conditions,
+      parameters: template.parameters,
+      parameterGroups: template.parameterGroups,
+      version: template.version,
+    };
+
+    const res = await apiClient.request<null, RemoteConfigTemplate>({
+      method: "PUT",
+      path: `/projects/${projectId}/remoteConfig`,
+      timeout: TIMEOUT,
+      headers: { "If-Match": ifMatch },
+      body: JSON.stringify(requestBody),
+    });
+
+    return res.body;
+  } catch (err: any) {
+    logger.debug(err.message);
+    throw new FirebaseError(
+      `Failed to publish Firebase Remote Config template for project ${projectId}. `,
+      { original: err },
+    );
+  }
+}


### PR DESCRIPTION
Added two new tool for firebase MCP server
- `publish_template` to publish a new remote config template
- `rollback_template` to rollback a remote config template to a specific version


