### PR TITLE
fix(next): detect next/image in Next.js 15+ App Router projects

### DIFF
--- a/src/frameworks/next/utils.ts
+++ b/src/frameworks/next/utils.ts
@@ -239,9 +239,7 @@ export async function isUsingImageOptimization(
   // Next.js 15+ may not populate manifests with next/image references;
   // fall back to scanning project source files in the app directory.
   if (!isNextImageImported && isUsingAppDirectory(join(projectDir, distDir))) {
-    if (await isNextImageInProjectSource(projectDir)) {
-      isNextImageImported = true;
-    }
+    isNextImageImported = await isNextImageInProjectSource(projectDir);
   }
 
   if (isNextImageImported) {
@@ -292,20 +290,23 @@ export async function isUsingNextImageInAppDirectory(
  * @return true if any .tsx/.ts/.jsx/.js file under `app/` imports next/image
  */
 export async function isNextImageInProjectSource(projectDir: string): Promise<boolean> {
-  const appDir = join(projectDir, "app");
-  if (!existsSync(appDir)) {
+  const dirsToScan = [
+    join(projectDir, "app"),
     // Also check src/app for projects using the src directory layout
-    const srcAppDir = join(projectDir, "src", "app");
-    if (!existsSync(srcAppDir)) {
-      return false;
+    join(projectDir, "src", "app"),
+  ];
+
+  for (const dir of dirsToScan) {
+    if (existsSync(dir)) {
+      return scanDirForNextImage(dir);
     }
-    return scanDirForNextImage(srcAppDir);
   }
-  return scanDirForNextImage(appDir);
+
+  return false;
 }
 
 async function scanDirForNextImage(dir: string): Promise<boolean> {
-  const files = globSync(join(dir, "**", "*.{tsx,ts,jsx,js}"));
+  const files = await glob(join(dir, "**", "*.{tsx,ts,jsx,js}"));
   for (const filepath of files) {
     const contents = await readFile(filepath, "utf-8");
     if (/from\s+['"]next\/image['"]/.test(contents)) {


### PR DESCRIPTION
Firebase Hosting with `frameworksBackend` does not detect `next/image` usage in Next.js 15+ App Router-only projects. This causes `firebase deploy` to skip adding Sharp to the Cloud Function, breaking image optimization.

**Affected:** Any Next.js 15+ project using App Router (no `pages/` directory) deployed via Firebase Hosting `frameworksBackend`.

## Root Cause

`isUsingImageOptimization()` in `src/frameworks/next/utils.ts` has two detection tiers that both fail:

### Tier 1: `export-marker.json` → `isNextImageImported`

Next.js sets `isNextImageImported` only for **Pages Router** pages. In `next/src/build/index.ts`:

```typescript
if (pageType === 'app' && originalAppPath) {
  // App Router - isNextImageImported is NEVER checked here
} else {
  // Pages Router only
  if (workerResult.isNextImageImported) {
    isNextImageImported = true;  // ← only set here
  }
}
```

For App Router-only projects, the flag remains `false` in `export-marker.json`.

### Tier 2: Client reference manifest scan

`isUsingNextImageInAppDirectory()` searches `*client-reference-manifest.js` files for the substring `node_modules/next/dist/client/image`.

**In Next.js 15.5.x, the image component is no longer listed as a separate entry in client-reference-manifest files.** The `next/image` component is bundled into page-level client chunks instead of being registered individually. Verified by building a Next.js 15.5.12 project and inspecting every manifest file - none contain the string `image`.

### Result

Both checks return `false` → `isUsingImageOptimization()` returns `false` → Sharp is not added to the Cloud Function → image optimization is silently disabled.

## Proposed Fix

Add a third fallback tier: scan project source files for `next/image` imports. This only runs when both existing checks fail, so it's fully backward compatible.

The source scan is the most defensible approach: targeted (no false positives), backward compatible (only runs when existing checks fail), and robust (`from 'next/image'` is a stable API contract).

## Reproduction

1. Create a Next.js 15.5+ project using **only App Router** (no `pages/` directory)
2. Use `next/image` in any component
3. Deploy via `firebase deploy --only hosting` with `frameworksBackend`
4. Check `.next/export-marker.json` - `isNextImageImported` is `false`
5. Image optimization is not included in the Cloud Function

## Workaround

Until fixed, patch `export-marker.json` after build:

```javascript
const fs = require('fs');
const marker = JSON.parse(fs.readFileSync('.next/export-marker.json', 'utf8'));
marker.isNextImageImported = true;
fs.writeFileSync('.next/export-marker.json', JSON.stringify(marker, null, 2));
```
