### PR TITLE
Fix misleading typing for options.json.

### DIFF
--- a/firebase-vscode/src/options.ts
+++ b/firebase-vscode/src/options.ts
@@ -26,7 +26,6 @@ const defaultOptions: Readonly<VsCodeOptions> = {
   projectNumber: "",
   projectRoot: "",
   account: "",
-  json: true,
   nonInteractive: true,
   interactive: false,
   debug: false,

--- a/src/checkValidTargetFilters.spec.ts
+++ b/src/checkValidTargetFilters.spec.ts
@@ -13,7 +13,6 @@ const SAMPLE_OPTIONS: Options = {
   only: "",
   except: "",
   nonInteractive: false,
-  json: false,
   interactive: false,
   debug: false,
   force: false,

--- a/src/command.ts
+++ b/src/command.ts
@@ -313,6 +313,7 @@ export class Command {
     }
 
     if (getInheritedOption(options, "json")) {
+      options.interactive = false;
       options.nonInteractive = true;
     } else if (!options.isMCP) {
       useConsoleLoggers();

--- a/src/commands/firestore-backups-delete.ts
+++ b/src/commands/firestore-backups-delete.ts
@@ -34,11 +34,7 @@ export const command = new Command("firestore:backups:delete <backup>")
       throw new FirebaseError(`Failed to delete the backup ${backupName}`, { original: err });
     }
 
-    if (options.json) {
-      logger.info(JSON.stringify(backup, undefined, 2));
-    } else {
-      logger.info(clc.bold(`Successfully deleted ${clc.yellow(backupName)}`));
-    }
+    logger.info(clc.bold(`Successfully deleted ${clc.yellow(backupName)}`));
 
     return backup;
   });

--- a/src/commands/firestore-backups-get.ts
+++ b/src/commands/firestore-backups-get.ts
@@ -15,11 +15,7 @@ export const command = new Command("firestore:backups:get <backup>")
     const backup: Backup = await getBackup(backupName);
     const printer = new PrettyPrint();
 
-    if (options.json) {
-      logger.info(JSON.stringify(backup, undefined, 2));
-    } else {
-      printer.prettyPrintBackup(backup);
-    }
+    printer.prettyPrintBackup(backup);
 
     return backup;
   });

--- a/src/commands/firestore-backups-list.ts
+++ b/src/commands/firestore-backups-list.ts
@@ -23,17 +23,15 @@ export const command = new Command("firestore:backups:list")
     const listBackupsResponse: ListBackupsResponse = await listBackups(options.project, location);
     const backups: Backup[] = listBackupsResponse.backups || [];
 
-    if (options.json) {
-      logger.info(JSON.stringify(listBackupsResponse, undefined, 2));
-    } else {
-      printer.prettyPrintBackups(backups);
-      if (listBackupsResponse.unreachable && listBackupsResponse.unreachable.length > 0) {
-        logWarning(
-          "We were not able to reach the following locations: " +
-            listBackupsResponse.unreachable.join(", "),
-        );
-      }
+    printer.prettyPrintBackups(backups);
+    if (listBackupsResponse.unreachable && listBackupsResponse.unreachable.length > 0) {
+      logWarning(
+        "We were not able to reach the following locations: " +
+          listBackupsResponse.unreachable.join(", "),
+      );
     }
 
+    // TODO: Consider returning listBackupResponse instead for --json. This will
+    // be a breaking change but exposes .unreachable, not just .backups.
     return backups;
   });

--- a/src/commands/firestore-backups-schedules-create.ts
+++ b/src/commands/firestore-backups-schedules-create.ts
@@ -81,13 +81,9 @@ export const command = new Command("firestore:backups:schedules:create")
       weeklyRecurrence,
     );
 
-    if (options.json) {
-      logger.info(JSON.stringify(backupSchedule, undefined, 2));
-    } else {
-      logger.info(
-        clc.bold(`Successfully created ${printer.prettyBackupScheduleString(backupSchedule)}`),
-      );
-    }
+    logger.info(
+      clc.bold(`Successfully created ${printer.prettyBackupScheduleString(backupSchedule)}`),
+    );
 
     return backupSchedule;
   });

--- a/src/commands/firestore-backups-schedules-delete.ts
+++ b/src/commands/firestore-backups-schedules-delete.ts
@@ -36,11 +36,7 @@ export const command = new Command("firestore:backups:schedules:delete <backupSc
       });
     }
 
-    if (options.json) {
-      logger.info(JSON.stringify(backupSchedule, undefined, 2));
-    } else {
-      logger.info(clc.bold(`Successfully deleted ${clc.yellow(backupScheduleName)}`));
-    }
+    logger.info(clc.bold(`Successfully deleted ${clc.yellow(backupScheduleName)}`));
 
     return backupSchedule;
   });

--- a/src/commands/firestore-backups-schedules-list.ts
+++ b/src/commands/firestore-backups-schedules-list.ts
@@ -24,11 +24,7 @@ export const command = new Command("firestore:backups:schedules:list")
       databaseId,
     );
 
-    if (options.json) {
-      logger.info(JSON.stringify(backupSchedules, undefined, 2));
-    } else {
-      printer.prettyPrintBackupSchedules(backupSchedules, databaseId);
-    }
+    printer.prettyPrintBackupSchedules(backupSchedules, databaseId);
 
     return backupSchedules;
   });

--- a/src/commands/firestore-backups-schedules-update.ts
+++ b/src/commands/firestore-backups-schedules-update.ts
@@ -30,13 +30,9 @@ export const command = new Command("firestore:backups:schedules:update <backupSc
       retention,
     );
 
-    if (options.json) {
-      logger.info(JSON.stringify(backupSchedule, undefined, 2));
-    } else {
-      logger.info(
-        clc.bold(`Successfully updated ${printer.prettyBackupScheduleString(backupSchedule)}`),
-      );
-    }
+    logger.info(
+      clc.bold(`Successfully updated ${printer.prettyBackupScheduleString(backupSchedule)}`),
+    );
 
     return backupSchedule;
   });

--- a/src/commands/firestore-bulkdelete.ts
+++ b/src/commands/firestore-bulkdelete.ts
@@ -75,21 +75,17 @@ export const command = new Command("firestore:bulkdelete")
 
     const op = await api.bulkDeleteDocuments(options.project, databaseId, collectionIds);
 
-    if (options.json) {
-      logger.info(JSON.stringify(op, undefined, 2));
+    if (op.name) {
+      logSuccess(`Successfully started bulk delete operation.`);
+      logBullet(`Operation name: ` + clc.cyan(op.name));
+      // TODO: Update this message to 'firebase firestore:operations:describe' command once it's implemented.
+      logBullet(
+        "You can monitor the operation's progress using the " +
+          clc.cyan(`gcloud firestore operations describe`) +
+          ` command.`,
+      );
     } else {
-      if (op.name) {
-        logSuccess(`Successfully started bulk delete operation.`);
-        logBullet(`Operation name: ` + clc.cyan(op.name));
-        // TODO: Update this message to 'firebase firestore:operations:describe' command once it's implemented.
-        logBullet(
-          "You can monitor the operation's progress using the " +
-            clc.cyan(`gcloud firestore operations describe`) +
-            ` command.`,
-        );
-      } else {
-        logLabeledError(`Bulk Delete:`, `Failed to start a bulk delete operation.`);
-      }
+      logLabeledError(`Bulk Delete:`, `Failed to start a bulk delete operation.`);
     }
 
     return op;

--- a/src/commands/firestore-databases-create.ts
+++ b/src/commands/firestore-databases-create.ts
@@ -108,19 +108,15 @@ export const command = new Command("firestore:databases:create <database>")
 
     const databaseResp: types.DatabaseResp = await api.createDatabase(createDatabaseReq);
 
-    if (options.json) {
-      logger.info(JSON.stringify(databaseResp, undefined, 2));
-    } else {
-      logger.info(clc.bold(`Successfully created ${printer.prettyDatabaseString(databaseResp)}`));
-      logger.info(
-        "Please be sure to configure Firebase rules in your Firebase config file for\n" +
-          "the new database. By default, created databases will have closed rules that\n" +
-          "block any incoming third-party traffic.",
-      );
-      logger.info(
-        `Your database may be viewed at ${printer.firebaseConsoleDatabaseUrl(options.project, database)}`,
-      );
-    }
+    logger.info(clc.bold(`Successfully created ${printer.prettyDatabaseString(databaseResp)}`));
+    logger.info(
+      "Please be sure to configure Firebase rules in your Firebase config file for\n" +
+        "the new database. By default, created databases will have closed rules that\n" +
+        "block any incoming third-party traffic.",
+    );
+    logger.info(
+      `Your database may be viewed at ${printer.firebaseConsoleDatabaseUrl(options.project, database)}`,
+    );
 
     return databaseResp;
   });

--- a/src/commands/firestore-databases-delete.ts
+++ b/src/commands/firestore-databases-delete.ts
@@ -31,11 +31,7 @@ export const command = new Command("firestore:databases:delete <database>")
 
     const databaseResp: types.DatabaseResp = await api.deleteDatabase(options.project, database);
 
-    if (options.json) {
-      logger.info(JSON.stringify(databaseResp, undefined, 2));
-    } else {
-      logger.info(clc.bold(`Successfully deleted ${printer.prettyDatabaseString(databaseResp)}`));
-    }
+    logger.info(clc.bold(`Successfully deleted ${printer.prettyDatabaseString(databaseResp)}`));
 
     return databaseResp;
   });

--- a/src/commands/firestore-databases-get.ts
+++ b/src/commands/firestore-databases-get.ts
@@ -19,11 +19,7 @@ export const command = new Command("firestore:databases:get [database]")
     const databaseId = database || "(default)";
     const databaseResp: types.DatabaseResp = await api.getDatabase(options.project, databaseId);
 
-    if (options.json) {
-      logger.info(JSON.stringify(databaseResp, undefined, 2));
-    } else {
-      printer.prettyPrintDatabase(databaseResp);
-    }
+    printer.prettyPrintDatabase(databaseResp);
 
     return databaseResp;
   });

--- a/src/commands/firestore-databases-list.ts
+++ b/src/commands/firestore-databases-list.ts
@@ -18,11 +18,7 @@ export const command = new Command("firestore:databases:list")
 
     const databases: types.DatabaseResp[] = await api.listDatabases(options.project);
 
-    if (options.json) {
-      logger.info(JSON.stringify(databases, undefined, 2));
-    } else {
-      printer.prettyPrintDatabases(databases);
-    }
+    printer.prettyPrintDatabases(databases);
 
     return databases;
   });

--- a/src/commands/firestore-databases-restore.ts
+++ b/src/commands/firestore-databases-restore.ts
@@ -72,21 +72,17 @@ export const command = new Command("firestore:databases:restore")
       encryptionConfig,
     );
 
-    if (options.json) {
-      logger.info(JSON.stringify(databaseResp, undefined, 2));
-    } else {
-      logger.info(
-        clc.bold(`Successfully initiated restore of ${printer.prettyDatabaseString(databaseResp)}`),
-      );
-      logger.info(
-        "Please be sure to configure Firebase rules in your Firebase config file for\n" +
-          "the new database. By default, created databases will have closed rules that\n" +
-          "block any incoming third-party traffic.",
-      );
-      logger.info(
-        `Once the restore is complete, your database may be viewed at ${printer.firebaseConsoleDatabaseUrl(options.project, databaseId)}`,
-      );
-    }
+    logger.info(
+      clc.bold(`Successfully initiated restore of ${printer.prettyDatabaseString(databaseResp)}`),
+    );
+    logger.info(
+      "Please be sure to configure Firebase rules in your Firebase config file for\n" +
+        "the new database. By default, created databases will have closed rules that\n" +
+        "block any incoming third-party traffic.",
+    );
+    logger.info(
+      `Once the restore is complete, your database may be viewed at ${printer.firebaseConsoleDatabaseUrl(options.project, databaseId)}`,
+    );
 
     return databaseResp;
 

--- a/src/commands/firestore-databases-update.ts
+++ b/src/commands/firestore-databases-update.ts
@@ -71,11 +71,7 @@ export const command = new Command("firestore:databases:update <database>")
       pointInTimeRecoveryEnablement,
     );
 
-    if (options.json) {
-      logger.info(JSON.stringify(databaseResp, undefined, 2));
-    } else {
-      logger.info(clc.bold(`Successfully updated ${printer.prettyDatabaseString(databaseResp)}`));
-    }
+    logger.info(clc.bold(`Successfully updated ${printer.prettyDatabaseString(databaseResp)}`));
 
     return databaseResp;
   });

--- a/src/commands/firestore-locations.ts
+++ b/src/commands/firestore-locations.ts
@@ -18,11 +18,7 @@ export const command = new Command("firestore:locations")
 
     const locations: types.Location[] = await api.locations(options.project);
 
-    if (options.json) {
-      logger.info(JSON.stringify(locations, undefined, 2));
-    } else {
-      printer.prettyPrintLocations(locations);
-    }
+    printer.prettyPrintLocations(locations);
 
     return locations;
   });

--- a/src/commands/firestore-operations-cancel.ts
+++ b/src/commands/firestore-operations-cancel.ts
@@ -34,14 +34,10 @@ export const command = new Command("firestore:operations:cancel <operationName>"
     const api = new fsi.FirestoreApi();
     const status = await api.cancelOperation(options.project, databaseId, operationName);
 
-    if (options.json) {
-      logger.info(JSON.stringify(status, undefined, 2));
+    if (status.success) {
+      utils.logSuccess("Operation cancelled successfully.");
     } else {
-      if (status.success) {
-        utils.logSuccess("Operation cancelled successfully.");
-      } else {
-        utils.logWarning("Canceling the operation failed.");
-      }
+      utils.logWarning("Canceling the operation failed.");
     }
 
     return status;

--- a/src/commands/firestore-operations-describe.ts
+++ b/src/commands/firestore-operations-describe.ts
@@ -21,12 +21,8 @@ export const command = new Command("firestore:operations:describe <operationName
     const api = new fsi.FirestoreApi();
     const operation = await api.describeOperation(options.project, databaseId, operationName);
 
-    if (options.json) {
-      logger.info(JSON.stringify(operation, undefined, 2));
-    } else {
-      const printer = new PrettyPrint();
-      printer.prettyPrintOperation(operation);
-    }
+    const printer = new PrettyPrint();
+    printer.prettyPrintOperation(operation);
 
     return operation;
   });

--- a/src/commands/firestore-operations-list.ts
+++ b/src/commands/firestore-operations-list.ts
@@ -22,12 +22,8 @@ export const command = new Command("firestore:operations:list")
     const api = new fsi.FirestoreApi();
     const { operations } = await api.listOperations(options.project, databaseId, limit);
 
-    if (options.json) {
-      logger.info(JSON.stringify(operations, undefined, 2));
-    } else {
-      const printer = new PrettyPrint();
-      printer.prettyPrintOperations(operations);
-    }
+    const printer = new PrettyPrint();
+    printer.prettyPrintOperations(operations);
 
     return operations;
   });

--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -19,7 +19,6 @@ const BASE_OPTS = {
   debug: false,
   filteredTargets: [],
   rc: new RC(),
-  json: false,
 };
 
 function initializeContext(): Context {

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -20,7 +20,6 @@ const BASE_OPTS = {
   debug: false,
   filteredTargets: [],
   rc: new RC(),
-  json: false,
 };
 
 function initializeContext(): Context {

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -16,7 +16,6 @@ const BASE_OPTS = {
   debug: false,
   filteredTargets: [],
   rc: new RC(),
-  json: false,
 };
 
 function initializeContext(): Context {

--- a/src/deploy/functions/prompts.spec.ts
+++ b/src/deploy/functions/prompts.spec.ts
@@ -35,7 +35,6 @@ const SAMPLE_OPTIONS: Options = {
   only: "functions",
   except: "",
   nonInteractive: false,
-  json: false,
   interactive: false,
   debug: false,
   force: false,

--- a/src/deploy/hosting/prepare.spec.ts
+++ b/src/deploy/hosting/prepare.spec.ts
@@ -62,7 +62,6 @@ describe("hosting prepare", () => {
       except: "",
       filteredTargets: ["HOSTING"],
       force: false,
-      json: false,
       nonInteractive: false,
       interactive: true,
       debug: false,

--- a/src/emulator/extensions/validation.spec.ts
+++ b/src/emulator/extensions/validation.spec.ts
@@ -21,7 +21,6 @@ const TEST_OPTIONS: Options = {
   filteredTargets: [""],
   nonInteractive: true,
   interactive: false,
-  json: false,
   debug: false,
   rc: new RC(),
   config: new Config("."),

--- a/src/emulator/storage/rules/config.spec.ts
+++ b/src/emulator/storage/rules/config.spec.ts
@@ -127,7 +127,6 @@ function getOptions(config: any): Options {
     only: "",
     except: "",
     nonInteractive: false,
-    json: false,
     interactive: false,
     debug: false,
     force: false,

--- a/src/filterTargets.spec.ts
+++ b/src/filterTargets.spec.ts
@@ -11,7 +11,6 @@ const SAMPLE_OPTIONS: Options = {
   only: "",
   except: "",
   nonInteractive: false,
-  json: false,
   interactive: false,
   debug: false,
   force: false,

--- a/src/gcp/cloudsql/cloudsqladmin.spec.ts
+++ b/src/gcp/cloudsql/cloudsqladmin.spec.ts
@@ -26,7 +26,6 @@ const options: Options = {
   config: new Config({}, { projectDir: "", cwd: "" }),
   filteredTargets: [],
   force: false,
-  json: false,
   nonInteractive: false,
   interactive: false,
   debug: false,

--- a/src/init/features/functions.spec.ts
+++ b/src/init/features/functions.spec.ts
@@ -53,7 +53,6 @@ describe("functions", () => {
       except: "",
       filteredTargets: [],
       force: false,
-      json: false,
       nonInteractive: false,
       interactive: false,
       debug: false,

--- a/src/init/features/genkit/index.spec.ts
+++ b/src/init/features/genkit/index.spec.ts
@@ -42,7 +42,6 @@ describe("genkit", () => {
       except: "",
       filteredTargets: [],
       force: false,
-      json: false,
       nonInteractive: false,
       interactive: false,
       debug: false,

--- a/src/management/studio.spec.ts
+++ b/src/management/studio.spec.ts
@@ -35,7 +35,6 @@ describe("Studio Management", () => {
       except: "",
       filteredTargets: [],
       force: false,
-      json: false,
       nonInteractive: false,
       interactive: false,
       debug: false,

--- a/src/options.ts
+++ b/src/options.ts
@@ -19,7 +19,6 @@ export interface BaseOptions {
   projectNumber?: string;
   projectRoot?: string;
   account?: string;
-  json: boolean;
   nonInteractive: boolean;
   interactive: boolean;
   debug: boolean;
@@ -30,6 +29,20 @@ export interface BaseOptions {
   import?: string;
 
   isMCP?: boolean;
+
+  /**
+   * Do not use this field when handling --json. It is never set in commands.
+   *
+   * Instead, return an object to be JSONified from the command action callback:
+   *
+   * ```typescript
+   *    .action(async (options: Options) => {
+   *      logger.info('Normal output'); // Automatically suppressed with --json.
+   *      return objectToBePrintedWhenTheJsonFlagIsPassed;
+   *    });
+   * ```
+   */
+  json?: undefined;
 }
 
 export interface Options extends BaseOptions {

--- a/src/requireConfig.spec.ts
+++ b/src/requireConfig.spec.ts
@@ -14,7 +14,6 @@ const options: Options = {
   config: new Config({}),
   filteredTargets: [],
   force: false,
-  json: false,
   nonInteractive: false,
   interactive: false,
   debug: false,

--- a/src/requireTosAcceptance.spec.ts
+++ b/src/requireTosAcceptance.spec.ts
@@ -15,7 +15,6 @@ const SAMPLE_OPTIONS: Options = {
   only: "",
   except: "",
   nonInteractive: false,
-  json: false,
   interactive: false,
   debug: false,
   force: false,


### PR DESCRIPTION
### Description

`options.json` has always been unset since at least 5 years ago but the typing
in `options.ts` says that it exists. This led to two kinds of mistakes.

1. Using `if (options.json)` in command handlers. This effectively creates a
    dead branch. I've tried my best to remove those -- should be noop.
1. Providing `json: false` when Options are required. It's a not a
    noop strictly-speaking but the tests should still pass since it is not
    actually accessed in commands. (These are mostly found in tests.)

----

Alternatives considered: Setting `options.json` for real seems appealing but
branching on `options.json` is almost always a mistake. Unless in some obscure
use cases (not found in the code base), it is best to let the global handling
deal with `--json` the flag.

Things taken care of by global handling:

1. Suppressing normal output: https://github.com/firebase/firebase-tools/blob/a952fb4067891bfd18c1c0fccecd82dc5dd7a8d5/src/command.ts#L315-L319
1. Serializing the return value to JSON: https://github.com/firebase/firebase-tools/blob/a952fb4067891bfd18c1c0fccecd82dc5dd7a8d5/src/command.ts#L211

Note that the last step wraps the return value in a wrapper object:
`{status: "success", result: ...}`. The dead branches I've removed all
failed to account for this. So if we had made `options.json` a real boolean,
it'd cause quite a few breaking changes unless we fix those one by one.

### Scenarios Tested

Existing unit tests. I've also logged `options.json` in commands and made sure
it is always unset regardless of flags.

### Sample Commands

N/A
