### PR TITLE
Fix issue where login didnt work as expected on studio

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -28,7 +28,7 @@ export const command = new Command("login")
     const user = options.user as User | undefined;
     const tokens = options.tokens as Tokens | undefined;
 
-    if (user && tokens && !options.reauth) {
+    if (user && tokens?.refresh_token && !options.reauth) {
       logger.info("Already logged in as", clc.bold(user.email));
       return user;
     }
@@ -53,7 +53,7 @@ export const command = new Command("login")
       if (geminiUsage || collectUsage) {
         logger.info();
         utils.logBullet(
-          "To change your the preference at any time, run `firebase logout` and `firebase login` again.",
+          "To change your the preferences at any time, run `firebase logout` and `firebase login` again.",
         );
       }
     }


### PR DESCRIPTION
### Description
Fixes an edge case where, on Firebase Studio, the MCP server would tell you to run 'firebase login' but 'firebase login' would tell you that you are already logged in and short circuit.

