### PR TITLE
[MCP] Always include core MCP tools + return instructions from firebase_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 - Updated Data Connect local toolkit to 2.12, which
   - Added ImpersonateQuery, ImpersonateMutation and IntrospectGraphql APIs to the Firebase Data Connect emulator
   - Added support for Firebase JS SDK v12
-- Add core MCP tools like `firebase_init` and `firebase_{set,get}_environment` `firebase_consult_assistant` MCP back. (#9045)
+- Add core MCP tools like `firebase_init` and `firebase_get_environment` `firebase_consult_assistant` MCP back. (#9045)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Adds additional Crashlytics tools for debugging/analyzing crashes (#9020)
 - Improve `firebase init dataconnect` to detect all apps and set up SDKs in platform-specific directories (#9026)
 - `firebase init dataconnect` provide an option to create an Next.JS app template (#9026)
+- Add core MCP tools like `firebase_init` and `firebase_{set,get}_environment` `firebase_consult_assistant` MCP back. (#9045)

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -15,6 +15,7 @@ import { Options } from "../options";
 import { isEnabled } from "../experiments";
 import { readTemplateSync } from "../templates";
 import { FirebaseError } from "../error";
+import { logBullet } from "../utils";
 
 const homeDir = os.homedir();
 
@@ -197,6 +198,7 @@ export async function initAction(feature: string, options: Options): Promise<voi
       json: true,
       fallback: {},
     }),
+    instructions: [],
   };
 
   // HACK: Windows Node has issues with selectables as the first prompt, so we
@@ -265,7 +267,13 @@ export async function initAction(feature: string, options: Options): Promise<voi
   if (!fsutils.fileExistsSync(config.path(".gitignore"))) {
     config.writeProjectFile(".gitignore", GITIGNORE_TEMPLATE);
   }
-
   logger.info();
   utils.logSuccess("Firebase initialization complete!");
+
+  if (setup.instructions.length) {
+    logger.info(`\n${clc.bold("To get started:")}\n`);
+    for (const i of setup.instructions) {
+      logBullet(i + "\n");
+    }
+  }
 }

--- a/src/init/features/dataconnect/index.spec.ts
+++ b/src/init/features/dataconnect/index.spec.ts
@@ -183,6 +183,7 @@ describe("init dataconnect", () => {
             rcfile: MOCK_RC,
             config: c.config.src,
             featureInfo: { dataconnect: c.requiredInfo, dataconnectSdk: { apps: [] } },
+            instructions: [],
           },
           c.config,
           {},

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -389,7 +389,7 @@ async function writeFiles(
       await config.askWriteProjectFile(join(dir, "schema", f.path), f.content, !!options.force);
     }
   } else {
-    // Even if the schema is empty, lets give them an empty .gql file What's next?.
+    // Even if the schema is empty, lets give them an empty .gql file to get started.
     fs.ensureFileSync(join(dir, "schema", "schema.gql"));
   }
 

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -158,6 +158,20 @@ export async function actuate(setup: Setup, config: Config, options: any): Promi
       flow: info.analyticsFlow,
     });
   }
+
+  if (info.appDescription) {
+    setup.instructions.push(
+      `You can visualize the Data Connect Schema in Firebase Console:
+
+    https://console.firebase.google.com/project/${setup.projectId!}/dataconnect/locations/${info.locationId}/services/${info.serviceId}/schema`,
+    );
+  }
+  if (!setup.isBillingEnabled) {
+    setup.instructions.push(upgradeInstructions(setup.projectId || "your-firebase-project"));
+  }
+  setup.instructions.push(
+    `Install the Data Connect VS Code Extensions. You can explore Data Connect Query on local pgLite and Cloud SQL Postgres Instance.`,
+  );
 }
 
 async function actuateWithInfo(
@@ -342,36 +356,6 @@ function schemasDeploySequence(
   ];
 }
 
-export async function postSetup(setup: Setup): Promise<void> {
-  const info = setup.featureInfo?.dataconnect;
-  if (!info) {
-    throw new Error("Data Connect feature RequiredInfo is not provided");
-  }
-
-  const instructions: string[] = [];
-  if (info.appDescription) {
-    instructions.push(
-      `You can visualize the Data Connect Schema in Firebase Console:
-
-    https://console.firebase.google.com/project/${setup.projectId!}/dataconnect/locations/${info.locationId}/services/${info.serviceId}/schema`,
-    );
-  }
-
-  if (!setup.isBillingEnabled) {
-    instructions.push(upgradeInstructions(setup.projectId || "your-firebase-project"));
-  }
-  instructions.push(
-    `Install the Data Connect VS Code Extensions. You can explore Data Connect Query on local pgLite and Cloud SQL Postgres Instance.`,
-  );
-
-  if (instructions.length) {
-    logger.info(`\n${clc.bold("To get started with Firebase Data Connect:")}`);
-    for (const i of instructions) {
-      logBullet(i + "\n");
-    }
-  }
-}
-
 async function writeFiles(
   config: Config,
   info: RequiredInfo,
@@ -405,7 +389,7 @@ async function writeFiles(
       await config.askWriteProjectFile(join(dir, "schema", f.path), f.content, !!options.force);
     }
   } else {
-    // Even if the schema is empty, lets give them an empty .gql file to get started.
+    // Even if the schema is empty, lets give them an empty .gql file What's next?.
     fs.ensureFileSync(join(dir, "schema", "schema.gql"));
   }
 

--- a/src/init/features/firestore/index.spec.ts
+++ b/src/init/features/firestore/index.spec.ts
@@ -26,6 +26,7 @@ describe("firestore feature init", () => {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
         projectId: "test-project",
+        instructions: [],
       };
       const cfg = new config.Config({}, { projectDir: "/", cwd: "/" });
       sandbox.stub(ensureApiEnabled, "ensure").resolves();
@@ -68,6 +69,7 @@ describe("firestore feature init", () => {
             locationId: "us-central",
           },
         },
+        instructions: [],
       };
       const cfg = new config.Config({}, { projectDir: "/", cwd: "/" });
       const writeStub = sandbox.stub(cfg, "writeProjectFile");

--- a/src/init/features/firestore/indexes.spec.ts
+++ b/src/init/features/firestore/indexes.spec.ts
@@ -22,6 +22,7 @@ describe("firestore indexes", () => {
       const setup: Setup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       const cfg = new config.Config({}, { projectDir: "/", cwd: "/" });
       const inputStub = sandbox.stub(prompt, "input").resolves("firestore.indexes.json");
@@ -47,6 +48,7 @@ describe("firestore indexes", () => {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
         projectId: "test-project",
+        instructions: [],
       };
       const cfg = new config.Config({}, { projectDir: "/", cwd: "/" });
       const listIndexesStub = sandbox.stub(FirestoreApi.prototype, "listIndexes").resolves([]);

--- a/src/init/features/firestore/rules.spec.ts
+++ b/src/init/features/firestore/rules.spec.ts
@@ -34,6 +34,7 @@ describe("firestore rules", () => {
       const setup: Setup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       const cfg = new config.Config({}, { projectDir: "/", cwd: "/" });
       sandbox.stub(prompt, "input").resolves("firestore.rules");
@@ -59,6 +60,7 @@ describe("firestore rules", () => {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
         projectId: "test-project",
+        instructions: [],
       };
       const cfg = new config.Config({}, { projectDir: "/", cwd: "/" });
       const getRulesetNameStub = sandbox

--- a/src/init/features/functions.spec.ts
+++ b/src/init/features/functions.spec.ts
@@ -26,6 +26,7 @@ function createExistingTestSetupAndConfig(): { setup: Setup; config: Config } {
       },
       rcfile: { projects: {}, targets: {}, etags: {} },
       featureArg: true,
+      instructions: [],
     },
     config: new Config({ functions: [cbconfig] }, { projectDir: "test", cwd: "test" }),
   };

--- a/src/init/features/genkit/index.spec.ts
+++ b/src/init/features/genkit/index.spec.ts
@@ -73,6 +73,7 @@ describe("genkit", () => {
       const setup: genkit.GenkitSetup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       spawnStub.spawnWithOutput.resolves("1.0.0");
       promptStub.confirm.resolves(true);
@@ -120,6 +121,7 @@ describe("genkit", () => {
       const setup: genkit.GenkitSetup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       spawnStub.spawnWithOutput.resolves("1.0.0");
       promptStub.confirm.resolves(true);
@@ -138,6 +140,7 @@ describe("genkit", () => {
       const setup: genkit.GenkitSetup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       spawnStub.spawnWithOutput.resolves("1.0.0");
       promptStub.confirm.resolves(true);
@@ -163,6 +166,7 @@ describe("genkit", () => {
       const setup: genkit.GenkitSetup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       spawnStub.spawnWithOutput.resolves("1.0.0");
       promptStub.confirm.onFirstCall().resolves(true).onSecondCall().resolves(false);
@@ -179,6 +183,7 @@ describe("genkit", () => {
       const setup: genkit.GenkitSetup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       spawnStub.spawnWithOutput.resolves("1.0.0");
       promptStub.confirm.onFirstCall().resolves(true).onSecondCall().resolves(false);
@@ -203,6 +208,7 @@ describe("genkit", () => {
       const setup: genkit.GenkitSetup = {
         config: {},
         rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
       };
       spawnStub.spawnWithOutput.resolves("1.0.0");
       promptStub.confirm.resolves(false);

--- a/src/init/features/index.ts
+++ b/src/init/features/index.ts
@@ -26,7 +26,6 @@ export {
   askQuestions as dataconnectAskQuestions,
   RequiredInfo as DataconnectInfo,
   actuate as dataconnectActuate,
-  postSetup as dataconnectPostSetup,
 } from "./dataconnect";
 export {
   askQuestions as dataconnectSdkAskQuestions,

--- a/src/init/features/storage.spec.ts
+++ b/src/init/features/storage.spec.ts
@@ -27,6 +27,7 @@ describe("storage", () => {
         rcfile: { projects: {}, targets: {}, etags: {} },
         projectId: "my-project-123",
         projectLocation: "us-central",
+        instructions: [],
       };
       const config = new Config({}, { projectDir: "test", cwd: "test" });
       promptStub.returns("storage.rules");

--- a/src/init/index.ts
+++ b/src/init/index.ts
@@ -17,6 +17,11 @@ export interface Setup {
   featureArg?: boolean;
   featureInfo?: SetupInfo;
 
+  // Each feature init flow may add instructions.
+  // They will be displayed at the end of `firebase init` or
+  // return back to `firebase_init` MCP tools.
+  instructions: string[];
+
   /** Basic Project information */
   project?: Record<string, any>;
   projectId?: string;
@@ -66,7 +71,6 @@ const featuresList: Feature[] = [
     name: "dataconnect",
     askQuestions: features.dataconnectAskQuestions,
     actuate: features.dataconnectActuate,
-    postSetup: features.dataconnectPostSetup,
   },
   {
     name: "dataconnect:sdk",

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -167,14 +167,24 @@ export const init = tool(
       projectId: projectId,
       features: [...featuresList],
       featureInfo: featureInfo,
+      instructions: [],
     };
     // Set force to true to avoid prompting the user for confirmation.
     await actuate(setup, config, { force: true });
     config.writeProjectFile("firebase.json", setup.config);
     config.writeProjectFile(".firebaserc", setup.rcfile);
+
+    if (featureInfo.dataconnectSdk && !featureInfo.dataconnectSdk.apps.length) {
+      setup.instructions.push(
+        `No apps is found in the current folder. We recommend you create an app (web, ios, android) first, then re-run the 'firebase_init' MCP tool to add Data Connect SDKs to your apps.
+        Consider popular commands like 'npx create-react-app my-app', 'npx create-next-app my-app', 'flutter create my-app', etc`,
+      );
+    }
     return toContent(
-      `Successfully setup the project ${projectId} with those features: ${featuresList.join(", ")}` +
-        " To deploy them, you can run `firebase deploy` in command line.",
+      `Successfully setup those features: ${featuresList.join(", ")}
+
+To get started:
+- ${setup.instructions.join("\n\n- ")}`,
     );
   },
 );

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -177,14 +177,16 @@ export const init = tool(
     if (featureInfo.dataconnectSdk && !featureInfo.dataconnectSdk.apps.length) {
       setup.instructions.push(
         `No apps is found in the current folder. We recommend you create an app (web, ios, android) first, then re-run the 'firebase_init' MCP tool to add Data Connect SDKs to your apps.
-        Consider popular commands like 'npx create-react-app my-app', 'npx create-next-app my-app', 'flutter create my-app', etc`,
+  Consider popular commands like 'npx create-react-app my-app', 'npx create-next-app my-app', 'flutter create my-app', etc`,
       );
     }
     return toContent(
       `Successfully setup those features: ${featuresList.join(", ")}
 
 To get started:
-- ${setup.instructions.join("\n\n- ")}`,
+
+- ${setup.instructions.join("\n\n- ")}
+`,
     );
   },
 );

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -17,6 +17,9 @@ export function availableTools(activeFeatures?: ServerFeature[]): ServerTool[] {
   if (!activeFeatures?.length) {
     activeFeatures = Object.keys(tools) as ServerFeature[];
   }
+  if (!activeFeatures.includes("core")) {
+    activeFeatures.unshift("core");
+  }
   for (const key of activeFeatures) {
     toolDefs.push(...tools[key]);
   }


### PR DESCRIPTION
While testing this, I realized that all of the core MCP tools were not included.


<img width="787" height="772" alt="Screenshot 2025-08-27 at 3 35 48 PM" src="https://github.com/user-attachments/assets/613b0db5-b065-47f4-a291-d9a0e60e9cfa" />
