### PR TITLE
Fix --help

### DIFF
--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -111,7 +111,10 @@ export function cli(pkg: any) {
   // If this is a help command, load all commands so we can display them.
   const commandName = args[0];
   const isHelp =
-    !args.length || commandName === "help" || (args.length === 1 && commandName === "ext");
+    !args.length ||
+    commandName === "help" ||
+    (args.length === 1 && commandName === "ext") ||
+    commandName === "--help";
   const hasHelpFlag = args.includes("--help") || args.includes("-h");
 
   if (hasHelpFlag) {


### PR DESCRIPTION
### Description
Fix --help in a bunch of cases where it was behaving badly:

`firebase --help` behaves like `firebase help`
<img width="989" height="632" alt="Screenshot 2025-12-08 at 1 02 25 PM" src="https://github.com/user-attachments/assets/0c460083-2dd2-437b-87ac-3de98c9fd8b4" />

`firebase [command] --help` behaves like `firebase help [command]`:
<img width="894" height="294" alt="Screenshot 2025-12-08 at 1 00 44 PM" src="https://github.com/user-attachments/assets/2c5b6246-4754-4da1-acfc-6bf6825f6f2d" />

`firebase help --help` displays help text for the help command:
<img width="406" height="83" alt="Screenshot 2025-12-08 at 1 01 05 PM" src="https://github.com/user-attachments/assets/c3efc208-4c23-445c-8fce-517e06c644f3" />

