### PR TITLE
feat: Add .env.<codebase> support for multi-instance functions

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -123,8 +123,9 @@ export async function prepare(
     const config = configForCodebase(context.config, codebase);
     const firebaseEnvs = functionsEnv.loadFirebaseEnvs(firebaseConfig, projectId);
     const userEnvOpt: functionsEnv.UserEnvsOpts = {
+      projectId,
+      codebase,
       functionsSource: options.config.path(config.source),
-      projectId: projectId,
       projectAlias: options.projectAlias,
     };
     const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);

--- a/src/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -17,7 +17,7 @@ async function resolveBackend(bd: build.Build): Promise<backend.Backend> {
         storageBucket: "foo.appspot.com",
         databaseURL: "https://foo.firebaseio.com",
       },
-      userEnvOpt: { functionsSource: "", projectId: "PROJECT" },
+      userEnvOpt: { functionsSource: "", projectId: "PROJECT", codebase: "default" },
       userEnvs: {},
     })
   ).backend;

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -553,6 +553,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         projectId: this.args.projectId,
         projectAlias: this.args.projectAlias,
         isEmulator: true,
+        codebase: emulatableBackend.codebase,
       };
       const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
       const discoveredBuild = await runtimeDelegate.discoverBuild(runtimeConfig, environment);
@@ -1378,6 +1379,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       projectId: this.args.projectId,
       projectAlias: this.args.projectAlias,
       isEmulator: true,
+      codebase: backend.codebase,
     };
 
     if (functionsEnv.hasUserEnvs(projectInfo)) {

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -310,11 +310,22 @@ FOO=foo
     it("never affects the filesystem if the list of keys to write is empty", () => {
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          codebase: "default",
+        },
       );
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true, codebase: "default" },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          isEmulator: true,
+          codebase: "default",
+        },
       );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
@@ -322,7 +333,10 @@ FOO=foo
     });
 
     it("touches .env.projectId if it doesn't already exist", () => {
-      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir, codebase: "default" });
+      env.writeUserEnvs(
+        { FOO: "bar" },
+        { projectId: "project", functionsSource: tmpdir, codebase: "default" },
+      );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(!!fs.statSync(path.join(tmpdir, ".env.project"))).to.be.true;
       expect(() => fs.statSync(path.join(tmpdir, ".env.local"))).to.throw;
@@ -343,7 +357,10 @@ FOO=foo
         [".env.project"]: "FOO=foo",
       });
       expect(() =>
-        env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir, codebase: "default" }),
+        env.writeUserEnvs(
+          { FOO: "bar" },
+          { projectId: "project", functionsSource: tmpdir, codebase: "default" },
+        ),
       ).to.throw(FirebaseError);
     });
 
@@ -373,7 +390,12 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { FOO: "baz" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            functionsSource: tmpdir,
+            codebase: "default",
+          },
         ),
       ).to.throw(FirebaseError);
     });
@@ -384,7 +406,13 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "baz" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true, codebase: "default" },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          isEmulator: true,
+          codebase: "default",
+        },
       );
       expect(
         env.loadUserEnvs({
@@ -413,19 +441,34 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { lowercase: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            functionsSource: tmpdir,
+            codebase: "default",
+          },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { GCP_PROJECT: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            functionsSource: tmpdir,
+            codebase: "default",
+          },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { FIREBASE_KEY: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            functionsSource: tmpdir,
+            codebase: "default",
+          },
         ),
       ).to.throw(env.KeyValidationError);
     });
@@ -433,12 +476,20 @@ FOO=foo
     it("writes the specified key to a .env.projectId that it created", () => {
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          codebase: "default",
+        },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" })[
-          "FOO"
-        ],
+        env.loadUserEnvs({
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          codebase: "default",
+        })["FOO"],
       ).to.equal("bar");
     });
 
@@ -448,19 +499,32 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          codebase: "default",
+        },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" })[
-          "FOO"
-        ],
+        env.loadUserEnvs({
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          codebase: "default",
+        })["FOO"],
       ).to.equal("bar");
     });
 
     it("writes multiple keys at once", () => {
       env.writeUserEnvs(
         { FOO: "foo", BAR: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          codebase: "default",
+        },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
@@ -479,7 +543,12 @@ FOO=foo
           WITH_SLASHES: "\n\\\r\\\t\\\v",
           QUOTES: "'\"'",
         },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          functionsSource: tmpdir,
+          codebase: "default",
+        },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
@@ -501,8 +570,11 @@ FOO=foo
       } catch (err: any) {
         // no-op
       }
-      expect(env.loadUserEnvs({ projectId: "project", functionsSource: tmpdir, codebase: "default" })["FOO"]).to.be
-        .undefined;
+      expect(
+        env.loadUserEnvs({ projectId: "project", functionsSource: tmpdir, codebase: "default" })[
+          "FOO"
+        ],
+      ).to.be.undefined;
     });
   });
 
@@ -721,9 +793,9 @@ FOO=foo
         });
 
         expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
-          FOO: "project",      // project overrides codebase
-          BAR: "codebase",     // codebase overrides global
-          BAZ: "global",       // only defined in global
+          FOO: "project", // project overrides codebase
+          BAR: "codebase", // codebase overrides global
+          BAZ: "global", // only defined in global
         });
       });
 
@@ -735,9 +807,9 @@ FOO=foo
         });
 
         expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
-          FOO: "alias",        // alias overrides codebase
-          BAR: "codebase",     // codebase overrides global
-          BAZ: "global",       // only defined in global
+          FOO: "alias", // alias overrides codebase
+          BAR: "codebase", // codebase overrides global
+          BAZ: "global", // only defined in global
         });
       });
 
@@ -748,7 +820,9 @@ FOO=foo
           ".env.profile-pics-resizer": "FOO=custom-codebase\nCUSTOM=value",
         });
 
-        expect(env.loadUserEnvs({ ...customProjectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+        expect(
+          env.loadUserEnvs({ ...customProjectInfo, functionsSource: tmpdir }),
+        ).to.be.deep.equal({
           FOO: "custom-codebase",
           CUSTOM: "value",
         });
@@ -765,12 +839,11 @@ FOO=foo
         expect(
           env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true }),
         ).to.be.deep.equal({
-          FOO: "local",        // .env.local has highest precedence in emulator
-          BAR: "codebase",     // codebase overrides global
-          BAZ: "global",       // only defined in global
+          FOO: "local", // .env.local has highest precedence in emulator
+          BAR: "codebase", // codebase overrides global
+          BAZ: "global", // only defined in global
         });
       });
-
     });
   });
 

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -310,11 +310,11 @@ FOO=foo
     it("never affects the filesystem if the list of keys to write is empty", () => {
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
       );
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true, codebase: "default" },
       );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
@@ -322,7 +322,7 @@ FOO=foo
     });
 
     it("touches .env.projectId if it doesn't already exist", () => {
-      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir });
+      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir, codebase: "default" });
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(!!fs.statSync(path.join(tmpdir, ".env.project"))).to.be.true;
       expect(() => fs.statSync(path.join(tmpdir, ".env.local"))).to.throw;
@@ -331,7 +331,7 @@ FOO=foo
     it("touches .env.local if it doesn't already exist in emulator mode", () => {
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", functionsSource: tmpdir, isEmulator: true, codebase: "default" },
       );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
@@ -343,7 +343,7 @@ FOO=foo
         [".env.project"]: "FOO=foo",
       });
       expect(() =>
-        env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir }),
+        env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir, codebase: "default" }),
       ).to.throw(FirebaseError);
     });
 
@@ -353,7 +353,7 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", functionsSource: tmpdir, isEmulator: true, codebase: "default" },
       );
       expect(
         env.loadUserEnvs({
@@ -361,6 +361,7 @@ FOO=foo
           projectAlias: "alias",
           functionsSource: tmpdir,
           isEmulator: true,
+          codebase: "default",
         })["FOO"],
       ).to.equal("bar");
     });
@@ -372,7 +373,7 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { FOO: "baz" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
         ),
       ).to.throw(FirebaseError);
     });
@@ -383,7 +384,7 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "baz" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true, codebase: "default" },
       );
       expect(
         env.loadUserEnvs({
@@ -391,6 +392,7 @@ FOO=foo
           projectAlias: "alias",
           functionsSource: tmpdir,
           isEmulator: true,
+          codebase: "default",
         })["FOO"],
       ).to.equal("baz");
     });
@@ -402,7 +404,7 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { ASDF: "bar" },
-          { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+          { projectId: "project", functionsSource: tmpdir, isEmulator: true, codebase: "default" },
         ),
       ).to.throw(FirebaseError);
     });
@@ -411,19 +413,19 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { lowercase: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { GCP_PROJECT: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { FIREBASE_KEY: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
         ),
       ).to.throw(env.KeyValidationError);
     });
@@ -431,10 +433,10 @@ FOO=foo
     it("writes the specified key to a .env.projectId that it created", () => {
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" })[
           "FOO"
         ],
       ).to.equal("bar");
@@ -446,10 +448,10 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" })[
           "FOO"
         ],
       ).to.equal("bar");
@@ -458,12 +460,13 @@ FOO=foo
     it("writes multiple keys at once", () => {
       env.writeUserEnvs(
         { FOO: "foo", BAR: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
         projectAlias: "alias",
         functionsSource: tmpdir,
+        codebase: "default",
       });
       expect(envs["FOO"]).to.equal("foo");
       expect(envs["BAR"]).to.equal("bar");
@@ -476,12 +479,13 @@ FOO=foo
           WITH_SLASHES: "\n\\\r\\\t\\\v",
           QUOTES: "'\"'",
         },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, codebase: "default" },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
         projectAlias: "alias",
         functionsSource: tmpdir,
+        codebase: "default",
       });
       expect(envs["ESCAPES"]).to.equal("\n\r\t\v");
       expect(envs["WITH_SLASHES"]).to.equal("\n\\\r\\\t\\\v");
@@ -492,12 +496,12 @@ FOO=foo
       try {
         env.writeUserEnvs(
           { FOO: "bar", lowercase: "bar" },
-          { projectId: "project", functionsSource: tmpdir },
+          { projectId: "project", functionsSource: tmpdir, codebase: "default" },
         );
       } catch (err: any) {
         // no-op
       }
-      expect(env.loadUserEnvs({ projectId: "project", functionsSource: tmpdir })["FOO"]).to.be
+      expect(env.loadUserEnvs({ projectId: "project", functionsSource: tmpdir, codebase: "default" })["FOO"]).to.be
         .undefined;
     });
   });
@@ -511,6 +515,7 @@ FOO=foo
     const projectInfo: Omit<env.UserEnvsOpts, "functionsSource"> = {
       projectId: "my-project",
       projectAlias: "dev",
+      codebase: "default",
     };
     let tmpdir: string;
 
@@ -694,6 +699,78 @@ FOO=foo
       expect(() => {
         env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir });
       }).to.throw("Failed to load");
+    });
+
+    describe("codebase environment variables", () => {
+      it("loads envs from .env.<codebase> file", () => {
+        createEnvFiles(tmpdir, {
+          [`.env.${projectInfo.codebase}`]: "FOO=codebase-foo\nBAR=codebase-bar",
+        });
+
+        expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+          FOO: "codebase-foo",
+          BAR: "codebase-bar",
+        });
+      });
+
+      it("loads envs with correct precedence: .env < .env.<codebase> < .env.<project>", () => {
+        createEnvFiles(tmpdir, {
+          ".env": "FOO=global\nBAR=global\nBAZ=global",
+          [`.env.${projectInfo.codebase}`]: "FOO=codebase\nBAR=codebase",
+          [`.env.${projectInfo.projectId}`]: "FOO=project",
+        });
+
+        expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+          FOO: "project",      // project overrides codebase
+          BAR: "codebase",     // codebase overrides global
+          BAZ: "global",       // only defined in global
+        });
+      });
+
+      it("loads envs with correct precedence: .env < .env.<codebase> < .env.<alias>", () => {
+        createEnvFiles(tmpdir, {
+          ".env": "FOO=global\nBAR=global\nBAZ=global",
+          [`.env.${projectInfo.codebase}`]: "FOO=codebase\nBAR=codebase",
+          [`.env.${projectInfo.projectAlias}`]: "FOO=alias",
+        });
+
+        expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+          FOO: "alias",        // alias overrides codebase
+          BAR: "codebase",     // codebase overrides global
+          BAZ: "global",       // only defined in global
+        });
+      });
+
+      it("works with custom codebase names", () => {
+        const customProjectInfo = { ...projectInfo, codebase: "profile-pics-resizer" };
+        createEnvFiles(tmpdir, {
+          ".env": "FOO=global",
+          ".env.profile-pics-resizer": "FOO=custom-codebase\nCUSTOM=value",
+        });
+
+        expect(env.loadUserEnvs({ ...customProjectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+          FOO: "custom-codebase",
+          CUSTOM: "value",
+        });
+      });
+
+      it("loads envs correctly for emulator with .env.local precedence", () => {
+        createEnvFiles(tmpdir, {
+          ".env": "FOO=global\nBAR=global\nBAZ=global",
+          [`.env.${projectInfo.codebase}`]: "FOO=codebase\nBAR=codebase",
+          [`.env.${projectInfo.projectId}`]: "FOO=project",
+          ".env.local": "FOO=local",
+        });
+
+        expect(
+          env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true }),
+        ).to.be.deep.equal({
+          FOO: "local",        // .env.local has highest precedence in emulator
+          BAR: "codebase",     // codebase overrides global
+          BAZ: "global",       // only defined in global
+        });
+      });
+
     });
   });
 

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -220,10 +220,12 @@ export function parseStrict(data: string): Record<string, string> {
 function findEnvfiles(
   functionsSource: string,
   projectId: string,
+  codebase: string,
   projectAlias?: string,
   isEmulator?: boolean,
 ): string[] {
   const files: string[] = [".env"];
+  files.push(`.env.${codebase}`);
   files.push(`.env.${projectId}`);
   if (projectAlias) {
     files.push(`.env.${projectAlias}`);
@@ -243,6 +245,7 @@ export interface UserEnvsOpts {
   projectId: string;
   projectAlias?: string;
   isEmulator?: boolean;
+  codebase: string;
 }
 
 /**
@@ -255,8 +258,9 @@ export function hasUserEnvs({
   projectId,
   projectAlias,
   isEmulator,
+  codebase,
 }: UserEnvsOpts): boolean {
-  return findEnvfiles(functionsSource, projectId, projectAlias, isEmulator).length > 0;
+  return findEnvfiles(functionsSource, projectId, codebase, projectAlias, isEmulator).length > 0;
 }
 
 /**
@@ -269,10 +273,10 @@ export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvs
   if (Object.keys(toWrite).length === 0) {
     return;
   }
-  const { functionsSource, projectId, projectAlias, isEmulator } = envOpts;
+  const { functionsSource, projectId, projectAlias, isEmulator, codebase } = envOpts;
 
   // Determine which .env file to write to, and create it if it doesn't exist
-  const allEnvFiles = findEnvfiles(functionsSource, projectId, projectAlias, isEmulator);
+  const allEnvFiles = findEnvfiles(functionsSource, projectId, codebase, projectAlias, isEmulator);
   const targetEnvFile = envOpts.isEmulator
     ? FUNCTIONS_EMULATOR_DOTENV
     : `.env.${envOpts.projectId}`;
@@ -356,8 +360,9 @@ function formatUserEnvForWrite(key: string, value: string): string {
  *
  * .env files are searched and merged in the following order:
  *
- *   1. .env
- *   2. .env.<project or alias>
+ *   1. .env (global defaults for all functions in source)
+ *   2. .env.<codebase> (codebase-specific settings)
+ *   3. .env.<project or alias> (project-specific overrides)
  *
  * If both .env.<project> and .env.<alias> files are found, an error is thrown.
  *
@@ -368,8 +373,9 @@ export function loadUserEnvs({
   projectId,
   projectAlias,
   isEmulator,
+  codebase,
 }: UserEnvsOpts): Record<string, string> {
-  const envFiles = findEnvfiles(functionsSource, projectId, projectAlias, isEmulator);
+  const envFiles = findEnvfiles(functionsSource, projectId, codebase, projectAlias, isEmulator);
   if (envFiles.length === 0) {
     return {};
   }


### PR DESCRIPTION
## Summary

Adds support for `.env.<codebase>` environment files as an enhancement to the multi-instance functions feature from #8911.

This enables per-codebase environment variable isolation by adding `.env.<codebase>` to the environment file loading precedence.

## Environment File Precedence (Updated)

1. `.env` (global defaults)
2. `.env.<codebase>` (codebase-specific) ← **NEW**
3. `.env.<project|alias>` (project overrides)
4. `.env.local` (emulator only)

## Changes

- Updated `UserEnvsOpts` interface to include required `codebase` parameter
- Modified `findEnvfiles()` to load `.env.<codebase>` files in correct precedence order
- Added unit tests for codebase environment variable functionality
- Updated all callers to pass codebase parameter

## Related

This builds on the multi-instance functions implementation in #8911 by adding the environment variable isolation component described in the original design spec.