### PR TITLE
Reference pub.dev package in dart template

### DIFF
--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -49,7 +49,7 @@ export async function tryCreateDelegate(
  * Minimum Dart SDK version required.
  * Dart 3.8+ is needed for cross-compilation flags (--target-os, --target-arch).
  */
-const MIN_DART_SDK_VERSION = "3.8.0";
+const MIN_DART_SDK_VERSION = "3.9.0";
 
 /** Default entry point for Dart functions projects. */
 export const DART_ENTRY_POINT = "bin/server.dart";

--- a/templates/init/functions/dart/pubspec.yaml
+++ b/templates/init/functions/dart/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.0
 publish_to: none
 
 environment:
-  sdk: ^3.8.0
+  sdk: ^3.9.0
 
 dependencies:
   firebase_functions: ^0.1.0

--- a/templates/init/functions/dart/pubspec.yaml
+++ b/templates/init/functions/dart/pubspec.yaml
@@ -1,13 +1,13 @@
 name: functions_template
 description: An app using Dart with Cloud Functions for Firebase
-version: 1.0.0
+version: 0.0.1
 publish_to: none
 
 environment:
   sdk: ^3.9.0
 
 dependencies:
-  firebase_functions: ^0.1.0
+  firebase_functions: ^0.5.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/templates/init/functions/dart/pubspec.yaml
+++ b/templates/init/functions/dart/pubspec.yaml
@@ -1,4 +1,4 @@
-name: functions_template
+name: my_function
 description: An app using Dart with Cloud Functions for Firebase
 version: 0.0.1
 publish_to: none

--- a/templates/init/functions/dart/pubspec.yaml
+++ b/templates/init/functions/dart/pubspec.yaml
@@ -1,14 +1,13 @@
 name: functions_template
-description: An app using Firebase Functions for Dart
+description: An app using Dart with Cloud Functions for Firebase
 version: 1.0.0
+publish_to: none
 
 environment:
   sdk: ^3.8.0
 
 dependencies:
-  # TODO(ehesp): Replace with published package version once available on pub.dev
-  firebase_functions:
-    path: ../
+  firebase_functions: ^0.1.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/templates/init/functions/dart/server.dart
+++ b/templates/init/functions/dart/server.dart
@@ -2,11 +2,13 @@ import 'package:firebase_functions/firebase_functions.dart';
 
 void main(List<String> args) {
   fireUp(args, (firebase) {
-    // Set maxInstances to control costs during unexpected traffic spikes.
+    // https://firebase.google.com/docs/functions/http-events
     firebase.https.onRequest(
       name: 'helloWorld',
       options: const HttpsOptions(
         cors: Cors(['*']),
+        // Set maxInstances to control costs during unexpected traffic spikes.
+        // https://firebase.google.com/docs/functions/manage-functions#min-max-instances
         maxInstances: Instances(10),
       ),
       (request) async => Response(200, body: 'Hello from Dart Functions!'),


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Fixes #10334 

- Reference [`firebase_functions`](https://pub.dev/packages/firebase_functions) instead of a local folder in the `firebase init functions` template.
    - ~I got the version from [here](https://github.com/firebase/firebase-functions-dart/blob/986ece5a6473569e421b9a98d688f694927a9851/pubspec.yaml#L17). Lmk if that's incorrect.~ I'm using `^0.5.0` from https://github.com/firebase/firebase-functions-dart/pull/125
- Update SDK to `^3.9.0` to match the functions package
- Add `publish_to: none` (this was feedback from the bug bash)

### Scenarios Tested

Can't test because this isn't actually published yet

### Sample Commands

`firebase init functions`