### PR TITLE
[FDC init] Handle error of template create

### DIFF
--- a/src/init/features/dataconnect/sdk.ts
+++ b/src/init/features/dataconnect/sdk.ts
@@ -75,18 +75,22 @@ export async function askQuestions(setup: Setup): Promise<void> {
         { name: "no", value: "no" },
       ],
     });
-    switch (choice) {
-      case "react":
-        await createReactApp(newUniqueId("web-app", listFiles(cwd)));
-        break;
-      case "next":
-        await createNextApp(newUniqueId("web-app", listFiles(cwd)));
-        break;
-      case "flutter":
-        await createFlutterApp(newUniqueId("flutter_app", listFiles(cwd)));
-        break;
-      case "no":
-        break;
+    try {
+      switch (choice) {
+        case "react":
+          await createReactApp(newUniqueId("web-app", listFiles(cwd)));
+          break;
+        case "next":
+          await createNextApp(newUniqueId("web-app", listFiles(cwd)));
+          break;
+        case "flutter":
+          await createFlutterApp(newUniqueId("flutter_app", listFiles(cwd)));
+          break;
+        case "no":
+          break;
+      }
+    } catch (err: any) {
+      logLabeledError("dataconnect", `Failed to create a ${choice} app template`);
     }
   }
 


### PR DESCRIPTION
If app template creation fails for any reason (e.g. npm or flutter command is not found or stale), FDC init flow should log an error and continue without generating SDKs.

<img width="1148" height="821" alt="Screenshot 2025-09-12 at 9 24 49 PM" src="https://github.com/user-attachments/assets/78f08aad-68e2-4190-abfd-371fa9d3223c" />
