### PR TITLE
fix(emulator, auth): allow SMS MFA finalization with obfuscated number

### DIFF
--- a/src/emulator/auth/operations.ts
+++ b/src/emulator/auth/operations.ts
@@ -2221,7 +2221,14 @@ async function mfaSignInFinalize(
 
   let { user, signInProvider } = parsePendingCredential(state, reqBody.mfaPendingCredential);
   const enrollment = user.mfaInfo?.find(
-    (enrollment) => enrollment.unobfuscatedPhoneInfo === phoneNumber,
+    (enrollment) => {
+      return
+        // all but firebase-ios-sdk finalize with unobfuscated phone number which we find easily...
+        enrollment.unobfuscatedPhoneInfo === phoneNumber ||
+        // ...but firebase-ios-sdk finalizes with obfuscated
+        // This works against cloud auth, so emulator should attempt to find enrollment obfuscated as well.
+        ('+********' + enrollment.unobfuscatedPhoneInfo.substring(enrollment.unobfuscatedPhoneInfo.length - 4)) === phoneNumber;
+    }
   );
 
   const { updates, extraClaims } = await fetchBlockingFunction(


### PR DESCRIPTION

### Description

Hi there 👋  - I'm one of the maintainers of react-native-firebase on behalf of Google

I'm trying to enable MFA testing with SMS as the second factor for the iOS platform, and I noticed a problem. This patch fixes it.

SMS MFA works using firebase-js-sdk and firebase-android-sdk against the emulator - these send unobfuscated phone numbers for the finalization step allowing successful enrollment location

firebase-ios-sdk sends an obfuscated phone number during the finalization step though and the enrollment isn't found, leading to SMS MFA failures against the emulator despite the same code working against cloud auth.

By allowing the enrollment lookup to check both unobfuscated and obfuscated numbers for enrollment id, the emulator will successfully finalize an MFA login with SMS as the second factor, on all platforms

### Scenarios Tested

See description

### Sample Commands

See descriptoin