### PR TITLE
fix(mcp): get_sdk_config base64 decodes for android/ios now.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
   - [fixed] Handle foreign key constraint error as FailedPrecondition.
 - [Added] Support for creating Firestore Enterprise databases using `firestore:databases:create --edition enterprise`. (#8952)
 - [Added] Support for Firestore Enterprise database index configurations. (#8939)
+- [fixed] MCP: The `get_sdk_config` tool now properly returns decoded file content for Android and iOS.

--- a/src/mcp/tools/core/get_sdk_config.ts
+++ b/src/mcp/tools/core/get_sdk_config.ts
@@ -43,7 +43,17 @@ export const get_sdk_config = tool(
         `Could not find an app for platform '${inputPlatform}' in project '${projectId}'`,
       );
     const sdkConfig = await getAppConfig(appId, platform);
-    // TODO: return as string with comment about filename for ios and android
+    if ("configFilename" in sdkConfig) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `SDK config content for \`${sdkConfig.configFilename}\`:\n\n\`\`\`\n${Buffer.from(sdkConfig.configFileContents, "base64").toString("utf-8")}\n\`\`\``,
+          },
+        ],
+      };
+    }
+
     return toContent(sdkConfig, { format: "json" });
   },
 );


### PR DESCRIPTION
Fixed:

<img width="1013" height="749" alt="image" src="https://github.com/user-attachments/assets/6108242a-de37-4011-84f7-530bffe0e190" />
