### PR TITLE
Update source map upload command options

### DIFF
--- a/src/commands/crashlytics-sourcemap-upload.spec.ts
+++ b/src/commands/crashlytics-sourcemap-upload.spec.ts
@@ -126,6 +126,21 @@ describe("crashlytics:sourcemap:upload", () => {
     );
   });
 
+  it("should find and upload mapping files in the current directory if no path is provided", async () => {
+    await command.runner()(undefined, { app: "test-app" });
+    expect(gcsMock.uploadObject).to.be.calledTwice;
+    const uploadedFiles = gcsMock.uploadObject
+      .getCalls()
+      .map((call) => call.args[0].file)
+      .sort();
+    expect(uploadedFiles[0]).to.match(
+      /test-app-.*-src-test-fixtures-mapping-files-mock_mapping\.js\.map\.zip/,
+    );
+    expect(uploadedFiles[1]).to.match(
+      /test-app-.*-src-test-fixtures-mapping-files-subdir-subdir_mock_mapping\.js\.map\.zip/,
+    );
+  });
+
   it("should use the provided app version", async () => {
     await command.runner()(FILE_PATH, {
       app: "test-app",

--- a/src/commands/crashlytics-sourcemap-upload.ts
+++ b/src/commands/crashlytics-sourcemap-upload.ts
@@ -54,7 +54,7 @@ export const command = new Command("crashlytics:sourcemap:upload [mappingFiles]"
 
     // Find and upload mapping files
     const rootDir = options.projectRoot ?? process.cwd();
-    const filePath = path.relative(rootDir, mappingFiles || "");
+    const filePath = path.relative(rootDir, mappingFiles || ".") || ".";
     let fstat: fs.Stats;
     try {
       fstat = statSync(filePath);
@@ -172,13 +172,12 @@ async function upsertBucket(
 
 async function uploadMap(
   projectId: string,
-  mappingFile: string,
+  filePath: string,
   bucketName: string,
   appVersion: string,
   options: CommandOptions,
 ): Promise<boolean> {
   try {
-    const filePath = path.relative(options.projectRoot ?? process.cwd(), mappingFile);
     const tmpArchive = await archiveFile(filePath, { archivedFileName: "mapping.js.map" });
     const gcsFile = `${options.app}-${appVersion}-${normalizeFileName(filePath)}.zip`;
     const uid = murmurHashV3(`${appVersion}-${filePath}`);
@@ -193,7 +192,7 @@ async function uploadMap(
       bucketName,
     );
     const fileUri = `gs://${bucket}/${object}`;
-    logger.debug(`Uploaded mapping file ${mappingFile} to ${fileUri}`);
+    logger.debug(`Uploaded mapping file ${filePath} to ${fileUri}`);
 
     await registerSourceMap(parent, {
       name,
@@ -204,7 +203,7 @@ async function uploadMap(
 
     return true;
   } catch (e) {
-    logLabeledWarning("crashlytics", `Failed to upload mapping file ${mappingFile}:\n${e}`);
+    logLabeledWarning("crashlytics", `Failed to upload mapping file ${filePath}:\n${e}`);
     return false;
   }
 }


### PR DESCRIPTION
- Remove `telemetryServerUrl` option
- Change mapping file positional argument from required to optional (defaults to root dir)

Feedback from API design.