### PR TITLE
update vscode to 1.5.1

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## NEXT
 
+## 1.5.1
+
 - Update internal `firebase-tools` dependency to 14.11.0
 - [Fixed] Language server now properly recognizes nested Dataconnect folders
 - [Fixed] Add Data and Read Data now properly support enum and list types

--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+- Update internal `firebase-tools` dependency to 14.11.0
 - [Fixed] Language server now properly recognizes nested Dataconnect folders
 - [Fixed] Add Data and Read Data now properly support enum and list types
 

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
- Update internal `firebase-tools` dependency to 14.11.0
- [Fixed] Language server now properly recognizes nested Dataconnect folders
- [Fixed] Add Data and Read Data now properly support enum and list types