### PR TITLE
Respect --database flag in firestore:delete and add database option to MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Improved GetDatabase API call caching for Firestore function deployments. (#8681)
 - Increased timeout for linking CloudSQL instances to Data Connect.
 - Fixed issue where `firebase use --add` didn't correctly set the active project. (#8694)
+- Correctly support '--database' flag in `firestore:delete`. (#6753)

--- a/src/firestore/delete.ts
+++ b/src/firestore/delete.ts
@@ -394,7 +394,7 @@ export class FirestoreDelete {
 
       numPendingDeletes++;
       firestore
-        .deleteDocuments(this.project, toDelete, true)
+        .deleteDocuments(this.project, toDelete, this.databaseId, true)
         .then((numDeleted) => {
           FirestoreDelete.progressBar.tick(numDeleted);
           numDocsDeleted += numDeleted;
@@ -526,7 +526,7 @@ export class FirestoreDelete {
    */
   public deleteDatabase(): Promise<any[]> {
     return firestore
-      .listCollectionIds(this.project, true)
+      .listCollectionIds(this.project, this.databaseId, true)
       .catch((err) => {
         logger.debug("deleteDatabase:listCollectionIds:error", err);
         return utils.reject("Unable to list collection IDs");

--- a/src/gcp/firestore.ts
+++ b/src/gcp/firestore.ts
@@ -169,10 +169,11 @@ export async function getDatabase(
  */
 export function listCollectionIds(
   project: string,
+  databaseId: string = "(default)",
   allowEmulator: boolean = false,
 ): Promise<string[]> {
   const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
-  const url = "projects/" + project + "/databases/(default)/documents:listCollectionIds";
+  const url = `projects/${project}/databases/${databaseId}/documents:listCollectionIds`;
   const data = {
     // Maximum 32-bit integer
     pageSize: 2147483647,
@@ -192,10 +193,11 @@ export function listCollectionIds(
 export async function getDocuments(
   project: string,
   paths: string[],
+  databaseId: string = "(default)",
   allowEmulator?: boolean,
 ): Promise<{ documents: FirestoreDocument[]; missing: string[] }> {
   const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
-  const basePath = `projects/${project}/databases/(default)/documents`;
+  const basePath = `projects/${project}/databases/${databaseId}/documents`;
   const url = `${basePath}:batchGet`;
   const fullPaths = paths.map((p) => `${basePath}/${p}`);
   const res = await apiClient.post<
@@ -216,10 +218,11 @@ export async function getDocuments(
 export async function queryCollection(
   project: string,
   structuredQuery: StructuredQuery,
+  databaseId: string = "(default)",
   allowEmulator?: boolean,
 ): Promise<{ documents: FirestoreDocument[] }> {
   const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
-  const basePath = `projects/${project}/databases/(default)/documents`;
+  const basePath = `projects/${project}/databases/${databaseId}/documents`;
   const url = `${basePath}:runQuery`;
   try {
     const res = await apiClient.post<
@@ -275,10 +278,11 @@ export async function deleteDocument(doc: any, allowEmulator: boolean = false): 
 export async function deleteDocuments(
   project: string,
   docs: any[],
+  databaseId: string = "(default)",
   allowEmulator: boolean = false,
 ): Promise<number> {
   const apiClient = allowEmulator ? emuOrProdClient : prodOnlyClient;
-  const url = "projects/" + project + "/databases/(default)/documents:commit";
+  const url = `projects/${project}/databases/${databaseId}/documents:commit`;
 
   const writes = docs.map((doc) => {
     return { delete: doc.name };

--- a/src/mcp/tools/firestore/delete_document.ts
+++ b/src/mcp/tools/firestore/delete_document.ts
@@ -10,11 +10,10 @@ export const delete_document = tool(
     description:
       "Deletes a Firestore documents from a database in the current project by full document paths. Use this if you know the exact path of a document.",
     inputSchema: z.object({
-      // TODO: Support configurable database
-      // database: z
-      //   .string()
-      //   .optional()
-      //   .describe("Database id to use. Defaults to `(default)` if unspecified."),
+      database: z
+        .string()
+        .optional()
+        .describe("Database id to use. Defaults to `(default)` if unspecified."),
       path: z
         .string()
         .describe(
@@ -30,14 +29,15 @@ export const delete_document = tool(
       requiresProject: true,
     },
   },
-  async ({ path }, { projectId }) => {
-    // database ??= "(default)";
-    const { documents, missing } = await getDocuments(projectId, [path]);
+  async ({ path, database }, { projectId }) => {
+    const { documents, missing } = await getDocuments(projectId, [path], database);
     if (missing.length > 0 && documents && documents.length === 0) {
       return mcpError(`None of the specified documents were found in project '${projectId}'`);
     }
 
-    const firestoreDelete = new FirestoreDelete(projectId, path, { databaseId: "(default)" });
+    const firestoreDelete = new FirestoreDelete(projectId, path, {
+      databaseId: database ?? "(default)",
+    });
 
     await firestoreDelete.execute();
 

--- a/src/mcp/tools/firestore/get_documents.ts
+++ b/src/mcp/tools/firestore/get_documents.ts
@@ -10,11 +10,10 @@ export const get_documents = tool(
     description:
       "Retrieves one or more Firestore documents from a database in the current project by full document paths. Use this if you know the exact path of a document.",
     inputSchema: z.object({
-      // TODO: Support configurable database
-      // database: z
-      //   .string()
-      //   .optional()
-      //   .describe("Database id to use. Defaults to `(default)` if unspecified."),
+      database: z
+        .string()
+        .optional()
+        .describe("Database id to use. Defaults to `(default)` if unspecified."),
       paths: z
         .array(z.string())
         .describe(
@@ -30,11 +29,10 @@ export const get_documents = tool(
       requiresProject: true,
     },
   },
-  async ({ paths }, { projectId }) => {
-    // database ??= "(default)";
+  async ({ paths, database }, { projectId }) => {
     if (!paths || !paths.length) return mcpError("Must supply at least one document path.");
 
-    const { documents, missing } = await getDocuments(projectId, paths);
+    const { documents, missing } = await getDocuments(projectId, paths, database);
     if (missing.length > 0 && documents && documents.length === 0) {
       return mcpError(`None of the specified documents were found in project '${projectId}'`);
     }

--- a/src/mcp/tools/firestore/list_collections.ts
+++ b/src/mcp/tools/firestore/list_collections.ts
@@ -11,10 +11,10 @@ export const list_collections = tool(
       "Retrieves a list of collections from a Firestore database in the current project.",
     inputSchema: z.object({
       // TODO: support multiple databases
-      // database: z
-      //   .string()
-      //   .optional()
-      //   .describe("Database id to use. Defaults to `(default)` if unspecified."),
+      database: z
+        .string()
+        .optional()
+        .describe("Database id to use. Defaults to `(default)` if unspecified."),
     }),
     annotations: {
       title: "List Firestore collections",
@@ -25,9 +25,9 @@ export const list_collections = tool(
       requiresProject: true,
     },
   },
-  async (_, { projectId }) => {
+  async ({ database }, { projectId }) => {
     // database ??= "(default)";
     if (!projectId) return NO_PROJECT_ERROR;
-    return toContent(await listCollectionIds(projectId));
+    return toContent(await listCollectionIds(projectId, database));
   },
 );

--- a/src/mcp/tools/firestore/query_collection.ts
+++ b/src/mcp/tools/firestore/query_collection.ts
@@ -10,11 +10,10 @@ export const query_collection = tool(
     description:
       "Retrieves one or more Firestore documents from a collection is a database in the current project by a collection with a full document path. Use this if you know the exact path of a collection and the filtering clause you would like for the document.",
     inputSchema: z.object({
-      // TODO: Support configurable database
-      // database: z
-      //   .string()
-      //   .optional()
-      //   .describe("Database id to use. Defaults to `(default)` if unspecified."),
+      database: z
+        .string()
+        .optional()
+        .describe("Database id to use. Defaults to `(default)` if unspecified."),
       collection_path: z
         .string()
         .describe(
@@ -84,7 +83,7 @@ export const query_collection = tool(
       requiresProject: true,
     },
   },
-  async ({ collection_path, filters, order, limit }, { projectId }) => {
+  async ({ collection_path, filters, order, limit, database }, { projectId }) => {
     // database ??= "(default)";
 
     if (!collection_path || !collection_path.length)
@@ -131,7 +130,7 @@ export const query_collection = tool(
     }
     structuredQuery.limit = limit ? limit : 10;
 
-    const { documents } = await queryCollection(projectId, structuredQuery);
+    const { documents } = await queryCollection(projectId, structuredQuery, database);
 
     const docs = documents.map(firestoreDocumentToJson);
 


### PR DESCRIPTION
### Description
Fixes #6753 and also adds database option to MCP tools.

It looks like we previously intentionally omitted the database option for tools - was it because of this issue, or were there other problems that we ran into?

