### PR TITLE
Add remoteurl to downloadable emulators json

### DIFF
--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -4,21 +4,24 @@
     "expectedSize": 34495935,
     "expectedChecksum": "2fd771101c0e1f7898c04c9204f2ce63",
     "expectedChecksumSHA256": "b70d99344caf17c98b6f910fa8f6edf32a7c016cb1035e8915f70d38901eb97f",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.11.2.jar"
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.11.2.jar",
+    "downloadPathRelativeToCacheDir": "firebase-database-emulator-v4.11.2.jar"
   },
   "firestore": {
     "version": "1.19.8",
     "expectedSize": 63634791,
     "expectedChecksum": "9b43a6daa590678de9b7df6d68260395",
     "expectedChecksumSHA256": "9d43599ed6151199e8d604dc87fac51218e49e5f3a48519b1ae560bbe5e3382d",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.19.8.jar"
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.19.8.jar",
+    "downloadPathRelativeToCacheDir": "cloud-firestore-emulator-v1.19.8.jar"
   },
   "storage": {
     "version": "1.1.3",
     "expectedSize": 52892936,
     "expectedChecksum": "2ca11ec1193003bea89f806cc085fa25",
     "expectedChecksumSHA256": "0cd52db6f6271d62078f805220706377c849220b73bd68aa27078d977df9c900",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-storage-rules-runtime-v1.1.3.jar"
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-storage-rules-runtime-v1.1.3.jar",
+    "downloadPathRelativeToCacheDir": "cloud-storage-rules-runtime-v1.1.3.jar"
   },
   "ui": {
     "snapshot": {
@@ -26,14 +29,18 @@
       "expectedSize": -1,
       "expectedChecksum": "",
       "expectedChecksumSHA256": "",
-      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vSNAPSHOT.zip"
+      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vSNAPSHOT.zip",
+      "downloadPathRelativeToCacheDir": "ui-vSNAPSHOT.zip",
+      "binaryPathRelativeToCacheDir": "ui-vSNAPSHOT/server/server.mjs"
     },
     "main": {
       "version": "1.15.0",
       "expectedSize": 3538469,
       "expectedChecksum": "2f13d5aea9524564c8b7adaa9cfa2128",
       "expectedChecksumSHA256": "97d8c4c574e3f20c4d690a2ce8373eef76ab024da73279a062dba8517f88cf9a",
-      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.15.0.zip"
+      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.15.0.zip",
+      "downloadPathRelativeToCacheDir": "ui-v1.15.0.zip",
+      "binaryPathRelativeToCacheDir": "ui-v1.15.0/server/server.mjs"
     }
   },
   "pubsub": {
@@ -41,7 +48,9 @@
     "expectedSize": 66786933,
     "expectedChecksum": "a9025b3e53fdeafd2969ccb3ba1e1d38",
     "expectedChecksumSHA256": "4fbeefd8ecb32b10e5ab522e5d8748e0c2b13891c471c0c327c04632dcc75a8d",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.14.zip"
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.14.zip",
+    "downloadPathRelativeToCacheDir": "pubsub-emulator-0.8.14.zip",
+    "binaryPathRelativeToCacheDir": "pubsub-emulator-0.8.14/pubsub-emulator/bin/cloud-pubsub-emulator"
   },
   "dataconnect": {
     "darwin": {
@@ -49,21 +58,24 @@
       "expectedSize": 27415296,
       "expectedChecksum": "5814d22b06b1321409f40693dfe47288",
       "expectedChecksumSHA256": "8df1cfac6ef747909b3c18b57ba52b70a11d53b9d0a22b197011d6550ceca133",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-v2.6.1"
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-v2.6.1",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.6.1"
     },
     "win32": {
       "version": "2.6.1",
       "expectedSize": 27875328,
       "expectedChecksum": "21381052c2bf767ee84fb85975cfd4d5",
       "expectedChecksumSHA256": "6bebaa9575b460c4fa170b191d94722923a3c869bc1eca24c7e444428e6b7a70",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-v2.6.1"
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-v2.6.1",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.6.1.exe"
     },
     "linux": {
       "version": "2.6.1",
       "expectedSize": 27332760,
       "expectedChecksum": "0480a92f5af8e8441e680dc4e7995263",
       "expectedChecksumSHA256": "4f60baf4649c670227314302056f50b1c40ccc8d673b98d16935977508342a67",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-v2.6.1"
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-v2.6.1",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.6.1"
     }
   }
 }

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -18,7 +18,7 @@
     "expectedSize": 52892936,
     "expectedChecksum": "2ca11ec1193003bea89f806cc085fa25",
     "expectedChecksumSHA256": "0cd52db6f6271d62078f805220706377c849220b73bd68aa27078d977df9c900",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v1.1.3.jar"
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-storage-rules-runtime-v1.1.3.jar"
   },
   "ui": {
     "snapshot": {

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -33,7 +33,7 @@
       "expectedSize": 3538469,
       "expectedChecksum": "2f13d5aea9524564c8b7adaa9cfa2128",
       "expectedChecksumSHA256": "97d8c4c574e3f20c4d690a2ce8373eef76ab024da73279a062dba8517f88cf9a",
-      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-1.15.0.zip"
+      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v1.15.0.zip"
     }
   },
   "pubsub": {

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -3,58 +3,67 @@
     "version": "4.11.2",
     "expectedSize": 34495935,
     "expectedChecksum": "2fd771101c0e1f7898c04c9204f2ce63",
-    "expectedChecksumSHA256": "b70d99344caf17c98b6f910fa8f6edf32a7c016cb1035e8915f70d38901eb97f"
+    "expectedChecksumSHA256": "b70d99344caf17c98b6f910fa8f6edf32a7c016cb1035e8915f70d38901eb97f",
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v4.11.2.jar"
   },
   "firestore": {
     "version": "1.19.8",
     "expectedSize": 63634791,
     "expectedChecksum": "9b43a6daa590678de9b7df6d68260395",
-    "expectedChecksumSHA256": "9d43599ed6151199e8d604dc87fac51218e49e5f3a48519b1ae560bbe5e3382d"
+    "expectedChecksumSHA256": "9d43599ed6151199e8d604dc87fac51218e49e5f3a48519b1ae560bbe5e3382d",
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v1.19.8.jar"
   },
   "storage": {
     "version": "1.1.3",
     "expectedSize": 52892936,
     "expectedChecksum": "2ca11ec1193003bea89f806cc085fa25",
-    "expectedChecksumSHA256": "0cd52db6f6271d62078f805220706377c849220b73bd68aa27078d977df9c900"
+    "expectedChecksumSHA256": "0cd52db6f6271d62078f805220706377c849220b73bd68aa27078d977df9c900",
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v1.1.3.jar"
   },
   "ui": {
     "snapshot": {
       "version": "SNAPSHOT",
       "expectedSize": -1,
       "expectedChecksum": "",
-      "expectedChecksumSHA256": ""
+      "expectedChecksumSHA256": "",
+      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-vSNAPSHOT.zip"
     },
     "main": {
       "version": "1.15.0",
       "expectedSize": 3538469,
       "expectedChecksum": "2f13d5aea9524564c8b7adaa9cfa2128",
-      "expectedChecksumSHA256": "97d8c4c574e3f20c4d690a2ce8373eef76ab024da73279a062dba8517f88cf9a"
+      "expectedChecksumSHA256": "97d8c4c574e3f20c4d690a2ce8373eef76ab024da73279a062dba8517f88cf9a",
+      "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/ui-1.15.0.zip"
     }
   },
   "pubsub": {
     "version": "0.8.14",
     "expectedSize": 66786933,
     "expectedChecksum": "a9025b3e53fdeafd2969ccb3ba1e1d38",
-    "expectedChecksumSHA256": "4fbeefd8ecb32b10e5ab522e5d8748e0c2b13891c471c0c327c04632dcc75a8d"
+    "expectedChecksumSHA256": "4fbeefd8ecb32b10e5ab522e5d8748e0c2b13891c471c0c327c04632dcc75a8d",
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.14.zip"
   },
   "dataconnect": {
     "darwin": {
       "version": "2.6.1",
       "expectedSize": 27415296,
       "expectedChecksum": "5814d22b06b1321409f40693dfe47288",
-      "expectedChecksumSHA256": "8df1cfac6ef747909b3c18b57ba52b70a11d53b9d0a22b197011d6550ceca133"
+      "expectedChecksumSHA256": "8df1cfac6ef747909b3c18b57ba52b70a11d53b9d0a22b197011d6550ceca133",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-v2.6.1"
     },
     "win32": {
       "version": "2.6.1",
       "expectedSize": 27875328,
       "expectedChecksum": "21381052c2bf767ee84fb85975cfd4d5",
-      "expectedChecksumSHA256": "6bebaa9575b460c4fa170b191d94722923a3c869bc1eca24c7e444428e6b7a70"
+      "expectedChecksumSHA256": "6bebaa9575b460c4fa170b191d94722923a3c869bc1eca24c7e444428e6b7a70",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-v2.6.1"
     },
     "linux": {
       "version": "2.6.1",
       "expectedSize": 27332760,
       "expectedChecksum": "0480a92f5af8e8441e680dc4e7995263",
-      "expectedChecksumSHA256": "4f60baf4649c670227314302056f50b1c40ccc8d673b98d16935977508342a67"
+      "expectedChecksumSHA256": "4f60baf4649c670227314302056f50b1c40ccc8d673b98d16935977508342a67",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-v2.6.1"
     }
   }
 }

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -58,7 +58,7 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
   database: {
     downloadPath: path.join(
       CACHE_DIR,
-      `firebase-database-emulator-v${EMULATOR_UPDATE_DETAILS.database.version}.jar`,
+      EMULATOR_UPDATE_DETAILS.database.downloadPathRelativeToCacheDir,
     ),
     version: EMULATOR_UPDATE_DETAILS.database.version,
     opts: {
@@ -70,7 +70,7 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
   firestore: {
     downloadPath: path.join(
       CACHE_DIR,
-      `cloud-firestore-emulator-v${EMULATOR_UPDATE_DETAILS.firestore.version}.jar`,
+      EMULATOR_UPDATE_DETAILS.firestore.downloadPathRelativeToCacheDir,
     ),
     version: EMULATOR_UPDATE_DETAILS.firestore.version,
     opts: {
@@ -82,7 +82,7 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
   storage: {
     downloadPath: path.join(
       CACHE_DIR,
-      `cloud-storage-rules-runtime-v${EMULATOR_UPDATE_DETAILS.storage.version}.jar`,
+      EMULATOR_UPDATE_DETAILS.storage.downloadPathRelativeToCacheDir,
     ),
     version: EMULATOR_UPDATE_DETAILS.storage.version,
     opts: {
@@ -93,9 +93,9 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
   },
   ui: {
     version: emulatorUiDetails.version,
-    downloadPath: path.join(CACHE_DIR, `ui-v${emulatorUiDetails.version}.zip`),
+    downloadPath: path.join(CACHE_DIR, emulatorUiDetails.downloadPathRelativeToCacheDir),
     unzipDir: path.join(CACHE_DIR, `ui-v${emulatorUiDetails.version}`),
-    binaryPath: path.join(CACHE_DIR, `ui-v${emulatorUiDetails.version}`, "server", "server.mjs"),
+    binaryPath: path.join(CACHE_DIR, emulatorUiDetails.binaryPathRelativeToCacheDir!),
     opts: {
       ...emulatorUiDetails,
       cacheDir: CACHE_DIR,
@@ -107,15 +107,11 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
   pubsub: {
     downloadPath: path.join(
       CACHE_DIR,
-      `pubsub-emulator-${EMULATOR_UPDATE_DETAILS.pubsub.version}.zip`,
+      EMULATOR_UPDATE_DETAILS.pubsub.downloadPathRelativeToCacheDir,
     ),
     version: EMULATOR_UPDATE_DETAILS.pubsub.version,
     unzipDir: path.join(CACHE_DIR, `pubsub-emulator-${EMULATOR_UPDATE_DETAILS.pubsub.version}`),
-    binaryPath: path.join(
-      CACHE_DIR,
-      `pubsub-emulator-${EMULATOR_UPDATE_DETAILS.pubsub.version}`,
-      `pubsub-emulator/bin/cloud-pubsub-emulator${process.platform === "win32" ? ".bat" : ""}`,
-    ),
+    binaryPath: path.join(CACHE_DIR, EMULATOR_UPDATE_DETAILS.pubsub.binaryPathRelativeToCacheDir!),
     opts: {
       ...EMULATOR_UPDATE_DETAILS.pubsub,
       cacheDir: CACHE_DIR,
@@ -123,15 +119,9 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
     },
   },
   dataconnect: {
-    downloadPath: path.join(
-      CACHE_DIR,
-      `dataconnect-emulator-${dataconnectDetails.version}${process.platform === "win32" ? ".exe" : ""}`,
-    ),
+    downloadPath: path.join(CACHE_DIR, dataconnectDetails.downloadPathRelativeToCacheDir),
     version: dataconnectDetails.version,
-    binaryPath: path.join(
-      CACHE_DIR,
-      `dataconnect-emulator-${dataconnectDetails.version}${process.platform === "win32" ? ".exe" : ""}`,
-    ),
+    binaryPath: path.join(CACHE_DIR, dataconnectDetails.downloadPathRelativeToCacheDir),
     opts: {
       ...dataconnectDetails,
       cacheDir: CACHE_DIR,

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -62,10 +62,8 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
     ),
     version: EMULATOR_UPDATE_DETAILS.database.version,
     opts: {
+      ...EMULATOR_UPDATE_DETAILS.database,
       cacheDir: CACHE_DIR,
-      remoteUrl: `https://storage.googleapis.com/firebase-preview-drop/emulator/firebase-database-emulator-v${EMULATOR_UPDATE_DETAILS.database.version}.jar`,
-      expectedSize: EMULATOR_UPDATE_DETAILS.database.expectedSize,
-      expectedChecksum: EMULATOR_UPDATE_DETAILS.database.expectedChecksum,
       namePrefix: "firebase-database-emulator",
     },
   },
@@ -76,10 +74,8 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
     ),
     version: EMULATOR_UPDATE_DETAILS.firestore.version,
     opts: {
+      ...EMULATOR_UPDATE_DETAILS.firestore,
       cacheDir: CACHE_DIR,
-      remoteUrl: `https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-firestore-emulator-v${EMULATOR_UPDATE_DETAILS.firestore.version}.jar`,
-      expectedSize: EMULATOR_UPDATE_DETAILS.firestore.expectedSize,
-      expectedChecksum: EMULATOR_UPDATE_DETAILS.firestore.expectedChecksum,
       namePrefix: "cloud-firestore-emulator",
     },
   },
@@ -90,10 +86,8 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
     ),
     version: EMULATOR_UPDATE_DETAILS.storage.version,
     opts: {
+      ...EMULATOR_UPDATE_DETAILS.storage,
       cacheDir: CACHE_DIR,
-      remoteUrl: `https://storage.googleapis.com/firebase-preview-drop/emulator/cloud-storage-rules-runtime-v${EMULATOR_UPDATE_DETAILS.storage.version}.jar`,
-      expectedSize: EMULATOR_UPDATE_DETAILS.storage.expectedSize,
-      expectedChecksum: EMULATOR_UPDATE_DETAILS.storage.expectedChecksum,
       namePrefix: "cloud-storage-rules-emulator",
     },
   },
@@ -103,10 +97,8 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
     unzipDir: path.join(CACHE_DIR, `ui-v${emulatorUiDetails.version}`),
     binaryPath: path.join(CACHE_DIR, `ui-v${emulatorUiDetails.version}`, "server", "server.mjs"),
     opts: {
+      ...emulatorUiDetails,
       cacheDir: CACHE_DIR,
-      remoteUrl: `https://storage.googleapis.com/firebase-preview-drop/emulator/ui-v${emulatorUiDetails.version}.zip`,
-      expectedSize: emulatorUiDetails.expectedSize,
-      expectedChecksum: emulatorUiDetails.expectedChecksum,
       skipCache: experiments.isEnabled("emulatoruisnapshot"),
       skipChecksumAndSize: experiments.isEnabled("emulatoruisnapshot"),
       namePrefix: "ui",
@@ -125,10 +117,8 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
       `pubsub-emulator/bin/cloud-pubsub-emulator${process.platform === "win32" ? ".bat" : ""}`,
     ),
     opts: {
+      ...EMULATOR_UPDATE_DETAILS.pubsub,
       cacheDir: CACHE_DIR,
-      remoteUrl: `https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-${EMULATOR_UPDATE_DETAILS.pubsub.version}.zip`,
-      expectedSize: EMULATOR_UPDATE_DETAILS.pubsub.expectedSize,
-      expectedChecksum: EMULATOR_UPDATE_DETAILS.pubsub.expectedChecksum,
       namePrefix: "pubsub-emulator",
     },
   },
@@ -143,15 +133,8 @@ export const DownloadDetails: { [s in DownloadableEmulators]: EmulatorDownloadDe
       `dataconnect-emulator-${dataconnectDetails.version}${process.platform === "win32" ? ".exe" : ""}`,
     ),
     opts: {
+      ...dataconnectDetails,
       cacheDir: CACHE_DIR,
-      remoteUrl:
-        process.platform === "darwin"
-          ? `https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-v${dataconnectDetails.version}`
-          : process.platform === "win32"
-            ? `https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-v${dataconnectDetails.version}`
-            : `https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-v${dataconnectDetails.version}`,
-      expectedSize: dataconnectDetails.expectedSize,
-      expectedChecksum: dataconnectDetails.expectedChecksum,
       skipChecksumAndSize: false,
       namePrefix: "dataconnect-emulator",
       auth: false,

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -187,6 +187,8 @@ export interface EmulatorUpdateDetails {
   expectedChecksum: string;
   expectedChecksumSHA256: string; // TODO: Use this for validation within the CLI as well.
   remoteUrl: string;
+  downloadPathRelativeToCacheDir: string;
+  binaryPathRelativeToCacheDir?: string;
 }
 
 export interface EmulatorDownloadDetails {

--- a/src/emulator/types.ts
+++ b/src/emulator/types.ts
@@ -186,6 +186,7 @@ export interface EmulatorUpdateDetails {
   expectedSize: number;
   expectedChecksum: string;
   expectedChecksumSHA256: string; // TODO: Use this for validation within the CLI as well.
+  remoteUrl: string;
 }
 
 export interface EmulatorDownloadDetails {


### PR DESCRIPTION
### Description
Adding some more information to downloadable emulators JSON to support studio predownloading.

Let me know if this is sufficient, or if we need to include downloadPath as well - I'd slightly prefer to keep that in the code since there is a bunch of branchin logic, but we can move it here if necessary
