### PR TITLE
update 1.5.0

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
-## NEXT
+## 
 
+## 1.5.0
+
+- Update internal `firebase-tools` dependency to 14.9.0
+- Update internal `graphql-language-server` dependency
+- Update internal `graphql-language-service-server` dependency
 - [Changed] Graphql Syntax Highlighter is now an extension dependency
 - [Fixed] Language server now recognizes fragments in other files
 

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
1.5.0:
- Update internal `firebase-tools` dependency to 14.9.0
- Update internal `graphql-language-server` dependency
- Update internal `graphql-language-service-server` dependency
- [Changed] Graphql Syntax Highlighter is now an extension dependency
- [Fixed] Language server now recognizes fragments in other files
