### PR TITLE
Add Firebase MCP server Claude plugin configuration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -31,23 +31,12 @@
         "cli"
       ],
       "category": "development",
-      "tags": [
-        "firebase",
-        "backend",
-        "database",
-        "cloud-services"
-      ],
+      "tags": ["firebase", "backend", "database", "cloud-services"],
       "mcpServers": {
         "firebase": {
           "description": "Firebase MCP server for understanding and managing your Firebase project, resources, and data",
           "command": "npx",
-          "args": [
-            "-y",
-            "firebase-tools",
-            "mcp",
-            "--dir",
-            "."
-          ],
+          "args": ["-y", "firebase-tools", "mcp", "--dir", "."],
           "env": {
             "IS_FIREBASE_MCP": "true"
           }

--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -62,15 +62,16 @@ The easiest way to set up the Firebase MCP server in Claude Code is to install t
    ```
 
 2. Install the Claude plugin for Firebase:
+
    ```bash
    claude plugin install firebase@firebase
    ```
 
-3.  Verify the installation:
+3. Verify the installation:
 
-    ```bash
-    claude plugin
-    ```
+   ```bash
+   claude plugin
+   ```
 
 ##### Option 2: Configure MCP server manually
 


### PR DESCRIPTION
Here's the complete step-by-step guide to install and test your Firebase MCP plugin locally:

  Step 1: Validate the marketplace configuration

  From your terminal in the firebase-tools directory:

  claude plugin validate .

  This will check if your marketplace.json is properly formatted.

  Step 2: Open Claude Code and add the marketplace

  Start Claude Code, then run this command in the Claude Code interface:

  /plugin marketplace add /Users/chliang/github/firebase-tools

  Or if you're already in a Claude Code session within the firebase-tools directory:

  /plugin marketplace add .

  You should see a confirmation that the marketplace was added.

  Step 3: List available marketplaces (optional)

  To verify the marketplace was added:

  /plugin marketplace list

  You should see firebase in the list.

  Step 4: Install the plugin

  /plugin install firebase-mcp-server@firebase

  Step 5: Verify the plugin is installed

  Check installed plugins:

  /plugin list

  You should see firebase-mcp-server@firebase in the list.

  Step 6: Test the MCP server

  Check if the Firebase MCP server is running:

  /mcp list

  You should see a firebase MCP server listed. You can now interact with Firebase services through the MCP
  interface in Claude Code.

  Step 7: Test Firebase functionality

  If you have a Firebase project in your current directory, try asking Claude Code to interact with Firebase.