### PR TITLE
Make dartfunctions experiment public in the CLI

### DIFF
--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -88,7 +88,7 @@ export const ALL_EXPERIMENTS = experiments({
   },
   dartfunctions: {
     shortDescription: "Enable Dart Functions.",
-    public: false,
+    public: true,
     default: false,
   },
 


### PR DESCRIPTION
This will make the dartfunctions experiment visible to users in the CLI when they list experiments using `firebase experiments:list`.