### PR TITLE
MCP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/mcp.md
+++ b/.github/ISSUE_TEMPLATE/mcp.md
@@ -1,0 +1,26 @@
+---
+name: "🤖 MCP Server"
+about: Report bugs or request features for the Firebase MCP Server.
+title: "[MCP]"
+labels: "api: mcp"
+assignees: ""
+---
+
+<!-- DO NOT DELETE
+validate_template=true
+template_path=.github/ISSUE_TEMPLATE/mcp.md
+-->
+
+## Summary
+
+<!-- what is your bug / feature request / feedback? -->
+
+## Bug Info <!-- please fill this out if you have a bug -->
+
+- **Affected Tool(s):** <!-- Which specific tool(s) were you using when you encountered the issue? -->
+- **MCP Client:** <!-- e.g. "Cursor v0.50.0" -->
+- **Operating System:** <!-- e.g. "Windows 11" or "macOS Sequoia" -->
+
+### Steps to Reproduce
+
+<!-- write a detailed description of how to reproduce>


### PR DESCRIPTION
Adds an MCP Server issue template to better group feedback we get about it. Let's have this in the hopper and merge late today / early tomorrow.