### PR TITLE
escape the dollar sign for snipper insert

### DIFF
--- a/firebase-vscode/src/data-connect/file-utils.ts
+++ b/firebase-vscode/src/data-connect/file-utils.ts
@@ -69,7 +69,7 @@ export function insertToBottomOfActiveFile(text: string) {
     return;
   }
   const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
-  const escapedText = text.replaceAll(/\$/g, "\\\$"); // escape $ symbols
+  const escapedText = text.replace(/\$/g, "\\\$"); // escape $ symbols
 
   editor.insertSnippet(
     new vscode.SnippetString(`\n\n${escapedText}`),

--- a/firebase-vscode/src/data-connect/file-utils.ts
+++ b/firebase-vscode/src/data-connect/file-utils.ts
@@ -69,8 +69,10 @@ export function insertToBottomOfActiveFile(text: string) {
     return;
   }
   const lastLine = editor.document.lineAt(editor.document.lineCount - 1);
+  const escapedText = text.replaceAll(/\$/g, "\\\$"); // escape $ symbols
+
   editor.insertSnippet(
-    new vscode.SnippetString(`\n\n${text}`),
+    new vscode.SnippetString(`\n\n${escapedText}`),
     lastLine.range.end,
   );
 }


### PR DESCRIPTION
When inserting snippets, $ signs get treated as templates or variables. Need to escape them properly for inserting them literally.