### PR TITLE
refactor(functions): require configDir in UserEnvsOpts

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -1,7 +1,6 @@
 import * as clc from "colorette";
 
 import * as args from "./args";
-import * as proto from "../../gcp/proto";
 import * as backend from "./backend";
 import * as build from "./build";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
@@ -124,11 +123,10 @@ export async function prepare(
     const config = configForCodebase(context.config, codebase);
     const firebaseEnvs = functionsEnv.loadFirebaseEnvs(firebaseConfig, projectId);
     const userEnvOpt: functionsEnv.UserEnvsOpts = {
-      functionsSource: options.config.path(config.source),
+      configDir: options.config.path(config.configDir),
       projectId: projectId,
       projectAlias: options.projectAlias,
     };
-    proto.convertIfPresent(userEnvOpt, config, "configDir", (cd) => options.config.path(cd));
     const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
     const envs = { ...userEnvs, ...firebaseEnvs };
 

--- a/src/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -17,7 +17,6 @@ async function resolveBackend(bd: build.Build): Promise<backend.Backend> {
         storageBucket: "foo.appspot.com",
         databaseURL: "https://foo.firebaseio.com",
       },
-      userEnvOpt: { functionsSource: "", projectId: "PROJECT" },
       userEnvs: {},
     })
   ).backend;

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -541,6 +541,7 @@ export async function startAll(
       }
       const backend: EmulatableBackend = {
         functionsDir,
+        configDir: path.join(projectDir, cfg.configDir),
         runtime,
         codebase: cfg.codebase,
         prefix: cfg.prefix,
@@ -553,7 +554,6 @@ export async function startAll(
         predefinedTriggers: options.extDevTriggers as ParsedTriggerDefinition[] | undefined,
         ignore: cfg.ignore,
       };
-      proto.convertIfPresent(backend, cfg, "configDir", (cd) => path.join(projectDir, cd));
       emulatableBackends.push(backend);
     }
   }

--- a/src/emulator/extensions/validation.spec.ts
+++ b/src/emulator/extensions/validation.spec.ts
@@ -60,6 +60,7 @@ function getTestEmulatableBackend(
 ): EmulatableBackend {
   return {
     functionsDir: ".",
+    configDir: ".",
     env: {},
     secretEnv: [],
     codebase: "",

--- a/src/emulator/extensionsEmulator.spec.ts
+++ b/src/emulator/extensionsEmulator.spec.ts
@@ -106,6 +106,10 @@ describe("Extensions Emulator", () => {
           functionsDir: join(
             "src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions",
           ),
+          // configDir defaults to functionsDir for emulator backends
+          configDir: join(
+            "src/test/emulators/extensions/firebase/storage-resize-images@0.1.18/functions",
+          ),
           runtime: "nodejs10",
           predefinedTriggers: [
             {

--- a/src/emulator/extensionsEmulator.ts
+++ b/src/emulator/extensionsEmulator.ts
@@ -275,6 +275,7 @@ export class ExtensionsEmulator implements EmulatorInstance {
       await getExtensionFunctionInfo(instance, env);
     const emulatableBackend: EmulatableBackend = {
       functionsDir,
+      configDir: functionsDir,
       runtime,
       bin: process.execPath,
       env: nonSecretEnv,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -85,7 +85,7 @@ const DATABASE_PATH_PATTERN = new RegExp("^projects/[^/]+/instances/([^/]+)/refs
  */
 export interface EmulatableBackend {
   functionsDir: string;
-  configDir?: string;
+  configDir: string;
   env: Record<string, string>;
   secretEnv: backend.SecretEnvVar[];
   codebase: string;
@@ -560,12 +560,12 @@ export class FunctionsEmulator implements EmulatorInstance {
         FIREBASE_CONFIG: firebaseConfig,
         ...emulatableBackend.env,
       };
+      // Load user envs from configDir
       const userEnvOpt: functionsEnv.UserEnvsOpts = {
-        functionsSource: emulatableBackend.functionsDir,
+        configDir: emulatableBackend.configDir,
         projectId: this.args.projectId,
         projectAlias: this.args.projectAlias,
         isEmulator: true,
-        configDir: emulatableBackend.configDir,
       };
       const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
       const discoveredBuild = await runtimeDelegate.discoverBuild(runtimeConfig, environment);
@@ -1388,7 +1388,6 @@ export class FunctionsEmulator implements EmulatorInstance {
 
   getUserEnvs(backend: EmulatableBackend): Record<string, string> {
     const projectInfo: functionsEnv.UserEnvsOpts = {
-      functionsSource: backend.functionsDir,
       configDir: backend.configDir,
       projectId: this.args.projectId,
       projectAlias: this.args.projectAlias,

--- a/src/emulator/functionsEmulatorShared.spec.ts
+++ b/src/emulator/functionsEmulatorShared.spec.ts
@@ -108,6 +108,7 @@ describe("FunctionsEmulatorShared", () => {
         desc: "should return the correct location for an Extension backend",
         in: {
           functionsDir: "extensions/functions",
+          configDir: "extensions/functions",
           env: {},
           secretEnv: [],
           extensionInstanceId: "my-extension-instance",
@@ -119,6 +120,7 @@ describe("FunctionsEmulatorShared", () => {
         desc: "should return the correct location for a CF3 backend",
         in: {
           functionsDir: "test/cf3",
+          configDir: "test/cf3",
           env: {},
           secretEnv: [],
           codebase: "",
@@ -198,6 +200,7 @@ describe("FunctionsEmulatorShared", () => {
         desc: "should transform a published Extension backend",
         in: {
           functionsDir: "test",
+          configDir: "test",
           env: {
             KEY: "value",
           },
@@ -223,6 +226,7 @@ describe("FunctionsEmulatorShared", () => {
         desc: "should transform a local Extension backend",
         in: {
           functionsDir: "test",
+          configDir: "test",
           env: {
             KEY: "value",
           },
@@ -246,6 +250,7 @@ describe("FunctionsEmulatorShared", () => {
         desc: "should transform a CF3 backend",
         in: {
           functionsDir: "test",
+          configDir: "test",
           env: {
             KEY: "value",
           },
@@ -264,6 +269,7 @@ describe("FunctionsEmulatorShared", () => {
         desc: "should add secretEnvVar into env",
         in: {
           functionsDir: "test",
+          configDir: "test",
           env: {
             KEY: "value",
           },

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -310,11 +310,11 @@ FOO=foo
     it("never affects the filesystem if the list of keys to write is empty", () => {
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", configDir: tmpdir },
       );
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", projectAlias: "alias", configDir: tmpdir, isEmulator: true },
       );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
@@ -322,7 +322,7 @@ FOO=foo
     });
 
     it("touches .env.projectId if it doesn't already exist", () => {
-      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir });
+      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", configDir: tmpdir });
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(!!fs.statSync(path.join(tmpdir, ".env.project"))).to.be.true;
       expect(() => fs.statSync(path.join(tmpdir, ".env.local"))).to.throw;
@@ -331,7 +331,7 @@ FOO=foo
     it("touches .env.local if it doesn't already exist in emulator mode", () => {
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", configDir: tmpdir, isEmulator: true },
       );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
@@ -343,7 +343,7 @@ FOO=foo
         [".env.project"]: "FOO=foo",
       });
       expect(() =>
-        env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir }),
+        env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", configDir: tmpdir }),
       ).to.throw(FirebaseError);
     });
 
@@ -353,13 +353,13 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", configDir: tmpdir, isEmulator: true },
       );
       expect(
         env.loadUserEnvs({
           projectId: "project",
           projectAlias: "alias",
-          functionsSource: tmpdir,
+          configDir: tmpdir,
           isEmulator: true,
         })["FOO"],
       ).to.equal("bar");
@@ -372,7 +372,7 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { FOO: "baz" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", configDir: tmpdir },
         ),
       ).to.throw(FirebaseError);
     });
@@ -383,13 +383,13 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "baz" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true },
+        { projectId: "project", projectAlias: "alias", configDir: tmpdir, isEmulator: true },
       );
       expect(
         env.loadUserEnvs({
           projectId: "project",
           projectAlias: "alias",
-          functionsSource: tmpdir,
+          configDir: tmpdir,
           isEmulator: true,
         })["FOO"],
       ).to.equal("baz");
@@ -402,7 +402,7 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { ASDF: "bar" },
-          { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+          { projectId: "project", configDir: tmpdir, isEmulator: true },
         ),
       ).to.throw(FirebaseError);
     });
@@ -411,19 +411,19 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { lowercase: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", configDir: tmpdir },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { GCP_PROJECT: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", configDir: tmpdir },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { FIREBASE_KEY: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          { projectId: "project", projectAlias: "alias", configDir: tmpdir },
         ),
       ).to.throw(env.KeyValidationError);
     });
@@ -431,10 +431,10 @@ FOO=foo
     it("writes the specified key to a .env.projectId that it created", () => {
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", configDir: tmpdir },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", configDir: tmpdir })[
           "FOO"
         ],
       ).to.equal("bar");
@@ -446,10 +446,10 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", configDir: tmpdir },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
+        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", configDir: tmpdir })[
           "FOO"
         ],
       ).to.equal("bar");
@@ -458,12 +458,12 @@ FOO=foo
     it("writes multiple keys at once", () => {
       env.writeUserEnvs(
         { FOO: "foo", BAR: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", configDir: tmpdir },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
         projectAlias: "alias",
-        functionsSource: tmpdir,
+        configDir: tmpdir,
       });
       expect(envs["FOO"]).to.equal("foo");
       expect(envs["BAR"]).to.equal("bar");
@@ -476,12 +476,12 @@ FOO=foo
           WITH_SLASHES: "\n\\\r\\\t\\\v",
           QUOTES: "'\"'",
         },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        { projectId: "project", projectAlias: "alias", configDir: tmpdir },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
         projectAlias: "alias",
-        functionsSource: tmpdir,
+        configDir: tmpdir,
       });
       expect(envs["ESCAPES"]).to.equal("\n\r\t\v");
       expect(envs["WITH_SLASHES"]).to.equal("\n\\\r\\\t\\\v");
@@ -492,12 +492,12 @@ FOO=foo
       try {
         env.writeUserEnvs(
           { FOO: "bar", lowercase: "bar" },
-          { projectId: "project", functionsSource: tmpdir },
+          { projectId: "project", configDir: tmpdir },
         );
       } catch (err: any) {
         // no-op
       }
-      expect(env.loadUserEnvs({ projectId: "project", functionsSource: tmpdir })["FOO"]).to.be
+      expect(env.loadUserEnvs({ projectId: "project", configDir: tmpdir })["FOO"]).to.be
         .undefined;
     });
   });
@@ -508,7 +508,7 @@ FOO=foo
         fs.writeFileSync(path.join(sourceDir, filename), data);
       }
     };
-    const projectInfo: Omit<env.UserEnvsOpts, "functionsSource"> = {
+    const projectInfo: Omit<env.UserEnvsOpts, "configDir"> = {
       projectId: "my-project",
       projectAlias: "dev",
     };
@@ -526,7 +526,7 @@ FOO=foo
     });
 
     it("loads nothing if .env files are missing", () => {
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({});
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({});
     });
 
     it("loads envs from .env file", () => {
@@ -534,7 +534,7 @@ FOO=foo
         ".env": "FOO=foo\nBAR=bar",
       });
 
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({
         FOO: "foo",
         BAR: "bar",
       });
@@ -545,7 +545,7 @@ FOO=foo
         ".env": "# THIS IS A COMMENT\nFOO=foo # inline comments\nBAR=bar",
       });
 
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({
         FOO: "foo",
         BAR: "bar",
       });
@@ -556,7 +556,7 @@ FOO=foo
         [`.env.${projectInfo.projectId}`]: "FOO=foo\nBAR=bar",
       });
 
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({
         FOO: "foo",
         BAR: "bar",
       });
@@ -567,7 +567,7 @@ FOO=foo
         [`.env.${projectInfo.projectAlias}`]: "FOO=foo\nBAR=bar",
       });
 
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({
         FOO: "foo",
         BAR: "bar",
       });
@@ -579,7 +579,7 @@ FOO=foo
         [`.env.${projectInfo.projectId}`]: "FOO=good",
       });
 
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({
         FOO: "good",
         BAR: "bar",
       });
@@ -592,7 +592,7 @@ FOO=foo
       });
 
       expect(
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true }),
+        env.loadUserEnvs({ ...projectInfo, configDir: tmpdir, isEmulator: true }),
       ).to.be.deep.equal({
         FOO: "good",
         BAR: "bar",
@@ -605,7 +605,7 @@ FOO=foo
         [`.env.${projectInfo.projectAlias}`]: "FOO=good",
       });
 
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({
         FOO: "good",
         BAR: "bar",
       });
@@ -618,7 +618,7 @@ FOO=foo
       });
 
       expect(
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true }),
+        env.loadUserEnvs({ ...projectInfo, configDir: tmpdir, isEmulator: true }),
       ).to.be.deep.equal({
         FOO: "good",
         BAR: "bar",
@@ -632,7 +632,7 @@ FOO=foo
         ".env.local": "FOO=bad",
       });
 
-      expect(env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir })).to.be.deep.equal({
+      expect(env.loadUserEnvs({ ...projectInfo, configDir: tmpdir })).to.be.deep.equal({
         FOO: "good",
         BAR: "bar",
       });
@@ -646,7 +646,7 @@ FOO=foo
       });
 
       expect(
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, isEmulator: true }),
+        env.loadUserEnvs({ ...projectInfo, configDir: tmpdir, isEmulator: true }),
       ).to.be.deep.equal({
         FOO: "good",
         BAR: "bar",
@@ -661,7 +661,7 @@ FOO=foo
       });
 
       expect(() => {
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir });
+        env.loadUserEnvs({ ...projectInfo, configDir: tmpdir });
       }).to.throw("Can't have both");
     });
 
@@ -671,7 +671,7 @@ FOO=foo
       });
 
       expect(() => {
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir });
+        env.loadUserEnvs({ ...projectInfo, configDir: tmpdir });
       }).to.throw("Failed to load");
     });
 
@@ -682,7 +682,7 @@ FOO=foo
       });
 
       expect(() => {
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir });
+        env.loadUserEnvs({ ...projectInfo, configDir: tmpdir });
       }).to.throw("Failed to load");
     });
 
@@ -692,7 +692,7 @@ FOO=foo
       });
 
       expect(() => {
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir });
+        env.loadUserEnvs({ ...projectInfo, configDir: tmpdir });
       }).to.throw("Failed to load");
     });
 
@@ -704,7 +704,7 @@ FOO=foo
       });
 
       expect(
-        env.loadUserEnvs({ ...projectInfo, functionsSource: tmpdir, configDir: configDir }),
+        env.loadUserEnvs({ ...projectInfo, configDir: configDir }),
       ).to.be.deep.equal({
         FOO: "foo",
         BAR: "bar",

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -239,8 +239,7 @@ function findEnvfiles(
 }
 
 export interface UserEnvsOpts {
-  functionsSource: string;
-  configDir?: string;
+  configDir: string;
   projectId: string;
   projectAlias?: string;
   isEmulator?: boolean;
@@ -252,8 +251,7 @@ export interface UserEnvsOpts {
  * @return True if there are any user-specified environment variables
  */
 export function hasUserEnvs(opts: UserEnvsOpts): boolean {
-  const configDir = opts.configDir || opts.functionsSource;
-  return findEnvfiles(configDir, opts.projectId, opts.projectAlias, opts.isEmulator).length > 0;
+  return findEnvfiles(opts.configDir, opts.projectId, opts.projectAlias, opts.isEmulator).length > 0;
 }
 
 /**
@@ -266,8 +264,7 @@ export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvs
   if (Object.keys(toWrite).length === 0) {
     return;
   }
-  const { projectId, projectAlias, isEmulator } = envOpts;
-  const configDir = envOpts.configDir || envOpts.functionsSource;
+  const { projectId, projectAlias, isEmulator, configDir } = envOpts;
 
   // Determine which .env file to write to, and create it if it doesn't exist
   const allEnvFiles = findEnvfiles(configDir, projectId, projectAlias, isEmulator);
@@ -362,8 +359,7 @@ function formatUserEnvForWrite(key: string, value: string): string {
  * @return {Record<string, string>} Environment variables for the project.
  */
 export function loadUserEnvs(opts: UserEnvsOpts): Record<string, string> {
-  const configDir = opts.configDir || opts.functionsSource;
-  const envFiles = findEnvfiles(configDir, opts.projectId, opts.projectAlias, opts.isEmulator);
+  const envFiles = findEnvfiles(opts.configDir, opts.projectId, opts.projectAlias, opts.isEmulator);
   if (envFiles.length === 0) {
     return {};
   }
@@ -384,7 +380,7 @@ export function loadUserEnvs(opts: UserEnvsOpts): Record<string, string> {
   let envs: Record<string, string> = {};
   for (const f of envFiles) {
     try {
-      const data = fs.readFileSync(path.join(configDir, f), "utf8");
+      const data = fs.readFileSync(path.join(opts.configDir, f), "utf8");
       envs = { ...envs, ...parseStrict(data) };
     } catch (err: any) {
       throw new FirebaseError(`Failed to load environment variables from ${f}.`, {

--- a/src/functions/projectConfig.spec.ts
+++ b/src/functions/projectConfig.spec.ts
@@ -7,15 +7,22 @@ const TEST_CONFIG_0 = { source: "foo" };
 
 describe("projectConfig", () => {
   describe("normalize", () => {
-    it("normalizes singleton config", () => {
-      expect(projectConfig.normalize(TEST_CONFIG_0)).to.deep.equal([TEST_CONFIG_0]);
+    it("normalizes singleton config and defaults configDir to source", () => {
+      const expectedConfig = { ...TEST_CONFIG_0, configDir: TEST_CONFIG_0.source };
+      expect(projectConfig.normalize(TEST_CONFIG_0)).to.deep.equal([expectedConfig]);
     });
 
-    it("normalizes array config", () => {
+    it("normalizes array config and defaults configDir to source", () => {
+      const expectedConfig = { ...TEST_CONFIG_0, configDir: TEST_CONFIG_0.source };
       expect(projectConfig.normalize([TEST_CONFIG_0, TEST_CONFIG_0])).to.deep.equal([
-        TEST_CONFIG_0,
-        TEST_CONFIG_0,
+        expectedConfig,
+        expectedConfig,
       ]);
+    });
+    
+    it("preserves explicit configDir", () => {
+      const configWithDir = { source: "foo", configDir: "bar" };
+      expect(projectConfig.normalize(configWithDir)).to.deep.equal([configWithDir]);
     });
 
     it("throws error if given empty config", () => {
@@ -158,11 +165,13 @@ describe("projectConfig", () => {
 
   describe("normalizeAndValidate", () => {
     it("returns normalized config for singleton config", () => {
-      expect(projectConfig.normalizeAndValidate(TEST_CONFIG_0)).to.deep.equal([TEST_CONFIG_0]);
+      const expectedConfig = { ...TEST_CONFIG_0, configDir: TEST_CONFIG_0.source };
+      expect(projectConfig.normalizeAndValidate(TEST_CONFIG_0)).to.deep.equal([expectedConfig]);
     });
 
     it("returns normalized config for multi-resource config", () => {
-      expect(projectConfig.normalizeAndValidate([TEST_CONFIG_0])).to.deep.equal([TEST_CONFIG_0]);
+      const expectedConfig = { ...TEST_CONFIG_0, configDir: TEST_CONFIG_0.source };
+      expect(projectConfig.normalizeAndValidate([TEST_CONFIG_0])).to.deep.equal([expectedConfig]);
     });
 
     it("fails validation given singleton config w/o source", () => {

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -30,8 +30,10 @@ export class FunctionsServer {
     const backends: EmulatableBackend[] = [];
     for (const cfg of config) {
       const functionsDir = path.join(options.config.projectDir, cfg.source);
+      const configDir = path.join(options.config.projectDir, cfg.configDir);
       backends.push({
         functionsDir,
+        configDir,
         codebase: cfg.codebase,
         runtime: cfg.runtime,
         env: {},


### PR DESCRIPTION
This commit refactors the functions configuration handling to make 'configDir' a required field in 'UserEnvsOpts'. This removes ambiguity between 'functionsSource' and 'configDir' and simplifies the interface for environment variable file handling.

Key changes:
- 'UserEnvsOpts' interface now requires 'configDir'.
- 'normalize' in 'projectConfig.ts' now defaults 'configDir' to the 'source' directory for local sources.
- All callers have been updated to provide 'configDir' and rely on it directly.