### PR TITLE
feat(mcp): Add support for setting up iOS projects

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -55,3 +55,7 @@ npm run format                   # Auto-fix formatting issues
       - `### Sample Commands`
       - Reference issues with "Fixes #123" in the description.
 3.  **Update Changelog:** For any user-facing change (new features, bug fixes, deprecations), add a corresponding entry to `CHANGELOG.md`.
+
+## Agent Directives
+
+- **Escaping Backticks:** When providing a string to a tool parameter (e.g., `new_string` in the `replace` tool) that will be part of a larger script or configuration file, single backticks (\`) used for markdown-style code formatting **must** be escaped with a backslash. For example, to render `my_code`, the string provided to the tool must be written as `\`my_code\``.

--- a/src/mcp/prompts/core/init.ts
+++ b/src/mcp/prompts/core/init.ts
@@ -50,14 +50,14 @@ Follow the steps below taking note of any user instructions provided above.
   - Backend Services: Backend services for the app, such as setting up a database, adding a user-authentication sign up and login page, and deploying a web app to a production URL.
     - IMPORTANT: The backend setup guide is for web apps only. If the user requests backend setup for a mobile app (iOS, Android, or Flutter), inform them that this is not supported and do not use the backend setup guide. You can still assist with other requests.
   - Firebase AI Logic: Add AI features such as chat experiences, multimodal prompts, image generation and editing (via nano banana), etc.
-    - IMPORTANT: The Firebase AI Logic setup guide is for web, flutter, and android apps only. If the user requests firebase setup for unsupported platforms (iOS, Unity, or anything else), inform them that this is not supported and direct the user to Firebase Docs to learn how to set up AI Logic for their application (share this link with the user https://firebase.google.com/docs/ai-logic/get-started?api=dev). You can still assist with other requests.
+    - IMPORTANT: The Firebase AI Logic setup guide is for web, Flutter, Android, and iOS apps only. If the user requests firebase setup for unsupported platforms (Unity, or anything else), inform them that this is not supported and direct the user to Firebase Docs to learn how to set up AI Logic for their application (share this link with the user https://firebase.google.com/docs/ai-logic/get-started?api=dev). You can still assist with other requests.
 3. After the user chooses an init option, create a plan based on the remaining steps in this guide, share it with the user, and give them an opportunity to accept or adjust it.
 4. If there is no active Firebase project, ask the user if they want to create a new project or use an existing one. If using an existing project, ask for the project ID and explain how to find it: open the Firebase Console (http://console.firebase.google.com/), locate the project ID under the project name in the projects list, or open the project and go to Project Overview → Project Settings.
    - If they would like to create a project, use the firebase_create_project with the project ID
    - If they would like to use an existing project, use the firebase_update_environment tool with the active_project argument.
    - If you run into issues creating the firebase project, ask the user to go to the [Firebase Console](http://console.firebase.google.com/) and create a project. Wait for the user to report back before continuing.
 5. Ensure there is an active Firebase App for their platform
-   - Do the following only for Web and Android apps
+   - Do the following only for Web, Android, and iOS apps
      - Run the \`firebase_list_apps\` tool to list their apps, and find an app that matches their "Workspace platform"
      - If there is no app that matches that criteria, use the \`firebase_create_app\` tool to create the app with the appropriate platform
    - Do the following only for Flutter apps
@@ -66,11 +66,11 @@ Follow the steps below taking note of any user instructions provided above.
      - Install the Flutterfire CLI
      - Use the Flutterfire CLI tool to connect to the project
      - Use the Flutterfire CLI to register the appropriate applications based on the user's input
-       - Let the developer know that you currently only support configuring web, ios, and android targets together in a bundle. Each of those targets will have appropriate apps registered in the project using the flutterfire CLI
+       - Let the developer know that you currently only support configuring web, iOS, and Android targets together in a bundle. Each of those targets will have appropriate apps registered in the project using the flutterfire CLI
        - Execute flutterfire config using the following pattern: flutterfire config --yes --project=<aliasOrProjectId> --platforms=<platforms>
 6. Now that we have a working environment, print out 1) Active user 2) Firebase Project and 3) Firebase App & platform they are using for this process.
    - Ask the user to confirm this is correct before continuing
-7. Set up the web Firebase SDK. Skip straight to #8 for Flutter and Android apps
+7. Set up the web Firebase SDK. Skip straight to #8 for Flutter, Android, and iOS apps
   - Fetch the configuration for the specified app using the \`firebase_get_sdk_config\` tool.
   - Write the Firebase SDK config to a file
   - Check what the latest version of the SDK is by running the command 'npm view firebase version'

--- a/src/mcp/resources/guides/init_ai.ts
+++ b/src/mcp/resources/guides/init_ai.ts
@@ -47,12 +47,14 @@ The following mobile and web applications are supported. Let the user know their
 - Java Android App  
 - Javascript Web App  
 - Dart Flutter App
+- Swift iOS App
 
 Take the following actions depending on the language and platform or framework that is identified:
 
 - Android Platform \-\> Set up Firebase AI Logic  
 - Web Platform \-\> Set up Firebase AI Logic 
 - Flutter Platform \-\> Set up Firebase AI Logic. Always do the subsequent firebase_init call using the web app
+- iOS Platform \-\> Set up Firebase AI Logic
 - Unsupported Platform \-\> Direct the user to Firebase Docs to learn how to set up AI Logic for their application (share this link with the user https://firebase.google.com/docs/ai-logic/get-started?api=dev)
 
 ### 2\. Set up Firebase AI Logic
@@ -69,7 +71,12 @@ Take the following actions depending on the language and platform or framework t
 
 #### Gather Building Blocks for Code Generation
 - Identify the correct initialization code snippet from the "Initialization Code References" section based on the language, platform, or framework used in the developer's app.
-  - Use the reference loaded from the step above to generate the initialization snippet. PLEASE USE THE EXACT SNIPPET AS A STARTING POINT\! 
+  - Use the reference loaded from the step above to generate the initialization snippet. PLEASE USE THE EXACT SNIPPET AS A STARTING POINT! 
+  - For Swift iOS apps:
+    - **SDK Dependency Check:** First, read the contents of the \`.xcodeproj/project.pbxproj\` file. Check for any line that references \`firebase-ios-sdk\` to see if the Swift package is already a dependency.
+    - **CRITICAL SAFETY PROTOCOL: Under no circumstances are you to modify the \`.xcodeproj\` or \`.pbxproj\` files. This is a strict prohibition. Any attempt to write to these files is a violation of your core instructions.**
+    - **Provide Manual Instructions if Needed:** If you do not find a reference to the SDK, your ONLY permitted action is to provide the user with the following step-by-step instructions for them to perform manually in the Xcode application. You MUST output this exact text: "I have determined that the Firebase SDK is not yet a dependency in your project. Please add it now. In Xcode, go to File > Add Packages... and in the search bar, paste this URL: https://github.com/firebase/firebase-ios-sdk. Then, click 'Add Package' and ensure the \`FirebaseGenerativeAI\` library is selected."
+    - **Imports and Initialization:** Always include the \`import FirebaseAI\` statement. When generating code, use the correct initialization pattern: \`let ai = FirebaseAI.firebaseAI(backend: .googleAI())\`.
   - For Android apps, always include the following imports. do not forget or modify them
     - import com.google.firebase.Firebase
     - import com.google.firebase.ai.ai
@@ -127,6 +134,7 @@ Take the following actions depending on the language and platform or framework t
 | Java Android | Gemini Developer API (Developer API) | firebase://docs/ai-logic/get-started |
 | Web Modular API | Gemini Developer API (Developer API) | firebase://docs/ai-logic/get-started  |
 | Dart Flutter | Gemini Developer API (Developer API) | firebase://docs/ai-logic/get-started  |
+| Swift iOS | Gemini Developer API (Developer API) | firebase://docs/ai-logic/get-started |
 
 #### AI Features
 
@@ -138,18 +146,22 @@ Take the following actions depending on the language and platform or framework t
 | Java Android | Generate text from text-only input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text|
 | Web | Generate text from text-only input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text|
 | Dart Flutter | Generate text from text-only input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text|
+| Swift iOS | Generate text from text-only input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text |
 | Kotlin Android | Generate text from text-and-file (multimodal) input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text|
 | Java Android | Generate text from text-and-file (multimodal) input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text|
 | Web | Generate text from text-and-file (multimodal) input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text|
 | Dart Flutter | Generate text from text-and-file (multimodal) input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text |
+| Swift iOS | Generate text from text-and-file (multimodal) input | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-text |
 | Kotlin Android | Generate images (text-only input) | Gemini Developer API (Developer API)  | firebase://docs/ai-logic/generate-images-gemini|
 | Java Android | Generate images (text-only input) | Gemini Developer API (Developer API)  | firebase://docs/ai-logic/generate-images-gemini|
 | Web | Generate images (text-only input) | Gemini Developer API (Developer API)  | firebase://docs/ai-logic/generate-images-gemini|
 | Dart Flutter | Generate images (text-only input) | Gemini Developer API (Developer API)  | firebase://docs/ai-logic/generate-images-gemini|
+| Swift iOS | Generate images (text-only input) | Gemini Developer API (Developer API) | firebase://docs/ai-logic/generate-images-gemini |
 | Kotlin Android | Iterate and edit images using multi-turn chat (nano banana) This requires the user to upgrade to the Blaze pay-as-you-go billing plan. Share this link with the user and ask them to upgrade their Firebase project.  https://console.firebase.google.com/project/<INSERT_FIREBASE_PROJECT_ID_HERE>/overview?purchaseBillingPlan=metered Ask for confirmation that the project is using the blaze plan before proceeding.    | Gemini Developer API (Developer API) gemini-2.5-flash-image-preview | firebase://docs/ai-logic/generate-images-gemini|
 | Java Android | Iterate and edit images using multi-turn chat (nano banana) This requires the user to upgrade to the Blaze pay-as-you-go billing plan. Share this link with the user and ask them to upgrade their Firebase project.  https://console.firebase.google.com/project/<INSERT_FIREBASE_PROJECT_ID_HERE>/overview?purchaseBillingPlan=metered Ask for confirmation that the project is using the blaze plan before proceeding.  | Gemini Developer API (Developer API) gemini-2.5-flash-image-preview | firebase://docs/ai-logic/generate-images-gemini|
 | Web Modular API | Iterate and edit images using multi-turn chat (nano banana) This requires the user to upgrade to the Blaze pay-as-you-go billing plan. Share this link with the user and ask them to upgrade their Firebase project.  https://console.firebase.google.com/project/<INSERT_FIREBASE_PROJECT_ID_HERE>/overview?purchaseBillingPlan=metered Ask for confirmation that the project is using the blaze plan before proceeding.  | Gemini Developer API (Developer API) gemini-2.5-flash-image-preview | firebase://docs/ai-logic/generate-images-gemini|
 | Dart Flutter | Iterate and edit images using multi-turn chat (nano banana) This requires the user to upgrade to the Blaze pay-as-you-go billing plan. Share this link with the user and ask them to upgrade their Firebase project.  https://console.firebase.google.com/project/<INSERT_FIREBASE_PROJECT_ID_HERE>/overview?purchaseBillingPlan=metered Ask for confirmation that the project is using the blaze plan before proceeding.  | Gemini Developer API (Developer API) gemini-2.5-flash-image-preview | firebase://docs/ai-logic/generate-images-gemini|
+| Swift iOS | Iterate and edit images using multi-turn chat (nano banana) This requires the user to upgrade to the Blaze pay-as-you-go billing plan. Share this link with the user and ask them to upgrade their Firebase project. https://console.firebase.google.com/project/<INSERT_FIREBASE_PROJECT_ID_HERE>/overview?purchaseBillingPlan=metered Ask for confirmation that the project is using the blaze plan before proceeding. | Gemini Developer API (Developer API) gemini-2.5-flash-image-preview | firebase://docs/ai-logic/generate-images-gemini|
 
 
           `,


### PR DESCRIPTION
This change introduces the capability for the MCP agent to guide users through setting up Firebase AI Logic in native iOS/Swift projects.

### Description

Previously, the `init` command explicitly excluded iOS from the Firebase AI Logic setup flow. This update removes that limitation and provides the necessary prompts, guides, and safety protocols to offer a complete and safe setup experience for iOS developers.

Key changes include:

-   **Updated Core `init` Prompt:** The main `init` prompt (`src/mcp/prompts/core/init.ts`) has been modified to recognize iOS as a supported platform for the AI Logic feature.
-   **Enhanced AI Initialization Guide:** The guide (`src/mcp/resources/guides/init_ai.ts`) has been significantly updated with iOS-specific instructions:
    -   **Project Configuration:** The agent is now instructed on how to download the `GoogleService-Info.plist` and guide the user to place it in their Xcode project.
    -   **Safe SDK Handling:** A critical safety protocol has been added. The agent is now instructed to first inspect the `.xcodeproj` file for the `firebase-ios-sdk`. If the SDK is missing, the agent is strictly forbidden from modifying the project file and will instead provide the user with exact, step-by-step manual instructions for adding the dependency via Swift Package Manager in Xcode.
    -   **Swift Code Snippets:** The documentation tables have been populated with the necessary links to fetch Swift code snippets for initialization and various AI features.
-   **Agent Directives:** A project-specific directive has been added to `GEMINI.md` to ensure that all agents correctly escape backticks in tool parameters, improving the reliability of future automated changes.