### PR TITLE
fix: skip extensions API check when no extensions are defined

### DIFF
--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -171,6 +171,14 @@ export async function prepareDynamicExtensions(
   const filters = getEndpointFilters(options, functionsConfig);
   const extensions = extractExtensionsFromBuilds(builds, filters);
   const projectId = needProjectId(options);
+
+  // Skip extensions API checks if no extensions are defined in the builds.
+  // This avoids unnecessary API calls and permission errors for projects
+  // that don't use Firebase Extensions but still deploy functions.
+  if (Object.keys(extensions).length === 0) {
+    return;
+  }
+
   const projectNumber = await needProjectNumber(options);
 
   await ensureExtensionsApiEnabled(options);
@@ -181,8 +189,8 @@ export async function prepareDynamicExtensions(
     extensionMatchesAnyFilter(e.labels?.codebase, e.instanceId, filters),
   );
 
-  if (Object.keys(extensions).length === 0 && haveExtensions.length === 0) {
-    // Nothing defined, and nothing to delete
+  if (haveExtensions.length === 0) {
+    // Nothing to delete
     return;
   }
 


### PR DESCRIPTION
## Problem

When deploying functions without any Firebase Extensions defined, the CLI was unnecessarily checking the `firebaseextensions.googleapis.com` API and requiring `firebaseextensions.instances.list` permission.

This caused deployment failures for projects that:
- Don't use Firebase Extensions at all
- Have the Firebase Extensions API disabled
- Don't have the required IAM permissions (even for project owners)

**Error message:**
```
Error: Request to https://firebaseextensions.googleapis.com/v1beta/projects/xxx/instances?pageSize=100&pageToken= had HTTP Error: 403, The caller does not have permission
```

## Solution

Add an early return in `prepareDynamicExtensions()` when no extensions are defined in the function builds. This avoids unnecessary API calls and permission checks for projects that don't use Firebase Extensions.

## Changes

Modified `src/deploy/extensions/prepare.ts`:
- Added early return check before calling `ensureExtensionsApiEnabled()` and `requirePermissions()`
- Skip all extensions-related API calls when `Object.keys(extensions).length === 0`

## Testing

Verified the fix by deploying functions to a project without Firebase Extensions. Previously failed with 403 error, now deploys successfully.

```bash
# Before fix: deployment failed with 403 permission error
# After fix: deployment succeeds
firebase deploy --only functions
```
