### PR TITLE
Make FDC generated SDK prompt clearer

### DIFF
--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -116,8 +116,7 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
     if (unusedFrameworks.length > 0) {
       const additionalFrameworks = await checkbox<(typeof SUPPORTED_FRAMEWORKS)[number]>({
         message:
-          "Which frameworks would you like to generate SDKs for? " +
-          "Press Space to select features, then Enter to confirm your choices.",
+          "Which frameworks would you like to generate SDKs for in addition to the TypeScript SDK? Press Enter to skip.\n",
         choices: SUPPORTED_FRAMEWORKS.map((frameworkStr) => ({
           value: frameworkStr,
           checked: newConnectorYaml?.generate?.javascriptSdk?.[frameworkStr],


### PR DESCRIPTION
When developers get started with the web SDKs, we ask what frameworks they want to support, but it isn't clear that this is optional, and the vanilla JS SDK is generated by default.

Before:
<img width="2286" height="212" alt="image" src="https://github.com/user-attachments/assets/3c175202-838e-4da6-b6a1-d6004396808d" />

After:
<img width="808" height="70" alt="image" src="https://github.com/user-attachments/assets/f4ed3297-0aa4-499c-85ab-a6257d9e0692" />
