### PR TITLE
feat: add warning nudges for cross-region event triggers

### DIFF
--- a/src/deploy/functions/triggerRegionHelper.spec.ts
+++ b/src/deploy/functions/triggerRegionHelper.spec.ts
@@ -3,7 +3,13 @@ import * as sinon from "sinon";
 
 import * as backend from "./backend";
 import * as storage from "../../gcp/storage";
+import * as firestore from "../../gcp/firestore";
+import * as database from "../../management/database";
+import * as utils from "../../utils";
 import * as triggerRegionHelper from "./triggerRegionHelper";
+import * as storageService from "./services/storage";
+import * as firestoreService from "./services/firestore";
+import * as databaseService from "./services/database";
 
 const SPEC = {
   region: "us-west1",
@@ -14,14 +20,26 @@ const SPEC = {
 describe("TriggerRegionHelper", () => {
   describe("ensureTriggerRegions", () => {
     let storageStub: sinon.SinonStub;
+    let firestoreStub: sinon.SinonStub;
+    let databaseStub: sinon.SinonStub;
+    let logWarningSpy: sinon.SinonSpy;
 
     beforeEach(() => {
+      storageService.clearCache();
+      firestoreService.clearCache();
+      databaseService.clearCache();
       storageStub = sinon.stub(storage, "getBucket").throws("unexpected call to storage.getBucket");
+      firestoreStub = sinon.stub(firestore, "getDatabase").throws("unexpected call to firestore.getDatabase");
+      databaseStub = sinon.stub(database, "getDatabaseInstanceDetails").throws("unexpected call to database.getDatabaseInstanceDetails");
+      logWarningSpy = sinon.spy(utils, "logLabeledWarning");
     });
 
     afterEach(() => {
       sinon.verifyAndRestore();
+      delete process.env.FIREBASE_SUPPRESS_REGION_WARNING;
     });
+
+    // --- V2 Tests ---
 
     it("should throw an error if we can't find the bucket region", async () => {
       const ep: backend.Endpoint = {
@@ -39,38 +57,6 @@ describe("TriggerRegionHelper", () => {
       await expect(triggerRegionHelper.ensureTriggerRegions(backend.of(ep))).to.be.rejectedWith(
         "Can't find the storage bucket region",
       );
-    });
-
-    it("should skip v1 and callable functions", async () => {
-      const v1EventFn: backend.Endpoint = {
-        id: "v1eventfn",
-        entryPoint: "v1Fn",
-        platform: "gcfv1",
-        eventTrigger: {
-          eventType: "google.storage.object.create",
-          eventFilters: { resource: "projects/_/buckets/my-bucket" },
-          retry: false,
-        },
-        ...SPEC,
-      };
-      const v2CallableFn: backend.Endpoint = {
-        id: "v2callablefn",
-        entryPoint: "v2callablefn",
-        platform: "gcfv2",
-        httpsTrigger: {},
-        ...SPEC,
-      };
-
-      await triggerRegionHelper.ensureTriggerRegions(backend.of(v1EventFn, v2CallableFn));
-
-      const want: backend.EventTrigger = {
-        eventType: "google.storage.object.create",
-        eventFilters: { resource: "projects/_/buckets/my-bucket" },
-        retry: false,
-      };
-
-      expect(v1EventFn.eventTrigger).to.deep.eq(want);
-      expect(v2CallableFn.httpsTrigger).to.deep.eq({});
     });
 
     it("should set trigger region from API", async () => {
@@ -99,7 +85,7 @@ describe("TriggerRegionHelper", () => {
     });
 
     it("should set trigger region from API then reject on invalid function region", async () => {
-      storageStub.resolves({ location: "US" });
+      storageStub.resolves({ location: "EUROPE-WEST1" });
       const wantFn: backend.Endpoint = {
         id: "wantFn",
         entryPoint: "wantFn",
@@ -110,12 +96,310 @@ describe("TriggerRegionHelper", () => {
           retry: false,
         },
         ...SPEC,
-        region: "europe-west4",
+        region: "us-west1",
       };
 
       await expect(triggerRegionHelper.ensureTriggerRegions(backend.of(wantFn))).to.be.rejectedWith(
-        "A function in region europe-west4 cannot listen to a bucket in region us",
+        "A function in region us-west1 cannot listen to a bucket in region europe-west1",
       );
+    });
+
+    it("should warn if a function region is us-central1 but the trigger is non-US", async () => {
+      firestoreStub.resolves({ locationId: "europe-west1" });
+      const ep: backend.Endpoint = {
+        id: "wantFn",
+        entryPoint: "wantFn",
+        platform: "gcfv2",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.written",
+          eventFilters: { database: "(default)" },
+          retry: false,
+          region: "europe-west1",
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+
+      expect(logWarningSpy.calledOnce).to.be.true;
+      expect(logWarningSpy.firstCall.args[1]).to.include("The following functions have triggers in different regions than they are located");
+      expect(logWarningSpy.firstCall.args[1]).to.include("- wantFn (us-central1, Trigger: europe-west1)");
+    });
+
+    it("should warn on multiple transatlantic latency hops with a rolled-up log message", async () => {
+      firestoreStub.withArgs(sinon.match.any, "(default)").resolves({ locationId: "europe-west1" });
+      firestoreStub.withArgs(sinon.match.any, "my-secondary-db").resolves({ locationId: "asia-northeast1" });
+      const wantFn1: backend.Endpoint = {
+        id: "wantFn1",
+        entryPoint: "wantFn1",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.written",
+          eventFilters: { database: "(default)" },
+          retry: false,
+          region: "europe-west1",
+        },
+        ...SPEC,
+        region: "us-central1",
+      };
+
+      const wantFn2: backend.Endpoint = {
+        id: "wantFn2",
+        entryPoint: "wantFn2",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.written",
+          eventFilters: { database: "my-secondary-db" },
+          retry: false,
+          region: "asia-northeast1",
+        },
+        ...SPEC,
+        region: "us-central1",
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(wantFn1, wantFn2));
+
+      expect(logWarningSpy.calledOnce).to.be.true;
+      expect(logWarningSpy.firstCall.args[1]).to.include("- wantFn1 (us-central1, Trigger: europe-west1)");
+      expect(logWarningSpy.firstCall.args[1]).to.include("- wantFn2 (us-central1, Trigger: asia-northeast1)");
+    });
+
+    it("should be able to suppress warnings with an environment flag for V2", async () => {
+      firestoreStub.resolves({ locationId: "europe-west1" });
+      const wantFn: backend.Endpoint = {
+        id: "wantFn",
+        entryPoint: "wantFn",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.written",
+          eventFilters: { database: "(default)" },
+          retry: false,
+          region: "europe-west1",
+        },
+        ...SPEC,
+        region: "us-central1",
+      };
+
+      process.env.FIREBASE_SUPPRESS_REGION_WARNING = "true";
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(wantFn));
+
+      expect(logWarningSpy.called).to.be.false;
+    });
+
+    it("should not warn when regions match for V2", async () => {
+      firestoreStub.resolves({ locationId: "us-central1" });
+      const wantFn: backend.Endpoint = {
+        id: "wantFn",
+        entryPoint: "wantFn",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.written",
+          eventFilters: { database: "(default)" },
+          retry: false,
+          region: "us-central1",
+        },
+        ...SPEC,
+        region: "us-central1",
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(wantFn));
+
+      expect(logWarningSpy.called).to.be.false;
+    });
+
+    it("should not warn when US function uses nam5 multi-region trigger for V2", async () => {
+      firestoreStub.resolves({ locationId: "nam5" });
+      const wantFn: backend.Endpoint = {
+        id: "wantFn",
+        entryPoint: "wantFn",
+        platform: "gcfv2",
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.written",
+          eventFilters: { database: "(default)" },
+          retry: false,
+          region: "nam5",
+        },
+        ...SPEC,
+        region: "us-central1",
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(wantFn));
+
+      expect(logWarningSpy.called).to.be.false;
+    });
+
+    // --- V1 Tests ---
+
+    it("should not warn if trigger region is a US region for V1", async () => {
+      storageStub.resolves({ location: "US" });
+      const ep: backend.Endpoint = {
+        id: "v1fn",
+        entryPoint: "v1Fn",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+      expect(logWarningSpy.called).to.be.false;
+    });
+
+    it("should not warn if trigger region is another specific US region like us-east1 for V1", async () => {
+      storageStub.resolves({ location: "US-EAST1" });
+      const ep: backend.Endpoint = {
+        id: "v1fn",
+        entryPoint: "v1Fn",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+      expect(logWarningSpy.called).to.be.false;
+    });
+
+    it("should warn for V1 storage function if bucket is non-US", async () => {
+      storageStub.resolves({ location: "EUROPE-WEST1" });
+      const ep: backend.Endpoint = {
+        id: "v1fn",
+        entryPoint: "v1Fn",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+
+      expect(logWarningSpy.calledOnce).to.be.true;
+      expect(logWarningSpy.firstCall.args[1]).to.include("- v1fn (us-central1, Trigger: europe-west1)");
+    });
+
+    it("should silently catch and handle failed V1 lookups", async () => {
+      storageStub.rejects(new Error("Access Denied"));
+      const ep: backend.Endpoint = {
+        id: "v1fn",
+        entryPoint: "v1Fn",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      // The deployment shouldn't fail with an error
+      await expect(triggerRegionHelper.ensureTriggerRegions(backend.of(ep))).to.be.fulfilled;
+      expect(logWarningSpy.called).to.be.false;
+    });
+
+    it("should warn for V1 firestore function if database location is non-US", async () => {
+      firestoreStub.resolves({ locationId: "EUROPE-WEST1" });
+      const ep: backend.Endpoint = {
+        id: "v1fs",
+        entryPoint: "v1fs",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "providers/cloud.firestore/eventTypes/document.create",
+          eventFilters: { resource: "projects/_/databases/(default)/documents/users/{uid}" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+
+      expect(logWarningSpy.calledOnce).to.be.true;
+      expect(logWarningSpy.firstCall.args[1]).to.include("- v1fs (us-central1, Trigger: europe-west1)");
+    });
+
+    it("should warn for V1 database function if instance location is non-US", async () => {
+      databaseStub.resolves({ location: "europe-west1" });
+      const ep: backend.Endpoint = {
+        id: "v1db",
+        entryPoint: "v1db",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "providers/google.firebase.database/eventTypes/ref.create",
+          eventFilters: { resource: "projects/_/instances/my-instance/refs/users/{uid}" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+
+      expect(logWarningSpy.calledOnce).to.be.true;
+      expect(logWarningSpy.firstCall.args[1]).to.include("- v1db (us-central1, Trigger: europe-west1)");
+    });
+
+    it("should skip warnings when FIREBASE_SUPPRESS_REGION_WARNING=true for V1", async () => {
+      process.env.FIREBASE_SUPPRESS_REGION_WARNING = "true";
+      storageStub.resolves({ location: "EUROPE-WEST1" });
+      const ep: backend.Endpoint = {
+        id: "v1fn",
+        entryPoint: "v1Fn",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+
+      expect(logWarningSpy.called).to.be.false;
+    });
+
+    it("should not warn when a V1 function matches a US multi-region trigger", async () => {
+      storageStub.resolves({ location: "NAM5" });
+      const ep: backend.Endpoint = {
+        id: "v1fs",
+        entryPoint: "v1fs",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: { resource: "projects/_/buckets/my-bucket" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+      expect(logWarningSpy.called).to.be.false;
     });
   });
 });

--- a/src/deploy/functions/triggerRegionHelper.spec.ts
+++ b/src/deploy/functions/triggerRegionHelper.spec.ts
@@ -29,8 +29,12 @@ describe("TriggerRegionHelper", () => {
       firestoreService.clearCache();
       databaseService.clearCache();
       storageStub = sinon.stub(storage, "getBucket").throws("unexpected call to storage.getBucket");
-      firestoreStub = sinon.stub(firestore, "getDatabase").throws("unexpected call to firestore.getDatabase");
-      databaseStub = sinon.stub(database, "getDatabaseInstanceDetails").throws("unexpected call to database.getDatabaseInstanceDetails");
+      firestoreStub = sinon
+        .stub(firestore, "getDatabase")
+        .throws("unexpected call to firestore.getDatabase");
+      databaseStub = sinon
+        .stub(database, "getDatabaseInstanceDetails")
+        .throws("unexpected call to database.getDatabaseInstanceDetails");
       logWarningSpy = sinon.spy(utils, "logLabeledWarning");
     });
 
@@ -124,13 +128,19 @@ describe("TriggerRegionHelper", () => {
       await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
 
       expect(logWarningSpy.calledOnce).to.be.true;
-      expect(logWarningSpy.firstCall.args[1]).to.include("The following functions have triggers in different regions than they are located");
-      expect(logWarningSpy.firstCall.args[1]).to.include("- wantFn (us-central1, Trigger: europe-west1)");
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "The following functions have triggers in different regions than they are located",
+      );
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "- wantFn (us-central1, Trigger: europe-west1)",
+      );
     });
 
     it("should warn on multiple transatlantic latency hops with a rolled-up log message", async () => {
       firestoreStub.withArgs(sinon.match.any, "(default)").resolves({ locationId: "europe-west1" });
-      firestoreStub.withArgs(sinon.match.any, "my-secondary-db").resolves({ locationId: "asia-northeast1" });
+      firestoreStub
+        .withArgs(sinon.match.any, "my-secondary-db")
+        .resolves({ locationId: "asia-northeast1" });
       const wantFn1: backend.Endpoint = {
         id: "wantFn1",
         entryPoint: "wantFn1",
@@ -162,8 +172,12 @@ describe("TriggerRegionHelper", () => {
       await triggerRegionHelper.ensureTriggerRegions(backend.of(wantFn1, wantFn2));
 
       expect(logWarningSpy.calledOnce).to.be.true;
-      expect(logWarningSpy.firstCall.args[1]).to.include("- wantFn1 (us-central1, Trigger: europe-west1)");
-      expect(logWarningSpy.firstCall.args[1]).to.include("- wantFn2 (us-central1, Trigger: asia-northeast1)");
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "- wantFn1 (us-central1, Trigger: europe-west1)",
+      );
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "- wantFn2 (us-central1, Trigger: asia-northeast1)",
+      );
     });
 
     it("should be able to suppress warnings with an environment flag for V2", async () => {
@@ -292,7 +306,9 @@ describe("TriggerRegionHelper", () => {
       await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
 
       expect(logWarningSpy.calledOnce).to.be.true;
-      expect(logWarningSpy.firstCall.args[1]).to.include("- v1fn (us-central1, Trigger: europe-west1)");
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "- v1fn (us-central1, Trigger: europe-west1)",
+      );
     });
 
     it("should silently catch and handle failed V1 lookups", async () => {
@@ -335,7 +351,9 @@ describe("TriggerRegionHelper", () => {
       await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
 
       expect(logWarningSpy.calledOnce).to.be.true;
-      expect(logWarningSpy.firstCall.args[1]).to.include("- v1fs (us-central1, Trigger: europe-west1)");
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "- v1fs (us-central1, Trigger: europe-west1)",
+      );
     });
 
     it("should warn for V1 database function if instance location is non-US", async () => {
@@ -357,7 +375,9 @@ describe("TriggerRegionHelper", () => {
       await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
 
       expect(logWarningSpy.calledOnce).to.be.true;
-      expect(logWarningSpy.firstCall.args[1]).to.include("- v1db (us-central1, Trigger: europe-west1)");
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "- v1db (us-central1, Trigger: europe-west1)",
+      );
     });
 
     it("should skip warnings when FIREBASE_SUPPRESS_REGION_WARNING=true for V1", async () => {

--- a/src/deploy/functions/triggerRegionHelper.spec.ts
+++ b/src/deploy/functions/triggerRegionHelper.spec.ts
@@ -311,6 +311,30 @@ describe("TriggerRegionHelper", () => {
       );
     });
 
+    it("should handle short-form bucket resource names for V1 storage", async () => {
+      storageStub.withArgs("my-bucket").resolves({ location: "EUROPE-WEST1" });
+      const ep: backend.Endpoint = {
+        id: "v1fn",
+        entryPoint: "v1Fn",
+        platform: "gcfv1",
+        region: "us-central1",
+        eventTrigger: {
+          eventType: "google.storage.object.create",
+          eventFilters: { resource: "my-bucket" },
+          retry: false,
+        },
+        project: "my-project",
+        runtime: "nodejs14" as const,
+      };
+
+      await triggerRegionHelper.ensureTriggerRegions(backend.of(ep));
+
+      expect(logWarningSpy.calledOnce).to.be.true;
+      expect(logWarningSpy.firstCall.args[1]).to.include(
+        "- v1fn (us-central1, Trigger: europe-west1)",
+      );
+    });
+
     it("should silently catch and handle failed V1 lookups", async () => {
       storageStub.rejects(new Error("Access Denied"));
       const ep: backend.Endpoint = {

--- a/src/deploy/functions/triggerRegionHelper.ts
+++ b/src/deploy/functions/triggerRegionHelper.ts
@@ -31,8 +31,11 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
                 triggerRegionMap.set(ep.id, bucket.location.toLowerCase());
               })
               .catch((err) => {
-                logger.debug(`Failed to resolve trigger region for V1 storage function ${ep.id}:`, err);
-              })
+                logger.debug(
+                  `Failed to resolve trigger region for V1 storage function ${ep.id}:`,
+                  err,
+                );
+              }),
           );
         }
       } else if (eventType.includes("firestore")) {
@@ -43,8 +46,11 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
               triggerRegionMap.set(ep.id, db.locationId.toLowerCase());
             })
             .catch((err) => {
-              logger.debug(`Failed to resolve trigger region for V1 firestore function ${ep.id}:`, err);
-            })
+              logger.debug(
+                `Failed to resolve trigger region for V1 firestore function ${ep.id}:`,
+                err,
+              );
+            }),
         );
       } else if (eventType.includes("database")) {
         const instanceName = extractInstanceName(resource);
@@ -57,8 +63,11 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
                 }
               })
               .catch((err) => {
-                logger.debug(`Failed to resolve trigger region for V1 database function ${ep.id}:`, err);
-              })
+                logger.debug(
+                  `Failed to resolve trigger region for V1 database function ${ep.id}:`,
+                  err,
+                );
+              }),
           );
         }
       }
@@ -126,4 +135,3 @@ function extractInstanceName(resource: string | undefined): string | null {
 function isUSRegion(region: string): boolean {
   return region === "us" || region === "nam5" || region === "nam7" || region.startsWith("us-");
 }
-

--- a/src/deploy/functions/triggerRegionHelper.ts
+++ b/src/deploy/functions/triggerRegionHelper.ts
@@ -87,7 +87,7 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
       continue;
     }
 
-    let triggerRegion: string | undefined = undefined;
+    let triggerRegion: string | undefined;
     if (ep.platform === "gcfv1") {
       triggerRegion = triggerRegionMap.get(backend.functionName(ep));
     } else {

--- a/src/deploy/functions/triggerRegionHelper.ts
+++ b/src/deploy/functions/triggerRegionHelper.ts
@@ -116,22 +116,28 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
 
 function extractBucketName(resource: string | undefined): string | null {
   if (!resource) return null;
-  const match = resource.match(/buckets\/([^\/]+)/);
-  return match ? match[1] : null;
+  const match = /buckets\/([^/]+)/.exec(resource);
+  if (match) return match[1];
+  if (!resource.includes("/")) return resource;
+  return null;
 }
 
 function extractDatabaseId(resource: string | undefined): string {
   if (!resource) return "(default)";
-  const match = resource.match(/databases\/([^\/]+)/);
-  return match ? match[1] : "(default)";
+  const match = /databases\/([^/]+)/.exec(resource);
+  if (match) return match[1];
+  if (!resource.includes("/")) return resource;
+  return "(default)";
 }
 
 function extractInstanceName(resource: string | undefined): string | null {
   if (!resource) return null;
-  const match = resource.match(/instances\/([^\/]+)/);
-  return match ? match[1] : null;
+  const match = /instances\/([^/]+)/.exec(resource);
+  if (match) return match[1];
+  if (!resource.includes("/")) return resource;
+  return null;
 }
 
 function isUSRegion(region: string): boolean {
-  return region === "us" || region === "nam5" || region === "nam7" || region.startsWith("us-");
+  return region === "us" || region.startsWith("nam") || region.startsWith("us-");
 }

--- a/src/deploy/functions/triggerRegionHelper.ts
+++ b/src/deploy/functions/triggerRegionHelper.ts
@@ -28,7 +28,7 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
           regionLookups.push(
             getBucket(bucketName)
               .then((bucket) => {
-                triggerRegionMap.set(ep.id, bucket.location.toLowerCase());
+                triggerRegionMap.set(backend.functionName(ep), bucket.location.toLowerCase());
               })
               .catch((err) => {
                 logger.debug(
@@ -43,7 +43,7 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
         regionLookups.push(
           getDatabase(ep.project, dbId)
             .then((db) => {
-              triggerRegionMap.set(ep.id, db.locationId.toLowerCase());
+              triggerRegionMap.set(backend.functionName(ep), db.locationId.toLowerCase());
             })
             .catch((err) => {
               logger.debug(
@@ -59,7 +59,7 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
             getDatabaseInstanceDetails(ep.project, instanceName)
               .then((details) => {
                 if (details.location && details.location !== "-") {
-                  triggerRegionMap.set(ep.id, details.location.toLowerCase());
+                  triggerRegionMap.set(backend.functionName(ep), details.location.toLowerCase());
                 }
               })
               .catch((err) => {
@@ -89,7 +89,7 @@ export async function ensureTriggerRegions(want: backend.Backend): Promise<void>
 
     let triggerRegion: string | undefined = undefined;
     if (ep.platform === "gcfv1") {
-      triggerRegion = triggerRegionMap.get(ep.id);
+      triggerRegion = triggerRegionMap.get(backend.functionName(ep));
     } else {
       triggerRegion = ep.eventTrigger.region;
     }

--- a/src/deploy/functions/triggerRegionHelper.ts
+++ b/src/deploy/functions/triggerRegionHelper.ts
@@ -1,19 +1,129 @@
 import * as backend from "./backend";
 import { serviceForEndpoint } from "./services";
+import { logger } from "../../logger";
+import * as utils from "../../utils";
+import { getBucket } from "./services/storage";
+import { getDatabase } from "./services/firestore";
+import { getDatabaseInstanceDetails } from "./services/database";
 
 /**
  * Ensures the trigger regions are set and correct
  * @param want the list of function specs we want to deploy
- * @param have the list of function specs we have deployed
  */
 export async function ensureTriggerRegions(want: backend.Backend): Promise<void> {
   const regionLookups: Array<Promise<void>> = [];
+  const triggerRegionMap = new Map<string, string>();
 
   for (const ep of backend.allEndpoints(want)) {
-    if (ep.platform === "gcfv1" || !backend.isEventTriggered(ep)) {
+    if (!backend.isEventTriggered(ep)) {
       continue;
     }
-    regionLookups.push(serviceForEndpoint(ep).ensureTriggerRegion(ep));
+
+    if (ep.platform === "gcfv1") {
+      const eventType = ep.eventTrigger.eventType || "";
+      const resource = ep.eventTrigger.eventFilters?.resource;
+      if (eventType.includes("storage")) {
+        const bucketName = extractBucketName(resource);
+        if (bucketName) {
+          regionLookups.push(
+            getBucket(bucketName)
+              .then((bucket) => {
+                triggerRegionMap.set(ep.id, bucket.location.toLowerCase());
+              })
+              .catch((err) => {
+                logger.debug(`Failed to resolve trigger region for V1 storage function ${ep.id}:`, err);
+              })
+          );
+        }
+      } else if (eventType.includes("firestore")) {
+        const dbId = extractDatabaseId(resource);
+        regionLookups.push(
+          getDatabase(ep.project, dbId)
+            .then((db) => {
+              triggerRegionMap.set(ep.id, db.locationId.toLowerCase());
+            })
+            .catch((err) => {
+              logger.debug(`Failed to resolve trigger region for V1 firestore function ${ep.id}:`, err);
+            })
+        );
+      } else if (eventType.includes("database")) {
+        const instanceName = extractInstanceName(resource);
+        if (instanceName) {
+          regionLookups.push(
+            getDatabaseInstanceDetails(ep.project, instanceName)
+              .then((details) => {
+                if (details.location && details.location !== "-") {
+                  triggerRegionMap.set(ep.id, details.location.toLowerCase());
+                }
+              })
+              .catch((err) => {
+                logger.debug(`Failed to resolve trigger region for V1 database function ${ep.id}:`, err);
+              })
+          );
+        }
+      }
+    } else {
+      regionLookups.push(serviceForEndpoint(ep).ensureTriggerRegion(ep));
+    }
   }
   await Promise.all(regionLookups);
+
+  if (process.env.FIREBASE_SUPPRESS_REGION_WARNING === "true") {
+    return;
+  }
+
+  const offendingFunctions: string[] = [];
+  for (const ep of backend.allEndpoints(want)) {
+    if (!backend.isEventTriggered(ep)) {
+      continue;
+    }
+
+    let triggerRegion: string | undefined = undefined;
+    if (ep.platform === "gcfv1") {
+      triggerRegion = triggerRegionMap.get(ep.id);
+    } else {
+      triggerRegion = ep.eventTrigger.region;
+    }
+
+    if (ep.region !== "us-central1" || !triggerRegion || triggerRegion === "global") {
+      continue;
+    }
+
+    if (!isUSRegion(triggerRegion)) {
+      offendingFunctions.push(`- ${ep.id} (us-central1, Trigger: ${triggerRegion})`);
+    }
+  }
+
+  if (offendingFunctions.length > 0) {
+    utils.logLabeledWarning(
+      "functions",
+      `The following functions have triggers in different regions than they are located:\n` +
+        offendingFunctions.join("\n") +
+        `\nTo avoid unnecessary cross-region network hops, consider assigning these functions to their trigger regions or collocating them. ` +
+        `To suppress this warning, set FIREBASE_SUPPRESS_REGION_WARNING=true in your environment variables.`,
+    );
+  }
 }
+
+function extractBucketName(resource: string | undefined): string | null {
+  if (!resource) return null;
+  const match = resource.match(/buckets\/([^\/]+)/);
+  return match ? match[1] : null;
+}
+
+function extractDatabaseId(resource: string | undefined): string {
+  if (!resource) return "(default)";
+  const match = resource.match(/databases\/([^\/]+)/);
+  return match ? match[1] : "(default)";
+}
+
+function extractInstanceName(resource: string | undefined): string | null {
+  if (!resource) return null;
+  const match = resource.match(/instances\/([^\/]+)/);
+  return match ? match[1] : null;
+}
+
+function isUSRegion(region: string): boolean {
+  return region === "us" || region === "nam5" || region === "nam7" || region.startsWith("us-");
+}
+


### PR DESCRIPTION
This PR implements robust cross-region latency warnings within the Firebase Functions deployment pipeline to nudge developers away from unnecessary transoceanic network hops. When an event-triggered function (such as Firestore or Cloud Storage) is explicitly assigned or defaults to us-central1 while its backing event resource operates in a distinct non-US location, the CLI now issues a user-friendly cautionary warning encouraging explicit collocation with the event trigger's region.

To maintain a clean CLI experience, the PR aggregates multiple offending functions into a single, consolidated warning log to avoid spamming the terminal during large deployments. It correctly exempts US multi-region databases (such as nam5 and nam7) to prevent false-positives, and introduces an opt-out environment flag (FIREBASE_SUPPRESS_REGION_WARNING=true). The flag allows headless CI/CD pipelines to silence repetitive warnings safely, with instructions on how to apply it printed directly inside the warning log.