### PR TITLE
firestore.database should not be required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where 'firestore.database' was accidentally treated as a required field. (#8678)

--- a/src/deploy/firestore/deploy.ts
+++ b/src/deploy/firestore/deploy.ts
@@ -19,8 +19,11 @@ async function createDatabase(context: any, options: Options): Promise<void> {
   if (!options.projectId) {
     throw new FirebaseError("Project ID is required to create a Firestore database.");
   }
-  if (!firestoreCfg || !firestoreCfg.database) {
-    throw new FirebaseError("Firestore database configuration is missing in firebase.json.");
+  if (!firestoreCfg) {
+    throw new FirebaseError("Firestore database configuration not found in firebase.json.");
+  }
+  if (!firestoreCfg.database) {
+    firestoreCfg.database = "(default)";
   }
   const api = new FirestoreApi();
   try {


### PR DESCRIPTION
### Description
In a previous PR, we accidentally made 'database' a required field in `firebase.json#firestore` - it should not be. Fixes #8678. 

### Scenarios tested
Successfully deployed without setting `firestore.database`