### PR TITLE
Fixing firestore deploy on fresh projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Fixed a bug when `firebase init dataconnect` failed to create a React app when launched from VS Code extension (#9171).
 - Improved the clarity of the `firebase apptesting:execute` command when you have zero or multiple apps.
 - `firebase dataconnect:sql:migrate` now supports Cloud SQL instances with only private IPs. The command must be run in the same VPC of the instance to work. (##9200)
+- Fixed an issue where `firebase deploy --only firestore` would fail with 403 errors on projects that never had a database created.

--- a/src/deploy/firestore/deploy.ts
+++ b/src/deploy/firestore/deploy.ts
@@ -1,68 +1,12 @@
 import * as clc from "colorette";
 
 import { FirestoreApi } from "../../firestore/api";
-import * as types from "../../firestore/api-types";
 import { logger } from "../../logger";
 import * as utils from "../../utils";
 import { RulesDeploy, RulesetServiceType } from "../../rulesDeploy";
 import { IndexContext } from "./prepare";
-import { FirestoreConfig } from "../../firebaseConfig";
 import { sleep } from "../../utils";
 import { Options } from "../../options";
-import { FirebaseError } from "../../error";
-
-async function createDatabase(context: any, options: Options): Promise<void> {
-  let firestoreCfg: FirestoreConfig = options.config.data.firestore;
-  if (Array.isArray(firestoreCfg)) {
-    firestoreCfg = firestoreCfg[0];
-  }
-  if (!options.projectId) {
-    throw new FirebaseError("Project ID is required to create a Firestore database.");
-  }
-  if (!firestoreCfg) {
-    throw new FirebaseError("Firestore database configuration not found in firebase.json.");
-  }
-  if (!firestoreCfg.database) {
-    firestoreCfg.database = "(default)";
-  }
-
-  let edition: types.DatabaseEdition = types.DatabaseEdition.STANDARD;
-  if (firestoreCfg.edition) {
-    const upperEdition = firestoreCfg.edition.toUpperCase();
-    if (
-      upperEdition !== types.DatabaseEdition.STANDARD &&
-      upperEdition !== types.DatabaseEdition.ENTERPRISE
-    ) {
-      throw new FirebaseError(
-        `Invalid edition specified for database in firebase.json: ${firestoreCfg.edition}`,
-      );
-    }
-    edition = upperEdition as types.DatabaseEdition;
-  }
-
-  const api = new FirestoreApi();
-  try {
-    await api.getDatabase(options.projectId, firestoreCfg.database);
-  } catch (e: any) {
-    if (e.status === 404) {
-      // Database is not found. Let's create it.
-      utils.logLabeledBullet(
-        "firetore",
-        `Creating the new Firestore database ${firestoreCfg.database}...`,
-      );
-      const createDatabaseReq: types.CreateDatabaseReq = {
-        project: options.projectId,
-        databaseId: firestoreCfg.database,
-        locationId: firestoreCfg.location || "nam5", // Default to 'nam5' if location is not specified
-        type: types.DatabaseType.FIRESTORE_NATIVE,
-        databaseEdition: edition,
-        deleteProtectionState: types.DatabaseDeleteProtectionState.DISABLED,
-        pointInTimeRecoveryEnablement: types.PointInTimeRecoveryEnablement.DISABLED,
-      };
-      await api.createDatabase(createDatabaseReq);
-    }
-  }
-}
 
 /**
  * Deploys Firestore Rules.
@@ -129,7 +73,6 @@ async function deployIndexes(context: any, options: any): Promise<void> {
  * @param options The CLI options object.
  */
 export default async function (context: any, options: Options): Promise<void> {
-  await createDatabase(context, options);
   await deployRules(context);
   await deployIndexes(context, options);
 }

--- a/src/deploy/firestore/prepare.ts
+++ b/src/deploy/firestore/prepare.ts
@@ -107,7 +107,7 @@ async function createDatabase(context: any, options: Options): Promise<void> {
     if (e.status === 404) {
       // Database is not found. Let's create it.
       utils.logLabeledBullet(
-        "firetore",
+        "firestore",
         `Creating the new Firestore database ${firestoreCfg.database}...`,
       );
       const createDatabaseReq: types.CreateDatabaseReq = {


### PR DESCRIPTION
### Description
`deploy --only firestore` was breaking on fresh projects for 2 reasons:
- First, it tried to call the `:test` endpoint to compile rules before any database was created. This would fail with 403 errors (presumably it needs p4sa provisioning to be performed?)
- Secondly, we weren't actually polling on the operation returned by create database, so it would sometimes try to deploy rules before the operation completed.

This PR fixes both.

### Scenarios tested

Before, broken: 
<img width="1012" height="190" alt="Screenshot 2025-09-30 at 2 58 50 PM" src="https://github.com/user-attachments/assets/84b759dd-0f9b-4704-a825-675bcc7f83d5" />
After, working on a fresh project:
<img width="667" height="333" alt="Screenshot 2025-09-30 at 3 19 43 PM" src="https://github.com/user-attachments/assets/a171a4be-9fbe-4c96-8014-c0c20c14b351" />
