### PR TITLE
Improve FDC serviceId argument parsing

### DIFF
--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs-extra";
 import * as path from "path";
+import * as clc from "colorette";
 
 import { FirebaseError } from "../error";
 import {
@@ -98,9 +99,19 @@ export async function pickService(
   const serviceCfgs = readFirebaseJson(config);
   let serviceInfo: ServiceInfo;
   if (serviceCfgs.length === 0) {
-    throw new FirebaseError("No Data Connect services found in firebase.json.");
+    throw new FirebaseError(
+      "No Data Connect services found in firebase.json. " +
+        ` Do you want to run ${clc.bold("firebase init dataconnect")} to add a Data Connect service?`,
+    );
   } else if (serviceCfgs.length === 1) {
     serviceInfo = await load(projectId, config, serviceCfgs[0].source);
+    if (serviceId && serviceId !== serviceInfo.dataConnectYaml.serviceId) {
+      throw new FirebaseError(
+        `No service named ${serviceId} declared in firebase.json. Found ${serviceInfo.dataConnectYaml.serviceId}.` +
+          ` Do you want to run ${clc.bold("firebase init dataconnect")} to add more services?`,
+      );
+    }
+    return serviceInfo;
   } else {
     if (!serviceId) {
       throw new FirebaseError(
@@ -111,11 +122,13 @@ export async function pickService(
     // TODO: handle cases where there are services with the same ID in 2 locations.
     const maybe = infos.find((i) => i.dataConnectYaml.serviceId === serviceId);
     if (!maybe) {
-      throw new FirebaseError(`No service named ${serviceId} declared in firebase.json.`);
+      throw new FirebaseError(
+        `No service named ${serviceId} declared in firebase.json. Found ${infos.map((i) => i.dataConnectYaml.serviceId).join(", ")}.` +
+          ` Do you want to run ${clc.bold("firebase init dataconnect")} to add a Data Connect service?`,
+      );
     }
-    serviceInfo = maybe;
+    return maybe;
   }
-  return serviceInfo;
 }
 
 // case insensitive exact match indicators for supported app platforms

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -100,15 +100,15 @@ export async function pickService(
   let serviceInfo: ServiceInfo;
   if (serviceCfgs.length === 0) {
     throw new FirebaseError(
-      "No Data Connect services found in firebase.json. " +
-        ` You can run ${clc.bold("firebase init dataconnect")} to add a Data Connect service?`,
+      "No Data Connect services found in firebase.json." +
+        `\nYou can run ${clc.bold("firebase init dataconnect")} to add a Data Connect service.`,
     );
   } else if (serviceCfgs.length === 1) {
     serviceInfo = await load(projectId, config, serviceCfgs[0].source);
     if (serviceId && serviceId !== serviceInfo.dataConnectYaml.serviceId) {
       throw new FirebaseError(
         `No service named ${serviceId} declared in firebase.json. Found ${serviceInfo.dataConnectYaml.serviceId}.` +
-          ` You can run ${clc.bold("firebase init dataconnect")} to add more Data Connnect services.`,
+          `\nYou can run ${clc.bold("firebase init dataconnect")} to add more Data Connect services.`,
       );
     }
     return serviceInfo;
@@ -124,7 +124,7 @@ export async function pickService(
     if (!maybe) {
       throw new FirebaseError(
         `No service named ${serviceId} declared in firebase.json. Found ${infos.map((i) => i.dataConnectYaml.serviceId).join(", ")}.` +
-          ` You can run ${clc.bold("firebase init dataconnect")} to add more Data Connect services.`,
+          `\nYou can run ${clc.bold("firebase init dataconnect")} to add more Data Connect services.`,
       );
     }
     return maybe;

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -108,7 +108,7 @@ export async function pickService(
     if (serviceId && serviceId !== serviceInfo.dataConnectYaml.serviceId) {
       throw new FirebaseError(
         `No service named ${serviceId} declared in firebase.json. Found ${serviceInfo.dataConnectYaml.serviceId}.` +
-          `\nYou can run ${clc.bold("firebase init dataconnect")} to add more Data Connect services.`,
+          `\nYou can run ${clc.bold("firebase init dataconnect")} to add this Data Connect service.`,
       );
     }
     return serviceInfo;
@@ -124,7 +124,7 @@ export async function pickService(
     if (!maybe) {
       throw new FirebaseError(
         `No service named ${serviceId} declared in firebase.json. Found ${infos.map((i) => i.dataConnectYaml.serviceId).join(", ")}.` +
-          `\nYou can run ${clc.bold("firebase init dataconnect")} to add more Data Connect services.`,
+          `\nYou can run ${clc.bold("firebase init dataconnect")} to add this Data Connect service.`,
       );
     }
     return maybe;

--- a/src/dataconnect/fileUtils.ts
+++ b/src/dataconnect/fileUtils.ts
@@ -101,14 +101,14 @@ export async function pickService(
   if (serviceCfgs.length === 0) {
     throw new FirebaseError(
       "No Data Connect services found in firebase.json. " +
-        ` Do you want to run ${clc.bold("firebase init dataconnect")} to add a Data Connect service?`,
+        ` You can run ${clc.bold("firebase init dataconnect")} to add a Data Connect service?`,
     );
   } else if (serviceCfgs.length === 1) {
     serviceInfo = await load(projectId, config, serviceCfgs[0].source);
     if (serviceId && serviceId !== serviceInfo.dataConnectYaml.serviceId) {
       throw new FirebaseError(
         `No service named ${serviceId} declared in firebase.json. Found ${serviceInfo.dataConnectYaml.serviceId}.` +
-          ` Do you want to run ${clc.bold("firebase init dataconnect")} to add more services?`,
+          ` You can run ${clc.bold("firebase init dataconnect")} to add more Data Connnect services.`,
       );
     }
     return serviceInfo;
@@ -124,7 +124,7 @@ export async function pickService(
     if (!maybe) {
       throw new FirebaseError(
         `No service named ${serviceId} declared in firebase.json. Found ${infos.map((i) => i.dataConnectYaml.serviceId).join(", ")}.` +
-          ` Do you want to run ${clc.bold("firebase init dataconnect")} to add a Data Connect service?`,
+          ` You can run ${clc.bold("firebase init dataconnect")} to add more Data Connect services.`,
       );
     }
     return maybe;

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -82,9 +82,15 @@ export async function diffSchema(
   try {
     await upsertSchema(schema, /** validateOnly=*/ true);
     if (validationMode === "STRICT") {
-      logLabeledSuccess("dataconnect", `database schema is up to date.`);
+      logLabeledSuccess(
+        "dataconnect",
+        `database schema of ${instanceId}:${databaseId} is up to date.`,
+      );
     } else {
-      logLabeledSuccess("dataconnect", `database schema is compatible.`);
+      logLabeledSuccess(
+        "dataconnect",
+        `database schema of ${instanceId}:${databaseId} is compatible.`,
+      );
     }
   } catch (err: any) {
     if (err?.status !== 400) {
@@ -168,8 +174,10 @@ export async function migrateSchema(args: {
 
   try {
     await upsertSchema(schema, validateOnly);
-    logLabeledBullet("dataconnect", `database schema is up to date.`);
-    logger.debug(`Database schema was up to date for ${instanceId}:${databaseId}`);
+    logLabeledBullet(
+      "dataconnect",
+      `database schema of ${instanceId}:${databaseId} is up to date.`,
+    );
   } catch (err: any) {
     if (err?.status !== 400) {
       throw err;

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -157,6 +157,8 @@ export async function migrateSchema(args: {
   await setupIAMUsers(instanceId, databaseId, options);
   let diffs: Diff[] = [];
 
+  logLabeledBullet("dataconnect", `generating required schema changes...`);
+
   // Make sure database is setup.
   await setupSchemaIfNecessary(instanceId, databaseId, options);
 
@@ -166,6 +168,7 @@ export async function migrateSchema(args: {
 
   try {
     await upsertSchema(schema, validateOnly);
+    logLabeledBullet("dataconnect", `database schema is up to date.`);
     logger.debug(`Database schema was up to date for ${instanceId}:${databaseId}`);
   } catch (err: any) {
     if (err?.status !== 400) {

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -70,9 +70,7 @@ export async function diffSchema(
   );
   let diffs: Diff[] = [];
 
-  if (!schemaValidation) {
-    logLabeledBullet("dataconnect", `generating required schema changes...`);
-  }
+  logLabeledBullet("dataconnect", `generating required schema changes...`);
   // Make sure database is setup.
   await setupSchemaIfNecessary(instanceId, databaseId, options);
 
@@ -83,9 +81,9 @@ export async function diffSchema(
   try {
     await upsertSchema(schema, /** validateOnly=*/ true);
     if (validationMode === "STRICT") {
-      logLabeledSuccess("dataconnect", `Database schema is up to date.`);
+      logLabeledSuccess("dataconnect", `database schema is up to date.`);
     } else {
-      logLabeledSuccess("dataconnect", `Database schema is compatible.`);
+      logLabeledSuccess("dataconnect", `database schema is compatible.`);
     }
   } catch (err: any) {
     if (err?.status !== 400) {

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -70,6 +70,9 @@ export async function diffSchema(
   );
   let diffs: Diff[] = [];
 
+  if (!schemaValidation) {
+    logLabeledBullet("dataconnect", `generating required schema changes...`);
+  }
   // Make sure database is setup.
   await setupSchemaIfNecessary(instanceId, databaseId, options);
 
@@ -78,9 +81,6 @@ export async function diffSchema(
   setSchemaValidationMode(schema, validationMode);
 
   try {
-    if (!schemaValidation) {
-      logLabeledBullet("dataconnect", `generating required schema changes...`);
-    }
     await upsertSchema(schema, /** validateOnly=*/ true);
     if (validationMode === "STRICT") {
       logLabeledSuccess("dataconnect", `Database schema is up to date.`);

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -61,6 +61,8 @@ export async function diffSchema(
   schema: Schema,
   schemaValidation?: SchemaValidation,
 ): Promise<Diff[]> {
+  logLabeledBullet("dataconnect", `generating required schema changes...`);
+
   const { serviceName, instanceName, databaseId, instanceId } = getIdentifiers(schema);
   await ensureServiceIsConnectedToCloudSql(
     serviceName,
@@ -70,9 +72,7 @@ export async function diffSchema(
   );
   let diffs: Diff[] = [];
 
-  logLabeledBullet("dataconnect", `generating required schema changes...`);
-
-  // Make sure database is setup. (this can be slow)
+  // Make sure database is setup.
   await setupSchemaIfNecessary(instanceId, databaseId, options);
 
   // If the schema validation mode is unset, we surface both STRICT and COMPATIBLE mode diffs, starting with COMPATIBLE.
@@ -151,8 +151,9 @@ export async function migrateSchema(args: {
   validateOnly: boolean;
   schemaValidation?: SchemaValidation;
 }): Promise<Diff[]> {
-  const { options, schema, validateOnly, schemaValidation } = args;
+  logLabeledBullet("dataconnect", `generating required schema changes...`);
 
+  const { options, schema, validateOnly, schemaValidation } = args;
   const { serviceName, instanceId, instanceName, databaseId } = getIdentifiers(schema);
   await ensureServiceIsConnectedToCloudSql(
     serviceName,
@@ -162,8 +163,6 @@ export async function migrateSchema(args: {
   );
   await setupIAMUsers(instanceId, databaseId, options);
   let diffs: Diff[] = [];
-
-  logLabeledBullet("dataconnect", `generating required schema changes...`);
 
   // Make sure database is setup.
   await setupSchemaIfNecessary(instanceId, databaseId, options);
@@ -589,7 +588,7 @@ export async function ensureServiceIsConnectedToCloudSql(
     }
     // TODO: make this prompt
     // Should we upsert service here as well? so `database:sql:migrate` work for new service as well.
-    logLabeledBullet("dataconnect", `Linking the Cloud SQL instance...`);
+    logLabeledBullet("dataconnect", `linking the Cloud SQL instance...`);
     // If no schema has been deployed yet, deploy an empty one to get connectivity.
     currentSchema = {
       name: `${serviceName}/schemas/${SCHEMA_ID}`,

--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -71,7 +71,8 @@ export async function diffSchema(
   let diffs: Diff[] = [];
 
   logLabeledBullet("dataconnect", `generating required schema changes...`);
-  // Make sure database is setup.
+
+  // Make sure database is setup. (this can be slow)
   await setupSchemaIfNecessary(instanceId, databaseId, options);
 
   // If the schema validation mode is unset, we surface both STRICT and COMPATIBLE mode diffs, starting with COMPATIBLE.


### PR DESCRIPTION
### Description

Previously, if a service ID argument is provided and there is a single FDC service, we didn't validate that the service ID match the local config. So `firebase dataconnect:sql:migrate other-service` might migrate `my-service` if that's defined in `firebase.json`. This is mis-leading and incorrect.


### Sample Commands
<img width="890" alt="Screenshot 2025-05-29 at 11 23 58 AM" src="https://github.com/user-attachments/assets/37d7bd5e-cdbf-4220-a251-edbe6417abb8" />

<img width="890" alt="Screenshot 2025-05-29 at 11 29 14 AM" src="https://github.com/user-attachments/assets/ea9d00ec-fb61-400a-8fbf-bf6a3bcc681a" />

<img width="890" alt="Screenshot 2025-05-29 at 11 23 11 AM" src="https://github.com/user-attachments/assets/a23798e8-b9c9-4c76-9e81-2396771f7308" />

We don't really support multiple FDC services in init right now.

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
