### PR TITLE
Fixed an issue with orderless fields in firestore indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixed ext:export command so that it correctly returns system params in the .env file (#8881)
 - Fixed an issue where the MCP server could not successfully use Application Default Credentials. (#8896)
 - Fixed an issue where the incorrect API was enabled for `apptesting` commands.
+- Fixed an issue where indexes with fields with no order would be handled incorrectly. (#8910)

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -31,7 +31,10 @@ export class FirestoreApi {
       let fields = index.fields;
       const lastField = index.fields?.[index.fields.length - 1];
       if (lastField?.fieldPath === "__name__") {
-        const defaultDirection = index.fields?.[index.fields.length - 2]?.order;
+        const lastOrderedField = [...fields]
+          .reverse()
+          .find((f) => f.fieldPath !== "__name__" && f.order);
+        const defaultDirection = lastOrderedField?.order;
         if (lastField?.order === defaultDirection) {
           fields = fields.slice(0, -1);
         }

--- a/src/firestore/indexes.spec.ts
+++ b/src/firestore/indexes.spec.ts
@@ -585,6 +585,33 @@ describe("IndexListingWithNameFields", () => {
     expect(result[0].fields[0].fieldPath).to.equal("foo");
     expect(result[0].fields[1].fieldPath).to.equal("bar");
   });
+
+  it("should filter out __name__ fields when the previous field is a vector", () => {
+    const mockIndexes: API.Index[] = [
+      {
+        name: "/projects/myproject/databases/(default)/collectionGroups/collection/indexes/abc123",
+        queryScope: API.QueryScope.COLLECTION,
+        fields: [
+          { fieldPath: "foo", order: API.Order.ASCENDING },
+          {
+            fieldPath: "bar",
+            vectorConfig: {
+              dimension: 100,
+              flat: {},
+            },
+          },
+          { fieldPath: "__name__", order: API.Order.ASCENDING },
+        ],
+        state: API.State.READY,
+      },
+    ];
+
+    const result = FirestoreApi.processIndexes(mockIndexes);
+
+    expect(result[0].fields).to.have.length(2);
+    expect(result[0].fields[0].fieldPath).to.equal("foo");
+    expect(result[0].fields[1].fieldPath).to.equal("bar");
+  });
 });
 
 describe("IndexSorting", () => {


### PR DESCRIPTION
### Description
Fixes #8910 - turns out some indexes don't have orders, so we need to look at the last index with an order when filtering.

I had Gemini work on this one, but the solution looks correct to me.