### PR TITLE
Disable broken VSCode integration tests

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -67,63 +67,63 @@ jobs:
       - uses: codecov/codecov-action@v3
         if: matrix.node-version == '20'
 
-  vscode_integration:
-    runs-on: macos-latest
-    strategy:
-      matrix:
-        node-version:
-          - "20"
+  # vscode_integration:
+  #   runs-on: macos-latest
+  #   strategy:
+  #     matrix:
+  #       node-version:
+  #         - "20"
 
-    env:
-      FIREBASE_EMULATORS_PATH: ${{ github.workspace }}/emulator-cache
-      # This overrides the binary which runs firebase commands in the extension tasks such as emulator start.
-      # Currently, CI fails to start with npx so we change it to the global firebase binary.
-      FIREBASE_BINARY: firebase
+  #   env:
+  #     FIREBASE_EMULATORS_PATH: ${{ github.workspace }}/emulator-cache
+  #     # This overrides the binary which runs firebase commands in the extension tasks such as emulator start.
+  #     # Currently, CI fails to start with npx so we change it to the global firebase binary.
+  #     FIREBASE_BINARY: firebase
 
-    steps:
-      - name: Setup Java JDK
-        uses: actions/setup-java@v3.3.0
-        with:
-          java-version: 17
-          distribution: temurin
+  #   steps:
+  #     - name: Setup Java JDK
+  #       uses: actions/setup-java@v3.3.0
+  #       with:
+  #         java-version: 17
+  #         distribution: temurin
 
-      - uses: actions/checkout@v4
-      - name: Setup Chrome
-        uses: browser-actions/setup-chrome@v1.7.2
-        with:
-          install-dependencies: true
-          install-chromedriver: true
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: npm
-          cache-dependency-path: firebase-vscode/package-lock.json
+  #     - uses: actions/checkout@v4
+  #     - name: Setup Chrome
+  #       uses: browser-actions/setup-chrome@v1.7.2
+  #       with:
+  #         install-dependencies: true
+  #         install-chromedriver: true
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #         cache: npm
+  #         cache-dependency-path: firebase-vscode/package-lock.json
 
-        # TODO temporary workaround for GitHub Actions CI issue:
-        # npm ERR! Your cache folder contains root-owned files, due to a bug in
-        # npm ERR! previous versions of npm which has since been addressed.
-      - run: sudo chown -R 501:20 "/Users/runner/.npm" || exit 1
-      - run: npm ci
-      - run: npm install
-        working-directory: firebase-vscode
-      - run: npm run build
-        working-directory: firebase-vscode
+  #       # TODO temporary workaround for GitHub Actions CI issue:
+  #       # npm ERR! Your cache folder contains root-owned files, due to a bug in
+  #       # npm ERR! previous versions of npm which has since been addressed.
+  #     - run: sudo chown -R 501:20 "/Users/runner/.npm" || exit 1
+  #     - run: npm ci
+  #     - run: npm install
+  #       working-directory: firebase-vscode
+  #     - run: npm run build
+  #       working-directory: firebase-vscode
 
-      - run: npm i -g firebase-tools@latest
+  #     - run: npm i -g firebase-tools@latest
 
-      - uses: GabrielBB/xvfb-action@v1
-        with:
-          run: npm run test:e2e
-          working-directory: firebase-vscode
+  #     - uses: GabrielBB/xvfb-action@v1
+  #       with:
+  #         run: npm run test:e2e
+  #         working-directory: firebase-vscode
 
-      - uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: screenshots
-          path: firebase-vscode/src/test/screenshots
+  #     - uses: actions/upload-artifact@v4
+  #       if: failure()
+  #       with:
+  #         name: screenshots
+  #         path: firebase-vscode/src/test/screenshots
 
-      - uses: codecov/codecov-action@v3
-        if: matrix.node-version == '20'
+  #     - uses: codecov/codecov-action@v3
+  #       if: matrix.node-version == '20'
 
   unit:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description
These have been confusing too many contributors. We can reenable them when they are fixed.
