### PR TITLE
support next build --webpack flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Add support for the --webpack flag in Next.js build (#9761)

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -17,6 +17,7 @@ import {
   getNodeModuleBin,
   warnIfCustomBuildScript,
   findDependency,
+  getBuildScript,
 } from "../utils";
 import {
   getAllTargets,
@@ -64,7 +65,10 @@ export async function build(dir: string, configuration: string): Promise<BuildRe
     baseHref: baseUrl,
     ssr,
   } = await getBuildConfig(dir, configuration);
-  await warnIfCustomBuildScript(dir, name, DEFAULT_BUILD_SCRIPT);
+  const buildScript = await getBuildScript(join(dir, "package.json"));
+  if (buildScript) {
+    warnIfCustomBuildScript(buildScript, name, DEFAULT_BUILD_SCRIPT);
+  }
   for (const target of targets) {
     // TODO there is a bug here. Spawn for now.
     // await scheduleTarget(prerenderTarget);

--- a/src/frameworks/astro/index.ts
+++ b/src/frameworks/astro/index.ts
@@ -3,7 +3,13 @@ import { copy, existsSync } from "fs-extra";
 import { join } from "path";
 import { BuildResult, Discovery, FrameworkType, SupportLevel } from "../interfaces";
 import { FirebaseError } from "../../error";
-import { readJSON, simpleProxy, warnIfCustomBuildScript, getNodeModuleBin } from "../utils";
+import {
+  readJSON,
+  simpleProxy,
+  warnIfCustomBuildScript,
+  getNodeModuleBin,
+  getBuildScript,
+} from "../utils";
 import { getAstroVersion, getBootstrapScript, getConfig } from "./utils";
 
 export const name = "Astro";
@@ -26,7 +32,10 @@ const DEFAULT_BUILD_SCRIPT = ["astro build"];
 
 export async function build(cwd: string): Promise<BuildResult> {
   const cli = getNodeModuleBin("astro", cwd);
-  await warnIfCustomBuildScript(cwd, name, DEFAULT_BUILD_SCRIPT);
+  const buildScript = await getBuildScript(join(cwd, "package.json"));
+  if (buildScript) {
+    warnIfCustomBuildScript(buildScript, name, DEFAULT_BUILD_SCRIPT);
+  }
   const { output, adapter } = await getConfig(cwd);
   const wantsBackend = output !== "static";
   if (wantsBackend && adapter?.name !== "@astrojs/node") {

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -28,6 +28,7 @@ import {
   findDependency,
   validateLocales,
   getNodeModuleBin,
+  getBuildScript,
 } from "../utils";
 import {
   BuildResult,
@@ -87,7 +88,7 @@ import { getAllSiteDomains, getDeploymentDomain } from "../../hosting/api";
 import { logger } from "../../logger";
 import { parseStrict } from "../../functions/env";
 
-const DEFAULT_BUILD_SCRIPT = ["next build"];
+const DEFAULT_BUILD_SCRIPT = ["next build", "next build --webpack"];
 const PUBLIC_DIR = "public";
 
 export const supportedRange = "12 - 15.0";
@@ -119,10 +120,13 @@ export async function discover(dir: string) {
  */
 export async function build(
   dir: string,
-  target: string,
+  _target: string,
   context?: FrameworkContext,
 ): Promise<BuildResult> {
-  await warnIfCustomBuildScript(dir, name, DEFAULT_BUILD_SCRIPT);
+  const buildScript = await getBuildScript(dir);
+  if (buildScript) {
+    warnIfCustomBuildScript(buildScript, name, DEFAULT_BUILD_SCRIPT);
+  }
 
   const reactVersion = getReactVersion(dir);
   if (reactVersion && gte(reactVersion, "18.0.0")) {
@@ -162,7 +166,11 @@ export async function build(
   const cli = getNodeModuleBin("next", dir);
 
   const nextBuild = new Promise((resolve, reject) => {
-    const buildProcess = spawn(cli, ["build"], { cwd: dir, env });
+    const buildProcess = spawn(
+      cli,
+      ["build", ...(buildScript?.includes("--webpack") ? ["--webpack"] : [])],
+      { cwd: dir, env },
+    );
     buildProcess.stdout?.on("data", (data) => logger.info(data.toString()));
     buildProcess.stderr?.on("data", (data) => logger.info(data.toString()));
     buildProcess.on("error", (err) => {
@@ -417,7 +425,7 @@ export async function init(setup: any, config: any) {
   });
   execSync(
     `npx --yes create-next-app@"${supportedRange}" -e hello-world ` +
-      `${setup.featureInfo.hosting.source} --use-npm --${language}`,
+    `${setup.featureInfo.hosting.source} --use-npm --${language}`,
     { stdio: "inherit", cwd: config.projectDir },
   );
 }

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -123,7 +123,7 @@ export async function build(
   _target: string,
   context?: FrameworkContext,
 ): Promise<BuildResult> {
-  const buildScript = await getBuildScript(dir);
+  const buildScript = await getBuildScript(join(dir, "package.json"));
   if (buildScript) {
     warnIfCustomBuildScript(buildScript, name, DEFAULT_BUILD_SCRIPT);
   }

--- a/src/frameworks/next/index.ts
+++ b/src/frameworks/next/index.ts
@@ -425,7 +425,7 @@ export async function init(setup: any, config: any) {
   });
   execSync(
     `npx --yes create-next-app@"${supportedRange}" -e hello-world ` +
-    `${setup.featureInfo.hosting.source} --use-npm --${language}`,
+      `${setup.featureInfo.hosting.source} --use-npm --${language}`,
     { stdio: "inherit", cwd: config.projectDir },
   );
 }

--- a/src/frameworks/nuxt/index.ts
+++ b/src/frameworks/nuxt/index.ts
@@ -4,7 +4,13 @@ import { join, posix } from "path";
 import { lt } from "semver";
 import { spawn, sync as spawnSync } from "cross-spawn";
 import { FrameworkType, SupportLevel } from "../interfaces";
-import { simpleProxy, warnIfCustomBuildScript, getNodeModuleBin, relativeRequire } from "../utils";
+import {
+  simpleProxy,
+  warnIfCustomBuildScript,
+  getNodeModuleBin,
+  relativeRequire,
+  getBuildScript,
+} from "../utils";
 import { getNuxtVersion } from "./utils";
 
 export const name = "Nuxt";
@@ -39,7 +45,10 @@ export async function discover(dir: string) {
 }
 
 export async function build(cwd: string) {
-  await warnIfCustomBuildScript(cwd, name, DEFAULT_BUILD_SCRIPT);
+  const buildScript = await getBuildScript(join(cwd, "package.json"));
+  if (buildScript) {
+    warnIfCustomBuildScript(buildScript, name, DEFAULT_BUILD_SCRIPT);
+  }
   const cli = getNodeModuleBin("nuxt", cwd);
   const {
     ssr: wantsBackend,

--- a/src/frameworks/utils.spec.ts
+++ b/src/frameworks/utils.spec.ts
@@ -89,7 +89,7 @@ describe("Frameworks utils", () => {
       packageJson.scripts.build = buildScript;
 
       sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
-      warnIfCustomBuildScript("fakedir/", framework, defaultBuildScripts);
+      warnIfCustomBuildScript(buildScript, framework, defaultBuildScripts);
 
       expect(consoleLogSpy).to.be.calledOnceWith(
         `\nWARNING: Your package.json contains a custom build that is being ignored. Only the ${framework} default build script (e.g, "${defaultBuildScripts[0]}") is respected. If you have a more advanced build process you should build a custom integration https://firebase.google.com/docs/hosting/express\n`,

--- a/src/frameworks/utils.spec.ts
+++ b/src/frameworks/utils.spec.ts
@@ -170,7 +170,10 @@ describe("Frameworks utils", () => {
     it("should return undefined if no build script exists", async () => {
       delete packageJson.scripts.build;
 
-      sandbox.stub(fs.promises, "readFile").withArgs("dir/package.json").resolves(JSON.stringify(packageJson));
+      sandbox
+        .stub(fs.promises, "readFile")
+        .withArgs("dir/package.json")
+        .resolves(JSON.stringify(packageJson));
       const buildScript = await getBuildScript("dir/package.json");
       expect(buildScript).to.be.undefined;
     });

--- a/src/frameworks/utils.spec.ts
+++ b/src/frameworks/utils.spec.ts
@@ -163,22 +163,21 @@ describe("Frameworks utils", () => {
 
       sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
 
-      const buildScript = await getBuildScript("fakedir/");
+      const buildScript = await getBuildScript("dir/package.json");
       expect(buildScript).to.equal("test build script");
     });
 
     it("should return undefined if no build script exists", async () => {
       delete packageJson.scripts.build;
 
-      sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
-
-      const buildScript = await getBuildScript("fakedir/");
+      sandbox.stub(fs.promises, "readFile").withArgs("dir/package.json").resolves(JSON.stringify(packageJson));
+      const buildScript = await getBuildScript("dir/package.json");
       expect(buildScript).to.be.undefined;
     });
 
     it("should return undefined if package.json is not found", async () => {
       sandbox.stub(fs.promises, "readFile").rejects(new Error());
-      const buildScript = await getBuildScript("fakedir/");
+      const buildScript = await getBuildScript("dir/package.json");
       expect(buildScript).to.be.undefined;
     });
   });

--- a/src/frameworks/utils.spec.ts
+++ b/src/frameworks/utils.spec.ts
@@ -158,7 +158,10 @@ describe("Frameworks utils", () => {
     it("should return the build script from package.json", async () => {
       packageJson.scripts.build = "test build script";
 
-      sandbox.stub(fs.promises, "readFile").withArgs("dir/package.json").resolves(JSON.stringify(packageJson));
+      sandbox
+        .stub(fs.promises, "readFile")
+        .withArgs("dir/package.json")
+        .resolves(JSON.stringify(packageJson));
 
       const buildScript = await getBuildScript("dir/package.json");
       expect(buildScript).to.equal("test build script");

--- a/src/frameworks/utils.spec.ts
+++ b/src/frameworks/utils.spec.ts
@@ -76,8 +76,6 @@ describe("Frameworks utils", () => {
       const defaultBuildScripts = ["next build"];
       packageJson.scripts.build = buildScript;
 
-      sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
-
       warnIfCustomBuildScript(buildScript, framework, defaultBuildScripts);
 
       expect(consoleLogSpy.callCount).to.equal(0);
@@ -88,7 +86,6 @@ describe("Frameworks utils", () => {
       const defaultBuildScripts = ["next build"];
       packageJson.scripts.build = buildScript;
 
-      sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
       warnIfCustomBuildScript(buildScript, framework, defaultBuildScripts);
 
       expect(consoleLogSpy).to.be.calledOnceWith(
@@ -161,7 +158,7 @@ describe("Frameworks utils", () => {
     it("should return the build script from package.json", async () => {
       packageJson.scripts.build = "test build script";
 
-      sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
+      sandbox.stub(fs.promises, "readFile").withArgs("dir/package.json").resolves(JSON.stringify(packageJson));
 
       const buildScript = await getBuildScript("dir/package.json");
       expect(buildScript).to.equal("test build script");
@@ -179,7 +176,7 @@ describe("Frameworks utils", () => {
     });
 
     it("should return undefined if package.json is not found", async () => {
-      sandbox.stub(fs.promises, "readFile").rejects(new Error());
+      sandbox.stub(fs.promises, "readFile").withArgs("dir/package.json").rejects(new Error());
       const buildScript = await getBuildScript("dir/package.json");
       expect(buildScript).to.be.undefined;
     });

--- a/src/frameworks/utils.spec.ts
+++ b/src/frameworks/utils.spec.ts
@@ -1,9 +1,15 @@
 import { expect } from "chai";
-import * as sinon from "sinon";
 import * as fs from "fs";
-import { resolve, join } from "path";
+import { join, resolve } from "path";
+import * as sinon from "sinon";
 
-import { warnIfCustomBuildScript, isUrl, getNodeModuleBin, conjoinOptions } from "./utils";
+import {
+  conjoinOptions,
+  getBuildScript,
+  getNodeModuleBin,
+  isUrl,
+  warnIfCustomBuildScript,
+} from "./utils";
 
 describe("Frameworks utils", () => {
   describe("getNodeModuleBin", () => {
@@ -65,26 +71,25 @@ describe("Frameworks utils", () => {
       sandbox.restore();
     });
 
-    it("should not print warning when a default build script is found.", async () => {
+    it("should not print warning when a default build script is found.", () => {
       const buildScript = "next build";
       const defaultBuildScripts = ["next build"];
       packageJson.scripts.build = buildScript;
 
       sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
 
-      await warnIfCustomBuildScript("fakedir/", framework, defaultBuildScripts);
+      warnIfCustomBuildScript(buildScript, framework, defaultBuildScripts);
 
       expect(consoleLogSpy.callCount).to.equal(0);
     });
 
-    it("should print warning when a custom build script is found.", async () => {
+    it("should print warning when a custom build script is found.", () => {
       const buildScript = "echo 'Custom build script' && next build";
       const defaultBuildScripts = ["next build"];
       packageJson.scripts.build = buildScript;
 
       sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
-
-      await warnIfCustomBuildScript("fakedir/", framework, defaultBuildScripts);
+      warnIfCustomBuildScript("fakedir/", framework, defaultBuildScripts);
 
       expect(consoleLogSpy).to.be.calledOnceWith(
         `\nWARNING: Your package.json contains a custom build that is being ignored. Only the ${framework} default build script (e.g, "${defaultBuildScripts[0]}") is respected. If you have a more advanced build process you should build a custom integration https://firebase.google.com/docs/hosting/express\n`,
@@ -133,6 +138,48 @@ describe("Frameworks utils", () => {
       expect(conjoinOptions(options, customConjuntion, defaultSeparator)).to.equal(
         `${options[0]}${defaultSeparator} ${options[1]}${defaultSeparator} ${customConjuntion} ${options[2]}`,
       );
+    });
+  });
+
+  describe("getBuildScript", () => {
+    let sandbox: sinon.SinonSandbox;
+    const packageJson: Record<string, Record<string, string>> = {
+      scripts: {
+        build: "",
+      },
+    };
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      packageJson.scripts.build = "";
+    });
+
+    it("should return the build script from package.json", async () => {
+      packageJson.scripts.build = "test build script";
+
+      sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
+
+      const buildScript = await getBuildScript("fakedir/");
+      expect(buildScript).to.equal("test build script");
+    });
+
+    it("should return undefined if no build script exists", async () => {
+      delete packageJson.scripts.build;
+
+      sandbox.stub(fs.promises, "readFile").resolves(JSON.stringify(packageJson));
+
+      const buildScript = await getBuildScript("fakedir/");
+      expect(buildScript).to.be.undefined;
+    });
+
+    it("should return undefined if package.json is not found", async () => {
+      sandbox.stub(fs.promises, "readFile").rejects(new Error());
+      const buildScript = await getBuildScript("fakedir/");
+      expect(buildScript).to.be.undefined;
     });
   });
 });

--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -67,7 +67,7 @@ export function warnIfCustomBuildScript(
  * Get the build script from package.json.
  *
  * @param packageJsonPath - The path to the package.json file.
- * @returns The build script from package.json.
+ * @returns The build script from package.json, or undefined if the build script or package.json is not found.
  */
 export async function getBuildScript(packageJsonPath: string): Promise<string | undefined> {
   try {

--- a/src/frameworks/utils.ts
+++ b/src/frameworks/utils.ts
@@ -51,19 +51,31 @@ export function readJSON<JsonType = any>(
  * Prints a warning if the build script in package.json
  * contains anything other than allowedBuildScripts.
  */
-export async function warnIfCustomBuildScript(
-  dir: string,
+export function warnIfCustomBuildScript(
+  buildScript: string,
   framework: string,
   defaultBuildScripts: string[],
-): Promise<void> {
-  const packageJsonBuffer = await readFile(join(dir, "package.json"));
-  const packageJson = JSON.parse(packageJsonBuffer.toString());
-  const buildScript = packageJson.scripts?.build;
-
-  if (buildScript && !defaultBuildScripts.includes(buildScript)) {
+): void {
+  if (!defaultBuildScripts.includes(buildScript)) {
     console.warn(
       `\nWARNING: Your package.json contains a custom build that is being ignored. Only the ${framework} default build script (e.g, "${defaultBuildScripts[0]}") is respected. If you have a more advanced build process you should build a custom integration https://firebase.google.com/docs/hosting/express\n`,
     );
+  }
+}
+
+/**
+ * Get the build script from package.json.
+ *
+ * @param packageJsonPath - The path to the package.json file.
+ * @returns The build script from package.json.
+ */
+export async function getBuildScript(packageJsonPath: string): Promise<string | undefined> {
+  try {
+    const packageJsonBuffer = await readFile(packageJsonPath);
+    const packageJson = JSON.parse(packageJsonBuffer.toString());
+    return packageJson.scripts?.build;
+  } catch (error) {
+    return undefined;
   }
 }
 

--- a/src/frameworks/vite/index.ts
+++ b/src/frameworks/vite/index.ts
@@ -12,6 +12,7 @@ import {
   findDependency,
   getNodeModuleBin,
   relativeRequire,
+  getBuildScript,
 } from "../utils";
 
 export const name = "Vite";
@@ -83,7 +84,10 @@ export async function discover(dir: string, plugin?: string, npmDependency?: str
 export async function build(root: string, target: string) {
   const { build } = await relativeRequire(root, "vite");
 
-  await warnIfCustomBuildScript(root, name, DEFAULT_BUILD_SCRIPT);
+  const buildScript = await getBuildScript(join(root, "package.json"));
+  if (buildScript) {
+    warnIfCustomBuildScript(buildScript, name, DEFAULT_BUILD_SCRIPT);
+  }
 
   // SvelteKit uses process.cwd() unfortunately, chdir
   const cwd = process.cwd();


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR adds support for the `next build --webpack` command in the Next.js framework integration. With Next.js 16 defaulting to Turbopack, this change allows users to explicitly opt-out and force Webpack usage by defining `"build": "next build --webpack"` in their `package.json`.

Previously, `firebase deploy` would ignore this flag and warn about a custom build script. This update detects the flag, forwards it to the build process, and suppresses the warning for this specific valid configuration.

Fixes #9749

### Scenarios Tested

*   **Standard Build:** Verified that `"build": "next build"` continues to work as expected without warnings.
*   **Webpack Opt-in:** Verified that `"build": "next build --webpack"` correctly forwards the `--webpack` flag to the build command and suppresses the custom script warning.
*   **Custom Scripts:** Verified that unsupported custom scripts (e.g., `"build": "next build --verbose"`) still trigger the standard warning and do not forward arbitrary flags.
*   **Unit Tests:** Added unit tests for the new `getBuildScript` utility and verified existing tests pass.

### Sample Commands

Users can now use the following in their `package.json`:
```
{
  "scripts": {
     "build": "next build --webpack"
   }
}
```