### PR TITLE
fix(dataconnect): skip confirmation prompts when using --force flag

### DIFF
--- a/src/dataconnect/schemaMigration.ts
+++ b/src/dataconnect/schemaMigration.ts
@@ -553,8 +553,8 @@ async function promptForSchemaMigration(
   const defaultChoice = validationMode === "STRICT_AFTER_COMPATIBLE" ? "none" : "all";
   displaySchemaChanges(err, validationMode);
   if (!options.nonInteractive) {
-    if (validateOnly && options.force) {
-      // `firebase dataconnect:sql:migrate --force` performs all compatible migrations.
+    if (options.force) {
+      // `--force` performs all compatible migrations without prompting.
       return defaultChoice;
     }
     let choices: { name: string; value: "none" | "safe" | "all" | "abort" }[] = [
@@ -582,14 +582,14 @@ async function promptForSchemaMigration(
     }
     return ans;
   }
-  if (!validateOnly) {
+  if (options.force) {
+    // `--nonInteractive --force` performs all migrations.
+    return defaultChoice;
+  } else if (!validateOnly) {
     // `firebase deploy --nonInteractive` performs no migrations
     throw new FirebaseError(
       "Command aborted. Your database schema is incompatible with your Data Connect schema. Run `firebase dataconnect:sql:migrate` to migrate your database schema",
     );
-  } else if (options.force) {
-    // `dataconnect:sql:migrate --nonInteractive --force` performs all migrations.
-    return defaultChoice;
   } else if (!err.destructive) {
     // `dataconnect:sql:migrate --nonInteractive` performs only non-destructive migrations.
     return defaultChoice;

--- a/src/deploy/dataconnect/deploy.ts
+++ b/src/deploy/dataconnect/deploy.ts
@@ -61,7 +61,7 @@ export default async function (context: Context, options: Options): Promise<void
     const serviceToDeleteList = servicesToDelete.map((s) => " - " + s.name).join("\n");
     if (
       await confirm({
-        force: false, // Don't delete anything in --force.
+        force: options.force,
         nonInteractive: options.nonInteractive,
         message: `The following services exist on ${projectId} but are not listed in your 'firebase.json'\n${serviceToDeleteList}\nWould you like to delete these services?`,
         default: false,


### PR DESCRIPTION
This PR updates `src/deploy/dataconnect/deploy.ts` to respect `options.force` when confirming deletion of unused services, bypassing the interactive prompt if `--force` is provided. It also updates `src/dataconnect/schemaMigration.ts` to automatically select the default migration option when `--force` is used, even in standard deployments (`validateOnly`=false), skipping the interactive migration prompt.

---
*PR created automatically by Jules for task [13878602467202867008](https://jules.google.com/task/13878602467202867008) started by @fredzqm*