### PR TITLE
Fix extensions emulator with demo- projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Add emulator support to firebase storage MCP tools. (#8707)
 - Removed overeager error catch in `functions:list`.
 - Add validation during `firebase init` feature selection. (#5232)
+- Fixed an issue where the extensiosn emulator did not work with `demo-` projects. (#8720)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 - Add emulator support to firebase storage MCP tools. (#8707)
 - Removed overeager error catch in `functions:list`.
 - Add validation during `firebase init` feature selection. (#5232)
-- Fixed an issue where the extensiosn emulator did not work with `demo-` projects. (#8720)
+- Fixed an issue where the extensions emulator did not work with `demo-` projects. (#8720)

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -156,7 +156,12 @@ export async function beforeEmulatorCommand(options: any): Promise<any> {
     !controller.shouldStart(optionsWithConfig, Emulators.FUNCTIONS) &&
     !controller.shouldStart(optionsWithConfig, Emulators.HOSTING);
 
-  if (!Constants.isDemoProject(options.project)) {
+  // We generally should not check for auth if you are using a demo project since prod calls to a fake project will fail.
+  // However, extensions makes 'publishers/*' calls that require auth, so we'll requireAuth if you are using extensions.
+  if (
+    !Constants.isDemoProject(options.project) ||
+    controller.shouldStart(optionsWithConfig, Emulators.EXTENSIONS)
+  ) {
     try {
       await requireAuth(options);
     } catch (e: any) {


### PR DESCRIPTION

### Description
Turns out the extensions emulator requires auth, even on `demo-` projects. Fixes #8720

### Scenarios Tested

Followed the repro steps at https://github.com/aalej/issues-8720 - after this fix, it runs as expected.
