### PR TITLE
Feat/retry 429 functions

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -578,16 +578,20 @@ export class Fabricator {
 
   async deleteV1Function(endpoint: backend.Endpoint): Promise<void> {
     const fnName = backend.functionName(endpoint);
+
     await this.functionExecutor
-      .run(async () => {
-        const op: { name: string } = await gcf.deleteFunction(fnName);
-        const pollerOptions = {
-          ...gcfV1PollerOptions,
-          pollerName: `delete-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
-          operationResourceName: op.name,
-        };
-        await poller.pollOperation<void>(pollerOptions);
-      })
+      .run(
+        async () => {
+          const op: { name: string } = await gcf.deleteFunction(fnName);
+          const pollerOptions = {
+            ...gcfV1PollerOptions,
+            pollerName: `delete-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
+            operationResourceName: op.name,
+          };
+          await poller.pollOperation<void>(pollerOptions);
+        },
+        { retryCodes: [...DEFAULT_RETRY_CODES] },
+      )
       .catch(rethrowAs(endpoint, "delete"));
   }
 


### PR DESCRIPTION
### Description

**https://github.com/firebase/firebase-tools/issues/3919**, while closed, is still an issue and has been for around 4 years now.

firebase-tools logs that retrying will happen, but instead, an error is actually thrown.

This PR implements retries using `exponential-backoff` (a dependency which you seem to use already to some extent), and a couple of helper functions, with what I believe to be some sensible defaults.

Opinions wanted on e.g. the delay timers, as I don't actually know your rate limits on these commands, but at least saw mention of a one-minute window somewhere, and these values seemed to provide a good result.

### Scenarios Tested

In practice, I have experienced issues with 50-70 functions. I tested creating/updating 200 dummy functions, and after some retries, the deployment succeeded in about 15 minutes. Myself, I'm not too concerned about the speed, and that does not seem to concern those commenting in the issue either - mainly, a stable deployment procedure to avoid CI/CD failures is prefereable.

Here is the tail-end of the output, for reference:
```
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction183; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction148; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction166; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction170; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction187; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction150; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction155; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction174; retrying (attempt 1)…
✔  functions[dummyFunction156(europe-west1)] Successful create operation.
✔  functions[dummyFunction161(europe-west1)] Successful create operation.
✔  functions[dummyFunction137(europe-west1)] Successful create operation.
✔  functions[dummyFunction167(europe-west1)] Successful create operation.
✔  functions[dummyFunction162(europe-west1)] Successful create operation.
✔  functions[dummyFunction184(europe-west1)] Successful create operation.
✔  functions[dummyFunction154(europe-west1)] Successful create operation.
✔  functions[dummyFunction165(europe-west1)] Successful create operation.
✔  functions[dummyFunction157(europe-west1)] Successful create operation.
✔  functions[dummyFunction163(europe-west1)] Successful create operation.
✔  functions[dummyFunction183(europe-west1)] Successful create operation.
✔  functions[dummyFunction182(europe-west1)] Successful create operation.
✔  functions[dummyFunction135(europe-west1)] Successful create operation.
✔  functions[dummyFunction169(europe-west1)] Successful create operation.
✔  functions[dummyFunction95(europe-west1)] Successful create operation.
✔  functions[dummyFunction153(europe-west1)] Successful create operation.
✔  functions[dummyFunction175(europe-west1)] Successful create operation.
✔  functions[dummyFunction120(europe-west1)] Successful create operation.
✔  functions[dummyFunction158(europe-west1)] Successful create operation.
✔  functions[dummyFunction174(europe-west1)] Successful create operation.
✔  functions[dummyFunction160(europe-west1)] Successful create operation.
✔  functions[dummyFunction125(europe-west1)] Successful create operation.
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction176; retrying (attempt 1)…
✔  functions[dummyFunction180(europe-west1)] Successful create operation.
✔  functions[dummyFunction149(europe-west1)] Successful create operation.
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction176; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction143; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction197; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction7; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction8; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction12; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction2; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction200; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction4; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction155; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction16; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction15; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction189; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction188; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction191; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction10; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction3; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction14; retrying (attempt 1)…
✔  functions[dummyFunction172(europe-west1)] Successful create operation.
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction188; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction17; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction7; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction150; retrying (attempt 3)…
✔  functions[dummyFunction13(europe-west1)] Successful update operation.
✔  functions[dummyFunction192(europe-west1)] Successful create operation.
✔  functions[dummyFunction173(europe-west1)] Successful create operation.
✔  functions[dummyFunction186(europe-west1)] Successful create operation.
✔  functions[dummyFunction96(europe-west1)] Successful create operation.
✔  functions[dummyFunction148(europe-west1)] Successful create operation.
✔  functions[dummyFunction3(europe-west1)] Successful update operation.
✔  functions[dummyFunction93(europe-west1)] Successful create operation.
✔  functions[dummyFunction177(europe-west1)] Successful create operation.
✔  functions[dummyFunction9(europe-west1)] Successful update operation.
✔  functions[dummyFunction193(europe-west1)] Successful create operation.
✔  functions[dummyFunction171(europe-west1)] Successful create operation.
✔  functions[dummyFunction168(europe-west1)] Successful create operation.
✔  functions[dummyFunction198(europe-west1)] Successful create operation.
✔  functions[dummyFunction179(europe-west1)] Successful create operation.
✔  functions[dummyFunction196(europe-west1)] Successful create operation.
✔  functions[dummyFunction185(europe-west1)] Successful create operation.
✔  functions[dummyFunction187(europe-west1)] Successful create operation.
✔  functions[dummyFunction166(europe-west1)] Successful create operation.
✔  functions[dummyFunction190(europe-west1)] Successful create operation.
✔  functions[dummyFunction19(europe-west1)] Successful update operation.
✔  functions[dummyFunction195(europe-west1)] Successful create operation.
✔  functions[dummyFunction6(europe-west1)] Successful update operation.
✔  functions[dummyFunction178(europe-west1)] Successful create operation.
✔  functions[dummyFunction194(europe-west1)] Successful create operation.
✔  functions[dummyFunction16(europe-west1)] Successful update operation.
✔  functions[dummyFunction144(europe-west1)] Successful create operation.
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction197; retrying (attempt 2)…
✔  functions[dummyFunction7(europe-west1)] Successful update operation.
✔  functions[dummyFunction170(europe-west1)] Successful create operation.
✔  functions[dummyFunction1(europe-west1)] Successful update operation.
✔  functions[dummyFunction200(europe-west1)] Successful create operation.
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction20; retrying (attempt 1)…
✔  functions[dummyFunction11(europe-west1)] Successful update operation.
✔  functions[dummyFunction5(europe-west1)] Successful update operation.
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction17; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction39; retrying (attempt 1)…
✔  functions[dummyFunction14(europe-west1)] Successful update operation.
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction2; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction28; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction34; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction41; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction43; retrying (attempt 1)…
✔  functions[dummyFunction29(europe-west1)] Successful update operation.
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction15; retrying (attempt 2)…
✔  functions[dummyFunction18(europe-west1)] Successful update operation.
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction106; retrying (attempt 3)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction37; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction20; retrying (attempt 2)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction24; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction25; retrying (attempt 1)…
⚠  functions: 429 (Quota Exceeded) on update projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction12; retrying (attempt 2)…
✔  functions[dummyFunction26(europe-west1)] Successful update operation.
✔  functions[dummyFunction40(europe-west1)] Successful update operation.
✔  functions[dummyFunction23(europe-west1)] Successful update operation.
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction197; retrying (attempt 3)…
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction143; retrying (attempt 3)…
✔  functions[dummyFunction141(europe-west1)] Successful create operation.
✔  functions[dummyFunction21(europe-west1)] Successful update operation.
✔  functions[dummyFunction181(europe-west1)] Successful create operation.
✔  functions[dummyFunction30(europe-west1)] Successful update operation.
✔  functions[dummyFunction8(europe-west1)] Successful update operation.
✔  functions[dummyFunction31(europe-west1)] Successful update operation.
✔  functions[dummyFunction46(europe-west1)] Successful update operation.
✔  functions[dummyFunction4(europe-west1)] Successful update operation.
✔  functions[dummyFunction188(europe-west1)] Successful create operation.
✔  functions[dummyFunction176(europe-west1)] Successful create operation.
✔  functions[dummyFunction10(europe-west1)] Successful update operation.
✔  functions[dummyFunction89(europe-west1)] Successful create operation.
✔  functions[dummyFunction22(europe-west1)] Successful update operation.
✔  functions[dummyFunction37(europe-west1)] Successful update operation.
✔  functions[dummyFunction27(europe-west1)] Successful update operation.
⚠  functions: 429 (Quota Exceeded) on create projects/<masked-project-id>-development/locations/europe-west1/functions/dummyFunction191; retrying (attempt 2)…
✔  functions[dummyFunction128(europe-west1)] Successful create operation.
✔  functions[dummyFunction108(europe-west1)] Successful create operation.
✔  functions[dummyFunction2(europe-west1)] Successful update operation.
✔  functions[dummyFunction36(europe-west1)] Successful update operation.
✔  functions[dummyFunction53(europe-west1)] Successful update operation.
✔  functions[dummyFunction35(europe-west1)] Successful update operation.
✔  functions[dummyFunction48(europe-west1)] Successful update operation.
✔  functions[dummyFunction33(europe-west1)] Successful update operation.
✔  functions[dummyFunction101(europe-west1)] Successful create operation.
✔  functions[dummyFunction42(europe-west1)] Successful update operation.
✔  functions[dummyFunction45(europe-west1)] Successful update operation.
✔  functions[dummyFunction189(europe-west1)] Successful create operation.
✔  functions[dummyFunction50(europe-west1)] Successful update operation.
✔  functions[dummyFunction32(europe-west1)] Successful update operation.
✔  functions[dummyFunction54(europe-west1)] Successful update operation.
✔  functions[dummyFunction38(europe-west1)] Successful update operation.
✔  functions[dummyFunction51(europe-west1)] Successful update operation.
✔  functions[dummyFunction41(europe-west1)] Successful update operation.
✔  functions[dummyFunction62(europe-west1)] Successful update operation.
✔  functions[dummyFunction58(europe-west1)] Successful update operation.
✔  functions[dummyFunction34(europe-west1)] Successful update operation.
✔  functions[dummyFunction70(europe-west1)] Successful update operation.
✔  functions[dummyFunction47(europe-west1)] Successful update operation.
✔  functions[dummyFunction49(europe-west1)] Successful update operation.
✔  functions[dummyFunction199(europe-west1)] Successful create operation.
✔  functions[dummyFunction44(europe-west1)] Successful update operation.
✔  functions[dummyFunction143(europe-west1)] Successful create operation.
✔  functions[dummyFunction129(europe-west1)] Successful create operation.
✔  functions[dummyFunction56(europe-west1)] Successful update operation.
✔  functions[dummyFunction71(europe-west1)] Successful update operation.
✔  functions[dummyFunction28(europe-west1)] Successful update operation.
✔  functions[dummyFunction57(europe-west1)] Successful update operation.
✔  functions[dummyFunction52(europe-west1)] Successful update operation.
✔  functions[dummyFunction59(europe-west1)] Successful update operation.
✔  functions[dummyFunction55(europe-west1)] Successful update operation.
✔  functions[dummyFunction67(europe-west1)] Successful update operation.
✔  functions[dummyFunction66(europe-west1)] Successful update operation.
✔  functions[dummyFunction39(europe-west1)] Successful update operation.
✔  functions[dummyFunction191(europe-west1)] Successful create operation.
✔  functions[dummyFunction63(europe-west1)] Successful update operation.
✔  functions[dummyFunction72(europe-west1)] Successful update operation.
✔  functions[dummyFunction78(europe-west1)] Successful update operation.
✔  functions[dummyFunction73(europe-west1)] Successful update operation.
✔  functions[dummyFunction164(europe-west1)] Successful create operation.
✔  functions[dummyFunction139(europe-west1)] Successful create operation.
✔  functions[dummyFunction60(europe-west1)] Successful update operation.
✔  functions[dummyFunction25(europe-west1)] Successful update operation.
✔  functions[dummyFunction74(europe-west1)] Successful update operation.
✔  functions[dummyFunction68(europe-west1)] Successful update operation.
✔  functions[dummyFunction64(europe-west1)] Successful update operation.
✔  functions[dummyFunction69(europe-west1)] Successful update operation.
✔  functions[dummyFunction61(europe-west1)] Successful update operation.
✔  functions[dummyFunction65(europe-west1)] Successful update operation.
✔  functions[dummyFunction86(europe-west1)] Successful update operation.
✔  functions[dummyFunction77(europe-west1)] Successful update operation.
✔  functions[dummyFunction75(europe-west1)] Successful update operation.
✔  functions[dummyFunction76(europe-west1)] Successful update operation.
✔  functions[dummyFunction24(europe-west1)] Successful update operation.
✔  functions[dummyFunction43(europe-west1)] Successful update operation.
✔  functions[dummyFunction155(europe-west1)] Successful create operation.
✔  functions[dummyFunction110(europe-west1)] Successful update operation.
✔  functions[dummyFunction150(europe-west1)] Successful create operation.
✔  functions[dummyFunction15(europe-west1)] Successful update operation.
✔  functions[dummyFunction17(europe-west1)] Successful update operation.
✔  functions[dummyFunction106(europe-west1)] Successful create operation.
✔  functions[dummyFunction20(europe-west1)] Successful update operation.
✔  functions[dummyFunction197(europe-west1)] Successful create operation.
✔  functions[dummyFunction12(europe-west1)] Successful update operation.

✔  Deploy complete!
```

### Notes

This is my first PR to this project, don't hesitate to point out any shortcomings and I'll amend it - with that said, I would much appreciate if this PR is considered, as it would help reduce pipeline flakiness for many.