### PR TITLE
feat: Add `firestore:operations:*` comamnds

### DIFF
--- a/src/commands/firestore-operations-cancel.spec.ts
+++ b/src/commands/firestore-operations-cancel.spec.ts
@@ -1,0 +1,96 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { command } from "./firestore-operations-cancel";
+import * as fsi from "../firestore/api";
+import * as prompt from "../prompt";
+import * as utils from "../utils";
+import { logger } from "../logger";
+
+describe("firestore:operations:cancel", () => {
+  const sandbox = sinon.createSandbox();
+  let firestoreApiStub: sinon.SinonStubbedInstance<fsi.FirestoreApi>;
+  let confirmStub: sinon.SinonStub;
+  let logSuccessStub: sinon.SinonStub;
+  let logWarningStub: sinon.SinonStub;
+  let loggerInfoStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    firestoreApiStub = sandbox.createStubInstance(fsi.FirestoreApi);
+    sandbox.stub(fsi, "FirestoreApi").returns(firestoreApiStub);
+    confirmStub = sandbox.stub(prompt, "confirm");
+    logSuccessStub = sandbox.stub(utils, "logSuccess");
+    logWarningStub = sandbox.stub(utils, "logWarning");
+    loggerInfoStub = sandbox.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should call the Firestore API with the correct parameters with --force", async () => {
+    const options = { project: "test-project", database: "test-db", force: true };
+    const operationName = "test-operation";
+    firestoreApiStub.cancelOperation.resolves({ success: true });
+
+    await command.runner()(operationName, options);
+
+    expect(firestoreApiStub.cancelOperation).to.be.calledOnceWith(
+      "test-project",
+      "test-db",
+      operationName,
+    );
+    expect(confirmStub).to.not.be.called;
+  });
+
+  it("should prompt for confirmation and continue if confirmed", async () => {
+    const options = { project: "test-project", database: "test-db", force: false };
+    const operationName = "test-operation";
+    confirmStub.resolves(true);
+    firestoreApiStub.cancelOperation.resolves({ success: true });
+
+    await command.runner()(operationName, options);
+
+    expect(confirmStub).to.be.calledOnce;
+    expect(firestoreApiStub.cancelOperation).to.be.calledOnceWith(
+      "test-project",
+      "test-db",
+      operationName,
+    );
+    expect(logSuccessStub).to.be.calledOnceWith("Operation cancelled successfully.");
+  });
+
+  it("should not cancel the operation if not confirmed", async () => {
+    const options = { project: "test-project", database: "test-db", force: false };
+    const operationName = "test-operation";
+    confirmStub.resolves(false);
+
+    await expect(command.runner()(operationName, options)).to.be.rejectedWith("Command aborted.");
+
+    expect(confirmStub).to.be.calledOnce;
+    expect(firestoreApiStub.cancelOperation).to.not.be.called;
+  });
+
+  it("should log a warning if operation cancellation fails", async () => {
+    const options = { project: "test-project", database: "test-db", force: true };
+    const operationName = "test-operation";
+    firestoreApiStub.cancelOperation.resolves({ success: false });
+
+    await command.runner()(operationName, options);
+
+    expect(firestoreApiStub.cancelOperation).to.be.calledOnce;
+    expect(logWarningStub).to.be.calledOnceWith("Canceling the operation failed.");
+  });
+
+  it("should print status in JSON format when --json is specified", async () => {
+    const options = { project: "test-project", database: "test-db", force: true, json: true };
+    const operationName = "test-operation";
+    const status = { success: true };
+    firestoreApiStub.cancelOperation.resolves(status);
+
+    await command.runner()(operationName, options);
+
+    expect(loggerInfoStub).to.be.calledOnceWith(JSON.stringify(status, undefined, 2));
+    expect(logSuccessStub).to.not.be.called;
+    expect(logWarningStub).to.not.be.called;
+  });
+});

--- a/src/commands/firestore-operations-cancel.ts
+++ b/src/commands/firestore-operations-cancel.ts
@@ -1,0 +1,49 @@
+import { Command } from "../command";
+import * as fsi from "../firestore/api";
+import { Emulators } from "../emulator/types";
+import { errorMissingProject, warnEmulatorNotSupported } from "../emulator/commandUtils";
+import { FirestoreOptions } from "../firestore/options";
+import { getShortOperationName } from "./firestore-utils";
+import { confirm } from "../prompt";
+import * as clc from "colorette";
+import * as utils from "../utils";
+import { logger } from "../logger";
+import { logSuccess, logWarning } from "../utils";
+
+export const command = new Command("firestore:operations:cancel <operationName>")
+  .description("retrieves information about a Cloud Firestore admin operation")
+  .option(
+    "--database <databaseName>",
+    'Database ID for which the operation is running. "(default)" if none is provided.',
+  )
+  .option("--force", "Forces the operation cancellation without asking for confirmation")
+  .before(errorMissingProject)
+  .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
+  .action(async (operationName: string, options: FirestoreOptions) => {
+    const databaseId = options.database || "(default)";
+    operationName = getShortOperationName(operationName);
+
+    if (!options.force) {
+      const fullName = `/projects/${options.project}/databases/${databaseId}/operations/${operationName}`;
+      const confirmMessage = `You are about to cancel the operation: ${clc.bold(clc.yellow(clc.underline(fullName)))}. Do you wish to continue?`;
+      const consent = await confirm(confirmMessage);
+      if (!consent) {
+        return utils.reject("Command aborted.", { exit: 1 });
+      }
+    }
+
+    const api = new fsi.FirestoreApi();
+    const status = await api.cancelOperation(options.project, databaseId, operationName);
+
+    if (options.json) {
+      logger.info(JSON.stringify(status, undefined, 2));
+    } else {
+      if (status.success) {
+        logSuccess("Operation cancelled successfully.");
+      } else {
+        logWarning("Canceling the operation failed.");
+      }
+    }
+
+    return status;
+  });

--- a/src/commands/firestore-operations-describe.spec.ts
+++ b/src/commands/firestore-operations-describe.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { command } from "./firestore-operations-describe";
+import * as fsi from "../firestore/api";
+import { logger } from "../logger";
+import { PrettyPrint } from "../firestore/pretty-print";
+import { FirebaseError } from "../error";
+
+describe("firestore:operations:describe", () => {
+  const sandbox = sinon.createSandbox();
+  let firestoreApiStub: sinon.SinonStubbedInstance<fsi.FirestoreApi>;
+  let loggerInfoStub: sinon.SinonStub;
+  let prettyPrintStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    firestoreApiStub = sandbox.createStubInstance(fsi.FirestoreApi);
+    sandbox.stub(fsi, "FirestoreApi").returns(firestoreApiStub);
+    loggerInfoStub = sandbox.stub(logger, "info");
+    prettyPrintStub = sandbox.stub(PrettyPrint.prototype, "prettyPrintOperation");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should call the Firestore API with the correct parameters", async () => {
+    const options = { project: "test-project", database: "test-db" };
+    const operationName = "test-operation";
+    firestoreApiStub.describeOperation.resolves({ name: "op1", done: false, metadata: {} });
+
+    await command.runner()(operationName, options);
+
+    expect(firestoreApiStub.describeOperation).to.be.calledOnceWith(
+      "test-project",
+      "test-db",
+      operationName,
+    );
+  });
+
+  it("should use default values for database if not provided", async () => {
+    const options = { project: "test-project" };
+    const operationName = "test-operation";
+    firestoreApiStub.describeOperation.resolves({ name: "op1", done: false, metadata: {} });
+
+    await command.runner()(operationName, options);
+
+    expect(firestoreApiStub.describeOperation).to.be.calledOnceWith(
+      "test-project",
+      "(default)",
+      operationName,
+    );
+  });
+
+  it("should print the operation in JSON format when --json is specified", async () => {
+    const options = { project: "test-project", json: true };
+    const operationName = "test-operation";
+    const operation = { name: "op1", done: false, metadata: {} };
+    firestoreApiStub.describeOperation.resolves(operation);
+
+    await command.runner()(operationName, options);
+
+    expect(loggerInfoStub).to.be.calledOnceWith(JSON.stringify(operation, undefined, 2));
+    expect(prettyPrintStub).to.not.be.called;
+  });
+
+  it("should pretty-print the operation when --json is not specified", async () => {
+    const options = { project: "test-project" };
+    const operationName = "test-operation";
+    const operation = { name: "op1", done: false, metadata: {} };
+    firestoreApiStub.describeOperation.resolves(operation);
+
+    await command.runner()(operationName, options);
+
+    expect(prettyPrintStub).to.be.calledOnceWith(operation);
+    expect(loggerInfoStub).to.not.be.called;
+  });
+
+  it("should throw a FirebaseError if project is not defined", async () => {
+    const options = {};
+    const operationName = "test-operation";
+    await expect(command.runner()(operationName, options)).to.be.rejectedWith(
+      FirebaseError,
+      "Project is not defined. Either use `--project` or use `firebase use` to set your active project.",
+    );
+  });
+
+  it("should throw a FirebaseError if operation name is invalid", async () => {
+    const options = { project: "test-project" };
+    await expect(command.runner()("", options)).to.be.rejectedWith(
+      FirebaseError,
+      '"" is not a valid operation name.',
+    );
+    await expect(command.runner()("projects/p/databases/d", options)).to.be.rejectedWith(
+      FirebaseError,
+      '"projects/p/databases/d" is not a valid operation name.',
+    );
+    await expect(
+      command.runner()("projects/p/databases/d/operations/", options),
+    ).to.be.rejectedWith(
+      FirebaseError,
+      '"projects/p/databases/d/operations/" is not a valid operation name.',
+    );
+  });
+});

--- a/src/commands/firestore-operations-describe.ts
+++ b/src/commands/firestore-operations-describe.ts
@@ -1,0 +1,52 @@
+import { Command } from "../command";
+import * as fsi from "../firestore/api";
+import { logger } from "../logger";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
+import { FirestoreOptions } from "../firestore/options";
+import { FirebaseError } from "../error";
+import { PrettyPrint } from "../firestore/pretty-print";
+
+export const command = new Command("firestore:operations:describe <operationName>")
+  .description("retrieves information about a Cloud Firestore admin operation")
+  .option(
+    "--database <databaseName>",
+    'Database ID for which the operation is running. "(default)" if none is provided.',
+  )
+  .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
+  .action(async (operationName: string, options: FirestoreOptions) => {
+    if (!options.project) {
+      throw new FirebaseError(
+        "Project is not defined. Either use `--project` or use `firebase use` to set your active project.",
+      );
+    }
+
+    const databaseId = options.database || "(default)";
+
+    // It's common for users to use full names
+    // such as `projects/foo/databases/bar/operations/operation_1`
+    // and operation names such as `operation_1` interchangeably.
+    // We must support both cases.
+    let opName = operationName;
+    if (operationName.includes("/operations/")) {
+      // Since operationName includes `/operations/`, it is guaranteed
+      // that the `split()` will result in a list of 2 or more elements.
+      opName = operationName.split("/operations/")[1];
+    }
+
+    if (opName.length === 0 || opName.includes("/")) {
+      throw new FirebaseError(`"${operationName}" is not a valid operation name.`);
+    }
+
+    const api = new fsi.FirestoreApi();
+    const operation = await api.describeOperation(options.project, databaseId, opName);
+
+    if (options.json) {
+      logger.info(JSON.stringify(operation, undefined, 2));
+    } else {
+      const printer = new PrettyPrint();
+      printer.prettyPrintOperation(operation);
+    }
+
+    return operation;
+  });

--- a/src/commands/firestore-operations-list.spec.ts
+++ b/src/commands/firestore-operations-list.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { command } from "./firestore-operations-list";
+import * as fsi from "../firestore/api";
+import { logger } from "../logger";
+import { PrettyPrint } from "../firestore/pretty-print";
+import { FirebaseError } from "../error";
+
+describe("firestore:operations:list", () => {
+  const sandbox = sinon.createSandbox();
+  let firestoreApiStub: sinon.SinonStubbedInstance<fsi.FirestoreApi>;
+  let loggerInfoStub: sinon.SinonStub;
+  let prettyPrintStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    firestoreApiStub = sandbox.createStubInstance(fsi.FirestoreApi);
+    sandbox.stub(fsi, "FirestoreApi").returns(firestoreApiStub);
+    loggerInfoStub = sandbox.stub(logger, "info");
+    prettyPrintStub = sandbox.stub(PrettyPrint.prototype, "prettyPrintOperations");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should call the Firestore API with the correct parameters", async () => {
+    const options = { project: "test-project", database: "test-db", limit: 50 };
+    firestoreApiStub.listOperations.resolves({ operations: [] });
+
+    await command.runner()(options);
+
+    expect(firestoreApiStub.listOperations).to.be.calledOnceWith("test-project", "test-db", 50);
+  });
+
+  it("should use default values for database and limit if not provided", async () => {
+    const options = { project: "test-project" };
+    firestoreApiStub.listOperations.resolves({ operations: [] });
+
+    await command.runner()(options);
+
+    expect(firestoreApiStub.listOperations).to.be.calledOnceWith("test-project", "(default)", 100);
+  });
+
+  it("should print operations in JSON format when --json is specified", async () => {
+    const options = { project: "test-project", json: true };
+    const operations = [
+      { name: "op1", done: false, metadata: {} },
+      { name: "op2", done: true, metadata: {} },
+    ];
+    firestoreApiStub.listOperations.resolves({ operations });
+
+    await command.runner()(options);
+
+    expect(loggerInfoStub).to.be.calledOnceWith(JSON.stringify(operations, undefined, 2));
+    expect(prettyPrintStub).to.not.be.called;
+  });
+
+  it("should pretty-print operations when --json is not specified", async () => {
+    const options = { project: "test-project" };
+    const operations = [
+      { name: "op1", done: false, metadata: {} },
+      { name: "op2", done: true, metadata: {} },
+    ];
+    firestoreApiStub.listOperations.resolves({ operations });
+
+    await command.runner()(options);
+
+    expect(prettyPrintStub).to.be.calledOnceWith(operations);
+    expect(loggerInfoStub).to.not.be.called;
+  });
+
+  it("should throw a FirebaseError if project is not defined", async () => {
+    const options = {};
+    await expect(command.runner()(options)).to.be.rejectedWith(
+      FirebaseError,
+      "Project is not defined. Either use `--project` or use `firebase use` to set your active project.",
+    );
+  });
+});

--- a/src/commands/firestore-operations-list.ts
+++ b/src/commands/firestore-operations-list.ts
@@ -2,9 +2,8 @@ import { Command } from "../command";
 import * as fsi from "../firestore/api";
 import { logger } from "../logger";
 import { Emulators } from "../emulator/types";
-import { warnEmulatorNotSupported } from "../emulator/commandUtils";
+import { errorMissingProject, warnEmulatorNotSupported } from "../emulator/commandUtils";
 import { FirestoreOptions } from "../firestore/options";
-import { FirebaseError } from "../error";
 import { PrettyPrint } from "../firestore/pretty-print";
 
 export const command = new Command("firestore:operations:list")
@@ -14,13 +13,9 @@ export const command = new Command("firestore:operations:list")
     'Database ID for database to list operations for. "(default)" if none is provided.',
   )
   .option("--limit <number>", "The maximum number of operations to list. Uses 100 by default.")
+  .before(errorMissingProject)
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
   .action(async (options: FirestoreOptions) => {
-    if (!options.project) {
-      throw new FirebaseError(
-        "Project is not defined. Either use `--project` or use `firebase use` to set your active project.",
-      );
-    }
     const databaseId = options.database || "(default)";
     const limit = (options.limit as number) || 100;
 

--- a/src/commands/firestore-operations-list.ts
+++ b/src/commands/firestore-operations-list.ts
@@ -11,7 +11,7 @@ export const command = new Command("firestore:operations:list")
   .description("list pending Cloud Firestore admin operations and their status")
   .option(
     "--database <databaseName>",
-    'Database ID for database to list operations fo. "(default)" if none is provided.',
+    'Database ID for database to list operations for. "(default)" if none is provided.',
   )
   .option("--limit <number>", "The maximum number of operations to list. Uses 100 by default.")
   .before(warnEmulatorNotSupported, Emulators.FIRESTORE)

--- a/src/commands/firestore-operations-list.ts
+++ b/src/commands/firestore-operations-list.ts
@@ -1,0 +1,38 @@
+import { Command } from "../command";
+import * as fsi from "../firestore/api";
+import { logger } from "../logger";
+import { Emulators } from "../emulator/types";
+import { warnEmulatorNotSupported } from "../emulator/commandUtils";
+import { FirestoreOptions } from "../firestore/options";
+import { FirebaseError } from "../error";
+import { PrettyPrint } from "../firestore/pretty-print";
+
+export const command = new Command("firestore:operations:list")
+  .description("list pending Cloud Firestore admin operations and their status")
+  .option(
+    "--database <databaseName>",
+    'Database ID for database to list operations fo. "(default)" if none is provided.',
+  )
+  .option("--limit <number>", "The maximum number of operations to list. Uses 100 by default.")
+  .before(warnEmulatorNotSupported, Emulators.FIRESTORE)
+  .action(async (options: FirestoreOptions) => {
+    if (!options.project) {
+      throw new FirebaseError(
+        "Project is not defined. Either use `--project` or use `firebase use` to set your active project.",
+      );
+    }
+    const databaseId = options.database || "(default)";
+    const limit = (options.limit as number) || 100;
+
+    const api = new fsi.FirestoreApi();
+    const { operations } = await api.listOperations(options.project, databaseId, limit);
+
+    if (options.json) {
+      logger.info(JSON.stringify(operations, undefined, 2));
+    } else {
+      const printer = new PrettyPrint();
+      printer.prettyPrintOperations(operations);
+    }
+
+    return operations;
+  });

--- a/src/commands/firestore-utils.ts
+++ b/src/commands/firestore-utils.ts
@@ -1,0 +1,28 @@
+import { FirebaseError } from "../error";
+
+/**
+ * Given an operation name, which may be a short name or full name,
+ * it returns the short name.
+ *
+ * It's common for users to use full names such as:
+ * `projects/foo/databases/bar/operations/operation_1`
+ * and short names such as `operation_1` interchangeably.
+ * If the input is a short name (with no '/'), it returns the name as-is.
+ * If the input is a full name, it returns the short name.
+ * If the input is not a valid operation name it throws an exception.
+ * @param name the operation name
+ */
+export function getShortOperationName(operationName: string): string {
+  let opName = operationName;
+  if (operationName.includes("/operations/")) {
+    // Since operationName includes `/operations/`, it is guaranteed
+    // that the `split()` will result in a list of 2 or more elements.
+    opName = operationName.split("/operations/")[1];
+  }
+
+  if (opName.length === 0 || opName.includes("/")) {
+    throw new FirebaseError(`"${operationName}" is not a valid operation name.`);
+  }
+
+  return opName;
+}

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -103,6 +103,8 @@ export function load(client: any): any {
   client.firestore.delete = loadCommand("firestore-delete");
   client.firestore.indexes = loadCommand("firestore-indexes-list");
   client.firestore.locations = loadCommand("firestore-locations");
+  client.firestore.operations = {};
+  client.firestore.operations.list = loadCommand("firestore-operations-list");
   client.firestore.databases = {};
   client.firestore.databases.list = loadCommand("firestore-databases-list");
   client.firestore.databases.get = loadCommand("firestore-databases-get");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -104,6 +104,7 @@ export function load(client: any): any {
   client.firestore.indexes = loadCommand("firestore-indexes-list");
   client.firestore.locations = loadCommand("firestore-locations");
   client.firestore.operations = {};
+  client.firestore.operations.desscribe = loadCommand("firestore-operations-describe");
   client.firestore.operations.list = loadCommand("firestore-operations-list");
   client.firestore.databases = {};
   client.firestore.databases.list = loadCommand("firestore-databases-list");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -104,6 +104,7 @@ export function load(client: any): any {
   client.firestore.indexes = loadCommand("firestore-indexes-list");
   client.firestore.locations = loadCommand("firestore-locations");
   client.firestore.operations = {};
+  client.firestore.operations.cancel = loadCommand("firestore-operations-cancel");
   client.firestore.operations.desscribe = loadCommand("firestore-operations-describe");
   client.firestore.operations.list = loadCommand("firestore-operations-list");
   client.firestore.databases = {};

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -137,6 +137,14 @@ export async function warnEmulatorNotSupported(
   }
 }
 
+export async function errorMissingProject(options: any): Promise<void> {
+  if (!options.project) {
+    throw new FirebaseError(
+      "Project is not defined. Either use `--project` or use `firebase use` to set your active project.",
+    );
+  }
+}
+
 /**
  * Utility method to be inserted in the "before" function for a command that
  * uses the emulator suite.

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -188,6 +188,12 @@ export interface Operation {
   done: boolean;
   metadata: Record<string, any>;
   response?: Record<string, any>;
+  error?: {
+    name: string;
+    message: string;
+    code: number;
+    details?: any[];
+  };
 }
 
 export interface ListOperationsResponse {

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -183,6 +183,17 @@ export interface DatabaseResp {
   databaseEdition?: DatabaseEdition;
 }
 
+export interface Operation {
+  name: string;
+  done: boolean;
+  metadata: Record<string, any>;
+  response?: Record<string, any>;
+}
+
+export interface ListOperationsResponse {
+  operations: Operation[];
+}
+
 export interface RestoreDatabaseReq {
   databaseId: string;
   backup: string;

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -13,7 +13,6 @@ import { firestoreOrigin } from "../api";
 import { FirebaseError } from "../error";
 import { Client } from "../apiv2";
 import { PrettyPrint } from "./pretty-print";
-import { ListOperationsResponse } from "./api-types";
 
 export class FirestoreApi {
   apiClient = new Client({ urlPrefix: firestoreOrigin(), apiVersion: "v1" });
@@ -827,11 +826,27 @@ export class FirestoreApi {
     limit: number,
   ): Promise<types.ListOperationsResponse> {
     const url = `/projects/${project}/databases/${databaseId}/operations`;
-    const res = await this.apiClient.get<ListOperationsResponse>(url, {
+    const res = await this.apiClient.get<types.ListOperationsResponse>(url, {
       queryParams: {
         pageSize: limit,
       },
     });
+    return res.body;
+  }
+
+  /**
+   * The information related to the LRO with the given name.
+   * @param project the Firebase project id.
+   * @param databaseId the id of the Firestore Database.
+   * @param operationName the name of the LRO.
+   */
+  async describeOperation(
+    project: string,
+    databaseId: string,
+    operationName: string,
+  ): Promise<types.Operation> {
+    const url = `/projects/${project}/databases/${databaseId}/operations/${operationName}`;
+    const res = await this.apiClient.get<types.Operation>(url);
     return res.body;
   }
 }

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -13,6 +13,7 @@ import { firestoreOrigin } from "../api";
 import { FirebaseError } from "../error";
 import { Client } from "../apiv2";
 import { PrettyPrint } from "./pretty-print";
+import { ListOperationsResponse } from "./api-types";
 
 export class FirestoreApi {
   apiClient = new Client({ urlPrefix: firestoreOrigin(), apiVersion: "v1" });
@@ -22,7 +23,7 @@ export class FirestoreApi {
    * Process indexes by filtering out implicit __name__ fields with ASCENDING order.
    * Keeps explicit __name__ fields with DESCENDING order.
    * @param indexes Array of indexes to process
-   * @returns Processed array of indexes with filtered fields
+   * @return Processed array of indexes with filtered fields
    */
   public static processIndexes(indexes: types.Index[]): types.Index[] {
     return indexes.map((index: types.Index): types.Index => {
@@ -813,5 +814,24 @@ export class FirestoreApi {
     }
 
     return database;
+  }
+
+  /**
+   * List the long-running Firestore operations.
+   * @param project the Firebase project id.
+   * @param databaseId the id of the Firestore Database.
+   */
+  async listOperations(
+    project: string,
+    databaseId: string,
+    limit: number,
+  ): Promise<types.ListOperationsResponse> {
+    const url = `/projects/${project}/databases/${databaseId}/operations`;
+    const res = await this.apiClient.get<ListOperationsResponse>(url, {
+      queryParams: {
+        pageSize: limit,
+      },
+    });
+    return res.body;
   }
 }

--- a/src/firestore/pretty-print.ts
+++ b/src/firestore/pretty-print.ts
@@ -7,6 +7,7 @@ import { logger } from "../logger";
 import * as util from "./util";
 import { consoleUrl } from "../utils";
 import { Backup, BackupSchedule } from "../gcp/firestore";
+import { Operation } from "./api-types";
 
 export class PrettyPrint {
   /**
@@ -203,6 +204,36 @@ export class PrettyPrint {
       ["Stats", clc.yellow(backup.stats!)],
     );
     logger.info(table.toString());
+  }
+
+  /**
+   * Print a Firestore operation as an ASCII table.
+   */
+  prettyPrintOperation(operation: Operation) {
+    const table = new Table({
+      head: ["Operation", ""],
+    });
+
+    table.push(
+      ["Name", clc.yellow(operation.name)],
+      ["Done?", clc.yellow(operation.done ? "YES" : "NO")],
+      ["Metadata", clc.yellow(JSON.stringify(operation.metadata, undefined, 2))],
+    );
+
+    if (operation.response) {
+      table.push(["Response", clc.yellow(JSON.stringify(operation.response, undefined, 2))]);
+    }
+
+    logger.info(table.toString());
+  }
+
+  /**
+   * Print Firestore operations as an ASCII table.
+   */
+  prettyPrintOperations(operations: Operation[]) {
+    for (const op of operations) {
+      this.prettyPrintOperation(op);
+    }
   }
 
   /**


### PR DESCRIPTION
Adds the following commands:
```
firestore:operations:list     [--database="(default)"][--limit=100]
firestore:operations:describe [--database="(default)"] <operation_name>
firestore:operations:cancel   [--database="(default)"] <operation_name>
```
