### PR TITLE
feat(mcp): Modify crashlytics:connect prompt to instruct app id saving

### DIFF
--- a/src/mcp/prompts/crashlytics/connect.ts
+++ b/src/mcp/prompts/crashlytics/connect.ts
@@ -22,6 +22,12 @@ mobile application by accessing their Firebase Crashlytics data.
 
 Active user: ${accountEmail || "<NONE>"}
 
+General rules:
+**ASK THE USER WHAT THEY WOULD LIKE TO DO BEFORE TAKING ACTION**
+**ASK ONLY ONE QUESTION OF THE USER AT A TIME**
+**MAKE SURE TO FOLLOW THE INSTRUCTIONS, ESPECIALLY WHERE THEY ASK YOU TO CHECK IN WITH THE USER**
+**ADHERE TO SUGGESTED FORMATTING**
+
 ## Required first steps! Absolutely required! Incredibly important!
 
   1. **Make sure the user is logged in. No Crashlytics tools will work if the user is not logged in.**
@@ -31,39 +37,39 @@ Active user: ${accountEmail || "<NONE>"}
        user is logged in. 
 
   2. **Get the app ID for the Firebase application.** 
-     
-    Use the information below to help you find the developer's app ID. If you cannot find it after 2-3 
-    attempts, just ask the user for the value they want to use, providing the description of what the 
-    value looks like.
-    
-    * **Description:** The app ID we are looking for contains four colon (":") delimited parts: a version 
-      number (typically "1"), a project number, a platform type ("android", "ios", or "web"), 
-      and a sequence of hexadecimal characters. This can be found in the project settings in the Firebase Console
-      or in the appropriate google services file for the application type.
-    * For Android apps, you will typically find the app ID in a file called google-services.json under the
-      mobilesdk_app_id key. The file is most often located in the app directory that contains the src directory.
-    * For iOS apps, you will typically find the app ID in a property list file called GoogleService-Info.plist under the
-      GOOGLE_APP_ID key. The plist file is most often located in the main project directory.
-    * Sometimes developers will not check in the google services file because it is a shared or public
-      repository. If you can't find the file, the files may be included in the .gitignore. Check again for the file 
-      removing restrictions around looking for tracked files.
-    * Developers may have multiple google services files that map to different releases. In cases like this,
-      developers may create different directories to hold each like alpha/google-services.json or alpha/GoogleService-Info.plist.
-      In other cases, developers may change the suffix of the file to something like google-services-alpha.json or 
-      GoogleService-Alpha.plist. Look for as many google services files as you can find.
-    * Sometimes developers may include the codebase for both the Android app and the iOS app in the same repository.
-    * If there are multiple files or multiple app IDs in a single file, ask the user to choose one by providing 
-      a numbered list of all the package names.
-    * Again, if you have trouble finding the app ID, just ask the user for it.
+    a. **PRIORITIZE REMEMBERED APP ID ENTRIES** If an entry for this directory exists in the remembered app ids, use the remembered app id 
+       for this directory without presenting any additional options.
+       i. If there are multiple remembered app ids for this directory, ask the user to choose one by providing 
+          a numbered list of all the package names. Tell them that these values came from memories and how they can modify those values.
+    b. **IF THERE IS NO REMEMBERED ENTRY FOR THIS DIRECTORY** Use the app IDs from the \`firebase_get_environment\` tool. 
+       i. If you've already called this tool, use the previous response from context.
+       ii. If the 'Detected App IDs' is set to <NONE>, ask the user for the value they want to use.
+       iii. If there are multiple 'Detected App IDs', ask the user to choose one by providing 
+            a numbered list of all the package names and app ids.
+    c. **IF THERE IS A REMEMBERED VALUE BUT IT DOES NOT MATCH ANY DETECTED APP IDS** Ask if the user would like to replace the value with one of
+       the detected values.
+       i. **Description:** A valid app ID to remember contains four colon (":") delimited parts: a version 
+          number (typically "1"), a project number, a platform type ("android", "ios", or "web"), 
+          and a sequence of hexadecimal characters. 
+       ii. Replace the value for this directory with this valid app id, the android package name or ios bundle identifier, and the project directory.
+    c. **IF THERE IS NO REMEMBERED ENTRY FOR THIS DIRECTORY** Ask if the user would like to remember the app id selection
+       i. **Description:** A valid app ID to remember contains four colon (":") delimited parts: a version 
+          number (typically "1"), a project number, a platform type ("android", "ios", or "web"), 
+          and a sequence of hexadecimal characters. 
+       ii. Store the valid app id value, the android package name or ios bundle identifier, and the project directory.
 
 ## Next steps
 
-Once you have confirmed that the user is logged in to Firebase, and confirmed the
-id for the application that they want to access, then you can ask the user what actions
-they would like to perform. Here are some possibilities and instructions follow below:
+Once you have confirmed that the user is logged in to Firebase, confirmed the
+id for the application that they want to access, and asked if they want to remember the app id for this directory, 
+ask the user what actions they would like to perform. 
+
+Use the following format to ask the user what actions they would like to perform:
 
   1. Prioritize the most impactful stability issues
   2. Diagnose and propose a fix for a crash
+
+Wait for their response before taking action.
 
 ## Instructions for Using Crashlytics Data
 


### PR DESCRIPTION
### Description

Add instructions to ask the user if they would like to save the app id that was found.

### Scenarios Tested

* Save an app id
* Start with a saved app id
* Save an app ids from different directories
* Don't save the app id
* Have a different app id saved than what is detected in the directory
   - This one is interesting because you cannot modify memories in Gemini CLI, only add, so this doesn't work great. I'm not sure how this works in Claude or other agents, so I'm leaving this alone for now.

### Sample Commands

`/crashlytics:connect`
