### PR TITLE
fix(cloudtasks): handle missing bindings in IAM policy response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed a crash in `setEnqueuer` when deploying Cloud Tasks functions whose IAM policy has no bindings.

--- a/src/gcp/cloudtasks.spec.ts
+++ b/src/gcp/cloudtasks.spec.ts
@@ -249,6 +249,21 @@ describe("CloudTasks", () => {
       });
     });
 
+    it("handles missing bindings in IAM policy", async () => {
+      ct.getIamPolicy.resolves({
+        etag: "",
+        version: 3,
+      } as iam.Policy);
+
+      await cloudtasks.setEnqueuer(NAME, ["public"]);
+      expect(ct.getIamPolicy).to.have.been.called;
+      expect(ct.setIamPolicy).to.have.been.calledWith(NAME, {
+        bindings: [PUBLIC_ENQUEUER_BINDING],
+        etag: "",
+        version: 3,
+      });
+    });
+
     it("can resolve conflicts", async () => {
       ct.getIamPolicy.onCall(0).resolves({
         bindings: [ADMIN_BINDING],

--- a/src/gcp/cloudtasks.ts
+++ b/src/gcp/cloudtasks.ts
@@ -172,7 +172,7 @@ export async function setEnqueuer(
   const invokerMembers = proto.getInvokerMembers(invoker, project);
   while (true) {
     const policy: iam.Policy = {
-      bindings: existing.bindings.filter((binding) => binding.role !== ENQUEUER_ROLE),
+      bindings: (existing.bindings || []).filter((binding) => binding.role !== ENQUEUER_ROLE),
       etag: existing.etag,
       version: existing.version,
     };


### PR DESCRIPTION
### Description

When a Cloud Tasks queue has no IAM bindings set, the Google Cloud IAM
API returns a policy object containing only `{etag, version}` — the
`bindings` field is omitted entirely. The `setEnqueuer()` function in
`src/gcp/cloudtasks.ts` accesses `existing.bindings.filter(...)` without
a null check, causing deployments to crash with:

    Cannot read properties of undefined (reading 'filter')

This surfaces during `firebase deploy --only functions` as:

    Unable to set the invoker for the IAM policy on the following functions:
        <functionName>(<region>)

The fix adds an `|| []` fallback: `(existing.bindings || []).filter(...)`,
matching the same defensive pattern already used in `src/gcp/run.ts`
inside `setInvokerUpdate()`.

### Scenarios Tested

- **New test case**: stubs `getIamPolicy` to return `{etag, version}` with
  no `bindings` field, confirming `setEnqueuer` no longer throws
- **All existing cloudtasks tests pass** (13/13)
- **Reproduced in production**: deployed a `onTaskDispatched` Cloud Function
  where the queue's IAM policy had no bindings — confirmed the crash, applied
  the fix, and confirmed successful deployment

### Sample Commands

\`\`\`
firebase deploy --only functions
\`\`\`