### PR TITLE
Adding nock based tests for the API methods in src/gcp

### DIFF
--- a/src/gcp/artifactregistry.spec.ts
+++ b/src/gcp/artifactregistry.spec.ts
@@ -1,0 +1,143 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as sinon from "sinon";
+import * as artifactRegistry from "./artifactregistry";
+import { artifactRegistryDomain } from "../api";
+import * as api from "../ensureApiEnabled";
+
+const API_VERSION = "v1";
+const PROJECT_ID = "test-project";
+const REGION = "us-central1";
+const REPO = "test-repo";
+const REPO_NAME = `projects/${PROJECT_ID}/locations/${REGION}/repositories/${REPO}`;
+
+describe("artifactRegistry", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("getRepository", () => {
+    it("should resolve with a repository object on success", async () => {
+      const repository: artifactRegistry.Repository = {
+        name: REPO_NAME,
+        format: "DOCKER",
+        description: "test repo",
+        createTime: "2022-01-01T00:00:00Z",
+        updateTime: "2022-01-01T00:00:00Z",
+      };
+      nock(artifactRegistryDomain()).get(`/${API_VERSION}/${REPO_NAME}`).reply(200, repository);
+
+      const result = await artifactRegistry.getRepository(REPO_NAME);
+
+      expect(result).to.deep.equal(repository);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(artifactRegistryDomain())
+        .get(`/${API_VERSION}/${REPO_NAME}`)
+        .reply(404, { error: { message: "Not Found" } });
+
+      await expect(artifactRegistry.getRepository(REPO_NAME)).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("deletePackage", () => {
+    const PKG_NAME = `${REPO_NAME}/packages/test-pkg`;
+
+    it("should resolve with an operation object on success", async () => {
+      const operation: artifactRegistry.Operation = {
+        name: `projects/${PROJECT_ID}/locations/${REGION}/operations/test-op`,
+        done: true,
+      };
+      nock(artifactRegistryDomain()).delete(`/${API_VERSION}/${PKG_NAME}`).reply(200, operation);
+
+      const result = await artifactRegistry.deletePackage(PKG_NAME);
+
+      expect(result).to.deep.equal(operation);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(artifactRegistryDomain())
+        .delete(`/${API_VERSION}/${PKG_NAME}`)
+        .reply(403, { error: { message: "Permission Denied" } });
+
+      await expect(artifactRegistry.deletePackage(PKG_NAME)).to.be.rejectedWith(
+        "Permission Denied",
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("updateRepository", () => {
+    it("should send a patch request with update mask if one is present", async () => {
+      const repo: artifactRegistry.RepositoryInput = {
+        name: REPO_NAME,
+        labels: {
+          foo: "bar",
+        },
+      };
+      const resultRepo: artifactRegistry.Repository = {
+        ...repo,
+        format: "DOCKER",
+        description: "test repo",
+        createTime: "2022-01-01T00:00:00Z",
+        updateTime: "2022-01-01T00:00:00Z",
+      };
+
+      nock(artifactRegistryDomain())
+        .patch(`/${API_VERSION}/${REPO_NAME}?updateMask=name,labels`)
+        .reply(200, resultRepo);
+
+      const result = await artifactRegistry.updateRepository(repo);
+
+      expect(result).to.deep.equal(resultRepo);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should send a patch request if only name is present", async () => {
+      const repo: artifactRegistry.RepositoryInput = {
+        name: REPO_NAME,
+      };
+      const resultRepo: artifactRegistry.Repository = {
+        ...repo,
+        format: "DOCKER",
+        description: "test repo",
+        createTime: "2022-01-01T00:00:00Z",
+        updateTime: "2022-01-01T00:00:00Z",
+      };
+
+      nock(artifactRegistryDomain())
+        .patch(`/${API_VERSION}/${REPO_NAME}?updateMask=name`)
+        .reply(200, resultRepo);
+
+      const result = await artifactRegistry.updateRepository(repo);
+
+      expect(result).to.deep.equal(resultRepo);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("ensureApiEnabled", () => {
+    let sandbox: sinon.SinonSandbox;
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+    it("should call the ensure api", async () => {
+      const ensureApiStub = sandbox.stub(api, "ensure").resolves();
+      await artifactRegistry.ensureApiEnabled(PROJECT_ID);
+      expect(ensureApiStub).to.have.been.calledWith(
+        PROJECT_ID,
+        "https://artifactregistry.googleapis.com",
+        "artifactregistry",
+        true,
+      );
+    });
+  });
+});

--- a/src/gcp/auth.spec.ts
+++ b/src/gcp/auth.spec.ts
@@ -1,0 +1,359 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as auth from "./auth";
+import { identityOrigin } from "../api";
+
+const PROJECT_ID = "test-project";
+
+describe("auth", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("getAuthDomains", () => {
+    it("should resolve with auth domains on success", async () => {
+      const authDomains = ["domain1.com", "domain2.com"];
+      nock(identityOrigin())
+        .get(`/admin/v2/projects/${PROJECT_ID}/config`)
+        .reply(200, { authorizedDomains: authDomains });
+
+      const result = await auth.getAuthDomains(PROJECT_ID);
+
+      expect(result).to.deep.equal(authDomains);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(identityOrigin())
+        .get(`/admin/v2/projects/${PROJECT_ID}/config`)
+        .reply(404, { error: { message: "Not Found" } });
+
+      await expect(auth.getAuthDomains(PROJECT_ID)).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("updateAuthDomains", () => {
+    const authDomains = ["domain1.com", "domain2.com"];
+    it("should resolve with auth domains on success", async () => {
+      nock(identityOrigin())
+        .patch(`/admin/v2/projects/${PROJECT_ID}/config?update_mask=authorizedDomains`, {
+          authorizedDomains: authDomains,
+        })
+        .reply(200, { authorizedDomains: authDomains });
+
+      const result = await auth.updateAuthDomains(PROJECT_ID, authDomains);
+
+      expect(result).to.deep.equal(authDomains);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(identityOrigin())
+        .patch(`/admin/v2/projects/${PROJECT_ID}/config?update_mask=authorizedDomains`, {
+          authorizedDomains: authDomains,
+        })
+        .reply(404, { error: { message: "Not Found" } });
+
+      await expect(auth.updateAuthDomains(PROJECT_ID, authDomains)).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("findUser", () => {
+    const userInfo = { localId: "test-uid", email: "test@test.com" };
+    const expectedUserInfo = { uid: "test-uid", email: "test@test.com" };
+
+    it("should resolve with user info on success (email)", async () => {
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          expression: [{ email: "test@test.com" }],
+          limit: "1",
+        })
+        .reply(200, { userInfo: [userInfo] });
+
+      const result = await auth.findUser(PROJECT_ID, "test@test.com");
+
+      expect(result).to.deep.equal(expectedUserInfo);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve with user info on success (phone)", async () => {
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          expression: [{ phoneNumber: "+11234567890" }],
+          limit: "1",
+        })
+        .reply(200, { userInfo: [userInfo] });
+
+      const result = await auth.findUser(PROJECT_ID, undefined, "+11234567890");
+
+      expect(result).to.deep.equal(expectedUserInfo);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve with user info on success (uid)", async () => {
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          expression: [{ userId: "test-uid" }],
+          limit: "1",
+        })
+        .reply(200, { userInfo: [userInfo] });
+
+      const result = await auth.findUser(PROJECT_ID, undefined, undefined, "test-uid");
+
+      expect(result).to.deep.equal(expectedUserInfo);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if no user is found", async () => {
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          expression: [{ email: "test@test.com" }],
+          limit: "1",
+        })
+        .reply(200, {});
+
+      await expect(auth.findUser(PROJECT_ID, "test@test.com")).to.be.rejectedWith("No users found");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("listUsers", () => {
+    const userInfo1 = { localId: "test-uid1", email: "test1@test.com" };
+    const userInfo2 = { localId: "test-uid2", email: "test2@test.com" };
+    const expectedUserInfo1 = { uid: "test-uid1", email: "test1@test.com" };
+    const expectedUserInfo2 = { uid: "test-uid2", email: "test2@test.com" };
+
+    it("should resolve with a list of users on success", async () => {
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          offset: "0",
+          limit: "2",
+        })
+        .reply(200, {
+          recordsCount: "2",
+          userInfo: [userInfo1, userInfo2],
+        });
+
+      const result = await auth.listUsers(PROJECT_ID, 2);
+
+      expect(result).to.deep.equal([expectedUserInfo1, expectedUserInfo2]);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should handle pagination correctly", async () => {
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          offset: "0",
+          limit: "500",
+        })
+        .reply(200, {
+          recordsCount: "1",
+          userInfo: [userInfo1],
+        });
+
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          offset: "1",
+          limit: "500",
+        })
+        .reply(200, {
+          recordsCount: "1",
+          userInfo: [userInfo2],
+        });
+
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`, {
+          offset: "2",
+          limit: "500",
+        })
+        .reply(200, {
+          recordsCount: "0",
+        });
+
+      const result = await auth.listUsers(PROJECT_ID, 1000);
+
+      expect(result).to.deep.equal([expectedUserInfo1, expectedUserInfo2]);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("disableUser", () => {
+    it("should resolve with true on success", async () => {
+      nock(identityOrigin())
+        .post("/v1/accounts:update", {
+          disableUser: true,
+          targetProjectId: PROJECT_ID,
+          localId: "test-uid",
+        })
+        .reply(200, {});
+
+      const result = await auth.disableUser(PROJECT_ID, "test-uid", true);
+
+      expect(result).to.be.true;
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(identityOrigin())
+        .post("/v1/accounts:update", {
+          disableUser: true,
+          targetProjectId: PROJECT_ID,
+          localId: "test-uid",
+        })
+        .reply(404, { error: { message: "Not Found" } });
+
+      await expect(auth.disableUser(PROJECT_ID, "test-uid", true)).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("setCustomClaim", () => {
+    const uid = "test-uid";
+    const claim = { admin: true };
+    const userInfo = {
+      localId: uid,
+      email: "test@test.com",
+      customAttributes: "",
+    };
+    const updatedUserInfo = {
+      uid: uid,
+      email: "test@test.com",
+      customAttributes: JSON.stringify(claim),
+    };
+
+    it("should resolve with updated user info on success (overwrite)", async () => {
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`)
+        .reply(200, { userInfo: [userInfo] });
+
+      nock(identityOrigin())
+        .post("/v1/accounts:update", {
+          customAttributes: JSON.stringify(claim),
+          targetProjectId: PROJECT_ID,
+          localId: uid,
+        })
+        .reply(200, {});
+
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`)
+        .reply(200, { userInfo: [{ ...userInfo, uid, customAttributes: JSON.stringify(claim) }] });
+
+      const result = await auth.setCustomClaim(PROJECT_ID, uid, claim);
+
+      expect(result).to.deep.equal(updatedUserInfo);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve with updated user info on success (merge)", async () => {
+      const existingClaim = { role: "user" };
+      const mergedClaim = { ...existingClaim, ...claim };
+      const userInfoWithClaim = { ...userInfo, customAttributes: JSON.stringify(existingClaim) };
+      const updatedUserInfoWithMergedClaim = {
+        uid: uid,
+        email: "test@test.com",
+        customAttributes: JSON.stringify(mergedClaim),
+      };
+
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`)
+        .reply(200, { userInfo: [userInfoWithClaim] });
+
+      nock(identityOrigin())
+        .post("/v1/accounts:update", {
+          customAttributes: JSON.stringify(mergedClaim),
+          targetProjectId: PROJECT_ID,
+          localId: uid,
+        })
+        .reply(200, {});
+
+      nock(identityOrigin())
+        .post(`/v1/projects/${PROJECT_ID}/accounts:query`)
+        .reply(200, {
+          userInfo: [{ ...userInfo, uid, customAttributes: JSON.stringify(mergedClaim) }],
+        });
+
+      const result = await auth.setCustomClaim(PROJECT_ID, uid, claim, {
+        merge: true,
+      });
+
+      expect(result).to.deep.equal(updatedUserInfoWithMergedClaim);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("setAllowSmsRegionPolicy", () => {
+    const countryCodes = ["US", "CA"];
+    it("should resolve with true on success", async () => {
+      nock(identityOrigin())
+        .patch(`/admin/v2/projects/${PROJECT_ID}/config?updateMask=sms_region_config`, {
+          sms_region_config: {
+            allowlist_only: {
+              allowed_regions: countryCodes,
+            },
+          },
+        })
+        .reply(200, {});
+
+      const result = await auth.setAllowSmsRegionPolicy(PROJECT_ID, countryCodes);
+
+      expect(result).to.be.true;
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(identityOrigin())
+        .patch(`/admin/v2/projects/${PROJECT_ID}/config?updateMask=sms_region_config`, {
+          sms_region_config: {
+            allowlist_only: {
+              allowed_regions: countryCodes,
+            },
+          },
+        })
+        .reply(400, { error: { message: "Bad Request" } });
+
+      await expect(auth.setAllowSmsRegionPolicy(PROJECT_ID, countryCodes)).to.be.rejectedWith(
+        "Bad Request",
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("setDenySmsRegionPolicy", () => {
+    const countryCodes = ["US", "CA"];
+    it("should resolve with true on success", async () => {
+      nock(identityOrigin())
+        .patch(`/admin/v2/projects/${PROJECT_ID}/config?updateMask=sms_region_config`, {
+          sms_region_config: {
+            allow_by_default: {
+              disallowed_regions: countryCodes,
+            },
+          },
+        })
+        .reply(200, {});
+
+      const result = await auth.setDenySmsRegionPolicy(PROJECT_ID, countryCodes);
+
+      expect(result).to.be.true;
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(identityOrigin())
+        .patch(`/admin/v2/projects/${PROJECT_ID}/config?updateMask=sms_region_config`, {
+          sms_region_config: {
+            allow_by_default: {
+              disallowed_regions: countryCodes,
+            },
+          },
+        })
+        .reply(400, { error: { message: "Bad Request" } });
+
+      await expect(auth.setDenySmsRegionPolicy(PROJECT_ID, countryCodes)).to.be.rejectedWith(
+        "Bad Request",
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});

--- a/src/gcp/cloudbilling.spec.ts
+++ b/src/gcp/cloudbilling.spec.ts
@@ -1,0 +1,154 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as cloudbilling from "./cloudbilling";
+import { cloudbillingOrigin } from "../api";
+import { Setup } from "../init";
+
+const PROJECT_ID = "test-project";
+
+describe("cloudbilling", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("checkBillingEnabled", () => {
+    it("should resolve with true if billing is enabled", async () => {
+      nock(cloudbillingOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .reply(200, { billingEnabled: true });
+
+      const result = await cloudbilling.checkBillingEnabled(PROJECT_ID);
+
+      expect(result).to.be.true;
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve with false if billing is not enabled", async () => {
+      nock(cloudbillingOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .reply(200, { billingEnabled: false });
+
+      const result = await cloudbilling.checkBillingEnabled(PROJECT_ID);
+
+      expect(result).to.be.false;
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(cloudbillingOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .reply(404, { error: { message: "Not Found" } });
+
+      await expect(cloudbilling.checkBillingEnabled(PROJECT_ID)).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("isBillingEnabled", () => {
+    it("should return the cached value if it exists", async () => {
+      const setup: Setup = {
+        isBillingEnabled: true,
+        config: {},
+        rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
+      };
+      const result = await cloudbilling.isBillingEnabled(setup);
+      expect(result).to.be.true;
+    });
+
+    it("should return false if projectId is not set", async () => {
+      const setup: Setup = {
+        config: {},
+        rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
+      };
+      const result = await cloudbilling.isBillingEnabled(setup);
+      expect(result).to.be.false;
+    });
+
+    it("should call checkBillingEnabled if cache is empty", async () => {
+      const setup: Setup = {
+        projectId: PROJECT_ID,
+        config: {},
+        rcfile: { projects: {}, targets: {}, etags: {} },
+        instructions: [],
+      };
+      nock(cloudbillingOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .reply(200, { billingEnabled: true });
+
+      const result = await cloudbilling.isBillingEnabled(setup);
+
+      expect(result).to.be.true;
+      expect(setup.isBillingEnabled).to.be.true;
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("setBillingAccount", () => {
+    const billingAccountName = "billingAccounts/test-billing-account";
+    it("should resolve with true on success", async () => {
+      nock(cloudbillingOrigin())
+        .put(`/v1/projects/${PROJECT_ID}/billingInfo`, {
+          billingAccountName: billingAccountName,
+        })
+        .reply(200, { billingEnabled: true });
+
+      const result = await cloudbilling.setBillingAccount(PROJECT_ID, billingAccountName);
+
+      expect(result).to.be.true;
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(cloudbillingOrigin())
+        .put(`/v1/projects/${PROJECT_ID}/billingInfo`, {
+          billingAccountName: billingAccountName,
+        })
+        .reply(403, { error: { message: "Permission Denied" } });
+
+      await expect(
+        cloudbilling.setBillingAccount(PROJECT_ID, billingAccountName),
+      ).to.be.rejectedWith("Permission Denied");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("listBillingAccounts", () => {
+    const billingAccount = {
+      name: "billingAccounts/test-billing-account",
+      open: "true",
+      displayName: "Test Billing Account",
+      masterBillingAccount: "",
+    };
+
+    it("should resolve with a list of billing accounts on success", async () => {
+      nock(cloudbillingOrigin())
+        .get("/v1/billingAccounts")
+        .reply(200, { billingAccounts: [billingAccount] });
+
+      const result = await cloudbilling.listBillingAccounts();
+
+      expect(result).to.deep.equal([billingAccount]);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resolve with an empty list if no billing accounts are returned", async () => {
+      nock(cloudbillingOrigin()).get("/v1/billingAccounts").reply(200, {});
+
+      const result = await cloudbilling.listBillingAccounts();
+
+      expect(result).to.deep.equal([]);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(cloudbillingOrigin())
+        .get("/v1/billingAccounts")
+        .reply(404, { error: { message: "Not Found" } });
+
+      await expect(cloudbilling.listBillingAccounts()).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});

--- a/src/gcp/cloudbuild.spec.ts
+++ b/src/gcp/cloudbuild.spec.ts
@@ -1,0 +1,172 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as cloudbuild from "./cloudbuild";
+import { cloudbuildOrigin } from "../api";
+
+const PROJECT_ID = "test-project";
+const LOCATION = "us-central1";
+
+describe("cloudbuild", () => {
+  const CONNECTION_ID = "test-connection";
+  const REPO_ID = "test-repo";
+  const OP_NAME = "operations/test-op";
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("createConnection", () => {
+    it("should resolve with an operation on success", async () => {
+      const operation = { name: OP_NAME, done: false };
+      nock(cloudbuildOrigin())
+        .post(
+          `/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections?connectionId=${CONNECTION_ID}`,
+        )
+        .reply(200, operation);
+
+      const result = await cloudbuild.createConnection(PROJECT_ID, LOCATION, CONNECTION_ID);
+
+      expect(result).to.deep.equal(operation);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("getConnection", () => {
+    it("should resolve with a connection on success", async () => {
+      const connection = { name: "test-connection" };
+      nock(cloudbuildOrigin())
+        .get(`/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections/${CONNECTION_ID}`)
+        .reply(200, connection);
+
+      const result = await cloudbuild.getConnection(PROJECT_ID, LOCATION, CONNECTION_ID);
+
+      expect(result).to.deep.equal(connection);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("listConnections", () => {
+    it("should resolve with a list of connections on success", async () => {
+      const connections = [{ name: "test-connection" }];
+      nock(cloudbuildOrigin())
+        .get(`/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections`)
+        .query({ pageSize: 100, pageToken: "" })
+        .reply(200, { connections: connections });
+
+      const result = await cloudbuild.listConnections(PROJECT_ID, LOCATION);
+
+      expect(result).to.deep.equal(connections);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("deleteConnection", () => {
+    it("should resolve with an operation on success", async () => {
+      const operation = { name: OP_NAME, done: false };
+      nock(cloudbuildOrigin())
+        .delete(`/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections/${CONNECTION_ID}`)
+        .reply(200, operation);
+
+      const result = await cloudbuild.deleteConnection(PROJECT_ID, LOCATION, CONNECTION_ID);
+
+      expect(result).to.deep.equal(operation);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("createRepository", () => {
+    it("should resolve with an operation on success", async () => {
+      const operation = { name: OP_NAME, done: false };
+      nock(cloudbuildOrigin())
+        .post(
+          `/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections/${CONNECTION_ID}/repositories?repositoryId=${REPO_ID}`,
+        )
+        .reply(200, operation);
+
+      const result = await cloudbuild.createRepository(
+        PROJECT_ID,
+        LOCATION,
+        CONNECTION_ID,
+        REPO_ID,
+        "https://github.com/test/repo",
+      );
+
+      expect(result).to.deep.equal(operation);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("getRepository", () => {
+    it("should resolve with a repository on success", async () => {
+      const repository = { name: "test-repo" };
+      nock(cloudbuildOrigin())
+        .get(
+          `/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections/${CONNECTION_ID}/repositories/${REPO_ID}`,
+        )
+        .reply(200, repository);
+
+      const result = await cloudbuild.getRepository(PROJECT_ID, LOCATION, CONNECTION_ID, REPO_ID);
+
+      expect(result).to.deep.equal(repository);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("deleteRepository", () => {
+    it("should resolve with an operation on success", async () => {
+      const operation = { name: OP_NAME, done: false };
+      nock(cloudbuildOrigin())
+        .delete(
+          `/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections/${CONNECTION_ID}/repositories/${REPO_ID}`,
+        )
+        .reply(200, operation);
+
+      const result = await cloudbuild.deleteRepository(
+        PROJECT_ID,
+        LOCATION,
+        CONNECTION_ID,
+        REPO_ID,
+      );
+
+      expect(result).to.deep.equal(operation);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("fetchLinkableRepositories", () => {
+    it("should resolve with a list of linkable repositories on success", async () => {
+      const repositories = { repositories: [{ name: "test-repo" }] };
+      nock(cloudbuildOrigin())
+        .get(
+          `/v2/projects/${PROJECT_ID}/locations/${LOCATION}/connections/${CONNECTION_ID}:fetchLinkableRepositories`,
+        )
+        .query({ pageSize: 1000, pageToken: "" })
+        .reply(200, repositories);
+
+      const result = await cloudbuild.fetchLinkableRepositories(
+        PROJECT_ID,
+        LOCATION,
+        CONNECTION_ID,
+      );
+
+      expect(result).to.deep.equal(repositories);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("getDefaultServiceAccount", () => {
+    it("should return the default service account", () => {
+      const projectNumber = "123456789";
+      const result = cloudbuild.getDefaultServiceAccount(projectNumber);
+      expect(result).to.equal("123456789@cloudbuild.gserviceaccount.com");
+    });
+  });
+
+  describe("getDefaultServiceAgent", () => {
+    it("should return the default service agent", () => {
+      const projectNumber = "123456789";
+      const result = cloudbuild.getDefaultServiceAgent(projectNumber);
+      expect(result).to.equal("service-123456789@gcp-sa-cloudbuild.iam.gserviceaccount.com");
+    });
+  });
+});

--- a/src/gcp/cloudfunctions.spec.ts
+++ b/src/gcp/cloudfunctions.spec.ts
@@ -8,7 +8,6 @@ import { BEFORE_CREATE_EVENT, BEFORE_SIGN_IN_EVENT } from "../functions/events/v
 import * as cloudfunctions from "./cloudfunctions";
 import * as projectConfig from "../functions/projectConfig";
 import { BLOCKING_LABEL, CODEBASE_LABEL, HASH_LABEL } from "../functions/constants";
-import { FirebaseError } from "../error";
 
 describe("cloudfunctions", () => {
   const FUNCTION_NAME: backend.TargetIds = {
@@ -756,26 +755,6 @@ describe("cloudfunctions", () => {
           "service-account1@",
         ]),
       ).to.not.be.rejected;
-    });
-  });
-
-  describe("listFunctions", () => {
-    it("should pass back an error with the correct status", async () => {
-      nock(functionsOrigin())
-        .get("/v1/projects/foo/locations/-/functions")
-        .reply(403, { error: "You don't have permissions." });
-
-      let errCaught = false;
-      try {
-        await cloudfunctions.listFunctions("foo", "-");
-      } catch (err: unknown) {
-        errCaught = true;
-        expect(err).instanceOf(FirebaseError);
-        expect(err).has.property("status", 403);
-      }
-
-      expect(errCaught, "should have caught an error").to.be.true;
-      expect(nock.isDone()).to.be.true;
     });
   });
 });

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -472,16 +472,6 @@ async function list(projectId: string, region: string): Promise<ListFunctionsRes
 }
 
 /**
- * List all existing Cloud Functions in a project and region.
- * @param projectId the Id of the project to check.
- * @param region the region to check in.
- */
-export async function listFunctions(projectId: string, region: string): Promise<CloudFunction[]> {
-  const res = await list(projectId, region);
-  return res.functions;
-}
-
-/**
  * List all existing Cloud Functions in a project.
  * @param projectId the Id of the project to check.
  */

--- a/src/gcp/cloudfunctionsv2.spec.ts
+++ b/src/gcp/cloudfunctionsv2.spec.ts
@@ -7,7 +7,6 @@ import * as events from "../functions/events";
 import * as projectConfig from "../functions/projectConfig";
 import { BLOCKING_LABEL, CODEBASE_LABEL, HASH_LABEL } from "../functions/constants";
 import { functionsV2Origin } from "../api";
-import { FirebaseError } from "../error";
 
 describe("cloudfunctionsv2", () => {
   const FUNCTION_NAME: backend.TargetIds = {
@@ -798,27 +797,6 @@ describe("cloudfunctionsv2", () => {
           serviceConfig: undefined,
         }),
       ).to.deep.equal(expectedEndpoint);
-    });
-  });
-
-  describe("listFunctions", () => {
-    it("should pass back an error with the correct status", async () => {
-      nock(functionsV2Origin())
-        .get("/v2/projects/foo/locations/-/functions")
-        .query({ filter: `environment="GEN_2"` })
-        .reply(403, { error: "You don't have permissions." });
-
-      let errCaught = false;
-      try {
-        await cloudfunctionsv2.listFunctions("foo", "-");
-      } catch (err: unknown) {
-        errCaught = true;
-        expect(err).instanceOf(FirebaseError);
-        expect(err).has.property("status", 403);
-      }
-
-      expect(errCaught, "should have caught an error").to.be.true;
-      expect(nock.isDone()).to.be.true;
     });
   });
 

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -333,21 +333,6 @@ export async function getFunction(
 }
 
 /**
- *  List all functions in a region.
- *  Customers should generally use backend.existingBackend.
- */
-export async function listFunctions(
-  projectId: string,
-  region: string,
-): Promise<OutputCloudFunction[]> {
-  const res = await listFunctionsInternal(projectId, region);
-  if (res.unreachable.includes(region)) {
-    throw new FirebaseError(`Cloud Functions region ${region} is unavailable`);
-  }
-  return res.functions;
-}
-
-/**
  *  List all functions in all regions
  *  Customers should generally use backend.existingBackend and backend.checkAvailability.
  */

--- a/src/gcp/cloudlogging.spec.ts
+++ b/src/gcp/cloudlogging.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import * as nock from "nock";
+
+import * as cloudlogging from "./cloudlogging";
+import { FirebaseError } from "../error";
+import { cloudloggingOrigin } from "../api";
+
+describe("cloudlogging", () => {
+  before(() => {
+    nock.disableNetConnect();
+  });
+
+  after(() => {
+    nock.enableNetConnect();
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe("listEntries", () => {
+    it("should resolve with a list of log entries on success", async () => {
+      const entries = [{ logName: "log1" }, { logName: "log2" }];
+      nock(cloudloggingOrigin()).post("/v2/entries:list").reply(200, { entries });
+
+      await expect(
+        cloudlogging.listEntries("project", "filter", 10, "desc"),
+      ).to.eventually.deep.equal(entries);
+    });
+
+    it("should reject if the API call fails", async () => {
+      nock(cloudloggingOrigin()).post("/v2/entries:list").reply(404, { error: "not found" });
+
+      await expect(cloudlogging.listEntries("project", "filter", 10, "desc")).to.be.rejectedWith(
+        FirebaseError,
+        "Failed to retrieve log entries from Google Cloud.",
+      );
+    });
+  });
+});

--- a/src/gcp/cloudsql/cloudsqladmin.spec.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.spec.ts
@@ -1,0 +1,314 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as sinon from "sinon";
+
+import * as sqladmin from "../../gcp/cloudsql/cloudsqladmin";
+import * as iam from "../../gcp/iam";
+import { cloudSQLAdminOrigin } from "../../api";
+import { Options } from "../../options";
+import * as operationPoller from "../../operation-poller";
+import { Config } from "../../config";
+import { RC } from "../../rc";
+
+const PROJECT_ID = "test-project";
+const INSTANCE_ID = "test-instance";
+const DATABASE_ID = "test-database";
+const USERNAME = "test-user";
+const API_VERSION = "v1";
+
+const options: Options = {
+  project: PROJECT_ID,
+  auth: true,
+  cwd: "",
+  configPath: "",
+  only: "",
+  except: "",
+  config: new Config({}, { projectDir: "", cwd: "" }),
+  filteredTargets: [],
+  force: false,
+  json: false,
+  nonInteractive: false,
+  interactive: false,
+  debug: false,
+  rc: new RC(),
+};
+
+describe("cloudsqladmin", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    nock.cleanAll();
+  });
+
+  describe("iamUserIsCSQLAdmin", () => {
+    it("should return true if user has required permissions", async () => {
+      sandbox.stub(iam, "testIamPermissions").resolves({ allowed: [], missing: [], passed: true });
+      const result = await sqladmin.iamUserIsCSQLAdmin(options);
+      expect(result).to.be.true;
+    });
+
+    it("should return false if user does not have required permissions", async () => {
+      sandbox
+        .stub(iam, "testIamPermissions")
+        .resolves({ allowed: [], missing: ["p1"], passed: false });
+      const result = await sqladmin.iamUserIsCSQLAdmin(options);
+      expect(result).to.be.false;
+    });
+
+    it("should return false on IAM error", async () => {
+      sandbox.stub(iam, "testIamPermissions").rejects(new Error("IAM error"));
+      const result = await sqladmin.iamUserIsCSQLAdmin(options);
+      expect(result).to.be.false;
+    });
+  });
+
+  describe("listInstances", () => {
+    it("should return a list of instances on success", async () => {
+      const instances = [{ name: INSTANCE_ID }];
+      nock(cloudSQLAdminOrigin())
+        .get(`/${API_VERSION}/projects/${PROJECT_ID}/instances`)
+        .reply(200, { items: instances });
+
+      const result = await sqladmin.listInstances(PROJECT_ID);
+      expect(result).to.deep.equal(instances);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should handle allowlist error", async () => {
+      nock(cloudSQLAdminOrigin())
+        .post(`/${API_VERSION}/projects/${PROJECT_ID}/instances`)
+        .reply(400, {
+          error: {
+            message: "Not allowed to set system label: firebase-data-connect",
+          },
+        });
+
+      await expect(
+        sqladmin.createInstance({
+          projectId: PROJECT_ID,
+          location: "us-central",
+          instanceId: INSTANCE_ID,
+          enableGoogleMlIntegration: false,
+          freeTrial: false,
+        }),
+      ).to.be.rejectedWith("Cloud SQL free trial instances are not yet available in us-central");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("getInstance", () => {
+    it("should return an instance on success", async () => {
+      const instance = { name: INSTANCE_ID, state: "RUNNABLE" };
+      nock(cloudSQLAdminOrigin())
+        .get(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
+        .reply(200, instance);
+
+      const result = await sqladmin.getInstance(PROJECT_ID, INSTANCE_ID);
+      expect(result).to.deep.equal(instance);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should update an instance with google ml integration", async () => {
+      const instance = {
+        name: INSTANCE_ID,
+        project: PROJECT_ID,
+        settings: { databaseFlags: [] },
+      };
+      const op = { name: "op-name", status: "DONE" };
+      nock(cloudSQLAdminOrigin())
+        .patch(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
+        .reply(200, op);
+      sandbox.stub(operationPoller, "pollOperation").resolves(instance);
+
+      const result = await sqladmin.updateInstanceForDataConnect(instance as any, true);
+
+      expect(result).to.deep.equal(instance);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should throw if instance is in a failed state", async () => {
+      const instance = { name: INSTANCE_ID, state: "FAILED" };
+      nock(cloudSQLAdminOrigin())
+        .get(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
+        .reply(200, instance);
+
+      await expect(sqladmin.getInstance(PROJECT_ID, INSTANCE_ID)).to.be.rejected;
+    });
+  });
+
+  describe("instanceConsoleLink", () => {
+    it("should return the correct console link", () => {
+      const link = sqladmin.instanceConsoleLink(PROJECT_ID, INSTANCE_ID);
+      expect(link).to.equal(
+        `https://console.cloud.google.com/sql/instances/${INSTANCE_ID}/overview?project=${PROJECT_ID}`,
+      );
+    });
+  });
+
+  describe("createInstance", () => {
+    it("should create an instance", async () => {
+      nock(cloudSQLAdminOrigin())
+        .post(`/${API_VERSION}/projects/${PROJECT_ID}/instances`)
+        .reply(200, {});
+
+      await sqladmin.createInstance({
+        projectId: PROJECT_ID,
+        location: "us-central",
+        instanceId: INSTANCE_ID,
+        enableGoogleMlIntegration: false,
+        freeTrial: false,
+      });
+
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("updateInstanceForDataConnect", () => {
+    it("should update an instance", async () => {
+      const instance = {
+        name: INSTANCE_ID,
+        project: PROJECT_ID,
+        settings: { databaseFlags: [] },
+      };
+      const op = { name: "op-name", status: "DONE" };
+      nock(cloudSQLAdminOrigin())
+        .patch(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}`)
+        .reply(200, op);
+      sandbox.stub(operationPoller, "pollOperation").resolves(instance);
+
+      const result = await sqladmin.updateInstanceForDataConnect(instance as any, false);
+
+      expect(result).to.deep.equal(instance);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("Databases", () => {
+    it("should list databases", async () => {
+      const databases = [{ name: DATABASE_ID }];
+      nock(cloudSQLAdminOrigin())
+        .get(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/databases`)
+        .reply(200, { items: databases });
+
+      const result = await sqladmin.listDatabases(PROJECT_ID, INSTANCE_ID);
+      expect(result).to.deep.equal(databases);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should get a database", async () => {
+      const database = { name: DATABASE_ID };
+      nock(cloudSQLAdminOrigin())
+        .get(
+          `/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/databases/${DATABASE_ID}`,
+        )
+        .reply(200, database);
+
+      const result = await sqladmin.getDatabase(PROJECT_ID, INSTANCE_ID, DATABASE_ID);
+      expect(result).to.deep.equal(database);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should create a database", async () => {
+      const op = { name: "op-name", status: "DONE" };
+      const database = { name: DATABASE_ID };
+      nock(cloudSQLAdminOrigin())
+        .post(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/databases`)
+        .reply(200, op);
+      sandbox.stub(operationPoller, "pollOperation").resolves(database);
+
+      const result = await sqladmin.createDatabase(PROJECT_ID, INSTANCE_ID, DATABASE_ID);
+      expect(result).to.deep.equal(database);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should delete a database", async () => {
+      const database = { name: DATABASE_ID };
+      nock(cloudSQLAdminOrigin())
+        .delete(
+          `/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/databases/${DATABASE_ID}`,
+        )
+        .reply(200, database);
+
+      const result = await sqladmin.deleteDatabase(PROJECT_ID, INSTANCE_ID, DATABASE_ID);
+      expect(result).to.deep.equal(database);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("Users", () => {
+    it("should create a user", async () => {
+      const op = { name: "op-name", status: "DONE" };
+      const user = { name: USERNAME };
+      nock(cloudSQLAdminOrigin())
+        .post(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/users`)
+        .reply(200, op);
+      sandbox.stub(operationPoller, "pollOperation").resolves(user);
+
+      const result = await sqladmin.createUser(PROJECT_ID, INSTANCE_ID, "BUILT_IN", USERNAME);
+      expect(result).to.deep.equal(user);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should retry creating a user if built-in role is not ready", async () => {
+      const op = { name: "op-name", status: "DONE" };
+      const user = { name: USERNAME };
+      nock(cloudSQLAdminOrigin())
+        .post(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/users`)
+        .reply(400, {
+          error: {
+            message: "cloudsqliamuser",
+          },
+        });
+      nock(cloudSQLAdminOrigin())
+        .post(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/users`)
+        .reply(200, op);
+      sandbox.stub(operationPoller, "pollOperation").resolves(user);
+
+      const result = await sqladmin.createUser(PROJECT_ID, INSTANCE_ID, "BUILT_IN", USERNAME);
+
+      expect(result).to.deep.equal(user);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should get a user", async () => {
+      const user = { name: USERNAME };
+      nock(cloudSQLAdminOrigin())
+        .get(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/users/${USERNAME}`)
+        .reply(200, user);
+
+      const result = await sqladmin.getUser(PROJECT_ID, INSTANCE_ID, USERNAME);
+      expect(result).to.deep.equal(user);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should delete a user", async () => {
+      const user = { name: USERNAME };
+      nock(cloudSQLAdminOrigin())
+        .delete(
+          `/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/users?name=${USERNAME}`,
+        )
+        .reply(200, user);
+
+      const result = await sqladmin.deleteUser(PROJECT_ID, INSTANCE_ID, USERNAME);
+      expect(result).to.deep.equal(user);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should list users", async () => {
+      const users = [{ name: USERNAME }];
+      nock(cloudSQLAdminOrigin())
+        .get(`/${API_VERSION}/projects/${PROJECT_ID}/instances/${INSTANCE_ID}/users`)
+        .reply(200, { items: users });
+
+      const result = await sqladmin.listUsers(PROJECT_ID, INSTANCE_ID);
+      expect(result).to.deep.equal(users);
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+});
+n;


### PR DESCRIPTION
### Description
From Jules:

Nock based tests for API methods in src/gcp. These are a bit rote, but are helpful as breakage detectors.
