### PR TITLE
[FDC] Print a warning if the FDC env override didn't match anything

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -35,15 +35,24 @@ export const command = new Command("login")
 
     if (!options.reauth) {
       utils.logBullet(
-        "Firebase optionally collects CLI and Emulator Suite usage and error reporting information to help improve our products. Data is collected in accordance with Google's privacy policy (https://policies.google.com/privacy) and is not used to identify you.\n",
+        "Firebase CLI integrates with Gemini in Firebase API to provide assistant features. Learn more about using Gemini in Firebase and how we train our models: https://firebase.google.com/docs/gemini-in-firebase/set-up-gemini#required-permissions",
+      );
+      const geminiUsage = await confirm("Enable Gemini in Firebase features?");
+      configstore.set("gemini", geminiUsage);
+
+      logger.info();
+      utils.logBullet(
+        "Firebase optionally collects CLI and Emulator Suite usage and error reporting information to help improve our products. Data is collected in accordance with Google's privacy policy (https://policies.google.com/privacy) and is not used to identify you.",
       );
       const collectUsage = await confirm(
         "Allow Firebase to collect CLI and Emulator Suite usage and error reporting information?",
       );
       configstore.set("usage", collectUsage);
-      if (collectUsage) {
+
+      if (geminiUsage || collectUsage) {
+        logger.info();
         utils.logBullet(
-          "To change your data collection preference at any time, run `firebase logout` and log in again.",
+          "To change your the preference at any time, run `firebase logout` and `firebase login` again.",
         );
       }
     }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -35,24 +35,15 @@ export const command = new Command("login")
 
     if (!options.reauth) {
       utils.logBullet(
-        "Firebase CLI integrates with Gemini in Firebase API to provide assistant features. Learn more about using Gemini in Firebase and how we train our models: https://firebase.google.com/docs/gemini-in-firebase/set-up-gemini#required-permissions",
-      );
-      const geminiUsage = await confirm("Enable Gemini in Firebase features?");
-      configstore.set("gemini", geminiUsage);
-
-      logger.info();
-      utils.logBullet(
-        "Firebase optionally collects CLI and Emulator Suite usage and error reporting information to help improve our products. Data is collected in accordance with Google's privacy policy (https://policies.google.com/privacy) and is not used to identify you.",
+        "Firebase optionally collects CLI and Emulator Suite usage and error reporting information to help improve our products. Data is collected in accordance with Google's privacy policy (https://policies.google.com/privacy) and is not used to identify you.\n",
       );
       const collectUsage = await confirm(
         "Allow Firebase to collect CLI and Emulator Suite usage and error reporting information?",
       );
       configstore.set("usage", collectUsage);
-
-      if (geminiUsage || collectUsage) {
-        logger.info();
+      if (collectUsage) {
         utils.logBullet(
-          "To change your the preference at any time, run `firebase logout` and `firebase login` again.",
+          "To change your data collection preference at any time, run `firebase logout` and log in again.",
         );
       }
     }

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -338,7 +338,6 @@ async function chooseExistingService(
       );
     });
     if (serviceFromEnvVar) {
-      // FDC_CONNECTOR or FDC_SERVICE env var match an existing service.
       logBullet(
         `Picking up the existing service ${clc.bold(serviceLocationFromEnvVar + "/" + serviceIdFromEnvVar)}.`,
       );

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -158,7 +158,7 @@ interface connectorChoice {
  */
 async function chooseExistingConnector(choices: connectorChoice[]): Promise<ConnectorInfo> {
   if (choices.length === 1) {
-    // On ly one connector available, use it.
+    // Only one connector available, use it.
     return choices[0].value;
   }
   const connectorEnvVar = envOverride("FDC_CONNECTOR", "");

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -165,7 +165,6 @@ async function chooseExistingConnector(choices: connectorChoice[]): Promise<Conn
   if (connectorEnvVar) {
     const existingConnector = choices.find((c) => c.name === connectorEnvVar);
     if (existingConnector) {
-      // FD C_CONNECTOR env var match an existing connector.
       logBullet(`Picking up the existing connector ${clc.bold(connectorEnvVar)}.`);
       return existingConnector.value;
     }

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -141,11 +141,6 @@ interface connectorChoice {
   value: ConnectorInfo;
 }
 
-// connectorEnvVar is used by Firebase Console to specify which connector to setup.
-// It should be in the form <location>/<serviceId>/<connectorId>.
-// We ignore it if this connector does not exist.
-// Firebase Console can provide either FDC_SERVICE or FDC_CONNECTOR environment variables based on its page.
-
 /**
  * Picks an existing connector from those present in the local workspace.
  *

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -204,8 +204,8 @@ export async function generateSdkYaml(
       outputDir: path.relative(connectorDir, path.join(appDir, `dataconnect-generated/js/${pkg}`)),
       package: `@firebasegen/${pkg}`,
       // If appDir has package.json, Emulator would add Generated JS SDK to `package.json`.
-      // Ot herwise, emulator would ignore it. Always add it here in case `package.json` is added later.
-      // TO DO: Explore other platforms that can be automatically installed. Dart? Android?
+      // Otherwise, emulator would ignore it. Always add it here in case `package.json` is added later.
+      // TODO: Explore other platforms that can be automatically installed. Dart? Android?
       packageJsonDir,
     };
     const packageJson = await resolvePackageJson(appDir);
@@ -237,9 +237,9 @@ export async function generateSdkYaml(
       outputDir: path.relative(connectorDir, path.join(appDir, `dataconnect-generated/kotlin`)),
       package: `connectors.${snakeCase(connectorYaml.connectorId)}`,
     };
-    // ap p/src/main/kotlin and app/src/main/java are conventional for Android,
-    // bu t not required or enforced. If one of them is present (preferring the
-    // "k otlin" directory), use it. Otherwise, fall back to the dataconnect-generated dir.
+    // app/src/main/kotlin and app/src/main/java are conventional for Android,
+    // but not required or enforced. If one of them is present (preferring the
+    // "kotlin" directory), use it. Otherwise, fall back to the dataconnect-generated dir.
     for (const candidateSubdir of ["app/src/main/java", "app/src/main/kotlin"]) {
       const candidateDir = path.join(appDir, candidateSubdir);
       if (dirExistsSync(candidateDir)) {
@@ -258,8 +258,8 @@ export async function actuate(sdkInfo: SDKInfo, config: Config) {
   await config.askWriteProjectFile(
     path.relative(config.projectDir, connectorYamlPath),
     sdkInfo.connectorYamlContents,
-    /* fo rce=*/ false,
-    /* co nfirmByDefault=*/ true,
+    /* force=*/ false,
+    /* confirmByDefault=*/ true,
   );
 
   const account = getGlobalDefaultAccount();
@@ -291,7 +291,7 @@ function logInfoForFramework(framework: keyof SupportedFrameworks) {
       "Visit https://firebase.google.com/docs/data-connect/web-sdk#react for more information on how to set up React Generated SDKs for Firebase Data Connect",
     );
   } else if (framework === "angular") {
-    // TO DO(mtewani): Replace this with `ng add @angular/fire` when ready.
+    // TODO(mtewani): Replace this with `ng add @angular/fire` when ready.
     logBullet(
       "Run `npm i --save @angular/fire @tanstack-query-firebase/angular @tanstack/angular-query-experimental` to install angular sdk dependencies.\nVisit https://github.com/invertase/tanstack-query-firebase/tree/main/packages/angular for more information on how to set up Angular Generated SDKs for Firebase Data Connect",
     );


### PR DESCRIPTION
Improve the error handling slightly.

FDC_CONNECTOR works for picking service as well.


```
FDC_SERVICE=us-central1/fredzqm-staging-se firebase init dataconnect -P fredzqm-staging
```

<img width="1116" alt="Screenshot 2025-05-29 at 3 30 56 PM" src="https://github.com/user-attachments/assets/ff9cc707-0683-4ba1-85fc-66918d8869f8" />

```
FDC_CONNECTOR=us-central1/fredzqm-staging-service/second-connec-wrong firebase init dataconnect:sdk
```

<img width="1116" alt="Screenshot 2025-05-29 at 3 31 55 PM" src="https://github.com/user-attachments/assets/4d2aba4b-da2c-4dce-a05d-ba28573074a4" />

```
FDC_CONNECTOR=us-central1/fredzqm-staging-service/second-connec-wrong firebase init dataconnect -P fredzqm-staging
```
<img width="1116" alt="Screenshot 2025-05-29 at 3 34 40 PM" src="https://github.com/user-attachments/assets/817f3821-7591-4c37-9fcc-b668cb4d6e37" />

```
FDC_CONNECTOR=us-central1/fredzqm-staging-service-wrong/second-connec-wrong firebase init dataconnect -P fredzqm-staging
```

<img width="1116" alt="Screenshot 2025-05-29 at 3 34 06 PM" src="https://github.com/user-attachments/assets/3c0a74fb-a5f9-49fb-9e3b-c0a754a8ade0" />

