### PR TITLE
fix(dataconnect): use correct env var in warning

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -330,7 +330,9 @@ interface serviceAndSchema {
 async function chooseExistingService(
   existing: serviceAndSchema[],
 ): Promise<serviceAndSchema | undefined> {
-  const serviceEnvVar = envOverride("FDC_CONNECTOR", "") || envOverride("FDC_SERVICE", "");
+  const fdcConnector = envOverride("FDC_CONNECTOR", "");
+  const fdcService = envOverride("FDC_SERVICE", "");
+  const serviceEnvVar = fdcConnector || fdcService;
   if (serviceEnvVar) {
     const [serviceLocationFromEnvVar, serviceIdFromEnvVar] = serviceEnvVar.split("/");
     const serviceFromEnvVar = existing.find((s) => {
@@ -346,7 +348,8 @@ async function chooseExistingService(
       );
       return serviceFromEnvVar;
     }
-    logWarning(`Unable to pick up an existing service based on FDC_SERVICE=${serviceEnvVar}.`);
+    const envVarName = fdcConnector ? "FDC_CONNECTOR" : "FDC_SERVICE";
+    logWarning(`Unable to pick up an existing service based on ${envVarName}=${serviceEnvVar}.`);
   }
   const choices: Array<{ name: string; value: serviceAndSchema | undefined }> = existing.map(
     (s) => {


### PR DESCRIPTION
The warning message for being unable to find an existing service was hardcoded to `FDC_SERVICE`, even when `FDC_CONNECTOR` was being used. This commit fixes the warning message to use the correct environment variable name.

Prompt to Jules
```
Fix a bug at this line. When FDC_CONNECTOR is set, it still prints out "Unable to pick up an existing service based on FDC_SERVICE"

https://github.com/firebase/firebase-tools/blob/2c576e61b0685caad414097beff8968941f19125/src/init/features/dataconnect/index.ts#L349
```