### PR TITLE
fix: update lodash to ^4.18.0 to resolve vulnerability

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -49,7 +49,7 @@
         "jsonwebtoken": "^9.0.2",
         "leven": "^3.1.0",
         "libsodium-wrappers": "^0.7.10",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.0",
         "lsofi": "1.0.0",
         "marked": "^13.0.2",
         "marked-terminal": "^7.0.0",
@@ -13779,9 +13779,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash._objecttypes": {
       "version": "2.4.1",
@@ -32399,9 +32400,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="
     },
     "lodash._objecttypes": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
     "jsonwebtoken": "^9.0.2",
     "leven": "^3.1.0",
     "libsodium-wrappers": "^0.7.10",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.0",
     "lsofi": "1.0.0",
     "marked": "^13.0.2",
     "marked-terminal": "^7.0.0",


### PR DESCRIPTION
### Description
Update lodash from 4.17.21 to 4.18.1 to resolve a vulnerability in older versions.
This updates root package.json and regenerates npm-shrinkwrap.json.

### Scenarios Tested
- npm list lodash confirms 4.18.1
- npm run mocha:fast (unit tests pass, except for one unrelated flaky test in registry.spec.ts)

### Sample Commands
npm list lodash