### PR TITLE
Bump timeout for linking CSQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Improved GetDatabase API call caching for Firestore function deployments. (#8681)
+- Increased timeout for linking CloudSQL instances to Data Connect.

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -132,6 +132,7 @@ export async function upsertSchema(
     apiOrigin: dataconnectOrigin(),
     apiVersion: DATACONNECT_API_VERSION,
     operationResourceName: op.body.name,
+    masterTimeout: 120000,
   });
 }
 


### PR DESCRIPTION
### Description
@dconeybe ran into a timeout here when linking a new CSQL instance. It seems pretty safe to bump this a bit.