### PR TITLE
store overwrite index prompt response to info.writeIndexes

### DIFF
--- a/src/init/features/firestore/indexes.ts
+++ b/src/init/features/firestore/indexes.ts
@@ -39,7 +39,7 @@ export async function initIndexes(setup: Setup, config: Config, info: RequiredIn
     }
   }
 
-  info.writeRules = await config.confirmWriteProjectFile(info.indexesFilename, info.indexes);
+  info.writeIndexes = await config.confirmWriteProjectFile(info.indexesFilename, info.indexes);
 }
 
 async function getIndexesFromConsole(


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

`info.writeIndexes` is always true, when running `firebase init firestore` and answering `No` to `File firestore.indexes.json already exists. Overwrite?`, the CLI will still update the indexes file
```
i  Downloaded the existing Firestore indexes from the Firebase console
✔ File firestore.indexes.json already exists. Overwrite? No
i  Skipping write of firestore.indexes.json
✔  Wrote firestore.indexes.json
```

we check for `info.writeIndexes` here
https://github.com/firebase/firebase-tools/blob/723546a9bc9fc19ddde14bb95319134ede48eae0/src/init/features/firestore/index.ts#L110-L112

but there seems to be a typo here, sets `info.writeRules` instead of `info.writeIndexes`
https://github.com/firebase/firebase-tools/blob/723546a9bc9fc19ddde14bb95319134ede48eae0/src/init/features/firestore/indexes.ts#L42



### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

```
i  Downloaded the existing Firestore indexes from the Firebase console
✔ File firestore.indexes.json already exists. Overwrite? No
i  Skipping write of firestore.indexes.json

✔  Wrote configuration info to firebase.json
✔  Wrote project information to .firebaserc
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
