### PR TITLE
Fix leaky unit test

### DIFF
--- a/src/init/features/dataconnect/sdk.spec.ts
+++ b/src/init/features/dataconnect/sdk.spec.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import * as fs from "fs-extra";
 import * as sinon from "sinon";
 import { expect } from "chai";
 
@@ -21,6 +21,7 @@ describe("init dataconnect:sdk", () => {
 
     beforeEach(() => {
       fsStub = sandbox.stub(fs, "writeFileSync");
+      sandbox.stub(fs, "ensureFileSync").returns();
       generateStub = sandbox.stub(DataConnectEmulator, "generate");
       emptyConfig = new Config({}, { projectDir: process.cwd() });
     });


### PR DESCRIPTION
### Description
This unit test was leaky because it was stubbing out 'fs' but the code was writing files with 'fs-extra'. This left a extra dataconnect/conector/connector.yaml file floating around after runs.

### Scenarios Tested
Ran the tests, and no leftover files/
