### PR TITLE
Add `product_init_mcp` and fix param of `product_init`

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,7 +15,6 @@ import { Options } from "../options";
 import { isEnabled } from "../experiments";
 import { readTemplateSync } from "../templates";
 import { FirebaseError } from "../error";
-import { trackGA4 } from "../track";
 
 const homeDir = os.homedir();
 
@@ -150,8 +149,6 @@ export async function initAction(feature: string, options: Options): Promise<voi
     );
   }
 
-  const start = process.uptime();
-
   const cwd = options.cwd || process.cwd();
 
   const warnings = [];
@@ -249,7 +246,6 @@ export async function initAction(feature: string, options: Options): Promise<voi
     setup.features = setup.features.filter((f) => f !== "hosting:github");
   }
 
-  const productsInitialized = setup.features?.join(",") || "";
   await init(setup, config, options);
 
   logger.info();
@@ -258,9 +254,6 @@ export async function initAction(feature: string, options: Options): Promise<voi
   if (!fsutils.fileExistsSync(config.path(".gitignore"))) {
     config.writeProjectFile(".gitignore", GITIGNORE_TEMPLATE);
   }
-
-  const duration = Math.floor((process.uptime() - start) * 1000);
-  await trackGA4("product_init", { products_initialized: productsInitialized }, duration);
 
   logger.info();
   utils.logSuccess("Firebase initialization complete!");

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -249,6 +249,7 @@ export async function initAction(feature: string, options: Options): Promise<voi
     setup.features = setup.features.filter((f) => f !== "hosting:github");
   }
 
+  const productsInitialized = setup.features?.join(",") || "";
   await init(setup, config, options);
 
   logger.info();
@@ -257,9 +258,9 @@ export async function initAction(feature: string, options: Options): Promise<voi
   if (!fsutils.fileExistsSync(config.path(".gitignore"))) {
     config.writeProjectFile(".gitignore", GITIGNORE_TEMPLATE);
   }
-  const duration = Math.floor((process.uptime() - start) * 1000);
 
-  await trackGA4("product_init", { products_initialized: setup.features?.join(",") }, duration);
+  const duration = Math.floor((process.uptime() - start) * 1000);
+  await trackGA4("product_init", { products_initialized: productsInitialized }, duration);
 
   logger.info();
   utils.logSuccess("Firebase initialization complete!");

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -125,7 +125,7 @@ export async function init(setup: Setup, config: Config, options: any): Promise<
     }
 
     const duration = Math.floor((process.uptime() - start) * 1000);
-    await trackGA4("product_init", { products_initialized: nextFeature }, duration);
+    await trackGA4("product_init", { feature: nextFeature }, duration);
 
     return init(setup, config, options);
   }
@@ -151,7 +151,7 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
     }
 
     const duration = Math.floor((process.uptime() - start) * 1000);
-    await trackGA4("product_init_mcp", { products_initialized: nextFeature }, duration);
+    await trackGA4("product_init_mcp", { feature: nextFeature }, duration);
 
     return actuate(setup, config, options);
   }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -134,6 +134,8 @@ export async function init(setup: Setup, config: Config, options: any): Promise<
 export async function actuate(setup: Setup, config: Config, options: any): Promise<any> {
   const nextFeature = setup.features?.shift();
   if (nextFeature) {
+    const start = process.uptime();
+
     const f = lookupFeature(nextFeature);
     logger.info(clc.bold(`\n${clc.white("===")} ${capitalize(nextFeature)} Setup Actuation`));
 
@@ -146,6 +148,10 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
         await f.actuate(setup, config, options);
       }
     }
+
+    const duration = Math.floor((process.uptime() - start) * 1000);
+    await trackGA4("product_init_mcp", { products_initialized: nextFeature }, duration);
+
     return actuate(setup, config, options);
   }
 }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -8,6 +8,7 @@ import { RCData } from "../rc";
 import { Config } from "../config";
 import { FirebaseConfig } from "../firebaseConfig";
 import { Options } from "../options";
+import { trackGA4 } from "../track";
 
 export interface Setup {
   config: FirebaseConfig;
@@ -93,6 +94,8 @@ const featureMap = new Map(featuresList.map((feature) => [feature.name, feature]
 export async function init(setup: Setup, config: Config, options: any): Promise<any> {
   const nextFeature = setup.features?.shift();
   if (nextFeature) {
+    const start = process.uptime();
+
     const f = featureMap.get(nextFeature);
     if (!f) {
       const availableFeatures = Object.keys(features)
@@ -120,6 +123,10 @@ export async function init(setup: Setup, config: Config, options: any): Promise<
     if (f.postSetup) {
       await f.postSetup(setup, config, options);
     }
+
+    const duration = Math.floor((process.uptime() - start) * 1000);
+    await trackGA4("product_init", { products_initialized: nextFeature }, duration);
+
     return init(setup, config, options);
   }
 }

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -131,6 +131,7 @@ export async function init(setup: Setup, config: Config, options: any): Promise<
   }
 }
 
+/** Actuate the feature init flow from firebase_init MCP tool. */
 export async function actuate(setup: Setup, config: Config, options: any): Promise<any> {
   const nextFeature = setup.features?.shift();
   if (nextFeature) {

--- a/src/track.ts
+++ b/src/track.ts
@@ -11,6 +11,7 @@ type cliEventNames =
   | "command_execution"
   | "product_deploy"
   | "product_init"
+  | "product_init_mcp"
   | "error"
   | "login"
   | "api_enabled"


### PR DESCRIPTION
In Google Analytics, `products_initialized` is always empty because the `init()` shifts it to an empty list in the end.

Want to figure out how many time `init dataconnect` was called.