### PR TITLE
Fix FCM send request construction

### DIFF
--- a/src/messaging/sendMessage.ts
+++ b/src/messaging/sendMessage.ts
@@ -2,7 +2,7 @@ import { messagingApiOrigin } from "../api";
 import { Client } from "../apiv2";
 import { logger } from "../logger";
 import { FirebaseError } from "../error";
-import { Message, Notification, TopicMessage } from "./interfaces";
+import { Message, Notification } from "./interfaces";
 
 const TIMEOUT = 10000;
 
@@ -14,9 +14,7 @@ const apiClient = new Client({
 /**
  * Function to send a message to an FCM Token.
  * @param projectId Project ID to which this token belongs to.
- * @param fcmToken The FCM Token to send to.
- * @param title The title of the message.
- * @param options The body of the message.
+ * @param options Parameters including message body and target.
  * @return {Promise} Returns a promise fulfilled with a unique message ID string
  * after the message has been successfully handed off to the FCM service for delivery.
  */
@@ -39,11 +37,15 @@ export async function sendFcmMessage(
     if (!options.token && !options.topic) {
       throw new FirebaseError("Must supply either token or topic to send FCM message.");
     }
-    const message: Message = {
-      token: options.token!,
-      topic: options.topic!,
-      notification: notification,
-    };
+    const message: Message = options.token
+      ? {
+          token: options.token!,
+          notification: notification,
+        }
+      : {
+          topic: options.topic!,
+          notification: notification,
+        };
     const messageData = {
       message: message,
     };
@@ -60,47 +62,5 @@ export async function sendFcmMessage(
       `Failed to send message to '${options.token || options.topic}' for the project '${projectId}'. `,
       { original: err },
     );
-  }
-}
-
-/**
- * Function to send a message to an FCM topic. This will initiate a message fanout to the topic members.
- * @param projectId Project ID to which this token belongs to.
- * @param fcmToken The FCM Token to send to.
- * @param title The title of the message.
- * @param body The body of the message.
- * @return {Promise} Returns a promise fulfilled with a unique message ID string
- * after the message has been successfully handed off to the FCM service for delivery.
- */
-export async function sendMessageToFcmTopic(
-  projectId: string,
-  topic: string,
-  title?: string,
-  body?: string,
-): Promise<string> {
-  try {
-    const notification: Notification = {
-      title: title,
-      body: body,
-    };
-    const message: TopicMessage = {
-      topic: topic,
-      notification: notification,
-    };
-    const messageData = {
-      message: message,
-    };
-    const res = await apiClient.request<null, string>({
-      method: "POST",
-      path: `/projects/${projectId}/messages:send`,
-      body: JSON.stringify(messageData),
-      timeout: TIMEOUT,
-    });
-    return res.body;
-  } catch (err: any) {
-    logger.debug(err.message);
-    throw new FirebaseError(`Failed to send message for the project ${projectId}. `, {
-      original: err,
-    });
   }
 }


### PR DESCRIPTION
The existing construction would put the `token` and `topic` property on the request. This triggers a likely bug on FCM service which complaints when both the both the property are present - even if one of them has empty value.