### PR TITLE
feat: add analytics for runtime config usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-- Added analytics to track runtime config usage in functions deployments.
+- Added analytics to track runtime config usage in functions deployments (#8870).
 - Fixed issue where `__name__` fields with DESCENDING order were incorrectly filtered from index listings, causing duplicate index issues (#7629) and deployment conflicts (#8859). The fix now preserves `__name__` fields with explicit DESCENDING order while filtering out implicit ASCENDING `__name__` fields.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Added analytics to track runtime config usage in functions deployments.
 - Fixed issue where `__name__` fields with DESCENDING order were incorrectly filtered from index listings, causing duplicate index issues (#7629) and deployment conflicts (#8859). The fix now preserves `__name__` fields with explicit DESCENDING order while filtering out implicit ASCENDING `__name__` fields.

--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -58,6 +58,9 @@ export interface Context {
 
   // Tracks context for extension deploy
   extensions?: ExtContext;
+
+  // True if functions deploy is using runtime config
+  hasRuntimeConfig?: boolean;
 }
 
 export interface CodebaseDeployEvent {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -89,7 +89,9 @@ export async function prepare(
   let runtimeConfig: Record<string, unknown> = { firebase: firebaseConfig };
   if (checkAPIsEnabled[1]) {
     // If runtime config API is enabled, load the runtime config.
-    runtimeConfig = { ...runtimeConfig, ...(await getFunctionsConfig(projectId)) };
+    const config = await getFunctionsConfig(projectId);
+    runtimeConfig = { ...runtimeConfig, ...config };
+    context.hasRuntimeConfig = Object.keys(config).length > 0;
   }
 
   context.codebaseDeployEvents = {};

--- a/src/deploy/functions/release/reporter.spec.ts
+++ b/src/deploy/functions/release/reporter.spec.ts
@@ -222,6 +222,7 @@ describe("reporter", () => {
         fn_deploy_num_successes: 1,
         fn_deploy_num_canceled: 1,
         fn_deploy_num_failures: 1,
+        has_runtime_config: "false",
       });
 
       // The 0ms for an aborted function isn't counted.

--- a/src/deploy/functions/release/reporter.ts
+++ b/src/deploy/functions/release/reporter.ts
@@ -118,7 +118,7 @@ export async function logAndTrackDeployStats(
     fn_deploy_num_successes: totalSuccesses,
     fn_deploy_num_canceled: totalAborts,
     fn_deploy_num_failures: totalErrors,
-    has_runtime_config: (context?.hasRuntimeConfig || false).toString(),
+    has_runtime_config: String(!!context?.hasRuntimeConfig),
   };
   reports.push(trackGA4("function_deploy_group", fnDeployGroupEvent));
 

--- a/src/deploy/functions/release/reporter.ts
+++ b/src/deploy/functions/release/reporter.ts
@@ -118,6 +118,7 @@ export async function logAndTrackDeployStats(
     fn_deploy_num_successes: totalSuccesses,
     fn_deploy_num_canceled: totalAborts,
     fn_deploy_num_failures: totalErrors,
+    has_runtime_config: (context?.hasRuntimeConfig || false).toString(),
   };
   reports.push(trackGA4("function_deploy_group", fnDeployGroupEvent));
 


### PR DESCRIPTION
Adds analytics to track whether a functions deployment includes a non-empty runtime config. This will help determine the impact of potentially removing runtime config from the deployment flow in the future.

The  flag is added to the  analytics event.