### PR TITLE
fix(mcp): Fix operator precedence in auth fallback logic

### DIFF
--- a/src/mcp/index.spec.ts
+++ b/src/mcp/index.spec.ts
@@ -6,7 +6,6 @@ import * as requireAuthModule from "../requireAuth";
 describe("FirebaseMcpServer.getAuthenticatedUser", () => {
   let server: FirebaseMcpServer;
   let requireAuthStub: sinon.SinonStub;
-  let resolveOptionsStub: sinon.SinonStub;
 
   beforeEach(() => {
     // Mock the methods that may cause hanging BEFORE creating the instance
@@ -16,7 +15,8 @@ describe("FirebaseMcpServer.getAuthenticatedUser", () => {
     server = new FirebaseMcpServer({});
 
     // Mock the resolveOptions method to avoid dependency issues
-    resolveOptionsStub = sinon.stub(server, "resolveOptions").resolves({});
+    sinon.stub(server, "resolveOptions").resolves({});
+
     requireAuthStub = sinon.stub(requireAuthModule, "requireAuth");
   });
 
@@ -50,7 +50,6 @@ describe("FirebaseMcpServer.getAuthenticatedUser", () => {
 
     expect(result).to.equal("Application Default Credentials");
     expect(requireAuthStub.calledOnce).to.be.true;
-    expect(resolveOptionsStub.calledOnce).to.be.true;
   });
 
   it("should return null when requireAuth throws an error", async () => {
@@ -60,6 +59,5 @@ describe("FirebaseMcpServer.getAuthenticatedUser", () => {
 
     expect(result).to.be.null;
     expect(requireAuthStub.calledOnce).to.be.true;
-    expect(resolveOptionsStub.calledOnce).to.be.true;
   });
 });

--- a/src/mcp/index.spec.ts
+++ b/src/mcp/index.spec.ts
@@ -1,0 +1,65 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { FirebaseMcpServer } from "./index";
+import * as requireAuthModule from "../requireAuth";
+
+describe("FirebaseMcpServer.getAuthenticatedUser", () => {
+  let server: FirebaseMcpServer;
+  let requireAuthStub: sinon.SinonStub;
+  let resolveOptionsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    // Mock the methods that may cause hanging BEFORE creating the instance
+    sinon.stub(FirebaseMcpServer.prototype, "detectProjectRoot").resolves("/test/project");
+    sinon.stub(FirebaseMcpServer.prototype, "detectActiveFeatures").resolves([]);
+
+    server = new FirebaseMcpServer({});
+
+    // Mock the resolveOptions method to avoid dependency issues
+    resolveOptionsStub = sinon.stub(server, "resolveOptions").resolves({});
+    requireAuthStub = sinon.stub(requireAuthModule, "requireAuth");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should return email when authenticated user is present", async () => {
+    const testEmail = "test@example.com";
+    requireAuthStub.resolves(testEmail);
+
+    const result = await server.getAuthenticatedUser();
+
+    expect(result).to.equal(testEmail);
+    expect(requireAuthStub.calledOnce).to.be.true;
+  });
+
+  it("should return null when no user and skipAutoAuth is true", async () => {
+    requireAuthStub.resolves(null);
+
+    const result = await server.getAuthenticatedUser(true);
+
+    expect(result).to.be.null;
+    expect(requireAuthStub.calledOnce).to.be.true;
+  });
+
+  it("should return 'Application Default Credentials' when no user and skipAutoAuth is false", async () => {
+    requireAuthStub.resolves(null);
+
+    const result = await server.getAuthenticatedUser(false);
+
+    expect(result).to.equal("Application Default Credentials");
+    expect(requireAuthStub.calledOnce).to.be.true;
+    expect(resolveOptionsStub.calledOnce).to.be.true;
+  });
+
+  it("should return null when requireAuth throws an error", async () => {
+    requireAuthStub.rejects(new Error("Auth failed"));
+
+    const result = await server.getAuthenticatedUser();
+
+    expect(result).to.be.null;
+    expect(requireAuthStub.calledOnce).to.be.true;
+    expect(resolveOptionsStub.calledOnce).to.be.true;
+  });
+});

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -233,7 +233,7 @@ export class FirebaseMcpServer {
       this.log("debug", `calling requireAuth`);
       const email = await requireAuth(await this.resolveOptions(), skipAutoAuth);
       this.log("debug", `detected authenticated account: ${email || "<none>"}`);
-      return email ?? skipAutoAuth ? null : "Application Default Credentials";
+      return email ?? (skipAutoAuth ? null : "Application Default Credentials");
     } catch (e) {
       this.log("debug", `error in requireAuth: ${e}`);
       return null;


### PR DESCRIPTION
Add parentheses to ensure skipAutoAuth check happens before fallback to "Application Default Credentials" string.

Also add unit tests to cover this logic and ensure correct behavior.

Fixes #8896.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fix regression documented in #8896. Issue was caused by incorrect operator precedence in the FirebaseMcpServer#getAuthenticatedUser method, causing properly logged in users to show as not logged in for MCP tool listings and calls (and probably other areas).

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

Besides creating and running unit tests, I also used `@modelcontextprotocol/inspector` to do tool calls of `firebase_get_environment` tool to ensure my login information showed up correctly after my change (and was incorrectly missing before my change).

### Sample Commands

(N/A)