### PR TITLE
fix: kill Java emulators on unexpected CLI process exits

### DIFF
--- a/scripts/emulator-tests/downloadableEmulators.spec.ts
+++ b/scripts/emulator-tests/downloadableEmulators.spec.ts
@@ -71,7 +71,7 @@ describe("downloadableEmulators integration constraints", () => {
         );
       } catch (e) {
         // ESRCH directly maps to 'No such process'. This proves our SIGKILL 'on exit' safety net works!
-        expect((e as any).code).to.equal("ESRCH");
+        expect((e as NodeJS.ErrnoException).code).to.equal("ESRCH");
         done();
       }
     });

--- a/scripts/emulator-tests/downloadableEmulators.spec.ts
+++ b/scripts/emulator-tests/downloadableEmulators.spec.ts
@@ -24,7 +24,10 @@ describe("downloadableEmulators integration constraints", () => {
         });
     `;
 
-    const rootPath = __dirname.substring(0, __dirname.indexOf(path.join("scripts", "emulator-tests")));
+    const rootPath = __dirname.substring(
+      0,
+      __dirname.indexOf(path.join("scripts", "emulator-tests")),
+    );
     const child = spawn("node", ["-e", script], {
       cwd: rootPath,
     });
@@ -42,25 +45,33 @@ describe("downloadableEmulators integration constraints", () => {
 
     let stderrLogs = "";
     child.stderr.on("data", (data) => {
-       stderrLogs += data.toString();
+      stderrLogs += data.toString();
     });
 
     child.on("exit", (code) => {
       // We expect the script to have terminated precisely on an exit 1 via process.exit(1)
-      expect(code).to.equal(1, `Expected child process to exit 1 but got code ${code}. Stderr: ${stderrLogs}`);
-      expect(javaPid).to.be.greaterThan(0, `Child process never returned a JAVA_PID! Stderr: ${stderrLogs}`);
+      expect(code).to.equal(
+        1,
+        `Expected child process to exit 1 but got code ${code}. Stderr: ${stderrLogs}`,
+      );
+      expect(javaPid).to.be.greaterThan(
+        0,
+        `Child process never returned a JAVA_PID! Stderr: ${stderrLogs}`,
+      );
 
       try {
         // Assert native OS PID checks to verify the Java Process doesn't still exist.
-        process.kill(javaPid, 0); 
-        
+        process.kill(javaPid, 0);
+
         // If we reach here without an ESRCH error, the java process is ALIVE, which is a logic FAILURE.
         // We MUST manually kill it so it doesn't leak out of the test environment.
         process.kill(javaPid, "SIGKILL");
-        done(new Error("Java process " + javaPid + " was still alive after parent abruptly exited!"));
-      } catch (e: any) {
+        done(
+          new Error("Java process " + javaPid + " was still alive after parent abruptly exited!"),
+        );
+      } catch (e) {
         // ESRCH directly maps to 'No such process'. This proves our SIGKILL 'on exit' safety net works!
-        expect(e.code).to.equal("ESRCH");
+        expect((e as any).code).to.equal("ESRCH");
         done();
       }
     });

--- a/scripts/emulator-tests/downloadableEmulators.spec.ts
+++ b/scripts/emulator-tests/downloadableEmulators.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import { spawn } from "child_process";
+import * as path from "path";
+
+describe("downloadableEmulators integration constraints", () => {
+  it("should forcefully kill detached java emulators when the CLI process abruptly dies", (done) => {
+    // This script bootstraps a detached emulator instance internally and simulates a crashing runtime
+    // to prove that process.on("exit") OS hooks behave properly.
+    const script = `
+      const { start, get } = require("./lib/emulator/downloadableEmulators");
+      const { Emulators } = require("./lib/emulator/types");
+      
+      start(Emulators.DATABASE, { port: 9006, host: "127.0.0.1", auto_download: true })
+        .then(() => {
+          const details = get(Emulators.DATABASE);
+          console.log("JAVA_PID=" + details.instance.pid);
+          // Wait 1000ms to simulate doing arbitrary work, then trigger an uncaught unhandled crash.
+          setTimeout(() => {
+            process.exit(1);
+          }, 1000);
+        })
+        .catch((err) => {
+          console.error("FAILED TO BOOT:", err);
+        });
+    `;
+
+    const rootPath = __dirname.substring(0, __dirname.indexOf(path.join("scripts", "emulator-tests")));
+    const child = spawn("node", ["-e", script], {
+      cwd: rootPath,
+    });
+
+    let javaPid = -1;
+
+    // Capture standard output to parse the returned process id integer from the mocked script.
+    child.stdout.on("data", (data) => {
+      const str = data.toString();
+      const match = str.match(/JAVA_PID=(\d+)/);
+      if (match) {
+        javaPid = parseInt(match[1], 10);
+      }
+    });
+
+    let stderrLogs = "";
+    child.stderr.on("data", (data) => {
+       stderrLogs += data.toString();
+    });
+
+    child.on("exit", (code) => {
+      // We expect the script to have terminated precisely on an exit 1 via process.exit(1)
+      expect(code).to.equal(1, `Expected child process to exit 1 but got code ${code}. Stderr: ${stderrLogs}`);
+      expect(javaPid).to.be.greaterThan(0, `Child process never returned a JAVA_PID! Stderr: ${stderrLogs}`);
+
+      try {
+        // Assert native OS PID checks to verify the Java Process doesn't still exist.
+        process.kill(javaPid, 0); 
+        
+        // If we reach here without an ESRCH error, the java process is ALIVE, which is a logic FAILURE.
+        // We MUST manually kill it so it doesn't leak out of the test environment.
+        process.kill(javaPid, "SIGKILL");
+        done(new Error("Java process " + javaPid + " was still alive after parent abruptly exited!"));
+      } catch (e: any) {
+        // ESRCH directly maps to 'No such process'. This proves our SIGKILL 'on exit' safety net works!
+        expect(e.code).to.equal("ESRCH");
+        done();
+      }
+    });
+  }).timeout(20000);
+});

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -520,19 +520,19 @@ async function _runBinary(
       if (emulator.instance) {
         try {
           emulator.instance.kill("SIGKILL");
-        } catch (e: any) {
+        } catch (e) {
           // ignore
         }
       }
     };
     process.on("exit", exitCleanup);
 
-    emulator.instance.once("exit", async (code, signal) => {
+    emulator.instance.once("exit", (code, signal) => {
       process.removeListener("exit", exitCleanup);
       if (signal) {
         utils.logWarning(`${description} has exited upon receiving signal: ${signal}`);
       } else if (code && code !== 0 && code !== /* SIGINT */ 130) {
-        await _fatal(emulator.name, `${description} has exited with code: ${code}`);
+        void _fatal(emulator.name, `${description} has exited with code: ${code}`);
       }
     });
     resolve();
@@ -588,12 +588,11 @@ export async function stop(targetName: DownloadableEmulators): Promise<void> {
     if (emulator.instance && emulator.instance.kill(0)) {
       const killTimeout = setTimeout(() => {
         const pid = emulator.instance ? emulator.instance.pid : -1;
-        const errorMsg =
-          Constants.description(emulator.name) + ": Unable to terminate process (PID=" + pid + "). Sending SIGKILL...";
+        const errorMsg = `${Constants.description(emulator.name)}: Unable to terminate process (PID=${pid}). Sending SIGKILL...`;
         logger.log("DEBUG", errorMsg);
         try {
           emulator.instance?.kill("SIGKILL");
-        } catch (e: any) {
+        } catch (e) {
           // ignore
         }
         reject(new FirebaseError(emulator.name + ": " + errorMsg));

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -456,8 +456,9 @@ async function _runBinary(
         }
       }
       emulator.instance = childProcess.spawn(command.binary, command.args, opts);
-    } catch (e: any) {
-      if (e.code === "EACCES") {
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      if (err.code === "EACCES") {
         // Known issue when WSL users don't have java
         // https://github.com/Microsoft/WSL/issues/3886
         logger.logLabeled(
@@ -474,7 +475,7 @@ async function _runBinary(
             `softwareupdate --install-rosetta`,
         );
       }
-      _fatal(emulator.name, e);
+      void _fatal(emulator.name, hasMessage(e) ? e.message : String(e));
     }
 
     const description = Constants.description(emulator.name);

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -516,7 +516,19 @@ async function _runBinary(
       void handleEmulatorProcessError(emulator.name, err, command.port);
     });
 
+    const exitCleanup = () => {
+      if (emulator.instance) {
+        try {
+          emulator.instance.kill("SIGKILL");
+        } catch (e: any) {
+          // ignore
+        }
+      }
+    };
+    process.on("exit", exitCleanup);
+
     emulator.instance.once("exit", async (code, signal) => {
+      process.removeListener("exit", exitCleanup);
       if (signal) {
         utils.logWarning(`${description} has exited upon receiving signal: ${signal}`);
       } else if (code && code !== 0 && code !== /* SIGINT */ 130) {
@@ -577,8 +589,13 @@ export async function stop(targetName: DownloadableEmulators): Promise<void> {
       const killTimeout = setTimeout(() => {
         const pid = emulator.instance ? emulator.instance.pid : -1;
         const errorMsg =
-          Constants.description(emulator.name) + ": Unable to terminate process (PID=" + pid + ")";
+          Constants.description(emulator.name) + ": Unable to terminate process (PID=" + pid + "). Sending SIGKILL...";
         logger.log("DEBUG", errorMsg);
+        try {
+          emulator.instance?.kill("SIGKILL");
+        } catch (e: any) {
+          // ignore
+        }
         reject(new FirebaseError(emulator.name + ": " + errorMsg));
       }, EMULATOR_INSTANCE_KILL_TIMEOUT);
       emulator.instance.once("exit", () => {


### PR DESCRIPTION
Previously, if the `firebase` CLI crashed abruptly
(e.g., due to an unhandled exception or explicit fatal error bypass)
during an active Emulator session, the detached Java background processes
created for emulators like Database, Firestore, and PubSub were left orphaned.
This caused unintended resource leakage and frustrating port collisions on subsequent emulator launches.

This commit resolves the issue by introducing a native `process.on("exit")`
cleanup hook to `downloadableEmulators.ts` that explicitly issues a
`SIGKILL` to all recorded Java sub-processes strictly right upon CLI
termination. The graceful shutdown `stop()` handler has also been fortified
with a `SIGKILL` timeout fallback mechanism specifically designed to terminate
definitively hanging JVM emulator instances.

An integration test suite was also explicitly authored in
`scripts/emulator-tests/downloadableEmulators.spec.ts` which correctly
wraps CLI execution, spins up an isolated orchestrator locally, internally
aborts, and validates the OS system call returns `ESRCH`, guaranteeing the
associated Java PID dissolved.

- Tested standard UI / Graceful `SIGINT` timeout logic.
- Simulated Hard CLI process crashes, immediately reaping lingering JVM processes.
