### PR TITLE
fix: detect @angular/platform-server to determine if Angular project uses SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Suppress SSR warning for non-SSR Angular projects on init hosting (#10364)

--- a/src/frameworks/angular/index.spec.ts
+++ b/src/frameworks/angular/index.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import * as fsExtra from "fs-extra";
 
+import * as frameworkUtils from "../utils";
 import { discover } from ".";
 
 describe("Angular", () => {
@@ -17,10 +18,25 @@ describe("Angular", () => {
       sandbox.restore();
     });
 
-    it("should find an Angular app", async () => {
+    it("should find an Angular app with SSR", async () => {
       sandbox.stub(fsExtra, "pathExists").resolves(true);
+      sandbox.stub(frameworkUtils, "findDependency").callsFake((name) => {
+        if (name === "@angular/platform-server") {
+          return { version: "17.0.0", resolved: "", overridden: false };
+        }
+        return undefined;
+      });
       expect(await discover(cwd)).to.deep.equal({
         mayWantBackend: true,
+        version: undefined,
+      });
+    });
+
+    it("should find an Angular app without SSR", async () => {
+      sandbox.stub(fsExtra, "pathExists").resolves(true);
+      sandbox.stub(frameworkUtils, "findDependency").returns(undefined);
+      expect(await discover(cwd)).to.deep.equal({
+        mayWantBackend: false,
         version: undefined,
       });
     });

--- a/src/frameworks/angular/index.spec.ts
+++ b/src/frameworks/angular/index.spec.ts
@@ -1,26 +1,43 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as fsExtra from "fs-extra";
+import { join } from "path";
 
 import * as frameworkUtils from "../utils";
 import { discover } from ".";
 
 describe("Angular", () => {
   describe("discovery", () => {
-    const cwd = Math.random().toString(36).split(".")[1];
+    const cwd = ".";
     let sandbox: sinon.SinonSandbox;
+    let pathExistsStub: sinon.SinonStub;
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
+      pathExistsStub = sandbox.stub(fsExtra, "pathExists");
     });
 
     afterEach(() => {
       sandbox.restore();
     });
 
+    it("should not discover if package.json is missing", async () => {
+      pathExistsStub.resolves(false);
+      expect(await discover(cwd)).to.be.undefined;
+    });
+
+    it("should not discover if angular.json is missing", async () => {
+      pathExistsStub.withArgs(join(cwd, "package.json")).resolves(true);
+      pathExistsStub.resolves(false);
+      expect(await discover(cwd)).to.be.undefined;
+    });
+
     it("should find an Angular app with SSR", async () => {
-      sandbox.stub(fsExtra, "pathExists").resolves(true);
+      pathExistsStub.resolves(true);
       sandbox.stub(frameworkUtils, "findDependency").callsFake((name) => {
+        if (name === "@angular/core") {
+          return { version: "17.0.0", resolved: "", overridden: false };
+        }
         if (name === "@angular/platform-server") {
           return { version: "17.0.0", resolved: "", overridden: false };
         }
@@ -28,16 +45,30 @@ describe("Angular", () => {
       });
       expect(await discover(cwd)).to.deep.equal({
         mayWantBackend: true,
-        version: undefined,
+        version: "17.0.0",
       });
     });
 
     it("should find an Angular app without SSR", async () => {
-      sandbox.stub(fsExtra, "pathExists").resolves(true);
+      pathExistsStub.resolves(true);
       sandbox.stub(frameworkUtils, "findDependency").returns(undefined);
       expect(await discover(cwd)).to.deep.equal({
         mayWantBackend: false,
         version: undefined,
+      });
+    });
+
+    it("should propagate the @angular/core version", async () => {
+      pathExistsStub.resolves(true);
+      sandbox.stub(frameworkUtils, "findDependency").callsFake((name) => {
+        if (name === "@angular/core") {
+          return { version: "18.2.1", resolved: "", overridden: false };
+        }
+        return undefined;
+      });
+      expect(await discover(cwd)).to.deep.equal({
+        mayWantBackend: false,
+        version: "18.2.1",
       });
     });
   });

--- a/src/frameworks/angular/index.ts
+++ b/src/frameworks/angular/index.ts
@@ -42,7 +42,12 @@ export async function discover(dir: string): Promise<Discovery | undefined> {
   if (!(await pathExists(join(dir, "package.json")))) return;
   if (!(await pathExists(join(dir, "angular.json")))) return;
   const version = getAngularVersion(dir);
-  return { mayWantBackend: true, version };
+  const mayWantBackend = !!findDependency("@angular/platform-server", {
+    cwd: dir,
+    depth: 0,
+    omitDev: false,
+  });
+  return { mayWantBackend, version };
 }
 
 export function init(setup: any, config: any) {


### PR DESCRIPTION
Per #10362 a "SSR warning" message appears when performing `firebase init hosting` in Angular workspaces that do not use SSR. Now, the `discover` function for the Angular framework checks for the presence of @angular/platform-server in installed dependencies.

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

This fix will prevent the following warning from being displayed in Angular workspaces that have no dependencies on @angular/ssr:

```
Detected a Angular codebase with SSR features. We can't guarantee that this site will work on Firebase Hosting, which is
optimized for static sites. Another product, Firebase App Hosting, was designed for SSR web apps. Would you like to use App
Hosting instead? Learn more here: https://firebase.google.com/docs/app-hosting/product-comparison#hostings
```

I know personally the first time I saw the warning message (in my codebase with no SSR) it made me think I had incorrectly initialized my Angular workspace to in fact use SSR.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

Scenario 1: SSR
1. Create new workspace with SSR
```
ng new ssr --style css --ssr true --ai-config none
cd ssr
```
2. Init hosting (this command will differ based upon the user)
```
node /Users/sam/Documents/firebase-tools/lib/bin/firebase.js init hosting
```
3. Observe the "SSR warning" appears

Scenario 2: No SSR
1. Create new workspace without SSR
```
ng new nossr --style css --ssr false --ai-config none
cd nossr
```
2. Init hosting (this command will differ based upon the user)
```
node /Users/sam/Documents/firebase-tools/lib/bin/firebase.js init hosting
```
3. Observe there is no "SSR warning"

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

N/A
