### PR TITLE
refactor: make resolveBackend side-effect free

### DIFF
--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -1,10 +1,9 @@
 import * as backend from "./backend";
 import * as proto from "../../gcp/proto";
-import * as api from "../../.../../api";
+import * as api from "../../api";
 import * as params from "./params";
 import { FirebaseError } from "../../error";
 import { assertExhaustive, mapObject, nullsafeVisitor } from "../../functional";
-import { UserEnvsOpts, writeUserEnvs } from "../../functions/env";
 import { FirebaseConfig } from "./args";
 import { Runtime } from "./runtimes/supported";
 import { ExprParseError } from "./cel";
@@ -284,22 +283,19 @@ export type DynamicExtension = {
 interface ResolveBackendOpts {
   build: Build;
   firebaseConfig: FirebaseConfig;
-  userEnvOpt: UserEnvsOpts;
   userEnvs: Record<string, string>;
   nonInteractive?: boolean;
   isEmulator?: boolean;
 }
 
 /**
- * Resolves user-defined parameters inside a Build, and generates a Backend.
- * Returns both the Backend and the literal resolved values of any params, since
- * the latter also have to be uploaded so user code can see them in process.env
+ * Resolves user-defined parameters inside a Build and generates a Backend.
+ * Callers are responsible for persisting resolved env vars.
  */
 export async function resolveBackend(
   opts: ResolveBackendOpts,
 ): Promise<{ backend: backend.Backend; envs: Record<string, params.ParamValue> }> {
-  let paramValues: Record<string, params.ParamValue> = {};
-  paramValues = await params.resolveParams(
+  const paramValues = await params.resolveParams(
     opts.build.params,
     opts.firebaseConfig,
     envWithTypes(opts.build.params, opts.userEnvs),
@@ -307,18 +303,9 @@ export async function resolveBackend(
     opts.isEmulator,
   );
 
-  const toWrite: Record<string, string> = {};
-  for (const paramName of Object.keys(paramValues)) {
-    const paramValue = paramValues[paramName];
-    if (Object.prototype.hasOwnProperty.call(opts.userEnvs, paramName) || paramValue.internal) {
-      continue;
-    }
-    toWrite[paramName] = paramValue.toString();
-  }
-  writeUserEnvs(toWrite, opts.userEnvOpt);
-
   return { backend: toBackend(opts.build, paramValues), envs: paramValues };
 }
+
 
 // Exported for testing
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -135,11 +135,12 @@ export async function prepare(
     const { backend: wantBackend, envs: resolvedEnvs } = await build.resolveBackend({
       build: wantBuild,
       firebaseConfig,
-      userEnvOpt,
       userEnvs,
       nonInteractive: options.nonInteractive,
       isEmulator: false,
     });
+
+    functionsEnv.writeResolvedEnvsToFile(resolvedEnvs, userEnvs, userEnvOpt);
 
     let hasEnvsFromParams = false;
     wantBackend.environmentVariables = envs;

--- a/src/deploy/functions/runtimes/discovery/index.ts
+++ b/src/deploy/functions/runtimes/discovery/index.ts
@@ -5,7 +5,7 @@ import * as yaml from "yaml";
 import { ChildProcess } from "child_process";
 
 import { logger } from "../../../../logger";
-import * as api from "../../.../../../../api";
+import * as api from "../../../../api";
 import * as build from "../../build";
 import { Runtime } from "../supported";
 import * as v1alpha1 from "./v1alpha1";

--- a/src/deploy/functions/runtimes/node/parseTriggers.spec.ts
+++ b/src/deploy/functions/runtimes/node/parseTriggers.spec.ts
@@ -17,7 +17,6 @@ async function resolveBackend(bd: build.Build): Promise<backend.Backend> {
         storageBucket: "foo.appspot.com",
         databaseURL: "https://foo.firebaseio.com",
       },
-      userEnvOpt: { functionsSource: "", projectId: "PROJECT" },
       userEnvs: {},
     })
   ).backend;

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -580,11 +580,12 @@ export class FunctionsEmulator implements EmulatorInstance {
       const resolution = await resolveBackend({
         build: discoveredBuild,
         firebaseConfig: JSON.parse(firebaseConfig),
-        userEnvOpt,
         userEnvs,
         nonInteractive: false,
         isEmulator: true,
       });
+
+      functionsEnv.writeResolvedEnvsToFile(resolution.envs, userEnvs, userEnvOpt);
       const discoveredBackend = resolution.backend;
       const endpoints = backend.allEndpoints(discoveredBackend);
       prepareEndpoints(endpoints);

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -758,4 +758,91 @@ FOO=foo
       expect(env.parseStrict(input)).to.deep.equal(expected);
     });
   });
+
+  describe("writeResolvedEnvsToFile", () => {
+    let tmpdir: string;
+
+    beforeEach(() => {
+      tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-functions-test-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmpdir, { recursive: true, force: true });
+    });
+
+    it("should write only new, non-internal params", () => {
+      const resolvedEnvs = {
+        EXISTING_PARAM: { internal: false, toString: () => "existing" },
+        NEW_PARAM: { internal: false, toString: () => "new_value" },
+        INTERNAL_PARAM: { internal: true, toString: () => "internal" },
+      };
+      const userEnvs = { EXISTING_PARAM: "old_value" };
+      const userEnvOpt = {
+        projectId: "test-project",
+        functionsSource: tmpdir,
+      };
+
+      env.writeResolvedEnvsToFile(resolvedEnvs, userEnvs, userEnvOpt);
+
+      // Check the written file
+      const writtenContent = fs.readFileSync(path.join(tmpdir, ".env.test-project"), "utf-8");
+      expect(writtenContent).to.include("NEW_PARAM=new_value");
+      expect(writtenContent).not.to.include("EXISTING_PARAM");
+      expect(writtenContent).not.to.include("INTERNAL_PARAM");
+    });
+
+    it("should not create file when no params to write", () => {
+      const resolvedEnvs = {
+        EXISTING_PARAM: { internal: false, toString: () => "existing" },
+        INTERNAL_PARAM: { internal: true, toString: () => "internal" },
+      };
+      const userEnvs = { EXISTING_PARAM: "old_value" };
+      const userEnvOpt = {
+        projectId: "test-project",
+        functionsSource: tmpdir,
+      };
+
+      env.writeResolvedEnvsToFile(resolvedEnvs, userEnvs, userEnvOpt);
+
+      // Check that no file was created
+      const envFile = path.join(tmpdir, ".env.test-project");
+      expect(fs.existsSync(envFile)).to.be.false;
+    });
+
+    it("should write to .env.local for emulator", () => {
+      const resolvedEnvs = {
+        NEW_PARAM: { internal: false, toString: () => "emulator_value" },
+      };
+      const userEnvs = {};
+      const userEnvOpt = {
+        projectId: "test-project",
+        functionsSource: tmpdir,
+        isEmulator: true,
+      };
+
+      env.writeResolvedEnvsToFile(resolvedEnvs, userEnvs, userEnvOpt);
+
+      // Check the written file is .env.local
+      const writtenContent = fs.readFileSync(path.join(tmpdir, ".env.local"), "utf-8");
+      expect(writtenContent).to.include("NEW_PARAM=emulator_value");
+      expect(fs.existsSync(path.join(tmpdir, ".env.test-project"))).to.be.false;
+    });
+
+    it("should handle params with special characters in values", () => {
+      const resolvedEnvs = {
+        NEW_PARAM: { internal: false, toString: () => "value with\nnewline" },
+      };
+      const userEnvs = {};
+      const userEnvOpt = {
+        projectId: "test-project",
+        functionsSource: tmpdir,
+      };
+
+      env.writeResolvedEnvsToFile(resolvedEnvs, userEnvs, userEnvOpt);
+
+      // Check the written file handles special chars correctly
+      const writtenContent = fs.readFileSync(path.join(tmpdir, ".env.test-project"), "utf-8");
+      expect(writtenContent).to.include("NEW_PARAM=\"value with\\nnewline\"");
+    });
+  });
 });

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -414,3 +414,26 @@ export function loadFirebaseEnvs(
     GCLOUD_PROJECT: projectId,
   };
 }
+
+/**
+ * Writes newly resolved params to the appropriate .env file.
+ * Skips internal params and params that already exist in userEnvs.
+ */
+export function writeResolvedEnvsToFile(
+  resolvedEnvs: Readonly<Record<string, { internal: boolean; toString(): string }>>,
+  userEnvs: Readonly<Record<string, string>>,
+  userEnvOpt: UserEnvsOpts,
+): void {
+  const toWrite: Record<string, string> = {};
+  
+  for (const paramName of Object.keys(resolvedEnvs)) {
+    const paramValue = resolvedEnvs[paramName];
+    if (!paramValue.internal && !Object.prototype.hasOwnProperty.call(userEnvs, paramName)) {
+      toWrite[paramName] = paramValue.toString();
+    }
+  }
+  
+  if (Object.keys(toWrite).length > 0) {
+    writeUserEnvs(toWrite, userEnvOpt);
+  }
+}


### PR DESCRIPTION
## Summary
Refactors `resolveBackend` to be a pure function by removing filesystem side-effects. This is step 1 of the "Road to Remote Source" plan, preparing for remote Git sources support.

## Changes
- Made `resolveBackend` pure - no longer writes to filesystem
- Added `writeResolvedEnvsToFile` helper in `src/functions/env.ts` for param persistence  
- Updated all callsites to handle writing separately
- Fixed malformed import paths (extra dots)
- Added unit tests for new helper

## Behavior 
No user-visible changes. New params are still written to `.env.local` (emulator) or `.env.<projectId>` (deployment).

## Benefits
- Better separation of concerns and testability
- Prepares for remote sources where dotenv may be optional
- Cleaner module organization