### PR TITLE
fix(functions/emulator): hidden-path ignore relative to functionsDir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed Functions emulator file watcher silently ignoring changes when the project path contains a dot-prefixed ancestor directory (e.g. `.worktrees/`). (#10187)

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -35,6 +35,7 @@ import {
   prepareEndpoints,
   BlockingTrigger,
   getTemporarySocketPath,
+  shouldIgnoreWatchPath,
 } from "./functionsEmulatorShared";
 import { EmulatorRegistry } from "./registry";
 import { EmulatorLogger, Verbosity } from "./emulatorLogger";
@@ -519,7 +520,12 @@ export class FunctionsEmulator implements EmulatorInstance {
       } else {
         const watcher = chokidar.watch(backend.functionsDir, {
           ignored: [
-            /(^|[\/\\])\../, // Ignore hidden files/dirs (covers .dart_tool, .git, etc.)
+            // Ignore hidden files/dirs within the watched directory (covers
+            // .dart_tool, .git, etc.). Match against the path relative to
+            // functionsDir so a dot-prefixed ancestor directory (e.g.
+            // `.worktrees/`) does not cause every file change to be ignored.
+            // See https://github.com/firebase/firebase-tools/issues/10187.
+            (filePath: string) => shouldIgnoreWatchPath(backend.functionsDir, filePath),
             /.+\.log/, // Ignore log files
             /.+?[\\\/]node_modules[\\\/].+?/, // Ignore node_modules
             /.+?[\\\/]venv[\\\/].+?/, // Ignore venv

--- a/src/emulator/functionsEmulatorShared.spec.ts
+++ b/src/emulator/functionsEmulatorShared.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from "chai";
+import * as path from "path";
 import { BackendInfo, EmulatableBackend } from "./functionsEmulator";
 import * as functionsEmulatorShared from "./functionsEmulatorShared";
 import {
@@ -294,5 +295,48 @@ describe("FunctionsEmulatorShared", () => {
         );
       });
     }
+  });
+
+  describe(`${functionsEmulatorShared.shouldIgnoreWatchPath.name}`, () => {
+    const functionsDir = path.join("/", "home", "user", ".worktrees", "project", "functions");
+
+    it("ignores hidden files inside the functions directory", () => {
+      const target = path.join(functionsDir, ".git", "HEAD");
+      expect(functionsEmulatorShared.shouldIgnoreWatchPath(functionsDir, target)).to.be.true;
+    });
+
+    it("ignores a hidden segment nested within the functions directory", () => {
+      const target = path.join(functionsDir, "src", ".cache", "module.js");
+      expect(functionsEmulatorShared.shouldIgnoreWatchPath(functionsDir, target)).to.be.true;
+    });
+
+    it("does not ignore a regular source file even when the functions directory is nested under a dot-prefixed ancestor", () => {
+      const target = path.join(functionsDir, "src", "index.ts");
+      expect(functionsEmulatorShared.shouldIgnoreWatchPath(functionsDir, target)).to.be.false;
+    });
+
+    it("does not ignore a nested source file without any hidden segment", () => {
+      const target = path.join(functionsDir, "lib", "handlers", "index.js");
+      expect(functionsEmulatorShared.shouldIgnoreWatchPath(functionsDir, target)).to.be.false;
+    });
+
+    it("does not ignore the functions directory itself", () => {
+      expect(functionsEmulatorShared.shouldIgnoreWatchPath(functionsDir, functionsDir)).to.be.false;
+    });
+
+    describe("when the functions directory has no dot-prefixed ancestor", () => {
+      const plainFunctionsDir = path.join("/", "home", "user", "project", "functions");
+
+      it("still ignores hidden files inside the functions directory", () => {
+        const target = path.join(plainFunctionsDir, ".git", "HEAD");
+        expect(functionsEmulatorShared.shouldIgnoreWatchPath(plainFunctionsDir, target)).to.be.true;
+      });
+
+      it("does not ignore a regular source file", () => {
+        const target = path.join(plainFunctionsDir, "src", "index.ts");
+        expect(functionsEmulatorShared.shouldIgnoreWatchPath(plainFunctionsDir, target)).to.be
+          .false;
+      });
+    });
   });
 });

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -545,3 +545,24 @@ export function toBackendInfo(
     }),
   );
 }
+
+// Matches paths whose last segment starts with a dot (e.g. ".git", ".cache").
+const HIDDEN_SEGMENT_REGEX = /(^|[\/\\])\../;
+
+/**
+ * Whether the functions emulator file watcher should ignore `filePath`.
+ *
+ * The hidden-segment check is applied against the path relative to
+ * `functionsDir`. chokidar invokes the ignore matcher with the absolute path,
+ * so matching the pattern against that path would also match dot-prefixed
+ * ancestor directories (e.g. `.worktrees/`, `.cache/`) in the containing
+ * project path and cause every file change to be ignored. See
+ * https://github.com/firebase/firebase-tools/issues/10187.
+ */
+export function shouldIgnoreWatchPath(functionsDir: string, filePath: string): boolean {
+  const rel = path.relative(functionsDir, filePath);
+  if (!rel) {
+    return false;
+  }
+  return HIDDEN_SEGMENT_REGEX.test(rel);
+}


### PR DESCRIPTION
### Description

Fixes #10187.

`FunctionsEmulator` configures chokidar's `ignored` option with a hidden-segment regex (`/(^|[\/\\])\../`) that was evaluated against the absolute file path. When the project lives under a dot-prefixed ancestor directory (for example `.worktrees/`, `.cache/`, or any other ancestor starting with `.`), that regex matches the ancestor segment of every path and the watcher silently filters out every change. The result is that saving a source file never triggers a reload.

This change extracts a `shouldIgnoreWatchPath(functionsDir, filePath)` helper in `functionsEmulatorShared.ts` that computes `path.relative(functionsDir, filePath)` and only tests the hidden-segment regex against the relative path. The matcher in `functionsEmulator.ts` uses that helper in place of the bare regex.

Behavior is preserved for the common case — files like `.git/HEAD`, `.dart_tool/…`, or `.cache/…` inside the watched directory are still ignored, because their relative path starts with a dot. The remaining built-in ignore patterns (`.log` files, `node_modules`, `venv`) and any user-supplied `backend.ignore` globs are unchanged.

### Scenarios Tested

Added unit tests in `src/emulator/functionsEmulatorShared.spec.ts` covering:

- Hidden file inside the functions directory (`.git/HEAD`) is still ignored.
- Hidden segment nested within the functions directory (`src/.cache/module.js`) is still ignored.
- Regular source file under a dot-prefixed ancestor (`/home/user/.worktrees/project/functions/src/index.ts`) is **not** ignored — the regression fix.
- Regular nested source file (`lib/handlers/index.js`) is not ignored.
- The functions directory itself is not ignored.
- No-op regression: a plain functions directory without any dot-prefixed ancestor still ignores `.git/HEAD` and still watches `src/index.ts`.

Also verified:

- `npm run lint:quiet` passes (eslint + prettier).
- `npm run build` passes.
- `npx mocha src/emulator/functionsEmulatorShared.spec.ts` — 20 passing (13 existing + 7 new).

### Sample Commands

Not applicable — internal emulator behavior, no public CLI surface change.