### PR TITLE
docs(readme): document --json as the supported machine-readable output

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,31 @@ Complete the following steps to run Firebase commands in a CI environment. Find 
 
 To disable access for the service account, [find the service account](https://console.cloud.google.com/projectselector/iam-admin/serviceaccounts) for your project in the Google Cloud Console, and then either remove the key, or disable or delete the service account.
 
+## Machine-readable output
+
+By default, the Firebase CLI prints human-readable output to `stdout`. That
+output is **not** part of the CLI's API — it may change at any time — so
+scripts and CI pipelines should not parse it directly.
+
+For scripting and automation, pass the `--json` flag to any command. With
+`--json`:
+
+- `stdout` receives a single JSON document describing the command's
+  result — parsable regardless of exit code.
+- The shape is stable across versions and intended for programmatic use.
+
+```bash
+# Human output (default) — do not parse this in scripts
+$ firebase hosting:channel:list --project my-project
+
+# Machine output — safe to parse in CI
+$ firebase hosting:channel:list --project my-project --json | jq '.result.channels[].name'
+```
+
+If `--json` isn't enough for your use case (e.g. you need to catch thrown
+errors rather than inspect an exit code), see [Using as a
+Module](#using-as-a-module) below.
+
 ## Using as a Module
 
 The Firebase CLI can also be used programmatically as a standard Node module.


### PR DESCRIPTION
### Description

Issue #3227 asked for a note in the README that the default human-readable CLI output is not a stable API and that scripts/CI should use \`--json\` instead. On that thread @samtstern (\"the CLI output without --json is *not* part of our API and you can change it at will\") and @bkendall (\"Adding some information to the README is always welcome! if you wanted to start a PR with what would be useful to you, we could iterate on that with you\") agreed and explicitly invited a PR.

The README currently has no mention of \`--json\` at all — users coming from issue triage or Stack Overflow land on \"Using with CI Systems\" and then \"Using as a Module\" without anything in between pointing them at the supported, parsable surface.

This PR adds a new \"Machine-readable output\" section between those two, covering:

- Why the default stdout format is not a stable API.
- What \`--json\` changes about the output (single JSON document on stdout regardless of exit code, stable across versions).
- A worked example pair showing the same \`hosting:channel:list\` call with and without \`--json | jq\`.
- A pointer to the existing \"Using as a Module\" section for callers that need thrown errors instead of exit codes.

### Scenarios Tested

- \`prettier --check README.md\` passes.
- Docs-only change — no runtime behavior or tests affected.
- Scanned the existing README for cross-reference anchors; used \`#using-as-a-module\` which is the slug the current section renders as.

### Sample Commands

No command surface changes. The new section documents existing \`--json\` behavior that already ships on commands today. The worked example from the docs:

\`\`\`bash
# Human output (default) — do not parse this in scripts
$ firebase hosting:channel:list --project my-project

# Machine output — safe to parse in CI
$ firebase hosting:channel:list --project my-project --json | jq '.result.channels[].name'
\`\`\`

Closes #3227.