### PR TITLE
update vscode 2.1.1

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## NEXT
 
+## 2.1.1
+
+- Update internal `firebase-tools` dependency to 15.5.1
 - Surface Compiler error / warnings at the right diagnosis level (#9805)
 
 ## 2.1.0

--- a/firebase-vscode/package-lock.json
+++ b/firebase-vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "firebase-dataconnect-vscode",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "firebase-dataconnect-vscode",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@preact/signals-core": "^1.4.0",
         "@preact/signals-react": "1.3.6",

--- a/firebase-vscode/package.json
+++ b/firebase-vscode/package.json
@@ -4,7 +4,7 @@
   "publisher": "GoogleCloudTools",
   "icon": "./resources/firebase_dataconnect_logo.png",
   "description": "Firebase Data Connect for VSCode",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "engines": {
     "vscode": "^1.69.0"
   },


### PR DESCRIPTION
## 2.1.1

- Update internal `firebase-tools` dependency to 15.5.1
- Surface Compiler error / warnings at the right diagnosis level (#9805)
