### PR TITLE
Update system packages when building Docker image to avoid picking up upstream vulnerabilities

### DIFF
--- a/scripts/publish/firebase-docker-image/Dockerfile
+++ b/scripts/publish/firebase-docker-image/Dockerfile
@@ -2,6 +2,8 @@ FROM node:lts-alpine AS app-env
 
 # Install Python and Java and pre-cache emulator dependencies.
 RUN apk add --no-cache python3 py3-pip openjdk11-jre bash && \
+    apk update && \
+    apk upgrade && \
     npm install -g firebase-tools && \
     firebase setup:emulators:database && \
     firebase setup:emulators:firestore && \


### PR DESCRIPTION
### Description
Update system packages during Docker build so that we don't pick up upstream vulnerabilities. See b/424671703 for context - lts-alpine had a vulnerable version of setuptools, which we picked up. It is not exposed through our image AFAICT, but I want to avoid seeing issues like this in the future.

### Scenarios Tested
Built the image on a test project - it runs w/o issue.

