### PR TITLE
More resilient release script

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,12 +10,15 @@ printusage() {
   echo "  version: 'patch', 'minor', 'major', or 'artifactsOnly'"
 }
 
+touch /workspace/version_number.txt
+
 VERSION=$1
 if [[ $VERSION == "" ]]; then
   printusage
   exit 1
 elif [[ $VERSION == "artifactsOnly" ]]; then
   echo "Skipping npm package publish since VERSION is artifactsOnly."
+  npm view firebase-tools version > /workspace/version_number.txt
   exit 0
 elif [[ ! ($VERSION == "patch" || $VERSION == "minor" || $VERSION == "major") ]]; then
   printusage
@@ -81,6 +84,7 @@ echo "Ran tests."
 echo "Making a $VERSION version..."
 npm version $VERSION
 NEW_VERSION=$(jq -r ".version" package.json)
+echo $NEW_VERSION > /workspace/version_number.txt
 echo "Made a $VERSION version."
 
 echo "Making the release notes..."

--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -117,12 +117,6 @@ steps:
     entrypoint: "node"
     args: ["/usr/src/app/pipeline.js", "--package=firebase-tools@latest", "--publish"]
 
-  # Grab the latest version, store in workspace
-  - id: "Read New Version Number from npm"
-    name: "node"
-    entrypoint: "sh"
-    args: ["-c", "npm view firebase-tools version > /workspace/version_number.txt"]
-
   # Publish the Firebase docker image
   - name: "gcr.io/cloud-builders/docker"
     entrypoint: "sh"


### PR DESCRIPTION
### Description
Update release script to have a more reliable method of getting the next version number. 
Previously, this script just waited a while for NPM, and then read the latest version from there. Over the past month or so, this has repeatedly failed and generated artifacts for latestVersion - 1. 


