### PR TITLE
Prototype of login via prototyper in Studio

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -11,12 +11,18 @@ import * as auth from "../auth";
 import { isCloudEnvironment } from "../utils";
 import { User, Tokens } from "../types/auth";
 
+import { Options } from "../options";
+
+export interface LoginOptions extends Options {
+  prototyperLogin?: boolean;
+}
+
 export const command = new Command("login")
   .description("log the CLI into Firebase")
   .option("--no-localhost", "login from a device without an accessible localhost")
   .option("--reauth", "force reauthentication even if already logged in")
-  .action(async (options: any) => {
-    if (options.nonInteractive) {
+  .action(async (options: LoginOptions) => {
+    if (options.nonInteractive && !options.prototyperLogin) {
       throw new FirebaseError(
         "Cannot run login in non-interactive mode. See " +
           clc.bold("login:ci") +
@@ -33,7 +39,7 @@ export const command = new Command("login")
       return user;
     }
 
-    if (!options.reauth) {
+    if (!options.reauth && !options.prototyperLogin) {
       utils.logBullet(
         "The Firebase CLI’s MCP server feature can optionally make use of Gemini in Firebase. " +
           "Learn more about Gemini in Firebase and how it uses your data: https://firebase.google.com/docs/gemini-in-firebase#how-gemini-in-firebase-uses-your-data",
@@ -58,11 +64,15 @@ export const command = new Command("login")
       }
     }
 
+    // Special escape hatch for logging in when using firebase-tools as a module.
+    if (options.prototyperLogin) {
+      return await auth.loginPrototyper();
+    }
+
     // Default to using the authorization code flow when the end
     // user is within a cloud-based environment, and therefore,
     // the authorization callback couldn't redirect to localhost.
-    const useLocalhost = isCloudEnvironment() ? false : options.localhost;
-
+    const useLocalhost = isCloudEnvironment() ? false : !!options.localhost;
     const result = await auth.loginGoogle(useLocalhost, user?.email);
     configstore.set("user", result.user);
     configstore.set("tokens", result.tokens);


### PR DESCRIPTION
### Description
Early prototype of a noninteractive login flow for use in Studio prototyper.

### Using it
Roughly, we'll do something like:
```
import fbt from "firebase-tools"
    const res = await fbt.login({prototyperLogin: true});

   // Show the user the sessionId and send them to the URI to do the login flow
    console.log(res.sessionId);
    console.log(res.uri);
    // After the flow, user copy + pastes an authorization code
    // We pass that to res.authorize to exchange it for a OAuth token and save their creds
    await res.authorize(authCode);
}
```
