### PR TITLE
clarify backend service use cases and ensure user permission before de…

### DIFF
--- a/src/mcp/prompts/core/init.ts
+++ b/src/mcp/prompts/core/init.ts
@@ -80,7 +80,7 @@ IMPORTANT: The backend setup guide is for web apps only. If the user requests ba
 
 The following Firebase services are available to be configured. Use the Firebase \`read_resources\` tool to load their instructions for further guidance.
 
-- [Backend Services](firebase://guides/init/backend): Read this resource to setup backend services for the user such as setting up a database, a user authentication sign up and login page, and deploying your app.
+- [Backend Services](firebase://guides/init/backend): Read this resource to setup backend services for the user such as a database, a user authentication sign up and login page, or deployments for static web apps.
 - [GenAI Services](firebase://guides/init/ai): Read this resource to setup GenAI services for the user such as building agents, LLM usage, unstructured data analysis, image editing, video generation, etc.
 
 UNAVAILABLE SERVICES: Analytics, Remote Config (feature flagging), A/B testing, Crashlytics (crash reporting), and Cloud Messaging (push notifications) are not yet available for setup via this command.

--- a/src/mcp/prompts/core/init.ts
+++ b/src/mcp/prompts/core/init.ts
@@ -80,7 +80,7 @@ IMPORTANT: The backend setup guide is for web apps only. If the user requests ba
 
 The following Firebase services are available to be configured. Use the Firebase \`read_resources\` tool to load their instructions for further guidance.
 
-- [Backend Services](firebase://guides/init/backend): Read this resource to setup backend services for the user such as user authentication, database, or hosting.
+- [Backend Services](firebase://guides/init/backend): Read this resource to setup backend services for the user such as setting up a database, a user authentication sign up and login page, and deploying your app.
 - [GenAI Services](firebase://guides/init/ai): Read this resource to setup GenAI services for the user such as building agents, LLM usage, unstructured data analysis, image editing, video generation, etc.
 
 UNAVAILABLE SERVICES: Analytics, Remote Config (feature flagging), A/B testing, Crashlytics (crash reporting), and Cloud Messaging (push notifications) are not yet available for setup via this command.

--- a/src/mcp/resources/guides/init_hosting.ts
+++ b/src/mcp/resources/guides/init_hosting.ts
@@ -21,11 +21,12 @@ export const init_hosting = resource(
 - Files included in the public folder of a hosting site are publicly accessible. Do not include sensitive API keys for services other than Firebase in these files.
 
 **When to Deploy:**
-- Introduce Firebase Hosting when developers are ready to deploy their application to production
-- Alternative: Developers can deploy later using the \`/firebase:deploy\` command
+- Introduce Firebase Hosting when developers are ready to deploy their application to production. 
+- Alternative: Developers can deploy later using the \`/firebase:deploy\` command.
 
 **Deployment Process:**
-- Request developer permission before implementing Firebase Hosting
+- Request developer's permission before implementing Firebase Hosting
+- Request developer's permission before deploying Firebase Hosting app to production. 
 - Configure Firebase Hosting and deploy the application to production
 `.trim(),
         },


### PR DESCRIPTION
- clarify backend service use cases
- ensure to get user's permission before deploying to hosting site.