### PR TITLE
Make fields in TestDeviceSchema required

### DIFF
--- a/src/mcp/tools/apptesting/tests.ts
+++ b/src/mcp/tools/apptesting/tests.ts
@@ -5,10 +5,15 @@ import { distribute, Distribution } from "../../../appdistribution/distribution"
 import { tool } from "../../tool";
 import { toContent } from "../../util";
 import { parseIntoStringArray, toAppName } from "../../../appdistribution/options-parser-util";
-import { TestDevice } from "../../../appdistribution/types";
 
 const TestDeviceSchema = z
-  .custom<TestDevice>()
+  .object({
+    model: z.string(),
+    version: z.string(),
+    locale: z.string(),
+    orientation: z.enum(["portrait", "landscape"]),
+  })
+  .required()
   .describe(
     `Device to run automated test on. Can run 'gcloud firebase test android|ios models list' to see available devices.`,
   );


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

The build was failing with the following error

```
Error: src/mcp/tools/apptesting/tests.ts(50,9): error TS2345: Argument of type '{ version?: string; locale?: string; model?: string; orientation?: "portrait" | "landscape"; }[]' is not assignable to parameter of type 'TestDevice[]'.
  Type '{ version?: string; locale?: string; model?: string; orientation?: "portrait" | "landscape"; }' is not assignable to type 'TestDevice'.
    Property 'model' is optional in type '{ version?: string; locale?: string; model?: string; orientation?: "portrait" | "landscape"; }' but required in type 'TestDevice'.
```

So I made all the fields in `TestDeviceSchema` required.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/master/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
