### PR TITLE
fix(dataconnect): run CREATE EXTENSION for uuid-ossp in PGlite

### DIFF
--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -107,6 +107,12 @@ export class PostgresServer {
     return { vector, uuidOssp };
   }
 
+  private async initExtensions(db: PGlite): Promise<void> {
+    // PGlite only makes extensions available through the `extensions` option.
+    // We have to create the extensions explicitly here.
+    await db.exec(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`);
+  }
+
   public async clearDb(): Promise<void> {
     const db = await this.getDb();
     await db.query(TRUNCATE_TABLES_SQL);
@@ -174,6 +180,7 @@ export class PostgresServer {
     const dumpText = await dumpResult.text();
     await newDb.exec(dumpText);
     await newDb.exec("SET SEARCH_PATH = public;");
+    await this.initExtensions(newDb);
 
     logger.info("Postgres database migration successful.");
     return newDb;
@@ -227,6 +234,7 @@ export class PostgresServer {
     try {
       const db = new PGlite({ ...baseArgs, dataDir: pg17Dir });
       await db.waitReady;
+      await this.initExtensions(db);
       return db;
     } catch (err: unknown) {
       if (pg17Dir && hasMessage(err) && /Database already exists/.test(err.message)) {
@@ -234,6 +242,7 @@ export class PostgresServer {
         fs.rmSync(pg17Dir, { force: true, recursive: true });
         const db = new PGlite({ ...baseArgs, dataDir: pg17Dir });
         await db.waitReady;
+        await this.initExtensions(db);
         return db;
       }
       logger.warn(`Error from pglite: ${err}`);


### PR DESCRIPTION


<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

PGlite loads extension bundles via the `extensions` option but does not automatically run CREATE EXTENSION. Add an `initExtensions` method that explicitly installs uuid-ossp so that uuid_generate_v4() is available when the Data Connect emulator binary processes id_expr: "uuidV4()" server values, fixing the FAILED_PRECONDITION crash reported in #9852.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
