### PR TITLE
chore(mcp): Refactor client directory config logic.

### DIFF
--- a/src/bin/mcp.ts
+++ b/src/bin/mcp.ts
@@ -5,6 +5,7 @@ import { FirebaseMcpServer } from "../mcp/index";
 import { parseArgs } from "util";
 import { SERVER_FEATURES, ServerFeature } from "../mcp/types";
 import { markdownDocsOfTools } from "../mcp/tools/index.js";
+import { resolve } from "path";
 
 const STARTUP_MESSAGE = `
 This is a running process of the Firebase MCP server. This command should only be executed by an MCP client. An example MCP client configuration might be:
@@ -36,7 +37,10 @@ export async function mcp(): Promise<void> {
   const activeFeatures = (values.only || "")
     .split(",")
     .filter((f) => SERVER_FEATURES.includes(f as ServerFeature)) as ServerFeature[];
-  const server = new FirebaseMcpServer({ activeFeatures, projectRoot: values.dir });
+  const server = new FirebaseMcpServer({
+    activeFeatures,
+    projectRoot: values.dir ? resolve(values.dir) : undefined,
+  });
   await server.start();
   if (process.stdin.isTTY) process.stderr.write(STARTUP_MESSAGE);
 }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -73,7 +73,7 @@ export class FirebaseMcpServer {
   }
 
   private get clientConfigKey() {
-    return `mcp.clientConfigs.${this.clientInfo?.name || "<unknown-client>"}`;
+    return `mcp.clientConfigs.${this.clientInfo?.name || "<unknown-client>"}${this.optionsRoot ? `:${this.optionsRoot}` : ""}`;
   }
 
   getStoredClientConfig(): ClientConfig {
@@ -91,10 +91,6 @@ export class FirebaseMcpServer {
     await this.ready();
     if (this.cachedProjectRoot) return this.cachedProjectRoot;
     const storedRoot = this.getStoredClientConfig().projectRoot;
-    if (storedRoot) {
-      this.cachedProjectRoot = storedRoot;
-      return storedRoot;
-    }
     this.cachedProjectRoot =
       storedRoot || this.optionsRoot || process.env.PROJECT_ROOT || process.cwd();
     return this.cachedProjectRoot;

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -8,7 +8,7 @@ import {
   ListToolsResult,
 } from "@modelcontextprotocol/sdk/types.js";
 import { checkFeatureActive, mcpError } from "./util.js";
-import { SERVER_FEATURES, ServerFeature } from "./types.js";
+import { ClientConfig, SERVER_FEATURES, ServerFeature } from "./types.js";
 import { availableTools } from "./tools/index.js";
 import { ServerTool, ServerToolContext } from "./tool.js";
 import { configstore } from "../configstore.js";
@@ -23,12 +23,14 @@ import { loadRC } from "../rc.js";
 import { EmulatorHubClient } from "../emulator/hubClient.js";
 
 const SERVER_VERSION = "0.0.1";
-const PROJECT_ROOT_KEY = "mcp.projectRoot";
 
 const cmd = new Command("experimental:mcp").before(requireAuth);
 
 export class FirebaseMcpServer {
-  projectRoot?: string;
+  private _ready: boolean = false;
+  private _readyPromises: { resolve: () => void; reject: (err: unknown) => void }[] = [];
+  optionsRoot?: string;
+  cachedProjectRoot?: string;
   server: Server;
   activeFeatures?: ServerFeature[];
   detectedFeatures?: ServerFeature[];
@@ -37,11 +39,12 @@ export class FirebaseMcpServer {
 
   constructor(options: { activeFeatures?: ServerFeature[]; projectRoot?: string }) {
     this.activeFeatures = options.activeFeatures;
+    this.optionsRoot = options.projectRoot;
     this.server = new Server({ name: "firebase", version: SERVER_VERSION });
     this.server.registerCapabilities({ tools: { listChanged: true } });
     this.server.setRequestHandler(ListToolsRequestSchema, this.mcpListTools.bind(this));
     this.server.setRequestHandler(CallToolRequestSchema, this.mcpCallTool.bind(this));
-    this.server.oninitialized = () => {
+    this.server.oninitialized = async () => {
       const clientInfo = this.server.getClientVersion();
       this.clientInfo = clientInfo;
       if (clientInfo?.name) {
@@ -50,13 +53,51 @@ export class FirebaseMcpServer {
           mcp_client_version: clientInfo.version,
         });
       }
+      if (!this.clientInfo?.name) this.clientInfo = { name: "<unknown-client>" };
+
+      this._ready = true;
+      while (this._readyPromises.length) {
+        this._readyPromises.pop()?.resolve();
+      }
     };
-    this.projectRoot =
-      options.projectRoot ??
-      (configstore.get(PROJECT_ROOT_KEY) as string) ??
-      process.env.PROJECT_ROOT ??
-      process.cwd();
+    this.detectProjectRoot();
     this.detectActiveFeatures();
+  }
+
+  /** Wait until initialization has finished. */
+  ready() {
+    if (this._ready) return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      this._readyPromises.push({ resolve: resolve as () => void, reject });
+    });
+  }
+
+  private get clientConfigKey() {
+    return `mcp.clientConfigs.${this.clientInfo?.name || "<unknown-client>"}`;
+  }
+
+  getStoredClientConfig(): ClientConfig {
+    return configstore.get(this.clientConfigKey) || {};
+  }
+
+  updateStoredClientConfig(update: Partial<ClientConfig>) {
+    const config = configstore.get(this.clientConfigKey) || {};
+    const newConfig = { ...config, ...update };
+    configstore.set(this.clientConfigKey, newConfig);
+    return newConfig;
+  }
+
+  async detectProjectRoot(): Promise<string> {
+    await this.ready();
+    if (this.cachedProjectRoot) return this.cachedProjectRoot;
+    const storedRoot = this.getStoredClientConfig().projectRoot;
+    if (storedRoot) {
+      this.cachedProjectRoot = storedRoot;
+      return storedRoot;
+    }
+    this.cachedProjectRoot =
+      storedRoot || this.optionsRoot || process.env.PROJECT_ROOT || process.cwd();
+    return this.cachedProjectRoot;
   }
 
   async detectActiveFeatures(): Promise<ServerFeature[]> {
@@ -97,21 +138,14 @@ export class FirebaseMcpServer {
   }
 
   setProjectRoot(newRoot: string | null): void {
-    if (newRoot === null) {
-      configstore.delete(PROJECT_ROOT_KEY);
-      this.projectRoot = process.env.PROJECT_ROOT || process.cwd();
-      void this.server.sendToolListChanged();
-      return;
-    }
-
-    configstore.set(PROJECT_ROOT_KEY, newRoot);
-    this.projectRoot = newRoot;
+    this.updateStoredClientConfig({ projectRoot: newRoot });
+    this.cachedProjectRoot = newRoot || undefined;
     this.detectedFeatures = undefined; // reset detected features
     void this.server.sendToolListChanged();
   }
 
   async resolveOptions(): Promise<Partial<Options>> {
-    const options: Partial<Options> = { cwd: this.projectRoot };
+    const options: Partial<Options> = { cwd: this.cachedProjectRoot };
     await cmd.prepare(options);
     return options;
   }
@@ -129,7 +163,7 @@ export class FirebaseMcpServer {
   }
 
   async mcpListTools(): Promise<ListToolsResult> {
-    if (!this.activeFeatures) await this.detectActiveFeatures();
+    await Promise.all([this.detectActiveFeatures(), this.detectProjectRoot()]);
     const hasActiveProject = !!(await this.getProjectId());
     await trackGA4("mcp_list_tools", {
       mcp_client_name: this.clientInfo?.name,
@@ -138,7 +172,7 @@ export class FirebaseMcpServer {
     return {
       tools: this.availableTools.map((t) => t.mcp),
       _meta: {
-        projectRoot: this.projectRoot,
+        projectRoot: this.cachedProjectRoot,
         projectDetected: hasActiveProject,
         authenticatedUser: await this.getAuthenticatedUser(),
         activeFeatures: this.activeFeatures,
@@ -148,6 +182,7 @@ export class FirebaseMcpServer {
   }
 
   async mcpCallTool(request: CallToolRequest): Promise<CallToolResult> {
+    await this.detectProjectRoot();
     const toolName = request.params.name;
     const toolArgs = request.params.arguments;
     const tool = this.getTool(toolName);
@@ -158,7 +193,7 @@ export class FirebaseMcpServer {
     if (tool.mcp._meta?.requiresAuth && !accountEmail) return mcpAuthError();
     if (tool.mcp._meta?.requiresProject && !projectId) return NO_PROJECT_ERROR;
 
-    const options = { projectDir: this.projectRoot, cwd: this.projectRoot };
+    const options = { projectDir: this.cachedProjectRoot, cwd: this.cachedProjectRoot };
     const toolsCtx: ServerToolContext = {
       projectId: projectId,
       host: this,

--- a/src/mcp/tools/core/get_environment.ts
+++ b/src/mcp/tools/core/get_environment.ts
@@ -24,8 +24,8 @@ export const get_environment = tool(
     const aliases = projectId ? getAliases({ rc }, projectId) : [];
     return toContent(`# Environment Information
 
-Project Directory: ${host.projectRoot}}
-Project Config Path: ${config.path("firebase.json")}
+Project Directory: ${host.cachedProjectRoot}
+Project Config Path: ${config.projectFileExists("firebase.json") ? config.path("firebase.json") : "<NO CONFIG PRESENT>"}
 Active Project ID: ${
       projectId ? `${projectId}${aliases.length ? ` (alias: ${aliases.join(",")})` : ""}` : "<NONE>"
     }
@@ -38,11 +38,20 @@ ${dump(rc.projects).trim()}
 # Available Accounts:
 
 ${dump(getAllAccounts().map((account) => account.user.email)).trim()}
-
+${
+  config.projectFileExists("firebase.json")
+    ? `
 # firebase.json contents:
 
 \`\`\`json
 ${config.readProjectFile("firebase.json")}
-\`\`\``);
+\`\`\``
+    : `\n# Empty Environment
+
+It looks like the current directory is not initialized as a Firebase project. The user will most likely want to:
+
+a) Change the project directory using the 'firebase_update_environment' tool to select a directory with a 'firebase.json' file in it, or
+b) Initialize a new Firebase project directory using the 'firebase_init' tool.`
+}`);
   },
 );

--- a/src/mcp/tools/core/update_environment.ts
+++ b/src/mcp/tools/core/update_environment.ts
@@ -34,8 +34,8 @@ export const update_environment = tool(
       readOnlyHint: true,
     },
     _meta: {
-      requiresAuth: true,
-      requiresProject: true,
+      requiresAuth: false,
+      requiresProject: false,
     },
   },
   async ({ project_dir, active_project, active_user_account }, { config, rc, host }) => {
@@ -50,7 +50,7 @@ export const update_environment = tool(
     }
     if (active_user_account) {
       assertAccount(active_user_account, { mcp: true });
-      setProjectAccount(host.projectRoot!, active_user_account);
+      setProjectAccount(host.cachedProjectRoot!, active_user_account);
       output += `- Updated active account to '${active_user_account}'\n`;
     }
 

--- a/src/mcp/tools/rules/validate_rules.ts
+++ b/src/mcp/tools/rules/validate_rules.ts
@@ -105,7 +105,7 @@ export function validateRulesTool(productName: string) {
       let rulesSourceContent: string;
       if (source_file) {
         try {
-          const filePath = resolve(source_file, host.projectRoot!);
+          const filePath = resolve(source_file, host.cachedProjectRoot!);
           if (filePath.includes("../"))
             return mcpError("Cannot read files outside of the project directory.");
           rulesSourceContent = config.readProjectFile(source_file);

--- a/src/mcp/tools/storage/get_download_url.ts
+++ b/src/mcp/tools/storage/get_download_url.ts
@@ -14,7 +14,7 @@ export const get_object_download_url = tool(
         .describe("The path to the object in Firebase storage without the bucket name attached"),
     }),
     annotations: {
-      title: "Get the download url for an obejct in Firebase Storage.",
+      title: "Get the download url for an object in Firebase Storage.",
       readOnlyHint: true,
     },
     _meta: {

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -7,3 +7,8 @@ export const SERVER_FEATURES = [
   "remoteconfig",
 ] as const;
 export type ServerFeature = (typeof SERVER_FEATURES)[number];
+
+export interface ClientConfig {
+  /** The current project root directory for this client. */
+  projectRoot?: string | null;
+}


### PR DESCRIPTION
This makes it so that project directory is stored on a per-client basis instead of globally, and also provides better instructions in `get_environment` for what happens if there is no active environment.