### PR TITLE
Add enterprise edition support to `firestore:databases:create`

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -88,6 +88,9 @@
                 "database": {
                     "type": "string"
                 },
+                "edition": {
+                    "type": "string"
+                },
                 "indexes": {
                     "type": "string"
                 },

--- a/src/commands/firestore-databases-create.spec.ts
+++ b/src/commands/firestore-databases-create.spec.ts
@@ -1,0 +1,255 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import { Command } from "../command";
+import { command as firestoreDatabasesCreate } from "./firestore-databases-create";
+import * as fsi from "../firestore/api";
+import * as types from "../firestore/api-types";
+import { FirebaseError } from "../error";
+
+describe("firestore:databases:create", () => {
+  const PROJECT = "test-project";
+  const DATABASE = "test-database";
+  const LOCATION = "nam5";
+
+  let command: Command;
+  let firestoreApiStub: sinon.SinonStubbedInstance<fsi.FirestoreApi>;
+
+  beforeEach(() => {
+    command = firestoreDatabasesCreate;
+    firestoreApiStub = sinon.createStubInstance(fsi.FirestoreApi);
+    sinon.stub(fsi, "FirestoreApi").returns(firestoreApiStub as any);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const mockDatabaseResp = (overrides: Partial<types.DatabaseResp>): types.DatabaseResp => {
+    return {
+      name: `projects/${PROJECT}/databases/${DATABASE}`,
+      uid: "test-uid",
+      createTime: "2025-07-28T12:00:00Z",
+      updateTime: "2025-07-28T12:00:00Z",
+      locationId: LOCATION,
+      type: types.DatabaseType.FIRESTORE_NATIVE,
+      databaseEdition: types.DatabaseEdition.STANDARD,
+      concurrencyMode: "OPTIMISTIC",
+      appEngineIntegrationMode: "DISABLED",
+      keyPrefix: `projects/${PROJECT}/databases/${DATABASE}`,
+      deleteProtectionState: types.DatabaseDeleteProtectionState.DISABLED,
+      pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.DISABLED,
+      etag: "test-etag",
+      versionRetentionPeriod: "1h",
+      earliestVersionTime: "2025-07-28T11:00:00Z",
+      ...overrides,
+    };
+  };
+
+  it("should create a new database with the correct parameters", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      json: true,
+    };
+    const expectedDatabase = mockDatabaseResp({});
+    firestoreApiStub.createDatabase.resolves(expectedDatabase);
+
+    const result = await command.runner()(DATABASE, options);
+
+    expect(result).to.deep.equal(expectedDatabase);
+    expect(
+      firestoreApiStub.createDatabase.calledOnceWith({
+        project: PROJECT,
+        databaseId: DATABASE,
+        locationId: LOCATION,
+        type: types.DatabaseType.FIRESTORE_NATIVE,
+        databaseEdition: types.DatabaseEdition.STANDARD,
+        deleteProtectionState: types.DatabaseDeleteProtectionState.DISABLED,
+        pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.DISABLED,
+        cmekConfig: undefined,
+      }),
+    ).to.be.true;
+  });
+
+  it("should throw an error if location is not provided", async () => {
+    const options = {
+      project: PROJECT,
+    };
+
+    await expect(command.runner()(DATABASE, options)).to.be.rejectedWith(
+      FirebaseError,
+      "Missing required flag --location",
+    );
+  });
+
+  it("should throw an error for invalid delete protection option", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      deleteProtection: "INVALID",
+    };
+
+    await expect(command.runner()(DATABASE, options)).to.be.rejectedWith(
+      FirebaseError,
+      "Invalid value for flag --delete-protection",
+    );
+  });
+
+  it("should throw an error for invalid point-in-time recovery option", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      pointInTimeRecovery: "INVALID",
+    };
+
+    await expect(command.runner()(DATABASE, options)).to.be.rejectedWith(
+      FirebaseError,
+      "Invalid value for flag --point-in-time-recovery",
+    );
+  });
+
+  it("should throw an error for invalid edition option", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      edition: "INVALID",
+    };
+
+    await expect(command.runner()(DATABASE, options)).to.be.rejectedWith(
+      FirebaseError,
+      "Invalid value for flag --edition",
+    );
+  });
+
+  it("should create a database with enterprise edition", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      edition: "enterprise",
+      json: true,
+    };
+    const expectedDatabase = mockDatabaseResp({
+      databaseEdition: types.DatabaseEdition.ENTERPRISE,
+    });
+    firestoreApiStub.createDatabase.resolves(expectedDatabase);
+
+    const result = await command.runner()(DATABASE, options);
+
+    expect(result).to.deep.equal(expectedDatabase);
+    expect(
+      firestoreApiStub.createDatabase.calledOnceWith({
+        project: PROJECT,
+        databaseId: DATABASE,
+        locationId: LOCATION,
+        type: types.DatabaseType.FIRESTORE_NATIVE,
+        databaseEdition: types.DatabaseEdition.ENTERPRISE,
+        deleteProtectionState: types.DatabaseDeleteProtectionState.DISABLED,
+        pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.DISABLED,
+        cmekConfig: undefined,
+      }),
+    ).to.be.true;
+  });
+
+  it("should create a database with delete protection enabled", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      deleteProtection: "ENABLED",
+      json: true,
+    };
+    const expectedDatabase = mockDatabaseResp({
+      deleteProtectionState: types.DatabaseDeleteProtectionState.ENABLED,
+    });
+    firestoreApiStub.createDatabase.resolves(expectedDatabase);
+
+    const result = await command.runner()(DATABASE, options);
+
+    expect(result).to.deep.equal(expectedDatabase);
+    expect(
+      firestoreApiStub.createDatabase.calledOnceWith({
+        project: PROJECT,
+        databaseId: DATABASE,
+        locationId: LOCATION,
+        type: types.DatabaseType.FIRESTORE_NATIVE,
+        databaseEdition: types.DatabaseEdition.STANDARD,
+        deleteProtectionState: types.DatabaseDeleteProtectionState.ENABLED,
+        pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.DISABLED,
+        cmekConfig: undefined,
+      }),
+    ).to.be.true;
+  });
+
+  it("should create a database with point-in-time recovery enabled", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      pointInTimeRecovery: "ENABLED",
+      json: true,
+    };
+    const expectedDatabase = mockDatabaseResp({
+      pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.ENABLED,
+    });
+    firestoreApiStub.createDatabase.resolves(expectedDatabase);
+
+    const result = await command.runner()(DATABASE, options);
+
+    expect(result).to.deep.equal(expectedDatabase);
+    expect(
+      firestoreApiStub.createDatabase.calledOnceWith({
+        project: PROJECT,
+        databaseId: DATABASE,
+        locationId: LOCATION,
+        type: types.DatabaseType.FIRESTORE_NATIVE,
+        databaseEdition: types.DatabaseEdition.STANDARD,
+        deleteProtectionState: types.DatabaseDeleteProtectionState.DISABLED,
+        pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.ENABLED,
+        cmekConfig: undefined,
+      }),
+    ).to.be.true;
+  });
+
+  it("should create a database with a KMS key", async () => {
+    const KMS_KEY = "test-kms-key";
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+      kmsKeyName: KMS_KEY,
+      json: true,
+    };
+    const expectedDatabase = mockDatabaseResp({
+      cmekConfig: {
+        kmsKeyName: KMS_KEY,
+      },
+    });
+    firestoreApiStub.createDatabase.resolves(expectedDatabase);
+
+    const result = await command.runner()(DATABASE, options);
+
+    expect(result).to.deep.equal(expectedDatabase);
+    expect(
+      firestoreApiStub.createDatabase.calledOnceWith({
+        project: PROJECT,
+        databaseId: DATABASE,
+        locationId: LOCATION,
+        type: types.DatabaseType.FIRESTORE_NATIVE,
+        databaseEdition: types.DatabaseEdition.STANDARD,
+        deleteProtectionState: types.DatabaseDeleteProtectionState.DISABLED,
+        pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.DISABLED,
+        cmekConfig: {
+          kmsKeyName: KMS_KEY,
+        },
+      }),
+    ).to.be.true;
+  });
+
+  it("should throw an error if the API call fails", async () => {
+    const options = {
+      project: PROJECT,
+      location: LOCATION,
+    };
+    const apiError = new Error("API Error");
+    firestoreApiStub.createDatabase.rejects(apiError);
+
+    await expect(command.runner()(DATABASE, options)).to.be.rejectedWith(apiError);
+  });
+});

--- a/src/commands/firestore-databases-create.spec.ts
+++ b/src/commands/firestore-databases-create.spec.ts
@@ -17,7 +17,7 @@ describe("firestore:databases:create", () => {
   beforeEach(() => {
     command = firestoreDatabasesCreate;
     firestoreApiStub = sinon.createStubInstance(fsi.FirestoreApi);
-    sinon.stub(fsi, "FirestoreApi").returns(firestoreApiStub as any);
+    sinon.stub(fsi, "FirestoreApi").returns(firestoreApiStub);
   });
 
   afterEach(() => {

--- a/src/commands/firestore-databases-create.spec.ts
+++ b/src/commands/firestore-databases-create.spec.ts
@@ -5,6 +5,7 @@ import { command as firestoreDatabasesCreate } from "./firestore-databases-creat
 import * as fsi from "../firestore/api";
 import * as types from "../firestore/api-types";
 import { FirebaseError } from "../error";
+import * as requireAuthModule from "../requireAuth";
 
 describe("firestore:databases:create", () => {
   const PROJECT = "test-project";
@@ -13,11 +14,14 @@ describe("firestore:databases:create", () => {
 
   let command: Command;
   let firestoreApiStub: sinon.SinonStubbedInstance<fsi.FirestoreApi>;
+  let requireAuthStub: sinon.SinonStub;
 
   beforeEach(() => {
     command = firestoreDatabasesCreate;
     firestoreApiStub = sinon.createStubInstance(fsi.FirestoreApi);
+    requireAuthStub = sinon.stub(requireAuthModule, "requireAuth");
     sinon.stub(fsi, "FirestoreApi").returns(firestoreApiStub);
+    requireAuthStub.resolves("a@b.com");
   });
 
   afterEach(() => {

--- a/src/commands/firestore-databases-create.ts
+++ b/src/commands/firestore-databases-create.ts
@@ -17,6 +17,7 @@ export const command = new Command("firestore:databases:create <database>")
     "--location <locationId>",
     "region to create database, for example 'nam5'. Run 'firebase firestore:locations' to get a list of eligible locations (required)",
   )
+  .option("--enterprise-edition", "create a database with enterprise capabilities")
   .option(
     "--delete-protection <deleteProtectionState>",
     "whether or not to prevent deletion of database, for example 'ENABLED' or 'DISABLED'. Default is 'DISABLED'",
@@ -44,6 +45,9 @@ export const command = new Command("firestore:databases:create <database>")
     }
     // Type is always Firestore Native since Firebase does not support Datastore Mode
     const type: types.DatabaseType = types.DatabaseType.FIRESTORE_NATIVE;
+    const databaseEdition: types.DatabaseEdition | undefined = options.enterpriseEdition
+      ? types.DatabaseEdition.ENTERPRISE
+      : undefined;
     if (
       options.deleteProtection &&
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.ENABLED &&
@@ -82,6 +86,7 @@ export const command = new Command("firestore:databases:create <database>")
       databaseId: database,
       locationId: options.location,
       type,
+      databaseEdition,
       deleteProtectionState,
       pointInTimeRecoveryEnablement,
       cmekConfig,

--- a/src/commands/firestore-databases-create.ts
+++ b/src/commands/firestore-databases-create.ts
@@ -17,7 +17,10 @@ export const command = new Command("firestore:databases:create <database>")
     "--location <locationId>",
     "region to create database, for example 'nam5'. Run 'firebase firestore:locations' to get a list of eligible locations (required)",
   )
-  .option("--enterprise-edition", "create a database with enterprise capabilities")
+  .option(
+    "--edition <edition>",
+    "the edition of the database to create, for example 'standard' or 'enterprise'. If not provided, 'standard' is used as a default.",
+  )
   .option(
     "--delete-protection <deleteProtectionState>",
     "whether or not to prevent deletion of database, for example 'ENABLED' or 'DISABLED'. Default is 'DISABLED'",
@@ -45,9 +48,17 @@ export const command = new Command("firestore:databases:create <database>")
     }
     // Type is always Firestore Native since Firebase does not support Datastore Mode
     const type: types.DatabaseType = types.DatabaseType.FIRESTORE_NATIVE;
-    const databaseEdition: types.DatabaseEdition | undefined = options.enterpriseEdition
-      ? types.DatabaseEdition.ENTERPRISE
-      : undefined;
+    if (options.edition &&
+      options.edition !== "standard" &&
+      options.edition !== "enterprise"
+    ) {
+      throw new FirebaseError(`Invalid value for flag --edition. ${helpCommandText}`);
+    }
+    const databaseEdition: types.DatabaseEdition =
+      options.edition === "enterprise"
+        ? types.DatabaseEdition.ENTERPRISE
+        : types.DatabaseEdition.STANDARD;
+   
     if (
       options.deleteProtection &&
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.ENABLED &&

--- a/src/commands/firestore-databases-create.ts
+++ b/src/commands/firestore-databases-create.ts
@@ -48,17 +48,23 @@ export const command = new Command("firestore:databases:create <database>")
     }
     // Type is always Firestore Native since Firebase does not support Datastore Mode
     const type: types.DatabaseType = types.DatabaseType.FIRESTORE_NATIVE;
-    if (options.edition &&
-      options.edition !== "standard" &&
-      options.edition !== "enterprise"
-    ) {
-      throw new FirebaseError(`Invalid value for flag --edition. ${helpCommandText}`);
+
+    // Figure out the database edition.
+    let databaseEdition: types.DatabaseEdition = types.DatabaseEdition.STANDARD;
+    if (options.edition) {
+      const edition = options.edition.toUpperCase();
+      if (
+        edition !== types.DatabaseEdition.STANDARD &&
+        edition !== types.DatabaseEdition.ENTERPRISE
+      ) {
+        throw new FirebaseError(`Invalid value for flag --edition. ${helpCommandText}`);
+      }
+      databaseEdition =
+        edition === types.DatabaseEdition.ENTERPRISE
+          ? types.DatabaseEdition.ENTERPRISE
+          : types.DatabaseEdition.STANDARD;
     }
-    const databaseEdition: types.DatabaseEdition =
-      options.edition === "enterprise"
-        ? types.DatabaseEdition.ENTERPRISE
-        : types.DatabaseEdition.STANDARD;
-   
+
     if (
       options.deleteProtection &&
       options.deleteProtection !== types.DatabaseDeleteProtectionStateOption.ENABLED &&

--- a/src/deploy/firestore/deploy.ts
+++ b/src/deploy/firestore/deploy.ts
@@ -25,6 +25,25 @@ async function createDatabase(context: any, options: Options): Promise<void> {
   if (!firestoreCfg.database) {
     firestoreCfg.database = "(default)";
   }
+
+  let edition: types.DatabaseEdition = types.DatabaseEdition.STANDARD;
+  if (!firestoreCfg.edition) {
+    edition = types.DatabaseEdition.STANDARD;
+  } else {
+    if (
+      firestoreCfg.edition !== types.DatabaseEdition.STANDARD &&
+      firestoreCfg.edition !== types.DatabaseEdition.ENTERPRISE
+    ) {
+      throw new FirebaseError(
+        `Invalid edition specified for database in firebase.json: ${firestoreCfg.edition}`,
+      );
+    }
+    edition =
+      firestoreCfg.edition.toUpperCase() === types.DatabaseEdition.ENTERPRISE
+        ? types.DatabaseEdition.ENTERPRISE
+        : types.DatabaseEdition.STANDARD;
+  }
+
   const api = new FirestoreApi();
   try {
     await api.getDatabase(options.projectId, firestoreCfg.database);
@@ -40,6 +59,7 @@ async function createDatabase(context: any, options: Options): Promise<void> {
         databaseId: firestoreCfg.database,
         locationId: firestoreCfg.location || "nam5", // Default to 'nam5' if location is not specified
         type: types.DatabaseType.FIRESTORE_NATIVE,
+        databaseEdition: edition,
         deleteProtectionState: types.DatabaseDeleteProtectionState.DISABLED,
         pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.DISABLED,
       };

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -39,6 +39,7 @@ type DatabaseMultiple = ({
 type FirestoreSingle = {
   database?: string;
   location?: string;
+  edition?: string;
   rules?: string;
   indexes?: string;
 } & Deployable;

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -101,6 +101,11 @@ export enum DatabaseType {
   FIRESTORE_NATIVE = "FIRESTORE_NATIVE",
 }
 
+export enum DatabaseEdition {
+  STANDARD = "STANDARD",
+  ENTERPRISE = "ENTERPRISE",
+}
+
 export enum DatabaseDeleteProtectionStateOption {
   ENABLED = "ENABLED",
   DISABLED = "DISABLED",
@@ -134,6 +139,7 @@ export interface CreateDatabaseReq {
   databaseId: string;
   locationId: string;
   type: DatabaseType;
+  databaseEdition?: DatabaseEdition;
   deleteProtectionState: DatabaseDeleteProtectionState;
   pointInTimeRecoveryEnablement: PointInTimeRecoveryEnablement;
   cmekConfig?: CmekConfig;
@@ -146,6 +152,7 @@ export interface DatabaseResp {
   updateTime: string;
   locationId: string;
   type: DatabaseType;
+  databaseEdition: DatabaseEdition;
   concurrencyMode: string;
   appEngineIntegrationMode: string;
   keyPrefix: string;

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -129,6 +129,7 @@ export enum PointInTimeRecoveryEnablement {
 export interface DatabaseReq {
   locationId?: string;
   type?: DatabaseType;
+  databaseEdition?: DatabaseEdition;
   deleteProtectionState?: DatabaseDeleteProtectionState;
   pointInTimeRecoveryEnablement?: PointInTimeRecoveryEnablement;
   cmekConfig?: CmekConfig;

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -101,11 +101,6 @@ export enum DatabaseType {
   FIRESTORE_NATIVE = "FIRESTORE_NATIVE",
 }
 
-export enum DatabaseEdition {
-  STANDARD = "STANDARD",
-  ENTERPRISE = "ENTERPRISE",
-}
-
 export enum DatabaseDeleteProtectionStateOption {
   ENABLED = "ENABLED",
   DISABLED = "DISABLED",
@@ -159,7 +154,6 @@ export interface DatabaseResp {
   updateTime: string;
   locationId: string;
   type: DatabaseType;
-  databaseEdition: DatabaseEdition;
   concurrencyMode: string;
   appEngineIntegrationMode: string;
   keyPrefix: string;

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -638,6 +638,7 @@ export class FirestoreApi {
     const payload: types.DatabaseReq = {
       locationId: req.locationId,
       type: req.type,
+      databaseEdition: req.databaseEdition,
       deleteProtectionState: req.deleteProtectionState,
       pointInTimeRecoveryEnablement: req.pointInTimeRecoveryEnablement,
       cmekConfig: req.cmekConfig,

--- a/src/firestore/options.ts
+++ b/src/firestore/options.ts
@@ -18,6 +18,7 @@ export interface FirestoreOptions extends Options {
   type?: types.DatabaseType;
   deleteProtection?: types.DatabaseDeleteProtectionStateOption;
   pointInTimeRecoveryEnablement?: types.PointInTimeRecoveryEnablementOption;
+  edition?: string;
 
   // backup schedules
   backupSchedule?: string;


### PR DESCRIPTION
### Description
Add enterprise edition support to `firestore:databases:create`.

I wanted to see if Gemini could implement simple features like this - so far, it passed with flying colors