### PR TITLE
Fix an issue where hosting upload errors were swallowed by a circular JSON error

### DIFF
--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -250,7 +250,7 @@ export class Uploader {
       logger.debug(
         `[hosting][upload] ${this.hashMap[toUpload]} (${toUpload}) HTTP ERROR ${
           res.status
-        }: headers=${JSON.stringify(res.response.headers)} ${errorMessage}`,
+        }: headers=${JSON.stringify(res.response.headers.raw())} ${errorMessage}`,
       );
       throw new Error(`Unexpected error while uploading file: ${errorMessage}`);
     }


### PR DESCRIPTION
### Description
Headers is a circular structure that can't be JSON.stringified. This was causing errors to be swallowed (as in #6639)
