### PR TITLE
Fix(dataconnect): Allow non-string variables in execute

### DIFF
--- a/src/dataconnect/types.ts
+++ b/src/dataconnect/types.ts
@@ -266,7 +266,7 @@ export function isMainSchema(schema: Schema): boolean {
 export interface ExecuteGraphqlRequest {
   query: string;
   operationName?: string;
-  variables?: { [key: string]: string };
+  variables?: { [key: string]: any };
   extensions?: { impersonate?: Impersonation };
 }
 
@@ -277,7 +277,7 @@ export interface GraphqlResponse {
 
 export interface ExecuteOperationRequest {
   operationName: string;
-  variables?: { [key: string]: string };
+  variables?: { [key: string]: any };
 }
 
 export interface GraphqlResponseError {


### PR DESCRIPTION
This PR fixes an issue where GraphQL variables of types other than string were not being correctly passed to the Data Connect backend. This was caused by a type mismatch in the `ExecuteGraphqlRequest` and `ExecuteOperationRequest` interfaces, where the `variables` field was typed as `{ [key: string]: string }` instead of `{ [key: string]: any }`.

This change updates the types to allow any value type for variables, which aligns with the actual usage in `dataconnect-execute.ts` and how the backend handles variables.