### PR TITLE
[FDC] `firebase init dataconnect:sdk` don't need confirmation to update connector.yaml

### DIFF
--- a/src/init/features/dataconnect/sdk.spec.ts
+++ b/src/init/features/dataconnect/sdk.spec.ts
@@ -18,13 +18,11 @@ describe("init dataconnect:sdk", () => {
     let generateStub: sinon.SinonStub;
     let fsStub: sinon.SinonStub;
     let emptyConfig: Config;
-    let askProjectWriteFileStub: sinon.SinonStub;
 
     beforeEach(() => {
       fsStub = sandbox.stub(fs, "writeFileSync");
       generateStub = sandbox.stub(DataConnectEmulator, "generate");
       emptyConfig = new Config({}, { projectDir: process.cwd() });
-      askProjectWriteFileStub = sandbox.stub(emptyConfig, "askWriteProjectFile");
     });
 
     afterEach(() => {
@@ -50,9 +48,6 @@ describe("init dataconnect:sdk", () => {
 
         await sdk.actuate(c.sdkInfo, emptyConfig);
         expect(generateStub.called).to.equal(c.shouldGenerate);
-        expect(askProjectWriteFileStub.args).to.deep.equal([
-          ["dataconnect/connector/connector.yaml", CONNECTOR_YAML_CONTENTS, false, true],
-        ]);
       });
     }
   });

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -249,11 +249,9 @@ export async function generateSdkYaml(
 export async function actuate(sdkInfo: SDKInfo, config: Config) {
   const connectorYamlPath = `${sdkInfo.connectorInfo.directory}/connector.yaml`;
   logBullet(`Writing your new SDK configuration to ${connectorYamlPath}`);
-  await config.askWriteProjectFile(
+  config.writeProjectFile(
     path.relative(config.projectDir, connectorYamlPath),
     sdkInfo.connectorYamlContents,
-    /* force=*/ false,
-    /* confirmByDefault=*/ true,
   );
 
   const account = getGlobalDefaultAccount();

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -68,17 +68,8 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
   }
 
   // First, lets check if we are in an app directory
-  let appDir = process.env[FDC_APP_FOLDER] || process.cwd();
+  const appDir = process.env[FDC_APP_FOLDER] || process.cwd();
   let targetPlatform = await getPlatformFromFolder(appDir);
-  if (targetPlatform === Platform.NONE && !process.env[FDC_APP_FOLDER]?.length) {
-    // If we aren't in an app directory, ask the user where their app is, and try to autodetect from there.
-    appDir = await promptForDirectory({
-      config,
-      message:
-        "Where is your app directory? Leave blank to set up a generated SDK in your current directory.",
-    });
-    targetPlatform = await getPlatformFromFolder(appDir);
-  }
   if (targetPlatform === Platform.NONE || targetPlatform === Platform.MULTIPLE) {
     if (targetPlatform === Platform.NONE) {
       logBullet(`Couldn't automatically detect app your in directory ${appDir}.`);

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -26,7 +26,7 @@ import {
 import { DataConnectEmulator } from "../../../emulator/dataconnectEmulator";
 import { FirebaseError } from "../../../error";
 import { camelCase, snakeCase, upperFirst } from "lodash";
-import { logSuccess, logBullet, promptForDirectory, envOverride, logWarning } from "../../../utils";
+import { logSuccess, logBullet, envOverride, logWarning } from "../../../utils";
 import { getGlobalDefaultAccount } from "../../../auth";
 
 export const FDC_APP_FOLDER = "_FDC_APP_FOLDER";

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -26,7 +26,7 @@ import {
 import { DataConnectEmulator } from "../../../emulator/dataconnectEmulator";
 import { FirebaseError } from "../../../error";
 import { camelCase, snakeCase, upperFirst } from "lodash";
-import { logSuccess, logBullet, envOverride, logWarning } from "../../../utils";
+import { logSuccess, logBullet, promptForDirectory, envOverride, logWarning } from "../../../utils";
 import { getGlobalDefaultAccount } from "../../../auth";
 
 export const FDC_APP_FOLDER = "_FDC_APP_FOLDER";
@@ -68,8 +68,17 @@ async function askQuestions(setup: Setup, config: Config): Promise<SDKInfo> {
   }
 
   // First, lets check if we are in an app directory
-  const appDir = process.env[FDC_APP_FOLDER] || process.cwd();
+  let appDir = process.env[FDC_APP_FOLDER] || process.cwd();
   let targetPlatform = await getPlatformFromFolder(appDir);
+  if (targetPlatform === Platform.NONE && !process.env[FDC_APP_FOLDER]?.length) {
+    // If we aren't in an app directory, ask the user where their app is, and try to autodetect from there.
+    appDir = await promptForDirectory({
+      config,
+      message:
+        "Where is your app directory? Leave blank to set up a generated SDK in your current directory.",
+    });
+    targetPlatform = await getPlatformFromFolder(appDir);
+  }
   if (targetPlatform === Platform.NONE || targetPlatform === Platform.MULTIPLE) {
     if (targetPlatform === Platform.NONE) {
       logBullet(`Couldn't automatically detect app your in directory ${appDir}.`);


### PR DESCRIPTION
Simplify it to only ask one question about "App Platform"

### Before

<img width="1371" height="911" alt="Screenshot 2025-08-06 at 1 18 27 PM" src="https://github.com/user-attachments/assets/3d922aa6-ae84-4ecb-8bf7-78176bdc3107" />

### After

<img width="1371" height="811" alt="Screenshot 2025-08-06 at 1 15 32 PM" src="https://github.com/user-attachments/assets/277fd49b-4f15-4284-90a0-85d093bc8e6c" />

We can make the one-linter script set `_FDC_APP_FOLDER`, so the cmd would skips the "app folder question"
