### PR TITLE
UpsertBucket uses a purpose label to detect & work around squatting

### DIFF
--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -75,25 +75,29 @@ describe("apphosting", () => {
 
     it("upserts regional GCS bucket", async () => {
       const context = initializeContext();
-      getProjectNumberStub.resolves("000000000000");
-      upsertBucketStub.resolves();
+      const projectNumber = "000000000000";
+      const location = "us-central1";
+      const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
+
+      getProjectNumberStub.resolves(projectNumber);
+      upsertBucketStub.resolves(bucketName);
       createArchiveStub.resolves("path/to/foo-1234.zip");
       uploadObjectStub.resolves({
-        bucket: "firebaseapphosting-sources-12345678-us-central1",
+        bucket: bucketName,
         object: "foo-1234",
       });
-      createReadStreamStub.resolves();
+      createReadStreamStub.returns("stream" as any);
 
       await deploy(context, opts);
 
       expect(upsertBucketStub).to.be.calledWith({
         product: "apphosting",
-        createMessage:
-          "Creating Cloud Storage bucket in us-central1 to store App Hosting source code uploads at firebaseapphosting-sources-000000000000-us-central1...",
+        createMessage: `Creating Cloud Storage bucket in ${location} to store App Hosting source code uploads at ${bucketName}...`,
         projectId: "my-project",
         req: {
-          name: "firebaseapphosting-sources-000000000000-us-central1",
-          location: "us-central1",
+          baseName: bucketName,
+          purposeLabel: `apphosting-source-${location}`,
+          location: location,
           lifecycle: {
             rule: [
               {
@@ -108,20 +112,22 @@ describe("apphosting", () => {
 
     it("correctly creates and sets storage URIs", async () => {
       const context = initializeContext();
-      getProjectNumberStub.resolves("000000000000");
-      upsertBucketStub.resolves();
+      const projectNumber = "000000000000";
+      const location = "us-central1";
+      const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
+
+      getProjectNumberStub.resolves(projectNumber);
+      upsertBucketStub.resolves(bucketName);
       createArchiveStub.resolves("path/to/foo-1234.zip");
       uploadObjectStub.resolves({
-        bucket: "firebaseapphosting-sources-12345678-us-central1",
+        bucket: bucketName,
         object: "foo-1234",
       });
-      createReadStreamStub.resolves();
+      createReadStreamStub.returns("stream" as any);
 
       await deploy(context, opts);
 
-      expect(context.backendStorageUris["foo"]).to.equal(
-        "gs://firebaseapphosting-sources-000000000000-us-central1/foo-1234.zip",
-      );
+      expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);
     });
   });
 });

--- a/src/deploy/functions/deploy.ts
+++ b/src/deploy/functions/deploy.ts
@@ -95,14 +95,15 @@ export async function uploadSourceV2(
   // Future behavior: BYO bucket if we're using the Cloud Run API directly because it does not provide a source upload API.
   // We use this behavior whenever the "runfunctions" experiment is enabled for now just to help vet the codepath incrementally.
   // Using project number to ensure we don't exceed the bucket name length limit (in addition to PII controversy).
-  const bucketName = `firebase-functions-src-${projectNumber}`;
-  await gcs.upsertBucket({
+  const baseName = `firebase-functions-src-${projectNumber}`;
+  const bucketName = await gcs.upsertBucket({
     product: "functions",
     projectId,
-    createMessage: `Creating Cloud Storage bucket in ${region} to store Functions source code uploads at ${bucketName}...`,
+    createMessage: `Creating Cloud Storage bucket in ${region} to store Functions source code uploads at ${baseName}...`,
     req: {
-      name: bucketName,
+      baseName,
       location: region,
+      purposeLabel: `functions-source-${region.toLowerCase()}`,
       lifecycle: {
         rule: [
           {

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -695,7 +695,7 @@ async function promptResourceString(
   const notFound = new FirebaseError(`No instances of ${input.resource.type} found.`);
   switch (input.resource.type) {
     case "storage.googleapis.com/Bucket":
-      const buckets = await listBuckets(projectId);
+      const buckets = (await listBuckets(projectId)).map((b) => b.name);
       if (buckets.length === 0) {
         throw notFound;
       }
@@ -723,7 +723,7 @@ async function promptResourceStrings(
   const notFound = new FirebaseError(`No instances of ${input.resource.type} found.`);
   switch (input.resource.type) {
     case "storage.googleapis.com/Bucket":
-      const buckets = await listBuckets(projectId);
+      const buckets = (await listBuckets(projectId)).map((b) => b.name);
       if (buckets.length === 0) {
         throw notFound;
       }

--- a/src/gcp/storage.spec.ts
+++ b/src/gcp/storage.spec.ts
@@ -7,126 +7,230 @@ import { FirebaseError } from "../error";
 
 describe("storage", () => {
   describe("upsertBucket", () => {
-    let getBucketStub: sinon.SinonStub;
+    let listBucketsStub: sinon.SinonStub;
     let createBucketStub: sinon.SinonStub;
+    let patchBucketStub: sinon.SinonStub;
     let logLabeledBulletStub: sinon.SinonStub;
     let logLabeledWarningStub: sinon.SinonStub;
+    let randomStringStub: sinon.SinonStub;
+
+    const PROJECT_ID = "test-project";
+    const BUCKET_LIFECYCLE = { rule: [{ action: { type: "Delete" }, condition: { age: 30 } }] };
+    const BASE_BUCKET_NAME = "test-bucket";
+    const PURPOSE_LABEL = "test-purpose";
 
     beforeEach(() => {
-      getBucketStub = sinon.stub(storage, "getBucket");
+      listBucketsStub = sinon.stub(storage, "listBuckets");
       createBucketStub = sinon.stub(storage, "createBucket");
+      patchBucketStub = sinon.stub(storage, "patchBucket");
       logLabeledBulletStub = sinon.stub(utils, "logLabeledBullet");
       logLabeledWarningStub = sinon.stub(utils, "logLabeledWarning");
+      randomStringStub = sinon.stub(storage, "randomString").returns("abcdef");
     });
 
     afterEach(() => {
       sinon.restore();
     });
 
-    it("should not call createBucket if the bucket already exists", async () => {
-      getBucketStub.resolves();
+    it("should return existing bucket name if a bucket with the purpose label is found", async () => {
+      const bucketName = "existing-bucket";
+      listBucketsStub.resolves([
+        { name: bucketName, labels: { [PURPOSE_LABEL]: "true" } },
+        { name: "another-bucket", labels: {} },
+      ] as any);
 
-      await storage.upsertBucket({
+      const result = await storage.upsertBucket({
         product: "test",
         createMessage: "Creating bucket",
-        projectId: "test-project",
-        req: { name: "test-bucket", location: "us-central1", lifecycle: { rule: [] } },
+        projectId: PROJECT_ID,
+        req: {
+          baseName: BASE_BUCKET_NAME,
+          location: "us-central1",
+          purposeLabel: PURPOSE_LABEL,
+          lifecycle: BUCKET_LIFECYCLE,
+        },
       });
 
-      expect(getBucketStub).to.be.calledOnceWith("test-bucket");
+      expect(result).to.equal(bucketName);
+      expect(listBucketsStub).to.be.calledOnceWith(PROJECT_ID);
       expect(createBucketStub).to.not.be.called;
-      expect(logLabeledBulletStub).to.not.be.called;
     });
 
-    it("should call createBucket if the bucket does not exist (404)", async () => {
-      const error = new FirebaseError("Not found", { original: { status: 404 } as any });
-      getBucketStub.rejects(error);
-      createBucketStub.resolves();
+    it("should patch an existing bucket if it does not have a purpose label", async () => {
+      const bucketName = "existing-unmanaged-bucket";
+      listBucketsStub.resolves([{ name: bucketName, labels: {} }] as any);
 
-      await storage.upsertBucket({
+      const result = await storage.upsertBucket({
         product: "test",
         createMessage: "Creating bucket",
-        projectId: "test-project",
-        req: { name: "test-bucket", location: "us-central1", lifecycle: { rule: [] } },
+        projectId: PROJECT_ID,
+        req: {
+          baseName: bucketName,
+          location: "us-central1",
+          purposeLabel: PURPOSE_LABEL,
+          lifecycle: BUCKET_LIFECYCLE,
+        },
       });
 
-      expect(getBucketStub).to.be.calledOnceWith("test-bucket");
-      expect(createBucketStub).to.be.calledOnceWith(
-        "test-project",
-        {
-          name: "test-bucket",
+      expect(result).to.equal(bucketName);
+      expect(listBucketsStub).to.be.calledOnceWith(PROJECT_ID);
+      expect(patchBucketStub).to.be.calledOnceWith(bucketName, {
+        labels: { [PURPOSE_LABEL]: "true" },
+      });
+      expect(createBucketStub).to.not.be.called;
+    });
+
+    it("should create a new bucket if no bucket with the purpose label is found", async () => {
+      listBucketsStub.resolves([{ name: "another-bucket", labels: {} }] as any);
+      createBucketStub.resolves({ name: BASE_BUCKET_NAME } as any);
+
+      const result = await storage.upsertBucket({
+        product: "test",
+        createMessage: "Creating bucket",
+        projectId: PROJECT_ID,
+        req: {
+          baseName: BASE_BUCKET_NAME,
           location: "us-central1",
-          lifecycle: { rule: [] },
+          purposeLabel: PURPOSE_LABEL,
+          lifecycle: BUCKET_LIFECYCLE,
+        },
+      });
+
+      expect(result).to.equal(BASE_BUCKET_NAME);
+      expect(listBucketsStub).to.be.calledOnceWith(PROJECT_ID);
+      expect(createBucketStub).to.be.calledOnceWith(
+        PROJECT_ID,
+        {
+          name: BASE_BUCKET_NAME,
+          location: "us-central1",
+          lifecycle: BUCKET_LIFECYCLE,
+          labels: { [PURPOSE_LABEL]: "true" },
         },
         true,
       );
-      expect(logLabeledBulletStub).to.be.calledOnceWith("test", "Creating bucket");
+      expect(logLabeledBulletStub).to.be.calledOnce;
     });
 
-    it("should call createBucket if the bucket does not exist (403)", async () => {
-      const error = new FirebaseError("Unauthenticated", { original: { status: 403 } as any });
-      getBucketStub.rejects(error);
-      createBucketStub.resolves();
+    it("should handle listBuckets failure", async () => {
+      const error = new FirebaseError("Failed to list buckets");
+      listBucketsStub.rejects(error);
 
-      await storage.upsertBucket({
+      await expect(
+        storage.upsertBucket({
+          product: "test",
+          createMessage: "Creating bucket",
+          projectId: PROJECT_ID,
+          req: {
+            baseName: BASE_BUCKET_NAME,
+            location: "us-central1",
+            purposeLabel: PURPOSE_LABEL,
+            lifecycle: BUCKET_LIFECYCLE,
+          },
+        }),
+      ).to.be.rejectedWith(error);
+
+      expect(listBucketsStub).to.be.calledOnceWith(PROJECT_ID);
+      expect(createBucketStub).to.not.be.called;
+    });
+
+    it("should retry with a new name on createBucket conflict", async () => {
+      const conflictError = new FirebaseError("Conflict", { original: { status: 409 } as any });
+      const randomSuffix = "abcdef";
+      const newBucketName = `${BASE_BUCKET_NAME}-${randomSuffix}`;
+
+      listBucketsStub.resolves([]);
+      createBucketStub.onFirstCall().rejects(conflictError);
+      createBucketStub.onSecondCall().resolves({ name: newBucketName } as any);
+
+      const result = await storage.upsertBucket({
         product: "test",
         createMessage: "Creating bucket",
-        projectId: "test-project",
-        req: { name: "test-bucket", location: "us-central1", lifecycle: { rule: [] } },
+        projectId: PROJECT_ID,
+        req: {
+          baseName: BASE_BUCKET_NAME,
+          location: "us-central1",
+          purposeLabel: PURPOSE_LABEL,
+          lifecycle: BUCKET_LIFECYCLE,
+        },
       });
 
-      expect(getBucketStub).to.be.calledOnceWith("test-bucket");
-      expect(createBucketStub).to.be.calledOnceWith(
-        "test-project",
-        {
-          name: "test-bucket",
-          location: "us-central1",
-          lifecycle: { rule: [] },
-        },
-        true,
-      );
-      expect(logLabeledBulletStub).to.be.calledOnceWith("test", "Creating bucket");
+      expect(result).to.equal(newBucketName);
+      expect(createBucketStub).to.be.calledTwice;
+      expect(createBucketStub.firstCall.args[1].name).to.equal(BASE_BUCKET_NAME);
+      expect(createBucketStub.secondCall.args[1].name).to.equal(newBucketName);
+      expect(randomStringStub).to.be.calledOnceWith(6);
     });
 
-    it("should explain IAM errors", async () => {
-      const notFound = new FirebaseError("Bucket not found", { original: { status: 404 } as any });
-      const permissionDenied = new FirebaseError("Permission denied", {
+    it("should error out after 5 createBucket conflicts", async () => {
+      const conflictError = new FirebaseError("Conflict", { original: { status: 409 } as any });
+      listBucketsStub.resolves([]);
+      createBucketStub.rejects(conflictError);
+
+      await expect(
+        storage.upsertBucket({
+          product: "test",
+          createMessage: "Creating bucket",
+          projectId: PROJECT_ID,
+          req: {
+            baseName: BASE_BUCKET_NAME,
+            location: "us-central1",
+            purposeLabel: PURPOSE_LABEL,
+            lifecycle: BUCKET_LIFECYCLE,
+          },
+        }),
+      ).to.be.rejectedWith("Failed to create a unique Cloud Storage bucket name after 5 attempts.");
+
+      expect(createBucketStub.callCount).to.equal(5);
+    });
+
+    it("should handle permission errors on createBucket", async () => {
+      const permError = new FirebaseError("Permission denied", {
         original: { status: 403 } as any,
       });
-      getBucketStub.rejects(notFound);
-      createBucketStub.rejects(permissionDenied);
+      listBucketsStub.resolves([]);
+      createBucketStub.rejects(permError);
 
       await expect(
         storage.upsertBucket({
           product: "test",
           createMessage: "Creating bucket",
-          projectId: "test-project",
-          req: { name: "test-bucket", location: "us-central1", lifecycle: { rule: [] } },
+          projectId: PROJECT_ID,
+          req: {
+            baseName: BASE_BUCKET_NAME,
+            location: "us-central1",
+            purposeLabel: PURPOSE_LABEL,
+            lifecycle: BUCKET_LIFECYCLE,
+          },
         }),
-      ).to.be.rejected;
+      ).to.be.rejectedWith(permError);
 
-      expect(logLabeledWarningStub).to.be.calledWithMatch(
-        "test",
-        /Failed to create Cloud Storage bucket because user does not have sufficient permissions/,
-      );
+      expect(logLabeledWarningStub).to.be.calledOnce;
+      expect(createBucketStub).to.be.calledOnce;
     });
 
-    it("should forward unexpected errors", async () => {
-      const error = new FirebaseError("Unexpected error", { original: { status: 500 } as any });
-      getBucketStub.rejects(error);
+    it("should forward unexpected errors from createBucket", async () => {
+      const unexpectedError = new FirebaseError("Unexpected error", {
+        original: { status: 500 } as any,
+      });
+      listBucketsStub.resolves([]);
+      createBucketStub.rejects(unexpectedError);
 
       await expect(
         storage.upsertBucket({
           product: "test",
           createMessage: "Creating bucket",
-          projectId: "test-project",
-          req: { name: "test-bucket", location: "us-central1", lifecycle: { rule: [] } },
+          projectId: PROJECT_ID,
+          req: {
+            baseName: BASE_BUCKET_NAME,
+            location: "us-central1",
+            purposeLabel: PURPOSE_LABEL,
+            lifecycle: BUCKET_LIFECYCLE,
+          },
         }),
-      ).to.be.rejectedWith("Unexpected error");
+      ).to.be.rejectedWith(unexpectedError);
 
-      expect(getBucketStub).to.be.calledOnceWith("test-bucket");
-      expect(createBucketStub).to.not.be.called;
-      expect(logLabeledBulletStub).to.not.be.called;
+      expect(logLabeledWarningStub).to.not.be.called;
+      expect(createBucketStub).to.be.calledOnce;
     });
   });
 });

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -399,7 +399,8 @@ export async function patchBucket(
 }
 
 export function randomString(length: number): string {
-  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  // NOTE: uppercase letters are not allowed in bucket names
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
   let result = "";
   for (let i = length; i > 0; --i) {
     result += chars[Math.floor(Math.random() * chars.length)];

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -8,6 +8,7 @@ import { FirebaseError, getErrStatus } from "../error";
 import { logger } from "../logger";
 import { ensure } from "../ensureApiEnabled";
 import * as utils from "../utils";
+import { fieldMasks } from "./proto";
 
 /** Bucket Interface */
 interface BucketResponse {
@@ -115,9 +116,7 @@ interface BucketResponse {
       },
     ];
   };
-  labels: {
-    (key: any): string;
-  };
+  labels: Record<string, string>;
   storageClass: string;
   billing: {
     requesterPays: boolean;
@@ -128,11 +127,7 @@ interface BucketResponse {
 interface ListBucketsResponse {
   kind: string;
   nextPageToken: string;
-  items: [
-    {
-      name: string;
-    },
-  ];
+  items: BucketResponse[];
 }
 
 interface GetDefaultBucketResponse {
@@ -143,9 +138,19 @@ interface GetDefaultBucketResponse {
   };
 }
 
+export interface UpsertBucketRequest {
+  baseName: string;
+  location: string;
+  purposeLabel: string;
+  lifecycle: {
+    rule: LifecycleRule[];
+  };
+}
+
 export interface CreateBucketRequest {
   name: string;
   location: string;
+  labels?: Record<string, string>;
   lifecycle: {
     rule: LifecycleRule[];
   };
@@ -360,45 +365,136 @@ export async function createBucket(
 }
 
 /**
- * Creates a storage bucket on GCP if it does not already exist.
+ * Patches a storage bucket on GCP.
+ * Ref: https://cloud.google.com/storage/docs/json_api/v1/buckets/patch
+ * @param bucketName name of the storage bucket
+ * @param metadata the bucket resource metadata to patch
+ * @return a bucket resource object
+ */
+export async function patchBucket(
+  bucketName: string,
+  metadata: Partial<BucketResponse>,
+): Promise<BucketResponse> {
+  try {
+    const localAPIClient = new Client({ urlPrefix: storageOrigin() });
+    const mask = fieldMasks(
+      metadata,
+      /* doNotRecurseIn = */ "labels",
+      "acl",
+      "defaultObjectAcl",
+      "lifecycle",
+    );
+    const result = await localAPIClient.patch<Partial<BucketResponse>, BucketResponse>(
+      `/storage/v1/b/${bucketName}`,
+      metadata,
+      { queryParams: { updateMask: mask.join(",") } },
+    );
+    return result.body;
+  } catch (err: any) {
+    logger.debug(err);
+    throw new FirebaseError("Failed to patch the storage bucket", {
+      original: err,
+    });
+  }
+}
+
+export function randomString(length: number): string {
+  const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = length; i > 0; --i) {
+    result += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return result;
+}
+
+// Call methods through the exports object so that they can be stubbed in tests.
+const dynamicDispatch = exports as {
+  listBuckets: typeof listBuckets;
+  createBucket: typeof createBucket;
+  patchBucket: typeof patchBucket;
+  randomString: typeof randomString;
+};
+
+/**
+ * Creates a storage bucket on GCP for a given purpose if it does not already exist.
+ * NOTE: It is a security issue if the bucket already exists but is not owned by this project.
+ * This function therefore only returns an existing bucket if it exists AND is in the project.
+ * We check that the bucket is in the project by calling "listBuckets" (project scoped) rather than
+ * getBucket (global scoped). If the bucket already exists, we use a name-collision nonce to avoid
+ * a denial of service. To find this collision-avoiding in the future, we use a label as a breadcrumb.
+ * Thus our base case of the bucket already existing uses the label not the base name to decide which
+ * bucket to return.
  */
 export async function upsertBucket(opts: {
   product: string;
   createMessage: string;
   projectId: string;
-  req: CreateBucketRequest;
-}): Promise<void> {
-  try {
-    await (exports as { getBucket: typeof getBucket }).getBucket(opts.req.name);
-    return;
-  } catch (err) {
-    const errStatus = getErrStatus((err as FirebaseError).original);
-    // Unfortunately, requests for a non-existent bucket from the GCS API sometimes return 403 responses as well as 404s.
-    // We must attempt to create a new bucket on both 403s and 404s.
-    if (errStatus !== 403 && errStatus !== 404) {
-      throw err;
-    }
+  req: UpsertBucketRequest;
+}): Promise<string> {
+  // Use labels to find whether an existing bucket is managed by us. Use labels, not the base name to detect
+  // a bucket that was created with name conflict resolution.
+  // Not using try/catch here because ignoring a failure could lead to multiple sources of truth.
+  const existingBuckets = await dynamicDispatch.listBuckets(opts.projectId);
+  const managedBucket = existingBuckets.find((b) => opts.req.purposeLabel in (b.labels || {}));
+  if (managedBucket) {
+    return managedBucket.name;
+  }
+
+  // Note: Some customers have created buckets before this new strategy of adding labels already existed.
+  // If the bucket with the base name already exists _and is returned by listBuckets_, we know it is owned
+  // by this project and is safet to use. Add the label.
+  const existingUnmanaged = existingBuckets.find((b) => b.name === opts.req.baseName);
+  if (existingUnmanaged) {
+    logger.debug(
+      `Found existing bucket ${existingUnmanaged.name} without purpose label. Because it is known not to be squatted, we can use it.`,
+    );
+    const labels = { ...existingUnmanaged.labels, [opts.req.purposeLabel]: "true" };
+    await dynamicDispatch.patchBucket(existingUnmanaged.name, { labels });
+    return existingUnmanaged.name;
   }
 
   utils.logLabeledBullet(opts.product, opts.createMessage);
-  try {
-    await (exports as { createBucket: typeof createBucket }).createBucket(
-      opts.projectId,
-      opts.req,
-      true /* projectPrivate */,
-    );
-  } catch (err) {
-    if (getErrStatus((err as FirebaseError).original) === 403) {
-      utils.logLabeledWarning(
-        opts.product,
-        "Failed to create Cloud Storage bucket because user does not have sufficient permissions. " +
-          "See https://cloud.google.com/storage/docs/access-control/iam-roles for more details on " +
-          "IAM roles that are able to create a Cloud Storage bucket, and ask your project administrator " +
-          "to grant you one of those roles.",
+  for (let retryCount = 0; retryCount < 5; retryCount++) {
+    const name =
+      retryCount === 0
+        ? opts.req.baseName
+        : `${opts.req.baseName}-${dynamicDispatch.randomString(6)}`;
+    try {
+      await dynamicDispatch.createBucket(
+        opts.projectId,
+        {
+          name,
+          location: opts.req.location,
+          lifecycle: opts.req.lifecycle,
+          labels: {
+            [opts.req.purposeLabel]: "true",
+          },
+        },
+        true /* projectPrivate */,
       );
+      return name;
+    } catch (err) {
+      if (getErrStatus((err as FirebaseError).original) === 409) {
+        utils.logLabeledBullet(
+          opts.product,
+          `Bucket ${name} already exists, creating a new bucket with a conflict-avoiding hash`,
+        );
+        continue;
+      }
+
+      if (getErrStatus((err as FirebaseError).original) === 403) {
+        utils.logLabeledWarning(
+          opts.product,
+          "Failed to create Cloud Storage bucket because user does not have sufficient permissions. " +
+            "See https://cloud.google.com/storage/docs/access-control/iam-roles for more details on " +
+            "IAM roles that are able to create a Cloud Storage bucket, and ask your project administrator " +
+            "to grant you one of those roles.",
+        );
+      }
+      throw err;
     }
-    throw err;
   }
+  throw new FirebaseError("Failed to create a unique Cloud Storage bucket name after 5 attempts.");
 }
 
 /**
@@ -407,13 +503,19 @@ export async function upsertBucket(opts: {
  * @param {string} bucketName name of the storage bucket
  * @return a bucket resource object
  */
-export async function listBuckets(projectId: string): Promise<Array<string>> {
+export async function listBuckets(projectId: string): Promise<BucketResponse[]> {
   try {
+    let buckets: BucketResponse[] = [];
     const localAPIClient = new Client({ urlPrefix: storageOrigin() });
-    const result = await localAPIClient.get<ListBucketsResponse>(
-      `/storage/v1/b?project=${projectId}`,
-    );
-    return result.body.items.map((bucket: { name: string }) => bucket.name);
+    let pageToken: string | undefined;
+    do {
+      const result = await localAPIClient.get<ListBucketsResponse>(
+        `/storage/v1/b?project=${projectId}`,
+      );
+      buckets = buckets.concat(result.body.items || []);
+      pageToken = result.body.nextPageToken;
+    } while (pageToken);
+    return buckets;
   } catch (err: any) {
     logger.debug(err);
     throw new FirebaseError("Failed to read the storage buckets", {


### PR DESCRIPTION
Fixes both a DoS and RCE vulnerability when an attacker could predict the bucket that App Hosting or Functions would use for uploading source.

Instead of returning a bucket when it exists (but could be owned by an attacker) we list the buckets actually owned by the user. There are three cases to consider:

1. There exists a bucket with the "purpose label". This will usually have the same name as the target bucket name, but may not in the case that the bucket was created with collision avoidance. Return whichever bucket has the label.
2. There exists a bucket without the "purpose label" but with the target bucket name. Since we got this bucket name from "listBuckets" we know that this is user owned and it is safe to add the purpose label to migrate the fleet to one shape
3. The bucket does not exist. Try to create it. If creation fails (e.g. naming conflict due to squatting) then add a random 6-character string at the end to avoid conflicts. We try this 4 times, so an attacker would need to have squatted on about 600 million buckets for there to be at least a 1% chance that deployment fails (and they can retry without consequence).

Manually tested:

1. Create a bucket without conflict
2. Create a bucket with conflict
3. Reuse a bucket
4. Add a purpose label to a legacy bucket