### PR TITLE
update valid python runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Update the valid Python runtimes for functions. Default Python runtime is now Python 3.14.

--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -12,7 +12,8 @@
                 "python310",
                 "python311",
                 "python312",
-                "python313"
+                "python313",
+                "python314"
             ],
             "type": "string"
         },
@@ -965,7 +966,8 @@
                         "python310",
                         "python311",
                         "python312",
-                        "python313"
+                        "python313",
+                        "python314"
                     ],
                     "type": "string"
                 },

--- a/src/deploy/functions/runtimes/python/index.ts
+++ b/src/deploy/functions/runtimes/python/index.ts
@@ -62,6 +62,8 @@ export function getPythonBinary(
     return "python3.12";
   } else if (runtime === "python313") {
     return "python3.13";
+  } else if (runtime === "python314") {
+    return "python3.14";
   }
   assertExhaustive(runtime, `Unhandled python runtime ${runtime as string}`);
 }

--- a/src/deploy/functions/runtimes/supported/types.ts
+++ b/src/deploy/functions/runtimes/supported/types.ts
@@ -119,6 +119,12 @@ export const RUNTIMES = runtimes({
     deprecationDate: "2029-10-10",
     decommissionDate: "2030-04-10",
   },
+  python314: {
+    friendly: "Python 3.14",
+    status: "GA",
+    deprecationDate: "2030-10-10",
+    decommissionDate: "2031-04-10",
+  },
   dart3: {
     friendly: "Dart 3",
     status: "experimental",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Partial fix for #10384 

Adds Python 3.14 to our list of runtimes 
- https://docs.cloud.google.com/functions/docs/runtime-support#python
### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

`firebase init functions --project demo-project`
- Correctly sets up with Python 3.14

```json
{
  "functions": [
    {
      "source": "functions",
      "codebase": "default",
      "disallowLegacyRuntimeConfig": true,
      "ignore": [
        "venv",
        ".git",
        "firebase-debug.log",
        "firebase-debug.*.log",
        "*.local"
      ],
      "runtime": "python314"
    }
  ]
}
```

`firebase deploy --only functions:on_request_example_py314 --project PROJECT_ID`
<details>
<summary>terminal logs</summary>

```
=== Deploying to 'PROJECT_ID'...

i  deploying functions
i  functions: preparing codebase default for deployment
i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
i  functions: ensuring required API cloudbuild.googleapis.com is enabled...
i  artifactregistry: ensuring required API artifactregistry.googleapis.com is enabled...
✔  functions: required API cloudbuild.googleapis.com is enabled
✔  artifactregistry: required API artifactregistry.googleapis.com is enabled
i  functions: Loading and analyzing source code for codebase default to determine what to deploy
 * Serving Flask app 'serving'
 * Debug mode: off

WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:8081

Press CTRL+C to quit

127.0.0.1 - - [21/Apr/2026 23:05:19] "GET /__/functions.yaml HTTP/1.1" 200 -

127.0.0.1 - - [21/Apr/2026 23:05:19] "GET /__/quitquitquit HTTP/1.1" 200 -

/bin/sh: line 1: 89689 Terminated: 15          python3.14 "PATH/firebase-tools/issues/10384/functions/venv/lib/python3.14/site-packages/firebase_functions/private/serving.py"

i  functions: preparing functions directory for uploading...
i  functions: packaged PATH/firebase-tools/issues/10384/functions (1.38 KB) for uploading
i  functions: ensuring required API run.googleapis.com is enabled...
i  functions: ensuring required API eventarc.googleapis.com is enabled...
i  functions: ensuring required API pubsub.googleapis.com is enabled...
i  functions: ensuring required API storage.googleapis.com is enabled...
✔  functions: required API run.googleapis.com is enabled
✔  functions: required API eventarc.googleapis.com is enabled
✔  functions: required API storage.googleapis.com is enabled
✔  functions: required API pubsub.googleapis.com is enabled
i  functions: generating the service identity for pubsub.googleapis.com...
i  functions: generating the service identity for eventarc.googleapis.com...
✔  functions: functions source uploaded successfully
i  functions: creating Python 3.14 (2nd Gen) function on_request_example_py314(us-central1)...
✔  functions[on_request_example_py314(us-central1)] Successful create operation.
Function URL (on_request_example_py314(us-central1)): https://us-central1-PROJECT_ID.cloudfunctions.net/on_request_example_py314

✔  Deploy complete!
```

</details>

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

### NOTE

This changes the default Python runtime to python314 instead of python313
