### PR TITLE
Allow MCP to use ADC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - Add validation during `firebase init` feature selection. (#5232)
 - Fixed an issue where the extensions emulator did not work with `demo-` projects. (#8720)
 - Fixed issue where `--export-on-exit` fails if the target directory does not exist. (#4688)
+- Fixed issue where the Firebase MCP server could not use application default credentials. (#8671)

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -174,7 +174,8 @@ export class FirebaseMcpServer {
 
   async getAuthenticatedUser(): Promise<string | null> {
     try {
-      return await requireAuth(await this.resolveOptions());
+      const email = await requireAuth(await this.resolveOptions());
+      return email ?? "Application default credentials";
     } catch (e) {
       return null;
     }
@@ -221,12 +222,8 @@ export class FirebaseMcpServer {
     projectId = projectId || "";
 
     const accountEmail = await this.getAuthenticatedUser();
-    if (tool.mcp._meta?.requiresAuth) {
-      try {
-        await requireAuth(await this.resolveOptions());
-      } catch (e: any) {
-        return mcpAuthError();
-      }
+    if (tool.mcp._meta?.requiresAuth && !accountEmail) {
+      return mcpAuthError();
     }
 
     const options = { projectDir: this.cachedProjectRoot, cwd: this.cachedProjectRoot };

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -221,8 +221,12 @@ export class FirebaseMcpServer {
     projectId = projectId || "";
 
     const accountEmail = await this.getAuthenticatedUser();
-    if (tool.mcp._meta?.requiresAuth && !accountEmail) {
-      return mcpAuthError();
+    if (tool.mcp._meta?.requiresAuth) {
+      try {
+        await requireAuth(await this.resolveOptions());
+      } catch (e: any) {
+        return mcpAuthError();
+      }
     }
 
     const options = { projectDir: this.cachedProjectRoot, cwd: this.cachedProjectRoot };

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -175,7 +175,7 @@ export class FirebaseMcpServer {
   async getAuthenticatedUser(): Promise<string | null> {
     try {
       const email = await requireAuth(await this.resolveOptions());
-      return email ?? "Application default credentials";
+      return email ?? "Application Default Credentials";
     } catch (e) {
       return null;
     }

--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -77,7 +77,9 @@ export async function refreshAuth(): Promise<Tokens> {
 }
 
 /**
- * Ensures that there is an authenticated user.
+ * Ensures that the user can make authenticated calls. Returns the email if the user is logged in,
+ * returns null if the user has Applciation Default Credentials set up, and errors out
+ * if the user is not authenticated
  * @param options CLI options.
  */
 export async function requireAuth(options: any): Promise<string | null> {


### PR DESCRIPTION
### Description
Fixes #8671.

### Scenarios Tested
Ran `firebase logout`, `gcloud auth application-default login`, and then tested a tool that required auth and confirmed that it did not error out.
