### PR TITLE
[FDC] `init dataconnect:sdk` should generate consistent hard-coded package name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added prefix support for multi-instance Cloud Functions extension parameters. (#8911)
 - Make it possible to init a dataconnect project in non interactive mode (#8993)
 - Added 2 new MCP tools for crashlytics `get_sample_crash_for_issue` and `get_issue_details` (#8995)
+- `firebase init dataconnect:sdk` generate consistent fixed package names (#9021)
 - Use Gemini to generate schema and seed_data.gql in `firebase init dataconnect` (#8988)
 - Fixed a bug when `firebase deploy --only dataconnect` didn't include GQL files in nested folders (#8981)
 - Changed `firebase deploy` create Cloud SQL instances asynchronously (#9004)

--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -211,7 +211,7 @@ export async function generateSdkYaml(
   if (targetPlatform === Platform.IOS) {
     const swiftSdk = {
       outputDir: path.relative(connectorDir, path.join(appDir, `dataconnect-generated/swift`)),
-      package: upperFirst(camelCase(connectorYaml.connectorId)) + "Connector",
+      package: "DataConnectGenerated",
     };
     connectorYaml.generate.swiftSdk = swiftSdk;
   }
@@ -221,7 +221,7 @@ export async function generateSdkYaml(
     const packageJsonDir = path.relative(connectorDir, appDir);
     const javascriptSdk: JavascriptSDK = {
       outputDir: path.relative(connectorDir, path.join(appDir, `dataconnect-generated/js/${pkg}`)),
-      package: `@firebasegen/${pkg}`,
+      package: `@dataconnect/generated`,
       // If appDir has package.json, Emulator would add Generated JS SDK to `package.json`.
       // Otherwise, emulator would ignore it. Always add it here in case `package.json` is added later.
       // TODO: Explore other platforms that can be automatically installed. Dart? Android?
@@ -246,7 +246,7 @@ export async function generateSdkYaml(
         connectorDir,
         path.join(appDir, `dataconnect-generated/dart/${pkg}`),
       ),
-      package: pkg,
+      package: "dataconnect_generated",
     };
     connectorYaml.generate.dartSdk = dartSdk;
   }
@@ -254,7 +254,7 @@ export async function generateSdkYaml(
   if (targetPlatform === Platform.ANDROID) {
     const kotlinSdk: KotlinSDK = {
       outputDir: path.relative(connectorDir, path.join(appDir, `dataconnect-generated/kotlin`)),
-      package: `connectors.${snakeCase(connectorYaml.connectorId)}`,
+      package: `com.google.firebase.dataconnect.generated`,
     };
     // app/src/main/kotlin and app/src/main/java are conventional for Android,
     // but not required or enforced. If one of them is present (preferring the


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
