### PR TITLE
refactor: create temporary directories in tests using os.tmpdir() for consistency.

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -79,8 +79,19 @@ describe("Config", () => {
   });
 
   describe("functions.source", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
+    });
+
+    afterEach(() => {
+      if (tmpDir) {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
     it("injects default source when default dir exists but source is missing", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
       fs.mkdirSync(path.join(tmpDir, Config.DEFAULT_FUNCTIONS_SOURCE));
 
       const cfg = new Config({ functions: {} }, { cwd: tmpDir, projectDir: tmpDir });
@@ -88,8 +99,6 @@ describe("Config", () => {
     });
 
     it("does not injects default source when default dir is missing", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
-
       const cfg = new Config(
         { functions: { runtime: "nodejs20" } },
         { cwd: tmpDir, projectDir: tmpDir },
@@ -98,7 +107,6 @@ describe("Config", () => {
     });
 
     it("does not inject source for remoteSource", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
       fs.mkdirSync(path.join(tmpDir, Config.DEFAULT_FUNCTIONS_SOURCE));
 
       const cfg = new Config(
@@ -114,7 +122,6 @@ describe("Config", () => {
     });
 
     it("injects into the first empty entry only when default dir exists", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
       fs.mkdirSync(path.join(tmpDir, Config.DEFAULT_FUNCTIONS_SOURCE));
 
       const cfg = new Config(
@@ -137,7 +144,6 @@ describe("Config", () => {
     });
 
     it("injects only one entry when multiple are empty", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
       fs.mkdirSync(path.join(tmpDir, Config.DEFAULT_FUNCTIONS_SOURCE));
 
       const cfg = new Config(
@@ -153,7 +159,6 @@ describe("Config", () => {
     });
 
     it("does not inject when no entry is empty", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
       fs.mkdirSync(path.join(tmpDir, Config.DEFAULT_FUNCTIONS_SOURCE));
 
       const cfg = new Config(
@@ -174,8 +179,6 @@ describe("Config", () => {
     });
 
     it("does not inject for arrays when default dir is missing", () => {
-      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-test"));
-
       const cfg = new Config(
         {
           functions: [{}, { source: "something" }],


### PR DESCRIPTION
This will stop createing firebase-test* folder in the workspace every time you run `npm run test`.