### PR TITLE
Split confirmWriteProjectFile out of askWriteProjectFile

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -230,12 +230,9 @@ export async function initAction(feature: string, options: Options): Promise<voi
   await init(setup, config, options);
 
   logger.info();
-  utils.logBullet("Writing configuration info to " + clc.bold("firebase.json") + "...");
   config.writeProjectFile("firebase.json", setup.config);
-  utils.logBullet("Writing project information to " + clc.bold(".firebaserc") + "...");
   config.writeProjectFile(".firebaserc", setup.rcfile);
   if (!fsutils.fileExistsSync(config.path(".gitignore"))) {
-    utils.logBullet("Writing gitignore file to " + clc.bold(".gitignore") + "...");
     config.writeProjectFile(".gitignore", GITIGNORE_TEMPLATE);
   }
   logger.info();

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,6 @@ import * as utils from "./utils";
 import { getValidator, getErrorMessage } from "./firebaseConfigValidate";
 import { logger } from "./logger";
 import { loadCJSON } from "./loadCJSON";
-import { b } from "@electric-sql/pglite/dist/pglite-DqRPKYWs";
 const parseBoltRules = require("./parseBoltRules");
 
 export class Config {

--- a/src/config.ts
+++ b/src/config.ts
@@ -260,7 +260,7 @@ export class Config {
       message: "File " + clc.underline(path) + " already exists. Overwrite?",
       default: !!confirmByDefault,
     });
-    if (shouldWrite) {
+    if (!shouldWrite) {
       utils.logBullet("Skipping write of " + clc.bold(path));
       return false;
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -323,7 +323,7 @@ export class Config {
 }
 
 function stringifyContent(content: any): string {
-  if (typeof content !== "string") {
+  if (typeof content === "string") {
     return content;
   }
   return JSON.stringify(content, null, 2) + "\n";

--- a/src/config.ts
+++ b/src/config.ts
@@ -216,7 +216,7 @@ export class Config {
     }
   }
 
-  writeProjectFile(p: string, content: any) {
+  writeProjectFile(p: string, content: any): void {
     const path = this.path(p);
     fs.ensureFileSync(path);
     fs.writeFileSync(path, stringifyContent(content), "utf8");
@@ -228,7 +228,7 @@ export class Config {
         utils.logSuccess("Wrote project information to " + clc.bold(".firebaserc"));
         break;
       default:
-        utils.logSuccess("Wrote " + clc.bold(path));
+        utils.logSuccess("Wrote " + clc.bold(p));
         break;
     }
   }

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -106,7 +106,7 @@ export default async function (context: Context, options: Options): Promise<void
         options.config.writeProjectFile(configPath, options.config.src);
         logLabeledBullet(
           "apphosting",
-          `Your deployment preferences have been saved to firebase.json. On future invocations of "firebase deploy", your local source will be deployed to ${cfg.backendId}. You can edit this setting in your firebase.json at any time.`,
+          `On future invocations of "firebase deploy", your local source will be deployed to ${cfg.backendId}. You can edit this setting in your firebase.json at any time.`,
         );
         if (!confirmDeploy) {
           logLabeledWarning("apphosting", `Skipping deployment of backend ${cfg.backendId}`);

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -217,7 +217,6 @@ export function writeExtensionsToFirebaseJson(specs: ManifestInstanceSpec[], con
   }
   config.set("extensions", extensions);
   config.writeProjectFile("firebase.json", config.src);
-  utils.logSuccess("Wrote extensions to " + clc.bold("firebase.json") + "...");
 }
 
 async function writeEnvFiles(

--- a/src/extensions/manifest.ts
+++ b/src/extensions/manifest.ts
@@ -1,4 +1,3 @@
-import * as clc from "colorette";
 import * as path from "path";
 import * as fs from "fs-extra";
 
@@ -9,7 +8,6 @@ import { logger } from "../logger";
 import { confirm, select } from "../prompt";
 import { readEnvFile } from "./paramHelper";
 import { FirebaseError } from "../error";
-import * as utils from "../utils";
 import { isLocalPath } from "./extensionsHelper";
 import { ParamType } from "./types";
 

--- a/src/init/features/apphosting.ts
+++ b/src/init/features/apphosting.ts
@@ -117,7 +117,6 @@ export async function doSetup(setup: Setup, config: Config): Promise<void> {
   });
 
   upsertAppHostingConfig(backendConfig, config);
-  utils.logBullet("Writing configuration info to firebase.json...");
   config.writeProjectFile("firebase.json", config.src);
 
   utils.logBullet("Writing default settings to " + clc.bold("apphosting.yaml") + "...");

--- a/src/init/features/database.ts
+++ b/src/init/features/database.ts
@@ -159,11 +159,11 @@ export async function askQuestions(setup: Setup, config: Config): Promise<void> 
     if (instanceDetails) {
       info.rules = await getDBRules(instanceDetails);
       utils.logBullet(
-        `Downloaded the existing Realtime Database Security Rules for ${clc.bold(instanceDetails.name)} from the Firebase console`,
+        `Downloaded the existing Realtime Database Security Rules of database ${clc.bold(instanceDetails.name)} from the Firebase console`,
       );
     }
   }
-  info.writeRules = await config.confirmWriteProjectFile(rulesFilename, DEFAULT_RULES);
+  info.writeRules = await config.confirmWriteProjectFile(rulesFilename, info.rules);
   // Populate featureInfo for the actuate step later.
   setup.featureInfo = setup.featureInfo || {};
   setup.featureInfo.database = info;

--- a/src/init/features/database.ts
+++ b/src/init/features/database.ts
@@ -153,9 +153,8 @@ export async function askQuestions(setup: Setup, config: Config): Promise<void> 
     rules: DEFAULT_RULES,
     writeRules: true,
   };
-  let instanceDetails: DatabaseInstance | null = null;
   if (setup.projectId) {
-    instanceDetails = await initializeDatabaseInstance(setup.projectId);
+    const instanceDetails = await initializeDatabaseInstance(setup.projectId);
     if (instanceDetails) {
       info.rules = await getDBRules(instanceDetails);
       utils.logBullet(

--- a/src/init/features/database.ts
+++ b/src/init/features/database.ts
@@ -51,18 +51,10 @@ async function getDBRules(instanceDetails: DatabaseInstance): Promise<string> {
   return await response.response.text();
 }
 
-function writeDBRules(
-  rules: string,
-  logMessagePrefix: string,
-  filename: string,
-  config: Config,
-): void {
+function writeDBRules(rules: string, filename: string, config: Config): void {
   config.writeProjectFile(filename, rules);
-  utils.logSuccess(`${logMessagePrefix} have been written to ${clc.bold(filename)}.`);
   logger.info(
-    `Future modifications to ${clc.bold(
-      filename,
-    )} will update Realtime Database Security Rules when you run`,
+    `Future modifications to ${clc.bold(filename)} will update Realtime Database Security Rules when you run`,
   );
   logger.info(clc.bold("firebase deploy") + ".");
 }
@@ -198,9 +190,9 @@ export async function actuate(setup: Setup, config: Config): Promise<void> {
 
   if (info.writeRules) {
     if (info.rules === DEFAULT_RULES) {
-      writeDBRules(info.rules, `Default rules for ${setup.projectId}`, info.rulesFilename, config);
+      writeDBRules(info.rules, info.rulesFilename, config);
     } else {
-      writeDBRules(info.rules, `Database Rules for ${setup.projectId}`, info.rulesFilename, config);
+      writeDBRules(info.rules, info.rulesFilename, config);
     }
   } else {
     logger.info("Skipping overwrite of Realtime Database Security Rules.");

--- a/src/init/features/firestore/rules.ts
+++ b/src/init/features/firestore/rules.ts
@@ -38,11 +38,10 @@ export async function initRules(setup: Setup, config: Config, info: RequiredInfo
     const downloadedRules = await getRulesFromConsole(setup.projectId);
     if (downloadedRules) {
       info.rules = downloadedRules;
-      utils.logBullet(
-        `Downloaded the existing Firestore Security Rules for ${clc.bold(setup.projectId)} from the Firebase console`,
-      );
+      utils.logBullet(`Downloaded the existing Firestore Security Rules from the Firebase console`);
     }
   }
+
   info.writeRules = await config.confirmWriteProjectFile(info.rulesFilename, info.rules);
 }
 


### PR DESCRIPTION
Doing some refactor to make split prompt and file write actuation easier. 

1. Moved logging into `config.writeProjectFile` method. Audited all use cases of it and update surrounding logs to avoid duplications.
2. Extract a `confirmWriteProjectFile` out of `askWriteProjectFile`.

It's very common in `doSetup` to use `askWriteProjectFile`.
After the refactor, we can make `askQuestions` calls `confirmWriteProjectFile` and saves the response. `actuate` calls `askWriteProjectFile`.

### From Empty Folder

<img width="707" alt="Screenshot 2025-05-22 at 5 57 29 PM" src="https://github.com/user-attachments/assets/a86fc60f-4b8b-446f-b0f1-e7e37a730576" />

### Re-running init again

<img width="699" alt="Screenshot 2025-05-22 at 5 58 24 PM" src="https://github.com/user-attachments/assets/9be7c7c9-4dde-4cc9-b72d-2559c114317c" />

It's arguably better than the existing behavior, which ask for confirmation even if there is no change in Firestore / storage rules.

#### [Existing] Re-running init

<img width="1123" alt="Screenshot 2025-05-22 at 5 50 14 PM" src="https://github.com/user-attachments/assets/1bae1231-8edb-496f-89d1-4e0b91f285d6" />

