### PR TITLE
fix(emulators): skip credentials check for demo projects in Functions emulator

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -449,11 +449,16 @@ export class FunctionsEmulator implements EmulatorInstance {
   }
 
   async start(): Promise<void> {
-    const credentialEnv = await getCredentialsEnvironment(
-      this.args.account,
-      this.logger,
-      "functions",
-    );
+    let credentialEnv: Record<string, string> = {};
+    // Skip fetching credentials for demo projects to avoid hanging on network calls
+    // to the GCP metadata server in local environments without credentials.
+    if (!Constants.isDemoProject(this.args.projectId)) {
+      credentialEnv = await getCredentialsEnvironment(
+        this.args.account,
+        this.logger,
+        "functions",
+      );
+    }
     for (const e of this.staticBackends) {
       e.env = { ...credentialEnv, ...e.env };
     }


### PR DESCRIPTION
### Description
Skips the call to `getCredentialsEnvironment` in `FunctionsEmulator.start()` when the project ID starts with `demo-`.

In local environments without Application Default Credentials (ADC) configured, `getCredentialsEnvironment` attempts to discover credentials by polling the Google Cloud Metadata Server (via `auth.getApplicationDefault()`). This request hangs indefinitely until a network timeout occurs, causing the emulator suite to appear frozen on startup.

Since demo projects are intended for local emulation and do not need real credentials to access production services, we can safely skip this check.

Fixes #10398

### Scenarios Tested
- Verified that the emulator suite starts up immediately without hanging when using a demo project ID (`demo-n26`).

### Sample Commands
- `node lib/bin/firebase.js emulators:start --config /path/to/firebase.json --project demo-n26`
