### PR TITLE
[FDC] Support private IP Cloud SQL with VPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,4 +3,4 @@
 - `firebase_update_environment` MCP tool supports accepting Gemini in Firebase Terms of Service.
 - Fixed a bug when `firebase init dataconnect` failed to create a React app when launched from VS Code extension (#9171).
 - Improved the clarity of the `firebase apptesting:execute` command when you have zero or multiple apps.
-- `firebase dataconnect:sql:migrate` now supports private IP Cloud SQL instance within its VPC. (##9200)
+- `firebase dataconnect:sql:migrate` now supports Cloud SQL instances with only private IPs. The command must be run in the same VPC of the instance to work. (##9200)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - `firebase_update_environment` MCP tool supports accepting Gemini in Firebase Terms of Service.
 - Fixed a bug when `firebase init dataconnect` failed to create a React app when launched from VS Code extension (#9171).
 - Improved the clarity of the `firebase apptesting:execute` command when you have zero or multiple apps.
+- `firebase dataconnect:sql:migrate` now supports private IP Cloud SQL instance within its VPC. (##9200)

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -140,7 +140,7 @@ export async function upsertSchema(
     apiOrigin: dataconnectOrigin(),
     apiVersion: DATACONNECT_API_VERSION,
     operationResourceName: op.body.name,
-    masterTimeout: 120000,
+    masterTimeout: 10000,
   });
 }
 

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -45,14 +45,14 @@ async function upsertInstance(args: {
       if (dryRun) {
         utils.logLabeledBullet(
           "dataconnect",
-          `Cloud SQL instance ${clc.bold(instanceId)} settings not compatible with Firebase Data Connect. ` +
+          `Cloud SQL instance ${clc.bold(instanceId)} settings are not compatible with Firebase Data Connect. ` +
             `It will be updated on your next deploy.` +
             why,
         );
       } else {
         utils.logLabeledBullet(
           "dataconnect",
-          `Cloud SQL instance ${clc.bold(instanceId)} settings not compatible with Firebase Data Connect. ` +
+          `Cloud SQL instance ${clc.bold(instanceId)} settings are not compatible with Firebase Data Connect. ` +
             why,
         );
         await promiseWithSpinner(

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -169,7 +169,7 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
     ${clc.bold("firebase dataconnect:sql:migrate")} will only work within its VPC (e.g. GCE, GKE).`,
     );
     if (!settings.ipConfiguration?.pscConfig?.pscEnabled) {
-      reason += "\n - to enable VPC private service connection for Google Cloud Services.";
+      reason += "\n - to enable VPC Private Service Connect (PSC) for Google Cloud Services.";
     }
   }
 

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -172,7 +172,6 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
     if (!settings.ipConfiguration?.enablePrivatePathForGoogleCloudServices) {
       reason += "\n - to enable Private Path for Google Cloud Services.";
     }
-    reason += "\n - to enable Private Path for Google Cloud Services.";
   }
 
   if (requireGoogleMlIntegration) {

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -161,6 +161,7 @@ async function upsertDatabase(args: {
 export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: boolean): string {
   let reason = "";
   const settings = instance.settings;
+  // console.log("settings", settings);
   if (!settings.ipConfiguration?.ipv4Enabled) {
     utils.logLabeledWarning(
       "dataconnect",
@@ -168,10 +169,10 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
     ${clc.bold("firebase dataconnect:sql:migrate")} will only work within its VPC (e.g. GCE, GKE).`,
     );
     // Cloud SQL instances with only private IP must enable PSC for Data Connect backend to connect to it.
-    if (!settings.ipConfiguration?.pscConfig?.pscEnabled) {
-      reason += "\n - to enable VPC Private Service Connect (PSC) for Google Cloud Services.";
+    if (!settings.ipConfiguration?.enablePrivatePathForGoogleCloudServices) {
+      reason += "\n - to enable Private Path for Google Cloud Services.";
     }
-    reason += "\n - to enable VPC Private Service Connect (PSC) for Google Cloud Services.";
+    reason += "\n - to enable Private Path for Google Cloud Services.";
   }
 
   if (requireGoogleMlIntegration) {

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -167,8 +167,11 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
       `Cloud SQL instance ${clc.bold(instance.name)} does not have a public IP.
     ${clc.bold("firebase dataconnect:sql:migrate")} will only work within its VPC (e.g. GCE, GKE).`,
     );
-    // Cloud SQL instances with only private IP must enable PSC for Data Connect backend to connect to it.
-    if (!settings.ipConfiguration?.enablePrivatePathForGoogleCloudServices) {
+    if (
+      settings.ipConfiguration?.privateNetwork &&
+      !settings.ipConfiguration?.enablePrivatePathForGoogleCloudServices
+    ) {
+      // Cloud SQL instances with only private IP must enable PSC for Data Connect backend to connect to it.
       reason += "\n - to enable Private Path for Google Cloud Services.";
     }
   }

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -36,20 +36,23 @@ async function upsertInstance(args: {
   const { projectId, instanceId, requireGoogleMlIntegration, dryRun } = args;
   try {
     const existingInstance = await cloudSqlAdminClient.getInstance(projectId, instanceId);
-    utils.logLabeledBullet("dataconnect", `Found existing Cloud SQL instance ${instanceId}.`);
+    utils.logLabeledBullet(
+      "dataconnect",
+      `Found existing Cloud SQL instance ${clc.bold(instanceId)}.`,
+    );
     const why = getUpdateReason(existingInstance, requireGoogleMlIntegration);
     if (why) {
       if (dryRun) {
         utils.logLabeledBullet(
           "dataconnect",
-          `Cloud SQL instance ${instanceId} settings not compatible with Firebase Data Connect. ` +
+          `Cloud SQL instance ${clc.bold(instanceId)} settings not compatible with Firebase Data Connect. ` +
             `It will be updated on your next deploy.` +
             why,
         );
       } else {
         utils.logLabeledBullet(
           "dataconnect",
-          `Cloud SQL instance ${instanceId} settings not compatible with Firebase Data Connect. ` +
+          `Cloud SQL instance ${clc.bold(instanceId)} settings not compatible with Firebase Data Connect. ` +
             why,
         );
         await promiseWithSpinner(
@@ -84,7 +87,7 @@ async function createInstance(args: {
   if (dryRun) {
     utils.logLabeledBullet(
       "dataconnect",
-      `Cloud SQL Instance ${instanceId} not found. It will be created on your next deploy.`,
+      `Cloud SQL Instance ${clc.bold(instanceId)} not found. It will be created on your next deploy.`,
     );
   } else {
     await cloudSqlAdminClient.createInstance({
@@ -110,7 +113,7 @@ export function cloudSQLBeingCreated(
   includeFreeTrialToS?: boolean,
 ): string {
   return (
-    `Cloud SQL Instance ${instanceId} is being created.` +
+    `Cloud SQL Instance ${clc.bold(instanceId)} is being created.` +
     (includeFreeTrialToS
       ? `\nThis instance is provided under the terms of the Data Connect no-cost trial ${freeTrialTermsLink()}`
       : "") +

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -171,6 +171,7 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
     if (!settings.ipConfiguration?.pscConfig?.pscEnabled) {
       reason += "\n - to enable VPC Private Service Connect (PSC) for Google Cloud Services.";
     }
+    reason += "\n - to enable public IP.";
   }
 
   if (requireGoogleMlIntegration) {

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -171,7 +171,7 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
     if (!settings.ipConfiguration?.pscConfig?.pscEnabled) {
       reason += "\n - to enable VPC Private Service Connect (PSC) for Google Cloud Services.";
     }
-    reason += "\n - to enable public IP.";
+    reason += "\n - to enable VPC Private Service Connect (PSC) for Google Cloud Services.";
   }
 
   if (requireGoogleMlIntegration) {

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -165,6 +165,9 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
       `Cloud SQL instance ${clc.bold(instance.name)} does not have a public IP.
     ${clc.bold("firebase dataconnect:sql:migrate")} will only work within its VPC (e.g. GCE, GKE).`,
     );
+    if (!settings.ipConfiguration?.pscConfig?.pscEnabled) {
+      reason += "\n - to enable VPC private service connection for Google Cloud Services.";
+    }
   }
 
   if (requireGoogleMlIntegration) {

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -161,7 +161,6 @@ async function upsertDatabase(args: {
 export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: boolean): string {
   let reason = "";
   const settings = instance.settings;
-  // console.log("settings", settings);
   if (!settings.ipConfiguration?.ipv4Enabled) {
     utils.logLabeledWarning(
       "dataconnect",

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -162,8 +162,8 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
   if (!settings.ipConfiguration?.ipv4Enabled) {
     utils.logLabeledWarning(
       "dataconnect",
-      `Cloud SQL instance ${instance.name} does not have a public IP address.
-  ${clc.bold("firebase dataconnect:sql:migrate")} works only in the VPC that the Cloud SQL instance is in.`,
+      `Cloud SQL instance ${clc.bold(instance.name)} does not have a public IP.
+    ${clc.bold("firebase dataconnect:sql:migrate")} will only work within its VPC (e.g. GCE, GKE).`,
     );
   }
 

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -161,13 +161,13 @@ async function upsertDatabase(args: {
 export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: boolean): string {
   let reason = "";
   const settings = instance.settings;
-  // Cloud SQL instances must have public IP enabled to be used with Firebase Data Connect.
   if (!settings.ipConfiguration?.ipv4Enabled) {
     utils.logLabeledWarning(
       "dataconnect",
       `Cloud SQL instance ${clc.bold(instance.name)} does not have a public IP.
     ${clc.bold("firebase dataconnect:sql:migrate")} will only work within its VPC (e.g. GCE, GKE).`,
     );
+    // Cloud SQL instances with only private IP must enable PSC for Data Connect backend to connect to it.
     if (!settings.ipConfiguration?.pscConfig?.pscEnabled) {
       reason += "\n - to enable VPC Private Service Connect (PSC) for Google Cloud Services.";
     }

--- a/src/dataconnect/provisionCloudSql.ts
+++ b/src/dataconnect/provisionCloudSql.ts
@@ -1,5 +1,6 @@
 import * as cloudSqlAdminClient from "../gcp/cloudsql/cloudsqladmin";
 import * as utils from "../utils";
+import * as clc from "colorette";
 import { grantRolesToCloudSqlServiceAccount } from "./checkIam";
 import { Instance } from "../gcp/cloudsql/types";
 import { promiseWithSpinner } from "../utils";
@@ -159,7 +160,11 @@ export function getUpdateReason(instance: Instance, requireGoogleMlIntegration: 
   const settings = instance.settings;
   // Cloud SQL instances must have public IP enabled to be used with Firebase Data Connect.
   if (!settings.ipConfiguration?.ipv4Enabled) {
-    reason += "\n - to enable public IP.";
+    utils.logLabeledWarning(
+      "dataconnect",
+      `Cloud SQL instance ${instance.name} does not have a public IP address.
+  ${clc.bold("firebase dataconnect:sql:migrate")} works only in the VPC that the Cloud SQL instance is in.`,
+    );
   }
 
   if (requireGoogleMlIntegration) {

--- a/src/gcp/cloudsql/cloudsqladmin.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.ts
@@ -1,5 +1,6 @@
 import { Client } from "../../apiv2";
 import { cloudSQLAdminOrigin } from "../../api";
+import * as clc from "colorette";
 import * as operationPoller from "../../operation-poller";
 import { Instance, Database, User, UserType, DatabaseFlag } from "./types";
 import { needProjectId } from "../../projectUtils";
@@ -47,7 +48,7 @@ export async function getInstance(projectId: string, instanceId: string): Promis
   const res = await client.get<Instance>(`projects/${projectId}/instances/${instanceId}`);
   if (res.body.state === "FAILED") {
     throw new FirebaseError(
-      `Cloud SQL instance ${instanceId} is in a failed state.\nGo to ${instanceConsoleLink(projectId, instanceId)} to repair or delete it.`,
+      `Cloud SQL instance ${clc.bold(instanceId)} is in a failed state.\nGo to ${instanceConsoleLink(projectId, instanceId)} to repair or delete it.`,
     );
   }
   return res.body;

--- a/src/gcp/cloudsql/cloudsqladmin.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.ts
@@ -124,7 +124,7 @@ export async function updateInstanceForDataConnect(
         ipConfiguration: {
           pscConfig: {
             pscEnabled: true,
-            allowedConsumerProjects: [],
+            allowedConsumerProjects: [instance.project],
           },
         },
         databaseFlags: dbFlags,

--- a/src/gcp/cloudsql/cloudsqladmin.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.ts
@@ -121,7 +121,10 @@ export async function updateInstanceForDataConnect(
     {
       settings: {
         ipConfiguration: {
-          ipv4Enabled: true,
+          pscConfig: {
+            pscEnabled: true,
+            allowedConsumerProjects: [],
+          },
         },
         databaseFlags: dbFlags,
         enableGoogleMlIntegration,

--- a/src/gcp/cloudsql/cloudsqladmin.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.ts
@@ -122,10 +122,7 @@ export async function updateInstanceForDataConnect(
     {
       settings: {
         ipConfiguration: {
-          pscConfig: {
-            pscEnabled: true,
-            allowedConsumerProjects: [instance.project],
-          },
+          enablePrivatePathForGoogleCloudServices: true,
         },
         databaseFlags: dbFlags,
         enableGoogleMlIntegration,

--- a/src/gcp/cloudsql/cloudsqladmin.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.ts
@@ -122,7 +122,8 @@ export async function updateInstanceForDataConnect(
     {
       settings: {
         ipConfiguration: {
-          enablePrivatePathForGoogleCloudServices: true,
+          enablePrivatePathForGoogleCloudServices:
+            !!instance?.settings?.ipConfiguration?.privateNetwork,
         },
         databaseFlags: dbFlags,
         enableGoogleMlIntegration,

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -68,9 +68,8 @@ export async function execute(
       break;
     }
   }
-  const clientOpts = await connector.getOptions(connectionOpts);
   const pool = new pg.Pool({
-    ...clientOpts,
+    ...(await connector.getOptions(connectionOpts)),
     connectionTimeoutMillis: 1000,
     password: opts.password,
     user: opts.username,

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -11,7 +11,6 @@ import { logger } from "../../logger";
 import { FirebaseError } from "../../error";
 import { Options } from "../../options";
 import { FBToolsAuthClient } from "./fbToolsAuthClient";
-import { i } from "pg-gateway/dist/connection-Wgmmyk18";
 
 export async function execute(
   sqlStatements: string[],

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -31,7 +31,6 @@ export async function execute(
   const ipType = instance.ipAddresses.some((ip) => ip.type === "PRIMARY")
     ? IpAddressTypes.PUBLIC
     : IpAddressTypes.PRIVATE;
-  console.log("ipType", ipType);
   if (!connectionName) {
     throw new FirebaseError(
       `Could not get instance connection string for ${opts.instanceId}:${opts.databaseId}`,

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -50,6 +50,7 @@ export async function execute(
       });
       pool = new pg.Pool({
         ...clientOpts,
+        connectionTimeoutMillis: 1000,
         user: opts.username,
         database: opts.databaseId,
       });
@@ -67,6 +68,7 @@ export async function execute(
       });
       pool = new pg.Pool({
         ...clientOpts,
+        connectionTimeoutMillis: 1000,
         user: opts.username,
         database: opts.databaseId,
       });
@@ -86,6 +88,7 @@ export async function execute(
       });
       pool = new pg.Pool({
         ...clientOpts,
+        connectionTimeoutMillis: 1000,
         user: opts.username,
         password: opts.password,
         database: opts.databaseId,

--- a/src/gcp/cloudsql/connect.ts
+++ b/src/gcp/cloudsql/connect.ts
@@ -11,6 +11,7 @@ import { logger } from "../../logger";
 import { FirebaseError } from "../../error";
 import { Options } from "../../options";
 import { FBToolsAuthClient } from "./fbToolsAuthClient";
+import { i } from "pg-gateway/dist/connection-Wgmmyk18";
 
 export async function execute(
   sqlStatements: string[],
@@ -28,6 +29,10 @@ export async function execute(
   const instance = await cloudSqlAdminClient.getInstance(opts.projectId, opts.instanceId);
   const user = await cloudSqlAdminClient.getUser(opts.projectId, opts.instanceId, opts.username);
   const connectionName = instance.connectionName;
+  const ipType = instance.ipAddresses.some((ip) => ip.type === "PRIMARY")
+    ? IpAddressTypes.PUBLIC
+    : IpAddressTypes.PRIVATE;
+  console.log("ipType", ipType);
   if (!connectionName) {
     throw new FirebaseError(
       `Could not get instance connection string for ${opts.instanceId}:${opts.databaseId}`,
@@ -42,7 +47,7 @@ export async function execute(
       });
       const clientOpts = await connector.getOptions({
         instanceConnectionName: connectionName,
-        ipType: IpAddressTypes.PUBLIC,
+        ipType: ipType,
         authType: AuthTypes.IAM,
       });
       pool = new pg.Pool({
@@ -59,7 +64,7 @@ export async function execute(
       // FR to add support for OAuth2 tokens.
       const clientOpts = await connector.getOptions({
         instanceConnectionName: connectionName,
-        ipType: IpAddressTypes.PUBLIC,
+        ipType: ipType,
         authType: AuthTypes.IAM,
       });
       pool = new pg.Pool({
@@ -79,7 +84,7 @@ export async function execute(
       });
       const clientOpts = await connector.getOptions({
         instanceConnectionName: connectionName,
-        ipType: IpAddressTypes.PUBLIC,
+        ipType: ipType,
       });
       pool = new pg.Pool({
         ...clientOpts,

--- a/src/gcp/cloudsql/types.ts
+++ b/src/gcp/cloudsql/types.ts
@@ -23,6 +23,7 @@ export interface IpConfiguration {
     allowedConsumerProjects: string[];
     pscEnabled: boolean;
   };
+  enablePrivatePathForGoogleCloudServices?: boolean;
 }
 
 export interface InstanceSettings {


### PR DESCRIPTION
Required settings
```
  const op = await client.patch<Partial<Instance>, Operation>(
    `projects/${instance.project}/instances/${instance.name}`,
    {
      settings: {
        ipConfiguration: {
          enablePrivatePathForGoogleCloudServices: /** iff has private IP */,
        },
        databaseFlags: dbFlags,
        enableGoogleMlIntegration,
      },
    },
  );
```

### `firebase deploy` with a private IP instance
<img width="1204" height="410" alt="Screenshot 2025-09-26 at 4 15 50 PM" src="https://github.com/user-attachments/assets/8effcc2f-da28-4809-b9dd-de450315b7eb" />

<img width="1204" height="191" alt="Screenshot 2025-09-26 at 4 16 16 PM" src="https://github.com/user-attachments/assets/b408d908-5a0a-47d9-8441-c60dba444cda" />


###  In a GCE VM within the VPC

<img width="1374" height="703" alt="Screenshot 2025-09-26 at 4 53 24 PM" src="https://github.com/user-attachments/assets/ad1beadd-ee25-4d33-82a2-198271d76752" />

<img width="1374" height="703" alt="Screenshot 2025-09-26 at 4 55 07 PM" src="https://github.com/user-attachments/assets/34b51876-76ae-4807-9da5-f8d43355c2ec" />
