### PR TITLE
Fix leaky storage init test

### DIFF
--- a/src/init/features/storage.spec.ts
+++ b/src/init/features/storage.spec.ts
@@ -12,7 +12,7 @@ describe("storage", () => {
   let promptStub: sinon.SinonStub;
 
   beforeEach(() => {
-    askWriteProjectFileStub = sandbox.stub(Config.prototype, "askWriteProjectFile");
+    askWriteProjectFileStub = sandbox.stub(Config.prototype, "writeProjectFile");
     promptStub = sandbox.stub(prompt, "input");
   });
 


### PR DESCRIPTION

### Description
Looks like we forgot to update this stub, and so it was leaking a storage.rules file.
