### PR TITLE
Remove 'format' property from $schema

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -1090,7 +1090,6 @@
     },
     "properties": {
         "$schema": {
-            "format": "uri",
             "type": "string"
         },
         "apphosting": {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Currently, because of the `uri` format in `$schema`, vscode will keep complaining that a relative path to the schema is not valid. It only accepts uri.

Ideally I could point the `$schema` to the local version of the schema definttion, e.g. `"$schema": "./node_modules/firebase-tools/schema/firebase-config.json",`. But this is not currently possible because of the `uri` format enforced by the schema.
