### PR TITLE
update emulators to 2.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
 - Fixed an issue where `firebase init dataconnect` didn't enable the Data Connect API by default (#8927).
+- Updated the Firebase Data Connect local toolkit to v2.11.0, which includes the following changes:
+  - [Fixed] Kotlin code generation with enums
+  - [Fixed] Deploying schemas with enums would report false breaking changes
+  - [Added] Support for ordering results by aggregate fields (min/max/count/sum/avg).
+  - [Added] Support for built-in and user-defined enums to LLM Tools generation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 - Fixed an issue where `firebase init dataconnect` didn't enable the Data Connect API by default (#8927).
-- Updated the Firebase Data Connect local toolkit to v2.11.0, which includes the following changes:
+- Updated the Firebase Data Connect local toolkit to v2.11.0, which includes the following changes (#8948):
   - [Fixed] Kotlin code generation with enums
   - [Fixed] Deploying schemas with enums would report false breaking changes
   - [Added] Support for ordering results by aggregate fields (min/max/count/sum/avg).

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -54,28 +54,28 @@
   },
   "dataconnect": {
     "darwin": {
-      "version": "2.10.1",
-      "expectedSize": 29336416,
-      "expectedChecksum": "328ae0a354505430f1c162edf37da776",
-      "expectedChecksumSHA256": "ede5dc299045151f228b2adc346f47ad5d3ee10c3c9d7528df5fc0f0c6d70808",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-v2.10.1",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.10.1"
+      "version": "2.11.0",
+      "expectedSize": 29234016,
+      "expectedChecksum": "96da48708b8210f0d3d97099d777b322",
+      "expectedChecksumSHA256": "10fe334f2c4145e4c9d27bc442bdc92b1252164d3daac47bb7555da42b6d7050",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-v2.11.0",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.11.0"
     },
     "win32": {
-      "version": "2.10.1",
-      "expectedSize": 29829632,
-      "expectedChecksum": "82e82e35c1728a214db37967dba751e7",
-      "expectedChecksumSHA256": "ba509e921c692ac60c1138b5b9c83a23b4e11feb339f08df5f1cfced44cffc91",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-v2.10.1",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.10.1.exe"
+      "version": "2.11.0",
+      "expectedSize": 29719040,
+      "expectedChecksum": "df6b221af204a4a21163bcc73367f99e",
+      "expectedChecksumSHA256": "af17c0d873b2b8f1919652c1ad9fd4aed417cd82bc35bbc5cc4a302fc90f9a03",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-v2.11.0",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.11.0.exe"
     },
     "linux": {
-      "version": "2.10.1",
-      "expectedSize": 29266104,
-      "expectedChecksum": "d183c2335e16f8c568bdc9e782dcd240",
-      "expectedChecksumSHA256": "338e0cce561d29993737b91abfe7fc12c7d82d014ef114348ccdafeb3b7be3ae",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-v2.10.1",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.10.1"
+      "version": "2.11.0",
+      "expectedSize": 29159608,
+      "expectedChecksum": "38d6161f7e8f06ee89e5dc4094f1a9b6",
+      "expectedChecksumSHA256": "3391efac3570164141b5d7f3e3d48b6426ec9c8cf9eafeabee3fa31678120218",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-v2.11.0",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-2.11.0"
     }
   }
 }


### PR DESCRIPTION
- Updated the Firebase Data Connect local toolkit to v2.11.0, which includes the following changes:
  - [Fixed] Kotlin code generation with enums
  - [Fixed] Deploying schemas with enums would report false breaking changes
  - [Added] Support for ordering results by aggregate fields (min/max/count/sum/avg).
  - [Added] Support for built-in and user-defined enums to LLM Tools generation.
