### PR TITLE
Fix never resolved grouped promise in apphosting release.spec.ts test

### DIFF
--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -66,7 +66,7 @@ describe("apphosting", () => {
           },
         },
       };
-      // Promise.allSettled is not resolving as expected with stubed tests.
+      // Promise.allSettled is not resolving as expected with stubbed Promise.
       // We stub allSettled here as a hack.
       sinon.stub(Promise, "allSettled").resolves([]);
       orchestrateRolloutStub = sinon.stub(rollout, "orchestrateRollout").resolves({


### PR DESCRIPTION
Promise.allSettled is not being resolved with stubbed Promise. The test passes but then the called function hangs.