### PR TITLE
fix: preserve existing cloud run invokers for scheduled v2 functions

### DIFF
--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -820,32 +820,37 @@ describe("Fabricator", () => {
     });
 
     describe("scheduledTrigger", () => {
-      it("sets the default compute service account by default", async () => {
+      it("sets the default compute service account by default and preserves existing invokers", async () => {
         gcfv2.createFunction.resolves({ name: "op", done: false });
         poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
-        run.setInvokerCreate.resolves();
+        run.setInvokerUpdate.resolves();
         const ep = endpoint(
           { scheduleTrigger: { schedule: "every 5 minutes" } },
           { platform: "gcfv2" },
         );
 
         await fab.createV2Function(ep, new scraper.SourceTokenScraper());
-        expect(run.setInvokerCreate).to.have.been.calledWith(ep.project, "service", [
-          await gce.getDefaultServiceAccount(fab.projectNumber),
-        ]);
+        expect(run.setInvokerUpdate).to.have.been.calledWith(
+          ep.project,
+          "service",
+          [await gce.getDefaultServiceAccount(fab.projectNumber)],
+          { mergeExistingMembers: true },
+        );
       });
 
       it("sets the an explicit service account", async () => {
         gcfv2.createFunction.resolves({ name: "op", done: false });
         poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
-        run.setInvokerCreate.resolves();
+        run.setInvokerUpdate.resolves();
         const ep = endpoint(
           { scheduleTrigger: { schedule: "every 5 minutes" } },
           { platform: "gcfv2", serviceAccount: "sa@" },
         );
 
         await fab.createV2Function(ep, new scraper.SourceTokenScraper());
-        expect(run.setInvokerCreate).to.have.been.calledWith(ep.project, "service", ["sa@"]);
+        expect(run.setInvokerUpdate).to.have.been.calledWith(ep.project, "service", ["sa@"], {
+          mergeExistingMembers: true,
+        });
       });
     });
 
@@ -962,6 +967,21 @@ describe("Fabricator", () => {
 
       await fab.updateV2Function(ep, new scraper.SourceTokenScraper());
       expect(run.setInvokerUpdate).to.have.been.calledWith(ep.project, "service", ["public"]);
+    });
+
+    it("sets scheduler invoker and preserves existing invokers on scheduled functions", async () => {
+      gcfv2.updateFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerUpdate.resolves();
+      const ep = endpoint(
+        { scheduleTrigger: { schedule: "every 5 minutes" } },
+        { platform: "gcfv2", serviceAccount: "sa@" },
+      );
+
+      await fab.updateV2Function(ep, new scraper.SourceTokenScraper());
+      expect(run.setInvokerUpdate).to.have.been.calledWith(ep.project, "service", ["sa@"], {
+        mergeExistingMembers: true,
+      });
     });
 
     it("does not set invoker by default", async () => {

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -504,7 +504,11 @@ export class Fabricator {
         ? [endpoint.serviceAccount]
         : [await gce.getDefaultServiceAccount(this.projectNumber)];
       await this.executor
-        .run(() => run.setInvokerCreate(endpoint.project, serviceName, invoker))
+        .run(() =>
+          run.setInvokerUpdate(endpoint.project, serviceName, invoker, {
+            mergeExistingMembers: true,
+          }),
+        )
         .catch(rethrowAs(endpoint, "set invoker"));
     }
   }
@@ -623,8 +627,11 @@ export class Fabricator {
     }
 
     if (invoker) {
+      const invokerOptions = backend.isScheduleTriggered(endpoint)
+        ? { mergeExistingMembers: true }
+        : undefined;
       await this.executor
-        .run(() => run.setInvokerUpdate(endpoint.project, serviceName, invoker!))
+        .run(() => run.setInvokerUpdate(endpoint.project, serviceName, invoker!, invokerOptions))
         .catch(rethrowAs(endpoint, "set invoker"));
     }
   }

--- a/src/gcp/run.spec.ts
+++ b/src/gcp/run.spec.ts
@@ -136,7 +136,7 @@ describe("run", () => {
         apiGetStub.onFirstCall().throws("Error calling get api.");
 
         await expect(
-          run.setInvokerUpdate("project", "service", ["public"], client),
+          run.setInvokerUpdate("project", "service", ["public"], undefined, client),
         ).to.be.rejectedWith("Failed to get the IAM Policy on the Service service");
 
         expect(apiGetStub).to.be.called;
@@ -147,7 +147,7 @@ describe("run", () => {
         apiPostStub.throws("Error calling set api.");
 
         await expect(
-          run.setInvokerUpdate("project", "service", ["public"], client),
+          run.setInvokerUpdate("project", "service", ["public"], undefined, client),
         ).to.be.rejectedWith("Failed to set the IAM Policy on the Service service");
         expect(apiGetStub).to.be.calledOnce;
         expect(apiPostStub).to.be.calledOnce;
@@ -170,8 +170,8 @@ describe("run", () => {
           return Promise.resolve();
         });
 
-        await expect(run.setInvokerUpdate("project", "service", ["public"], client)).to.not.be
-          .rejected;
+        await expect(run.setInvokerUpdate("project", "service", ["public"], undefined, client)).to
+          .not.be.rejected;
         expect(apiGetStub).to.be.calledOnce;
         expect(apiPostStub).to.be.calledOnce;
       });
@@ -200,8 +200,8 @@ describe("run", () => {
           return Promise.resolve();
         });
 
-        await expect(run.setInvokerUpdate("project", "service", ["private"], client)).to.not.be
-          .rejected;
+        await expect(run.setInvokerUpdate("project", "service", ["private"], undefined, client)).to
+          .not.be.rejected;
         expect(apiGetStub).to.be.calledOnce;
         expect(apiPostStub).to.be.calledOnce;
       });
@@ -228,6 +228,51 @@ describe("run", () => {
               "service-account2@project.iam.gserviceaccount.com",
               "service-account3@",
             ],
+            undefined,
+            client,
+          ),
+        ).to.not.be.rejected;
+        expect(apiGetStub).to.be.calledOnce;
+        expect(apiPostStub).to.be.calledOnce;
+      });
+
+      it("should merge existing invoker members when requested", async () => {
+        apiGetStub.onFirstCall().resolves({
+          body: {
+            bindings: [
+              {
+                role: "roles/run.invoker",
+                members: ["serviceAccount:custom@project.iam.gserviceaccount.com"],
+              },
+              { role: "random-role", members: ["user:pineapple"] },
+            ],
+            etag: "1234",
+            version: 3,
+          },
+        });
+        apiPostStub.onFirstCall().callsFake((path: string, json: any) => {
+          const invokerBinding = json.policy.bindings.find(
+            (binding: any) => binding.role === "roles/run.invoker",
+          );
+          expect(invokerBinding.members.sort()).to.deep.eq([
+            "serviceAccount:custom@project.iam.gserviceaccount.com",
+            "serviceAccount:scheduler@project.iam.gserviceaccount.com",
+          ]);
+          expect(json.policy.bindings).to.deep.include({
+            role: "random-role",
+            members: ["user:pineapple"],
+          });
+          expect(json.policy.etag).to.equal("1234");
+
+          return Promise.resolve();
+        });
+
+        await expect(
+          run.setInvokerUpdate(
+            "project",
+            "service",
+            ["scheduler@"],
+            { mergeExistingMembers: true },
             client,
           ),
         ).to.not.be.rejected;
@@ -262,6 +307,7 @@ describe("run", () => {
               "service-account3@",
               "service-account1@",
             ],
+            undefined,
             client,
           ),
         ).to.not.be.rejected;

--- a/src/gcp/run.ts
+++ b/src/gcp/run.ts
@@ -303,6 +303,10 @@ export async function setInvokerCreate(
   await setIamPolicy(serviceName, policy, httpClient);
 }
 
+export interface InvokerUpdateOptions {
+  mergeExistingMembers?: boolean;
+}
+
 /**
  * Gets the current IAM policy for the run service and overrides the invoker role with the supplied invoker members
  * @param projectId id of the project
@@ -314,17 +318,21 @@ export async function setInvokerUpdate(
   projectId: string,
   serviceName: string,
   invoker: string[],
+  options: InvokerUpdateOptions = {},
   httpClient: Client = client, // for unit testing
 ) {
   if (invoker.length === 0) {
     throw new FirebaseError("Invoker cannot be an empty array");
   }
-  const invokerMembers = proto.getInvokerMembers(invoker, projectId);
+  const desiredInvokerMembers = proto.getInvokerMembers(invoker, projectId);
   const invokerRole = "roles/run.invoker";
   const currentPolicy = await getIamPolicy(serviceName, httpClient);
   const currentInvokerBinding = currentPolicy.bindings?.find(
     (binding) => binding.role === invokerRole,
   );
+  const invokerMembers = options.mergeExistingMembers
+    ? Array.from(new Set([...(currentInvokerBinding?.members || []), ...desiredInvokerMembers]))
+    : desiredInvokerMembers;
   if (
     currentInvokerBinding &&
     JSON.stringify(currentInvokerBinding.members.sort()) === JSON.stringify(invokerMembers.sort())


### PR DESCRIPTION
## **Summary**

Fixes https://github.com/firebase/firebase-tools/issues/6549

Scheduled GCFv2 functions currently **overwrite** the `roles/run.invoker` binding on Cloud Run during deploy. This causes externally added invoker members to be removed on create/update, even if the scheduler-required service account is still present.

This change ensures that scheduled GCFv2 deploys **preserve existing Cloud Run invoker members** by **merging** them with the required scheduler invoker, instead of replacing the binding outright.

---

## **What Changed**

- Added an optional **merge mode** to:
  ```ts
  src/gcp/run.ts -> setInvokerUpdate(...)
  ```

- Updated scheduled GCFv2 **create flow** in `src/deploy/functions/release/fabricator.ts`
  to use:
  ```ts
  setInvokerUpdate(..., { mergeExistingMembers: true })
  ```

- Updated scheduled GCFv2 **update flow** in the same file to pass the same merge option.

- Added helper-level test coverage in `src/gcp/run.spec.ts`

- Added deploy-layer test coverage in `src/deploy/functions/release/fabricator.spec.ts` for scheduled create/update call paths.

---

## **Why**

Before this change, scheduled GCFv2 deploys computed a single desired invoker:

- The function’s configured `serviceAccount`, **or**
- The default compute service account

This value was then written back as the full `roles/run.invoker` binding, which **removed any additional invoker members** added outside of Firebase.

### **Reproduction**

1. Deploy a scheduled GCFv2 function
2. Add an additional custom invoker member on the backing Cloud Run service
3. Re-deploy the function (or make a trivial update)
4. Observe that the custom invoker is removed

Further details of this reproduction can be seen [here](https://github.com/firebase/firebase-tools/issues/6549#issuecomment-4296806721)

---

## **Tests**

Added coverage for:

- ```ts
  run.setInvokerUpdate(..., { mergeExistingMembers: true })
  ```
  preserving existing invoker members

- Scheduled `createV2Function` using merge mode with:
  - default service account
  - explicit service account

- Scheduled `updateV2Function` using merge mode

---

## **Important Behavior Note**

This change is currently **unconditional** for scheduled GCFv2 functions. It does **not** consult or derive from the `preserveExternalChanges / preserve_external_changes` option. 

Instead, scheduled-function invoker updates now **always merge existing `roles/run.invoker` members by default**. This is intentional for this fix, but worth calling out explicitly.

---

## **Potential Follow-up**

A future improvement could thread a real `preserveExternalChanges` signal into this path, making the behavior **conditional** rather than always-on for scheduled GCFv2 functions.