### PR TITLE
fix: honor functions --except for codebases and IAM checks

### DIFF
--- a/src/deploy/functions/args.ts
+++ b/src/deploy/functions/args.ts
@@ -36,6 +36,7 @@ export interface Payload {
 export interface Context {
   projectId: string;
   filters?: deployHelper.EndpointFilter[];
+  filtersExcept?: deployHelper.EndpointFilter[];
 
   // Filled in the "prepare" phase.
   config?: projectConfig.ValidatedConfig;

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -25,6 +25,7 @@ import { Options } from "../../options";
 import {
   EndpointFilter,
   endpointMatchesAnyFilter,
+  endpointMatchesDeploymentFilters,
   getEndpointFilters,
   groupEndpointsByCodebase,
   targetCodebases,
@@ -69,10 +70,18 @@ export async function prepare(
 
   context.config = normalizeAndValidate(options.config.src.functions);
   context.filters = getEndpointFilters(options, context.config); // Parse --only filters for functions.
+  context.filtersExcept = getEndpointFilters(options, context.config, "except");
 
-  const codebases = targetCodebases(context.config, context.filters);
+  const codebases = targetCodebases(context.config, context.filters, context.filtersExcept);
   if (codebases.length === 0) {
-    throw new FirebaseError("No function matches given --only filters. Aborting deployment.");
+    if (context.filters?.length) {
+      throw new FirebaseError("No function matches given --only filters. Aborting deployment.");
+    }
+    logLabeledBullet(
+      "functions",
+      "No functions codebases to deploy after applying --except filters, skipping.",
+    );
+    return;
   }
   for (const codebase of codebases) {
     logLabeledBullet("functions", `preparing codebase ${clc.bold(codebase)} for deployment`);
@@ -112,6 +121,7 @@ export async function prepare(
     firebaseConfig,
     runtimeConfig,
     context.filters,
+    context.filtersExcept,
   );
 
   // == Phase 1.5 Prepare extensions found in codebases if any
@@ -266,7 +276,7 @@ export async function prepare(
   // ===Phase 6. Ask for user prompts for things might warrant user attentions.
   // We limit the scope endpoints being deployed.
   const matchingBackend = backend.matchingBackend(wantBackend, (endpoint) => {
-    return endpointMatchesAnyFilter(endpoint, context.filters);
+    return endpointMatchesDeploymentFilters(endpoint, context.filters, context.filtersExcept);
   });
   await promptForFailurePolicies(options, matchingBackend, haveBackend);
   await promptForMinInstances(options, matchingBackend, haveBackend);
@@ -446,8 +456,9 @@ export async function loadCodebases(
   firebaseConfig: args.FirebaseConfig,
   runtimeConfig: Record<string, unknown>,
   filters?: EndpointFilter[],
+  excludeFilters?: EndpointFilter[],
 ): Promise<Record<string, build.Build>> {
-  const codebases = targetCodebases(config, filters);
+  const codebases = targetCodebases(config, filters, excludeFilters);
   const projectId = needProjectId(options);
 
   const wantBuilds: Record<string, build.Build> = {};

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -48,6 +48,7 @@ export async function release(
         wantBackend,
         haveBackend,
         filters: context.filters,
+        excludeFilters: context.filtersExcept,
       }),
     };
   }


### PR DESCRIPTION
- parse/propagate exclude filters alongside --only, skipping excluded codebases/endpoints
- apply include/exclude filtering in prepare, deploy planning, and HTTP IAM checks
- add unit coverage for deployment filters, codebase targeting, and excluded build skipping

Now if you do

```
firebase deploy --except functions:<codebase_a>
```

it will not try and load `codebase_a`.  However if you do

```
firebase deploy --except functions:<codebase_a>:<function_x>
```

It will still load the codebase in case there are other functions in the codebase