### PR TITLE
Avoid vulnerable python dependencies

### DIFF
--- a/scripts/publish/firebase-docker-image/Dockerfile
+++ b/scripts/publish/firebase-docker-image/Dockerfile
@@ -2,8 +2,12 @@ FROM node:lts-alpine AS app-env
 
 # Install Python (for Cloud Functions) and Java (for emulators) and pre-cache emulator dependencies.
 RUN apk update && \
-    apk add --no-cache python3 py3-pip openjdk21-jre-headless bash && \
+    apk add --no-cache python3 openjdk21-jre-headless bash && \
     apk upgrade && \
+    wget https://bootstrap.pypa.io/get-pip.py && \
+    python3 get-pip.py --no-cache-dir --break-system-packages && \
+    rm get-pip.py && \
+    rm -rf /usr/lib/python*/ensurepip && \
     rm -rf /var/cache/apk/*
 
 


### PR DESCRIPTION
### Description
Totally change how we download Python and pip onto the Docker image in order to avoid picking up vulnerable versions.

Previously, we got these from the Alpine registry, which is stuck on out of date versions with minor vulnerabilities. Now, we download Python via Alpine, use that to install the latest version of pip, then clean up the vulnerable versions of pip that come packaged in

### Scenarios Tested
Built a test version of the image, no Python or pip vulnerabilites
<img width="1293" height="271" alt="Screenshot 2026-02-18 at 4 20 16 PM" src="https://github.com/user-attachments/assets/427c3eac-b85b-4238-a90f-ea56db04ca8c" />
(The other vulnerabilities there will be address in seperate PRs - Go and Maven will be fixed by the next version of the Data Connect and PubSub emulators, respectively.)
