### PR TITLE
Respect configured timeout on storage emulator integration test

### DIFF
--- a/scripts/storage-emulator-integration/conformance/persistence.test.ts
+++ b/scripts/storage-emulator-integration/conformance/persistence.test.ts
@@ -62,7 +62,10 @@ describe("Storage persistence conformance tests", () => {
       devtools: true,
     });
     page = await browser.newPage();
-    await page.goto("https://example.com", { waitUntil: "networkidle2", timeout: TEST_SETUP_TIMEOUT });
+    await page.goto("https://example.com", {
+      waitUntil: "networkidle2",
+      timeout: TEST_SETUP_TIMEOUT - 5000,
+    });
     await page.addScriptTag({
       url: "https://www.gstatic.com/firebasejs/9.9.1/firebase-app-compat.js",
     });

--- a/scripts/storage-emulator-integration/conformance/persistence.test.ts
+++ b/scripts/storage-emulator-integration/conformance/persistence.test.ts
@@ -62,7 +62,7 @@ describe("Storage persistence conformance tests", () => {
       devtools: true,
     });
     page = await browser.newPage();
-    await page.goto("https://example.com", { waitUntil: "networkidle2" });
+    await page.goto("https://example.com", { waitUntil: "networkidle2", timeout: TEST_SETUP_TIMEOUT });
     await page.addScriptTag({
       url: "https://www.gstatic.com/firebasejs/9.9.1/firebase-app-compat.js",
     });

--- a/scripts/storage-emulator-integration/utils.ts
+++ b/scripts/storage-emulator-integration/utils.ts
@@ -7,7 +7,7 @@ import { FrameworkOptions } from "../integration-helpers/framework";
 const { google } = require("googleapis");
 
 /* Various delays needed when integration test spawns parallel emulator subprocesses. */
-export const TEST_SETUP_TIMEOUT = 60000;
+export const TEST_SETUP_TIMEOUT = 120000;
 export const EMULATORS_SHUTDOWN_DELAY_MS = 5000;
 export const SMALL_FILE_SIZE = 200 * 1024; /* 200 kB */
 // Firebase Emulator config, for starting up emulators


### PR DESCRIPTION

### Description
This test has been flaking due to timeouts on this page.goto(). Previously, it was defaulting to 30000ms - let's use the test timeout instead.
