### PR TITLE
[FDC] Add GA metrics `dataconnect_init`

### DIFF
--- a/src/init/features/dataconnect/index.spec.ts
+++ b/src/init/features/dataconnect/index.spec.ts
@@ -235,6 +235,7 @@ function mockConfig(data: Record<string, any> = {}): Config {
 }
 function mockRequiredInfo(info: Partial<init.RequiredInfo> = {}): init.RequiredInfo {
   return {
+    analyticsFlow: "test",
     appDescription: "",
     serviceId: "test-service",
     locationId: "europe-north3",

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -39,6 +39,7 @@ import {
 } from "../../../gemini/fdcExperience";
 import { configstore } from "../../../configstore";
 import { Options } from "../../../options";
+import { trackGA4 } from "../../../track";
 
 const DATACONNECT_YAML_TEMPLATE = readTemplateSync("init/dataconnect/dataconnect.yaml");
 const CONNECTOR_YAML_TEMPLATE = readTemplateSync("init/dataconnect/connector.yaml");
@@ -47,6 +48,8 @@ const QUERIES_TEMPLATE = readTemplateSync("init/dataconnect/queries.gql");
 const MUTATIONS_TEMPLATE = readTemplateSync("init/dataconnect/mutations.gql");
 
 export interface RequiredInfo {
+  // The GA analytics metric to track how developers go through `init dataconnect`.
+  analyticsFlow: string;
   appDescription: string;
   serviceId: string;
   locationId: string;
@@ -93,6 +96,7 @@ const defaultSchema = { path: "schema.gql", content: SCHEMA_TEMPLATE };
 // logic should live here, and _no_ actuation logic should live here.
 export async function askQuestions(setup: Setup): Promise<void> {
   const info: RequiredInfo = {
+    analyticsFlow: "cli",
     appDescription: "",
     serviceId: "",
     locationId: "",
@@ -144,9 +148,26 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
   info.locationId = info.locationId || `us-central1`;
   info.cloudSqlDatabase = info.cloudSqlDatabase || `fdcdb`;
 
+  try {
+    await actuateWithInfo(setup, config, info, options);
+  } finally {
+    void trackGA4("dataconnect_init", {
+      project_status: setup.projectId ? (setup.isBillingEnabled ? "blaze" : "spark") : "missing",
+      flow: info.analyticsFlow,
+    });
+  }
+}
+
+async function actuateWithInfo(
+  setup: Setup,
+  config: Config,
+  info: RequiredInfo,
+  options: any,
+): Promise<void> {
   const projectId = setup.projectId;
   if (!projectId) {
     // Use the static template if it starts from scratch.
+    info.analyticsFlow = "_save_template";
     return await writeFiles(
       config,
       info,
@@ -169,9 +190,11 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
   if (!info.appDescription) {
     // Download an existing service to a local workspace.
     if (info.serviceGql) {
+      info.analyticsFlow = "_save_downloaded";
       return await writeFiles(config, info, info.serviceGql, options);
     }
     // Use the static template if it starts from scratch or the existing service has no GQL source.
+    info.analyticsFlow = "_save_template";
     return await writeFiles(
       config,
       info,
@@ -179,7 +202,6 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
       options,
     );
   }
-
   const serviceName = `projects/${projectId}/locations/${info.locationId}/services/${info.serviceId}`;
   const serviceAlreadyExists = !(await createService(projectId, info.locationId, info.serviceId));
 
@@ -200,6 +222,7 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
       "dataconnect",
       `Data Connect Service ${serviceName} already exists. Skip saving them...`,
     );
+    info.analyticsFlow = "_save_gemini_service_already_exists";
     return await writeFiles(config, info, { schemaGql: schemaFiles, connectors: [] }, options);
   }
 
@@ -241,6 +264,7 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
         ],
       },
     ];
+    info.analyticsFlow = "_save_gemini";
     await writeFiles(
       config,
       info,
@@ -251,6 +275,7 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
     logLabeledError("dataconnect", `Operation Generation failed...`);
     // GiF generate operation API has stability concerns.
     // Fallback to save only the generated schema.
+    info.analyticsFlow = "_save_gemini_operation_error";
     await writeFiles(config, info, { schemaGql: schemaFiles, connectors: [] }, options);
     throw err;
   }
@@ -460,6 +485,7 @@ async function promptForExistingServices(setup: Setup, info: RequiredInfo): Prom
   if (!existingServices.length) {
     return;
   }
+  info.analyticsFlow += "_has_existing";
   const existingServicesAndSchemas = await Promise.all(
     existingServices.map(async (s) => {
       return { service: s, schema: await getSchema(s.name) };
@@ -472,6 +498,7 @@ async function promptForExistingServices(setup: Setup, info: RequiredInfo): Prom
     return;
   }
   // Choose to use an existing service.
+  info.analyticsFlow += "_pick_existing";
   const serviceName = parseServiceName(choice.service.name);
   info.serviceId = serviceName.serviceId;
   info.locationId = serviceName.location;
@@ -593,9 +620,11 @@ async function promptForCloudSQL(setup: Setup, info: RequiredInfo): Promise<void
         choices,
       });
       if (info.cloudSqlInstanceId !== "") {
+        info.analyticsFlow += "_pick_existing_csql";
         // Infer location if a CloudSQL instance is chosen.
         info.locationId = choices.find((c) => c.value === info.cloudSqlInstanceId)!.location;
       } else {
+        info.analyticsFlow += "_pick_new_csql";
         info.cloudSqlInstanceId = await input({
           message: `What ID would you like to use for your new CloudSQL instance?`,
           default: newUniqueId(

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -167,7 +167,7 @@ async function actuateWithInfo(
   const projectId = setup.projectId;
   if (!projectId) {
     // Use the static template if it starts from scratch.
-    info.analyticsFlow = "_save_template";
+    info.analyticsFlow += "_save_template";
     return await writeFiles(
       config,
       info,
@@ -190,11 +190,11 @@ async function actuateWithInfo(
   if (!info.appDescription) {
     // Download an existing service to a local workspace.
     if (info.serviceGql) {
-      info.analyticsFlow = "_save_downloaded";
+      info.analyticsFlow += "_save_downloaded";
       return await writeFiles(config, info, info.serviceGql, options);
     }
     // Use the static template if it starts from scratch or the existing service has no GQL source.
-    info.analyticsFlow = "_save_template";
+    info.analyticsFlow += "_save_template";
     return await writeFiles(
       config,
       info,
@@ -222,7 +222,7 @@ async function actuateWithInfo(
       "dataconnect",
       `Data Connect Service ${serviceName} already exists. Skip saving them...`,
     );
-    info.analyticsFlow = "_save_gemini_service_already_exists";
+    info.analyticsFlow += "_save_gemini_service_already_exists";
     return await writeFiles(config, info, { schemaGql: schemaFiles, connectors: [] }, options);
   }
 
@@ -264,7 +264,7 @@ async function actuateWithInfo(
         ],
       },
     ];
-    info.analyticsFlow = "_save_gemini";
+    info.analyticsFlow += "_save_gemini";
     await writeFiles(
       config,
       info,
@@ -275,7 +275,7 @@ async function actuateWithInfo(
     logLabeledError("dataconnect", `Operation Generation failed...`);
     // GiF generate operation API has stability concerns.
     // Fallback to save only the generated schema.
-    info.analyticsFlow = "_save_gemini_operation_error";
+    info.analyticsFlow += "_save_gemini_operation_error";
     await writeFiles(config, info, { schemaGql: schemaFiles, connectors: [] }, options);
     throw err;
   }
@@ -485,7 +485,6 @@ async function promptForExistingServices(setup: Setup, info: RequiredInfo): Prom
   if (!existingServices.length) {
     return;
   }
-  info.analyticsFlow += "_has_existing";
   const existingServicesAndSchemas = await Promise.all(
     existingServices.map(async (s) => {
       return { service: s, schema: await getSchema(s.name) };
@@ -495,10 +494,11 @@ async function promptForExistingServices(setup: Setup, info: RequiredInfo): Prom
   if (!choice) {
     const existingServiceIds = existingServices.map((s) => s.name.split("/").pop()!);
     info.serviceId = newUniqueId(defaultServiceId(), existingServiceIds);
+    info.analyticsFlow += "_pick_new_service";
     return;
   }
   // Choose to use an existing service.
-  info.analyticsFlow += "_pick_existing";
+  info.analyticsFlow += "_pick_existing_service";
   const serviceName = parseServiceName(choice.service.name);
   info.serviceId = serviceName.serviceId;
   info.locationId = serviceName.location;

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -148,6 +148,7 @@ export const init = tool(
     if (features.dataconnect) {
       featuresList.push("dataconnect");
       featureInfo.dataconnect = {
+        analyticsFlow: "mcp",
         appDescription: features.dataconnect.app_description || "",
         serviceId: features.dataconnect.service_id || "",
         locationId: features.dataconnect.location_id || "",

--- a/src/track.ts
+++ b/src/track.ts
@@ -12,6 +12,7 @@ type cliEventNames =
   | "product_deploy"
   | "product_init"
   | "product_init_mcp"
+  | "dataconnect_init"
   | "error"
   | "login"
   | "api_enabled"


### PR DESCRIPTION
###

A couple of example metrics I manage to re-produce.

```
dataconnect_init { project_status: 'missing', flow: 'cli_save_template' }

dataconnect_init { project_status: 'spark', flow: 'cli_save_gemini' }
dataconnect_init { project_status: 'spark', flow: 'cli_pick_existing_service_save_downloaded' }
dataconnect_init { project_status: 'spark', flow: 'cli_pick_new_service_save_template' }
dataconnect_init { project_status: 'spark', flow: 'cli_pick_new_service_save_gemini' }

dataconnect_init { project_status: 'blaze', flow: 'cli_save_template' }
dataconnect_init { project_status: 'blaze', flow: 'cli_pick_existing_service_save_downloaded' }
dataconnect_init { project_status: 'blaze', flow: 'cli_pick_existing_csql_save_template' }
dataconnect_init { project_status: 'blaze', flow: 'cli_pick_existing_csql_save_gemini' }
dataconnect_init { project_status: 'blaze', flow: 'cli_pick_new_csql_save_template' }
dataconnect_init { project_status: 'blaze', flow: 'cli_pick_new_service_pick_new_csql_save_template' }
dataconnect_init { project_status: 'blaze', flow: 'cli_pick_new_service_pick_existing_csql_save_gemini' }
dataconnect_init { project_status: 'blaze', flow: 'cli_pick_new_service_pick_new_csql_save_gemini' }
```