### PR TITLE
fix functions deployment blocking firebaseextensions.googleapis.com by checking for extensions only when not needed

### DIFF
--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -115,7 +115,7 @@ export async function prepare(
   );
 
   // == Phase 1.5 Prepare extensions found in codebases if any
-  if (Object.values(wantBuilds).some((b) => b.extensions)) {
+  if (Object.values(wantBuilds).some((b) => b.extensions && Object.keys(b.extensions).length > 0)) {
     const extContext: ExtContext = {};
     const extPayload: ExtPayload = {};
     await prepareDynamicExtensions(extContext, options, extPayload, wantBuilds);


### PR DESCRIPTION
### Description

Today there was an issue (outage) with firebase extension due to some kind of permissions issue resuting in all firebase function deployments failing 
```
extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
Error: Request to https://firebaseextensions.googleapis.com/v1beta/projects/uniqueminds-staging/instances?pageSize=100&pageToken= had HTTP Error: 403, The caller does not have permission
```

I'm sure a root fix for this will be coming soon, however, for functions that don't use dynamic extensions this check is not needed and there is no reason to block deployments with it.  A simple workaround that has unblocked us is to do a proper check for id extensions are needed before checking.  this appears to be a bug in the code.

### Scenarios Tested

deployed our firebase functions, and we no longer are blocked by the firebaseextensions regression / outage.

### Sample Commands

firebase deploy --only functions
