### PR TITLE
Clean up 'storage.rules' file created during 'npm run test'

### DIFF
--- a/src/init/features/storage.spec.ts
+++ b/src/init/features/storage.spec.ts
@@ -1,12 +1,15 @@
 import { expect } from "chai";
 import * as _ from "lodash";
 import * as sinon from "sinon";
+import * as tmp from "tmp";
+import { rmSync } from "node:fs";
 
 import { Config } from "../../config";
 import { askQuestions, actuate } from "./storage";
 import * as prompt from "../../prompt";
 
 describe("storage", () => {
+  const tempdir = tmp.dirSync();
   const sandbox: sinon.SinonSandbox = sinon.createSandbox();
   let askWriteProjectFileStub: sinon.SinonStub;
   let promptStub: sinon.SinonStub;
@@ -18,6 +21,7 @@ describe("storage", () => {
 
   afterEach(() => {
     sandbox.restore();
+    rmSync(tempdir.name, { recursive: true });
   });
 
   describe("doSetup", () => {
@@ -28,7 +32,7 @@ describe("storage", () => {
         projectId: "my-project-123",
         projectLocation: "us-central",
       };
-      const config = new Config({}, { projectDir: "test", cwd: "test" });
+      const config = new Config({}, { projectDir: tempdir.name, cwd: tempdir.name });
       promptStub.returns("storage.rules");
       askWriteProjectFileStub.resolves();
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Running `npm run test` creates a file `/test/storage.rules`.
![image](https://github.com/user-attachments/assets/5bfbdcfc-75ad-4cba-a623-da65f5176609)

This PR change creates a temporary directory where the test can run. Also removes the temporary directory after tests. Copied similar code from https://github.com/firebase/firebase-tools/blob/master/src/appdistribution/options-parser-util.spec.ts

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Verified that `npm run test` creates and removes the temporary directory created.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
