### PR TITLE
Preserve quota statuses so function deploy retries work

### DIFF
--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -26,6 +26,7 @@ function parseErrorCode(err: any): number {
     err.status ||
     err.code ||
     err.context?.response?.statusCode ||
+    err.original?.status ||
     err.original?.code ||
     err.original?.context?.response?.statusCode
   );

--- a/src/gcp/cloudfunctions.ts
+++ b/src/gcp/cloudfunctions.ts
@@ -173,6 +173,7 @@ export function captureRuntimeValidationError(errMessage: string): string {
  * @param err The error returned from the operation.
  */
 function functionsOpLogReject(funcName: string, type: string, err: any): void {
+  const status = err?.context?.response?.statusCode || err?.status;
   // Sniff for runtime validation errors and log a more user-friendly warning.
   if ((err?.message as string).includes("Runtime validation errors")) {
     const capturedMessage = captureRuntimeValidationError(err.message);
@@ -180,7 +181,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
       clc.bold(clc.yellow("functions:")) + " " + capturedMessage + " for function " + funcName,
     );
   }
-  if (err?.context?.response?.statusCode === 429) {
+  if (status === 429) {
     utils.logWarning(
       `${clc.bold(
         clc.yellow("functions:"),
@@ -193,7 +194,7 @@ function functionsOpLogReject(funcName: string, type: string, err: any): void {
   }
   throw new FirebaseError(`Failed to ${type} function ${funcName}`, {
     original: err,
-    status: err?.context?.response?.statusCode,
+    status,
     context: { function: funcName },
   });
 }

--- a/src/gcp/cloudfunctionsv2.ts
+++ b/src/gcp/cloudfunctionsv2.ts
@@ -216,6 +216,7 @@ interface GenerateUploadUrlResponse {
  * @param err The error returned from the operation.
  */
 function functionsOpLogReject(func: InputCloudFunction, type: string, err: any): void {
+  const status = err?.context?.response?.statusCode || err?.status;
   // Sniff for runtime validation errors and log a more user-friendly warning.
   if (err?.message?.includes("Runtime validation errors")) {
     const capturedMessage = captureRuntimeValidationError(err.message);
@@ -238,7 +239,7 @@ function functionsOpLogReject(func: InputCloudFunction, type: string, err: any):
     );
   } else {
     utils.logLabeledWarning("functions", `${err?.message}`);
-    if (err?.context?.response?.statusCode === 429) {
+    if (status === 429) {
       utils.logLabeledWarning(
         "functions",
         `Got "Quota Exceeded" error while trying to ${type} ${func.name}. Waiting to retry...`,
@@ -261,7 +262,7 @@ function functionsOpLogReject(func: InputCloudFunction, type: string, err: any):
   }
   throw new FirebaseError(`Failed to ${type} function ${func.name}`, {
     original: err,
-    status: err?.context?.response?.statusCode,
+    status,
     context: { function: func.name },
   });
 }


### PR DESCRIPTION
- Fix Cloud Functions v1/v2 error wrapping to retain HTTP status so 429/RESOURCE_EXHAUSTED surfaces correctly instead of being lost on rethrow.
- Broaden retry code parsing in the deploy executor to check nested original.status, letting quota errors re-queue instead of silently succeeding.
- This ensures quota-hit deploys actually retry and fail properly instead of yielding false-positive success.
