### PR TITLE
fix(functions): isolate SourceTokenScraper per codebase

### DIFF
--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -1618,6 +1618,46 @@ describe("Fabricator", () => {
       expect(results[0].error).to.be.instanceOf(reporter.DeploymentError);
       expect(results[0].error?.message).to.match(/create function/);
     });
+    it("uses different scrapers for different codebases", async () => {
+      const ep1 = endpoint({ httpsTrigger: {} }, { codebase: "codebaseA" });
+      const ep2 = endpoint({ httpsTrigger: {} }, { codebase: "codebaseB" });
+      const plan: planner.DeploymentPlan = {
+        "us-central1": {
+          endpointsToCreate: [ep1],
+          endpointsToUpdate: [],
+          endpointsToDelete: [],
+          endpointsToSkip: [],
+        },
+        "us-west1": {
+          endpointsToCreate: [ep2],
+          endpointsToUpdate: [],
+          endpointsToDelete: [],
+          endpointsToSkip: [],
+        },
+      };
+
+      const applyUpsertsSpy = sinon.spy(fab, "applyUpserts");
+
+      sinon.stub(fab, "createEndpoint").resolves();
+      sinon.stub(fab, "updateEndpoint").resolves();
+      sinon.stub(fab, "deleteEndpoint").resolves();
+
+      await fab.applyPlan(plan);
+
+      expect(applyUpsertsSpy.calledTwice).to.be.true;
+
+      const call1 = applyUpsertsSpy.getCall(0);
+      const call2 = applyUpsertsSpy.getCall(1);
+
+      const scraperV1Call1 = call1.args[1];
+      const scraperV2Call1 = call1.args[2];
+
+      const scraperV1Call2 = call2.args[1];
+      const scraperV2Call2 = call2.args[2];
+
+      expect(scraperV1Call1).to.not.equal(scraperV1Call2);
+      expect(scraperV2Call1).to.not.equal(scraperV2Call2);
+    });
   });
 
   describe("getLogSuccessMessage", () => {

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -103,31 +103,19 @@ export class Fabricator {
     const scrapersV2 = new Map<string, SourceTokenScraper>();
 
     const createAndUpdatePromises = changesets.map((changes) => {
-      // Find codebase from endpoints in changeset
-      let codebase = "default";
-      if (changes.endpointsToCreate.length > 0) {
-        codebase = changes.endpointsToCreate[0].codebase || "default";
-      } else if (changes.endpointsToUpdate.length > 0) {
-        codebase = changes.endpointsToUpdate[0].endpoint.codebase || "default";
-      } else if (changes.endpointsToDelete.length > 0) {
-        codebase = changes.endpointsToDelete[0].codebase || "default";
-      } else if (changes.endpointsToSkip.length > 0) {
-        codebase = changes.endpointsToSkip[0].codebase || "default";
-      }
+      const codebase =
+        changes.endpointsToCreate[0]?.codebase ||
+        changes.endpointsToUpdate[0]?.endpoint.codebase ||
+        changes.endpointsToDelete[0]?.codebase ||
+        changes.endpointsToSkip[0]?.codebase ||
+        "default";
 
-      let scraperV1 = scrapersV1.get(codebase);
-      if (!scraperV1) {
-        scraperV1 = new SourceTokenScraper();
-        scrapersV1.set(codebase, scraperV1);
-      }
+      const scraperV1 = scrapersV1.get(codebase) ?? new SourceTokenScraper();
+      scrapersV1.set(codebase, scraperV1);
+      const scraperV2 = scrapersV2.get(codebase) ?? new SourceTokenScraper();
+      scrapersV2.set(codebase, scraperV2);
 
-      let scraperV2 = scrapersV2.get(codebase);
-      if (!scraperV2) {
-        scraperV2 = new SourceTokenScraper();
-        scrapersV2.set(codebase, scraperV2);
-      }
-
-      return this.applyUpserts(changes, scraperV1!, scraperV2!);
+      return this.applyUpserts(changes, scraperV1, scraperV2);
     });
     const createAndUpdateResultsArray = await Promise.allSettled(createAndUpdatePromises);
 

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -99,10 +99,35 @@ export class Fabricator {
     const changesets = Object.values(plan);
 
     // Phase 1: Creates and Updates
-    const scraperV1 = new SourceTokenScraper();
-    const scraperV2 = new SourceTokenScraper();
+    const scrapersV1 = new Map<string, SourceTokenScraper>();
+    const scrapersV2 = new Map<string, SourceTokenScraper>();
+
     const createAndUpdatePromises = changesets.map((changes) => {
-      return this.applyUpserts(changes, scraperV1, scraperV2);
+      // Find codebase from endpoints in changeset
+      let codebase = "default";
+      if (changes.endpointsToCreate.length > 0) {
+        codebase = changes.endpointsToCreate[0].codebase || "default";
+      } else if (changes.endpointsToUpdate.length > 0) {
+        codebase = changes.endpointsToUpdate[0].endpoint.codebase || "default";
+      } else if (changes.endpointsToDelete.length > 0) {
+        codebase = changes.endpointsToDelete[0].codebase || "default";
+      } else if (changes.endpointsToSkip.length > 0) {
+        codebase = changes.endpointsToSkip[0].codebase || "default";
+      }
+
+      let scraperV1 = scrapersV1.get(codebase);
+      if (!scraperV1) {
+        scraperV1 = new SourceTokenScraper();
+        scrapersV1.set(codebase, scraperV1);
+      }
+
+      let scraperV2 = scrapersV2.get(codebase);
+      if (!scraperV2) {
+        scraperV2 = new SourceTokenScraper();
+        scrapersV2.set(codebase, scraperV2);
+      }
+
+      return this.applyUpserts(changes, scraperV1!, scraperV2!);
     });
     const createAndUpdateResultsArray = await Promise.allSettled(createAndUpdatePromises);
 


### PR DESCRIPTION
### Description

**Fixes a regression introduced in v15.15.0** (likely via the `Fabricator` refactor in #10293) where `SourceTokenScraper` instances were moved from a per-changeset scope to a plan-wide scope.

In projects utilizing multiple `codebase` definitions (common in monorepos), each codebase has its own isolated source bundle and ZIP file. Because the `SourceTokenScraper` is stateful and captures optimization tokens from GCF deployment operations, sharing a single scraper across the entire deployment plan caused different codebases to "leak" source tokens to one another.

When **Codebase B** incorrectly uses a source token intended for **Codebase A**, Google Cloud reuses the processed module/container from Codebase A. This results in Codebase B being deployed with the wrong code, leading to runtime failures: `Function '...' is not defined in the provided module`.

This PR restores isolation by maintaining a registry of scrapers keyed by `codebase` within the `Fabricator.applyPlan` method. This ensures that tokens are only shared among functions that actually share the same source (same codebase across different regions), while keeping independent codebases strictly isolated.

### Scenarios Tested

- **Monorepo Batch Deployment**: Tested on a project with 48 independent codebases. Verified that batch deployments (batch size 10) no longer cause functions to be deployed with the wrong source code artifacts.
- **Runtime Validation**: Confirmed that the "Function not defined" error is resolved in the Google Cloud logs for all functions when deployed concurrently.
- **Cross-Region Consistency**: Verified that functions within the *same* codebase (e.g., the same source directory deployed to `us-central1` and `europe-west1`) still correctly share the same scraper instance to maintain existing deployment performance optimizations.

### Sample Commands

Standard deployment command in a monorepo setup:
`firebase deploy --only functions`

Example `firebase.json` structure where this fix is critical:
```json
{
  "functions": [
    { "codebase": "app-api", "source": "packages/api/dist" },
    { "codebase": "app-auth", "source": "packages/auth/dist" }
  ]
}
```
