### PR TITLE
Fix cleaning up `clean` directory for clean-install.sh

### DIFF
--- a/scripts/clean-install.sh
+++ b/scripts/clean-install.sh
@@ -1,20 +1,23 @@
 #!/bin/bash
 set -ex
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 function cleanup() {
-  echo "Cleaning up artifacts..."
-  rm -rf ./clean
+  CLEAN_DIR="$ROOT_DIR/clean"
+  echo "Cleaning up artifacts at $CLEAN_DIR..."
+  rm -rf $CLEAN_DIR
   echo "Artifacts deleted."
 }
 
 trap cleanup EXIT
 
-rm -rf ./clean || true
+rm -rf $ROOT_DIR/clean || true
 echo "Running clean-publish@5.0.0 --without-publish, as we would before publishing to npm..."
 npx --yes clean-publish@5.0.0 --without-publish --before-script ./scripts/clean-shrinkwrap.sh --temp-dir clean
 echo "Ran clean-publish@5.0.0 --without-publish."
 echo "Packaging cleaned firebase-tools..."
-cd ./clean
+cd $ROOT_DIR/clean
 PACKED=$(npm pack --pack-destination ./ | tail -n 1)
 echo "Packaged firebase-tools to $PACKED."
 echo "Installing clean-packaged firebase-tools..."


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description
Previously `rm -rf ./clean` failed because we had already cd'd into `clean`. This makes the root directory explicit.

### Sample Commands

`./scripts/clean-install.sh`