### PR TITLE
[VS Code] Support projectless & loginless emulator experience

### DIFF
--- a/firebase-vscode/src/core/index.ts
+++ b/firebase-vscode/src/core/index.ts
@@ -15,7 +15,7 @@ import { registerWebhooks } from "./webhook";
 import { createE2eMockable } from "../utils/test_hooks";
 import { runTerminalTask } from "../data-connect/terminal";
 import { AnalyticsLogger } from "../analytics";
-import { EmulatorHub } from "../emulator/hub";
+import { EmulatorHub } from "../../../src/emulator/hub";
 
 export async function registerCore(
   broker: ExtensionBrokerImpl,

--- a/firebase-vscode/src/core/index.ts
+++ b/firebase-vscode/src/core/index.ts
@@ -15,6 +15,7 @@ import { registerWebhooks } from "./webhook";
 import { createE2eMockable } from "../utils/test_hooks";
 import { runTerminalTask } from "../data-connect/terminal";
 import { AnalyticsLogger } from "../analytics";
+import { EmulatorHub } from "../emulator/hub";
 
 export async function registerCore(
   broker: ExtensionBrokerImpl,
@@ -66,10 +67,8 @@ export async function registerCore(
       );
       return;
     }
-    const initCommand = currentProjectId.value
-      ? `${settings.firebasePath} init dataconnect --project ${currentProjectId.value}`
-      : `${settings.firebasePath} init dataconnect`;
-
+    const projectId = currentProjectId.value || EmulatorHub.MISSING_PROJECT_PLACEHOLDER;
+    const initCommand = `${settings.firebasePath} init dataconnect --project ${projectId}`;
     initSpy.call("firebase init", initCommand, { focus: true });
   });
 

--- a/firebase-vscode/webviews/SidebarApp.tsx
+++ b/firebase-vscode/webviews/SidebarApp.tsx
@@ -277,14 +277,13 @@ export function SidebarApp() {
         <ConfigPicker />
       </PanelSection>
 
-      {user.value &&
-        (isInitialized.value ? (
-          <Content />
-        ) : (
-          <PanelSection isLast={true}>
-            <Welcome />
-          </PanelSection>
-        ))}
+      {isInitialized.value ? (
+        <Content />
+      ) : (
+        <PanelSection isLast={true}>
+          <Welcome />
+        </PanelSection>
+      )}
     </App>
   );
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -16,6 +16,7 @@ import { isEnabled } from "../experiments";
 import { readTemplateSync } from "../templates";
 import { FirebaseError } from "../error";
 import { logBullet } from "../utils";
+import { EmulatorHub } from "../emulator/hub";
 
 const homeDir = os.homedir();
 
@@ -147,7 +148,6 @@ ${[...featureNames]
 export const command = new Command("init [feature]")
   .description("interactively configure the current directory as a Firebase project directory")
   .help(HELP)
-  .before(requireAuth)
   .action(initAction);
 
 /**
@@ -163,6 +163,9 @@ export async function initAction(feature: string, options: Options): Promise<voi
         featureNames.join(", ") +
         ".",
     );
+  }
+  if (options.project !== EmulatorHub.MISSING_PROJECT_PLACEHOLDER) {
+    await requireAuth(options);
   }
 
   const cwd = options.cwd || process.cwd();

--- a/src/init/features/project.ts
+++ b/src/init/features/project.ts
@@ -15,6 +15,7 @@ import { logger } from "../../logger";
 import * as utils from "../../utils";
 import * as prompt from "../../prompt";
 import { Options } from "../../options";
+import { EmulatorHub } from "../../emulator/hub";
 
 const OPTION_NO_PROJECT = "Don't set up a default project";
 const OPTION_USE_PROJECT = "Use an existing project";
@@ -100,6 +101,10 @@ async function projectChoicePrompt(options: any): Promise<FirebaseProjectMetadat
  */
 export async function doSetup(setup: any, config: any, options: any): Promise<void> {
   setup.project = {};
+  if (options.projectId === EmulatorHub.MISSING_PROJECT_PLACEHOLDER) {
+    logger.info(`Skipping Firebase project given --project=${options.projectId}`);
+    return;
+  }
 
   logger.info();
   logger.info(`First, let's associate this project directory with a Firebase project.`);


### PR DESCRIPTION
`firebase init` requires `firebase login`.

This is a reasonable requirement for most use cases.
However, if you want to try out the emulator experience without a project, you shouldn't need to login either.

This PR supports `firebase init --project demo-no-project`.