### PR TITLE
Update function deploy to add necessary Genkit monitoring permissions when deploying Genkit function

### DIFF
--- a/src/deploy/functions/checkIam.spec.ts
+++ b/src/deploy/functions/checkIam.spec.ts
@@ -161,8 +161,8 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty()
-        )
+          backend.empty(),
+        ),
       ).to.not.be.rejected;
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -194,12 +194,12 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty()
-        )
+          backend.empty(),
+        ),
       ).to.be.rejectedWith(
         "We failed to modify the IAM policy for the project. The functions " +
           "deployment requires specific roles to be granted to service agents," +
-          " otherwise the deployment will fail."
+          " otherwise the deployment will fail.",
       );
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -256,7 +256,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.empty()
+        backend.empty(),
       );
 
       expect(storageStub).to.have.been.calledOnce;
@@ -312,7 +312,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(storageStub).to.have.been.calledOnce;
@@ -365,7 +365,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -401,7 +401,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -452,7 +452,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -488,7 +488,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -539,7 +539,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -575,7 +575,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -636,7 +636,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;

--- a/src/deploy/functions/checkIam.spec.ts
+++ b/src/deploy/functions/checkIam.spec.ts
@@ -133,7 +133,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.of(v1EventFn, v2CallableFn, wantFn)
+        backend.of(v1EventFn, v2CallableFn, wantFn),
       );
 
       expect(storageStub).to.not.have.been.called;
@@ -161,8 +161,8 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty()
-        )
+          backend.empty(),
+        ),
       ).to.not.be.rejected;
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -194,12 +194,12 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty()
-        )
+          backend.empty(),
+        ),
       ).to.be.rejectedWith(
         "We failed to modify the IAM policy for the project. The functions " +
           "deployment requires specific roles to be granted to service agents," +
-          " otherwise the deployment will fail."
+          " otherwise the deployment will fail.",
       );
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -256,7 +256,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.empty()
+        backend.empty(),
       );
 
       expect(storageStub).to.have.been.calledOnce;
@@ -312,7 +312,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(storageStub).to.have.been.calledOnce;
@@ -365,7 +365,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -401,7 +401,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -452,7 +452,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -488,7 +488,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -539,7 +539,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -575,7 +575,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn)
+      backend.of(haveFn),
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -636,7 +636,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty()
+      backend.empty(),
     );
 
     expect(getIamStub).to.have.been.calledOnce;

--- a/src/deploy/functions/checkIam.spec.ts
+++ b/src/deploy/functions/checkIam.spec.ts
@@ -133,7 +133,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.of(v1EventFn, v2CallableFn, wantFn),
+        backend.of(v1EventFn, v2CallableFn, wantFn)
       );
 
       expect(storageStub).to.not.have.been.called;
@@ -161,8 +161,8 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty(),
-        ),
+          backend.empty()
+        )
       ).to.not.be.rejected;
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -194,12 +194,12 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty(),
-        ),
+          backend.empty()
+        )
       ).to.be.rejectedWith(
         "We failed to modify the IAM policy for the project. The functions " +
           "deployment requires specific roles to be granted to service agents," +
-          " otherwise the deployment will fail.",
+          " otherwise the deployment will fail."
       );
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -256,7 +256,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.empty(),
+        backend.empty()
       );
 
       expect(storageStub).to.have.been.calledOnce;
@@ -312,7 +312,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(storageStub).to.have.been.calledOnce;
@@ -365,7 +365,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -401,7 +401,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -452,7 +452,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -488,7 +488,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -539,7 +539,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -575,14 +575,14 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(getIamStub).to.not.have.been.called;
     expect(setIamStub).to.not.have.been.called;
   });
 
-  it.only("should add the default bindings for a new genkit v2 deployed function", async () => {
+  it("should add the default bindings for a new genkit v2 deployed function", async () => {
     const newIamPolicy = {
       etag: "etag",
       version: 3,
@@ -636,7 +636,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;

--- a/src/deploy/functions/checkIam.spec.ts
+++ b/src/deploy/functions/checkIam.spec.ts
@@ -161,8 +161,8 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty(),
-        ),
+          backend.empty()
+        )
       ).to.not.be.rejected;
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -194,12 +194,12 @@ describe("checkIam", () => {
           projectId,
           projectNumber,
           backend.of(wantFn),
-          backend.empty(),
-        ),
+          backend.empty()
+        )
       ).to.be.rejectedWith(
         "We failed to modify the IAM policy for the project. The functions " +
           "deployment requires specific roles to be granted to service agents," +
-          " otherwise the deployment will fail.",
+          " otherwise the deployment will fail."
       );
       expect(storageStub).to.have.been.calledOnce;
       expect(getIamStub).to.have.been.calledOnce;
@@ -256,7 +256,7 @@ describe("checkIam", () => {
         projectId,
         projectNumber,
         backend.of(wantFn),
-        backend.empty(),
+        backend.empty()
       );
 
       expect(storageStub).to.have.been.calledOnce;
@@ -312,7 +312,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(storageStub).to.have.been.calledOnce;
@@ -365,7 +365,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -401,7 +401,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -452,7 +452,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -488,7 +488,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -539,7 +539,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;
@@ -575,7 +575,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.of(haveFn),
+      backend.of(haveFn)
     );
 
     expect(getIamStub).to.not.have.been.called;
@@ -636,7 +636,7 @@ describe("checkIam", () => {
       projectId,
       projectNumber,
       backend.of(wantFn),
-      backend.empty(),
+      backend.empty()
     );
 
     expect(getIamStub).to.have.been.calledOnce;

--- a/src/deploy/functions/checkIam.spec.ts
+++ b/src/deploy/functions/checkIam.spec.ts
@@ -391,6 +391,7 @@ describe("checkIam", () => {
       expect(getIamStub).to.have.been.calledWith(projectNumber);
       expect(setIamStub).to.have.been.calledOnce;
     });
+
     it("should not update policy if it already has necessary bindings", async () => {
       const serviceAccount = `test-sa@${projectId}.iam.gserviceaccount.com`;
       const iamPolicy = {

--- a/src/deploy/functions/checkIam.spec.ts
+++ b/src/deploy/functions/checkIam.spec.ts
@@ -75,28 +75,6 @@ describe("checkIam", () => {
     });
   });
 
-  describe("obtainGenkitMonitoringServiceAgentBindings", () => {
-    it("should obtain the bindings", async () => {
-      const bindings = await checkIam.obtainGenkitMonitoringServiceAgentBindings(projectNumber);
-
-      expect(bindings.length).to.equal(3);
-      expect(bindings).to.include.deep.members([
-        {
-          role: "roles/monitoring.metricWriter",
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-        {
-          role: "roles/cloudtrace.agent",
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-        {
-          role: "roles/logging.logWriter",
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-      ]);
-    });
-  });
-
   describe("ensureServiceAgentRoles", () => {
     it("should return early if we do not have new services", async () => {
       const v1EventFn: backend.Endpoint = {
@@ -263,6 +241,363 @@ describe("checkIam", () => {
       expect(getIamStub).to.have.been.calledOnce;
       expect(setIamStub).to.have.been.calledOnce;
       expect(setIamStub).to.have.been.calledWith(projectNumber, newIamPolicy, "bindings");
+    });
+  });
+
+  describe("ensureGenkitMonitoringRoles", () => {
+    it("should return early if we do not have new endpoints", async () => {
+      const fn1: backend.Endpoint = {
+        id: "genkitFn1",
+        platform: "gcfv2",
+        entryPoint: "genkitFn1",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+      const fn2: backend.Endpoint = {
+        id: "genkitFn2",
+        platform: "gcfv2",
+        entryPoint: "genkitFn2",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+      const wantFn: backend.Endpoint = {
+        id: "wantGenkitFnFn",
+        entryPoint: "wantGenkitFn",
+        platform: "gcfv2",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+
+      await checkIam.ensureGenkitMonitoringRoles(
+        projectId,
+        projectNumber,
+        backend.of(wantFn),
+        backend.of(fn1, fn2, wantFn),
+      );
+
+      expect(getIamStub).to.not.have.been.called;
+      expect(setIamStub).to.not.have.been.called;
+    });
+
+    it("should return early if none of the new endpoints are genkit", async () => {
+      const fn1: backend.Endpoint = {
+        id: "genkitFn1",
+        platform: "gcfv2",
+        entryPoint: "genkitFn1",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+      const fn2: backend.Endpoint = {
+        id: "genkitFn2",
+        platform: "gcfv2",
+        entryPoint: "genkitFn2",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+      const wantFn1: backend.Endpoint = {
+        id: "wantFn1",
+        entryPoint: "wantFn1",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.storage.object.v1.finalized",
+          eventFilters: { bucket: "my-bucket" },
+          retry: false,
+        },
+        ...SPEC,
+      };
+      const wantFn2: backend.Endpoint = {
+        id: "wantFn2",
+        entryPoint: "wantFn2",
+        platform: "gcfv2",
+        callableTrigger: {},
+        ...SPEC,
+      };
+
+      await checkIam.ensureGenkitMonitoringRoles(
+        projectId,
+        projectNumber,
+        backend.of(wantFn1, wantFn2),
+        backend.of(fn1, fn2),
+      );
+
+      expect(getIamStub).to.not.have.been.called;
+      expect(setIamStub).to.not.have.been.called;
+    });
+
+    it("should return early if we fail to get the IAM policy", async () => {
+      getIamStub.rejects("Failed to get the IAM policy");
+      const wantFn: backend.Endpoint = {
+        id: "genkitFn1",
+        platform: "gcfv2",
+        entryPoint: "wantFn",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+
+      await expect(
+        checkIam.ensureGenkitMonitoringRoles(
+          projectId,
+          projectNumber,
+          backend.of(wantFn),
+          backend.empty(),
+        ),
+      ).to.not.be.rejected;
+      expect(getIamStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledWith(projectNumber);
+      expect(setIamStub).to.not.have.been.called;
+    });
+
+    it("should error if we fail to set the IAM policy", async () => {
+      getIamStub.resolves({
+        etag: "etag",
+        version: 3,
+        bindings: [BINDING],
+      });
+      const wantFn: backend.Endpoint = {
+        id: "genkitFn1",
+        platform: "gcfv2",
+        entryPoint: "wantFn",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+
+      await expect(
+        checkIam.ensureGenkitMonitoringRoles(
+          projectId,
+          projectNumber,
+          backend.of(wantFn),
+          backend.empty(),
+        ),
+      ).to.be.rejectedWith(
+        "We failed to modify the IAM policy for the project. The functions " +
+          "deployment requires specific roles to be granted to service agents," +
+          " otherwise the deployment will fail.",
+      );
+      expect(getIamStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledWith(projectNumber);
+      expect(setIamStub).to.have.been.calledOnce;
+    });
+    it("should not update policy if it already has necessary bindings", async () => {
+      const serviceAccount = `test-sa@${projectId}.iam.gserviceaccount.com`;
+      const iamPolicy = {
+        etag: "etag",
+        version: 3,
+        bindings: [
+          BINDING,
+          {
+            role: "roles/monitoring.metricWriter",
+            members: [`serviceAccount:${serviceAccount}`, "anotheruser"],
+          },
+          {
+            role: "roles/cloudtrace.agent",
+            members: [`serviceAccount:${serviceAccount}`, "anotheruser"],
+          },
+          {
+            role: "roles/logging.logWriter",
+            members: [`serviceAccount:${serviceAccount}`, "anotheruser"],
+          },
+        ],
+      };
+      getIamStub.resolves(iamPolicy);
+      const wantFn: backend.Endpoint = {
+        id: "genkitFn1",
+        platform: "gcfv2",
+        entryPoint: "wantFn",
+        serviceAccount: serviceAccount,
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+
+      await checkIam.ensureGenkitMonitoringRoles(
+        projectId,
+        projectNumber,
+        backend.of(wantFn),
+        backend.empty(),
+      );
+
+      expect(getIamStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledWith(projectNumber);
+      expect(setIamStub).to.not.have.been.called;
+    });
+
+    it("should update policy if any bindings are missing", async () => {
+      const serviceAccount = `test-sa@${projectId}.iam.gserviceaccount.com`;
+      const initialPolicy = {
+        etag: "etag",
+        version: 3,
+        bindings: [
+          BINDING,
+          {
+            role: "roles/monitoring.metricWriter",
+            members: [`serviceAccount:${serviceAccount}`, "anotheruser"],
+          },
+          {
+            role: "roles/logging.logWriter",
+            members: [`serviceAccount:${serviceAccount}`, "anotheruser"],
+          },
+        ],
+      };
+      getIamStub.resolves(initialPolicy);
+      setIamStub.resolves({});
+      const wantFn: backend.Endpoint = {
+        id: "genkitFn1",
+        platform: "gcfv2",
+        entryPoint: "wantFn",
+        serviceAccount: serviceAccount,
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+
+      await checkIam.ensureGenkitMonitoringRoles(
+        projectId,
+        projectNumber,
+        backend.of(wantFn),
+        backend.empty(),
+      );
+
+      expect(getIamStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledWith(projectNumber);
+      expect(setIamStub).to.have.been.calledOnce;
+      expect(setIamStub).to.have.been.calledWith(
+        projectNumber,
+        {
+          etag: "etag",
+          version: 3,
+          bindings: [
+            BINDING,
+            {
+              role: "roles/monitoring.metricWriter",
+              members: [`serviceAccount:${serviceAccount}`, "anotheruser"],
+            },
+            {
+              role: "roles/logging.logWriter",
+              members: [`serviceAccount:${serviceAccount}`, "anotheruser"],
+            },
+            // Should include this missing binding
+            {
+              role: "roles/cloudtrace.agent",
+              members: [`serviceAccount:${serviceAccount}`],
+            },
+          ],
+        },
+        "bindings",
+      );
+    });
+
+    it("should update policy for all missing roles and service accounts", async () => {
+      const serviceAccount1 = `test-sa-1@${projectId}.iam.gserviceaccount.com`;
+      const serviceAccount2 = `test-sa-2@${projectId}.iam.gserviceaccount.com`;
+      const defaultServiceAccount = `${projectNumber}-compute@developer.gserviceaccount.com`;
+      const initialPolicy = {
+        etag: "etag",
+        version: 3,
+        bindings: [BINDING],
+      };
+      getIamStub.resolves(initialPolicy);
+      setIamStub.resolves({});
+      const fn1: backend.Endpoint = {
+        id: "genkitFn1",
+        platform: "gcfv2",
+        entryPoint: "wantFn1",
+        serviceAccount: serviceAccount1,
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+      const fn2: backend.Endpoint = {
+        id: "genkitFn2",
+        platform: "gcfv2",
+        entryPoint: "wantFn2",
+        serviceAccount: serviceAccount1,
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+      const fn3: backend.Endpoint = {
+        id: "genkitFn3",
+        platform: "gcfv2",
+        entryPoint: "wantFn3",
+        serviceAccount: serviceAccount2,
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+      const fn4: backend.Endpoint = {
+        id: "genkitFnWithDefaultServiceAccount",
+        platform: "gcfv2",
+        entryPoint: "wantFn",
+        callableTrigger: {
+          genkitAction: "action",
+        },
+        ...SPEC,
+      };
+
+      await checkIam.ensureGenkitMonitoringRoles(
+        projectId,
+        projectNumber,
+        backend.of(fn1, fn2, fn3, fn4),
+        backend.empty(),
+      );
+
+      expect(getIamStub).to.have.been.calledOnce;
+      expect(getIamStub).to.have.been.calledWith(projectNumber);
+      expect(setIamStub).to.have.been.calledOnce;
+      expect(setIamStub).to.have.been.calledWith(
+        projectNumber,
+        {
+          etag: "etag",
+          version: 3,
+          bindings: [
+            BINDING,
+            {
+              role: "roles/monitoring.metricWriter",
+              members: [
+                `serviceAccount:${serviceAccount1}`,
+                `serviceAccount:${serviceAccount2}`,
+                `serviceAccount:${defaultServiceAccount}`,
+              ],
+            },
+            {
+              role: "roles/cloudtrace.agent",
+              members: [
+                `serviceAccount:${serviceAccount1}`,
+                `serviceAccount:${serviceAccount2}`,
+                `serviceAccount:${defaultServiceAccount}`,
+              ],
+            },
+            {
+              role: "roles/logging.logWriter",
+              members: [
+                `serviceAccount:${serviceAccount1}`,
+                `serviceAccount:${serviceAccount2}`,
+                `serviceAccount:${defaultServiceAccount}`,
+              ],
+            },
+          ],
+        },
+        "bindings",
+      );
     });
   });
 
@@ -580,67 +915,5 @@ describe("checkIam", () => {
 
     expect(getIamStub).to.not.have.been.called;
     expect(setIamStub).to.not.have.been.called;
-  });
-
-  it("should add the default bindings for a new genkit v2 deployed function", async () => {
-    const newIamPolicy = {
-      etag: "etag",
-      version: 3,
-      bindings: [
-        BINDING,
-        {
-          role: checkIam.SERVICE_ACCOUNT_TOKEN_CREATOR_ROLE,
-          members: [
-            `serviceAccount:service-${projectNumber}@gcp-sa-pubsub.iam.gserviceaccount.com`,
-          ],
-        },
-        {
-          role: checkIam.RUN_INVOKER_ROLE,
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-        {
-          role: checkIam.EVENTARC_EVENT_RECEIVER_ROLE,
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-        {
-          role: "roles/monitoring.metricWriter",
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-        {
-          role: "roles/cloudtrace.agent",
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-        {
-          role: "roles/logging.logWriter",
-          members: [`serviceAccount:${projectNumber}-compute@developer.gserviceaccount.com`],
-        },
-      ],
-    };
-    getIamStub.resolves({
-      etag: "etag",
-      version: 3,
-      bindings: [BINDING],
-    });
-    setIamStub.resolves(newIamPolicy);
-    const wantFn: backend.Endpoint = {
-      id: "genkitFn",
-      platform: "gcfv2",
-      entryPoint: "wantFn",
-      callableTrigger: {
-        genkitAction: "action",
-      },
-      ...SPEC,
-    };
-
-    await checkIam.ensureServiceAgentRoles(
-      projectId,
-      projectNumber,
-      backend.of(wantFn),
-      backend.empty(),
-    );
-
-    expect(getIamStub).to.have.been.calledOnce;
-    expect(setIamStub).to.have.been.calledOnce;
-    expect(setIamStub).to.have.been.calledWith(projectNumber, newIamPolicy, "bindings");
   });
 });

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -220,9 +220,6 @@ export async function ensureServiceAgentRoles(
   const newServices = wantServices.filter(
     (wantS) => !haveServices.find((haveS) => wantS.name === haveS.name),
   );
-  if (newServices.length === 0) {
-    return;
-  }
 
   // obtain all the bindings we need to have active in the project
   const requiredBindingsPromises: Array<Promise<Array<iam.Binding>>> = [];

--- a/src/deploy/functions/checkIam.ts
+++ b/src/deploy/functions/checkIam.ts
@@ -139,7 +139,7 @@ function reduceEventsToServices(services: Array<Service>, endpoint: backend.Endp
 }
 
 /** Checks whether the given endpoint is a Genkit callable function. */
-function isGenkitEndpoint(endpoint: backend.Endpoint) {
+function isGenkitEndpoint(endpoint: backend.Endpoint): boolean {
   return (
     backend.isCallableTriggered(endpoint) && endpoint.callableTrigger.genkitAction !== undefined
   );

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -34,7 +34,7 @@ import { promptForFailurePolicies, promptForMinInstances } from "./prompts";
 import { needProjectId, needProjectNumber } from "../../projectUtils";
 import { logger } from "../../logger";
 import { ensureTriggerRegions } from "./triggerRegionHelper";
-import { ensureServiceAgentRoles } from "./checkIam";
+import { ensureServiceAgentRoles, ensureGenkitMonitoringRoles } from "./checkIam";
 import { FirebaseError } from "../../error";
 import {
   configForCodebase,
@@ -259,6 +259,13 @@ export async function prepare(
   await backend.checkAvailability(context, matchingBackend);
   await validate.secretsAreValid(projectId, matchingBackend);
   await ensureServiceAgentRoles(
+    projectId,
+    projectNumber,
+    matchingBackend,
+    haveBackend,
+    options.dryRun,
+  );
+  await ensureGenkitMonitoringRoles(
     projectId,
     projectNumber,
     matchingBackend,


### PR DESCRIPTION
### Description

Genkit Monitoring requires that the service account running the Genkit code has permission to write metrics, traces and logs. This change adds those permissions to the default service account when deploying as a Firebase Function.

### Scenarios Tested

* Tested with newly added Genkit function and ensure the permissions are set on the first firebase deploy
* Added unit tests
