### PR TITLE
Fix for starting FAH emulator when no NPM deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Address crash when starting the App Hosting emulator in certain applications (#8624)

--- a/src/emulator/apphosting/serve.ts
+++ b/src/emulator/apphosting/serve.ts
@@ -224,7 +224,7 @@ async function tripFirebasePostinstall(
     return;
   }
   const npmLsResults = JSON.parse(npmLs.stdout.toString().trim());
-  const dependenciesToSearch: Dependency[] = Object.values(npmLsResults.dependencies);
+  const dependenciesToSearch: Dependency[] = Object.values(npmLsResults.dependencies || {});
   const firebaseUtilPaths: string[] = [];
   for (const dependency of dependenciesToSearch) {
     if (


### PR DESCRIPTION
Fix #8620, we weren't handling null dependencies on the `npm ls @firebase/util --json --long`