### PR TITLE
Address vulnerable version of tar in firebase-docker-image

### DIFF
--- a/scripts/publish/firebase-docker-image/package-lock.json
+++ b/scripts/publish/firebase-docker-image/package-lock.json
@@ -3125,9 +3125,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -4543,9 +4543,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.3.tgz",
-      "integrity": "sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==",
+      "version": "4.11.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.7.tgz",
+      "integrity": "sha512-l7qMiNee7t82bH3SeyUCt9UF15EVmaBvsppY2zQtrbIhl/yzBTny+YUxsVjSjQ6gaqaeVtZmGocom8TzBlA4Yw==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/scripts/publish/firebase-docker-image/package.json
+++ b/scripts/publish/firebase-docker-image/package.json
@@ -3,6 +3,8 @@
     "firebase-tools": "latest"
   },
   "overrides": {
-    "tar": "^7.5.4"
+    "tar": "^7.5.4",
+    "diff": "^4.0.4",
+    "hono": "^4.11.7"
   }
 }


### PR DESCRIPTION
### Description
Adding a version override to ensure that we use tar>7.5.4 in our Docker image, and regenerating package-lock.json. 

Addresses https://github.com/advisories/GHSA-34x7-hfp2-rc4v, https://github.com/advisories/GHSA-r6q2-hw4h-h46w, and  https://github.com/advisories/GHSA-8qq5-rm4j-mr97

