### PR TITLE
feat(functions): avoid blocking on missing v2 source tokens

### DIFF
--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -52,6 +52,9 @@ const eventarcPollerOptions: Omit<poller.OperationPollerOptions, "operationResou
 };
 
 const CLOUD_RUN_RESOURCE_EXHAUSTED_CODE = 8;
+// Bail out quickly when waiting for source tokens so we don't serialize builds
+// if the backend never returns a token (observed with some GCFv2 responses).
+const SOURCE_TOKEN_FETCH_TIMEOUT_MS = 2_000;
 
 export interface FabricatorArgs {
   executor: Executor;
@@ -375,7 +378,9 @@ export class Fabricator {
       resultFunction = await this.functionExecutor
         .run(async () => {
           if (experiments.isEnabled("functionsv2deployoptimizations")) {
-            apiFunction.buildConfig.sourceToken = await scraper.getToken();
+            apiFunction.buildConfig.sourceToken = await scraper.getToken({
+              timeoutMs: SOURCE_TOKEN_FETCH_TIMEOUT_MS,
+            });
           }
           const op: { name: string } = await gcfV2.createFunction(apiFunction);
           return await poller.pollOperation<gcfV2.OutputCloudFunction>({
@@ -515,7 +520,9 @@ export class Fabricator {
       .run(
         async () => {
           if (experiments.isEnabled("functionsv2deployoptimizations")) {
-            apiFunction.buildConfig.sourceToken = await scraper.getToken();
+            apiFunction.buildConfig.sourceToken = await scraper.getToken({
+              timeoutMs: SOURCE_TOKEN_FETCH_TIMEOUT_MS,
+            });
           }
           const op: { name: string } = await gcfV2.updateFunction(apiFunction);
           return await poller.pollOperation<gcfV2.OutputCloudFunction>({

--- a/src/deploy/functions/release/sourceTokenScraper.spec.ts
+++ b/src/deploy/functions/release/sourceTokenScraper.spec.ts
@@ -42,6 +42,24 @@ describe("SourceTokenScraper", () => {
     await expect(scraper.getToken()).to.eventually.equal("magic token");
   });
 
+  it("returns early when configured with a timeout", async () => {
+    const scraper = new SourceTokenScraper();
+    // Put the scraper into FETCHING state.
+    await scraper.getToken();
+
+    const start = Date.now();
+    await expect(scraper.getToken({ timeoutMs: 5 })).to.eventually.be.undefined;
+    expect(Date.now() - start).to.be.lessThan(100);
+
+    scraper.poller({
+      metadata: {
+        sourceToken: "magic token",
+        target: "projects/p/locations/l/functions/f",
+      },
+    });
+    await expect(scraper.getToken()).to.eventually.equal("magic token");
+  });
+
   it("refreshes token after timer expires", async () => {
     const scraper = new SourceTokenScraper(10);
     await expect(scraper.getToken()).to.eventually.be.undefined;


### PR DESCRIPTION
Add an optional timeout to SourceTokenScraper so callers can bail out when a
source token never returns. Use a 2s cap in v2 create/update paths to keep
builds running in parallel, while still reusing tokens when available. Add a
spec covering the timeout behavior.
