### PR TITLE
Adding global default project when running on firebase studio

### DIFF
--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -64,6 +64,8 @@ async function autoAuth(options: Options, authScopes: string[]): Promise<null | 
 
     // project is also selected in monospace auth flow
     options.projectId = await client.getProjectId();
+    // Persist this project so it is used by other commands, too.
+    utils.setGlobalDefaultProject(options.projectId);
   }
   return clientEmail || null;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -349,7 +349,9 @@ export function setGlobalDefaultProject(project: string): void {
   configstore.set("globalDefaultProject", project);
   logger.info("");
   logger.info(`${clc.bold(project)} is now your global default project.`);
-  logger.info("When no other project is specified (by 'firebase use' or '--project'), this project will be used.");
+  logger.info(
+    "When no other project is specified (by 'firebase use' or '--project'), this project will be used.",
+  );
   logger.info("");
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -341,6 +341,19 @@ export function makeActiveProject(projectDir: string, newActive?: string): void 
 }
 
 /**
+ * Sets the global default project.
+ * When no other project is specified (either via the current directory or the --project flag),
+ * this project will be used.
+ */
+export function setGlobalDefaultProject(project: string): void {
+  configstore.set("globalDefaultProject", project);
+  logger.info("");
+  logger.info(`${clc.bold(project)} is now your global default project.`);
+  logger.info("When no other project is specified (by 'firebase use' or '--project'), this project will be used.");
+  logger.info("");
+}
+
+/**
  * Creates API endpoint string, e.g. /v1/projects/pid/cloudfunctions
  */
 export function endpoint(parts: string[]): string {


### PR DESCRIPTION
### Description
Adds a new setting for globalDefaultProject - when no other project is specified, this will be the fallback instead of erroring out.

This is motivated by Firebase Studio. When you use the CLI on Firebase Studio, you pick a project from the OAuth flow. Today, this project will get used for the remainder of the command (if no other project is specified) and then will be forgotten forever. This change will instead make that project the global default.

In the future, we probably want to give a way to set this via commands (and outside of Studio), but i want to float this idea out before we go further.