### PR TITLE
add bun as a supported package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ui-debug.log
 test_output.log
 scripts/emulator-tests/functions/index.js
 yarn.lock
+bun.lock
 .npmrc
 
 .DS_Store

--- a/src/emulator/apphosting/developmentServer.spec.ts
+++ b/src/emulator/apphosting/developmentServer.spec.ts
@@ -51,4 +51,16 @@ describe("utils", () => {
 
     expect(await detectPackageManager("./")).to.equal("yarn");
   });
+
+  it("returns bun if bun.lock file fond", async () => {
+    pathExistsStub.callsFake((...args) => {
+      if (args[0] === "bun.lock") {
+        return true;
+      }
+
+      return false;
+    });
+
+    expect(await detectPackageManager("./")).to.equal("bun");
+  });
 });

--- a/src/emulator/apphosting/developmentServer.ts
+++ b/src/emulator/apphosting/developmentServer.ts
@@ -9,7 +9,7 @@ export const logger = EmulatorLogger.forEmulator(Emulators.APPHOSTING);
 /**
  * Supported package managers. This mirrors production.
  */
-export type PackageManager = "npm" | "yarn" | "pnpm";
+export type PackageManager = "npm" | "yarn" | "pnpm" | "bun";
 
 /**
  * Returns the package manager used by the project
@@ -19,6 +19,10 @@ export type PackageManager = "npm" | "yarn" | "pnpm";
 export async function detectPackageManager(rootdir: string): Promise<PackageManager> {
   if (await pathExists(join(rootdir, "pnpm-lock.yaml"))) {
     return "pnpm";
+  }
+
+  if (await pathExists(join(rootdir, "bun.lock"))) {
+    return "bun";
   }
 
   if (await pathExists(join(rootdir, "yarn.lock"))) {

--- a/src/frameworks/compose/discover/runtime/node.spec.ts
+++ b/src/frameworks/compose/discover/runtime/node.spec.ts
@@ -54,6 +54,16 @@ describe("NodejsRuntime", () => {
 
       expect(actual).to.equal(expected);
     });
+
+    it("should return bun package manager", async () => {
+      const fileSystem = new MockFileSystem({
+        "bun.lock": "It is test file",
+      });
+      const actual = await nodeJSRuntime.getPackageManager(fileSystem);
+      const expected = "bun";
+
+      expect(actual).to.equal(expected);
+    });
   });
 
   describe("getDependencies", () => {

--- a/src/frameworks/compose/discover/runtime/node.ts
+++ b/src/frameworks/compose/discover/runtime/node.ts
@@ -14,7 +14,7 @@ export interface PackageJSON {
   scripts?: Record<string, string>;
   engines?: Record<string, string>;
 }
-type PackageManager = "npm" | "yarn";
+type PackageManager = "npm" | "yarn" | "bun";
 
 const supportedNodeVersions: string[] = ["18"];
 const NODE_RUNTIME_ID = "nodejs";
@@ -61,6 +61,9 @@ export class NodejsRuntime implements Runtime {
       if (await fs.exists(YARN_LOCK)) {
         return "yarn";
       }
+      if (await fs.exists("bun.lock")) {
+        return "bun";
+      }
 
       return "npm";
     } catch (error: any) {
@@ -78,6 +81,9 @@ export class NodejsRuntime implements Runtime {
     if (packageManager === "yarn") {
       packages.push("yarn");
     }
+    if (packageManager === "bun") {
+      packages.push("bun");
+    }
     if (!packages.length) {
       return undefined;
     }
@@ -90,6 +96,9 @@ export class NodejsRuntime implements Runtime {
 
     if (packageManager === "yarn") {
       installCmd = "yarn install";
+    }
+    if (packageManager === "bun") {
+      installCmd = "bun install";
     }
 
     return installCmd;
@@ -115,6 +124,9 @@ export class NodejsRuntime implements Runtime {
   executeFrameworkCommand(packageManager: PackageManager, command: Command): Command {
     if (packageManager === "npm" || packageManager === "yarn") {
       command.cmd = "npx " + command.cmd;
+    }
+    if (packageManager === "bun") {
+      command.cmd = "bun x " + command.cmd;
     }
 
     return command;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Adds https://bun.com as a supported package manager option by successfully detecting its lockfile.

### Scenarios Tested

Adds tests too.
