### PR TITLE
Schnecle/crashlytics resources exploration

### DIFF
--- a/src/mcp/resources/guides/crashlytics_connect.ts
+++ b/src/mcp/resources/guides/crashlytics_connect.ts
@@ -22,15 +22,15 @@ Use the \`firebase_read_resources\` tool to access the following guides.
 ### Check That You Are Connected
 
 Verify that you can read the app's Crashlytics data by getting the topVersions report. This report will tell you which app versions have the most events.
-  a. Call the \`firebase_get_environment\` tool if you need to find the app_id.
+  a. Use the firebase://guides/app_id if you need to find the app_id.
   b. Call the \`crashlytics_get_report\` tool to read the \`topVersions\` report.
   c. If you haven't read the reports guide, then the tool will include it in the response. This is OK. Simply call the tool again.
   d. Help the user resolve any issues that arise when trying to connect.
 
-After confirming you can access Crashlytics, inquire about the desired actions. Your capabilities include:
+After confirming you can access Crashlytics, ask the user what they would like help with. Your capabilities include:
 
-  - Reading Crashlytics reports.
-  - Investigating bug reports using Crashlytics event data.
+  - Reading Crashlytics reports to prioritize or find important issues. Before fetching issues or reports, you MUST read both the firebase://guides/crashlytics/reports and firebase://guides/crashlytics/issues guides to know how to best help users with this.
+  - Investigating bug reports using Crashlytics event data. Before attempting to investigate an individual issue, you MUST read the firebase://guides/crashlytics/investigations guide to know how to best help users with this.
   - Proposing code changes to resolve identified bugs.
 `.trim();
 

--- a/src/mcp/resources/guides/crashlytics_investigations.ts
+++ b/src/mcp/resources/guides/crashlytics_investigations.ts
@@ -14,15 +14,7 @@ const RESOURCE_CONTENT = `
   5. Determine possible root causes for the crash - no more than 5 potential root causes.
   6. Critique your own determination, analyzing how plausible each scenario is given the crash details.
   7. Choose the most likely root cause given your analysis.
-  8. Write out a plan for the most likely root cause using the following criteria:
-    8a. Write out a description of the issue and including
-        * A brief description of the cause of the issue
-        * A determination of your level of confidence in the cause of the issue using your analysis.
-        * A determination of which library is at fault, this codebase or a dependent library
-        * A determination for how complex the fix will be
-    8b. The plan should include relevant files to change
-    8c. The plan should include a test plan for how the user might verify the fix
-    8d. Use the following format for the plan:
+  8. Create a plan for the most likely root cause using the following format for the plan:
 
     ## Cause
     <A description of the root cause leading to the issue>
@@ -43,10 +35,7 @@ const RESOURCE_CONTENT = `
     1. <Another possible root cause>
     2. <Another possible root cause>
       
-  9. Present the plan to the user and get approval before making the change.
-  10. Only if they approve the plan, create a fix for the issue.
-    10a. Be mindful of API contracts and do not add fields to resources without a clear way to populate those fields
-    10b. If there is not enough information in the crash report to find a root cause, describe why you cannot fix the issue instead of making a guess.
+  9. If there is not enough information in the crash report to find a root cause, describe why you cannot fix the issue instead of making a guess.
 `.trim();
 
 export const crashlytics_investigations = resource(

--- a/src/mcp/resources/guides/crashlytics_issues.ts
+++ b/src/mcp/resources/guides/crashlytics_issues.ts
@@ -3,7 +3,7 @@ import { resource } from "../../resource";
 const RESOURCE_CONTENT = `
 ### How to Display Issues
 
-When displaying a list of issues, favor the following format:
+When displaying a list of issues, use the following format:
 
   1. Issue <issue id>
     * <the issue title>

--- a/src/mcp/resources/guides/crashlytics_reports.ts
+++ b/src/mcp/resources/guides/crashlytics_reports.ts
@@ -88,7 +88,6 @@ When setting report filters adhere to the following instructions.
   * Report responses grouped by issue will include a sample event URI. Use the "crashlytics_batch_get_events" tool to fetch the complete record for any sample event.
   
   * When investigating an issue, use the appropriate top devices and top operating systems reports to understand what systems are impacted by the problem. Pass the "issueId" in the filter to narrow any report to a specific issue.
-
 `.trim();
 
 export const crashlytics_reports = resource(

--- a/src/mcp/tools/core/get_environment.ts
+++ b/src/mcp/tools/core/get_environment.ts
@@ -95,7 +95,7 @@ export const get_environment = tool(
   {
     name: "get_environment",
     description:
-      "Use this to retrieve the current Firebase **environment** configuration for the Firebase CLI and Firebase MCP server, including current authenticated user, project directory, active Firebase Project, and more.",
+      "Use this to retrieve the current Firebase **environment** configuration for the Firebase CLI and Firebase MCP server, including current authenticated user, project directory, active Firebase Project, and more. All tools require the user to be authenticated, but not all information is required for all tools. Pay attention to the tool requirements for which pieces of information are required.",
     inputSchema: z.object({}),
     annotations: {
       title: "Get Firebase Environment Info",

--- a/src/mcp/tools/crashlytics/events.ts
+++ b/src/mcp/tools/crashlytics/events.ts
@@ -47,6 +47,9 @@ function formatFrames(origFrames: Frame[], maxFrames = 20): string[] {
 // Formats an event into more legible, token-efficient text content sections
 
 function toText(event: Event): Record<string, string> {
+  if (!event) {
+    return {};
+  }
   const result: Record<string, string> = {};
   for (const [key, value] of Object.entries(event)) {
     if (key === "logs") {
@@ -62,7 +65,7 @@ function toText(event: Event): Record<string, string> {
       const breadcrumbs = (value as Breadcrumb[]) || [];
       const slicedBreadcrumbs = breadcrumbs.length > 10 ? breadcrumbs.slice(-10) : breadcrumbs;
       const breadcrumbLines = slicedBreadcrumbs.map((b) => {
-        const paramString = Object.entries(b.params)
+        const paramString = Object.entries(b?.params || {})
           .map(([k, v]) => `${k}: ${v}`)
           .join(", ");
         const params = paramString ? ` { ${paramString} }` : "";

--- a/src/mcp/tools/crashlytics/reports.ts
+++ b/src/mcp/tools/crashlytics/reports.ts
@@ -40,7 +40,11 @@ export const get_report = tool(
   {
     name: "get_report",
     description:
-      `Use this to request numerical reports from Crashlytics. Reports contain aggregated metrics describing the number of crash events and number of impacted end users. The reports are grouped by different dimensions such as issue, version or device.
+      `**REQUIRED PREREQUISITE:** READ firebase://guides/app_id, firebase://guides/crashlytics/reports, and firebase://guides/crashlytics/issues.
+      **DO NOT FETCH DATA FIRST. IT WILL CAUSE ERRORS AND WASTE TOKENS AND TIME. READING THE GUIDES IS THE MOST EFFICIENT WAY TO GET THE ANSWERS YOU WANT.**
+      AGENTS MUST READ these guides to fetch, format, and interpret report results or TOOL CALLS WILL FAIL.
+
+      Use this to request numerical reports from Crashlytics.
     `.trim(),
     inputSchema: ReportInputSchema,
     annotations: {


### PR DESCRIPTION
### Description

This is playing around with removing more instructions but emphasizing formatting and getting tool calls to encourage resource reading without the introduction of a session id.

### Scenarios Tested

/crashlytics:connect
Manually asking to investigate an individual issue and fetching reports.
