### PR TITLE
[VS Code] Surface all execute error back

### DIFF
--- a/firebase-vscode/src/data-connect/execution/execution.ts
+++ b/firebase-vscode/src/data-connect/execution/execution.ts
@@ -199,14 +199,6 @@ export function registerExecution(
       }
     }
 
-    // build schema to check for compilation errors
-    // TODO: run schema check on locally modified schema
-    const introspect = await dataConnectService.introspect();
-    if (!introspect.data) {
-      executionError("Please check your compilation errors");
-      return undefined;
-    }
-
     // get all gql files from connector and validate
     const gqlText = await getConnectorGQLText(documentPath);
 


### PR DESCRIPTION
Bug report: https://github.com/firebase/firebase-tools/issues/9419

The introspection check swallowed the underlying bug "service is not found" (from my repro), making it hard to tell what actually happened.

We should allow the request to execute and surface the underlying error back, so customers has more information to diagnose the issue.

NOTE: This didn't address the underlying bug.