### PR TITLE
Create new "dartfunctions" experiment

### DIFF
--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -14,6 +14,7 @@ import { logLabeledBullet } from "../../../../utils";
 import { Build } from "../../build";
 import { EmulatorRegistry } from "../../../../emulator/registry";
 import { Emulators } from "../../../../emulator/types";
+import * as experiments from "../../../../experiments";
 
 /**
  * Create a runtime delegate for the Dart runtime, if applicable.
@@ -29,6 +30,8 @@ export async function tryCreateDelegate(
     logger.debug("Customer code is not Dart code.");
     return;
   }
+
+  experiments.assertEnabled("dartfunctions", "use Dart functions");
   const runtime = context.runtime ?? supported.latest("dart");
   if (!supported.isRuntime(runtime)) {
     throw new FirebaseError(`Runtime ${runtime as string} is not a valid Dart runtime`);

--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -6,7 +6,6 @@ import * as python from "./python";
 import * as validate from "../validate";
 import { FirebaseError } from "../../../error";
 import * as supported from "./supported";
-import * as experiments from "../../../experiments";
 
 /**
  * RuntimeDelegate is a language-agnostic strategy for managing

--- a/src/deploy/functions/runtimes/index.ts
+++ b/src/deploy/functions/runtimes/index.ts
@@ -75,10 +75,7 @@ type Factory = (context: DelegateContext) => Promise<RuntimeDelegate | undefined
 const factories: Factory[] = [
   node.tryCreateDelegate,
   python.tryCreateDelegate,
-  (ctx) =>
-    experiments.isEnabled("functionsrunapionly")
-      ? dart.tryCreateDelegate(ctx)
-      : Promise.resolve(undefined),
+  dart.tryCreateDelegate,
 ];
 
 /**

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -86,6 +86,11 @@ export const ALL_EXPERIMENTS = experiments({
     public: false,
     default: false,
   },
+  dartfunctions: {
+    shortDescription: "Enable Dart Functions.",
+    public: false,
+    default: false,
+  },
 
   // Emulator experiments
   emulatoruisnapshot: {

--- a/src/init/features/functions.spec.ts
+++ b/src/init/features/functions.spec.ts
@@ -144,8 +144,8 @@ describe("functions", () => {
         expect(values).to.not.include("dart");
       });
 
-      it("shows Dart as an option when functionsrunapionly is enabled", async () => {
-        experiments.setEnabled("functionsrunapionly", true);
+      it("shows Dart as an option when dartfunctions is enabled", async () => {
+        experiments.setEnabled("dartfunctions", true);
         const setup = { config: { functions: [] }, rcfile: {} };
         prompt.select.onFirstCall().resolves("javascript");
         prompt.confirm.resolves(false);
@@ -158,7 +158,7 @@ describe("functions", () => {
           const values = choices.map((c: any) => c.value);
           expect(values).to.include("dart");
         } finally {
-          experiments.setEnabled("functionsrunapionly", false);
+          experiments.setEnabled("dartfunctions", false);
         }
       });
     });

--- a/src/init/features/functions/index.ts
+++ b/src/init/features/functions/index.ts
@@ -178,7 +178,7 @@ async function languageSetup(setup: any): Promise<void> {
       value: "python",
     });
   }
-  if (experiments.isEnabled("functionsrunapionly")) {
+  if (experiments.isEnabled("dartfunctions")) {
     choices.push({
       name: "Dart",
       value: "dart",


### PR DESCRIPTION
This creates a new experiment to enable Dart for Cloud Functions, and separates out some of the dart-specific features gated by the functionsrunapionly experiment.

Tested by:
* `firebase init functions` (dartfunctions disabled), no dart option.
* `firebase init functions` (dartfunctions enabled), shows dart option.
* `firebase deploy --only functions` (with dart code, but disabled dartfunctions). Observed `Error: Cannot use Dart functions because the experiment dartfunctions is not enabled. To enable dartfunctions run firebase experiments:enable dartfunctions`
* `firebase deploy --only functions` (with dartfucntions enabled and dart code using https://paste.googleplex.com/5448076111249408 as the pubspec.yaml), successful deployment.

In a Node project, ran 
`firebase deploy --only functions` with dartfunctions enabled and deployment was successful.  Did not see the same issue as  https://github.com/firebase/firebase-tools/issues/10252