### PR TITLE
Enable FDC API in `firebase init dataconnect` for Spark projects

### DIFF
--- a/src/dataconnect/ensureApis.ts
+++ b/src/dataconnect/ensureApis.ts
@@ -12,6 +12,7 @@ export async function ensureApis(projectId: string): Promise<void> {
 export async function ensureSparkApis(projectId: string): Promise<void> {
   // These are the APIs that can be enabled without a billing account.
   await ensure(projectId, api.cloudSQLAdminOrigin(), prefix);
+  await ensure(projectId, api.dataconnectOrigin(), prefix);
 }
 
 export async function ensureGIFApis(projectId: string): Promise<void> {


### PR DESCRIPTION

### Existing behavior

> `firebase init dataconnect`

<img width="1727" height="779" alt="Screenshot 2025-08-01 at 4 58 30 PM" src="https://github.com/user-attachments/assets/fc5fd778-3357-4605-b90b-3d69ef5331d8" />

### Scenarios Tested

> `firebase init dataconnect`

<img width="1149" height="989" alt="Screenshot 2025-08-01 at 5 02 15 PM" src="https://github.com/user-attachments/assets/ba8d968b-b95d-4ddb-a045-6cdbd19224c4" />

### Sample Commands
