### PR TITLE
Move apptesting:execute out from behind apptesting experiment

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -266,9 +266,9 @@ export function load(client: CLIClient): CLIClient {
   client.target.clear = loadCommand("target-clear");
   client.target.remove = loadCommand("target-remove");
   client.use = loadCommand("use");
+  client.apptesting = {};
+  client.apptesting.execute = loadCommand("apptesting");
   if (experiments.isEnabled("apptesting")) {
-    client.apptesting = {};
-    client.apptesting.execute = loadCommand("apptesting");
     client.apptesting.wata = loadCommand("apptesting-wata");
   }
 


### PR DESCRIPTION
This is in preparation for final testing and release of this feature.

Before:

```
$ firebase apptesting:execute
Error: apptesting:execute is not a Firebase command
```

After:

```
$ firebase apptesting:execute
error: missing required argument 'release-binary-file'
```