### PR TITLE
Change relative path to include nested dataconnect folders

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+- [Fixed] Language server now properly recognizes nested Dataconnect folders
+
 ## 1.5.0
 
 - Update internal `firebase-tools` dependency to 14.9.0

--- a/firebase-vscode/src/data-connect/config.ts
+++ b/firebase-vscode/src/data-connect/config.ts
@@ -268,7 +268,10 @@ export class ResolvedDataConnectConfig {
   }
 
   get relativePath(): string {
-    return path.relative(vscode.workspace.rootPath, this.path);
+    if (!getConfigPath()) {
+      return this.path.split("/").pop()!;
+    }
+    return path.relative(getConfigPath()!, this.path);
   }
 
   get relativeSchemaPath(): string {

--- a/firebase-vscode/src/data-connect/config.ts
+++ b/firebase-vscode/src/data-connect/config.ts
@@ -268,7 +268,7 @@ export class ResolvedDataConnectConfig {
   }
 
   get relativePath(): string {
-    return this.path.split("/").pop()!;
+    return path.relative(vscode.workspace.rootPath, this.path);
   }
 
   get relativeSchemaPath(): string {

--- a/firebase-vscode/src/data-connect/language-client.ts
+++ b/firebase-vscode/src/data-connect/language-client.ts
@@ -141,15 +141,5 @@ export function setupLanguageClient(
     outputChannel.appendLine("Firebase GraphQL Language Server restarted");
   });
 
-  // ** DISABLED FOR NOW WHILE WE TEST GENERATED YAML **
-  // restart server whenever config file changes
-  // const watcher = vscode.workspace.createFileSystemWatcher(
-  //   "**/.graphqlrc.*", // TODO: extend to schema files, and other config types
-  //   false,
-  //   false,
-  //   false,
-  // );
-  // watcher.onDidChange(() => restartGraphqlLSP());
-
   return client;
 }


### PR DESCRIPTION
Fixes an issue where language server was writing the wrong path to .graphqlrc