### PR TITLE
feat(dataconnect): add confirmation for Gemini schema generation

### DIFF
--- a/src/init/features/dataconnect/index.ts
+++ b/src/init/features/dataconnect/index.ts
@@ -118,9 +118,16 @@ export async function askQuestions(setup: Setup): Promise<void> {
           "Learn more about Gemini in Firebase and how it uses your data: https://firebase.google.com/docs/gemini-in-firebase#how-gemini-in-firebase-uses-your-data",
         );
       }
-      info.appDescription = await input({
-        message: `Describe your app to automatically generate a schema with Gemini [Enter to use a template]:`,
+      const wantToGenerate = await confirm({
+        message: "Do you want to generate a schema with Gemini?",
+        default: true,
       });
+      if (wantToGenerate) {
+        info.appDescription = await input({
+          message: `Describe your app to automatically generate a schema with Gemini:`,
+          default: `an app for ${setup.projectId}`,
+        });
+      }
       if (info.appDescription) {
         configstore.set("gemini", true);
         await ensureGIFApiTos(setup.projectId);


### PR DESCRIPTION
Instead of directly asking for an app description to generate a schema with Gemini, this change first asks the user to confirm if they want to use Gemini.

If the user confirms, it then prompts for the app description with a default value of "an app for ${setup.projectId}".

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
