### PR TITLE
feat: add mcpapps experiment flag and helper

### DIFF
--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -24,6 +24,12 @@ export const ALL_EXPERIMENTS = experiments({
     shortDescription: "enables the experiments family of commands",
   },
 
+  mcpapps: {
+    shortDescription: "Enables MCP Apps features",
+    fullDescription: "Enables MCP Apps features, including returning UI resource URIs.",
+    public: true,
+  },
+
   // Realtime Database experiments
   rtdbrules: {
     shortDescription: "Advanced security rules management",

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -24,12 +24,6 @@ export const ALL_EXPERIMENTS = experiments({
     shortDescription: "enables the experiments family of commands",
   },
 
-  mcpapps: {
-    shortDescription: "Enables MCP Apps features",
-    fullDescription: "Enables MCP Apps features, including returning UI resource URIs.",
-    public: true,
-  },
-
   // Realtime Database experiments
   rtdbrules: {
     shortDescription: "Advanced security rules management",
@@ -183,6 +177,11 @@ export const ALL_EXPERIMENTS = experiments({
   mcpalpha: {
     shortDescription: "Opt-in to early MCP features before they're widely released.",
     default: false,
+    public: true,
+  },
+  mcpapps: {
+    shortDescription: "Enables MCP Apps features",
+    fullDescription: "Enables MCP Apps features, including returning UI resource URIs.",
     public: true,
   },
   fdcift: {

--- a/src/mcp/util.spec.ts
+++ b/src/mcp/util.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "chai";
-import { cleanSchema } from "./util";
+import * as sinon from "sinon";
+import * as experiments from "../experiments";
+import { cleanSchema, applyAppMeta } from "./util";
 
 interface TestCase {
   desc: string;
@@ -472,5 +474,35 @@ describe("cleanSchema", () => {
     it(tc.desc, () => {
       expect(cleanSchema(tc.input)).to.deep.equal(tc.expected);
     });
+  });
+});
+
+describe("applyAppMeta", () => {
+  let experimentsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    experimentsStub = sinon.stub(experiments, "isEnabled");
+  });
+
+  afterEach(() => {
+    experimentsStub.restore();
+  });
+
+  it("should add _meta if mcpapps experiment is enabled", () => {
+    experimentsStub.withArgs("mcpapps").returns(true);
+    const result = { content: [{ type: "text", text: "hello" }] } as any;
+    const uri = "ui://test";
+    const expected = {
+      content: [{ type: "text", text: "hello" }],
+      _meta: { ui: { resourceUri: uri } },
+    };
+    expect(applyAppMeta(result, uri)).to.deep.equal(expected);
+  });
+
+  it("should NOT add _meta if mcpapps experiment is disabled", () => {
+    experimentsStub.withArgs("mcpapps").returns(false);
+    const result = { content: [{ type: "text", text: "hello" }] } as any;
+    const uri = "ui://test";
+    expect(applyAppMeta(result, uri)).to.deep.equal(result);
   });
 });

--- a/src/mcp/util.spec.ts
+++ b/src/mcp/util.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
+import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import * as experiments from "../experiments";
 import { cleanSchema, applyAppMeta } from "./util";
 
@@ -490,7 +491,7 @@ describe("applyAppMeta", () => {
 
   it("should add _meta if mcpapps experiment is enabled", () => {
     experimentsStub.withArgs("mcpapps").returns(true);
-    const result = { content: [{ type: "text", text: "hello" }] } as any;
+    const result: CallToolResult = { content: [{ type: "text", text: "hello" }] };
     const uri = "ui://test";
     const expected = {
       content: [{ type: "text", text: "hello" }],
@@ -501,7 +502,7 @@ describe("applyAppMeta", () => {
 
   it("should NOT add _meta if mcpapps experiment is disabled", () => {
     experimentsStub.withArgs("mcpapps").returns(false);
-    const result = { content: [{ type: "text", text: "hello" }] } as any;
+    const result: CallToolResult = { content: [{ type: "text", text: "hello" }] };
     const uri = "ui://test";
     expect(applyAppMeta(result, uri)).to.deep.equal(result);
   });

--- a/src/mcp/util.ts
+++ b/src/mcp/util.ts
@@ -1,5 +1,6 @@
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { dump } from "js-yaml";
+import * as experiments from "../experiments";
 import { ServerFeature } from "./types";
 import {
   apphostingOrigin,
@@ -43,6 +44,26 @@ export function toContent(
     content: [{ type: "text", text: `${prefix}${text}${suffix}` }],
     structuredContent: data,
   } as CallToolResult & { structuredContent: any };
+}
+
+/**
+ * Conditionally adds MCP App metadata (_meta.ui.resourceUri) to a CallToolResult.
+ */
+export function applyAppMeta(
+  result: CallToolResult,
+  resourceUri: string,
+): CallToolResult & { _meta?: { ui?: { resourceUri: string } } } {
+  if (experiments.isEnabled("mcpapps")) {
+    return {
+      ...result,
+      _meta: {
+        ui: {
+          resourceUri,
+        },
+      },
+    };
+  }
+  return result;
 }
 
 /**

--- a/src/mcp/util.ts
+++ b/src/mcp/util.ts
@@ -57,6 +57,7 @@ export function applyAppMeta(
     return {
       ...result,
       _meta: {
+        ...result._meta,
         ui: {
           resourceUri,
         },


### PR DESCRIPTION
Adds `mcpapps` experiment flag and applyAppMeta helper function, which will be used later to omit the `_meta.ui.reourceUri` field when the experiment is disabled.