### PR TITLE
fix: prevent hosting deploy to site in wrong project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed an issue where hosting deploy allowed publishing to a site in a different project. (#10376)

--- a/src/deploy/hosting/prepare.spec.ts
+++ b/src/deploy/hosting/prepare.spec.ts
@@ -181,16 +181,6 @@ describe("hosting prepare", () => {
     await expect(prepare(context, options)).to.eventually.be.fulfilled;
   });
 
-  it("skips check for demo projects", async () => {
-    const context: Context = {
-      projectId: "demo-project",
-    };
-    hostingStub.createVersion.resolves("version");
-
-    await expect(prepare(context, options)).to.eventually.be.fulfilled;
-    expect(hostingStub.getSite).to.not.have.been.called;
-  });
-
   describe("unsafePins", () => {
     const apiRewriteWithoutPin: hostingApi.Rewrite = {
       glob: "**",

--- a/src/deploy/hosting/prepare.spec.ts
+++ b/src/deploy/hosting/prepare.spec.ts
@@ -153,20 +153,15 @@ describe("hosting prepare", () => {
     });
   });
 
-  it("throws error if site does not belong to project", async () => {
-    hostingStub.getSite.resolves({
-      name: "projects/other-project/sites/site",
-      defaultUrl: "https://site.web.app",
-      appId: "app-id",
-      labels: {},
-    });
+  it("throws error if site does not exist in project", async () => {
+    hostingStub.getSite.rejects(new Error(`could not find site "site" for project "project"`));
 
     const context: Context = {
       projectId: "project",
     };
 
     await expect(prepare(context, options)).to.eventually.be.rejectedWith(
-      `Site "site" does not belong to project "project"`,
+      `could not find site "site" for project "project"`,
     );
   });
 

--- a/src/deploy/hosting/prepare.spec.ts
+++ b/src/deploy/hosting/prepare.spec.ts
@@ -29,6 +29,12 @@ describe("hosting prepare", () => {
     trackingStub = sinon.stub(tracking);
     backendStub = sinon.stub(backend);
     loggerStub = sinon.stub(utils, "logLabeledBullet");
+    hostingStub.getSite.resolves({
+      name: "projects/project/sites/site",
+      defaultUrl: "https://site.web.app",
+      appId: "app-id",
+      labels: {},
+    });
 
     // We're intentionally using pointer references so that editing site
     // edits the results of hostingConfig() and changes firebase.json
@@ -145,6 +151,49 @@ describe("hosting prepare", () => {
         },
       ],
     });
+  });
+
+  it("throws error if site does not belong to project", async () => {
+    hostingStub.getSite.resolves({
+      name: "projects/other-project/sites/site",
+      defaultUrl: "https://site.web.app",
+      appId: "app-id",
+      labels: {},
+    });
+
+    const context: Context = {
+      projectId: "project",
+    };
+
+    await expect(prepare(context, options)).to.eventually.be.rejectedWith(
+      `Site "site" does not belong to project "project"`,
+    );
+  });
+
+  it("passes if site belongs to project", async () => {
+    hostingStub.getSite.resolves({
+      name: "projects/project/sites/site",
+      defaultUrl: "https://site.web.app",
+      appId: "app-id",
+      labels: {},
+    });
+    hostingStub.createVersion.resolves("version");
+
+    const context: Context = {
+      projectId: "project",
+    };
+
+    await expect(prepare(context, options)).to.eventually.be.fulfilled;
+  });
+
+  it("skips check for demo projects", async () => {
+    const context: Context = {
+      projectId: "demo-project",
+    };
+    hostingStub.createVersion.resolves("version");
+
+    await expect(prepare(context, options)).to.eventually.be.fulfilled;
+    expect(hostingStub.getSite).to.not.have.been.called;
   });
 
   describe("unsafePins", () => {

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -118,6 +118,7 @@ export async function prepare(
   const versions = await Promise.all(
     configs.map(async (config) => {
       if (!Constants.isDemoProject(context.projectId)) {
+        // Get the site to confirm that it exists on this project
         await api.getSite(context.projectId, config.site);
       }
       const labels: Record<string, string> = {

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -117,10 +117,8 @@ export async function prepare(
 
   const versions = await Promise.all(
     configs.map(async (config) => {
-      if (!Constants.isDemoProject(context.projectId)) {
-        // Get the site to confirm that it exists on this project
-        await api.getSite(context.projectId, config.site);
-      }
+      // Get the site to confirm that it exists on this project
+      await api.getSite(context.projectId, config.site);
       const labels: Record<string, string> = {
         ...deploymentTool.labels(),
       };

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -13,6 +13,7 @@ import { HostingSource, RunRewrite } from "../../firebaseConfig";
 import * as backend from "../functions/backend";
 import { ensureTargeted } from "../../functions/ensureTargeted";
 import { generateSSRCodebaseId } from "../../frameworks";
+import { Constants } from "../../emulator/constants";
 
 function handlePublicDirectoryFlag(options: HostingOptions & DeployOptions): void {
   // Allow the public directory to be overridden by the --public flag
@@ -116,6 +117,15 @@ export async function prepare(
 
   const versions = await Promise.all(
     configs.map(async (config) => {
+      if (!Constants.isDemoProject(context.projectId)) {
+        const site = await api.getSite(context.projectId, config.site);
+        if (!site.name.startsWith(`projects/${context.projectId}/`)) {
+          throw new FirebaseError(
+            `Site "${config.site}" does not belong to project "${context.projectId}"`,
+            { status: 400 },
+          );
+        }
+      }
       const labels: Record<string, string> = {
         ...deploymentTool.labels(),
       };

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -13,7 +13,6 @@ import { HostingSource, RunRewrite } from "../../firebaseConfig";
 import * as backend from "../functions/backend";
 import { ensureTargeted } from "../../functions/ensureTargeted";
 import { generateSSRCodebaseId } from "../../frameworks";
-import { Constants } from "../../emulator/constants";
 
 function handlePublicDirectoryFlag(options: HostingOptions & DeployOptions): void {
   // Allow the public directory to be overridden by the --public flag

--- a/src/deploy/hosting/prepare.ts
+++ b/src/deploy/hosting/prepare.ts
@@ -118,13 +118,7 @@ export async function prepare(
   const versions = await Promise.all(
     configs.map(async (config) => {
       if (!Constants.isDemoProject(context.projectId)) {
-        const site = await api.getSite(context.projectId, config.site);
-        if (!site.name.startsWith(`projects/${context.projectId}/`)) {
-          throw new FirebaseError(
-            `Site "${config.site}" does not belong to project "${context.projectId}"`,
-            { status: 400 },
-          );
-        }
+        await api.getSite(context.projectId, config.site);
       }
       const labels: Record<string, string> = {
         ...deploymentTool.labels(),


### PR DESCRIPTION
### Description
Prevent accidental deployments to a hosting site that does not belong to the active project.
The CLI now verifies that the site belongs to the project before creating a version.

Fixes #10376

### Scenarios Tested
- Verified that error is thrown when site does not belong to project.
- Verified that deploy passes when site belongs to project.
- Verified that check is skipped for demo projects.

### Sample Commands
`firebase deploy --project project-b` (where site in firebase.json belongs to project-a) -> should fail.
