### PR TITLE
[MCP] Added function documentation to Remote Config tools to help MCP clients to identify tool usage accurately

### DIFF
--- a/src/mcp/tools/remoteconfig/get_template.ts
+++ b/src/mcp/tools/remoteconfig/get_template.ts
@@ -6,9 +6,14 @@ import { getTemplate } from "../../../remoteconfig/get.js";
 export const get_rc_template = tool(
   {
     name: "get_template",
-    description: "Retrieves a remote config template for the project",
+    description:
+      "Retrieves a remote config template for the project." +
+      "If 'version_number' is omitted, the latest version will be returned.",
     inputSchema: z.object({
-      version_number: z.string().optional(),
+      version_number: z
+        .number()
+        .optional()
+        .describe("Specifiy version number to fetch specific version of the template"),
     }),
     annotations: {
       title: "Get remote config template",
@@ -20,6 +25,6 @@ export const get_rc_template = tool(
     },
   },
   async ({ version_number }, { projectId }) => {
-    return toContent(await getTemplate(projectId!, version_number));
+    return toContent(await getTemplate(projectId!, version_number?.toString()));
   },
 );

--- a/src/mcp/tools/remoteconfig/publish_template.ts
+++ b/src/mcp/tools/remoteconfig/publish_template.ts
@@ -7,13 +7,16 @@ import { RemoteConfigTemplate } from "../../../remoteconfig/interfaces.js";
 export const publish_rc_template = tool(
   {
     name: "publish_template",
-    description: "Publishes a new remote config template for the project",
+    description:
+      "Publishes a new remote config template for the project." +
+      "Provide a 'version' in the template body to update a specific version." +
+      "Alternatively, set 'force' to true to update the most recent version.,",
     inputSchema: z.object({
-      template: z.object({}),
-      force: z.boolean().optional(),
+      template: z.object({}).describe("Remote Config template in JSON format"),
+      force: z.boolean().optional().describe("Set to true to update the latest template"),
     }),
     annotations: {
-      title: "Publish remote config template",
+      title: "Publish Remote Config template",
       readOnlyHint: false,
     },
     _meta: {
@@ -24,6 +27,9 @@ export const publish_rc_template = tool(
   async ({ template, force }, { projectId }) => {
     if (template === undefined) {
       return mcpError(`No template specified in the publish requests`);
+    }
+    if ((template as RemoteConfigTemplate).version === undefined) {
+      force = true;
     }
     if (force === undefined) {
       return toContent(await publishTemplate(projectId!, template as RemoteConfigTemplate));

--- a/src/mcp/tools/remoteconfig/rollback_template.ts
+++ b/src/mcp/tools/remoteconfig/rollback_template.ts
@@ -6,9 +6,9 @@ import { rollbackTemplate } from "../../../remoteconfig/rollback.js";
 export const rollback_rc_template = tool(
   {
     name: "rollback_template",
-    description: "Rollback to a specific version of Remote Config template for a project",
+    description: "Rolls back a previous version of the project's Remote Config template.",
     inputSchema: z.object({
-      version_number: z.number().optional(),
+      version_number: z.number().describe("Required version number to rollback to"),
     }),
     annotations: {
       title: "Rollback remote config template",


### PR DESCRIPTION
Added detailed description for remote config tools`get_template`, `publish_template` and `rollback_template` and described each input parameters and its usage for LLMs/MCP clients to easily interpret tool usage