### PR TITLE
Change default resource locations for functions

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -83,7 +83,7 @@ export const functionsV2Origin = () =>
   utils.envOverride("FIREBASE_FUNCTIONS_V2_URL", "https://cloudfunctions.googleapis.com");
 export const runOrigin = () => utils.envOverride("CLOUD_RUN_URL", "https://run.googleapis.com");
 export const functionsDefaultRegion = () =>
-  utils.envOverride("FIREBASE_FUNCTIONS_DEFAULT_REGION", "us-central1");
+  utils.envOverride("FIREBASE_FUNCTIONS_DEFAULT_REGION", "REGION_TBD");
 
 export const cloudbuildOrigin = () =>
   utils.envOverride("FIREBASE_CLOUDBUILD_URL", "https://cloudbuild.googleapis.com");

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -323,46 +323,68 @@ describe("prepare", () => {
       expect(want.endpoints["us-east1"]?.["onPublish"]).to.exist;
     });
 
-    it("resolves region for Firestore event triggers based on database location", async () => {
-      const wantE: backend.Endpoint = {
-        ...ENDPOINT_BASE,
-        id: "onDocumentCreate",
-        region: build.REGION_TBD,
-        eventTrigger: {
-          eventType: "google.cloud.firestore.document.v1.created",
-          eventFilters: { database: "(default)" },
-          retry: false,
-        },
-      };
-      const want = backend.of(wantE);
-      const have = backend.empty();
+    describe("Firestore event triggers", () => {
+      const testCases = [
+        { dbLocation: "nam5", expectedRegion: "us-central1" },
+        { dbLocation: "nam7", expectedRegion: "us-central1" },
+        { dbLocation: "eur3", expectedRegion: "europe-west1" },
+        { dbLocation: "asia-northeast1", expectedRegion: "asia-northeast1" },
+      ];
 
-      getDatabaseStub.resolves({ locationId: "nam5" });
+      testCases.forEach(({ dbLocation, expectedRegion }) => {
+        it(`should resolve ${expectedRegion} when database location is ${dbLocation}`, async () => {
+          const wantE: backend.Endpoint = {
+            ...ENDPOINT_BASE,
+            id: "onDocumentCreate",
+            region: build.REGION_TBD,
+            eventTrigger: {
+              eventType: "google.cloud.firestore.document.v1.created",
+              eventFilters: { database: "(default)" },
+              retry: false,
+            },
+          };
+          const want = backend.of(wantE);
+          const have = backend.empty();
 
-      await prepare.resolveDefaultRegions(want, have);
+          getDatabaseStub.resolves({ locationId: dbLocation });
 
-      expect(want.endpoints["us-central1"]?.["onDocumentCreate"]).to.exist;
+          await prepare.resolveDefaultRegions(want, have);
+
+          expect(want.endpoints[expectedRegion]?.["onDocumentCreate"]).to.exist;
+        });
+      });
     });
 
-    it("resolves region for Storage event triggers based on bucket location", async () => {
-      const wantE: backend.Endpoint = {
-        ...ENDPOINT_BASE,
-        id: "onArchive",
-        region: build.REGION_TBD,
-        eventTrigger: {
-          eventType: "google.cloud.storage.object.v1.archived",
-          eventFilters: { bucket: "my-bucket" },
-          retry: false,
-        },
-      };
-      const want = backend.of(wantE);
-      const have = backend.empty();
+    describe("Storage event triggers", () => {
+      const testCases = [
+        { bucketLocation: "us", expectedRegion: "us-east1" },
+        { bucketLocation: "eu", expectedRegion: "europe-west1" },
+        { bucketLocation: "asia", expectedRegion: "asia-east1" },
+        { bucketLocation: "us-central1", expectedRegion: "us-central1" },
+      ];
 
-      getBucketStub.resolves({ location: "us" });
+      testCases.forEach(({ bucketLocation, expectedRegion }) => {
+        it(`should resolve ${expectedRegion} when bucket location is ${bucketLocation}`, async () => {
+          const wantE: backend.Endpoint = {
+            ...ENDPOINT_BASE,
+            id: "onArchive",
+            region: build.REGION_TBD,
+            eventTrigger: {
+              eventType: "google.cloud.storage.object.v1.archived",
+              eventFilters: { bucket: "my-bucket" },
+              retry: false,
+            },
+          };
+          const want = backend.of(wantE);
+          const have = backend.empty();
 
-      await prepare.resolveDefaultRegions(want, have);
+          getBucketStub.resolves({ location: bucketLocation });
 
-      expect(want.endpoints["us-east1"]?.["onArchive"]).to.exist;
+          await prepare.resolveDefaultRegions(want, have);
+
+          expect(want.endpoints[expectedRegion]?.["onArchive"]).to.exist;
+        });
+      });
     });
 
     it("resolves region for Database event triggers based on instance location", async () => {

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -5,6 +5,9 @@ import * as prepare from "./prepare";
 import * as runtimes from "./runtimes";
 import * as backend from "./backend";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
+import * as firestoreService from "./services/firestore";
+import * as storageService from "./services/storage";
+import * as databaseService from "./services/database";
 import * as serviceusage from "../../gcp/serviceusage";
 import * as prompt from "../../prompt";
 import { RuntimeDelegate } from "./runtimes";
@@ -234,6 +237,22 @@ describe("prepare", () => {
   });
 
   describe("resolveDefaultRegions", () => {
+    let sandbox: sinon.SinonSandbox;
+    let getDatabaseStub: sinon.SinonStub;
+    let getBucketStub: sinon.SinonStub;
+    let getDatabaseInstanceDetailsStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      getDatabaseStub = sandbox.stub(firestoreService, "getDatabase");
+      getBucketStub = sandbox.stub(storageService, "getBucket");
+      getDatabaseInstanceDetailsStub = sandbox.stub(databaseService, "getDatabaseInstanceDetails");
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
     it("does nothing if no endpoints in REGION_TBD", async () => {
       const want = backend.empty();
       const have = backend.empty();
@@ -302,6 +321,69 @@ describe("prepare", () => {
       await prepare.resolveDefaultRegions(want, have);
 
       expect(want.endpoints["us-east1"]?.["onPublish"]).to.exist;
+    });
+
+    it("resolves region for Firestore event triggers based on database location", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "onDocumentCreate",
+        region: build.REGION_TBD,
+        eventTrigger: {
+          eventType: "google.cloud.firestore.document.v1.created",
+          eventFilters: { database: "(default)" },
+          retry: false,
+        },
+      };
+      const want = backend.of(wantE);
+      const have = backend.empty();
+
+      getDatabaseStub.resolves({ locationId: "nam5" });
+
+      await prepare.resolveDefaultRegions(want, have);
+
+      expect(want.endpoints["us-central1"]?.["onDocumentCreate"]).to.exist;
+    });
+
+    it("resolves region for Storage event triggers based on bucket location", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "onArchive",
+        region: build.REGION_TBD,
+        eventTrigger: {
+          eventType: "google.cloud.storage.object.v1.archived",
+          eventFilters: { bucket: "my-bucket" },
+          retry: false,
+        },
+      };
+      const want = backend.of(wantE);
+      const have = backend.empty();
+
+      getBucketStub.resolves({ location: "us" });
+
+      await prepare.resolveDefaultRegions(want, have);
+
+      expect(want.endpoints["us-east1"]?.["onArchive"]).to.exist;
+    });
+
+    it("resolves region for Database event triggers based on instance location", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "onWrite",
+        region: build.REGION_TBD,
+        eventTrigger: {
+          eventType: "google.firebase.database.ref.v1.written",
+          eventFilters: { instance: "my-instance" },
+          retry: false,
+        },
+      };
+      const want = backend.of(wantE);
+      const have = backend.empty();
+
+      getDatabaseInstanceDetailsStub.resolves({ location: "europe-west1" });
+
+      await prepare.resolveDefaultRegions(want, have);
+
+      expect(want.endpoints["europe-west1"]?.["onWrite"]).to.exist;
     });
 
     it("does not infer region from have backend if it belongs to a different codebase", async () => {

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -408,6 +408,49 @@ describe("prepare", () => {
       expect(want.endpoints["europe-west1"]?.["onWrite"]).to.exist;
     });
 
+    it("resolves region for DataConnect event triggers based on service location", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "onMutationExecuted",
+        region: build.REGION_TBD,
+        eventTrigger: {
+          eventType: "google.firebase.dataconnect.connector.v1.mutationExecuted",
+          eventFilters: {
+            service: "projects/project/locations/europe-west1/services/my-service",
+          },
+          retry: false,
+        },
+      };
+      const want = backend.of(wantE);
+      const have = backend.empty();
+
+      await prepare.resolveDefaultRegions(want, have);
+
+      expect(want.endpoints["europe-west1"]?.["onMutationExecuted"]).to.exist;
+    });
+
+    it("resolves region for DataConnect event triggers based on connector location", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "onMutationExecutedConnector",
+        region: build.REGION_TBD,
+        eventTrigger: {
+          eventType: "google.firebase.dataconnect.connector.v1.mutationExecuted",
+          eventFilters: {
+            connector:
+              "projects/project/locations/europe-west2/services/my-service/connectors/my-connector",
+          },
+          retry: false,
+        },
+      };
+      const want = backend.of(wantE);
+      const have = backend.empty();
+
+      await prepare.resolveDefaultRegions(want, have);
+
+      expect(want.endpoints["europe-west2"]?.["onMutationExecutedConnector"]).to.exist;
+    });
+
     it("does not infer region from have backend if it belongs to a different codebase", async () => {
       const wantE = { ...ENDPOINT, region: build.REGION_TBD, codebase: "codebaseA" };
       const want = backend.of(wantE);

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -269,16 +269,39 @@ describe("prepare", () => {
       );
     });
 
-    it("falls back to us-central1 if not found in have", async () => {
-      const wantE = { ...ENDPOINT, region: build.REGION_TBD };
+    it("resolves us-east1 for global resource blocking triggers", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "beforeCreate",
+        region: build.REGION_TBD,
+        blockingTrigger: {
+          eventType: "providers/cloud.auth/eventTypes/user.beforeCreate",
+        },
+      };
       const want = backend.of(wantE);
       const have = backend.empty();
 
       await prepare.resolveDefaultRegions(want, have);
 
-      expect(want.endpoints["us-central1"]?.["id"]).to.exist;
-      expect(want.endpoints["us-central1"]?.["id"].region).to.equal("us-central1");
-      expect(want.endpoints[build.REGION_TBD]).to.not.exist;
+      expect(want.endpoints["us-east1"]?.["beforeCreate"]).to.exist;
+    });
+
+    it("resolves us-east1 for global event triggers", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "onPublish",
+        region: build.REGION_TBD,
+        eventTrigger: {
+          eventType: "google.cloud.pubsub.topic.v1.messagePublished",
+          retry: false,
+        },
+      };
+      const want = backend.of(wantE);
+      const have = backend.empty();
+
+      await prepare.resolveDefaultRegions(want, have);
+
+      expect(want.endpoints["us-east1"]?.["onPublish"]).to.exist;
     });
 
     it("does not infer region from have backend if it belongs to a different codebase", async () => {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -12,6 +12,7 @@ import * as runtimes from "./runtimes";
 import * as supported from "./runtimes/supported";
 import * as validate from "./validate";
 import * as ensure from "./ensure";
+import * as events from "../../functions/events/v1";
 import { getDatabase } from "./services/firestore";
 import { getBucket } from "./services/storage";
 import { getDatabaseInstanceDetails } from "./services/database";
@@ -42,7 +43,8 @@ import { needProjectId, needProjectNumber } from "../../projectUtils";
 import { logger } from "../../logger";
 import { ensureTriggerRegions } from "./triggerRegionHelper";
 import { ensureServiceAgentRoles, ensureGenkitMonitoringRoles } from "./checkIam";
-import { FirebaseError } from "../../error";
+import { FirebaseError, getErrStack } from "../../error";
+
 import {
   configForCodebase,
   normalizeAndValidate,
@@ -61,6 +63,7 @@ import { DeployOptions } from "..";
 import * as prompt from "../../prompt";
 
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
+export const DEFAULT_FUNCTION_REGION = "us-central1";
 
 /**
  * Prepare functions codebases for deploy.
@@ -405,7 +408,7 @@ export async function resolveDefaultRegions(
 
   const endpoints = Object.values(want.endpoints[build.REGION_TBD] || {});
 
-  const resolvedEndpoints = await Promise.all(
+  await Promise.all(
     endpoints.map(async (endpoint) => {
       let resolvedRegion = "us-central1";
 
@@ -418,27 +421,20 @@ export async function resolveDefaultRegions(
       } catch (err: any) {
         logger.debug(
           `Failed to resolve region for endpoint ${endpoint.id}. Defaulting to us-central1.`,
-          err,
+          getErrStack(err),
         );
       }
 
-      return { endpoint, resolvedRegion };
+      moveEndpointToRegion(want, endpoint, resolvedRegion);
     }),
   );
-
-  for (const { endpoint, resolvedRegion } of resolvedEndpoints) {
-    moveEndpointToRegion(want, endpoint, resolvedRegion);
-  }
 }
 
 function resolveRegionForBlockingTrigger(
   endpoint: backend.Endpoint & backend.BlockingTriggered,
 ): string {
   const eventType = endpoint.blockingTrigger.eventType;
-  if (
-    eventType === "providers/cloud.auth/eventTypes/user.beforeCreate" ||
-    eventType === "providers/cloud.auth/eventTypes/user.beforeSignIn"
-  ) {
+  if (eventType === events.BEFORE_CREATE_EVENT || eventType === events.BEFORE_SIGN_IN_EVENT) {
     return "us-east1";
   }
 
@@ -446,7 +442,7 @@ function resolveRegionForBlockingTrigger(
     return "us-east1";
   }
 
-  return "us-central1";
+  return DEFAULT_FUNCTION_REGION;
 }
 
 async function resolveRegionForEventTrigger(
@@ -455,6 +451,7 @@ async function resolveRegionForEventTrigger(
   const eventTrigger = endpoint.eventTrigger;
   const eventType = eventTrigger.eventType;
 
+  // Global functions should be deployed to us-east1.
   if (
     eventType.startsWith("google.cloud.pubsub.") ||
     eventType.startsWith("providers/cloud.auth/eventTypes/") ||
@@ -466,6 +463,11 @@ async function resolveRegionForEventTrigger(
     return "us-east1";
   }
 
+  // Firestore functions should be deployed to the same region as the database.
+  // In multi-region locations, we default to:
+  // * nam5 -> us-central1
+  // * nam7 -> us-central1
+  // * eur3 -> europe-west1
   if (eventType.startsWith("google.cloud.firestore.")) {
     try {
       const databaseId = eventTrigger.eventFilters?.database || "(default)";
@@ -476,10 +478,15 @@ async function resolveRegionForEventTrigger(
       if (locationId === "eur3") return "europe-west1";
       return locationId;
     } catch (err: any) {
-      logger.debug("Failed to resolve Firestore database location", err);
+      logger.debug("Failed to resolve Firestore database location", getErrStack(err));
     }
   }
 
+  // Cloud Storage functions should be deployed to the same region as the bucket.
+  // In multi-region locations, we default to:
+  // * us -> us-east1
+  // * eu -> europe-west1
+  // * asia -> asia-east1
   if (eventType.startsWith("google.cloud.storage.")) {
     try {
       const bucketName = eventTrigger.eventFilters?.bucket;
@@ -493,10 +500,11 @@ async function resolveRegionForEventTrigger(
         return locationId;
       }
     } catch (err: any) {
-      logger.debug("Failed to resolve Cloud Storage bucket location", err);
+      logger.debug("Failed to resolve Cloud Storage bucket location", getErrStack(err));
     }
   }
 
+  // Realtime Database functions should be deployed to the same region as the database.
   if (eventType.startsWith("google.firebase.database.")) {
     if (eventTrigger.region) return eventTrigger.region;
 
@@ -509,15 +517,16 @@ async function resolveRegionForEventTrigger(
         }
       }
     } catch (err: any) {
-      logger.debug("Failed to resolve Realtime Database instance location", err);
+      logger.debug("Failed to resolve Realtime Database instance location", getErrStack(err));
     }
   }
 
+  // DataConnect functions should be deployed to the same region as the database.
   if (eventType.startsWith("google.firebase.dataconnect.")) {
     if (eventTrigger.region) return eventTrigger.region;
   }
 
-  return "us-central1";
+  return DEFAULT_FUNCTION_REGION;
 }
 
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -409,7 +409,7 @@ export async function resolveDefaultRegions(
 
     if (backend.isBlockingTriggered(endpoint)) {
       // Set region for blocking functions to us-east1. This includes:
-      // - Auth blocking functions
+      // - Auth blocking functions (beforeCreate, beforeSignIn)
       // - Global AI Logic functions
       const eventType = endpoint.blockingTrigger.eventType;
       if (
@@ -677,11 +677,11 @@ export async function loadCodebases(
     if (firebaseJsonRuntime && !supported.isRuntime(firebaseJsonRuntime as string)) {
       throw new FirebaseError(
         `Functions codebase ${codebase} has invalid runtime ` +
-          `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
-          (Object.keys(supported.RUNTIMES) as supported.Runtime[])
-            .filter((runtime) => !supported.isDecommissioned(runtime))
-            .map((s) => `- ${s}`)
-            .join("\n"),
+        `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
+        (Object.keys(supported.RUNTIMES) as supported.Runtime[])
+          .filter((runtime) => !supported.isDecommissioned(runtime))
+          .map((s) => `- ${s}`)
+          .join("\n"),
       );
     }
     const runtimeDelegate = await runtimes.getRuntimeDelegate(delegateContext);
@@ -734,8 +734,8 @@ function warnIfDartBackendHasUnsupportedTriggers(want: backend.Backend): void {
     logLabeledWarning(
       "functions",
       `The following Dart functions use triggers that are not yet supported for production deployment: ${unsupported.map((ep) => ep.id).join(", ")}. ` +
-        "They will be deployed but may not work as expected. " +
-        "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
+      "They will be deployed but may not work as expected. " +
+      "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
     );
   }
 }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -459,6 +459,7 @@ async function resolveRegionForEventTrigger(
   if (
     eventType === v2Events.PUBSUB_PUBLISH_EVENT ||
     eventType.startsWith("providers/cloud.auth/eventTypes/") ||
+    eventType.startsWith("providers/firebase.auth/eventTypes/") || 
     eventType.startsWith("google.firebase.testlab.") ||
     eventType.startsWith("google.firebase.remoteconfig.") ||
     eventType.startsWith("google.firebase.firebasealerts.")

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -409,33 +409,31 @@ export async function resolveDefaultRegions(
 
   const endpoints = Object.values(want.endpoints[build.REGION_TBD] || {});
 
-  await Promise.all(
-    endpoints.map(async (endpoint) => {
-      let resolvedRegion = "us-central1";
+  for (const endpoint of endpoints) {
+    let resolvedRegion = "us-central1";
 
-      try {
-        if (backend.isBlockingTriggered(endpoint)) {
-          resolvedRegion = resolveRegionForBlockingTrigger(endpoint);
-        } else if (backend.isEventTriggered(endpoint)) {
-          resolvedRegion = await resolveRegionForEventTrigger(endpoint);
-        }
-      } catch (err: any) {
-        logger.debug(
-          `Failed to resolve region for endpoint ${endpoint.id}. Defaulting to us-central1.`,
-          getErrStack(err),
-        );
+    try {
+      if (backend.isBlockingTriggered(endpoint)) {
+        resolvedRegion = resolveRegionForBlockingTrigger(endpoint);
+      } else if (backend.isEventTriggered(endpoint)) {
+        resolvedRegion = await resolveRegionForEventTrigger(endpoint);
       }
+    } catch (err: any) {
+      logger.debug(
+        `Failed to resolve region for endpoint ${endpoint.id}. Defaulting to us-central1.`,
+        getErrStack(err),
+      );
+    }
 
-      moveEndpointToRegion(want, endpoint, resolvedRegion);
-    }),
-  );
+    moveEndpointToRegion(want, endpoint, resolvedRegion);
+  }
 }
 
 function resolveRegionForBlockingTrigger(
   endpoint: backend.Endpoint & backend.BlockingTriggered,
 ): string {
   const eventType = endpoint.blockingTrigger.eventType;
-  if (eventType === events.BEFORE_CREATE_EVENT || eventType === events.BEFORE_SIGN_IN_EVENT) {
+  if ((events.AUTH_BLOCKING_EVENTS as readonly string[]).includes(eventType)) {
     return "us-east1";
   }
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -458,7 +458,7 @@ async function resolveRegionForEventTrigger(
   if (
     eventType.startsWith("google.cloud.pubsub.") ||
     eventType.startsWith("providers/cloud.auth/eventTypes/") ||
-    eventType.startsWith("providers/firebase.auth/eventTypes/") || 
+    eventType.startsWith("providers/firebase.auth/eventTypes/") ||
     eventType.startsWith("google.firebase.testlab.") ||
     eventType.startsWith("google.firebase.remoteconfig.") ||
     eventType.startsWith("google.firebase.firebasealerts.")

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -17,6 +17,7 @@ import { getDatabase } from "./services/firestore";
 import { getBucket } from "./services/storage";
 import { getDatabaseInstanceDetails } from "./services/database";
 import { isGlobalAILogicEndpoint } from "./services/ailogic";
+import { parseServiceName, parseConnectorName } from "../../dataconnect/names";
 import {
   functionsOrigin,
   artifactRegistryDomain,
@@ -521,9 +522,23 @@ async function resolveRegionForEventTrigger(
     }
   }
 
-  // DataConnect functions should be deployed to the same region as the database.
+  // DataConnect functions should be deployed to the same region as the service or connector.
   if (eventType.startsWith("google.firebase.dataconnect.")) {
     if (eventTrigger.region) return eventTrigger.region;
+
+    try {
+      const service = eventTrigger.eventFilters?.service;
+      if (service) {
+        return parseServiceName(service).location;
+      }
+
+      const connector = eventTrigger.eventFilters?.connector;
+      if (connector) {
+        return parseConnectorName(connector).location;
+      }
+    } catch (err: any) {
+      logger.debug("Failed to resolve DataConnect location", getErrStack(err));
+    }
   }
 
   return DEFAULT_FUNCTION_REGION;

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -12,7 +12,6 @@ import * as runtimes from "./runtimes";
 import * as supported from "./runtimes/supported";
 import * as validate from "./validate";
 import * as ensure from "./ensure";
-import * as storage from "../../gcp/storage";
 import { getDatabase } from "./services/firestore";
 import { getBucket } from "./services/storage";
 import { getDatabaseInstanceDetails } from "./services/database";

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -14,7 +14,8 @@ import * as validate from "./validate";
 import * as ensure from "./ensure";
 import * as storage from "../../gcp/storage";
 import { getDatabase } from "./services/firestore";
-import { getDatabaseInstanceDetails } from "../../management/database";
+import { getBucket } from "./services/storage";
+import { getDatabaseInstanceDetails } from "./services/database";
 import { v2 as v2Events } from "../../functions/events";
 import { isGlobalAILogicEndpoint } from "./services/ailogic";
 import {
@@ -484,7 +485,7 @@ async function resolveRegionForEventTrigger(
     try {
       const bucketName = eventTrigger.eventFilters?.bucket;
       if (bucketName) {
-        const bucket = await storage.getBucket(bucketName);
+        const bucket = await getBucket(bucketName);
         const locationId = bucket.location.toLowerCase();
 
         if (locationId === "us") return "us-east1";

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -677,11 +677,11 @@ export async function loadCodebases(
     if (firebaseJsonRuntime && !supported.isRuntime(firebaseJsonRuntime as string)) {
       throw new FirebaseError(
         `Functions codebase ${codebase} has invalid runtime ` +
-        `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
-        (Object.keys(supported.RUNTIMES) as supported.Runtime[])
-          .filter((runtime) => !supported.isDecommissioned(runtime))
-          .map((s) => `- ${s}`)
-          .join("\n"),
+          `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
+          (Object.keys(supported.RUNTIMES) as supported.Runtime[])
+            .filter((runtime) => !supported.isDecommissioned(runtime))
+            .map((s) => `- ${s}`)
+            .join("\n"),
       );
     }
     const runtimeDelegate = await runtimes.getRuntimeDelegate(delegateContext);
@@ -734,8 +734,8 @@ function warnIfDartBackendHasUnsupportedTriggers(want: backend.Backend): void {
     logLabeledWarning(
       "functions",
       `The following Dart functions use triggers that are not yet supported for production deployment: ${unsupported.map((ep) => ep.id).join(", ")}. ` +
-      "They will be deployed but may not work as expected. " +
-      "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
+        "They will be deployed but may not work as expected. " +
+        "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
     );
   }
 }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -522,7 +522,7 @@ async function resolveRegionForEventTrigger(
     }
   }
 
-  // DataConnect functions should be deployed to the same region as the service or connector.
+  // DataConnect functions should be deployed to the same region as the service.
   if (eventType.startsWith("google.firebase.dataconnect.")) {
     if (eventTrigger.region) return eventTrigger.region;
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -404,105 +404,120 @@ export async function resolveDefaultRegions(
 ): Promise<void> {
   matchRegionsForExisting(want, have);
 
-  for (const endpoint of Object.values(want.endpoints[build.REGION_TBD] || {})) {
-    let resolvedRegion = "us-central1";
+  const endpoints = Object.values(want.endpoints[build.REGION_TBD] || {});
 
-    if (backend.isBlockingTriggered(endpoint)) {
-      // Set region for blocking functions to us-east1. This includes:
-      // - Auth blocking functions (beforeCreate, beforeSignIn)
-      // - Global AI Logic functions
-      const eventType = endpoint.blockingTrigger.eventType;
-      if (
-        eventType === "providers/cloud.auth/eventTypes/user.beforeCreate" ||
-        eventType === "providers/cloud.auth/eventTypes/user.beforeSignIn"
-      ) {
-        resolvedRegion = "us-east1";
-      } else if (isGlobalAILogicEndpoint(endpoint)) {
-        resolvedRegion = "us-east1";
+  const resolvedEndpoints = await Promise.all(
+    endpoints.map(async (endpoint) => {
+      let resolvedRegion = "us-central1";
+
+      try {
+        if (backend.isBlockingTriggered(endpoint)) {
+          resolvedRegion = resolveRegionForBlockingTrigger(endpoint);
+        } else if (backend.isEventTriggered(endpoint)) {
+          resolvedRegion = await resolveRegionForEventTrigger(endpoint);
+        }
+      } catch (err: any) {
+        logger.debug(
+          `Failed to resolve region for endpoint ${endpoint.id}. Defaulting to us-central1.`,
+          err,
+        );
       }
-    } else if (backend.isEventTriggered(endpoint)) {
-      // Set region for global event triggered functions to us-east1. This includes:
-      // - Pub/Sub publish events
-      // - Auth events
-      // - Test Lab events
-      // - Remote Config events
-      // - Firebase Alerts events
-      const eventTrigger = endpoint.eventTrigger;
-      const eventType = eventTrigger.eventType;
 
-      if (
-        eventType === v2Events.PUBSUB_PUBLISH_EVENT ||
-        eventType.startsWith("providers/cloud.auth/eventTypes/") ||
-        eventType.startsWith("google.firebase.testlab.") ||
-        eventType.startsWith("google.firebase.remoteconfig.") ||
-        eventType.startsWith("google.firebase.firebasealerts.")
-      ) {
-        resolvedRegion = "us-east1";
-      } else if (eventType.startsWith("google.cloud.firestore.")) {
-        // Set region for Firestore events based on database location, or to the
-        // nearest single-region location if the database is multi-regional.
-        try {
-          const databaseId = eventTrigger.eventFilters?.database || "(default)";
-          const db = await getDatabase(endpoint.project, databaseId);
-          const locationId = db.locationId.toLowerCase();
-          if (locationId === "nam5" || locationId === "nam7") {
-            resolvedRegion = "us-central1";
-          } else if (locationId === "eur3") {
-            resolvedRegion = "europe-west1";
-          } else {
-            resolvedRegion = locationId;
-          }
-        } catch (err: any) {
-          logger.debug("Failed to resolve Firestore database location", err);
-        }
-      } else if (eventType.startsWith("google.cloud.storage.")) {
-        // Set region for Cloud Storage events based on bucket location, or to the
-        // nearest single-region location if the bucket is multi-regional.
-        try {
-          const bucketName = eventTrigger.eventFilters?.bucket;
-          if (bucketName) {
-            const bucket = await storage.getBucket(bucketName);
-            const locationId = bucket.location.toLowerCase();
-            if (locationId === "us") {
-              resolvedRegion = "us-east1";
-            } else if (locationId === "eu") {
-              resolvedRegion = "europe-west1";
-            } else if (locationId === "asia") {
-              resolvedRegion = "asia-east1";
-            } else {
-              resolvedRegion = locationId;
-            }
-          }
-        } catch (err: any) {
-          logger.debug("Failed to resolve Cloud Storage bucket location", err);
-        }
-      } else if (eventType.startsWith("google.firebase.database.")) {
-        // Set region for Realtime Database events based on instance location.
-        if (eventTrigger.region) {
-          resolvedRegion = eventTrigger.region;
-        } else {
-          try {
-            const instanceName = eventTrigger.eventFilters?.instance;
-            if (instanceName) {
-              const details = await getDatabaseInstanceDetails(endpoint.project, instanceName);
-              if (details.location && details.location !== "-") {
-                resolvedRegion = details.location.toLowerCase();
-              }
-            }
-          } catch (err: any) {
-            logger.debug("Failed to resolve Realtime Database instance location", err);
-          }
-        }
-      } else if (eventType.startsWith("google.firebase.dataconnect.")) {
-        // Set region for DataConnect events based on instance location.
-        if (eventTrigger.region) {
-          resolvedRegion = eventTrigger.region;
-        }
-      }
-    }
+      return { endpoint, resolvedRegion };
+    }),
+  );
 
+  for (const { endpoint, resolvedRegion } of resolvedEndpoints) {
     moveEndpointToRegion(want, endpoint, resolvedRegion);
   }
+}
+
+function resolveRegionForBlockingTrigger(
+  endpoint: backend.Endpoint & backend.BlockingTriggered,
+): string {
+  const eventType = endpoint.blockingTrigger.eventType;
+  if (
+    eventType === "providers/cloud.auth/eventTypes/user.beforeCreate" ||
+    eventType === "providers/cloud.auth/eventTypes/user.beforeSignIn"
+  ) {
+    return "us-east1";
+  }
+
+  if (isGlobalAILogicEndpoint(endpoint)) {
+    return "us-east1";
+  }
+
+  return "us-central1";
+}
+
+async function resolveRegionForEventTrigger(
+  endpoint: backend.Endpoint & backend.EventTriggered,
+): Promise<string> {
+  const eventTrigger = endpoint.eventTrigger;
+  const eventType = eventTrigger.eventType;
+
+  if (
+    eventType === v2Events.PUBSUB_PUBLISH_EVENT ||
+    eventType.startsWith("providers/cloud.auth/eventTypes/") ||
+    eventType.startsWith("google.firebase.testlab.") ||
+    eventType.startsWith("google.firebase.remoteconfig.") ||
+    eventType.startsWith("google.firebase.firebasealerts.")
+  ) {
+    return "us-east1";
+  }
+
+  if (eventType.startsWith("google.cloud.firestore.")) {
+    try {
+      const databaseId = eventTrigger.eventFilters?.database || "(default)";
+      const db = await getDatabase(endpoint.project, databaseId);
+      const locationId = db.locationId.toLowerCase();
+
+      if (locationId === "nam5" || locationId === "nam7") return "us-central1";
+      if (locationId === "eur3") return "europe-west1";
+      return locationId;
+    } catch (err: any) {
+      logger.debug("Failed to resolve Firestore database location", err);
+    }
+  }
+
+  if (eventType.startsWith("google.cloud.storage.")) {
+    try {
+      const bucketName = eventTrigger.eventFilters?.bucket;
+      if (bucketName) {
+        const bucket = await storage.getBucket(bucketName);
+        const locationId = bucket.location.toLowerCase();
+
+        if (locationId === "us") return "us-east1";
+        if (locationId === "eu") return "europe-west1";
+        if (locationId === "asia") return "asia-east1";
+        return locationId;
+      }
+    } catch (err: any) {
+      logger.debug("Failed to resolve Cloud Storage bucket location", err);
+    }
+  }
+
+  if (eventType.startsWith("google.firebase.database.")) {
+    if (eventTrigger.region) return eventTrigger.region;
+
+    try {
+      const instanceName = eventTrigger.eventFilters?.instance;
+      if (instanceName) {
+        const details = await getDatabaseInstanceDetails(endpoint.project, instanceName);
+        if (details.location && details.location !== "-") {
+          return details.location.toLowerCase();
+        }
+      }
+    } catch (err: any) {
+      logger.debug("Failed to resolve Realtime Database instance location", err);
+    }
+  }
+
+  if (eventType.startsWith("google.firebase.dataconnect.")) {
+    if (eventTrigger.region) return eventTrigger.region;
+  }
+
+  return "us-central1";
 }
 
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -15,7 +15,6 @@ import * as ensure from "./ensure";
 import { getDatabase } from "./services/firestore";
 import { getBucket } from "./services/storage";
 import { getDatabaseInstanceDetails } from "./services/database";
-import { v2 as v2Events } from "../../functions/events";
 import { isGlobalAILogicEndpoint } from "./services/ailogic";
 import {
   functionsOrigin,
@@ -457,7 +456,7 @@ async function resolveRegionForEventTrigger(
   const eventType = eventTrigger.eventType;
 
   if (
-    eventType === v2Events.PUBSUB_PUBLISH_EVENT ||
+    eventType.startsWith("google.cloud.pubsub.") ||
     eventType.startsWith("providers/cloud.auth/eventTypes/") ||
     eventType.startsWith("providers/firebase.auth/eventTypes/") || 
     eventType.startsWith("google.firebase.testlab.") ||

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -12,6 +12,11 @@ import * as runtimes from "./runtimes";
 import * as supported from "./runtimes/supported";
 import * as validate from "./validate";
 import * as ensure from "./ensure";
+import * as storage from "../../gcp/storage";
+import { getDatabase } from "./services/firestore";
+import { getDatabaseInstanceDetails } from "../../management/database";
+import { v2 as v2Events } from "../../functions/events";
+import { isGlobalAILogicEndpoint } from "./services/ailogic";
 import {
   functionsOrigin,
   artifactRegistryDomain,
@@ -400,20 +405,103 @@ export async function resolveDefaultRegions(
   matchRegionsForExisting(want, have);
 
   for (const endpoint of Object.values(want.endpoints[build.REGION_TBD] || {})) {
-    // TODO: Start adding dynamic region support per event type to distribute away from us-central1.
-    // Other regions have faster cold start times and will give a better customer experience. Ideas:
-    // 1. NAM5 resources can be put in us-east1 instead.
-    // 2. Regional resources can be placed in that region instead of assuming us-central1 (which is
-    //    the right behavior anyway and only works through legacy support in GCF). E.g. Put the storage
-    //    function in the storage bucket's region. Then we can nudge people to not have us-central1
-    //    be the default.
-    // 3. Functions that have a global resource (e.g. Auth, Test Lab, Pub/Sub, etc.) can be placed in
-    //    a region with higher headroom.
-    // 4. HTTP functions may be defaultable to a different region because it is up to the customer to
-    //    wire up the URL we give them irrespective.
-    // 5. Callable functions could be moved by default, though this will require breaking changes to
-    //    the client SDKs as well.
-    moveEndpointToRegion(want, endpoint, "us-central1");
+    let resolvedRegion = "us-central1";
+
+    if (backend.isBlockingTriggered(endpoint)) {
+      // Set region for blocking functions to us-east1. This includes:
+      // - Auth blocking functions
+      // - Global AI Logic functions
+      const eventType = endpoint.blockingTrigger.eventType;
+      if (
+        eventType === "providers/cloud.auth/eventTypes/user.beforeCreate" ||
+        eventType === "providers/cloud.auth/eventTypes/user.beforeSignIn"
+      ) {
+        resolvedRegion = "us-east1";
+      } else if (isGlobalAILogicEndpoint(endpoint)) {
+        resolvedRegion = "us-east1";
+      }
+    } else if (backend.isEventTriggered(endpoint)) {
+      // Set region for global event triggered functions to us-east1. This includes:
+      // - Pub/Sub publish events
+      // - Auth events
+      // - Test Lab events
+      // - Remote Config events
+      // - Firebase Alerts events
+      const eventTrigger = endpoint.eventTrigger;
+      const eventType = eventTrigger.eventType;
+
+      if (
+        eventType === v2Events.PUBSUB_PUBLISH_EVENT ||
+        eventType.startsWith("providers/cloud.auth/eventTypes/") ||
+        eventType.startsWith("google.firebase.testlab.") ||
+        eventType.startsWith("google.firebase.remoteconfig.") ||
+        eventType.startsWith("google.firebase.firebasealerts.")
+      ) {
+        resolvedRegion = "us-east1";
+      } else if (eventType.startsWith("google.cloud.firestore.")) {
+        // Set region for Firestore events based on database location, or to the
+        // nearest single-region location if the database is multi-regional.
+        try {
+          const databaseId = eventTrigger.eventFilters?.database || "(default)";
+          const db = await getDatabase(endpoint.project, databaseId);
+          const locationId = db.locationId.toLowerCase();
+          if (locationId === "nam5" || locationId === "nam7") {
+            resolvedRegion = "us-central1";
+          } else if (locationId === "eur3") {
+            resolvedRegion = "europe-west1";
+          } else {
+            resolvedRegion = locationId;
+          }
+        } catch (err: any) {
+          logger.debug("Failed to resolve Firestore database location", err);
+        }
+      } else if (eventType.startsWith("google.cloud.storage.")) {
+        // Set region for Cloud Storage events based on bucket location, or to the
+        // nearest single-region location if the bucket is multi-regional.
+        try {
+          const bucketName = eventTrigger.eventFilters?.bucket;
+          if (bucketName) {
+            const bucket = await storage.getBucket(bucketName);
+            const locationId = bucket.location.toLowerCase();
+            if (locationId === "us") {
+              resolvedRegion = "us-east1";
+            } else if (locationId === "eu") {
+              resolvedRegion = "europe-west1";
+            } else if (locationId === "asia") {
+              resolvedRegion = "asia-east1";
+            } else {
+              resolvedRegion = locationId;
+            }
+          }
+        } catch (err: any) {
+          logger.debug("Failed to resolve Cloud Storage bucket location", err);
+        }
+      } else if (eventType.startsWith("google.firebase.database.")) {
+        // Set region for Realtime Database events based on instance location.
+        if (eventTrigger.region) {
+          resolvedRegion = eventTrigger.region;
+        } else {
+          try {
+            const instanceName = eventTrigger.eventFilters?.instance;
+            if (instanceName) {
+              const details = await getDatabaseInstanceDetails(endpoint.project, instanceName);
+              if (details.location && details.location !== "-") {
+                resolvedRegion = details.location.toLowerCase();
+              }
+            }
+          } catch (err: any) {
+            logger.debug("Failed to resolve Realtime Database instance location", err);
+          }
+        }
+      } else if (eventType.startsWith("google.firebase.dataconnect.")) {
+        // Set region for DataConnect events based on instance location.
+        if (eventTrigger.region) {
+          resolvedRegion = eventTrigger.region;
+        }
+      }
+    }
+
+    moveEndpointToRegion(want, endpoint, resolvedRegion);
   }
 }
 

--- a/src/deploy/functions/services/ailogic.ts
+++ b/src/deploy/functions/services/ailogic.ts
@@ -32,6 +32,13 @@ export function isAILogicEvent(endpoint: backend.Endpoint): endpoint is AILogicE
   );
 }
 
+export function isGlobalAILogicEndpoint(endpoint: backend.Endpoint): boolean {
+  if (!isAILogicEvent(endpoint)) {
+    return false;
+  }
+  return !endpoint.blockingTrigger.options?.regionalWebhook;
+}
+
 export class AILogicService implements Service {
   name: Name;
   api: string;

--- a/src/deploy/functions/services/database.spec.ts
+++ b/src/deploy/functions/services/database.spec.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai";
+import * as sinon from "sinon";
 import { Endpoint } from "../backend";
 import * as database from "./database";
+import * as databaseManagement from "../../../management/database";
 
 const projectNumber = "123456789";
 
@@ -19,30 +21,71 @@ const endpoint: Endpoint = {
   runtime: "nodejs16",
 };
 
-describe("ensureDatabaseTriggerRegion", () => {
-  it("should set the trigger location to the function region", async () => {
-    const ep = { ...endpoint };
-
-    await database.ensureDatabaseTriggerRegion(ep);
-
-    expect(ep.eventTrigger.region).to.eq("us-central1");
+describe("database service", () => {
+  afterEach(() => {
+    sinon.verifyAndRestore();
   });
 
-  it("should not error if the trigger location is already set correctly", async () => {
-    const ep = { ...endpoint };
-    ep.eventTrigger.region = "us-central1";
+  describe("ensureDatabaseTriggerRegion", () => {
+    it("should set the trigger location to the function region", async () => {
+      const ep = { ...endpoint };
 
-    await database.ensureDatabaseTriggerRegion(ep);
+      await database.ensureDatabaseTriggerRegion(ep);
 
-    expect(ep.eventTrigger.region).to.eq("us-central1");
+      expect(ep.eventTrigger.region).to.eq("us-central1");
+    });
+
+    it("should not error if the trigger location is already set correctly", async () => {
+      const ep = { ...endpoint };
+      ep.eventTrigger.region = "us-central1";
+
+      await database.ensureDatabaseTriggerRegion(ep);
+
+      expect(ep.eventTrigger.region).to.eq("us-central1");
+    });
+
+    it("should error if the trigger location is set incorrectly", () => {
+      const ep = { ...endpoint };
+      ep.eventTrigger.region = "us-west1";
+
+      expect(() => database.ensureDatabaseTriggerRegion(ep)).to.throw(
+        "A database trigger location must match the function region.",
+      );
+    });
   });
 
-  it("should error if the trigger location is set incorrectly", () => {
-    const ep = { ...endpoint };
-    ep.eventTrigger.region = "us-west1";
+  describe("getDatabaseInstanceDetails", () => {
+    let instanceStub: sinon.SinonStub;
 
-    expect(() => database.ensureDatabaseTriggerRegion(ep)).to.throw(
-      "A database trigger location must match the function region.",
-    );
+    beforeEach(() => {
+      database.clearCache();
+      instanceStub = sinon
+        .stub(databaseManagement, "getDatabaseInstanceDetails")
+        .throws("unexpected call to getDatabaseInstanceDetails");
+    });
+
+    it("should cache instance details lookups to prevent multiple API calls", async () => {
+      const detailsResp = { location: "us-central1" } as any;
+      instanceStub.resolves(detailsResp);
+
+      const d1 = await database.getDatabaseInstanceDetails(projectNumber, "instance1");
+      const d2 = await database.getDatabaseInstanceDetails(projectNumber, "instance1");
+
+      expect(d1).to.deep.equal(detailsResp);
+      expect(d2).to.deep.equal(detailsResp);
+      expect(instanceStub).to.have.been.calledOnce;
+    });
+
+    it("should make separate API calls for different instances", async () => {
+      instanceStub.onFirstCall().resolves({ location: "us-central1" });
+      instanceStub.onSecondCall().resolves({ location: "europe-west1" });
+
+      const d1 = await database.getDatabaseInstanceDetails(projectNumber, "instance1");
+      const d2 = await database.getDatabaseInstanceDetails(projectNumber, "instance2");
+
+      expect(d1.location).to.eq("us-central1");
+      expect(d2.location).to.eq("europe-west1");
+      expect(instanceStub).to.have.been.calledTwice;
+    });
   });
 });

--- a/src/deploy/functions/services/database.ts
+++ b/src/deploy/functions/services/database.ts
@@ -1,5 +1,53 @@
 import * as backend from "../backend";
 import { FirebaseError } from "../../../error";
+import { getDatabaseInstanceDetails as getDetails, DatabaseInstance } from "../../../management/database";
+
+const instanceCache = new Map<string, DatabaseInstance>();
+const instancePromiseCache = new Map<string, Promise<DatabaseInstance>>();
+
+/**
+ * Clear the database instance cache. Used for testing.
+ * @internal
+ */
+export function clearCache(): void {
+  instanceCache.clear();
+  instancePromiseCache.clear();
+}
+
+/**
+ * A memoized version of getDatabaseInstanceDetails that avoids repeated calls to the API.
+ *
+ * @param projectId the project ID
+ * @param instanceName the database instance ID
+ */
+export async function getDatabaseInstanceDetails(
+  projectId: string,
+  instanceName: string,
+): Promise<DatabaseInstance> {
+  const key = `${projectId}/${instanceName}`;
+
+  if (instanceCache.has(key)) {
+    return instanceCache.get(key)!;
+  }
+
+  if (instancePromiseCache.has(key)) {
+    return instancePromiseCache.get(key)!;
+  }
+
+  const instancePromise = getDetails(projectId, instanceName)
+    .then((details) => {
+      instanceCache.set(key, details);
+      instancePromiseCache.delete(key);
+      return details;
+    })
+    .catch((error) => {
+      instancePromiseCache.delete(key);
+      throw error;
+    });
+
+  instancePromiseCache.set(key, instancePromise);
+  return instancePromise;
+}
 
 /**
  * Sets a database event trigger's region to the function region.

--- a/src/deploy/functions/services/database.ts
+++ b/src/deploy/functions/services/database.ts
@@ -1,6 +1,9 @@
 import * as backend from "../backend";
 import { FirebaseError } from "../../../error";
-import { getDatabaseInstanceDetails as getDetails, DatabaseInstance } from "../../../management/database";
+import {
+  getDatabaseInstanceDetails as getDetails,
+  DatabaseInstance,
+} from "../../../management/database";
 
 const instanceCache = new Map<string, DatabaseInstance>();
 const instancePromiseCache = new Map<string, Promise<DatabaseInstance>>();

--- a/src/deploy/functions/services/database.ts
+++ b/src/deploy/functions/services/database.ts
@@ -6,7 +6,6 @@ import {
 } from "../../../management/database";
 
 const instanceCache = new Map<string, DatabaseInstance>();
-const instancePromiseCache = new Map<string, Promise<DatabaseInstance>>();
 
 /**
  * Clear the database instance cache. Used for testing.
@@ -14,7 +13,6 @@ const instancePromiseCache = new Map<string, Promise<DatabaseInstance>>();
  */
 export function clearCache(): void {
   instanceCache.clear();
-  instancePromiseCache.clear();
 }
 
 /**
@@ -33,23 +31,9 @@ export async function getDatabaseInstanceDetails(
     return instanceCache.get(key)!;
   }
 
-  if (instancePromiseCache.has(key)) {
-    return instancePromiseCache.get(key)!;
-  }
-
-  const instancePromise = getDetails(projectId, instanceName)
-    .then((details) => {
-      instanceCache.set(key, details);
-      instancePromiseCache.delete(key);
-      return details;
-    })
-    .catch((error) => {
-      instancePromiseCache.delete(key);
-      throw error;
-    });
-
-  instancePromiseCache.set(key, instancePromise);
-  return instancePromise;
+  const details = await getDetails(projectId, instanceName);
+  instanceCache.set(key, details);
+  return details;
 }
 
 /**

--- a/src/deploy/functions/services/firestore.ts
+++ b/src/deploy/functions/services/firestore.ts
@@ -21,7 +21,10 @@ export function clearCache(): void {
  * @param project the project ID
  * @param databaseId the database ID or "(default)"
  */
-async function getDatabase(project: string, databaseId: string): Promise<firestore.Database> {
+export async function getDatabase(
+  project: string,
+  databaseId: string,
+): Promise<firestore.Database> {
   const key = `${project}/${databaseId}`;
 
   if (dbCache.has(key)) {

--- a/src/deploy/functions/services/storage.spec.ts
+++ b/src/deploy/functions/services/storage.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { obtainStorageBindings } from "./storage";
+import { obtainStorageBindings, getBucket, clearCache } from "./storage";
 import * as storage from "../../../gcp/storage";
 
 const projectNumber = "123456789";
@@ -10,10 +10,11 @@ const STORAGE_RES = {
   kind: "storage#serviceAccount",
 };
 
-describe("obtainStorageBindings", () => {
+describe("storage service", () => {
   let storageStub: sinon.SinonStub;
 
   beforeEach(() => {
+    clearCache();
     storageStub = sinon
       .stub(storage, "getServiceAccount")
       .throws("unexpected call to storage.getServiceAccount");
@@ -23,15 +24,51 @@ describe("obtainStorageBindings", () => {
     sinon.verifyAndRestore();
   });
 
-  it("should return the correct storage binding", async () => {
-    storageStub.resolves(STORAGE_RES);
+  describe("obtainStorageBindings", () => {
+    it("should return the correct storage binding", async () => {
+      storageStub.resolves(STORAGE_RES);
 
-    const bindings = await obtainStorageBindings(projectNumber);
+      const bindings = await obtainStorageBindings(projectNumber);
 
-    expect(bindings.length).to.equal(1);
-    expect(bindings[0]).to.deep.equal({
-      role: "roles/pubsub.publisher",
-      members: [`serviceAccount:${STORAGE_RES.email_address}`],
+      expect(bindings.length).to.equal(1);
+      expect(bindings[0]).to.deep.equal({
+        role: "roles/pubsub.publisher",
+        members: [`serviceAccount:${STORAGE_RES.email_address}`],
+      });
+    });
+  });
+
+  describe("getBucket", () => {
+    let getBucketStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      getBucketStub = sinon
+        .stub(storage, "getBucket")
+        .throws("unexpected call to storage.getBucket");
+    });
+
+    it("should cache bucket lookups to prevent multiple API calls", async () => {
+      const bucketResp = { location: "US" } as any;
+      getBucketStub.resolves(bucketResp);
+
+      const b1 = await getBucket("bucket1");
+      const b2 = await getBucket("bucket1");
+
+      expect(b1).to.deep.equal(bucketResp);
+      expect(b2).to.deep.equal(bucketResp);
+      expect(getBucketStub).to.have.been.calledOnce;
+    });
+
+    it("should make separate API calls for different buckets", async () => {
+      getBucketStub.onFirstCall().resolves({ location: "US" });
+      getBucketStub.onSecondCall().resolves({ location: "EU" });
+
+      const b1 = await getBucket("bucket1");
+      const b2 = await getBucket("bucket2");
+
+      expect(b1.location).to.eq("US");
+      expect(b2.location).to.eq("EU");
+      expect(getBucketStub).to.have.been.calledTwice;
     });
   });
 });

--- a/src/deploy/functions/services/storage.ts
+++ b/src/deploy/functions/services/storage.ts
@@ -8,7 +8,6 @@ import { regionInLocation } from "../../../gcp/location";
 const PUBSUB_PUBLISHER_ROLE = "roles/pubsub.publisher";
 
 const bucketCache = new Map<string, { location: string }>();
-const bucketPromiseCache = new Map<string, Promise<{ location: string }>>();
 
 /**
  * Clear the storage bucket cache. Used for testing.
@@ -16,7 +15,6 @@ const bucketPromiseCache = new Map<string, Promise<{ location: string }>>();
  */
 export function clearCache(): void {
   bucketCache.clear();
-  bucketPromiseCache.clear();
 }
 
 /**
@@ -29,24 +27,9 @@ export async function getBucket(bucketName: string): Promise<{ location: string 
     return bucketCache.get(bucketName)!;
   }
 
-  if (bucketPromiseCache.has(bucketName)) {
-    return bucketPromiseCache.get(bucketName)!;
-  }
-
-  const bucketPromise = storage
-    .getBucket(bucketName)
-    .then((b) => {
-      bucketCache.set(bucketName, b);
-      bucketPromiseCache.delete(bucketName);
-      return b;
-    })
-    .catch((error) => {
-      bucketPromiseCache.delete(bucketName);
-      throw error;
-    });
-
-  bucketPromiseCache.set(bucketName, bucketPromise);
-  return bucketPromise;
+  const b = await storage.getBucket(bucketName);
+  bucketCache.set(bucketName, b);
+  return b;
 }
 
 /**

--- a/src/deploy/functions/services/storage.ts
+++ b/src/deploy/functions/services/storage.ts
@@ -87,9 +87,7 @@ export async function ensureStorageTriggerRegion(
       `Looking up bucket region for the storage event trigger on bucket ${eventTrigger.eventFilters.bucket}`,
     );
     try {
-      const bucket: { location: string } = await getBucket(
-        eventTrigger.eventFilters.bucket,
-      );
+      const bucket: { location: string } = await getBucket(eventTrigger.eventFilters.bucket);
       eventTrigger.region = bucket.location.toLowerCase();
       logger.debug("Setting the event trigger region to", eventTrigger.region, ".");
     } catch (err: any) {

--- a/src/deploy/functions/services/storage.ts
+++ b/src/deploy/functions/services/storage.ts
@@ -7,6 +7,48 @@ import { regionInLocation } from "../../../gcp/location";
 
 const PUBSUB_PUBLISHER_ROLE = "roles/pubsub.publisher";
 
+const bucketCache = new Map<string, { location: string }>();
+const bucketPromiseCache = new Map<string, Promise<{ location: string }>>();
+
+/**
+ * Clear the storage bucket cache. Used for testing.
+ * @internal
+ */
+export function clearCache(): void {
+  bucketCache.clear();
+  bucketPromiseCache.clear();
+}
+
+/**
+ * A memoized version of storage.getBucket that avoids repeated calls to the API.
+ *
+ * @param bucketName the bucket ID
+ */
+export async function getBucket(bucketName: string): Promise<{ location: string }> {
+  if (bucketCache.has(bucketName)) {
+    return bucketCache.get(bucketName)!;
+  }
+
+  if (bucketPromiseCache.has(bucketName)) {
+    return bucketPromiseCache.get(bucketName)!;
+  }
+
+  const bucketPromise = storage
+    .getBucket(bucketName)
+    .then((b) => {
+      bucketCache.set(bucketName, b);
+      bucketPromiseCache.delete(bucketName);
+      return b;
+    })
+    .catch((error) => {
+      bucketPromiseCache.delete(bucketName);
+      throw error;
+    });
+
+  bucketPromiseCache.set(bucketName, bucketPromise);
+  return bucketPromise;
+}
+
 /**
  * Finds the required project level IAM bindings for the Cloud Storage service agent
  * @param projectId project identifier
@@ -45,7 +87,7 @@ export async function ensureStorageTriggerRegion(
       `Looking up bucket region for the storage event trigger on bucket ${eventTrigger.eventFilters.bucket}`,
     );
     try {
-      const bucket: { location: string } = await storage.getBucket(
+      const bucket: { location: string } = await getBucket(
         eventTrigger.eventFilters.bucket,
       );
       eventTrigger.region = bucket.location.toLowerCase();

--- a/src/emulator/functionsEmulatorShared.ts
+++ b/src/emulator/functionsEmulatorShared.ts
@@ -7,6 +7,7 @@ import * as express from "express";
 import { CloudFunction } from "firebase-functions";
 
 import * as backend from "../deploy/functions/backend";
+import * as build from "../deploy/functions/build";
 import { Constants } from "./constants";
 import { BackendInfo, EmulatableBackend, InvokeRuntimeOpts } from "./functionsEmulator";
 import { ENV_DIRECTORY } from "../extensions/manifest";
@@ -163,7 +164,7 @@ export function emulatedFunctionsFromEndpoints(
 ): EmulatedTriggerDefinition[] {
   const regionDefinitions: EmulatedTriggerDefinition[] = [];
   for (const endpoint of endpoints) {
-    if (!endpoint.region) {
+    if (!endpoint.region || endpoint.region === build.REGION_TBD) {
       endpoint.region = "us-central1";
     }
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
This updates the default resource location for various functions from us-central1. This should only impact NEW functions, not the location of existing functions. The exhaustive list includes:

- New event functions match the resource of their event source. (Firestore, Cloud Storage, Firebase Realtime Database, Firebase Data Connect)
- If a Firestore bucket is in a multi-region, then nam5 & nam7  -> us-central1, and  eur3 -> europe-west1
- If a Cloud storage bucket is in a multi-region, then
   - “us” -> us-east1
   - “eu” -> “europe-west1”
   - “asia” -> asia-east1
- Auth blocking functions and Global AI Logic blocking functions (beforeGenerateContent, afterGenerateContent) are set to us-east1.
- Remaining global event functions (Pub/Sub, Firebase Auth/GCIP, Firebase Test Lab, Firebase Remote Config, Firebase Alerts) are set to us-east1