### PR TITLE
Slightly nicer handling for --port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- App Hosting Emulator: Respects --port flag in start command (e.g. ng serve --port) unless it conflicts with firebase.json configuration (#9113)
 - Added initial zip deploy support in functions deploy for HTTP functions (#9707)
 - Fixes an issue where Python was missing from the firebase-tools Docker image (#9855).
 - Fixes billing information check to use user's project quota (#9879).

--- a/src/emulator/apphosting/index.ts
+++ b/src/emulator/apphosting/index.ts
@@ -10,6 +10,7 @@ interface AppHostingEmulatorArgs {
   host?: string;
   startCommand?: string;
   rootDirectory?: string;
+  portFixed?: boolean;
 }
 
 /**
@@ -26,6 +27,7 @@ export class AppHostingEmulator implements EmulatorInstance {
       port: this.args.port,
       startCommand: this.args.startCommand,
       rootDirectory: this.args.rootDirectory,
+      portFixed: this.args.portFixed,
     });
     this.args.options.host = hostname;
     this.args.options.port = port;

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -985,6 +985,7 @@ export async function startAll(
       backendId: apphostingConfig?.backendId,
       host: apphostingAddr.host,
       port: apphostingAddr.port,
+      portFixed: listenConfig[Emulators.APPHOSTING]?.portFixed,
       startCommand:
         apphostingEmulatorConfig?.startCommand || apphostingEmulatorConfig?.startCommandOverride,
       rootDirectory,


### PR DESCRIPTION
### Description
Slight refactoring of #9113 - instead of hard erroring out, we use the --port that was configured as the port for the AH emulator. If that port was explicitly set, we'll error out instead.

I _think_ this fixes #9699 and  #9884 in a smoother way that is less breaking, but I'm gonna defer to the experts on this one  as to whether it is a good idea(@annajowang )
