### PR TITLE
Make availablePrompts logic the same as the availableTools logic to fix prompts not appearing

### DIFF
--- a/src/mcp/prompts/index.ts
+++ b/src/mcp/prompts/index.ts
@@ -40,17 +40,17 @@ function namespacePrompts(
 /**
  * Return available prompts based on the list of registered features.
  */
-export function availablePrompts(features?: ServerFeature[]): ServerPrompt[] {
-  const allPrompts: ServerPrompt[] = namespacePrompts(prompts["core"], "core");
+export function availablePrompts(activeFeatures?: ServerFeature[]): ServerPrompt[] {
+  const allPrompts: ServerPrompt[] = [];
 
-  if (!features) {
-    features = Object.keys(prompts).filter((f) => f !== "core") as ServerFeature[];
+  if (!activeFeatures?.length) {
+    activeFeatures = Object.keys(prompts) as ServerFeature[];
   }
-
-  for (const feature of features) {
-    if (prompts[feature] && feature !== "core") {
-      allPrompts.push(...namespacePrompts(prompts[feature], feature));
-    }
+  if (!activeFeatures.includes("core")) {
+    activeFeatures = ["core", ...activeFeatures];
+  }
+  for (const feature of activeFeatures) {
+    allPrompts.push(...namespacePrompts(prompts[feature], feature));
   }
   return allPrompts;
 }

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -19,7 +19,7 @@ export function availableTools(activeFeatures?: ServerFeature[]): ServerTool[] {
     activeFeatures = Object.keys(tools) as ServerFeature[];
   }
   if (!activeFeatures.includes("core")) {
-    activeFeatures.unshift("core");
+    activeFeatures = ["core", ...activeFeatures];
   }
   for (const key of activeFeatures) {
     toolDefs.push(...tools[key]);


### PR DESCRIPTION
Fix bug where non-core prompts would not appear when there are no active features

Specifically, the block inside`if (!features)` was skipped if `features = []`
