### PR TITLE
Fix apptesting enablement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixed ext:export command so that it correctly returns system params in the .env file (#8881)
 - Fixed an issue where the MCP server could not successfully use Application Default Credentials. (#8896)
+- Fixed an issue where we enabled the incorrect API for apptesting usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Fixed ext:export command so that it correctly returns system params in the .env file (#8881)
 - Fixed an issue where the MCP server could not successfully use Application Default Credentials. (#8896)
-- Fixed an issue where we enabled the incorrect API for apptesting usage
+- Fixed an issue where we enabled the incorrect API for apptesting usage.

--- a/src/apptesting/ensureProjectConfigured.spec.ts
+++ b/src/apptesting/ensureProjectConfigured.spec.ts
@@ -41,23 +41,29 @@ describe("ensureProjectConfigured", () => {
 
     await apptesting.ensureProjectConfigured(projectId);
 
-    expect(ensureApiEnabledStub).to.be.calledThrice;
+    expect(ensureApiEnabledStub).to.be.callCount(4);
+    expect(ensureApiEnabledStub).to.be.calledWith(
+      projectId,
+      "https://firebaseapptesting.googleapis.com",
+      "Firebase App Testing",
+      false,
+    );
     expect(ensureApiEnabledStub).to.be.calledWith(
       projectId,
       "https://storage.googleapis.com",
-      "apptesting",
+      "Cloud Storage",
       false,
     );
     expect(ensureApiEnabledStub).to.be.calledWith(
       projectId,
       "https://run.googleapis.com",
-      "apptesting",
+      "Cloud Run",
       false,
     );
     expect(ensureApiEnabledStub).to.be.calledWith(
       projectId,
       "https://artifactregistry.googleapis.com",
-      "apptesting",
+      "Artifact Registry",
       false,
     );
   });

--- a/src/apptesting/ensureProjectConfigured.spec.ts
+++ b/src/apptesting/ensureProjectConfigured.spec.ts
@@ -42,12 +42,22 @@ describe("ensureProjectConfigured", () => {
     await apptesting.ensureProjectConfigured(projectId);
 
     expect(ensureApiEnabledStub).to.be.calledThrice;
-    expect(ensureApiEnabledStub).to.be.calledWith(projectId, sinon.match.any, "storage", false);
-    expect(ensureApiEnabledStub).to.be.calledWith(projectId, sinon.match.any, "run", false);
     expect(ensureApiEnabledStub).to.be.calledWith(
       projectId,
-      sinon.match.any,
-      "artifactregistry",
+      "https://storage.googleapis.com",
+      "apptesting",
+      false,
+    );
+    expect(ensureApiEnabledStub).to.be.calledWith(
+      projectId,
+      "https://run.googleapis.com",
+      "apptesting",
+      false,
+    );
+    expect(ensureApiEnabledStub).to.be.calledWith(
+      projectId,
+      "https://artifactregistry.googleapis.com",
+      "apptesting",
       false,
     );
   });

--- a/src/apptesting/ensureProjectConfigured.ts
+++ b/src/apptesting/ensureProjectConfigured.ts
@@ -1,6 +1,6 @@
 import { addServiceAccountToRoles, serviceAccountHasRoles } from "../gcp/resourceManager";
 import { ensure } from "../ensureApiEnabled";
-import { artifactRegistryDomain, cloudRunApiOrigin, storageOrigin } from "../api";
+import { appTestingOrigin, artifactRegistryDomain, cloudRunApiOrigin, storageOrigin } from "../api";
 import { logBullet, logWarning } from "../utils";
 import { FirebaseError, getErrStatus } from "../error";
 import * as iam from "../gcp/iam";
@@ -10,9 +10,10 @@ const TEST_RUNNER_ROLE = "roles/firebaseapptesting.testRunner";
 const TEST_RUNNER_SERVICE_ACCOUNT_NAME = "firebaseapptesting-test-runner";
 
 export async function ensureProjectConfigured(projectId: string) {
-  await ensure(projectId, cloudRunApiOrigin(), "apptesting", false);
-  await ensure(projectId, storageOrigin(), "apptesting", false);
-  await ensure(projectId, artifactRegistryDomain(), "apptesting", false);
+  await ensure(projectId, appTestingOrigin(), "Firebase App Testing", false);
+  await ensure(projectId, cloudRunApiOrigin(), "Cloud Run", false);
+  await ensure(projectId, storageOrigin(), "Storage", false);
+  await ensure(projectId, artifactRegistryDomain(), "Artifact Registry", false);
   const serviceAccount = runnerServiceAccount(projectId);
 
   const serviceAccountExistsAndIsRunner = await serviceAccountHasRoles(

--- a/src/apptesting/ensureProjectConfigured.ts
+++ b/src/apptesting/ensureProjectConfigured.ts
@@ -1,6 +1,6 @@
 import { addServiceAccountToRoles, serviceAccountHasRoles } from "../gcp/resourceManager";
 import { ensure } from "../ensureApiEnabled";
-import { appTestingOrigin } from "../api";
+import { artifactRegistryDomain, cloudRunApiOrigin, storageOrigin } from "../api";
 import { logBullet, logWarning } from "../utils";
 import { FirebaseError, getErrStatus } from "../error";
 import * as iam from "../gcp/iam";
@@ -10,9 +10,9 @@ const TEST_RUNNER_ROLE = "roles/firebaseapptesting.testRunner";
 const TEST_RUNNER_SERVICE_ACCOUNT_NAME = "firebaseapptesting-test-runner";
 
 export async function ensureProjectConfigured(projectId: string) {
-  await ensure(projectId, appTestingOrigin(), "storage", false);
-  await ensure(projectId, appTestingOrigin(), "run", false);
-  await ensure(projectId, appTestingOrigin(), "artifactregistry", false);
+  await ensure(projectId, cloudRunApiOrigin(), "apptesting", false);
+  await ensure(projectId, storageOrigin(), "apptesting", false);
+  await ensure(projectId, artifactRegistryDomain(), "apptesting", false);
   const serviceAccount = runnerServiceAccount(projectId);
 
   const serviceAccountExistsAndIsRunner = await serviceAccountHasRoles(


### PR DESCRIPTION
### Description

We incorrectly are passing in the origin of various apis that need to be enabled to use app testing. Correct them.

### Scenarios Tested

1) User having no apis enabled, enabling them
2) User having all apis enabled, attempting to enable them, and it not causing any problems

### Sample Commands

firebase init apptesting
