### PR TITLE
Fixed an issue where empty firebase.json files would break init

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,7 +6,6 @@ import * as _ from "lodash";
 import * as clc from "colorette";
 import * as fs from "fs-extra";
 import * as path from "path";
-const cjson = require("cjson");
 
 import { detectProjectRoot } from "./detectProjectRoot";
 import { FirebaseError } from "./error";
@@ -303,7 +302,10 @@ export class Config {
     if (pd) {
       try {
         const filePath = path.resolve(pd, path.basename(filename));
-        const data = cjson.load(filePath);
+        let data: unknown = {};
+        if (fs.readFileSync(filePath, "utf-8") !== "") {
+          data = loadCJSON(filePath);
+        }
 
         // Validate config against JSON Schema. For now we just print these to debug
         // logs but in a future CLI version they could be warnings and/or errors.


### PR DESCRIPTION
### Description
@jpreid7396 caught this one - `firebase init` should work even if firebase.json is an empty file.

### Scenarios Tested
Tested init with an empty file, and with a populated one. Both work correctly.
Tested deploy with an empty file - it still errors out with 'Could not understand what targets to deploy/serve'
