### PR TITLE
Silence punycode deprecation notice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Suppressed the 'punycode' deprecation warning on Node 22 by ignoring the `DEP0040` code.
 - Fixed an issue where hosting deploy allowed publishing to a site in a different project. (#10376)
 - Added 'firebase_deploy' and 'firebase_deploy_status' MCP tools.
 - Added SSE mode support to `firebase mcp`. To use it, run `firebase mcp --mode=sse --port=3000`, and connect your client on `http://localhost:3000`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Suppressed the 'punycode' deprecation warning on Node 22 by ignoring the `DEP0040` code.
+- Suppressed the 'punycode' deprecation warning during `firebase deploy` on Node 22. (#10385)
 - Fixed an issue where hosting deploy allowed publishing to a site in a different project. (#10376)
 - Added 'firebase_deploy' and 'firebase_deploy_status' MCP tools.
 - Added SSE mode support to `firebase mcp`. To use it, run `firebase mcp --mode=sse --port=3000`, and connect your client on `http://localhost:3000`.

--- a/src/bin/firebase.ts
+++ b/src/bin/firebase.ts
@@ -3,6 +3,24 @@
 // Check for older versions of Node no longer supported by the CLI.
 import * as semver from "semver";
 const pkg = require("../../package.json");
+
+interface NodeWarning extends Error {
+  code?: string;
+}
+
+// List of warning codes to silence
+const IGNORED_WARNINGS = [
+  "DEP0040", // Punycode module is deprecated. Ignored because transitive dependencies (e.g. tr46) still use it via require('punycode/') or directly.
+];
+
+process.on("warning", (warning) => {
+  const nodeWarning = warning as NodeWarning;
+  if (nodeWarning.code && IGNORED_WARNINGS.includes(nodeWarning.code)) {
+    return;
+  }
+  console.warn(nodeWarning.stack || nodeWarning.message);
+});
+
 const nodeVersion = process.version;
 if (!semver.satisfies(nodeVersion, pkg.engines.node)) {
   console.error(


### PR DESCRIPTION
### Description
Silence the `punycode` deprecation warning that was being printed pout during deploy on Node 22. This is coming from a transitive dependency and has no effect on our users, so this was pure noise. Fixes #10385
