### PR TITLE
Javaupdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Marks Java 11 and below as deprecated. Support will be dropped in Firebase CLI v15. Please upgrade to Java version 21 or above to continue using the emulators.
 - Fixed an issue with deploying indexes to Firestore Enterprise edition databases where explicit `__name__` fields could be incorrectly handled.
 - The `experimental:mcp` command has been renamed to `mcp`. The old name is now an alias.
 - `firebase_update_environment` MCP tool supports accepting Gemini in Firebase Terms of Service.

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -587,7 +587,7 @@ export async function checkJavaMajorVersion(): Promise<number> {
   });
 }
 
-export const MIN_SUPPORTED_JAVA_MAJOR_VERSION = 11;
+export const MIN_SUPPORTED_JAVA_MAJOR_VERSION = 21;
 export const JAVA_DEPRECATION_WARNING =
-  "firebase-tools no longer supports Java versions before 11. " +
-  "Please install a JDK at version 11 or above to get a compatible runtime.";
+  "firebase-tools will drop support for Java version < 21 soon in firebase-tools@15. " +
+  "Please install a JDK at version 21 or above to get a compatible runtime.";

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -298,7 +298,7 @@ export async function startAll(
   if (targets.some(requiresJava)) {
     if ((await commandUtils.checkJavaMajorVersion()) < MIN_SUPPORTED_JAVA_MAJOR_VERSION) {
       utils.logLabeledError("emulators", JAVA_DEPRECATION_WARNING, "warn");
-      throw new FirebaseError(JAVA_DEPRECATION_WARNING);
+      deprecationNotices.push(JAVA_DEPRECATION_WARNING);
     }
   }
   if (options.logVerbosity) {

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -295,6 +295,7 @@ export async function startAll(
       `No emulators to start, run ${clc.bold("firebase init emulators")} to get started.`,
     );
   }
+  const deprecationNotices: string[] = [];
   if (targets.some(requiresJava)) {
     if ((await commandUtils.checkJavaMajorVersion()) < MIN_SUPPORTED_JAVA_MAJOR_VERSION) {
       utils.logLabeledError("emulators", JAVA_DEPRECATION_WARNING, "warn");


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR checks the Java version before starting emulators that require Java and warns users if the Java version < 21.

### Scenarios Tested

Tested this with Java 11 and Java 25.

Java 11 output:
```
node lib/bin/firebase.js emulators:start --only firestore                                       
⚠  Could not find config (firebase.json) so using defaults.
⬢  emulators: firebase-tools will drop support for Java version < 21 soon in firebase-tools@15. Please install a JDK at version 21 or above to get a compatible runtime.
i  emulators: Starting emulators: firestore
⚠  firestore: Did not find a Cloud Firestore rules file specified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator UI websocket is running on 9150.
```

Java 25 output:
```
node lib/bin/firebase.js emulators:start --only firestore
⚠  Could not find config (firebase.json) so using defaults.
i  emulators: Starting emulators: firestore
⚠  firestore: Did not find a Cloud Firestore rules file specified in a firebase.json config file.
⚠  firestore: The emulator will default to allowing all reads and writes. Learn more about this option: https://firebase.google.com/docs/emulator-suite/install_and_configure#security_rules_configuration.
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator UI websocket is running on 9150.
```

