### PR TITLE
Update message to show correct timeout

### DIFF
--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -79,12 +79,13 @@ export async function detectFromPort(
   timeout = 10_000 /* 10s to boot up */,
 ): Promise<build.Build> {
   let res: Response;
+  const discoveryTimeout = getFunctionDiscoveryTimeout() || timeout;
   const timedOut = new Promise<never>((resolve, reject) => {
     setTimeout(() => {
       const originalError = "User code failed to load. Cannot determine backend specification.";
-      const error = `${originalError} Timeout after ${timeout}. See https://firebase.google.com/docs/functions/tips#avoid_deployment_timeouts_during_initialization'`;
+      const error = `${originalError} Timeout after ${discoveryTimeout}. See https://firebase.google.com/docs/functions/tips#avoid_deployment_timeouts_during_initialization'`;
       reject(new FirebaseError(error));
-    }, getFunctionDiscoveryTimeout() || timeout);
+    }, discoveryTimeout);
   });
 
   // Initial delay to wait for admin server to boot.


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

When setting `FUNCTIONS_DISCOVERY_TIMEOUT` to increase the functions timeout, if the function discovery takes too long, the error message still indicates that the timeout is 10000(`Timeout after 10000`).
```
$ export FUNCTIONS_DISCOVERY_TIMEOUT=25
$ firebase emulators:start --project demo-project
i  emulators: Starting emulators: functions, extensions
i  emulators: Detected demo project ID "demo-project", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  functions: Watching "/Users/PATH/8776/functions" for Cloud Functions...
⚠  functions: Your requested "node" version "22" doesn't match your global version "20". Using node@20 from host.
Serving at port 8593

⬢  functions: Failed to load function definition from source: FirebaseError: User code failed to load. Cannot determine backend specification. Timeout after 10000. See https://firebase.google.com/docs/functions/tips#avoid_deployment_timeouts_during_initialization'
```

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Verified that the error message now uses the set value `FUNCTIONS_DISCOVERY_TIMEOUT`(`Timeout after 25000`).
```
$ export FUNCTIONS_DISCOVERY_TIMEOUT=25
$ firebase emulators:start --project demo-project
i  emulators: Starting emulators: functions, extensions
i  emulators: Detected demo project ID "demo-project", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  functions: Watching "/Users/PATH/8776/functions" for Cloud Functions...
⚠  functions: Your requested "node" version "22" doesn't match your global version "20". Using node@20 from host.
Serving at port 8944

⬢  functions: Failed to load function definition from source: FirebaseError: User code failed to load. Cannot determine backend specification. Timeout after 25000. See https://firebase.google.com/docs/functions/tips#avoid_deployment_timeouts_during_initialization'
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
