### PR TITLE
[FDC] VS Code SDK init button should always run CLI

### DIFF
--- a/firebase-vscode/src/data-connect/config.ts
+++ b/firebase-vscode/src/data-connect/config.ts
@@ -14,7 +14,7 @@ import {
   readConnectorYaml,
   readDataConnectYaml,
   readFirebaseJson as readFdcFirebaseJson,
-} from "../../../src/dataconnect/fileUtils";
+} from "../../../src/dataconnect/load";
 import { Config } from "../config";
 import { DataConnectMultiple } from "../firebaseConfig";
 import path from "path";

--- a/firebase-vscode/src/data-connect/sdk-generation.ts
+++ b/firebase-vscode/src/data-connect/sdk-generation.ts
@@ -6,15 +6,8 @@ import { dataConnectConfigs, ResolvedConnectorYaml } from "./config";
 import { runCommand, setTerminalEnvVars } from "./terminal";
 import { ExtensionBrokerImpl } from "../extension-broker";
 import { DATA_CONNECT_EVENT_NAME } from "../analytics";
-import { getPlatformFromFolder } from "../../../src/dataconnect/fileUtils";
-import { ConnectorYaml, Platform } from "../../../src/dataconnect/types";
-import * as yaml from "yaml";
-import * as fs from "fs-extra";
 import { getSettings } from "../utils/settings";
-import {
-  FDC_APP_FOLDER,
-  generateSdkYaml,
-} from "../../../src/init/features/dataconnect/sdk";
+import { FDC_APP_FOLDER, } from "../../../src/init/features/dataconnect/sdk";
 import { createE2eMockable } from "../utils/test_hooks";
 import { AnalyticsLogger} from "../analytics";
 
@@ -50,14 +43,14 @@ export function registerFdcSdkGeneration(
   // codelense from inside connector.yaml file
   const configureSDKCodelense = vscode.commands.registerCommand(
     "fdc.connector.configure-sdk",
-    async (connectorConfig) => {
+    async () => {
       analyticsLogger.logger.logUsage(
         DATA_CONNECT_EVENT_NAME.INIT_SDK_CODELENSE,
       );
       const configs = await firstWhereDefined(dataConnectConfigs).then(
         (c) => c.requireValue,
       );
-      await openAndWriteYaml(connectorConfig);
+      await selectAppFolderAndRunInitSdk();
     },
   );
 
@@ -66,54 +59,14 @@ export function registerFdcSdkGeneration(
     "fdc.configure-sdk",
     async () => {
       analyticsLogger.logger.logUsage(DATA_CONNECT_EVENT_NAME.INIT_SDK);
-      const configs = await firstWhereDefined(dataConnectConfigs).then(
-        (c) => c.requireValue,
-      );
-
-      // pick service, auto pick if only one
-      const pickedService =
-        configs?.serviceIds.length === 1
-          ? configs?.serviceIds[0]
-          : await pickService(configs?.serviceIds ?? []);
-      if (!pickedService) {
-        return;
-      }
-      const serviceConfig = configs?.findById(pickedService);
-      const connectorIds = serviceConfig?.connectorIds;
-
-      // pick connector for service, auto pick if only one
-      const pickedConnectorId =
-        connectorIds?.length === 1
-          ? connectorIds[0]
-          : await pickConnector(connectorIds);
-      if (pickedConnectorId) {
-        const connectorConfig =
-          serviceConfig?.findConnectorById(pickedConnectorId);
-        if (connectorConfig) {
-          await openAndWriteYaml(connectorConfig);
-        }
-      }
+      await selectAppFolderAndRunInitSdk();
     },
   );
 
-  async function openAndWriteYaml(connectorConfig: ResolvedConnectorYaml) {
-    const connectorYamlPath = Uri.joinPath(
-      Uri.file(connectorConfig.path),
-      "connector.yaml",
-    );
-    const connectorYaml = connectorConfig.value;
-
-    // open connector.yaml file
-    await vscode.window.showTextDocument(connectorYamlPath);
-
+  async function selectAppFolderAndRunInitSdk() {
     const appFolder = await selectFolderSpy.call();
     if (appFolder) {
-      await writeYaml(
-        appFolder,
-        connectorYamlPath,
-        connectorConfig.path, // needed for relative path comparison
-        connectorYaml,
-      );
+      await runInitSdk(appFolder);
     }
   }
 
@@ -153,30 +106,8 @@ export function registerFdcSdkGeneration(
     return folderUris[0].fsPath; // can only pick one folder, but return type is an array
   }
 
-  async function writeYaml(
-    appFolder: string,
-    connectorYamlPath: Uri,
-    connectorYamlFolderPath: string,
-    connectorYaml: ConnectorYaml,
-  ) {
-    const platform = await getPlatformFromFolder(appFolder);
-    // if app platform undetermined, run init command
-    if (platform === Platform.NONE || platform === Platform.MULTIPLE) {
-      vscode.window.showErrorMessage(
-        "Could not determine platform for specified app folder. Configuring from command line.",
-      );
-      vscode.commands.executeCommand("fdc.init-sdk", { appFolder });
-    } else {
-      // generate yaml
-      const newConnectorYaml = await generateSdkYaml(
-        platform,
-        connectorYaml,
-        connectorYamlFolderPath,
-        appFolder,
-      );
-      const connectorYamlContents = yaml.stringify(newConnectorYaml);
-      fs.writeFileSync(connectorYamlPath.fsPath, connectorYamlContents, "utf8");
-    }
+  async function runInitSdk(appFolder: string) {
+    vscode.commands.executeCommand("fdc.init-sdk", { appFolder });
   }
 
   const configureSDKSub = broker.on("fdc.configure-sdk", async () =>

--- a/src/dataconnect/load.ts
+++ b/src/dataconnect/load.ts
@@ -136,7 +136,7 @@ export function readFirebaseJson(config?: Config): DataConnectMultiple {
   }
 }
 
-async function readDataConnectYaml(sourceDirectory: string): Promise<DataConnectYaml> {
+export async function readDataConnectYaml(sourceDirectory: string): Promise<DataConnectYaml> {
   const file = await readFileFromDirectory(sourceDirectory, "dataconnect.yaml");
   const dataconnectYaml = await wrappedSafeLoad(file.source);
   return validateDataConnectYaml(dataconnectYaml);
@@ -150,7 +150,7 @@ function validateDataConnectYaml(unvalidated: any): DataConnectYaml {
   return unvalidated as DataConnectYaml;
 }
 
-async function readConnectorYaml(sourceDirectory: string): Promise<ConnectorYaml> {
+export async function readConnectorYaml(sourceDirectory: string): Promise<ConnectorYaml> {
   const file = await readFileFromDirectory(sourceDirectory, "connector.yaml");
   const connectorYaml = await wrappedSafeLoad(file.source);
   return validateConnectorYaml(connectorYaml);


### PR DESCRIPTION
We have been making lots of improvements to `firebase init dataconnect`.

VS Code should always delegate to CLI as opposed to manipulate the `connector.yaml` itself.