### PR TITLE
Don't pass undefined to getCommand

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -11,7 +11,7 @@ export const command = new Command("help [command]")
   .action(function (commandName) {
     // @ts-ignore
     const client = this.client; // eslint-disable-line @typescript-eslint/no-invalid-this
-    const cmd = client.getCommand(commandName);
+    const cmd = commandName ? client.getCommand(commandName) : undefined;
     if (cmd) {
       cmd.outputHelp();
     } else if (commandName) {


### PR DESCRIPTION
### Description
Fixes an issue that was breaking 'firebase help':

<img width="898" height="295" alt="Screenshot 2025-12-08 at 10 20 28 AM" src="https://github.com/user-attachments/assets/5da23dfb-1f98-4c8c-a230-9e190be7e754" />
