### PR TITLE
Improved active project detection in MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
 - Fixed an issue where core MCP tools would be excluded from `listTools`. (#9045)
-- Fixed an issue where the MCP server would fail to idenitfy active projects.
+- Fixed an issue where the MCP server would fail to identify active projects.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
-- Add core MCP tools like `firebase_init` and `firebase_get_environment` `firebase_consult_assistant` MCP back. (#9045)
+- Fixed an issue where core MCP tools would be excluded from `listTools`. (#9045)
+- Fixed an issue where the MCP server would fail to idenitfy active projects.

--- a/src/command.ts
+++ b/src/command.ts
@@ -15,7 +15,7 @@ import { getProject } from "./management/projects";
 import { reconcileStudioFirebaseProject } from "./management/studio";
 import { requireAuth } from "./requireAuth";
 import { Options } from "./options";
-import { logger, useConsoleLoggers } from "./logger";
+import { useConsoleLoggers } from "./logger";
 import { isFirebaseStudio } from "./env";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -356,10 +356,7 @@ export class Command {
   private async applyRC(options: Options) {
     const rc = loadRC(options);
     options.rc = rc;
-    const configstoreProj = this.configstoreProject(options.projectRoot || process.cwd())
-    let activeProject: string | undefined = options.projectRoot
-      ? configstoreProj
-      : undefined;
+    let activeProject = this.configstoreProject(options.projectRoot || process.cwd());
 
     // Only fetch the Studio Workspace project if we're running in Firebase
     // Studio. If the user passes the project via --project, it should take
@@ -395,25 +392,19 @@ export class Command {
   }
 
   private configstoreProject(dir: string) {
-    logger.debug(dir);
     const projectMap = configstore.get("activeProjects") ?? {};
     let currentDir = path.resolve(dir);
-
     while (true) {
-
-      logger.debug("trying " + currentDir);
       if (projectMap[currentDir]) {
-        logger.debug("active project is " + currentDir);
         return projectMap[currentDir];
       }
       const parentDir = path.dirname(currentDir);
       if (parentDir === currentDir) {
-        return null; 
+        return null;
       }
       currentDir = parentDir;
     }
   }
-
 
   private async resolveProjectIdentifiers(options: {
     project?: string;

--- a/src/mcp/tools/firestore/list_collections.ts
+++ b/src/mcp/tools/firestore/list_collections.ts
@@ -33,8 +33,6 @@ export const list_collections = tool(
     if (use_emulator) {
       emulatorUrl = await host.getEmulatorUrl(Emulators.FIRESTORE);
     }
-
-    if (!projectId) return NO_PROJECT_ERROR;
     return toContent(await listCollectionIds(projectId, database, emulatorUrl));
   },
 );

--- a/src/mcp/tools/firestore/list_collections.ts
+++ b/src/mcp/tools/firestore/list_collections.ts
@@ -2,7 +2,6 @@ import { z } from "zod";
 import { tool } from "../../tool";
 import { toContent } from "../../util";
 import { listCollectionIds } from "../../../gcp/firestore";
-import { NO_PROJECT_ERROR } from "../../errors";
 import { Emulators } from "../../../emulator/types";
 
 export const list_collections = tool(


### PR DESCRIPTION
### Description
Fixed up some broken cases where the MCP server would fail to discover the active project. Specifically, if you did not have a firebase.json and were in a child directory of the directory listed in Configstore, we would not detect the project from the parent directory.

### Scenarios Tested
Using MCP inspector, I tested all combos of:
- firebase.json, no firebase.json
- Parent directory in configstore, child directory in configstore, no project in configstore
I also directly tested the flow of 'No active project, run update_environment, active project is now set correctly'
