### PR TITLE
[MCP] [Cleanup] Declare project ID a required string with default if missing

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -196,7 +196,7 @@ export class FirebaseMcpServer {
     if (tool.mcp._meta?.requiresProject && !projectId) {
       return NO_PROJECT_ERROR;
     }
-    projectId = projectId || "<missing-project-id>";
+    projectId = projectId || "";
 
     const accountEmail = await this.getAuthenticatedUser();
     if (tool.mcp._meta?.requiresAuth && !accountEmail) {

--- a/src/mcp/tool.ts
+++ b/src/mcp/tool.ts
@@ -7,8 +7,8 @@ import { RC } from "../rc";
 import { cleanSchema } from "./util";
 
 export interface ServerToolContext {
-  projectId?: string;
-  accountEmail?: string | null;
+  projectId: string;
+  accountEmail: string | null;
   config: Config;
   host: FirebaseMcpServer;
   rc: RC;

--- a/src/mcp/tools/apphosting/fetch_logs.ts
+++ b/src/mcp/tools/apphosting/fetch_logs.ts
@@ -36,7 +36,6 @@ export const fetch_logs = tool(
     },
   },
   async ({ buildLogs, backendId, location } = {}, { projectId }) => {
-    projectId ||= "";
     location ||= "";
     if (!backendId) {
       return toContent(`backendId must be specified.`);

--- a/src/mcp/tools/auth/disable_user.ts
+++ b/src/mcp/tools/auth/disable_user.ts
@@ -22,7 +22,7 @@ export const disable_user = tool(
     },
   },
   async ({ uid, disabled }, { projectId }) => {
-    const res = await disableUser(projectId!, uid, disabled);
+    const res = await disableUser(projectId, uid, disabled);
     if (res) {
       return toContent(`User ${uid} as been ${disabled ? "disabled" : "enabled"}`);
     }

--- a/src/mcp/tools/auth/get_user.ts
+++ b/src/mcp/tools/auth/get_user.ts
@@ -38,6 +38,6 @@ export const get_user = tool(
     if (email === undefined && phone_number === undefined && uid === undefined) {
       return mcpError(`No user identifier supplied in auth_get_user tool`);
     }
-    return toContent(await findUser(projectId!, email, phone_number, uid));
+    return toContent(await findUser(projectId, email, phone_number, uid));
   },
 );

--- a/src/mcp/tools/auth/list_users.ts
+++ b/src/mcp/tools/auth/list_users.ts
@@ -28,7 +28,7 @@ export const list_users = tool(
       limit = 100;
     }
 
-    const users = await listUsers(projectId!, limit);
+    const users = await listUsers(projectId, limit);
     const usersPruned = users.map((user) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { passwordHash, salt, ...prunedUser } = user;

--- a/src/mcp/tools/auth/set_claims.ts
+++ b/src/mcp/tools/auth/set_claims.ts
@@ -42,6 +42,6 @@ export const set_claim = tool(
         return mcpError(`Provided \`json_value\` was not valid JSON: ${json_value}`);
       }
     }
-    return toContent(await setCustomClaim(projectId!, uid, { [claim]: value }, { merge: true }));
+    return toContent(await setCustomClaim(projectId, uid, { [claim]: value }, { merge: true }));
   },
 );

--- a/src/mcp/tools/auth/set_sms_region_policy.ts
+++ b/src/mcp/tools/auth/set_sms_region_policy.ts
@@ -33,8 +33,8 @@ export const set_sms_region_policy = tool(
       return code.toUpperCase();
     });
     if (policy_type === "ALLOW") {
-      return toContent(await setAllowSmsRegionPolicy(projectId!, country_codes));
+      return toContent(await setAllowSmsRegionPolicy(projectId, country_codes));
     }
-    return toContent(await setDenySmsRegionPolicy(projectId!, country_codes));
+    return toContent(await setDenySmsRegionPolicy(projectId, country_codes));
   },
 );

--- a/src/mcp/tools/core/consult_assistant.ts
+++ b/src/mcp/tools/core/consult_assistant.ts
@@ -24,7 +24,7 @@ export const consult_assistant = tool(
     },
   },
   async ({ prompt }, { projectId }) => {
-    const schema = await chatWithFirebase(prompt, projectId!);
+    const schema = await chatWithFirebase(prompt, projectId);
     return toContent(schema);
   },
 );

--- a/src/mcp/tools/core/create_android_sha.ts
+++ b/src/mcp/tools/core/create_android_sha.ts
@@ -35,7 +35,7 @@ export const create_android_sha = tool(
   async ({ app_id, sha_hash }, { projectId }) => {
     // Add the SHA certificate
     const certType = getCertHashType(sha_hash);
-    const shaCertificate = await createAppAndroidSha(projectId!, app_id, {
+    const shaCertificate = await createAppAndroidSha(projectId, app_id, {
       shaHash: sha_hash,
       certType,
     });

--- a/src/mcp/tools/core/create_app.ts
+++ b/src/mcp/tools/core/create_app.ts
@@ -61,7 +61,7 @@ export const create_app = tool(
       switch (platform) {
         case "android":
           return toContent(
-            await createAndroidApp(projectId!, {
+            await createAndroidApp(projectId, {
               displayName: display_name,
               packageName: android_config!.package_name,
             }),
@@ -73,7 +73,7 @@ export const create_app = tool(
           );
         case "ios":
           return toContent(
-            await createIosApp(projectId!, {
+            await createIosApp(projectId, {
               displayName: display_name,
               bundleId: ios_config!.bundle_id,
               appStoreId: ios_config!.app_store_id,
@@ -86,7 +86,7 @@ export const create_app = tool(
           );
         case "web":
           return toContent(
-            await createWebApp(projectId!, {
+            await createWebApp(projectId, {
               displayName: display_name,
             }),
             {

--- a/src/mcp/tools/core/get_project.ts
+++ b/src/mcp/tools/core/get_project.ts
@@ -18,6 +18,6 @@ export const get_project = tool(
     },
   },
   async (_, { projectId }) => {
-    return toContent(await getProject(projectId!));
+    return toContent(await getProject(projectId));
   },
 );

--- a/src/mcp/tools/core/get_sdk_config.ts
+++ b/src/mcp/tools/core/get_sdk_config.ts
@@ -35,7 +35,7 @@ export const get_sdk_config = tool(
       return mcpError(
         "Must specify one of 'web', 'ios', or 'android' for platform or an app_id for get_sdk_config tool.",
       );
-    const apps = await listFirebaseApps(projectId!, platform ?? AppPlatform.ANY);
+    const apps = await listFirebaseApps(projectId, platform ?? AppPlatform.ANY);
     platform = platform || apps.find((app) => app.appId === appId)?.platform;
     appId = appId || apps.find((app) => app.platform === platform)?.appId;
     if (!appId)

--- a/src/mcp/tools/core/list_apps.ts
+++ b/src/mcp/tools/core/list_apps.ts
@@ -24,7 +24,7 @@ export const list_apps = tool(
   },
   async ({ platform }, { projectId }) => {
     const apps = await listFirebaseApps(
-      projectId!,
+      projectId,
       (platform?.toUpperCase() as AppPlatform) ?? AppPlatform.ANY,
     );
     return toContent(apps);

--- a/src/mcp/tools/crashlytics/list_top_issues.ts
+++ b/src/mcp/tools/crashlytics/list_top_issues.ts
@@ -33,6 +33,6 @@ export const list_top_issues = tool(
 
     issue_count ??= 10;
 
-    return toContent(await listTopIssues(projectId!, app_id, issue_count));
+    return toContent(await listTopIssues(projectId, app_id, issue_count));
   },
 );

--- a/src/mcp/tools/dataconnect/execute_graphql.ts
+++ b/src/mcp/tools/dataconnect/execute_graphql.ts
@@ -40,7 +40,7 @@ export const execute_graphql = tool(
     { query, service_id, variables: unparsedVariables, use_emulator },
     { projectId, config, host },
   ) => {
-    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config, service_id || undefined);
 
     let apiClient: Client;
 

--- a/src/mcp/tools/dataconnect/execute_graphql.ts
+++ b/src/mcp/tools/dataconnect/execute_graphql.ts
@@ -40,7 +40,7 @@ export const execute_graphql = tool(
     { query, service_id, variables: unparsedVariables, use_emulator },
     { projectId, config, host },
   ) => {
-    const serviceInfo = await pickService(projectId!, config!, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
 
     let apiClient: Client;
 

--- a/src/mcp/tools/dataconnect/execute_graphql_read.ts
+++ b/src/mcp/tools/dataconnect/execute_graphql_read.ts
@@ -41,7 +41,7 @@ export const execute_graphql_read = tool(
     { query, service_id, variables: unparsedVariables, use_emulator },
     { projectId, config, host },
   ) => {
-    const serviceInfo = await pickService(projectId!, config, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config, service_id || undefined);
 
     let apiClient: Client;
     if (use_emulator) {

--- a/src/mcp/tools/dataconnect/execute_mutation.ts
+++ b/src/mcp/tools/dataconnect/execute_mutation.ts
@@ -48,7 +48,7 @@ export const execute_mutation = tool(
     { operationName, service_id, connector_id, variables: unparsedVariables, use_emulator },
     { projectId, config, host },
   ) => {
-    const serviceInfo = await pickService(projectId!, config, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config, service_id || undefined);
     let apiClient: Client;
 
     if (!connector_id) {

--- a/src/mcp/tools/dataconnect/execute_query.ts
+++ b/src/mcp/tools/dataconnect/execute_query.ts
@@ -48,7 +48,7 @@ export const execute_query = tool(
     { operationName, service_id, connector_id, variables: unparsedVariables, use_emulator },
     { projectId, config, host },
   ) => {
-    const serviceInfo = await pickService(projectId!, config, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config, service_id || undefined);
     let apiClient: Client;
 
     if (!connector_id) {

--- a/src/mcp/tools/dataconnect/generate_operation.ts
+++ b/src/mcp/tools/dataconnect/generate_operation.ts
@@ -34,7 +34,7 @@ export const generate_operation = tool(
     },
   },
   async ({ prompt, service_id }, { projectId, config }) => {
-    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config, service_id || undefined);
     const schema = await generateOperation(prompt, serviceInfo.serviceName, projectId);
     return toContent(schema);
   },

--- a/src/mcp/tools/dataconnect/generate_operation.ts
+++ b/src/mcp/tools/dataconnect/generate_operation.ts
@@ -34,8 +34,8 @@ export const generate_operation = tool(
     },
   },
   async ({ prompt, service_id }, { projectId, config }) => {
-    const serviceInfo = await pickService(projectId!, config!, service_id || undefined);
-    const schema = await generateOperation(prompt, serviceInfo.serviceName, projectId!);
+    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
+    const schema = await generateOperation(prompt, serviceInfo.serviceName, projectId);
     return toContent(schema);
   },
 );

--- a/src/mcp/tools/dataconnect/generate_schema.ts
+++ b/src/mcp/tools/dataconnect/generate_schema.ts
@@ -22,7 +22,7 @@ export const generate_schema = tool(
     },
   },
   async ({ prompt }, { projectId }) => {
-    const schema = await generateSchema(prompt, projectId!);
+    const schema = await generateSchema(prompt, projectId);
     return toContent(schema);
   },
 );

--- a/src/mcp/tools/dataconnect/get_connector.ts
+++ b/src/mcp/tools/dataconnect/get_connector.ts
@@ -28,7 +28,7 @@ export const get_connectors = tool(
     },
   },
   async ({ service_id }, { projectId, config }) => {
-    const serviceInfo = await pickService(projectId!, config!, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
     const connectors = await client.listConnectors(serviceInfo.serviceName, ["*"]);
     return toContent(connectors.map(connectorToText).join("\n\n"));
   },

--- a/src/mcp/tools/dataconnect/get_connector.ts
+++ b/src/mcp/tools/dataconnect/get_connector.ts
@@ -28,7 +28,7 @@ export const get_connectors = tool(
     },
   },
   async ({ service_id }, { projectId, config }) => {
-    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config, service_id || undefined);
     const connectors = await client.listConnectors(serviceInfo.serviceName, ["*"]);
     return toContent(connectors.map(connectorToText).join("\n\n"));
   },

--- a/src/mcp/tools/dataconnect/get_schema.ts
+++ b/src/mcp/tools/dataconnect/get_schema.ts
@@ -28,7 +28,7 @@ export const get_schema = tool(
     },
   },
   async ({ service_id }, { projectId, config }) => {
-    const serviceInfo = await pickService(projectId!, config!, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
     const schemas = await client.listSchemas(serviceInfo.serviceName, ["*"]);
     return toContent(schemas?.map(schemaToText).join("\n\n"));
   },

--- a/src/mcp/tools/dataconnect/get_schema.ts
+++ b/src/mcp/tools/dataconnect/get_schema.ts
@@ -28,7 +28,7 @@ export const get_schema = tool(
     },
   },
   async ({ service_id }, { projectId, config }) => {
-    const serviceInfo = await pickService(projectId, config!, service_id || undefined);
+    const serviceInfo = await pickService(projectId, config, service_id || undefined);
     const schemas = await client.listSchemas(serviceInfo.serviceName, ["*"]);
     return toContent(schemas?.map(schemaToText).join("\n\n"));
   },

--- a/src/mcp/tools/dataconnect/list_services.ts
+++ b/src/mcp/tools/dataconnect/list_services.ts
@@ -18,7 +18,7 @@ export const list_services = tool(
     },
   },
   async (_, { projectId }) => {
-    const services = await client.listAllServices(projectId!);
+    const services = await client.listAllServices(projectId);
     return toContent(services, { format: "yaml" });
   },
 );

--- a/src/mcp/tools/firestore/delete_document.ts
+++ b/src/mcp/tools/firestore/delete_document.ts
@@ -32,7 +32,7 @@ export const delete_document = tool(
   },
   async ({ path }, { projectId }) => {
     // database ??= "(default)";
-    const { documents, missing } = await getDocuments(projectId [path]);
+    const { documents, missing } = await getDocuments(projectId, [path]);
     if (missing.length > 0 && documents && documents.length === 0) {
       return mcpError(`None of the specified documents were found in project '${projectId}'`);
     }

--- a/src/mcp/tools/firestore/delete_document.ts
+++ b/src/mcp/tools/firestore/delete_document.ts
@@ -32,17 +32,17 @@ export const delete_document = tool(
   },
   async ({ path }, { projectId }) => {
     // database ??= "(default)";
-    const { documents, missing } = await getDocuments(projectId!, [path]);
+    const { documents, missing } = await getDocuments(projectId [path]);
     if (missing.length > 0 && documents && documents.length === 0) {
       return mcpError(`None of the specified documents were found in project '${projectId}'`);
     }
 
-    const firestoreDelete = new FirestoreDelete(projectId!, path, { databaseId: "(default)" });
+    const firestoreDelete = new FirestoreDelete(projectId, path, { databaseId: "(default)" });
 
     await firestoreDelete.execute();
 
     const { documents: postDeleteDocuments, missing: postDeleteMissing } = await getDocuments(
-      projectId!,
+      projectId,
       [path],
     );
     if (postDeleteMissing.length > 0 && postDeleteDocuments.length === 0) {

--- a/src/mcp/tools/firestore/get_documents.ts
+++ b/src/mcp/tools/firestore/get_documents.ts
@@ -34,7 +34,7 @@ export const get_documents = tool(
     // database ??= "(default)";
     if (!paths || !paths.length) return mcpError("Must supply at least one document path.");
 
-    const { documents, missing } = await getDocuments(projectId!, paths);
+    const { documents, missing } = await getDocuments(projectId, paths);
     if (missing.length > 0 && documents && documents.length === 0) {
       return mcpError(`None of the specified documents were found in project '${projectId}'`);
     }

--- a/src/mcp/tools/firestore/query_collection.ts
+++ b/src/mcp/tools/firestore/query_collection.ts
@@ -131,7 +131,7 @@ export const query_collection = tool(
     }
     structuredQuery.limit = limit ? limit : 10;
 
-    const { documents } = await queryCollection(projectId!, structuredQuery);
+    const { documents } = await queryCollection(projectId, structuredQuery);
 
     const docs = documents.map(firestoreDocumentToJson);
 

--- a/src/mcp/tools/messaging/send_message.ts
+++ b/src/mcp/tools/messaging/send_message.ts
@@ -48,7 +48,7 @@ export const send_message = tool(
       );
     }
     return toContent(
-      await sendFcmMessage(projectId!, { token: registration_token, topic, title, body }),
+      await sendFcmMessage(projectId, { token: registration_token, topic, title, body }),
     );
   },
 );

--- a/src/mcp/tools/remoteconfig/get_template.ts
+++ b/src/mcp/tools/remoteconfig/get_template.ts
@@ -25,6 +25,6 @@ export const get_template = tool(
     },
   },
   async ({ version_number }, { projectId }) => {
-    return toContent(await getTemplate(projectId!, version_number));
+    return toContent(await getTemplate(projectId, version_number));
   },
 );

--- a/src/mcp/tools/remoteconfig/publish_template.ts
+++ b/src/mcp/tools/remoteconfig/publish_template.ts
@@ -33,8 +33,6 @@ export const publish_template = tool(
     if (force === undefined) {
       return toContent(await publishTemplate(projectId, template as RemoteConfigTemplate));
     }
-    return toContent(
-      await publishTemplate(projectId, template as RemoteConfigTemplate, { force }),
-    );
+    return toContent(await publishTemplate(projectId, template as RemoteConfigTemplate, { force }));
   },
 );

--- a/src/mcp/tools/remoteconfig/publish_template.ts
+++ b/src/mcp/tools/remoteconfig/publish_template.ts
@@ -31,10 +31,10 @@ export const publish_template = tool(
       return mcpError(`No template specified in the publish requests`);
     }
     if (force === undefined) {
-      return toContent(await publishTemplate(projectId!, template as RemoteConfigTemplate));
+      return toContent(await publishTemplate(projectId, template as RemoteConfigTemplate));
     }
     return toContent(
-      await publishTemplate(projectId!, template as RemoteConfigTemplate, { force }),
+      await publishTemplate(projectId, template as RemoteConfigTemplate, { force }),
     );
   },
 );

--- a/src/mcp/tools/remoteconfig/rollback_template.ts
+++ b/src/mcp/tools/remoteconfig/rollback_template.ts
@@ -25,6 +25,6 @@ export const rollback_template = tool(
     if (version_number === undefined) {
       return mcpError(`No version number specified in the rollback requests`);
     }
-    return toContent(await rollbackTemplate(projectId!, version_number!));
+    return toContent(await rollbackTemplate(projectId, version_number!));
   },
 );

--- a/src/mcp/tools/rules/get_rules.ts
+++ b/src/mcp/tools/rules/get_rules.ts
@@ -19,7 +19,7 @@ export function getRulesTool(productName: string, releaseName: string) {
       },
     },
     async (_, { projectId }) => {
-      const rulesetName = await getLatestRulesetName(projectId!, releaseName);
+      const rulesetName = await getLatestRulesetName(projectId, releaseName);
       if (!rulesetName)
         return mcpError(`No active Firestore rules were found in project '${projectId}'`);
       const rules = await getRulesetContent(rulesetName);

--- a/src/mcp/tools/rules/validate_rules.ts
+++ b/src/mcp/tools/rules/validate_rules.ts
@@ -120,7 +120,7 @@ export function validateRulesTool(productName: string) {
         rulesSourceContent = "";
       }
 
-      const result = await testRuleset(projectId!, [
+      const result = await testRuleset(projectId, [
         // The name "firestore.rules" is a convention for testRuleset,
         // actual fileName from issues will be used in formatting.
         { name: "test.rules", content: rulesSourceContent },

--- a/src/mcp/tools/storage/get_rules.ts
+++ b/src/mcp/tools/storage/get_rules.ts
@@ -18,7 +18,7 @@ export const get_rules = tool(
     },
   },
   async (_, { projectId }) => {
-    const rulesetName = await getLatestRulesetName(projectId!, "firebase.storage");
+    const rulesetName = await getLatestRulesetName(projectId, "firebase.storage");
     if (!rulesetName)
       return mcpError(`No active Firebase Storage rules were found in project '${projectId}'`);
     const rules = await getRulesetContent(rulesetName);


### PR DESCRIPTION
Most tools has `requiresProject: true,`, but we have seen `projectId!` in so many tools.

To simply logics a bit, we can pass a fixed sentinel string in a MCP tool that doesn't require `projectId`.

