### PR TITLE
Add public-image tag to opt into scanning

### DIFF
--- a/scripts/publish/firebase-docker-image/cloudbuild.yaml
+++ b/scripts/publish/firebase-docker-image/cloudbuild.yaml
@@ -13,7 +13,7 @@ steps:
     entrypoint: "sh"
     args:
       - "-c"
-      - "docker build -t us-docker.pkg.dev/$PROJECT_ID/us/firebase:$(cat /workspace/version_number.txt) -t us-docker.pkg.dev/$PROJECT_ID/us/firebase:latest -f ./Dockerfile ."
+      - "docker build -t us-docker.pkg.dev/$PROJECT_ID/us/firebase:$(cat /workspace/version_number.txt) -t us-docker.pkg.dev/$PROJECT_ID/us/firebase:latest -t us-docker.pkg.dev/$PROJECT_ID/us/firebase:public-image-$(cat /workspace/version_number.txt) -f ./Dockerfile ."
 
 images:
   - "us-docker.pkg.dev/$PROJECT_ID/us/firebase"


### PR DESCRIPTION
### Description
Add public-image- tag to Docker images so that they are opted into image scanning [go/autovm/vmprograms/public_image_scanning](https://goto.google.com/autovm/vmprograms/public_image_scanning)

