### PR TITLE
Improve GetDatabase Caching for Firestore Function Deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Improved GetDatabase API call caching for Firestore function deployments. (#8681)

--- a/src/deploy/functions/services/firestore.spec.ts
+++ b/src/deploy/functions/services/firestore.spec.ts
@@ -23,7 +23,7 @@ describe("ensureFirestoreTriggerRegion", () => {
   let firestoreStub: sinon.SinonStub;
 
   beforeEach(() => {
-    clearCache(); // Clear the cache before each test
+    clearCache();
     firestoreStub = sinon
       .stub(firestore, "getDatabase")
       .throws("unexpected call to firestore.getDatabase");
@@ -92,13 +92,8 @@ describe("ensureFirestoreTriggerRegion", () => {
       },
     };
 
-    // Call concurrently
-    await Promise.all([
-      ensureFirestoreTriggerRegion(ep1),
-      ensureFirestoreTriggerRegion(ep2),
-    ]);
+    await Promise.all([ensureFirestoreTriggerRegion(ep1), ensureFirestoreTriggerRegion(ep2)]);
 
-    // Should only call API once despite two concurrent requests
     expect(firestoreStub).to.have.been.calledOnce;
     expect(ep1.eventTrigger.region).to.eq("nam5");
     expect(ep2.eventTrigger.region).to.eq("nam5");
@@ -106,8 +101,10 @@ describe("ensureFirestoreTriggerRegion", () => {
 
   it("should make separate API calls for different databases", async () => {
     firestoreStub.onFirstCall().resolves(databaseResp);
-    firestoreStub.onSecondCall().resolves({ ...databaseResp, name: "projects/123456789/databases/db2" });
-    
+    firestoreStub
+      .onSecondCall()
+      .resolves({ ...databaseResp, name: "projects/123456789/databases/db2" });
+
     const ep1: any = {
       project: projectNumber,
       eventTrigger: {
@@ -121,12 +118,8 @@ describe("ensureFirestoreTriggerRegion", () => {
       },
     };
 
-    await Promise.all([
-      ensureFirestoreTriggerRegion(ep1),
-      ensureFirestoreTriggerRegion(ep2),
-    ]);
+    await Promise.all([ensureFirestoreTriggerRegion(ep1), ensureFirestoreTriggerRegion(ep2)]);
 
-    // Should call API twice for different databases
     expect(firestoreStub).to.have.been.calledTwice;
   });
 });

--- a/src/deploy/functions/services/firestore.spec.ts
+++ b/src/deploy/functions/services/firestore.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { ensureFirestoreTriggerRegion } from "./firestore";
+import { ensureFirestoreTriggerRegion, clearCache } from "./firestore";
 import * as firestore from "../../../gcp/firestore";
 
 const projectNumber = "123456789";
@@ -23,6 +23,7 @@ describe("ensureFirestoreTriggerRegion", () => {
   let firestoreStub: sinon.SinonStub;
 
   beforeEach(() => {
+    clearCache(); // Clear the cache before each test
     firestoreStub = sinon
       .stub(firestore, "getDatabase")
       .throws("unexpected call to firestore.getDatabase");
@@ -74,5 +75,58 @@ describe("ensureFirestoreTriggerRegion", () => {
     await ensureFirestoreTriggerRegion(ep);
 
     expect(ep.eventTrigger.region).to.eq("nam5");
+  });
+
+  it("should cache database lookups to prevent multiple API calls", async () => {
+    firestoreStub.resolves(databaseResp);
+    const ep1: any = {
+      project: projectNumber,
+      eventTrigger: {
+        eventFilters: { database: "(default)" },
+      },
+    };
+    const ep2: any = {
+      project: projectNumber,
+      eventTrigger: {
+        eventFilters: { database: "(default)" },
+      },
+    };
+
+    // Call concurrently
+    await Promise.all([
+      ensureFirestoreTriggerRegion(ep1),
+      ensureFirestoreTriggerRegion(ep2),
+    ]);
+
+    // Should only call API once despite two concurrent requests
+    expect(firestoreStub).to.have.been.calledOnce;
+    expect(ep1.eventTrigger.region).to.eq("nam5");
+    expect(ep2.eventTrigger.region).to.eq("nam5");
+  });
+
+  it("should make separate API calls for different databases", async () => {
+    firestoreStub.onFirstCall().resolves(databaseResp);
+    firestoreStub.onSecondCall().resolves({ ...databaseResp, name: "projects/123456789/databases/db2" });
+    
+    const ep1: any = {
+      project: projectNumber,
+      eventTrigger: {
+        eventFilters: { database: "(default)" },
+      },
+    };
+    const ep2: any = {
+      project: projectNumber,
+      eventTrigger: {
+        eventFilters: { database: "db2" },
+      },
+    };
+
+    await Promise.all([
+      ensureFirestoreTriggerRegion(ep1),
+      ensureFirestoreTriggerRegion(ep2),
+    ]);
+
+    // Should call API twice for different databases
+    expect(firestoreStub).to.have.been.calledTwice;
   });
 });

--- a/src/deploy/functions/services/firestore.ts
+++ b/src/deploy/functions/services/firestore.ts
@@ -23,27 +23,27 @@ export function clearCache(): void {
  */
 async function getDatabase(project: string, databaseId: string): Promise<firestore.Database> {
   const key = `${project}/${databaseId}`;
-  
-  // Check if we already have the result
+
   if (dbCache.has(key)) {
     return dbCache.get(key)!;
   }
-  
-  // Check if there's already a pending request for this database
+
   if (dbPromiseCache.has(key)) {
     return dbPromiseCache.get(key)!;
   }
-  
-  // Create a new request and cache the promise
-  const dbPromise = firestore.getDatabase(project, databaseId, false).then((db) => {
-    dbCache.set(key, db);
-    dbPromiseCache.delete(key); // Clean up the promise cache
-    return db;
-  }).catch((error) => {
-    dbPromiseCache.delete(key); // Clean up on error
-    throw error;
-  });
-  
+
+  const dbPromise = firestore
+    .getDatabase(project, databaseId, false)
+    .then((db) => {
+      dbCache.set(key, db);
+      dbPromiseCache.delete(key);
+      return db;
+    })
+    .catch((error) => {
+      dbPromiseCache.delete(key);
+      throw error;
+    });
+
   dbPromiseCache.set(key, dbPromise);
   return dbPromise;
 }


### PR DESCRIPTION
When deploying multiple 2nd gen Firestore functions, we send many concurrent GetDatabase API requests. The existing caching mechanism was not effective for these simultaneous calls, leading to redundant requests and (potentially) API quota issue.

This change introduces caching for the promise of the GetDatabase API call itself, in addition to the result. This should  improves cache hits for concurrent requests, resulting in more reliable function deployments.