### PR TITLE
Improve Firebase App Hosting skills

### DIFF
--- a/skills/firebase-app-hosting-basics/SKILL.md
+++ b/skills/firebase-app-hosting-basics/SKILL.md
@@ -22,11 +22,18 @@ This skill enables the agent to deploy and manage modern, full-stack web applica
 - You need Server-Side Rendering (SSR) or ISR.
 - You want an automated "git push to deploy" workflow with zero configuration.
 
+## Importing an Existing Project
+
+When a user asks to import a Firebase App Hosting project:
+- Confirm Information and ask the user for any information you need (e.g., their project ID, backend names, region, or source code location).
+- When importing a project for the first time, ask the user for a test or staging backend to deploy to (i.e., a new backend) to test changes safely. Do NOT deploy to production when doing an initial deployment.
+- If you run into an error cloning a repository via HTTPS (like `fatal: could not read Username for 'https://github.com': Device not configured`), it might be due to the user's local git setup, and the SSH git clone (`git clone git@github.com:...`) might work instead.
+
 ## Deploying to App Hosting
 
 ### Deploy from Source
 
-This is the recommended flow for most users. 
+This is the recommended flow for most users. You should prefer to do source deployment (`firebase init apphosting` + `firebase deploy`). This allows the user or LLM agent to make changes to the code and deploy them without requiring Git commits or pushes. 
 1. Configure `firebase.json` with an `apphosting` block.
     ```json
     {


### PR DESCRIPTION
This addresses some friction points. We recently re-did the testing after these official skills were published.

### Description
Summary of  changes:
* When importing a Firebase App Hosting project, ask the user where their code is (instead of guessing or trying to download it from GCS.)
* Ask the user for info like project ids and backend names and regions instead of guessing
* Handle Git Clone issues related to HTTPS and use SSH as an alternative. If they run into the same issue I did with HTTPS git clone, try to use the SSH git clone method. 

### Scenarios Tested

I created an empty folder and asked the agent `I want to import my Firebase App Hosting project. I want to modify my existing project and work with it in Antigravity and also deploy my changes.` I took note of various friction points.
