### PR TITLE
Add back Python to Firebase Docker image

### DIFF
--- a/scripts/publish/firebase-docker-image/Dockerfile
+++ b/scripts/publish/firebase-docker-image/Dockerfile
@@ -1,7 +1,8 @@
 FROM node:lts-alpine AS app-env
 
 # Install Python and Java and pre-cache emulator dependencies.
-RUN apk add --no-cache openjdk21-jre-headless bash && \
+# Python is necessary for dynamic code discovery when deploying Python functions.
+RUN apk add --no-cache python3 py3-pip openjdk21-jre-headless bash && \
     apk update && \
     apk upgrade
 


### PR DESCRIPTION
### Description

Bugfix for #9855 - just adding back Python dependencies to the Docker image to fix deploying Python Firebase functions. Targeted revert of a change introduced in #9767.