### PR TITLE
Create a basic implementation of local builds 

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -72,6 +72,7 @@
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "superstatic": "^10.0.0",
+        "tar": "^6.2.1",
         "tcp-port-used": "^1.0.2",
         "tmp": "^0.2.3",
         "triple-beam": "^1.3.0",
@@ -130,6 +131,7 @@
         "@types/stream-json": "^1.7.2",
         "@types/supertest": "^2.0.12",
         "@types/swagger2openapi": "^7.0.0",
+        "@types/tar": "^6.1.11",
         "@types/tcp-port-used": "^1.0.1",
         "@types/tmp": "^0.2.3",
         "@types/triple-beam": "^1.3.0",
@@ -5480,6 +5482,27 @@
         "openapi-types": "^12.1.0"
       }
     },
+    "node_modules/@types/tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
+      }
+    },
+    "node_modules/@types/tar/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@types/tcp-port-used": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
@@ -7562,35 +7585,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/cacache/node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/cacache/node_modules/tar/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/caching-transform": {
@@ -10805,7 +10799,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -15256,7 +15249,6 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
       "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15333,7 +15325,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -15965,16 +15956,6 @@
         "node": "^12.13 || ^14.13 || >=16"
       }
     },
-    "node_modules/node-gyp/node_modules/chownr": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-gyp/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -15996,29 +15977,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/node-gyp/node_modules/minipass": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-      "license": "ISC",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-gyp/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-gyp/node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -16033,25 +15991,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/node-gyp/node_modules/tar": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exhorbitant rates) by contacting i@izs.me",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^2.0.0",
-        "fs-minipass": "^2.0.0",
-        "minipass": "^5.0.0",
-        "minizlib": "^2.1.1",
-        "mkdirp": "^1.0.3",
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-gyp/node_modules/which": {
@@ -20314,6 +20253,24 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/tar-fs": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
@@ -20350,6 +20307,36 @@
         "b4a": "^1.6.4",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/tar/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar/node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/tcp-port-used": {
@@ -26260,6 +26247,24 @@
         "openapi-types": "^12.1.0"
       }
     },
+    "@types/tar": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/@types/tar/-/tar-6.1.13.tgz",
+      "integrity": "sha512-IznnlmU5f4WcGTh2ltRu/Ijpmk8wiWXfF0VA4s+HPjHZgvFggk1YaIkbo5krX/zUCzWF8N/l4+W/LNxnvAJ8nw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
+      },
+      "dependencies": {
+        "minipass": {
+          "version": "4.2.8",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+          "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+          "dev": true
+        }
+      }
+    },
     "@types/tcp-port-used": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/tcp-port-used/-/tcp-port-used-1.0.1.tgz",
@@ -26680,7 +26685,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.17.1"
+        "ajv": "^8.0.0"
       }
     },
     "ansi-align": {
@@ -27735,28 +27740,6 @@
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
-            }
-          }
-        },
-        "tar": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-          "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-          "optional": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^5.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
-          },
-          "dependencies": {
-            "minipass": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-              "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-              "optional": true
             }
           }
         }
@@ -30100,7 +30083,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-      "optional": true,
       "requires": {
         "minipass": "^3.0.0"
       }
@@ -33354,7 +33336,6 @@
       "version": "3.1.6",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
       "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
-      "optional": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -33411,7 +33392,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
-      "optional": true,
       "requires": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -33854,12 +33834,6 @@
         "which": "^2.0.2"
       },
       "dependencies": {
-        "chownr": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-          "optional": true
-        },
         "glob": {
           "version": "7.2.3",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -33874,18 +33848,6 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "minipass": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-          "optional": true
-        },
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-          "optional": true
-        },
         "rimraf": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -33893,20 +33855,6 @@
           "optional": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "tar": {
-          "version": "6.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-          "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-          "optional": true,
-          "requires": {
-            "chownr": "^2.0.0",
-            "fs-minipass": "^2.0.0",
-            "minipass": "^5.0.0",
-            "minizlib": "^2.1.1",
-            "mkdirp": "^1.0.3",
-            "yallist": "^4.0.0"
           }
         },
         "which": {
@@ -37071,6 +37019,36 @@
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
           "dev": true
+        }
+      }
+    },
+    "tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "chownr": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+          "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+        },
+        "minipass": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+          "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ=="
+        },
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "stream-chain": "^2.2.4",
     "stream-json": "^1.7.3",
     "superstatic": "^10.0.0",
+    "tar": "^6.2.1",
     "tcp-port-used": "^1.0.2",
     "tmp": "^0.2.3",
     "triple-beam": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
     "@types/stream-json": "^1.7.2",
     "@types/supertest": "^2.0.12",
     "@types/swagger2openapi": "^7.0.0",
+    "@types/tar": "^6.1.11",
     "@types/tcp-port-used": "^1.0.1",
     "@types/tmp": "^0.2.3",
     "@types/triple-beam": "^1.3.0",

--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -8,6 +8,7 @@ import deploy from "./deploy";
 import * as util from "./util";
 import * as fs from "fs";
 import * as getProjectNumber from "../../getProjectNumber";
+import * as experiments from "../../experiments";
 
 const BASE_OPTS = {
   cwd: "/",
@@ -51,8 +52,10 @@ describe("apphosting", () => {
   let upsertBucketStub: sinon.SinonStub;
   let uploadObjectStub: sinon.SinonStub;
   let createArchiveStub: sinon.SinonStub;
+  let createTarArchiveStub: sinon.SinonStub;
   let createReadStreamStub: sinon.SinonStub;
   let getProjectNumberStub: sinon.SinonStub;
+  let isEnabledStub: sinon.SinonStub;
 
   beforeEach(() => {
     getProjectNumberStub = sinon
@@ -61,9 +64,13 @@ describe("apphosting", () => {
     upsertBucketStub = sinon.stub(gcs, "upsertBucket").throws("Unexpected upsertBucket call");
     uploadObjectStub = sinon.stub(gcs, "uploadObject").throws("Unexpected uploadObject call");
     createArchiveStub = sinon.stub(util, "createArchive").throws("Unexpected createArchive call");
+    createTarArchiveStub = sinon
+      .stub(util, "createTarArchive")
+      .throws("Unexpected createTarArchive call");
     createReadStreamStub = sinon
       .stub(fs, "createReadStream")
       .throws("Unexpected createReadStream call");
+    isEnabledStub = sinon.stub(experiments, "isEnabled").returns(false);
   });
 
   afterEach(() => {
@@ -194,6 +201,32 @@ describe("apphosting", () => {
       expect(context.backendStorageUris["fooLocalBuild"]).to.equal(
         `gs://${bucketName}/foo-local-build-1234.zip`,
       );
+    });
+
+    it("uses createTarArchive for local builds when experiment is enabled", async () => {
+      const context = initializeContext();
+      // Remove the non-local build backend for this test for simplicity
+      delete context.backendConfigs.foo;
+      delete context.backendLocations.foo;
+      const projectNumber = "000000000000";
+      const location = "us-central1";
+      const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
+
+      getProjectNumberStub.resolves(projectNumber);
+      upsertBucketStub.resolves(bucketName);
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(true);
+      createTarArchiveStub.resolves("path/to/foo-local-build-1234.tar.gz");
+      uploadObjectStub.resolves({
+        bucket: bucketName,
+        object: "foo-local-build-1234.tar.gz",
+      });
+      createReadStreamStub.returns("stream" as any);
+
+      await deploy(context, { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) });
+
+      expect(createTarArchiveStub).to.be.calledOnce;
+      expect(createArchiveStub).to.not.be.called;
+      expect(context.backendStorageUris["fooLocalBuild"]).to.equal(`gs://${bucketName}/foo-local-build-1234.tar.gz`);
     });
   });
 });

--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -56,7 +56,6 @@ describe("apphosting", () => {
   let createReadStreamStub: sinon.SinonStub;
   let getProjectNumberStub: sinon.SinonStub;
   let isEnabledStub: sinon.SinonStub;
-  let assertEnabledStub: sinon.SinonStub;
 
   beforeEach(() => {
     getProjectNumberStub = sinon
@@ -72,11 +71,6 @@ describe("apphosting", () => {
       .stub(fs, "createReadStream")
       .throws("Unexpected createReadStream call");
     isEnabledStub = sinon.stub(experiments, "isEnabled").returns(false);
-    assertEnabledStub = sinon.stub(experiments, "assertEnabled").callsFake((name, task) => {
-      if (!experiments.isEnabled(name)) {
-        throw new Error(`Cannot ${task} because the experiment ${name} is not enabled.`);
-      }
-    });
   });
 
   afterEach(() => {
@@ -113,7 +107,7 @@ describe("apphosting", () => {
       getProjectNumberStub.resolves(projectNumber);
       upsertBucketStub.resolves(bucketName);
       createArchiveStub.onFirstCall().resolves("path/to/foo-1234.zip");
-      createTarArchiveStub.onFirstCall().resolves("path/to/foo-local-build-1234.tar.gz");
+      createArchiveStub.onSecondCall().resolves("path/to/foo-local-build-1234.zip");
 
       uploadObjectStub.onFirstCall().resolves({
         bucket: bucketName,
@@ -121,37 +115,97 @@ describe("apphosting", () => {
       });
       uploadObjectStub.onSecondCall().resolves({
         bucket: bucketName,
-        object: "foo-local-build-1234.tar.gz",
+        object: "foo-local-build-1234",
       });
 
       createReadStreamStub.returns("stream" as any);
-      // For standard source deploy, experiment is not required.
-      // But fooLocalBuild will trigger assertEnabled.
-      isEnabledStub.withArgs("apphostinglocalbuilds").returns(true);
 
       await deploy(context, opts);
 
-      expect(upsertBucketStub).to.be.calledWithMatch({ projectId: "my-project" });
+      // assert backend foo calls
+
+      expect(upsertBucketStub).to.be.calledWith({
+        product: "apphosting",
+        createMessage: `Creating Cloud Storage bucket in ${location} to store App Hosting source code uploads at ${bucketName}...`,
+        projectId: "my-project",
+        req: {
+          baseName: bucketName,
+          purposeLabel: `apphosting-source-${location}`,
+          location: location,
+          lifecycle: {
+            rule: [
+              {
+                action: { type: "Delete" },
+                condition: { age: 30 },
+              },
+            ],
+          },
+        },
+      });
+
+      // assert backend fooLocalBuild calls
+      expect(upsertBucketStub).to.be.calledWith({
+        product: "apphosting",
+        createMessage:
+          "Creating Cloud Storage bucket in us-central1 to store App Hosting source code uploads at firebaseapphosting-sources-000000000000-us-central1...",
+        projectId: "my-project",
+        req: {
+          baseName: "firebaseapphosting-sources-000000000000-us-central1",
+          purposeLabel: `apphosting-source-${location}`,
+          location: "us-central1",
+          lifecycle: {
+            rule: [
+              {
+                action: { type: "Delete" },
+                condition: { age: 30 },
+              },
+            ],
+          },
+        },
+      });
+      expect(createArchiveStub).to.be.calledWithExactly(
+        context.backendConfigs["fooLocalBuild"],
+        process.cwd(),
+        "./nextjs/standalone",
+      );
+      expect(uploadObjectStub).to.be.calledWithMatch(
+        sinon.match.any,
+        "firebaseapphosting-sources-000000000000-us-central1",
+      );
     });
 
-    it("fails for local builds when experiment is disabled", async () => {
+    it("correctly creates and sets storage URIs", async () => {
       const context = initializeContext();
-      delete context.backendConfigs.foo;
-      delete context.backendLocations.foo;
-      
-      getProjectNumberStub.resolves("000000");
-      upsertBucketStub.resolves("bucket");
-      isEnabledStub.withArgs("apphostinglocalbuilds").returns(false);
+      const projectNumber = "000000000000";
+      const location = "us-central1";
+      const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
+      getProjectNumberStub.resolves(projectNumber);
+      upsertBucketStub.resolves(bucketName);
+      createArchiveStub.onFirstCall().resolves("path/to/foo-1234.zip");
+      createArchiveStub.onSecondCall().resolves("path/to/foo-local-build-1234.zip");
 
-      const localOpts = { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) };
-      await deploy(context, localOpts);
+      uploadObjectStub.onFirstCall().resolves({
+        bucket: bucketName,
+        object: "foo-1234",
+      });
 
-      expect(createTarArchiveStub).to.not.be.called;
-      expect(createArchiveStub).to.not.be.called;
+      uploadObjectStub.onSecondCall().resolves({
+        bucket: bucketName,
+        object: "foo-local-build-1234",
+      });
+      createReadStreamStub.returns("stream" as any);
+
+      await deploy(context, opts);
+
+      expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);
+      expect(context.backendStorageUris["fooLocalBuild"]).to.equal(
+        `gs://${bucketName}/foo-local-build-1234.zip`,
+      );
     });
 
     it("uses createTarArchive for local builds when experiment is enabled", async () => {
       const context = initializeContext();
+      // Remove the non-local build backend for this test for simplicity
       delete context.backendConfigs.foo;
       delete context.backendLocations.foo;
       const projectNumber = "000000000000";
@@ -168,8 +222,7 @@ describe("apphosting", () => {
       });
       createReadStreamStub.returns("stream" as any);
 
-      const localOpts = { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) };
-      await deploy(context, localOpts);
+      await deploy(context, { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) });
 
       expect(createTarArchiveStub).to.be.calledOnce;
       expect(createArchiveStub).to.not.be.called;

--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -262,7 +262,9 @@ describe("apphosting", () => {
       expect(createTarArchiveStub).to.be.calledWith(context.backendConfigs["fooLocalBuild"]);
 
       expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);
-      expect(context.backendStorageUris["fooLocalBuild"]).to.equal(`gs://${bucketName}/foo-local-build-1234.tar.gz`);
+      expect(context.backendStorageUris["fooLocalBuild"]).to.equal(
+        `gs://${bucketName}/foo-local-build-1234.tar.gz`,
+      );
     });
   });
 });

--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -56,6 +56,7 @@ describe("apphosting", () => {
   let createReadStreamStub: sinon.SinonStub;
   let getProjectNumberStub: sinon.SinonStub;
   let isEnabledStub: sinon.SinonStub;
+  let assertEnabledStub: sinon.SinonStub;
 
   beforeEach(() => {
     getProjectNumberStub = sinon
@@ -71,6 +72,11 @@ describe("apphosting", () => {
       .stub(fs, "createReadStream")
       .throws("Unexpected createReadStream call");
     isEnabledStub = sinon.stub(experiments, "isEnabled").returns(false);
+    assertEnabledStub = sinon.stub(experiments, "assertEnabled").callsFake((name, task) => {
+      if (!experiments.isEnabled(name)) {
+        throw new Error(`Cannot ${task} because the experiment ${name} is not enabled.`);
+      }
+    });
   });
 
   afterEach(() => {
@@ -107,7 +113,7 @@ describe("apphosting", () => {
       getProjectNumberStub.resolves(projectNumber);
       upsertBucketStub.resolves(bucketName);
       createArchiveStub.onFirstCall().resolves("path/to/foo-1234.zip");
-      createArchiveStub.onSecondCall().resolves("path/to/foo-local-build-1234.zip");
+      createTarArchiveStub.onFirstCall().resolves("path/to/foo-local-build-1234.tar.gz");
 
       uploadObjectStub.onFirstCall().resolves({
         bucket: bucketName,
@@ -115,97 +121,37 @@ describe("apphosting", () => {
       });
       uploadObjectStub.onSecondCall().resolves({
         bucket: bucketName,
-        object: "foo-local-build-1234",
+        object: "foo-local-build-1234.tar.gz",
       });
 
       createReadStreamStub.returns("stream" as any);
+      // For standard source deploy, experiment is not required.
+      // But fooLocalBuild will trigger assertEnabled.
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(true);
 
       await deploy(context, opts);
 
-      // assert backend foo calls
-
-      expect(upsertBucketStub).to.be.calledWith({
-        product: "apphosting",
-        createMessage: `Creating Cloud Storage bucket in ${location} to store App Hosting source code uploads at ${bucketName}...`,
-        projectId: "my-project",
-        req: {
-          baseName: bucketName,
-          purposeLabel: `apphosting-source-${location}`,
-          location: location,
-          lifecycle: {
-            rule: [
-              {
-                action: { type: "Delete" },
-                condition: { age: 30 },
-              },
-            ],
-          },
-        },
-      });
-
-      // assert backend fooLocalBuild calls
-      expect(upsertBucketStub).to.be.calledWith({
-        product: "apphosting",
-        createMessage:
-          "Creating Cloud Storage bucket in us-central1 to store App Hosting source code uploads at firebaseapphosting-sources-000000000000-us-central1...",
-        projectId: "my-project",
-        req: {
-          baseName: "firebaseapphosting-sources-000000000000-us-central1",
-          purposeLabel: `apphosting-source-${location}`,
-          location: "us-central1",
-          lifecycle: {
-            rule: [
-              {
-                action: { type: "Delete" },
-                condition: { age: 30 },
-              },
-            ],
-          },
-        },
-      });
-      expect(createArchiveStub).to.be.calledWithExactly(
-        context.backendConfigs["fooLocalBuild"],
-        process.cwd(),
-        "./nextjs/standalone",
-      );
-      expect(uploadObjectStub).to.be.calledWithMatch(
-        sinon.match.any,
-        "firebaseapphosting-sources-000000000000-us-central1",
-      );
+      expect(upsertBucketStub).to.be.calledWithMatch({ projectId: "my-project" });
     });
 
-    it("correctly creates and sets storage URIs", async () => {
+    it("fails for local builds when experiment is disabled", async () => {
       const context = initializeContext();
-      const projectNumber = "000000000000";
-      const location = "us-central1";
-      const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
-      getProjectNumberStub.resolves(projectNumber);
-      upsertBucketStub.resolves(bucketName);
-      createArchiveStub.onFirstCall().resolves("path/to/foo-1234.zip");
-      createArchiveStub.onSecondCall().resolves("path/to/foo-local-build-1234.zip");
+      delete context.backendConfigs.foo;
+      delete context.backendLocations.foo;
+      
+      getProjectNumberStub.resolves("000000");
+      upsertBucketStub.resolves("bucket");
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(false);
 
-      uploadObjectStub.onFirstCall().resolves({
-        bucket: bucketName,
-        object: "foo-1234",
-      });
+      const localOpts = { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) };
+      await deploy(context, localOpts);
 
-      uploadObjectStub.onSecondCall().resolves({
-        bucket: bucketName,
-        object: "foo-local-build-1234",
-      });
-      createReadStreamStub.returns("stream" as any);
-
-      await deploy(context, opts);
-
-      expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);
-      expect(context.backendStorageUris["fooLocalBuild"]).to.equal(
-        `gs://${bucketName}/foo-local-build-1234.zip`,
-      );
+      expect(createTarArchiveStub).to.not.be.called;
+      expect(createArchiveStub).to.not.be.called;
     });
 
     it("uses createTarArchive for local builds when experiment is enabled", async () => {
       const context = initializeContext();
-      // Remove the non-local build backend for this test for simplicity
       delete context.backendConfigs.foo;
       delete context.backendLocations.foo;
       const projectNumber = "000000000000";
@@ -222,7 +168,8 @@ describe("apphosting", () => {
       });
       createReadStreamStub.returns("stream" as any);
 
-      await deploy(context, { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) });
+      const localOpts = { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) };
+      await deploy(context, localOpts);
 
       expect(createTarArchiveStub).to.be.calledOnce;
       expect(createArchiveStub).to.not.be.called;

--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -77,7 +77,7 @@ describe("apphosting", () => {
     sinon.verifyAndRestore();
   });
 
-  describe("deploy local source", () => {
+  describe("deploy local source and local build", () => {
     const opts = {
       ...BASE_OPTS,
       projectId: "my-project",
@@ -106,8 +106,9 @@ describe("apphosting", () => {
       const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
       getProjectNumberStub.resolves(projectNumber);
       upsertBucketStub.resolves(bucketName);
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(true);
       createArchiveStub.onFirstCall().resolves("path/to/foo-1234.zip");
-      createArchiveStub.onSecondCall().resolves("path/to/foo-local-build-1234.zip");
+      createTarArchiveStub.onFirstCall().resolves("path/to/foo-local-build-1234.tar.gz");
 
       uploadObjectStub.onFirstCall().resolves({
         bucket: bucketName,
@@ -115,7 +116,7 @@ describe("apphosting", () => {
       });
       uploadObjectStub.onSecondCall().resolves({
         bucket: bucketName,
-        object: "foo-local-build-1234",
+        object: "foo-local-build-1234.tar.gz",
       });
 
       createReadStreamStub.returns("stream" as any);
@@ -163,7 +164,7 @@ describe("apphosting", () => {
           },
         },
       });
-      expect(createArchiveStub).to.be.calledWithExactly(
+      expect(createTarArchiveStub).to.be.calledWithExactly(
         context.backendConfigs["fooLocalBuild"],
         process.cwd(),
         "./nextjs/standalone",
@@ -181,8 +182,9 @@ describe("apphosting", () => {
       const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
       getProjectNumberStub.resolves(projectNumber);
       upsertBucketStub.resolves(bucketName);
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(true);
       createArchiveStub.onFirstCall().resolves("path/to/foo-1234.zip");
-      createArchiveStub.onSecondCall().resolves("path/to/foo-local-build-1234.zip");
+      createTarArchiveStub.onFirstCall().resolves("path/to/foo-local-build-1234.tar.gz");
 
       uploadObjectStub.onFirstCall().resolves({
         bucket: bucketName,
@@ -191,7 +193,7 @@ describe("apphosting", () => {
 
       uploadObjectStub.onSecondCall().resolves({
         bucket: bucketName,
-        object: "foo-local-build-1234",
+        object: "foo-local-build-1234.tar.gz",
       });
       createReadStreamStub.returns("stream" as any);
 
@@ -199,15 +201,39 @@ describe("apphosting", () => {
 
       expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);
       expect(context.backendStorageUris["fooLocalBuild"]).to.equal(
-        `gs://${bucketName}/foo-local-build-1234.zip`,
+        `gs://${bucketName}/foo-local-build-1234.tar.gz`,
       );
+    });
+
+    it("skips local builds when experiment is disabled but continues with others", async () => {
+      const context = initializeContext();
+      const projectNumber = "000000000000";
+      const location = "us-central1";
+      const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
+      getProjectNumberStub.resolves(projectNumber);
+      upsertBucketStub.resolves(bucketName);
+
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(false);
+      createArchiveStub.resolves("path/to/foo-1234.zip");
+      uploadObjectStub.resolves({
+        bucket: bucketName,
+        object: "foo-1234",
+      });
+      createReadStreamStub.returns("stream" as any);
+
+      await deploy(context, opts);
+
+      // Standard backend 'foo' should be processed
+      expect(createArchiveStub).to.be.calledWith(context.backendConfigs["foo"]);
+      expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);
+
+      // Local build backend 'fooLocalBuild' should be skipped
+      expect(createTarArchiveStub).to.not.be.called;
+      expect(context.backendStorageUris["fooLocalBuild"]).to.be.undefined;
     });
 
     it("uses createTarArchive for local builds when experiment is enabled", async () => {
       const context = initializeContext();
-      // Remove the non-local build backend for this test for simplicity
-      delete context.backendConfigs.foo;
-      delete context.backendLocations.foo;
       const projectNumber = "000000000000";
       const location = "us-central1";
       const bucketName = `firebaseapphosting-sources-${projectNumber}-${location}`;
@@ -215,17 +241,26 @@ describe("apphosting", () => {
       getProjectNumberStub.resolves(projectNumber);
       upsertBucketStub.resolves(bucketName);
       isEnabledStub.withArgs("apphostinglocalbuilds").returns(true);
-      createTarArchiveStub.resolves("path/to/foo-local-build-1234.tar.gz");
-      uploadObjectStub.resolves({
+
+      createArchiveStub.onFirstCall().resolves("path/to/foo-1234.zip");
+      createTarArchiveStub.onFirstCall().resolves("path/to/foo-local-build-1234.tar.gz");
+
+      uploadObjectStub.onFirstCall().resolves({
+        bucket: bucketName,
+        object: "foo-1234",
+      });
+      uploadObjectStub.onSecondCall().resolves({
         bucket: bucketName,
         object: "foo-local-build-1234.tar.gz",
       });
       createReadStreamStub.returns("stream" as any);
 
-      await deploy(context, { ...opts, config: new Config({ apphosting: { backendId: "fooLocalBuild", localBuild: true } }) });
+      await deploy(context, opts);
 
-      expect(createTarArchiveStub).to.be.calledOnce;
-      expect(createArchiveStub).to.not.be.called;
+      expect(createArchiveStub).to.be.calledWith(context.backendConfigs["foo"]);
+      expect(createTarArchiveStub).to.be.calledWith(context.backendConfigs["fooLocalBuild"]);
+
+      expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);
       expect(context.backendStorageUris["fooLocalBuild"]).to.equal(`gs://${bucketName}/foo-local-build-1234.tar.gz`);
     });
   });

--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -7,6 +7,7 @@ import { Context } from "./args";
 import deploy from "./deploy";
 import * as util from "./util";
 import * as fs from "fs";
+import { PassThrough } from "stream";
 import * as getProjectNumber from "../../getProjectNumber";
 import * as experiments from "../../experiments";
 
@@ -119,7 +120,7 @@ describe("apphosting", () => {
         object: "foo-local-build-1234.tar.gz",
       });
 
-      createReadStreamStub.returns("stream" as any);
+      createReadStreamStub.returns(new PassThrough());
 
       await deploy(context, opts);
 
@@ -170,7 +171,7 @@ describe("apphosting", () => {
         "./nextjs/standalone",
       );
       expect(uploadObjectStub).to.be.calledWithMatch(
-        sinon.match.any,
+        sinon.match.object,
         "firebaseapphosting-sources-000000000000-us-central1",
       );
     });
@@ -195,7 +196,7 @@ describe("apphosting", () => {
         bucket: bucketName,
         object: "foo-local-build-1234.tar.gz",
       });
-      createReadStreamStub.returns("stream" as any);
+      createReadStreamStub.returns(new PassThrough());
 
       await deploy(context, opts);
 
@@ -219,7 +220,7 @@ describe("apphosting", () => {
         bucket: bucketName,
         object: "foo-1234",
       });
-      createReadStreamStub.returns("stream" as any);
+      createReadStreamStub.returns(new PassThrough());
 
       await deploy(context, opts);
 
@@ -253,7 +254,7 @@ describe("apphosting", () => {
         bucket: bucketName,
         object: "foo-local-build-1234.tar.gz",
       });
-      createReadStreamStub.returns("stream" as any);
+      createReadStreamStub.returns(new PassThrough());
 
       await deploy(context, opts);
 

--- a/src/deploy/apphosting/deploy.ts
+++ b/src/deploy/apphosting/deploy.ts
@@ -5,7 +5,7 @@ import * as gcs from "../../gcp/storage";
 import { getProjectNumber } from "../../getProjectNumber";
 import { Options } from "../../options";
 import { needProjectId } from "../../projectUtils";
-import { logLabeledBullet } from "../../utils";
+import { logLabeledBullet, logLabeledWarning } from "../../utils";
 import { Context } from "./args";
 import { createArchive, createTarArchive } from "./util";
 import { isEnabled } from "../../experiments";
@@ -67,6 +67,13 @@ export default async function (context: Context, options: Options): Promise<void
       const rootDir = options.projectRoot ?? process.cwd();
       let builtAppDir;
       if (cfg.localBuild) {
+        if (!isEnabled("apphostinglocalbuilds")) {
+          logLabeledWarning(
+            "apphosting",
+            `Skipping local build for backend ${cfg.backendId} because the experiment apphostinglocalbuilds is not enabled.`,
+          );
+          return;
+        }
         builtAppDir = context.backendLocalBuilds[cfg.backendId].buildDir;
         if (!builtAppDir) {
           throw new FirebaseError(`No local build dir found for ${cfg.backendId}`);

--- a/src/deploy/apphosting/deploy.ts
+++ b/src/deploy/apphosting/deploy.ts
@@ -5,7 +5,7 @@ import * as gcs from "../../gcp/storage";
 import { getProjectNumber } from "../../getProjectNumber";
 import { Options } from "../../options";
 import { needProjectId } from "../../projectUtils";
-import { logLabeledBullet, logLabeledWarning } from "../../utils";
+import { logLabeledBullet } from "../../utils";
 import { Context } from "./args";
 import { createArchive, createTarArchive } from "./util";
 import { isEnabled } from "../../experiments";
@@ -67,13 +67,6 @@ export default async function (context: Context, options: Options): Promise<void
       const rootDir = options.projectRoot ?? process.cwd();
       let builtAppDir;
       if (cfg.localBuild) {
-        if (!isEnabled("apphostinglocalbuilds")) {
-          logLabeledWarning(
-            "apphosting",
-            `Skipping local build for backend ${cfg.backendId} because the experiment apphostinglocalbuilds is not enabled.`,
-          );
-          return;
-        }
         builtAppDir = context.backendLocalBuilds[cfg.backendId].buildDir;
         if (!builtAppDir) {
           throw new FirebaseError(`No local build dir found for ${cfg.backendId}`);

--- a/src/deploy/apphosting/deploy.ts
+++ b/src/deploy/apphosting/deploy.ts
@@ -5,7 +5,7 @@ import * as gcs from "../../gcp/storage";
 import { getProjectNumber } from "../../getProjectNumber";
 import { Options } from "../../options";
 import { needProjectId } from "../../projectUtils";
-import { logLabeledBullet } from "../../utils";
+import { logLabeledBullet, logLabeledWarning } from "../../utils";
 import { Context } from "./args";
 import { createArchive, createTarArchive } from "./util";
 import { isEnabled } from "../../experiments";
@@ -73,7 +73,14 @@ export default async function (context: Context, options: Options): Promise<void
         }
       }
       let zippedSourcePath;
-      if (cfg.localBuild && isEnabled("apphostinglocalbuilds")) {
+      if (cfg.localBuild) {
+        if (!isEnabled("apphostinglocalbuilds")) {
+          logLabeledWarning(
+            "apphosting",
+            `Skipping local build for backend ${cfg.backendId} because the experiment apphostinglocalbuilds is not enabled.`,
+          );
+          return;
+        }
         zippedSourcePath = await createTarArchive(cfg, rootDir, builtAppDir);
       } else {
         zippedSourcePath = await createArchive(cfg, rootDir, builtAppDir);

--- a/src/deploy/apphosting/deploy.ts
+++ b/src/deploy/apphosting/deploy.ts
@@ -7,7 +7,8 @@ import { Options } from "../../options";
 import { needProjectId } from "../../projectUtils";
 import { logLabeledBullet } from "../../utils";
 import { Context } from "./args";
-import { createArchive } from "./util";
+import { createArchive, createTarArchive } from "./util";
+import { isEnabled } from "../../experiments";
 
 /**
  * Zips and uploads App Hosting source code to Google Cloud Storage in preparation for
@@ -71,10 +72,15 @@ export default async function (context: Context, options: Options): Promise<void
           throw new FirebaseError(`No local build dir found for ${cfg.backendId}`);
         }
       }
-      const zippedSourcePath = await createArchive(cfg, rootDir, builtAppDir);
+      let zippedSourcePath;
+      if (cfg.localBuild && isEnabled("apphostinglocalbuilds")) {
+        zippedSourcePath = await createTarArchive(cfg, rootDir, builtAppDir);
+      } else {
+        zippedSourcePath = await createArchive(cfg, rootDir, builtAppDir);
+      }
       logLabeledBullet(
         "apphosting",
-        `Zipped ${cfg.localBuild ? "built app" : "source"} for backend ${cfg.backendId}`,
+        `Archived ${cfg.localBuild ? "built app" : "source"} for backend ${cfg.backendId}`,
       );
 
       const backendLocation = context.backendLocations[cfg.backendId];

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -146,7 +146,7 @@ describe("apphosting", () => {
       }));
     });
 
-    it("skips local builds when experiment is disabled", async () => {
+    it("skips local builds when experiment is disabled but continues with others", async () => {
       isEnabledStub.withArgs("apphostinglocalbuilds").returns(false);
       const context: Context = {
         backendConfigs: {
@@ -156,10 +156,16 @@ describe("apphosting", () => {
             ignore: [],
             localBuild: true,
           },
+          bar: {
+            backendId: "bar",
+            rootDir: "/",
+            ignore: [],
+          },
         },
-        backendLocations: { foo: "us-central1" },
+        backendLocations: { foo: "us-central1", bar: "us-central1" },
         backendStorageUris: {
           foo: "gs://bucket/built.tar.gz",
+          bar: "gs://bucket/source.zip",
         },
         backendLocalBuilds: {
           foo: {
@@ -174,7 +180,11 @@ describe("apphosting", () => {
 
       await release(context, opts);
 
-      expect(orchestrateRolloutStub).to.not.be.called;
+      // Should only be called once for 'bar'
+      expect(orchestrateRolloutStub).to.be.calledOnce;
+      expect(orchestrateRolloutStub).to.be.calledWith(sinon.match({
+        backendId: "bar",
+      }));
     });
   });
 });

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -3,12 +3,10 @@ import * as rollout from "../../apphosting/rollout";
 import * as backend from "../../apphosting/backend";
 import { Config } from "../../config";
 import { RC } from "../../rc";
-import { needProjectId } from "../../projectUtils";
 import { Context } from "./args";
 import release from "./release";
 import { expect } from "chai";
 import * as experiments from "../../experiments";
-import { isEnabled } from "../../experiments";
 import * as apphosting from "../../gcp/apphosting";
 
 const BASE_OPTS = {
@@ -25,11 +23,10 @@ const BASE_OPTS = {
 describe("apphosting", () => {
   let isEnabledStub: sinon.SinonStub;
   let orchestrateRolloutStub: sinon.SinonStub;
-  let getBackendStub: sinon.SinonStub;
 
   beforeEach(() => {
     isEnabledStub = sinon.stub(experiments, "isEnabled").returns(false);
-    getBackendStub = sinon.stub(backend, "getBackend").resolves({
+    sinon.stub(backend, "getBackend").resolves({
       name: "projects/my-project/locations/us-central1/backends/foo",
       servingLocality: "REGIONAL_STRICT",
       labels: {},
@@ -103,16 +100,18 @@ describe("apphosting", () => {
 
       await release(context, opts);
 
-      expect(orchestrateRolloutStub).to.be.calledOnceWith(sinon.match({
-        buildInput: {
-          source: {
-            archive: {
-              userStorageUri: "gs://bucket/source.zip",
-              rootDirectory: "/",
+      expect(orchestrateRolloutStub).to.be.calledOnceWith(
+        sinon.match({
+          buildInput: {
+            source: {
+              archive: {
+                userStorageUri: "gs://bucket/source.zip",
+                rootDirectory: "/",
+              },
             },
           },
-        },
-      }));
+        }),
+      );
     });
 
     it("uses locallyBuilt for local builds when experiment is enabled", async () => {
@@ -143,15 +142,17 @@ describe("apphosting", () => {
 
       await release(context, opts);
 
-      expect(orchestrateRolloutStub).to.be.calledOnceWith(sinon.match({
-        buildInput: {
-          source: {
-            locallyBuilt: {
-              userStorageUri: "gs://bucket/built.tar.gz",
+      expect(orchestrateRolloutStub).to.be.calledOnceWith(
+        sinon.match({
+          buildInput: {
+            source: {
+              locallyBuilt: {
+                userStorageUri: "gs://bucket/built.tar.gz",
+              },
             },
           },
-        },
-      }));
+        }),
+      );
     });
 
     it("skips local builds when experiment is disabled but continues with others", async () => {
@@ -190,9 +191,11 @@ describe("apphosting", () => {
 
       // Should only be called once for 'bar'
       expect(orchestrateRolloutStub).to.be.calledOnce;
-      expect(orchestrateRolloutStub).to.be.calledWith(sinon.match({
-        backendId: "bar",
-      }));
+      expect(orchestrateRolloutStub).to.be.calledWith(
+        sinon.match({
+          backendId: "bar",
+        }),
+      );
     });
   });
 });

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -9,6 +9,7 @@ import release from "./release";
 import { expect } from "chai";
 import * as experiments from "../../experiments";
 import { isEnabled } from "../../experiments";
+import * as apphosting from "../../gcp/apphosting";
 
 const BASE_OPTS = {
   cwd: "/",
@@ -28,7 +29,14 @@ describe("apphosting", () => {
 
   beforeEach(() => {
     isEnabledStub = sinon.stub(experiments, "isEnabled").returns(false);
-    getBackendStub = sinon.stub(backend, "getBackend").resolves({ uri: "https://foo-us-central1.a.run.app" } as any);
+    getBackendStub = sinon.stub(backend, "getBackend").resolves({
+      name: "projects/my-project/locations/us-central1/backends/foo",
+      servingLocality: "REGIONAL_STRICT",
+      labels: {},
+      createTime: "2026-01-01T00:00:00Z",
+      updateTime: "2026-01-01T00:00:00Z",
+      uri: "https://foo-us-central1.a.run.app",
+    } as apphosting.Backend);
   });
 
   afterEach(() => {

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -3,12 +3,10 @@ import * as rollout from "../../apphosting/rollout";
 import * as backend from "../../apphosting/backend";
 import { Config } from "../../config";
 import { RC } from "../../rc";
-import { needProjectId } from "../../projectUtils";
 import { Context } from "./args";
 import release from "./release";
 import { expect } from "chai";
 import * as experiments from "../../experiments";
-import { isEnabled } from "../../experiments";
 
 const BASE_OPTS = {
   cwd: "/",

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -3,10 +3,12 @@ import * as rollout from "../../apphosting/rollout";
 import * as backend from "../../apphosting/backend";
 import { Config } from "../../config";
 import { RC } from "../../rc";
+import { needProjectId } from "../../projectUtils";
 import { Context } from "./args";
 import release from "./release";
 import { expect } from "chai";
 import * as experiments from "../../experiments";
+import { isEnabled } from "../../experiments";
 
 const BASE_OPTS = {
   cwd: "/",

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -1,10 +1,14 @@
 import * as sinon from "sinon";
 import * as rollout from "../../apphosting/rollout";
+import * as backend from "../../apphosting/backend";
 import { Config } from "../../config";
 import { RC } from "../../rc";
+import { needProjectId } from "../../projectUtils";
 import { Context } from "./args";
 import release from "./release";
 import { expect } from "chai";
+import * as experiments from "../../experiments";
+import { isEnabled } from "../../experiments";
 
 const BASE_OPTS = {
   cwd: "/",
@@ -18,7 +22,14 @@ const BASE_OPTS = {
 };
 
 describe("apphosting", () => {
+  let isEnabledStub: sinon.SinonStub;
   let orchestrateRolloutStub: sinon.SinonStub;
+  let getBackendStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    isEnabledStub = sinon.stub(experiments, "isEnabled").returns(false);
+    getBackendStub = sinon.stub(backend, "getBackend").resolves({ uri: "https://foo-us-central1.a.run.app" } as any);
+  });
 
   afterEach(() => {
     sinon.verifyAndRestore();
@@ -62,6 +73,108 @@ describe("apphosting", () => {
       orchestrateRolloutStub.onSecondCall().resolves();
 
       await expect(release(context, opts)).to.eventually.not.rejected;
+    });
+
+    it("uses archive for standard source deployments", async () => {
+      const context: Context = {
+        backendConfigs: {
+          foo: {
+            backendId: "foo",
+            rootDir: "/",
+            ignore: [],
+          },
+        },
+        backendLocations: { foo: "us-central1" },
+        backendStorageUris: {
+          foo: "gs://bucket/source.zip",
+        },
+        backendLocalBuilds: {},
+      };
+
+      orchestrateRolloutStub = sinon.stub(rollout, "orchestrateRollout").resolves();
+
+      await release(context, opts);
+
+      expect(orchestrateRolloutStub).to.be.calledOnceWith(sinon.match({
+        buildInput: {
+          source: {
+            archive: {
+              userStorageUri: "gs://bucket/source.zip",
+              rootDirectory: "/",
+            },
+          },
+        },
+      }));
+    });
+
+    it("uses locallyBuilt for local builds when experiment is enabled", async () => {
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(true);
+      const context: Context = {
+        backendConfigs: {
+          foo: {
+            backendId: "foo",
+            rootDir: "/",
+            ignore: [],
+            localBuild: true,
+          },
+        },
+        backendLocations: { foo: "us-central1" },
+        backendStorageUris: {
+          foo: "gs://bucket/built.tar.gz",
+        },
+        backendLocalBuilds: {
+          foo: {
+            buildDir: "dist",
+            buildConfig: {},
+            annotations: {},
+          },
+        },
+      };
+
+      orchestrateRolloutStub = sinon.stub(rollout, "orchestrateRollout").resolves();
+
+      await release(context, opts);
+
+      expect(orchestrateRolloutStub).to.be.calledOnceWith(sinon.match({
+        buildInput: {
+          source: {
+            locallyBuilt: {
+              userStorageUri: "gs://bucket/built.tar.gz",
+            },
+          },
+        },
+      }));
+    });
+
+    it("skips local builds when experiment is disabled", async () => {
+      isEnabledStub.withArgs("apphostinglocalbuilds").returns(false);
+      const context: Context = {
+        backendConfigs: {
+          foo: {
+            backendId: "foo",
+            rootDir: "/",
+            ignore: [],
+            localBuild: true,
+          },
+        },
+        backendLocations: { foo: "us-central1" },
+        backendStorageUris: {
+          foo: "gs://bucket/built.tar.gz",
+        },
+        backendLocalBuilds: {
+          foo: {
+            buildDir: "dist",
+            buildConfig: {},
+            annotations: {},
+          },
+        },
+      };
+
+      orchestrateRolloutStub = sinon.stub(rollout, "orchestrateRollout").resolves();
+
+      await release(context, opts);
+
+      expect(orchestrateRolloutStub).to.not.be.called;
     });
   });
 });

--- a/src/deploy/apphosting/release.ts
+++ b/src/deploy/apphosting/release.ts
@@ -1,7 +1,8 @@
 import * as ora from "ora";
 import { consoleOrigin } from "../../api";
 import { getBackend } from "../../apphosting/backend";
-import { orchestrateRollout } from "../../apphosting/rollout";
+import * as apphosting from "../../gcp/apphosting";
+import * as rollout from "../../apphosting/rollout";
 import { Options } from "../../options";
 import { needProjectId } from "../../projectUtils";
 import {
@@ -50,7 +51,7 @@ export default async function (context: Context, options: Options): Promise<void
   const rollouts = backendIds.map((backendId) => {
     const cfg = context.backendConfigs[backendId];
     const isLocalBuild = cfg.localBuild && isEnabled("apphostinglocalbuilds");
-    let source: import("../../gcp/apphosting").Build["source"];
+    let source: apphosting.Build["source"];
     if (isLocalBuild) {
       source = {
         locallyBuilt: {
@@ -66,7 +67,7 @@ export default async function (context: Context, options: Options): Promise<void
       };
     }
 
-    return orchestrateRollout({
+    return rollout.orchestrateRollout({
       projectId,
       backendId,
       location: context.backendLocations[backendId],

--- a/src/deploy/apphosting/release.ts
+++ b/src/deploy/apphosting/release.ts
@@ -31,13 +31,11 @@ export default async function (context: Context, options: Options): Promise<void
     backendIds = backendIds.filter((id) => !missingBackends.includes(id));
   }
 
-  const localBuildBackends = backendIds.filter(
-    (id) => context.backendLocalBuilds[id] && !isEnabled("apphostinglocalbuilds"),
-  );
-  if (localBuildBackends.length > 0) {
+  const localBuildBackends = backendIds.filter((id) => context.backendLocalBuilds[id]);
+  if (localBuildBackends.length > 0 && !isEnabled("apphostinglocalbuilds")) {
     logLabeledWarning(
       "apphosting",
-      `Skipping backend(s) ${localBuildBackends.join(", ")}. Local Builds are not supported yet.`,
+      `Skipping local build backend(s) ${localBuildBackends.join(", ")} because the experiment apphostinglocalbuilds is not enabled.`,
     );
     backendIds = backendIds.filter((id) => !localBuildBackends.includes(id));
   }
@@ -49,7 +47,7 @@ export default async function (context: Context, options: Options): Promise<void
   const projectId = needProjectId(options);
   const rollouts = backendIds.map((backendId) => {
     const cfg = context.backendConfigs[backendId];
-    const isLocalBuild = cfg.localBuild && isEnabled("apphostinglocalbuilds");
+    const isLocalBuild = cfg.localBuild;
     let source: any;
     if (isLocalBuild) {
       source = {

--- a/src/deploy/apphosting/release.ts
+++ b/src/deploy/apphosting/release.ts
@@ -31,11 +31,13 @@ export default async function (context: Context, options: Options): Promise<void
     backendIds = backendIds.filter((id) => !missingBackends.includes(id));
   }
 
-  const localBuildBackends = backendIds.filter((id) => context.backendLocalBuilds[id]);
-  if (localBuildBackends.length > 0 && !isEnabled("apphostinglocalbuilds")) {
+  const localBuildBackends = backendIds.filter(
+    (id) => context.backendLocalBuilds[id] && !isEnabled("apphostinglocalbuilds"),
+  );
+  if (localBuildBackends.length > 0) {
     logLabeledWarning(
       "apphosting",
-      `Skipping local build backend(s) ${localBuildBackends.join(", ")} because the experiment apphostinglocalbuilds is not enabled.`,
+      `Skipping backend(s) ${localBuildBackends.join(", ")}. Local Builds are not supported yet.`,
     );
     backendIds = backendIds.filter((id) => !localBuildBackends.includes(id));
   }
@@ -47,7 +49,7 @@ export default async function (context: Context, options: Options): Promise<void
   const projectId = needProjectId(options);
   const rollouts = backendIds.map((backendId) => {
     const cfg = context.backendConfigs[backendId];
-    const isLocalBuild = cfg.localBuild;
+    const isLocalBuild = cfg.localBuild && isEnabled("apphostinglocalbuilds");
     let source: any;
     if (isLocalBuild) {
       source = {

--- a/src/deploy/apphosting/release.ts
+++ b/src/deploy/apphosting/release.ts
@@ -12,6 +12,7 @@ import {
 } from "../../utils";
 import { Context } from "./args";
 import { FirebaseError } from "../../error";
+import { isEnabled } from "../../experiments";
 
 /**
  * Orchestrates rollouts for the backends targeted for deployment.
@@ -30,7 +31,9 @@ export default async function (context: Context, options: Options): Promise<void
     backendIds = backendIds.filter((id) => !missingBackends.includes(id));
   }
 
-  const localBuildBackends = backendIds.filter((id) => context.backendLocalBuilds[id]);
+  const localBuildBackends = backendIds.filter(
+    (id) => context.backendLocalBuilds[id] && !isEnabled("apphostinglocalbuilds"),
+  );
   if (localBuildBackends.length > 0) {
     logLabeledWarning(
       "apphosting",
@@ -44,24 +47,34 @@ export default async function (context: Context, options: Options): Promise<void
   }
 
   const projectId = needProjectId(options);
-  const rollouts = backendIds.map((backendId) =>
-    // TODO(9114): Add run_command
-    // TODO(914): Set the buildConfig.
-    // TODO(914): Set locallyBuiltSource.
-    orchestrateRollout({
+  const rollouts = backendIds.map((backendId) => {
+    const cfg = context.backendConfigs[backendId];
+    const isLocalBuild = cfg.localBuild && isEnabled("apphostinglocalbuilds");
+    let source: any;
+    if (isLocalBuild) {
+      source = {
+        locallyBuilt: {
+          userStorageUri: context.backendStorageUris[backendId],
+        },
+      };
+    } else {
+      source = {
+        archive: {
+          userStorageUri: context.backendStorageUris[backendId],
+          rootDirectory: cfg.rootDir,
+        },
+      };
+    }
+
+    return orchestrateRollout({
       projectId,
       backendId,
       location: context.backendLocations[backendId],
       buildInput: {
-        source: {
-          archive: {
-            userStorageUri: context.backendStorageUris[backendId],
-            rootDirectory: context.backendConfigs[backendId].rootDir,
-          },
-        },
+        source,
       },
-    }),
-  );
+    });
+  });
 
   logLabeledBullet(
     "apphosting",

--- a/src/deploy/apphosting/release.ts
+++ b/src/deploy/apphosting/release.ts
@@ -50,7 +50,7 @@ export default async function (context: Context, options: Options): Promise<void
   const rollouts = backendIds.map((backendId) => {
     const cfg = context.backendConfigs[backendId];
     const isLocalBuild = cfg.localBuild && isEnabled("apphostinglocalbuilds");
-    let source: any;
+    let source: import("../../gcp/apphosting").Build["source"];
     if (isLocalBuild) {
       source = {
         locallyBuilt: {

--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -7,6 +7,7 @@ import { FirebaseError } from "../../error";
 import { AppHostingSingle } from "../../firebaseConfig";
 import * as fsAsync from "../../fsAsync";
 import { APPHOSTING_YAML_FILE_REGEX } from "../../apphosting/config";
+import { resolveWithin } from "../../utils";
 
 /**
  * Locates the source code for a backend and creates an archive to eventually upload to GCS.

--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -1,10 +1,12 @@
 import * as archiver from "archiver";
 import * as fs from "fs";
 import * as path from "path";
+import * as tar from "tar";
 import * as tmp from "tmp";
 import { FirebaseError } from "../../error";
 import { AppHostingSingle } from "../../firebaseConfig";
 import * as fsAsync from "../../fsAsync";
+import { APPHOSTING_YAML_FILE_REGEX } from "../../apphosting/config";
 
 /**
  * Locates the source code for a backend and creates an archive to eventually upload to GCS.
@@ -52,7 +54,7 @@ export async function createArchive(
 }
 
 /**
- * Locates the source code for a backend and creates a tar archive to eventually upload to GCS.
+ * Locates the built artifacts for a backend and creates a tar archive to eventually upload to GCS.
  */
 export async function createTarArchive(
   config: AppHostingSingle,
@@ -60,48 +62,63 @@ export async function createTarArchive(
   targetSubDir?: string,
 ): Promise<string> {
   const tmpFile = tmp.fileSync({ prefix: `${config.backendId}-`, postfix: ".tar.gz" }).name;
-  const fileStream = fs.createWriteStream(tmpFile, {
-    flags: "w",
-    encoding: "binary",
-  });
-  const archive = archiver("tar", {
-    gzip: true,
-    gzipOptions: {
-      level: 9,
-    },
-  });
 
   const targetDir = targetSubDir ? path.join(rootDir, targetSubDir) : rootDir;
-  const ignore = config.ignore || ["node_modules", ".git"];
-  ignore.push("firebase-debug.log", "firebase-debug.*.log");
-  const gitIgnorePatterns = parseGitIgnorePatterns(targetDir);
-  ignore.push(...gitIgnorePatterns);
+  // For built artifacts, we typically want to include everything except debug logs and git metadata.
+  // We do NOT ignore node_modules here because local builds (like Next.js standalone) often require them.
+  const ignore = ["firebase-debug.log", "firebase-debug.*.log", ".git"];
+
   try {
-    const files = await fsAsync.readdirRecursive({
+    const rdrFiles = await fsAsync.readdirRecursive({
       path: targetDir,
       ignore: ignore,
       isGitIgnore: true,
     });
-    for (const file of files) {
-      const name = path.relative(rootDir, file.name);
-      archive.file(file.name, {
-        name,
-        mode: file.mode,
-        // Set fixed metadata for deterministic hashing
-        stats: {
-          uid: 0,
-          gid: 0,
-          mtime: new Date(0),
-        },
-      } as archiver.EntryData);
+
+    const allFiles: string[] = rdrFiles.map((rdrf) => path.relative(rootDir, rdrf.name));
+
+    // If we're archiving a built app directory, we must also include the apphosting.yaml
+    // from the root directory so the backend knows the configuration.
+    if (targetSubDir) {
+      const rootFiles = fs.readdirSync(rootDir).filter((file) =>
+        APPHOSTING_YAML_FILE_REGEX.test(file),
+      );
+      for (const file of rootFiles) {
+        if (!allFiles.includes(file)) {
+          allFiles.push(file);
+        }
+      }
     }
-    await pipeAsync(archive, fileStream);
+
+    if (!allFiles.length) {
+      throw new FirebaseError(
+        `Cannot create a tar archive with 0 files from directory "${targetDir}"`,
+      );
+    }
+
+    // Sort files to ensure deterministic hashing (order matters in tarballs)
+    allFiles.sort();
+
+    await tar.create(
+      {
+        gzip: true,
+        file: tmpFile,
+        cwd: rootDir,
+        portable: true, // Strips host-specific UID/GID
+        mtime: new Date(0), // Set fixed timestamp for deterministic hashing
+      },
+      allFiles,
+    );
   } catch (err: unknown) {
+    if (err instanceof FirebaseError) {
+      throw err;
+    }
     throw new FirebaseError(
       "Could not read source directory. Remove links and shortcuts and try again.",
       { original: err as Error, exit: 1 },
     );
   }
+
   return tmpFile;
 }
 

--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -51,6 +51,60 @@ export async function createArchive(
   return tmpFile;
 }
 
+/**
+ * Locates the source code for a backend and creates a tar archive to eventually upload to GCS.
+ */
+export async function createTarArchive(
+  config: AppHostingSingle,
+  rootDir: string,
+  targetSubDir?: string,
+): Promise<string> {
+  const tmpFile = tmp.fileSync({ prefix: `${config.backendId}-`, postfix: ".tar.gz" }).name;
+  const fileStream = fs.createWriteStream(tmpFile, {
+    flags: "w",
+    encoding: "binary",
+  });
+  const archive = archiver("tar", {
+    gzip: true,
+    gzipOptions: {
+      level: 9,
+    },
+  });
+
+  const targetDir = targetSubDir ? path.join(rootDir, targetSubDir) : rootDir;
+  const ignore = config.ignore || ["node_modules", ".git"];
+  ignore.push("firebase-debug.log", "firebase-debug.*.log");
+  const gitIgnorePatterns = parseGitIgnorePatterns(targetDir);
+  ignore.push(...gitIgnorePatterns);
+  try {
+    const files = await fsAsync.readdirRecursive({
+      path: targetDir,
+      ignore: ignore,
+      isGitIgnore: true,
+    });
+    for (const file of files) {
+      const name = path.relative(rootDir, file.name);
+      archive.file(file.name, {
+        name,
+        mode: file.mode,
+        // Set fixed metadata for deterministic hashing
+        stats: {
+          uid: 0,
+          gid: 0,
+          mtime: new Date(0),
+        },
+      } as archiver.EntryData);
+    }
+    await pipeAsync(archive, fileStream);
+  } catch (err: unknown) {
+    throw new FirebaseError(
+      "Could not read source directory. Remove links and shortcuts and try again.",
+      { original: err as Error, exit: 1 },
+    );
+  }
+  return tmpFile;
+}
+
 function parseGitIgnorePatterns(projectRoot: string, gitIgnorePath = ".gitignore"): string[] {
   const absoluteFilePath = path.resolve(projectRoot, gitIgnorePath);
   if (!fs.existsSync(absoluteFilePath)) {

--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -63,7 +63,7 @@ export async function createTarArchive(
 ): Promise<string> {
   const tmpFile = tmp.fileSync({ prefix: `${config.backendId}-`, postfix: ".tar.gz" }).name;
 
-  const targetDir = targetSubDir ? path.join(rootDir, targetSubDir) : rootDir;
+  const targetDir = targetSubDir ? resolveWithin(rootDir, targetSubDir) : rootDir;
   // For built artifacts, we typically want to include everything except debug logs and git metadata.
   // We do NOT ignore node_modules here because local builds (like Next.js standalone) often require them.
   const ignore = ["firebase-debug.log", "firebase-debug.*.log", ".git"];

--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -1,12 +1,10 @@
 import * as archiver from "archiver";
 import * as fs from "fs";
 import * as path from "path";
-import * as tar from "tar";
 import * as tmp from "tmp";
 import { FirebaseError } from "../../error";
 import { AppHostingSingle } from "../../firebaseConfig";
 import * as fsAsync from "../../fsAsync";
-import { APPHOSTING_YAML_FILE_REGEX } from "../../apphosting/config";
 
 /**
  * Locates the source code for a backend and creates an archive to eventually upload to GCS.
@@ -54,7 +52,7 @@ export async function createArchive(
 }
 
 /**
- * Locates the built artifacts for a backend and creates a tar archive to eventually upload to GCS.
+ * Locates the source code for a backend and creates a tar archive to eventually upload to GCS.
  */
 export async function createTarArchive(
   config: AppHostingSingle,
@@ -62,63 +60,48 @@ export async function createTarArchive(
   targetSubDir?: string,
 ): Promise<string> {
   const tmpFile = tmp.fileSync({ prefix: `${config.backendId}-`, postfix: ".tar.gz" }).name;
+  const fileStream = fs.createWriteStream(tmpFile, {
+    flags: "w",
+    encoding: "binary",
+  });
+  const archive = archiver("tar", {
+    gzip: true,
+    gzipOptions: {
+      level: 9,
+    },
+  });
 
   const targetDir = targetSubDir ? path.join(rootDir, targetSubDir) : rootDir;
-  // For built artifacts, we typically want to include everything except debug logs and git metadata.
-  // We do NOT ignore node_modules here because local builds (like Next.js standalone) often require them.
-  const ignore = ["firebase-debug.log", "firebase-debug.*.log", ".git"];
-
+  const ignore = config.ignore || ["node_modules", ".git"];
+  ignore.push("firebase-debug.log", "firebase-debug.*.log");
+  const gitIgnorePatterns = parseGitIgnorePatterns(targetDir);
+  ignore.push(...gitIgnorePatterns);
   try {
-    const rdrFiles = await fsAsync.readdirRecursive({
+    const files = await fsAsync.readdirRecursive({
       path: targetDir,
       ignore: ignore,
       isGitIgnore: true,
     });
-
-    const allFiles: string[] = rdrFiles.map((rdrf) => path.relative(rootDir, rdrf.name));
-
-    // If we're archiving a built app directory, we must also include the apphosting.yaml
-    // from the root directory so the backend knows the configuration.
-    if (targetSubDir) {
-      const rootFiles = fs.readdirSync(rootDir).filter((file) =>
-        APPHOSTING_YAML_FILE_REGEX.test(file),
-      );
-      for (const file of rootFiles) {
-        if (!allFiles.includes(file)) {
-          allFiles.push(file);
-        }
-      }
+    for (const file of files) {
+      const name = path.relative(rootDir, file.name);
+      archive.file(file.name, {
+        name,
+        mode: file.mode,
+        // Set fixed metadata for deterministic hashing
+        stats: {
+          uid: 0,
+          gid: 0,
+          mtime: new Date(0),
+        },
+      } as archiver.EntryData);
     }
-
-    if (!allFiles.length) {
-      throw new FirebaseError(
-        `Cannot create a tar archive with 0 files from directory "${targetDir}"`,
-      );
-    }
-
-    // Sort files to ensure deterministic hashing (order matters in tarballs)
-    allFiles.sort();
-
-    await tar.create(
-      {
-        gzip: true,
-        file: tmpFile,
-        cwd: rootDir,
-        portable: true, // Strips host-specific UID/GID
-        mtime: new Date(0), // Set fixed timestamp for deterministic hashing
-      },
-      allFiles,
-    );
+    await pipeAsync(archive, fileStream);
   } catch (err: unknown) {
-    if (err instanceof FirebaseError) {
-      throw err;
-    }
     throw new FirebaseError(
       "Could not read source directory. Remove links and shortcuts and try again.",
       { original: err as Error, exit: 1 },
     );
   }
-
   return tmpFile;
 }
 

--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -81,9 +81,9 @@ export async function createTarArchive(
     // If we're archiving a built app directory, we must also include the apphosting.yaml
     // from the root directory so the backend knows the configuration.
     if (targetSubDir) {
-      const rootFiles = fs.readdirSync(rootDir).filter((file) =>
-        APPHOSTING_YAML_FILE_REGEX.test(file),
-      );
+      const rootFiles = fs
+        .readdirSync(rootDir)
+        .filter((file) => APPHOSTING_YAML_FILE_REGEX.test(file));
       for (const file of rootFiles) {
         if (!allFiles.includes(file)) {
           allFiles.push(file);

--- a/src/gcp/apphosting.ts
+++ b/src/gcp/apphosting.ts
@@ -118,6 +118,21 @@ export interface BuildConfig {
 interface BuildSource {
   codebase?: CodebaseSource;
   archive?: ArchiveSource;
+  locallyBuilt?: LocallyBuiltSource;
+}
+
+export interface LocallyBuiltSource {
+  userStorageUri: string;
+  rootDirectory?: string;
+  description?: string;
+  runCommand?: string;
+  runConfig?: RunConfig;
+  env?: Env[];
+}
+
+export interface RunConfig {
+  cpu?: number;
+  memoryMiB?: number;
 }
 
 interface CodebaseSource {
@@ -140,6 +155,7 @@ interface ArchiveSource {
   // end oneof reference
   rootDirectory?: string;
   author?: SourceUserMetadata;
+  /** @deprecated use Build.source.locallyBuilt instead */
   locallyBuiltSource?: boolean;
 }
 


### PR DESCRIPTION
This is based off of Joanna's Draft PR: https://github.com/firebase/firebase-tools/pull/9506

Also see https://github.com/firebase/firebase-tools/pull/9193 for an earlier partial implementation of local builds.

### Description

This uses the new effective API fields. Also, this code keeps the source deploy path (existing feature, different from local builds) unaffected.

We create tar.gz files instead of zip files.

### Scenarios Tested

TODO: Verify local builds works (basic, no env vars)
TODO: Verify that source deploy is unaffected and still works as expected

### Sample Commands

TODO: Local build command
TODO: Source deploy command