### PR TITLE
express: avoid shell interpolation in npm pack

### DIFF
--- a/src/frameworks/express/index.spec.ts
+++ b/src/frameworks/express/index.spec.ts
@@ -1,0 +1,48 @@
+import * as childProcess from "child_process";
+import { expect } from "chai";
+import * as fs from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import * as sinon from "sinon";
+import { ɵcodegenFunctionsDirectory } from "./index";
+
+describe("express codegen", () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("packs the app without shell interpolation", async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), "express root-"));
+    const dest = await fs.mkdtemp(join(tmpdir(), "express dest-"));
+    try {
+      await fs.writeFile(
+        join(root, "package.json"),
+        JSON.stringify({ name: "test-express-app", main: "index.js" }),
+      );
+      await fs.writeFile(join(root, "index.js"), "exports.handle = () => {};\n");
+
+      const packOutput = JSON.stringify([
+        { name: "test-express-app", filename: "test-express-app-1.0.0.tgz" },
+      ]);
+      const execFileSyncStub = sandbox
+        .stub(childProcess, "execFileSync")
+        .returns(Buffer.from(packOutput));
+
+      const result = await ɵcodegenFunctionsDirectory(root, dest);
+
+      expect(execFileSyncStub).to.have.been.calledWith(
+        "npm",
+        ["pack", root, "--json"],
+        sinon.match({ cwd: dest }),
+      );
+      expect(result.packageJson.dependencies?.["test-express-app"]).to.equal(
+        "file:test-express-app-1.0.0.tgz",
+      );
+    } finally {
+      await fs.rm(root, { recursive: true, force: true });
+      await fs.rm(dest, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/frameworks/express/index.ts
+++ b/src/frameworks/express/index.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import * as childProcess from "child_process";
 import { copy, pathExists } from "fs-extra";
 import { mkdir, readFile } from "fs/promises";
 import { join } from "path";
@@ -29,7 +29,7 @@ export async function discover(dir: string) {
 }
 
 export async function build(cwd: string): Promise<BuildResult> {
-  execSync(`npm run build`, { stdio: "inherit", cwd });
+  childProcess.execSync(`npm run build`, { stdio: "inherit", cwd });
   const wantsBackend = !!(await getBootstrapScript(cwd));
   return { wantsBackend };
 }
@@ -100,7 +100,7 @@ export async function ɵcodegenFunctionsDirectory(root: string, dest: string) {
 
   const { packageJson } = await getConfig(root);
 
-  const packResults = execSync(`npm pack ${root} --json`, { cwd: dest });
+  const packResults = childProcess.execFileSync("npm", ["pack", root, "--json"], { cwd: dest });
   const npmPackResults = JSON.parse(packResults.toString());
   const matchingPackResult = npmPackResults.find((it: any) => it.name === packageJson.name);
   const { filename } = matchingPackResult;


### PR DESCRIPTION
## Context\nThe express codegen path invokes 
> firebase-tools@15.2.1 prepare
> npm run clean && npm run build:publish


> firebase-tools@15.2.1 clean
> node -e "fs.rmSync('lib', { recursive: true, force: true }); fs.rmSync('dev', { recursive: true, force: true });"


> firebase-tools@15.2.1 build:publish
> tsc --build tsconfig.publish.json && npm run copyfiles via a shell. If the project path includes shell metacharacters, the command can be interpreted by the shell.\n\n## Change\nCall npm via execFileSync with explicit args, and add a regression test that uses a path with spaces.\n\n## Testing\n- Ubuntu 22.04 (AWS eu-west-2), Node 20\n- npx mocha --no-config --require ts-node/register --require source-map-support/register --require src/test/helpers/mocha-bootstrap.ts --file src/test/helpers/global-mock-auth.ts src/frameworks/express/index.spec.ts