### PR TITLE
feat: Display Firestore database edition

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3602,6 +3602,18 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -4543,6 +4555,40 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "node_modules/@swc/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-0mshAzMvdhL0v3lNMJowzMd8Du0bJf+PUTxhVm4uIb/h8qCDQjFERXj0RGejcDFSL7fJzLI3MzS5WR45KDrrLA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "swcx": "run_swcx.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-android-arm-eabi": "1.3.0",
+        "@swc/core-android-arm64": "1.3.0",
+        "@swc/core-darwin-arm64": "1.3.0",
+        "@swc/core-darwin-x64": "1.3.0",
+        "@swc/core-freebsd-x64": "1.3.0",
+        "@swc/core-linux-arm-gnueabihf": "1.3.0",
+        "@swc/core-linux-arm64-gnu": "1.3.0",
+        "@swc/core-linux-arm64-musl": "1.3.0",
+        "@swc/core-linux-x64-gnu": "1.3.0",
+        "@swc/core-linux-x64-musl": "1.3.0",
+        "@swc/core-win32-arm64-msvc": "1.3.0",
+        "@swc/core-win32-ia32-msvc": "1.3.0",
+        "@swc/core-win32-x64-msvc": "1.3.0"
+      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
@@ -20042,6 +20088,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/terser": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "optional": true,
+      "peer": true
+    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -24366,6 +24440,18 @@
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -25001,6 +25087,29 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
+    },
+    "@swc/core": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.0.tgz",
+      "integrity": "sha512-0mshAzMvdhL0v3lNMJowzMd8Du0bJf+PUTxhVm4uIb/h8qCDQjFERXj0RGejcDFSL7fJzLI3MzS5WR45KDrrLA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@swc/core-android-arm-eabi": "1.3.0",
+        "@swc/core-android-arm64": "1.3.0",
+        "@swc/core-darwin-arm64": "1.3.0",
+        "@swc/core-darwin-x64": "1.3.0",
+        "@swc/core-freebsd-x64": "1.3.0",
+        "@swc/core-linux-arm-gnueabihf": "1.3.0",
+        "@swc/core-linux-arm64-gnu": "1.3.0",
+        "@swc/core-linux-arm64-musl": "1.3.0",
+        "@swc/core-linux-x64-gnu": "1.3.0",
+        "@swc/core-linux-x64-musl": "1.3.0",
+        "@swc/core-win32-arm64-msvc": "1.3.0",
+        "@swc/core-win32-ia32-msvc": "1.3.0",
+        "@swc/core-win32-x64-msvc": "1.3.0"
+      }
     },
     "@swc/helpers": {
       "version": "0.5.2",
@@ -36569,6 +36678,30 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
       "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
       "dev": true
+    },
+    "terser": {
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+      "dev": true,
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true,
+          "peer": true
+        }
+      }
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3602,18 +3602,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -4555,40 +4543,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "node_modules/@swc/core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.0.tgz",
-      "integrity": "sha512-0mshAzMvdhL0v3lNMJowzMd8Du0bJf+PUTxhVm4uIb/h8qCDQjFERXj0RGejcDFSL7fJzLI3MzS5WR45KDrrLA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "swcx": "run_swcx.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/swc"
-      },
-      "optionalDependencies": {
-        "@swc/core-android-arm-eabi": "1.3.0",
-        "@swc/core-android-arm64": "1.3.0",
-        "@swc/core-darwin-arm64": "1.3.0",
-        "@swc/core-darwin-x64": "1.3.0",
-        "@swc/core-freebsd-x64": "1.3.0",
-        "@swc/core-linux-arm-gnueabihf": "1.3.0",
-        "@swc/core-linux-arm64-gnu": "1.3.0",
-        "@swc/core-linux-arm64-musl": "1.3.0",
-        "@swc/core-linux-x64-gnu": "1.3.0",
-        "@swc/core-linux-x64-musl": "1.3.0",
-        "@swc/core-win32-arm64-msvc": "1.3.0",
-        "@swc/core-win32-ia32-msvc": "1.3.0",
-        "@swc/core-win32-x64-msvc": "1.3.0"
-      }
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.2",
@@ -20088,34 +20042,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "node_modules/test-exclude": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -24440,18 +24366,6 @@
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
-    "@jridgewell/source-map": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/gen-mapping": "^0.3.0",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
@@ -25087,29 +25001,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "@swc/core": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.0.tgz",
-      "integrity": "sha512-0mshAzMvdhL0v3lNMJowzMd8Du0bJf+PUTxhVm4uIb/h8qCDQjFERXj0RGejcDFSL7fJzLI3MzS5WR45KDrrLA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@swc/core-android-arm-eabi": "1.3.0",
-        "@swc/core-android-arm64": "1.3.0",
-        "@swc/core-darwin-arm64": "1.3.0",
-        "@swc/core-darwin-x64": "1.3.0",
-        "@swc/core-freebsd-x64": "1.3.0",
-        "@swc/core-linux-arm-gnueabihf": "1.3.0",
-        "@swc/core-linux-arm64-gnu": "1.3.0",
-        "@swc/core-linux-arm64-musl": "1.3.0",
-        "@swc/core-linux-x64-gnu": "1.3.0",
-        "@swc/core-linux-x64-musl": "1.3.0",
-        "@swc/core-win32-arm64-msvc": "1.3.0",
-        "@swc/core-win32-ia32-msvc": "1.3.0",
-        "@swc/core-win32-x64-msvc": "1.3.0"
-      }
     },
     "@swc/helpers": {
       "version": "0.5.2",
@@ -36678,30 +36569,6 @@
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.0.tgz",
       "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
       "dev": true
-    },
-    "terser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
-      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jridgewell/source-map": "^0.3.2",
-        "acorn": "^8.5.0",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.20.3",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        }
-      }
     },
     "test-exclude": {
       "version": "6.0.0",

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -121,6 +121,12 @@ export enum PointInTimeRecoveryEnablement {
   DISABLED = "POINT_IN_TIME_RECOVERY_DISABLED",
 }
 
+export enum DatabaseEdition {
+  DATABASE_EDITION_UNSPECIFIED = "DATABASE_EDITION_UNSPECIFIED",
+  STANDARD = "STANDARD",
+  ENTERPRISE = "ENTERPRISE",
+}
+
 export interface DatabaseReq {
   locationId?: string;
   type?: DatabaseType;
@@ -155,6 +161,7 @@ export interface DatabaseResp {
   versionRetentionPeriod: string;
   earliestVersionTime: string;
   cmekConfig?: CmekConfig;
+  databaseEdition?: DatabaseEdition;
 }
 
 export interface RestoreDatabaseReq {

--- a/src/firestore/pretty-print.spec.ts
+++ b/src/firestore/pretty-print.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai";
+import * as sinon from "sinon";
 import * as API from "./api-types";
 import { PrettyPrint } from "./pretty-print";
+import { logger } from "../logger";
 
 const printer = new PrettyPrint();
 
@@ -90,5 +92,91 @@ describe("prettyStringArray", () => {
 
   it("should print nothing if the array is empty", () => {
     expect(printer.prettyStringArray([])).to.equal("");
+  });
+});
+
+describe("prettyPrintDatabase", () => {
+  let loggerInfoStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    loggerInfoStub = sinon.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    loggerInfoStub.restore();
+  });
+
+  it("should display STANDARD edition when databaseEdition is not provided", () => {
+    const database: API.DatabaseResp = {
+      name: "projects/my-project/databases/(default)",
+      uid: "uid",
+      createTime: "2020-01-01T00:00:00Z",
+      updateTime: "2020-01-01T00:00:00Z",
+      locationId: "us-central1",
+      type: API.DatabaseType.FIRESTORE_NATIVE,
+      concurrencyMode: "OPTIMISTIC",
+      appEngineIntegrationMode: "ENABLED",
+      keyPrefix: "prefix",
+      deleteProtectionState: API.DatabaseDeleteProtectionState.DISABLED,
+      pointInTimeRecoveryEnablement: API.PointInTimeRecoveryEnablement.DISABLED,
+      etag: "etag",
+      versionRetentionPeriod: "1h",
+      earliestVersionTime: "2020-01-01T00:00:00Z",
+    };
+
+    printer.prettyPrintDatabase(database);
+
+    expect(loggerInfoStub.firstCall.args[0]).to.include("Edition");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("STANDARD");
+  });
+
+  it("should display STANDARD edition when databaseEdition is UNSPECIFIED", () => {
+    const database: API.DatabaseResp = {
+      name: "projects/my-project/databases/(default)",
+      uid: "uid",
+      createTime: "2020-01-01T00:00:00Z",
+      updateTime: "2020-01-01T00:00:00Z",
+      locationId: "us-central1",
+      type: API.DatabaseType.FIRESTORE_NATIVE,
+      concurrencyMode: "OPTIMISTIC",
+      appEngineIntegrationMode: "ENABLED",
+      keyPrefix: "prefix",
+      deleteProtectionState: API.DatabaseDeleteProtectionState.DISABLED,
+      pointInTimeRecoveryEnablement: API.PointInTimeRecoveryEnablement.DISABLED,
+      etag: "etag",
+      versionRetentionPeriod: "1h",
+      earliestVersionTime: "2020-01-01T00:00:00Z",
+      databaseEdition: API.DatabaseEdition.DATABASE_EDITION_UNSPECIFIED,
+    };
+
+    printer.prettyPrintDatabase(database);
+
+    expect(loggerInfoStub.firstCall.args[0]).to.include("Edition");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("STANDARD");
+  });
+
+  it("should display ENTERPRISE edition when databaseEdition is ENTERPRISE", () => {
+    const database: API.DatabaseResp = {
+      name: "projects/my-project/databases/(default)",
+      uid: "uid",
+      createTime: "2020-01-01T00:00:00Z",
+      updateTime: "2020-01-01T00:00:00Z",
+      locationId: "us-central1",
+      type: API.DatabaseType.FIRESTORE_NATIVE,
+      concurrencyMode: "OPTIMISTIC",
+      appEngineIntegrationMode: "ENABLED",
+      keyPrefix: "prefix",
+      deleteProtectionState: API.DatabaseDeleteProtectionState.DISABLED,
+      pointInTimeRecoveryEnablement: API.PointInTimeRecoveryEnablement.DISABLED,
+      etag: "etag",
+      versionRetentionPeriod: "1h",
+      earliestVersionTime: "2020-01-01T00:00:00Z",
+      databaseEdition: API.DatabaseEdition.ENTERPRISE,
+    };
+
+    printer.prettyPrintDatabase(database);
+
+    expect(loggerInfoStub.firstCall.args[0]).to.include("Edition");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("ENTERPRISE");
   });
 });

--- a/src/firestore/pretty-print.ts
+++ b/src/firestore/pretty-print.ts
@@ -59,11 +59,17 @@ export class PrettyPrint {
       colWidths: [30, colValueWidth],
     });
 
+    const edition =
+      !database.databaseEdition ||
+      database.databaseEdition === types.DatabaseEdition.DATABASE_EDITION_UNSPECIFIED
+        ? types.DatabaseEdition.STANDARD
+        : database.databaseEdition;
     table.push(
       ["Name", clc.yellow(database.name)],
       ["Create Time", clc.yellow(database.createTime)],
       ["Last Update Time", clc.yellow(database.updateTime)],
       ["Type", clc.yellow(database.type)],
+      ["Edition", clc.yellow(edition)],
       ["Location", clc.yellow(database.locationId)],
       ["Delete Protection State", clc.yellow(database.deleteProtectionState)],
       ["Point In Time Recovery", clc.yellow(database.pointInTimeRecoveryEnablement)],


### PR DESCRIPTION
Adds the 'Edition' to the output of the `firestore:databases:get` command.

The `Database` resource in the Firestore API now includes a `databaseEdition` field. This change updates the `DatabaseResp` type to include this new field and modifies the `prettyPrintDatabase` function to display the database edition in the output table.

The possible values for the edition are `STANDARD` and `ENTERPRISE`. If the edition is not specified or is `DATABASE_EDITION_UNSPECIFIED`, it will default to `STANDARD`.
