### PR TITLE
feat: add SSE mode support for MCP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Added 'firebase_deploy' and 'firebase_deploy_status' MCP tools.
+- Added SSE mode support to `firebase mcp`. To use it, run `firebase mcp --mode=sse --port=3000`, and connect your client on `http://localhost:3000`.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -93,6 +93,7 @@
         "@angular-devkit/architect": "^0.1402.2",
         "@angular-devkit/core": "^14.2.2",
         "@google/events": "^5.1.1",
+        "@modelcontextprotocol/ext-apps": "^1.3.2",
         "@types/archiver": "^6.0.0",
         "@types/async-lock": "^1.4.2",
         "@types/body-parser": "^1.17.0",
@@ -2961,9 +2962,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
-      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -3701,13 +3702,40 @@
       "integrity": "sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw==",
       "dev": true
     },
+    "node_modules/@modelcontextprotocol/ext-apps": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.5.0.tgz",
+      "integrity": "sha512-q4fut89TOoP2LEPHSGfZErIf1K1xOTTzV+41h/bB2BqKw2gKb0uLKbHusOy1UtbY0puS16zBho/vFp3f5XMVbQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "examples/*"
+      ],
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
-      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -3715,14 +3743,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "engines": {
         "node": ">=18"
@@ -10029,10 +10058,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
       "engines": {
         "node": ">= 16"
       },
@@ -10040,7 +10072,16 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express-rate-limit/node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/express/node_modules/cookie": {
@@ -12200,11 +12241,10 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -21989,9 +22029,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg==",
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -24124,9 +24164,9 @@
       }
     },
     "@hono/node-server": {
-      "version": "1.19.7",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.7.tgz",
-      "integrity": "sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {
@@ -24570,12 +24610,19 @@
       "integrity": "sha512-4/RWEeXDO6bocPONheFe6gX/oQdP/bEpv0oL4HqjPP5DCenBSt0mHgahppY49N0CpsaqffdwPq+TlX9CYOq2Dw==",
       "dev": true
     },
+    "@modelcontextprotocol/ext-apps": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/ext-apps/-/ext-apps-1.5.0.tgz",
+      "integrity": "sha512-q4fut89TOoP2LEPHSGfZErIf1K1xOTTzV+41h/bB2BqKw2gKb0uLKbHusOy1UtbY0puS16zBho/vFp3f5XMVbQ==",
+      "dev": true,
+      "requires": {}
+    },
     "@modelcontextprotocol/sdk": {
-      "version": "1.25.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
-      "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "requires": {
-        "@hono/node-server": "^1.19.7",
+        "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -24583,14 +24630,15 @@
         "cross-spawn": "^7.0.5",
         "eventsource": "^3.0.2",
         "eventsource-parser": "^3.0.0",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "jose": "^6.1.1",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
         "json-schema-typed": "^8.0.2",
         "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
         "zod": "^3.25 || ^4.0",
-        "zod-to-json-schema": "^3.25.0"
+        "zod-to-json-schema": "^3.25.1"
       },
       "dependencies": {
         "accepts": {
@@ -29277,10 +29325,19 @@
       }
     },
     "express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
-      "requires": {}
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "requires": {
+        "ip-address": "10.1.0"
+      },
+      "dependencies": {
+        "ip-address": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+          "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q=="
+        }
+      }
     },
     "extend": {
       "version": "3.0.2",
@@ -30811,10 +30868,9 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
     "hono": {
-      "version": "4.11.9",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
-      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
-      "peer": true
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q=="
     },
     "hosted-git-info": {
       "version": "2.8.9",
@@ -37958,9 +38014,9 @@
       }
     },
     "zod": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.3.tgz",
-      "integrity": "sha512-HhY1oqzWCQWuUqvBFnsyrtZRhyPeR7SUGv+C4+MsisMuVfSPx8HpwWqH8tRahSlt6M3PiFAcoeFhZAqIXTxoSg=="
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     },
     "zod-to-json-schema": {
       "version": "3.24.5",

--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "@angular-devkit/architect": "^0.1402.2",
     "@angular-devkit/core": "^14.2.2",
     "@google/events": "^5.1.1",
+    "@modelcontextprotocol/ext-apps": "^1.3.2",
     "@types/archiver": "^6.0.0",
     "@types/async-lock": "^1.4.2",
     "@types/body-parser": "^1.17.0",

--- a/src/bin/mcp.ts
+++ b/src/bin/mcp.ts
@@ -49,6 +49,8 @@ Options:
                             If specified, auto-detection is disabled for other features.
   --tools <tools>           Comma-separated list of specific tools to enable. Disables
                             auto-detection entirely.
+  --sse                     Start the server in SSE (HTTP) mode instead of default Stdio.
+  --port <port>             The port to listen on when running in SSE mode (defaults to 3000).
   -h, --help                Show this help message.
 `;
 
@@ -58,6 +60,8 @@ export async function mcp(): Promise<void> {
       only: { type: "string", default: "" },
       tools: { type: "string", default: "" },
       dir: { type: "string" },
+      sse: { type: "boolean", default: false },
+      port: { type: "string", default: "3000" },
       "generate-tool-list": { type: "boolean", default: false },
       "generate-prompt-list": { type: "boolean", default: false },
       "generate-resource-list": { type: "boolean", default: false },
@@ -103,6 +107,9 @@ export async function mcp(): Promise<void> {
     enabledTools,
     projectRoot: values.dir ? resolve(values.dir) : undefined,
   });
-  await server.start();
+  await server.start({
+    useSSE: values.sse,
+    port: values.port ? parseInt(values.port, 10) : undefined,
+  });
   if (process.stdin.isTTY) process.stderr.write(STARTUP_MESSAGE);
 }

--- a/src/bin/mcp.ts
+++ b/src/bin/mcp.ts
@@ -49,7 +49,7 @@ Options:
                             If specified, auto-detection is disabled for other features.
   --tools <tools>           Comma-separated list of specific tools to enable. Disables
                             auto-detection entirely.
-  --sse                     Start the server in SSE (HTTP) mode instead of default Stdio.
+  --mode <mode>             Server mode: stdio, sse (defaults to stdio).
   --port <port>             The port to listen on when running in SSE mode (defaults to 3000).
   -h, --help                Show this help message.
 `;
@@ -60,7 +60,7 @@ export async function mcp(): Promise<void> {
       only: { type: "string", default: "" },
       tools: { type: "string", default: "" },
       dir: { type: "string" },
-      sse: { type: "boolean", default: false },
+      mode: { type: "string", default: "stdio" },
       port: { type: "string", default: "3000" },
       "generate-tool-list": { type: "boolean", default: false },
       "generate-prompt-list": { type: "boolean", default: false },
@@ -89,6 +89,11 @@ export async function mcp(): Promise<void> {
   }
   if (earlyExit) return;
 
+  if (values.mode !== "stdio" && values.mode !== "sse") {
+    console.error("Error: --mode must be either 'stdio' or 'sse'");
+    process.exit(1);
+  }
+
   setFirebaseMcp(true);
   // Write debug logs to ~/.cache/firebase to avoid polluting the user's project directory.
   const mcpLogDir = join(homedir(), ".cache", "firebase");
@@ -108,7 +113,7 @@ export async function mcp(): Promise<void> {
     projectRoot: values.dir ? resolve(values.dir) : undefined,
   });
   await server.start({
-    useSSE: values.sse,
+    useSSE: values.mode === "sse",
     port: values.port ? parseInt(values.port, 10) : undefined,
   });
   if (process.stdin.isTTY) process.stderr.write(STARTUP_MESSAGE);

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -184,6 +184,11 @@ export const ALL_EXPERIMENTS = experiments({
     default: false,
     public: true,
   },
+  mcpapps: {
+    shortDescription: "Enables MCP Apps features",
+    fullDescription: "Enables MCP Apps features, including returning UI resource URIs.",
+    public: true,
+  },
   fdcift: {
     shortDescription: "Enable instrumentless trial for SQL Connect",
     default: true,

--- a/src/mcp/apps/update_environment/mcp-app.html
+++ b/src/mcp/apps/update_environment/mcp-app.html
@@ -1,0 +1,299 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Update Firebase Environment</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap" rel="stylesheet" />
+    <style>
+      :root {
+        --primary-color: #ffca28; /* Firebase Yellow */
+        --primary-hover: #ffb300;
+        --bg-glass: rgba(30, 30, 30, 0.7);
+        --text-main: #ffffff;
+        --text-sub: #b0b0b0;
+        --border-color: rgba(255, 255, 255, 0.1);
+        --transition-speed: 0.2s;
+        --accent-blue: #1976d2;
+      }
+
+      body {
+        font-family: 'Inter', sans-serif;
+        background-color: #121212;
+        color: var(--text-main);
+        margin: 0;
+        padding: 24px;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: flex-start;
+        min-height: 100vh;
+        box-sizing: border-box;
+      }
+
+      .container {
+        width: 100%;
+        max-width: 500px;
+        background: var(--bg-glass);
+        backdrop-filter: blur(12px);
+        -webkit-backdrop-filter: blur(12px);
+        border: 1px solid var(--border-color);
+        border-radius: 16px;
+        padding: 32px;
+        box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.37);
+        display: flex;
+        flex-direction: column;
+        gap: 24px;
+      }
+
+      .header {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        text-align: center;
+      }
+
+      h1 {
+        font-size: 24px;
+        font-weight: 600;
+        margin: 0;
+        background: linear-gradient(135deg, #ffca28 0%, #ff8f00 100%);
+        -webkit-background-clip: text;
+        -webkit-text-fill-color: transparent;
+      }
+
+      p.subtitle {
+        font-size: 14px;
+        color: var(--text-sub);
+        margin: 0;
+      }
+
+      .search-box {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      label {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--text-sub);
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+      }
+
+      input[type="text"] {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        padding: 12px 16px;
+        color: var(--text-main);
+        font-size: 14px;
+        transition: border-color var(--transition-speed);
+        width: 100%;
+        box-sizing: border-box;
+      }
+
+      input[type="text"]:focus {
+        outline: none;
+        border-color: var(--primary-color);
+        background: rgba(255, 255, 255, 0.08);
+      }
+
+      .dropdown-container {
+        position: relative;
+        width: 100%;
+      }
+
+      .dropdown-list {
+        background: #1e1e1e;
+        border: 1px solid var(--border-color);
+        border-radius: 8px;
+        max-height: 250px;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        box-sizing: border-box;
+        margin-top: 4px;
+      }
+
+      .dropdown-item {
+        padding: 12px 16px;
+        cursor: pointer;
+        transition: background-color var(--transition-speed);
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+      }
+
+      .dropdown-item:last-child {
+        border-bottom: none;
+      }
+
+      .dropdown-item:hover, .dropdown-item.selected {
+        background: rgba(255, 255, 255, 0.1);
+      }
+
+      .dropdown-item.selected {
+        border-left: 3px solid var(--primary-color);
+      }
+
+      .item-name {
+        font-size: 14px;
+        font-weight: 500;
+      }
+
+      .item-id {
+        font-size: 12px;
+        color: var(--text-sub);
+      }
+
+      .actions {
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+
+      button {
+        background: linear-gradient(135deg, #ffca28 0%, #ff9100 100%);
+        color: #000000;
+        border: none;
+        border-radius: 12px;
+        padding: 14px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+        transition: transform 0.1s ease, box-shadow 0.2s ease;
+        box-shadow: 0 4px 12px rgba(255, 179, 0, 0.3);
+      }
+
+      button:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 6px 16px rgba(255, 179, 0, 0.4);
+      }
+
+      button:active {
+        transform: translateY(0);
+      }
+
+      button:disabled {
+        background: #4a4a4a;
+        color: #888888;
+        cursor: not-allowed;
+        transform: none;
+        box-shadow: none;
+      }
+
+      #status-box {
+        padding: 12px;
+        border-radius: 8px;
+        font-size: 14px;
+        display: none;
+        animation: fadeIn 0.3s ease;
+      }
+
+      @keyframes fadeIn {
+        from { opacity: 0; transform: translateY(-10px); }
+        to { opacity: 1; transform: translateY(0); }
+      }
+
+      .status.success {
+        display: block;
+        background: rgba(76, 175, 80, 0.15);
+        border: 1px solid #4caf50;
+        color: #4caf50;
+      }
+
+      .status.error {
+        display: block;
+        background: rgba(244, 67, 54, 0.15);
+        border: 1px solid #f44336;
+        color: #f44336;
+      }
+
+      .status.info {
+        display: block;
+        background: rgba(33, 150, 243, 0.15);
+        border: 1px solid #2196f3;
+        color: #2196f3;
+      }
+
+      /* Custom Scrollbar */
+      .dropdown-list::-webkit-scrollbar {
+        width: 8px;
+      }
+      .dropdown-list::-webkit-scrollbar-track {
+        background: rgba(0, 0, 0, 0.1);
+      }
+      .dropdown-list::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.2);
+        border-radius: 4px;
+      }
+      .dropdown-list::-webkit-scrollbar-thumb:hover {
+        background: rgba(255, 255, 255, 0.4);
+      }
+      .current-env-box {
+        background: rgba(255, 255, 255, 0.05);
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        border-radius: var(--border-radius-md, 8px);
+        padding: 16px;
+        margin-bottom: 24px;
+        text-align: left;
+      }
+      .current-env-box h3 {
+        margin-top: 0;
+        margin-bottom: 8px;
+        font-size: var(--font-text-md-size, 14px);
+        color: var(--color-text-secondary, #a1a1aa);
+      }
+      .current-env-box p {
+        margin: 4px 0;
+        font-size: var(--font-text-sm-size, 13px);
+      }
+      .current-env-box span {
+        font-weight: bold;
+        color: var(--color-text, #ffffff);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <div class="header">
+        <h1>Choose a Firebase Project</h1>
+        <p class="subtitle">Select an active Firebase project for your workspace.</p>
+      </div>
+
+      <div id="current-env" class="current-env-box">
+        <h3>Current Context</h3>
+        <p>Project ID: <span id="env-project-id">-</span></p>
+        <p>User: <span id="env-user">-</span></p>
+      </div>
+
+      <div class="search-box">
+        <label for="search-input">Search Projects</label>
+        <input type="text" id="search-input" placeholder="Type to filter projects..." />
+      </div>
+
+      <div class="dropdown-container">
+        <label>Available Projects</label>
+        <div id="project-list" class="dropdown-list">
+          <!-- Items will be injected here -->
+          <div class="dropdown-item" style="cursor: default;">
+            <div class="item-name">Loading projects...</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="actions">
+        <button id="submit-btn" disabled>Set Active Project</button>
+        <div id="status-box"></div>
+      </div>
+    </div>
+    <script type="module" src="mcp-app.ts"></script>
+  </body>
+</html>

--- a/src/mcp/apps/update_environment/mcp-app.ts
+++ b/src/mcp/apps/update_environment/mcp-app.ts
@@ -1,0 +1,155 @@
+import {
+  App,
+  applyDocumentTheme,
+  applyHostStyleVariables,
+  applyHostFonts,
+} from "@modelcontextprotocol/ext-apps";
+
+const app = new App({ name: "Update Firebase Environment", version: "1.0.0" });
+
+const projectListContainer = document.getElementById("project-list") as HTMLDivElement;
+const searchInput = document.getElementById("search-input") as HTMLInputElement;
+const submitBtn = document.getElementById("submit-btn") as HTMLButtonElement;
+const statusBox = document.getElementById("status-box") as HTMLDivElement;
+
+let projects: any[] = [];
+let filteredProjects: any[] = [];
+let selectedProjectId: string | null = null;
+
+const envProjectIdEl = document.getElementById("env-project-id") as HTMLSpanElement;
+const envUserEl = document.getElementById("env-user") as HTMLSpanElement;
+
+function showStatus(message: string, type: "success" | "error" | "info") {
+  statusBox.textContent = message;
+  statusBox.className = `status ${type}`;
+  statusBox.style.display = "block";
+}
+
+function renderProjects() {
+  projectListContainer.innerHTML = "";
+
+  if (filteredProjects.length === 0) {
+    projectListContainer.innerHTML = `
+      <div class="dropdown-item" style="cursor: default;">
+        <div class="item-name">No projects found.</div>
+      </div>
+    `;
+    return;
+  }
+
+  filteredProjects.forEach((p) => {
+    const item = document.createElement("div");
+    item.className = "dropdown-item";
+    if (p.projectId === selectedProjectId) {
+      item.classList.add("selected");
+    }
+
+    const displayName = p.displayName || p.projectId;
+    const projectId = p.projectId;
+
+    item.innerHTML = `
+      <div class="item-name">${displayName}</div>
+      <div class="item-id">${projectId}</div>
+    `;
+
+    item.onclick = () => {
+      selectedProjectId = projectId;
+      submitBtn.disabled = false;
+      renderProjects(); // Re-render to show selection
+    };
+
+    projectListContainer.appendChild(item);
+  });
+}
+
+searchInput.oninput = () => {
+  const query = searchInput.value.toLowerCase().trim();
+  if (query === "") {
+    filteredProjects = projects;
+  } else {
+    filteredProjects = projects.filter((p) => {
+      const name = (p.displayName || p.projectId).toLowerCase();
+      const id = p.projectId.toLowerCase();
+      return name.includes(query) || id.includes(query);
+    });
+  }
+  renderProjects();
+};
+
+submitBtn.onclick = async () => {
+  if (!selectedProjectId) return;
+
+  submitBtn.disabled = true;
+  showStatus(`Updating active project to ${selectedProjectId}...`, "info");
+
+  try {
+    const result = await app.callServerTool({
+      name: "firebase_update_environment",
+      arguments: { active_project: selectedProjectId },
+    });
+
+    const textContent = result.content?.find((c: any) => c.type === "text");
+    const text = textContent ? (textContent as any).text : "Update complete.";
+
+    if (result.isError) {
+      showStatus(text, "error");
+      submitBtn.disabled = false;
+    } else {
+      showStatus(text, "success");
+    }
+  } catch (err: any) {
+    showStatus(`Error updating environment: ${err.message}`, "error");
+    submitBtn.disabled = false;
+  }
+};
+
+app.onhostcontextchanged = (ctx: any) => {
+  if (ctx.theme) applyDocumentTheme(ctx.theme);
+  if (ctx.styles?.variables) applyHostStyleVariables(ctx.styles.variables);
+  if (ctx.styles?.css?.fonts) applyHostFonts(ctx.styles.css.fonts);
+  if (ctx.safeAreaInsets) {
+    const { top, right, bottom, left } = ctx.safeAreaInsets;
+    document.body.style.padding = `${top}px ${right}px ${bottom}px ${left}px`;
+  }
+};
+
+(async () => {
+  try {
+    await app.connect();
+    showStatus("Connecting to server...", "info");
+
+    // Fetch current environment
+    try {
+      const envResult = await app.callServerTool({
+        name: "firebase_get_environment",
+        arguments: {},
+      });
+      const envData = envResult.structuredContent as any;
+      if (envData) {
+        envProjectIdEl.textContent = envData.projectId || "<NONE>";
+        envUserEl.textContent = envData.authenticatedUser || "<NONE>";
+      }
+    } catch (err: any) {
+      console.error("Failed to fetch environment:", err);
+      showStatus(`Failed to fetch environment: ${err.message}`, "error");
+    }
+
+    // Fetch projects on load
+    const result = await app.callServerTool({ name: "firebase_list_projects", arguments: {} });
+    const data = result.structuredContent as any;
+
+    if (data && data.projects) {
+      projects = data.projects;
+      filteredProjects = projects;
+      renderProjects();
+      showStatus("Projects loaded successfully.", "success");
+      setTimeout(() => {
+        if (statusBox.className === "status success") statusBox.style.display = "none";
+      }, 3000);
+    } else {
+      showStatus("No projects returned from server.", "error");
+    }
+  } catch (err: any) {
+    showStatus(`Failed to load projects: ${err.message}`, "error");
+  }
+})();

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -497,7 +497,7 @@ export class FirebaseMcpServer {
   async start(options?: { useSSE?: boolean; port?: number }): Promise<void> {
     if (options?.useSSE) {
       const app = express();
-      
+
       app.use(cors());
 
       const port = options.port || 3000;
@@ -509,9 +509,9 @@ export class FirebaseMcpServer {
           const transport = new SSEServerTransport("/message", res);
           const sessionId = (transport as any).sessionId; // Typecast if type defs are lagging
           transports[sessionId] = transport;
-          
+
           this.logger.debug(`[SSE] Connected session ${sessionId}`);
-          
+
           await this.server.connect(transport);
           this.logger.debug(`[SSE] Server connected to transport`);
 
@@ -531,7 +531,7 @@ export class FirebaseMcpServer {
       app.post("/message", async (req: express.Request, res: express.Response) => {
         const sessionId = req.query.sessionId as string;
         this.logger.debug(`[SSE] POST /message attempt for session ${sessionId}`);
-        
+
         const transport = transports[sessionId];
 
         if (transport) {
@@ -542,7 +542,9 @@ export class FirebaseMcpServer {
             this.logger.error(`[SSE] Error handling message for session ${sessionId}: ${err}`);
           }
         } else {
-          this.logger.error(`[SSE] Rejecting message: No active transport found for session ${sessionId}`);
+          this.logger.error(
+            `[SSE] Rejecting message: No active transport found for session ${sessionId}`,
+          );
           res.status(400).send("No active SSE transport connection found for this session");
         }
       });

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -462,7 +462,7 @@ export class FirebaseMcpServer {
   }
 
   async mcpListResources(): Promise<ListResourcesResult> {
-    await trackGA4("mcp_read_resource", {});
+    await this.trackGA4("mcp_list_resources", { resource_name: "__list__" });
     return {
       resources: resources.map((r) => r.mcp),
     };
@@ -504,51 +504,51 @@ export class FirebaseMcpServer {
       const transports: Record<string, SSEServerTransport> = {}; // session ID to transport
 
       app.get("/sse", async (req: express.Request, res: express.Response) => {
-        console.error(`[SSE] GET /sse connection attempt from ${req.ip}`);
+        this.logger.debug(`[SSE] GET /sse connection attempt from ${req.ip}`);
         try {
           const transport = new SSEServerTransport("/message", res);
           const sessionId = (transport as any).sessionId; // Typecast if type defs are lagging
           transports[sessionId] = transport;
           
-          console.error(`[SSE] Connected session ${sessionId}`);
+          this.logger.debug(`[SSE] Connected session ${sessionId}`);
           
           await this.server.connect(transport);
-          console.error(`[SSE] Server connected to transport`);
+          this.logger.debug(`[SSE] Server connected to transport`);
 
           // Keep handler alive
           await new Promise<void>((resolve) => {
             req.on("close", () => {
-              console.error(`[SSE] Session ${sessionId} disconnected`);
+              this.logger.debug(`[SSE] Session ${sessionId} disconnected`);
               delete transports[sessionId];
               resolve();
             });
           });
         } catch (err) {
-          console.error(`[SSE] Connection error:`, err);
+          this.logger.error(`[SSE] Connection error: ${err}`);
         }
       });
 
       app.post("/message", async (req: express.Request, res: express.Response) => {
         const sessionId = req.query.sessionId as string;
-        console.error(`[SSE] POST /message attempt for session ${sessionId}`);
+        this.logger.debug(`[SSE] POST /message attempt for session ${sessionId}`);
         
         const transport = transports[sessionId];
 
         if (transport) {
           try {
             await transport.handlePostMessage(req, res);
-            console.error(`[SSE] Handled message for session ${sessionId}`);
+            this.logger.debug(`[SSE] Handled message for session ${sessionId}`);
           } catch (err) {
-            console.error(`[SSE] Error handling message for session ${sessionId}:`, err);
+            this.logger.error(`[SSE] Error handling message for session ${sessionId}: ${err}`);
           }
         } else {
-          console.error(`[SSE] Rejecting message: No active transport found for session ${sessionId}`);
+          this.logger.error(`[SSE] Rejecting message: No active transport found for session ${sessionId}`);
           res.status(400).send("No active SSE transport connection found for this session");
         }
       });
 
-      app.listen(port, "0.0.0.0", () => {
-        console.error(`MCP Server running on HTTP/SSE mode at http://0.0.0.0:${port}`);
+      app.listen(port, "127.0.0.1", () => {
+        this.logger.info(`MCP Server running on HTTP/SSE mode at http://127.0.0.1:${port}`);
       });
       return;
     }

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,5 +1,7 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import express from "express";
 import {
   CallToolRequest,
   CallToolRequestSchema,
@@ -381,6 +383,9 @@ export class FirebaseMcpServer {
 
     const isBillingEnabled = projectId ? await this.safeCheckBillingEnabled(projectId) : false;
     const toolsCtx = this._createMcpContext(projectId, accountEmail, isBillingEnabled);
+    if (request.params._meta?.progressToken) {
+      toolsCtx.progressToken = request.params._meta.progressToken;
+    }
     try {
       const res = await tool.fn(toolArgs, toolsCtx);
       await this.trackGA4("mcp_tool_call", {
@@ -456,7 +461,7 @@ export class FirebaseMcpServer {
   }
 
   async mcpListResources(): Promise<ListResourcesResult> {
-    await this.trackGA4("mcp_list_resources", { resource_name: "__list__" });
+    await trackGA4("mcp_read_resource", {});
     return {
       resources: resources.map((r) => r.mcp),
     };
@@ -488,7 +493,67 @@ export class FirebaseMcpServer {
     return resolved.result;
   }
 
-  async start(): Promise<void> {
+  async start(options?: { useSSE?: boolean; port?: number }): Promise<void> {
+    if (options?.useSSE) {
+      const express = require("express");
+      const cors = require("cors");
+      const app = express();
+      
+      app.use(cors());
+
+      const port = options.port || 3000;
+      const transports: Record<string, any> = {}; // session ID to transport
+
+      app.get("/sse", async (req: any, res: any) => {
+        console.error(`[SSE] GET /sse connection attempt from ${req.ip}`);
+        try {
+          const transport = new SSEServerTransport("/message", res);
+          const sessionId = (transport as any).sessionId; // Typecast if type defs are lagging
+          transports[sessionId] = transport;
+          
+          console.error(`[SSE] Connected session ${sessionId}`);
+          
+          await this.server.connect(transport);
+          console.error(`[SSE] Server connected to transport`);
+
+          // Keep handler alive
+          await new Promise<void>((resolve) => {
+            req.on("close", () => {
+              console.error(`[SSE] Session ${sessionId} disconnected`);
+              delete transports[sessionId];
+              resolve();
+            });
+          });
+        } catch (err) {
+          console.error(`[SSE] Connection error:`, err);
+        }
+      });
+
+      app.post("/message", async (req: any, res: any) => {
+        const sessionId = req.query.sessionId as string;
+        console.error(`[SSE] POST /message attempt for session ${sessionId}`);
+        
+        const transport = transports[sessionId];
+
+        if (transport) {
+          try {
+            await transport.handlePostMessage(req, res);
+            console.error(`[SSE] Handled message for session ${sessionId}`);
+          } catch (err) {
+            console.error(`[SSE] Error handling message for session ${sessionId}:`, err);
+          }
+        } else {
+          console.error(`[SSE] Rejecting message: No active transport found for session ${sessionId}`);
+          res.status(400).send("No active SSE transport connection found for this session");
+        }
+      });
+
+      app.listen(port, "0.0.0.0", () => {
+        console.error(`MCP Server running on HTTP/SSE mode at http://0.0.0.0:${port}`);
+      });
+      return;
+    }
+
     const transport = process.env.FIREBASE_MCP_DEBUG_LOG
       ? new LoggingStdioServerTransport(process.env.FIREBASE_MCP_DEBUG_LOG)
       : new StdioServerTransport();

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -507,7 +507,11 @@ export class FirebaseMcpServer {
         this.logger.debug(`[SSE] GET /sse connection attempt from ${req.ip}`);
         try {
           const transport = new SSEServerTransport("/message", res);
-          const sessionId = (transport as any).sessionId; // Typecast if type defs are lagging
+          // SSEServerTransport has sessionId but it might not be in the typings
+          interface SSEServerTransportWithSessionId extends SSEServerTransport {
+            sessionId: string;
+          }
+          const sessionId = (transport as SSEServerTransportWithSessionId).sessionId;
           transports[sessionId] = transport;
 
           this.logger.debug(`[SSE] Connected session ${sessionId}`);

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -2,6 +2,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import express from "express";
+import cors from "cors";
 import {
   CallToolRequest,
   CallToolRequestSchema,
@@ -495,16 +496,14 @@ export class FirebaseMcpServer {
 
   async start(options?: { useSSE?: boolean; port?: number }): Promise<void> {
     if (options?.useSSE) {
-      const express = require("express");
-      const cors = require("cors");
       const app = express();
       
       app.use(cors());
 
       const port = options.port || 3000;
-      const transports: Record<string, any> = {}; // session ID to transport
+      const transports: Record<string, SSEServerTransport> = {}; // session ID to transport
 
-      app.get("/sse", async (req: any, res: any) => {
+      app.get("/sse", async (req: express.Request, res: express.Response) => {
         console.error(`[SSE] GET /sse connection attempt from ${req.ip}`);
         try {
           const transport = new SSEServerTransport("/message", res);
@@ -529,7 +528,7 @@ export class FirebaseMcpServer {
         }
       });
 
-      app.post("/message", async (req: any, res: any) => {
+      app.post("/message", async (req: express.Request, res: express.Response) => {
         const sessionId = req.query.sessionId as string;
         console.error(`[SSE] POST /message attempt for session ${sessionId}`);
         
@@ -563,12 +562,12 @@ export class FirebaseMcpServer {
   private async safeCheckBillingEnabled(projectId: string): Promise<boolean> {
     try {
       return await checkBillingEnabled(projectId);
-    } catch (e: any) {
+    } catch (e: unknown) {
       this.logger.debug(
         "[mcp] Error on billingInfo for " +
           projectId +
           ", failing open (assuming false): " +
-          (e.message || e),
+          (e instanceof Error ? e.message : String(e)),
       );
       return false;
     }

--- a/src/mcp/resource.ts
+++ b/src/mcp/resource.ts
@@ -7,6 +7,7 @@ export interface ServerResource {
     name: string;
     description?: string;
     title?: string;
+    mimeType?: string;
     _meta?: {
       /** Set this on a resource if it *always* requires a signed-in user to work. */
       requiresAuth?: boolean;

--- a/src/mcp/resources/index.ts
+++ b/src/mcp/resources/index.ts
@@ -13,6 +13,10 @@ import { ServerResource, ServerResourceTemplate } from "../resource";
 import { trackGA4 } from "../../track";
 import { crashlytics_issues } from "./guides/crashlytics_issues";
 import { crashlytics_reports } from "./guides/crashlytics_reports";
+// import { login_ui } from "./login_ui";
+import { update_environment_ui } from "./update_environment_ui";
+// import { deploy_ui } from "./deploy_ui";
+// import { init_ui } from "./init_ui";
 
 export const resources = [
   app_id,
@@ -25,6 +29,10 @@ export const resources = [
   init_firestore_rules,
   init_auth,
   init_hosting,
+  // login_ui,
+  update_environment_ui,
+  // deploy_ui,
+  // init_ui,
 ];
 
 export const resourceTemplates = [docs];

--- a/src/mcp/resources/update_environment_ui.ts
+++ b/src/mcp/resources/update_environment_ui.ts
@@ -1,0 +1,32 @@
+import { resource } from "../resource";
+import * as path from "path";
+import * as fs from "fs/promises";
+
+import { RESOURCE_MIME_TYPE } from "../util";
+const resourceUri = "ui://core/update_environment/mcp-app.html";
+
+export const update_environment_ui = resource(
+  {
+    uri: resourceUri,
+    name: "Update Environment UI",
+    description: "Visual interface for selecting active Firebase project",
+    mimeType: RESOURCE_MIME_TYPE,
+  },
+  async () => {
+    try {
+      const htmlPath = path.join(__dirname, "../apps/update_environment/mcp-app.html");
+      const html = await fs.readFile(htmlPath, "utf-8");
+      return {
+        contents: [
+          {
+            uri: resourceUri,
+            mimeType: RESOURCE_MIME_TYPE,
+            text: html,
+          },
+        ],
+      };
+    } catch (e: any) {
+      throw new Error(`Failed to load Update Environment UI: ${e.message}`);
+    }
+  },
+);

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -32,4 +32,5 @@ export interface McpContext {
   rc: RC;
   firebaseCliCommand: string;
   isBillingEnabled: boolean;
+  progressToken?: string | number;
 }

--- a/src/mcp/util.spec.ts
+++ b/src/mcp/util.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from "chai";
-import { cleanSchema } from "./util";
+import * as sinon from "sinon";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import * as experiments from "../experiments";
+import { cleanSchema, applyAppMeta } from "./util";
 
 interface TestCase {
   desc: string;
@@ -472,5 +475,35 @@ describe("cleanSchema", () => {
     it(tc.desc, () => {
       expect(cleanSchema(tc.input)).to.deep.equal(tc.expected);
     });
+  });
+});
+
+describe("applyAppMeta", () => {
+  let experimentsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    experimentsStub = sinon.stub(experiments, "isEnabled");
+  });
+
+  afterEach(() => {
+    experimentsStub.restore();
+  });
+
+  it("should add _meta if mcpapps experiment is enabled", () => {
+    experimentsStub.withArgs("mcpapps").returns(true);
+    const result: CallToolResult = { content: [{ type: "text", text: "hello" }] };
+    const uri = "ui://test";
+    const expected = {
+      content: [{ type: "text", text: "hello" }],
+      _meta: { ui: { resourceUri: uri } },
+    };
+    expect(applyAppMeta(result, uri)).to.deep.equal(expected);
+  });
+
+  it("should NOT add _meta if mcpapps experiment is disabled", () => {
+    experimentsStub.withArgs("mcpapps").returns(false);
+    const result: CallToolResult = { content: [{ type: "text", text: "hello" }] };
+    const uri = "ui://test";
+    expect(applyAppMeta(result, uri)).to.deep.equal(result);
   });
 });

--- a/src/mcp/util.ts
+++ b/src/mcp/util.ts
@@ -1,5 +1,6 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { dump } from "js-yaml";
+import * as experiments from "../experiments";
 import { ServerFeature } from "./types";
 import {
   apphostingOrigin,
@@ -43,6 +44,27 @@ export function toContent(
     content: [{ type: "text", text: `${prefix}${text}${suffix}` }],
     structuredContent: data,
   } as CallToolResult & { structuredContent: any };
+}
+
+/**
+ * Conditionally adds MCP App metadata (_meta.ui.resourceUri) to a CallToolResult.
+ */
+export function applyAppMeta(
+  result: CallToolResult,
+  resourceUri: string,
+): CallToolResult & { _meta?: { ui?: { resourceUri: string } } } {
+  if (experiments.isEnabled("mcpapps")) {
+    return {
+      ...result,
+      _meta: {
+        ...result._meta,
+        ui: {
+          resourceUri,
+        },
+      },
+    };
+  }
+  return result;
 }
 
 /**
@@ -304,3 +326,5 @@ export function cleanSchema(schema: Record<string, any>): Record<string, any> {
   const result = deepClean(schema, true); // Pass true for isRootLevel
   return result === null ? {} : result;
 }
+
+export const RESOURCE_MIME_TYPE = "application/vnd.mcp.ext-app+html";

--- a/src/mcp/util.ts
+++ b/src/mcp/util.ts
@@ -41,7 +41,8 @@ export function toContent(
   const suffix = options?.contentSuffix || "";
   return {
     content: [{ type: "text", text: `${prefix}${text}${suffix}` }],
-  };
+    structuredContent: data,
+  } as CallToolResult & { structuredContent: any };
 }
 
 /**


### PR DESCRIPTION
Adds support for running the MCP server in SSE (HTTP) mode. This opens up some interesting use cases, but mostly it makes it much easier to test out the MCP apps work that is incoming.

I also opened up the typing to support structured content returned from tools - minor, but makes ti much easier to have apps read tool responses later.