### PR TITLE
[FDC] init confirms Cloud SQL provision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - `firebase emulator:start` use a default project `demo-no-project` if no project can be found. (#9072)
 - `firebase init dataconnect` also supports bootstrapping flutter template. (#9084)
-- `firebase init dataconnect` confirms Cloud SQL provisioning. (#9084)
+- `firebase init dataconnect` confirms Cloud SQL provisioning. (#9095)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - `firebase emulator:start` use a default project `demo-no-project` if no project can be found. (#9072)
 - `firebase init dataconnect` also supports bootstrapping flutter template. (#9084)
+- `firebase init dataconnect` confirms Cloud SQL provisioning. (#9084)

--- a/src/init/features/dataconnect/index.spec.ts
+++ b/src/init/features/dataconnect/index.spec.ts
@@ -246,6 +246,7 @@ function mockRequiredInfo(info: Partial<init.RequiredInfo> = {}): init.RequiredI
     locationId: "europe-north3",
     cloudSqlInstanceId: "csql-instance",
     cloudSqlDatabase: "csql-db",
+    shouldProvisionCSQL: true,
     ...info,
   };
 }

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -2,7 +2,7 @@ import { join, basename } from "path";
 import * as clc from "colorette";
 import * as fs from "fs-extra";
 
-import { input, select } from "../../../prompt";
+import { input, select, confirm } from "../../../prompt";
 import { Config } from "../../../config";
 import { Setup } from "../..";
 import { setupCloudSql } from "../../../dataconnect/provisionCloudSql";
@@ -54,6 +54,8 @@ export interface RequiredInfo {
   locationId: string;
   cloudSqlInstanceId: string;
   cloudSqlDatabase: string;
+  // If true, we should provision a new Cloud SQL instance.
+  shouldProvisionCSQL: boolean;
   // If present, this is downloaded from an existing deployed service.
   serviceGql?: ServiceGQL;
 }
@@ -101,6 +103,7 @@ export async function askQuestions(setup: Setup): Promise<void> {
     locationId: "",
     cloudSqlInstanceId: "",
     cloudSqlDatabase: "",
+    shouldProvisionCSQL: false,
   };
   if (setup.projectId) {
     const hasBilling = await isBillingEnabled(setup);
@@ -623,6 +626,10 @@ async function promptForCloudSQL(setup: Setup, info: RequiredInfo): Promise<void
       message: "What location would like to use?",
       choices,
       default: "us-central1",
+    });
+    info.shouldProvisionCSQL = await confirm({
+      message: `Would you like to provision your Cloud SQL instance and database now?`,
+      default: true,
     });
   }
 

--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -194,8 +194,8 @@ async function actuateWithInfo(
       options,
     );
   }
-  const hasBilling = await isBillingEnabled(setup);
-  if (hasBilling) {
+  const provisionCSQL = info.shouldProvisionCSQL && (await isBillingEnabled(setup));
+  if (provisionCSQL) {
     // Kicks off Cloud SQL provisioning if the project has billing enabled.
     await setupCloudSql({
       projectId: projectId,
@@ -250,7 +250,7 @@ async function actuateWithInfo(
       projectId,
       info,
       schemaFiles,
-      hasBilling,
+      provisionCSQL,
     );
     await upsertSchema(saveSchemaGql);
     if (waitForCloudSQLProvision) {

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -80,7 +80,8 @@ export const init = tool(
               .string()
               .optional()
               .describe(
-                "The GCP Cloud SQL instance ID to use in the Firebase Data Connect service. By default, use <serviceId>-fdc.",
+                "The GCP Cloud SQL instance ID to use in the Firebase Data Connect service. By default, use <serviceId>-fdc. " +
+                "\nSet `provision_cloudsql` to true to start Cloud SQL provisioning.",
               ),
             cloudsql_database: z
               .string()

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -81,7 +81,7 @@ export const init = tool(
               .optional()
               .describe(
                 "The GCP Cloud SQL instance ID to use in the Firebase Data Connect service. By default, use <serviceId>-fdc. " +
-                "\nSet `provision_cloudsql` to true to start Cloud SQL provisioning.",
+                  "\nSet `provision_cloudsql` to true to start Cloud SQL provisioning.",
               ),
             cloudsql_database: z
               .string()

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -3,6 +3,7 @@ import { tool } from "../../tool";
 import { toContent } from "../../util";
 import { DEFAULT_RULES } from "../../../init/features/database";
 import { actuate, Setup, SetupInfo } from "../../../init/index";
+import { freeTrialTermsLink } from "../../../dataconnect/freeTrial";
 
 export const init = tool(
   {
@@ -91,7 +92,8 @@ export const init = tool(
               .optional()
               .default(true)
               .describe(
-                "Whether to provision the Cloud SQL instance as part of this initialization. Then first ",
+                "Whether to provision the Cloud SQL instance if `cloudsql_instance_id` doesn't exist already. " +
+                  `\nThis first instance is provided under the terms of the Data Connect no-cost trial ${freeTrialTermsLink()}.`,
               ),
           })
           .optional()

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -92,8 +92,8 @@ export const init = tool(
               .optional()
               .default(true)
               .describe(
-                "Whether to provision the Cloud SQL instance if `cloudsql_instance_id` doesn't exist already. " +
-                  `\nThis first instance is provided under the terms of the Data Connect no-cost trial ${freeTrialTermsLink()}.`,
+                "If true, provision the Cloud SQL instance if `cloudsql_instance_id` does not exist already. " +
+                  `\nThe first Cloud SQL instance in the project will use the Data Connect no-cost trial. See its terms of service: ${freeTrialTermsLink()}.`,
               ),
           })
           .optional()

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -90,7 +90,7 @@ export const init = tool(
             provision_cloudsql: z
               .boolean()
               .optional()
-              .default(true)
+              .default(false)
               .describe(
                 "If true, provision the Cloud SQL instance if `cloudsql_instance_id` does not exist already. " +
                   `\nThe first Cloud SQL instance in the project will use the Data Connect no-cost trial. See its terms of service: ${freeTrialTermsLink()}.`,

--- a/src/mcp/tools/core/init.ts
+++ b/src/mcp/tools/core/init.ts
@@ -86,6 +86,13 @@ export const init = tool(
               .optional()
               .default("fdcdb")
               .describe("The Postgres database ID to use in the Firebase Data Connect service."),
+            provision_cloudsql: z
+              .boolean()
+              .optional()
+              .default(true)
+              .describe(
+                "Whether to provision the Cloud SQL instance as part of this initialization. Then first ",
+              ),
           })
           .optional()
           .describe(
@@ -155,6 +162,7 @@ export const init = tool(
         locationId: features.dataconnect.location_id || "",
         cloudSqlInstanceId: features.dataconnect.cloudsql_instance_id || "",
         cloudSqlDatabase: features.dataconnect.cloudsql_database || "",
+        shouldProvisionCSQL: !!features.dataconnect.provision_cloudsql,
       };
       featureInfo.dataconnectSdk = {
         // Add FDC generated SDKs to all apps detected.


### PR DESCRIPTION
### Description

During `firebase init dataconnect`, add a confirmation prompt before provisioning the Cloud SQL instance.

In MCP tool `firebase_init`, add option to opt-in provision Cloud SQL instance. By default, don't provision Cloud SQL.

### Scenarios Tested
<img width="1410" height="836" alt="Screenshot 2025-09-08 at 11 28 26 AM" src="https://github.com/user-attachments/assets/ae9a5583-f3f8-4653-8eeb-6462e14a19c1" />

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
