### PR TITLE
`init dataconnect:sdk` pick connector name from env as well

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -33,7 +33,7 @@ const MUTATIONS_TEMPLATE = readTemplateSync("init/dataconnect/mutations.gql");
 // serviceEnvVar is used by Firebase Console to specify which service to import.
 // It should be in the form <location>/<serviceId>
 // It must be an existing service - if set to anything else, we'll ignore it.
-const serviceEnvVar = () => envOverride("FDC_SERVICE", "");
+const serviceEnvVar = () => envOverride("FDC_CONNECTOR", "") || envOverride("FDC_SERVICE", "");
 
 export interface RequiredInfo {
   serviceId: string;
@@ -104,9 +104,7 @@ export async function askQuestions(setup: Setup): Promise<void> {
     hasBilling &&
     requiredConfigUnset &&
     (await confirm({
-      message: `Would you like to configure your backend resources now?`,
-      // For Blaze Projects, configure Cloud SQL by default.
-      // TODO: For Spark projects, allow them to configure Cloud SQL but deploy as unlinked Postgres.
+      message: `Would you like to configure your Cloud SQL datasource now?`,
       default: true,
     }));
   if (shouldConfigureBackend) {
@@ -275,37 +273,7 @@ async function promptForExistingServices(setup: Setup, info: RequiredInfo): Prom
     }),
   );
   if (existingServicesAndSchemas.length) {
-    let choice: { service: Service; schema?: Schema } | undefined;
-    const [serviceLocationFromEnvVar, serviceIdFromEnvVar] = serviceEnvVar().split("/");
-    const serviceFromEnvVar = existingServicesAndSchemas.find((s) => {
-      const serviceName = parseServiceName(s.service.name);
-      return (
-        serviceName.serviceId === serviceIdFromEnvVar &&
-        serviceName.location === serviceLocationFromEnvVar
-      );
-    });
-    if (serviceFromEnvVar) {
-      choice = serviceFromEnvVar;
-    } else {
-      interface Choice {
-        service: Service;
-        schema?: Schema;
-      }
-      const choices: Array<{ name: string; value: Choice | undefined }> =
-        existingServicesAndSchemas.map((s) => {
-          const serviceName = parseServiceName(s.service.name);
-          return {
-            name: `${serviceName.location}/${serviceName.serviceId}`,
-            value: s,
-          };
-        });
-      choices.push({ name: "Create a new service", value: undefined });
-      choice = await select<Choice | undefined>({
-        message:
-          "Your project already has existing services. Which would you like to set up local files for?",
-        choices,
-      });
-    }
+    const choice = await chooseExistingService(existingServicesAndSchemas);
     if (choice) {
       const serviceName = parseServiceName(choice.service.name);
       info.serviceId = serviceName.serviceId;
@@ -343,6 +311,46 @@ async function promptForExistingServices(setup: Setup, info: RequiredInfo): Prom
     }
   }
   return info;
+}
+
+interface serviceAndSchema {
+  service: Service;
+  schema?: Schema;
+}
+
+async function chooseExistingService(
+  existing: serviceAndSchema[],
+): Promise<serviceAndSchema | undefined> {
+  const [serviceLocationFromEnvVar, serviceIdFromEnvVar] = serviceEnvVar().split("/");
+  const serviceFromEnvVar = existing.find((s) => {
+    const serviceName = parseServiceName(s.service.name);
+    return (
+      serviceName.serviceId === serviceIdFromEnvVar &&
+      serviceName.location === serviceLocationFromEnvVar
+    );
+  });
+  if (serviceFromEnvVar) {
+    // FDC_CONNECTOR or FDC_SERVICE env var match an existing service.
+    logBullet(
+      `Picking up the existing service ${clc.bold(serviceLocationFromEnvVar + "/" + serviceIdFromEnvVar)}.`,
+    );
+    return serviceFromEnvVar;
+  }
+  const choices: Array<{ name: string; value: serviceAndSchema | undefined }> = existing.map(
+    (s) => {
+      const serviceName = parseServiceName(s.service.name);
+      return {
+        name: `${serviceName.location}/${serviceName.serviceId}`,
+        value: s,
+      };
+    },
+  );
+  choices.push({ name: "Create a new service", value: undefined });
+  return await select<serviceAndSchema | undefined>({
+    message:
+      "Your project already has existing services. Which would you like to set up local files for?",
+    choices,
+  });
 }
 
 async function promptForCloudSQL(setup: Setup, info: RequiredInfo): Promise<RequiredInfo> {

--- a/src/init/features/dataconnect/sdk.spec.ts
+++ b/src/init/features/dataconnect/sdk.spec.ts
@@ -51,7 +51,7 @@ describe("init dataconnect:sdk", () => {
         await sdk.actuate(c.sdkInfo, emptyConfig);
         expect(generateStub.called).to.equal(c.shouldGenerate);
         expect(askProjectWriteFileStub.args).to.deep.equal([
-          ["dataconnect/connector/connector.yaml", CONNECTOR_YAML_CONTENTS],
+          ["dataconnect/connector/connector.yaml", CONNECTOR_YAML_CONTENTS, false, true],
         ]);
       });
     }


### PR DESCRIPTION
A couple of small improves on the `init:sdk` flow.

- If there is only one connector, don't prompt.
- Take a `FDC_CONNECTOR` env variable to resume from console off board flow. 
- Default to confirm `connector.yaml` file write.

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

### Init a with `FDC_SERVICE`

`FDC_SERVICE=us-central1/fredzqm-staging-service firebase init dataconnect -P fredzqm-staging`

Completes with no prompt.

<img width="1098" alt="Screenshot 2025-05-29 at 1 10 15 PM" src="https://github.com/user-attachments/assets/c1bd0edc-35f3-49a4-b23a-c0aeb7da02ed" />

### Init a with `FDC_SERVICE` w/o existing cloud sql

`FDC_SERVICE=us-central1/app firebase init dataconnect -P fredzqm-staging`

Prompt for Cloud SQL setup

<img width="1098" alt="Screenshot 2025-05-29 at 1 08 25 PM" src="https://github.com/user-attachments/assets/83f63d35-6e15-48a9-a986-274c02b76ef4" />

### init SDK with `FDC_CONNECTOR`

`FDC_CONNECTOR=us-central1/fredzqm-staging-service/second-connector fb init dataconnect:sdk`

Automatically picks the connector.

<img width="1098" alt="Screenshot 2025-05-29 at 1 14 45 PM" src="https://github.com/user-attachments/assets/78c317d4-e5e4-40f8-a2f4-c485f5b82069" />
