### PR TITLE
PoC of `firebase login` tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - `firebase init dataconnect` confirms Cloud SQL provisioning. (#9095)
 - MCP `firebase_init` tool can download an existing FDC service returned from `dataconnect_list_services` (#9091)
 - Updated the Firebase Data Connect local toolkit to v2.13.0, which adds validation that checks that `_insert` data includes all non-null columns without defaults. (#9106)
+- Added `firebase_login` and `firebase_logout` MCP tools.

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -8,9 +8,10 @@ export const NO_PROJECT_ERROR = mcpError(
 );
 
 export function mcpAuthError(skipADC: boolean): CallToolResult {
-  const cmd = commandExistsSync("firebase") ? "firebase" : "npx -y firebase-tools";
   if (skipADC) {
-    return mcpError(`The user is not currently logged into the Firebase CLI, which is required to use this tool. Please run the 'firebase_login' tool to log in.`);
+    return mcpError(
+      `The user is not currently logged into the Firebase CLI, which is required to use this tool. Please run the 'firebase_login' tool to log in.`,
+    );
   }
   return mcpError(`The user is not currently logged into the Firebase CLI, which is required to use this tool. Please run the 'firebase_login' tool to log in, or instruct the user to configure [Application Default Credentials][ADC] on their machine.
 [ADC]: https://cloud.google.com/docs/authentication/application-default-credentials`);

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -10,16 +10,9 @@ export const NO_PROJECT_ERROR = mcpError(
 export function mcpAuthError(skipADC: boolean): CallToolResult {
   const cmd = commandExistsSync("firebase") ? "firebase" : "npx -y firebase-tools";
   if (skipADC) {
-    return mcpError(`The user is not currently logged into the Firebase CLI, which is required to use this tool. Please instruct the user to execute this shell command to sign in.
-\`\`\`sh
-${cmd} login
-\`\`\``);
+    return mcpError(`The user is not currently logged into the Firebase CLI, which is required to use this tool. Please run the 'firebase_login' tool to log in.`);
   }
-  return mcpError(`The user is not currently logged into the Firebase CLI, which is required to use this tool. Please instruct the user to execute this shell command to sign in or to configure [Application Default Credentials][ADC] on their machine.
-\`\`\`sh
-${cmd} login
-\`\`\`
-
+  return mcpError(`The user is not currently logged into the Firebase CLI, which is required to use this tool. Please run the 'firebase_login' tool to log in, or instruct the user to configure [Application Default Credentials][ADC] on their machine.
 [ADC]: https://cloud.google.com/docs/authentication/application-default-credentials`);
 }
 

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -1,6 +1,5 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { mcpError } from "./util";
-import { commandExistsSync } from "../utils";
 
 export const NO_PROJECT_ERROR = mcpError(
   'No active project was found. Use the `firebase_update_environment` tool to set the project directory to an absolute folder location containing a firebase.json config file. Alternatively, change the MCP server config to add [...,"--dir","/absolute/path/to/project/directory"] in its command-line arguments.',

--- a/src/mcp/tools/core/index.ts
+++ b/src/mcp/tools/core/index.ts
@@ -13,9 +13,11 @@ import { update_environment } from "./update_environment";
 import { list_projects } from "./list_projects";
 import { consult_assistant } from "./consult_assistant";
 import { login } from "./login";
+import { logout } from "./logout";
 
 export const coreTools: ServerTool[] = [
   login,
+  logout,
   get_project,
   list_apps,
   get_admin_sdk_config,

--- a/src/mcp/tools/core/index.ts
+++ b/src/mcp/tools/core/index.ts
@@ -12,8 +12,10 @@ import { get_environment } from "./get_environment";
 import { update_environment } from "./update_environment";
 import { list_projects } from "./list_projects";
 import { consult_assistant } from "./consult_assistant";
+import { login } from "./login";
 
 export const coreTools: ServerTool[] = [
+  login,
   get_project,
   list_apps,
   get_admin_sdk_config,

--- a/src/mcp/tools/core/login.spec.ts
+++ b/src/mcp/tools/core/login.spec.ts
@@ -30,7 +30,7 @@ describe("login tool", () => {
     const result = await login.fn({ authCode: undefined }, { host: server } as any);
 
     const expectedResult = toContent(
-      `Please visit this URL to login: https://fake.login.uri/auth\nYour session ID is: FAKE_SESSION_ID\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`,
+      `Please visit this URL to login: https://fake.login.uri/auth\nYour session ID is: FAKE_SESSION_ID\nInstruct the use to copy the authorization code from that link, and paste it into chat.\nThen, run this tool again with that as the authCode argument to complete the login.`,
     );
     expect(loginPrototyperStub.calledOnce).to.be.true;
     expect(result).to.deep.equal(expectedResult);

--- a/src/mcp/tools/core/login.spec.ts
+++ b/src/mcp/tools/core/login.spec.ts
@@ -30,13 +30,7 @@ describe("login tool", () => {
     const result = await login.fn({ authCode: undefined }, { host: server } as any);
 
     const expectedResult = toContent(
-      {
-        uri: "https://fake.login.uri/auth",
-        sessionId: "FAKE_SESSION_ID",
-      },
-      {
-        contentSuffix: `\nPlease visit this URL to login: https://fake.login.uri/auth\nYour session ID is: FAKE_SESSION_ID\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`,
-      },
+      `Please visit this URL to login: https://fake.login.uri/auth\nYour session ID is: FAKE_SESSION_ID\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`,
     );
     expect(loginPrototyperStub.calledOnce).to.be.true;
     expect(result).to.deep.equal(expectedResult);
@@ -50,12 +44,7 @@ describe("login tool", () => {
     const result = await login.fn({ authCode: "fake_auth_code" }, { host: server } as any);
 
     expect(fakeAuthorize.calledOnceWith("fake_auth_code")).to.be.true;
-    expect(result).to.deep.equal(
-      toContent({
-        status: "success",
-        user: { email: "test@example.com" },
-      }),
-    );
+    expect(result).to.deep.equal(toContent(`Successfully logged in as test@example.com`));
     expect((server as any).__login_authorize).to.not.exist;
   });
 

--- a/src/mcp/tools/core/login.spec.ts
+++ b/src/mcp/tools/core/login.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { login } from "./login";
+import { login, ServerWithLoginState } from "./login";
 import * as auth from "../../../auth";
 import { FirebaseMcpServer } from "../../../mcp";
 import { toContent } from "../../util";
@@ -34,18 +34,18 @@ describe("login tool", () => {
     );
     expect(loginPrototyperStub.calledOnce).to.be.true;
     expect(result).to.deep.equal(expectedResult);
-    expect((server as any).__login_authorize).to.exist;
+    expect((server as ServerWithLoginState).authorize).to.exist;
   });
 
   it("should call authorize when authCode is provided", async () => {
-    (server as any).__login_authorize = fakeAuthorize;
+    (server as ServerWithLoginState).authorize = fakeAuthorize;
     fakeAuthorize.resolves({ user: { email: "test@example.com" } });
 
     const result = await login.fn({ authCode: "fake_auth_code" }, { host: server } as any);
 
     expect(fakeAuthorize.calledOnceWith("fake_auth_code")).to.be.true;
     expect(result).to.deep.equal(toContent(`Successfully logged in as test@example.com`));
-    expect((server as any).__login_authorize).to.not.exist;
+    expect((server as ServerWithLoginState).authorize).to.not.exist;
   });
 
   it("should return an error if authCode is provided without starting the flow", async () => {

--- a/src/mcp/tools/core/login.spec.ts
+++ b/src/mcp/tools/core/login.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { login } from "./login";
+import * as auth from "../../../auth";
+import { FirebaseMcpServer } from "../../../mcp";
+import { toContent } from "../../util";
+
+describe("login tool", () => {
+  let sandbox: sinon.SinonSandbox;
+  let loginPrototyperStub: sinon.SinonStub;
+  let server: FirebaseMcpServer;
+  const fakeAuthorize = sinon.stub();
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    loginPrototyperStub = sandbox.stub(auth, "loginPrototyper").resolves({
+      uri: "https://fake.login.uri/auth",
+      sessionId: "FAKE_SESSION_ID",
+      authorize: fakeAuthorize,
+    });
+    server = new FirebaseMcpServer({ projectRoot: "" });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    fakeAuthorize.reset();
+  });
+
+  it("should return uri and sessionId when no authCode is provided", async () => {
+    const result = await login.fn({ authCode: undefined }, { host: server } as any);
+
+    const expectedResult = toContent(
+      {
+        uri: "https://fake.login.uri/auth",
+        sessionId: "FAKE_SESSION_ID",
+      },
+      {
+        contentSuffix: `\nPlease visit this URL to login: https://fake.login.uri/auth\nYour session ID is: FAKE_SESSION_ID\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`,
+      },
+    );
+    expect(loginPrototyperStub.calledOnce).to.be.true;
+    expect(result).to.deep.equal(expectedResult);
+    expect((server as any).__login_authorize).to.exist;
+  });
+
+  it("should call authorize when authCode is provided", async () => {
+    (server as any).__login_authorize = fakeAuthorize;
+    fakeAuthorize.resolves({ user: { email: "test@example.com" } });
+
+    const result = await login.fn({ authCode: "fake_auth_code" }, { host: server } as any);
+
+    expect(fakeAuthorize.calledOnceWith("fake_auth_code")).to.be.true;
+    expect(result).to.deep.equal(
+      toContent({
+        status: "success",
+        user: { email: "test@example.com" },
+      }),
+    );
+    expect((server as any).__login_authorize).to.not.exist;
+  });
+
+  it("should return an error if authCode is provided without starting the flow", async () => {
+    const result = await login.fn({ authCode: "fake_auth_code" }, { host: server } as any);
+
+    expect(result.isError).to.be.true;
+    expect(result.content[0].text).to.include("Login flow not started");
+  });
+});

--- a/src/mcp/tools/core/login.ts
+++ b/src/mcp/tools/core/login.ts
@@ -3,11 +3,14 @@ import { tool } from "../../tool";
 import { loginPrototyper } from "../../../auth";
 import { FirebaseMcpServer } from "../../../mcp";
 import { toContent, mcpError } from "../../util";
-
+import { User, UserCredentials } from "../../../types/auth";
 const LoginInputSchema = z.object({
   authCode: z.string().optional().describe("The authorization code from the login flow"),
 });
 
+export type ServerWithLoginState = FirebaseMcpServer & {
+  authorize?: (authCode: string) => Promise<UserCredentials>;
+}
 export const login = tool(
   {
     name: "login",
@@ -19,26 +22,28 @@ export const login = tool(
   },
   async (input: z.infer<typeof LoginInputSchema>, ctx: { host: FirebaseMcpServer }) => {
     const { authCode } = input;
-    const serverWithState = ctx.host as any;
+
+    const serverWithState: ServerWithLoginState = ctx.host;
 
     if (authCode) {
-      if (!serverWithState.__login_authorize) {
+      if (!serverWithState.authorize) {
         return mcpError(
           "Login flow not started. Please call this tool without the authCode argument first to get a login URI.",
         );
       }
 
       try {
-        const creds = await serverWithState.__login_authorize(authCode);
-        delete serverWithState.__login_authorize;
-        return toContent(`Successfully logged in as ${creds.user.email}`);
+        const creds = await serverWithState.authorize(authCode);
+        delete serverWithState.authorize;
+        const user = creds.user as User;
+        return toContent(`Successfully logged in as ${user.email}`);
       } catch (e: any) {
-        delete serverWithState.__login_authorize;
+        delete serverWithState.authorize;
         return mcpError(`Login failed: ${e.message}`);
       }
     } else {
       const prototyper = await loginPrototyper();
-      serverWithState.__login_authorize = prototyper.authorize;
+      serverWithState.authorize = prototyper.authorize;
       const result = {
         uri: prototyper.uri,
         sessionId: prototyper.sessionId,

--- a/src/mcp/tools/core/login.ts
+++ b/src/mcp/tools/core/login.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { tool } from "../../tool";
+import { loginPrototyper } from "../../../auth";
+import { FirebaseMcpServer } from "../../../mcp";
+import { toContent, mcpError } from "../../util";
+
+const LoginInputSchema = z.object({
+  authCode: z.string().optional().describe("The authorization code from the login flow"),
+});
+
+export const login = tool(
+  {
+    name: "login",
+    description: "Logs the user into Firebase.",
+    inputSchema: LoginInputSchema,
+    _meta: {
+      requiresAuth: false,
+    },
+  },
+  async (input: z.infer<typeof LoginInputSchema>, ctx: { host: FirebaseMcpServer }) => {
+    const { authCode } = input;
+    const serverWithState = ctx.host as any;
+
+    if (authCode) {
+      if (!serverWithState.__login_authorize) {
+        return mcpError(
+          "Login flow not started. Please call this tool without the authCode argument first to get a login URI.",
+        );
+      }
+
+      try {
+        const creds = await serverWithState.__login_authorize(authCode);
+        delete serverWithState.__login_authorize;
+        return toContent({
+          status: "success",
+          user: creds.user,
+        });
+      } catch (e: any) {
+        delete serverWithState.__login_authorize;
+        return mcpError(`Login failed: ${e.message}`);
+      }
+    } else {
+      const prototyper = await loginPrototyper();
+      serverWithState.__login_authorize = prototyper.authorize;
+      const result = {
+        uri: prototyper.uri,
+        sessionId: prototyper.sessionId,
+      };
+      const humanReadable = `\nPlease visit this URL to login: ${result.uri}\nYour session ID is: ${result.sessionId}\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`;
+      return toContent(result, { contentSuffix: humanReadable });
+    }
+  },
+);

--- a/src/mcp/tools/core/login.ts
+++ b/src/mcp/tools/core/login.ts
@@ -14,7 +14,7 @@ export type ServerWithLoginState = FirebaseMcpServer & {
 export const login = tool(
   {
     name: "login",
-    description: "Logs the user into Firebase.",
+    description: "Logs the user into the Firebase CLI and MCP server.",
     inputSchema: LoginInputSchema,
     _meta: {
       requiresAuth: false,

--- a/src/mcp/tools/core/login.ts
+++ b/src/mcp/tools/core/login.ts
@@ -10,7 +10,7 @@ const LoginInputSchema = z.object({
 
 export type ServerWithLoginState = FirebaseMcpServer & {
   authorize?: (authCode: string) => Promise<UserCredentials>;
-}
+};
 export const login = tool(
   {
     name: "login",
@@ -48,7 +48,7 @@ export const login = tool(
         uri: prototyper.uri,
         sessionId: prototyper.sessionId,
       };
-      const humanReadable = `Please visit this URL to login: ${result.uri}\nYour session ID is: ${result.sessionId}\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`;
+      const humanReadable = `Please visit this URL to login: ${result.uri}\nYour session ID is: ${result.sessionId}\nInstruct the use to copy the authorization code from that link, and paste it into chat.\nThen, run this tool again with that as the authCode argument to complete the login.`;
       return toContent(humanReadable);
     }
   },

--- a/src/mcp/tools/core/login.ts
+++ b/src/mcp/tools/core/login.ts
@@ -31,10 +31,7 @@ export const login = tool(
       try {
         const creds = await serverWithState.__login_authorize(authCode);
         delete serverWithState.__login_authorize;
-        return toContent({
-          status: "success",
-          user: creds.user,
-        });
+        return toContent(`Successfully logged in as ${creds.user.email}`);
       } catch (e: any) {
         delete serverWithState.__login_authorize;
         return mcpError(`Login failed: ${e.message}`);
@@ -46,8 +43,8 @@ export const login = tool(
         uri: prototyper.uri,
         sessionId: prototyper.sessionId,
       };
-      const humanReadable = `\nPlease visit this URL to login: ${result.uri}\nYour session ID is: ${result.sessionId}\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`;
-      return toContent(result, { contentSuffix: humanReadable });
+      const humanReadable = `Please visit this URL to login: ${result.uri}\nYour session ID is: ${result.sessionId}\nAfter you have the authorization code, call this tool again with the 'authCode' argument.`;
+      return toContent(humanReadable);
     }
   },
 );

--- a/src/mcp/tools/core/logout.spec.ts
+++ b/src/mcp/tools/core/logout.spec.ts
@@ -48,7 +48,7 @@ describe("logout tool", () => {
   it("should inform if no user is logged in", async () => {
     getAllAccountsStub.returns([]);
     const result = await logout.fn({ email: undefined }, {} as any);
-    expect(result).to.deep.equal(toContent("No need to logout, not logged in"));
+    expect(result).to.deep.equal(toContent("No need to log out, not logged in"));
   });
 
   it("should log out a single user", async () => {

--- a/src/mcp/tools/core/logout.spec.ts
+++ b/src/mcp/tools/core/logout.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { logout } from "./logout";
+import * as auth from "../../../auth";
+import { toContent } from "../../util";
+import { Account } from "../../../types/auth";
+
+describe("logout tool", () => {
+  let sandbox: sinon.SinonSandbox;
+  let getAllAccountsStub: sinon.SinonStub;
+  let getGlobalDefaultAccountStub: sinon.SinonStub;
+  let getAdditionalAccountsStub: sinon.SinonStub;
+  let setGlobalDefaultAccountStub: sinon.SinonStub;
+  let logoutStub: sinon.SinonStub;
+
+  const fakeAccount1: Account = {
+    user: { email: "test1@example.com" },
+    tokens: {
+      refresh_token: "token1",
+      access_token: "atok1",
+      id_token: "idtok1",
+      expires_at: 3600,
+    },
+  };
+  const fakeAccount2: Account = {
+    user: { email: "test2@example.com" },
+    tokens: {
+      refresh_token: "token2",
+      access_token: "atok2",
+      id_token: "idtok2",
+      expires_at: 3600,
+    },
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    getAllAccountsStub = sandbox.stub(auth, "getAllAccounts");
+    getGlobalDefaultAccountStub = sandbox.stub(auth, "getGlobalDefaultAccount");
+    getAdditionalAccountsStub = sandbox.stub(auth, "getAdditionalAccounts");
+    setGlobalDefaultAccountStub = sandbox.stub(auth, "setGlobalDefaultAccount");
+    logoutStub = sandbox.stub(auth, "logout").resolves();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should inform if no user is logged in", async () => {
+    getAllAccountsStub.returns([]);
+    const result = await logout.fn({ email: undefined }, {} as any);
+    expect(result).to.deep.equal(toContent("No need to logout, not logged in"));
+  });
+
+  it("should log out a single user", async () => {
+    getAllAccountsStub.returns([fakeAccount1]);
+    getGlobalDefaultAccountStub.returns(fakeAccount1);
+    getAdditionalAccountsStub.returns([]);
+
+    const result = await logout.fn({ email: undefined }, {} as any);
+
+    expect(logoutStub.calledOnceWith("token1")).to.be.true;
+    expect(result.content[0].text).to.include("Logged out from test1@example.com");
+  });
+
+  it("should log out a specific user by email", async () => {
+    getAllAccountsStub.returns([fakeAccount1, fakeAccount2]);
+    getGlobalDefaultAccountStub.returns(fakeAccount1);
+    getAdditionalAccountsStub.returns([fakeAccount2]);
+
+    const result = await logout.fn({ email: "test2@example.com" }, {} as any);
+
+    expect(logoutStub.calledOnceWith("token2")).to.be.true;
+    expect(logoutStub.callCount).to.equal(1);
+    expect(result.content[0].text).to.include("Logged out from test2@example.com");
+  });
+
+  it("should log out all users if no email is provided", async () => {
+    getAllAccountsStub.returns([fakeAccount1, fakeAccount2]);
+    getGlobalDefaultAccountStub.returns(fakeAccount1);
+    getAdditionalAccountsStub.returns([fakeAccount2]);
+
+    await logout.fn({ email: undefined }, {} as any);
+
+    expect(logoutStub.calledTwice).to.be.true;
+    expect(logoutStub.calledWith("token1")).to.be.true;
+    expect(logoutStub.calledWith("token2")).to.be.true;
+  });
+
+  it("should set a new default user when logging out the default", async () => {
+    getAllAccountsStub.returns([fakeAccount1, fakeAccount2]);
+    getGlobalDefaultAccountStub.returns(fakeAccount1);
+    getAdditionalAccountsStub.returns([fakeAccount2]);
+
+    await logout.fn({ email: "test1@example.com" }, {} as any);
+
+    expect(setGlobalDefaultAccountStub.calledOnceWith(fakeAccount2)).to.be.true;
+  });
+});

--- a/src/mcp/tools/core/logout.ts
+++ b/src/mcp/tools/core/logout.ts
@@ -1,0 +1,81 @@
+import { z } from "zod";
+import * as clc from "colorette";
+import { tool } from "../../tool";
+import { toContent } from "../../util";
+import {
+  getAllAccounts,
+  getGlobalDefaultAccount,
+  getAdditionalAccounts,
+  logout as authLogout,
+  setGlobalDefaultAccount,
+} from "../../../auth";
+import { logger } from "../../../logger";
+
+export const logout = tool(
+  {
+    name: "logout",
+    description: "Log the CLI out of Firebase",
+    inputSchema: z.object({
+      email: z
+        .string()
+        .optional()
+        .describe(
+          "The email of the account to log out. If not provided, all accounts will be logged out.",
+        ),
+    }),
+    _meta: {
+      requiresAuth: false,
+      requiresProject: false,
+    },
+  },
+  async ({ email }) => {
+    const allAccounts = getAllAccounts();
+    if (allAccounts.length === 0) {
+      return toContent("No need to log out, not logged in");
+    }
+
+    const defaultAccount = getGlobalDefaultAccount();
+    const additionalAccounts = getAdditionalAccounts();
+
+    const accountsToLogOut = email
+      ? allAccounts.filter((a) => a.user.email === email)
+      : allAccounts;
+
+    if (email && accountsToLogOut.length === 0) {
+      return toContent(`No account matches ${email}, can't log out.`);
+    }
+
+    // If they are logging out of their primary account, choose one to
+    // replace it.
+    const logoutDefault = email === defaultAccount?.user.email;
+    let newDefaultAccount = undefined;
+    if (logoutDefault && additionalAccounts.length > 0) {
+      newDefaultAccount = additionalAccounts[0];
+    }
+
+    const logoutMessages = [];
+    for (const account of accountsToLogOut) {
+      const token = account.tokens.refresh_token;
+
+      if (token) {
+        try {
+          await authLogout(token);
+          logoutMessages.push(`Logged out from ${clc.bold(account.user.email)}`);
+        } catch (e: unknown) {
+          if (e instanceof Error) {
+            logger.debug(e.message);
+          }
+          logoutMessages.push(
+            `Could not deauthorize ${account.user.email}, assuming already deauthorized.`,
+          );
+        }
+      }
+    }
+
+    if (newDefaultAccount) {
+      setGlobalDefaultAccount(newDefaultAccount);
+      logoutMessages.push(`Setting default account to "${newDefaultAccount.user.email}"`);
+    }
+    return toContent(logoutMessages.join("\n"));
+  },
+);

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -63,7 +63,10 @@ export function markdownDocsOfTools(): string {
 | Tool Name | Feature Group | Description |
 | --------- | ------------- | ----------- |`;
   for (const tool of allTools) {
-    const feature = tool.mcp?._meta?.feature || "";
+    let feature = tool.mcp?._meta?.feature || "";
+     if (feature === "firebase") {
+      feature = "core";
+    }
     doc += `
 | ${tool.mcp.name} | ${feature} | ${tool.mcp?.description || ""} |`;
   }

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -27,7 +27,7 @@ export function availableTools(activeFeatures?: ServerFeature[]): ServerTool[] {
 }
 
 const tools: Record<ServerFeature, ServerTool[]> = {
-  core: addFeaturePrefix("core", coreTools),
+  core: addFeaturePrefix("firebase", coreTools),
   firestore: addFeaturePrefix("firestore", firestoreTools),
   auth: addFeaturePrefix("auth", authTools),
   dataconnect: addFeaturePrefix("dataconnect", dataconnectTools),

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -27,7 +27,7 @@ export function availableTools(activeFeatures?: ServerFeature[]): ServerTool[] {
 }
 
 const tools: Record<ServerFeature, ServerTool[]> = {
-  core: addFeaturePrefix("firebase", coreTools),
+  core: addFeaturePrefix("core", coreTools),
   firestore: addFeaturePrefix("firestore", firestoreTools),
   auth: addFeaturePrefix("auth", authTools),
   dataconnect: addFeaturePrefix("dataconnect", dataconnectTools),
@@ -63,10 +63,7 @@ export function markdownDocsOfTools(): string {
 | Tool Name | Feature Group | Description |
 | --------- | ------------- | ----------- |`;
   for (const tool of allTools) {
-    let feature = tool.mcp?._meta?.feature || "";
-    if (feature === "firebase") {
-      feature = "core";
-    }
+    const feature = tool.mcp?._meta?.feature || "";
     doc += `
 | ${tool.mcp.name} | ${feature} | ${tool.mcp?.description || ""} |`;
   }

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -64,7 +64,7 @@ export function markdownDocsOfTools(): string {
 | --------- | ------------- | ----------- |`;
   for (const tool of allTools) {
     let feature = tool.mcp?._meta?.feature || "";
-     if (feature === "firebase") {
+    if (feature === "firebase") {
       feature = "core";
     }
     doc += `


### PR DESCRIPTION
### Description
Assisted by Jules:
Implement 'core_login' tool that logs you into Firebase. To use this tool, first call it with no auth code argument. It will get back a login URI, which the user should follow and get an auth code. Call the tool again with that authCode to complete the login.

### Scenarios Tested
- Run 'firebase logout'
- Run the tool via MCP inspector, complete the flow.
- Run 'firebase login', get 'already logged in' message