### PR TITLE
feat: Add agent detection via env vars and tag GA4 with user property agent

### DIFF
--- a/src/track.ts
+++ b/src/track.ts
@@ -7,6 +7,16 @@ import { logger } from "./logger";
 import { isFirebaseStudio } from "./env";
 const pkg = require("../package.json");
 
+// Detect if the CLI was invoked by a coding agent, based on well-known env vars.
+function detectAgent(): string | undefined {
+  if (process.env.CODEX_SANDBOX) return "codex_cli";
+  if (process.env.CLAUDECODE) return "claude_code";
+  if (process.env.GEMINI_CLI) return "gemini_cli";
+  if (process.env.CURSOR_AGENT) return "cursor";
+  if (process.env.OPENCODE) return "open_code";
+  return undefined;
+}
+
 type cliEventNames =
   | "command_execution"
   | "product_deploy"
@@ -85,6 +95,11 @@ const GA4_USER_PROPS = {
   is_firebase_studio: {
     value: isFirebaseStudio().toString(),
   },
+  // When present, indicates the command was invoked by an agent.
+  agent: (() => {
+    const agent = detectAgent();
+    return agent ? { value: agent } : undefined;
+  })(),
 };
 
 export interface AnalyticsParams {


### PR DESCRIPTION
Add agent detection via env vars and tag GA4 with user property agent. Supported signals:

- CODEX_SANDBOX -> codex_cli
- CLAUDECODE -> claude_code
- GEMINI_CLI -> gemini_cli
- CURSOR_AGENT -> cursor
- OPENCODE -> open_code