### PR TITLE
Correctly set attachment_point for rules deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 - Added SSE mode support to `firebase mcp`. To use it, run `firebase mcp --mode=sse --port=3000`, and connect your client on `http://localhost:3000`.
 - Update the valid Python runtimes for functions. Default Python runtime is now Python 3.14.
 - Fix CLI non-interactive mode for dataconnect init (#10401)
+- Fixed issue where rules for non-default Firestore databases were not being deployed correctly.

--- a/src/deploy/firestore/prepare.ts
+++ b/src/deploy/firestore/prepare.ts
@@ -38,7 +38,7 @@ function prepareRules(
   databaseId: string,
   rulesFile: string,
 ): void {
-  rulesDeploy.addFile(rulesFile);
+  rulesDeploy.addFile(rulesFile, databaseId);
   context.firestore.rules.push({
     databaseId,
     rulesFile,

--- a/src/gcp/rules.ts
+++ b/src/gcp/rules.ts
@@ -28,9 +28,9 @@ function _handleErrorResponse(response: any): any {
 export async function getLatestRulesetName(
   projectId: string,
   service: string,
+  releases: Release[],
   resourceName?: string,
 ): Promise<string | null> {
-  const releases = await listAllReleases(projectId);
   let prefix = `projects/${projectId}/releases/${service}`;
   if (resourceName) {
     prefix += `/${resourceName}`;
@@ -198,7 +198,9 @@ export async function createRuleset(
   files: RulesetFile[],
   attachmentPoint?: string,
 ): Promise<string> {
-  const payload: any = { source: { files } };
+  const payload: { source: { files: RulesetFile[] }; attachment_point?: string } = {
+    source: { files },
+  };
   if (attachmentPoint) {
     payload.attachment_point = attachmentPoint;
   }

--- a/src/gcp/rules.ts
+++ b/src/gcp/rules.ts
@@ -193,8 +193,15 @@ export async function deleteRuleset(projectId: string, id: string): Promise<void
  * @param projectId Project on which you want to create the ruleset.
  * @param {Array} files Array of `{name, content}` for the source files.
  */
-export async function createRuleset(projectId: string, files: RulesetFile[]): Promise<string> {
-  const payload = { source: { files } };
+export async function createRuleset(
+  projectId: string,
+  files: RulesetFile[],
+  attachmentPoint?: string,
+): Promise<string> {
+  const payload: any = { source: { files } };
+  if (attachmentPoint) {
+    payload.attachment_point = attachmentPoint;
+  }
 
   const response = await apiClient.post<unknown, { name: string }>(
     `/projects/${projectId}/rulesets`,

--- a/src/init/features/firestore/rules.spec.ts
+++ b/src/init/features/firestore/rules.spec.ts
@@ -63,6 +63,10 @@ describe("firestore rules", () => {
         instructions: [],
       };
       const cfg = new config.Config({}, { projectDir: "/", cwd: "/" });
+      const releases: gcp.rules.Release[] = [
+        { rulesetName: "ruleset-name", name: "release-name", createTime: "", updateTime: "" },
+      ];
+      sandbox.stub(gcp.rules, "listAllReleases").resolves(releases);
       const getRulesetNameStub = sandbox
         .stub(gcp.rules, "getLatestRulesetName")
         .resolves("ruleset-name");
@@ -83,7 +87,7 @@ describe("firestore rules", () => {
       };
       await initRules(setup, cfg, info);
 
-      expect(getRulesetNameStub.calledOnceWith("test-project", "cloud.firestore")).to.be.true;
+      expect(getRulesetNameStub.calledOnceWith("test-project", "cloud.firestore", releases)).to.be.true;
       expect(getRulesetContentStub.calledOnceWith("ruleset-name")).to.be.true;
       expect(writeStub.calledOnceWith("firestore.rules", "console rules")).to.be.true;
       expect(info.rules).to.equal("console rules");

--- a/src/init/features/firestore/rules.spec.ts
+++ b/src/init/features/firestore/rules.spec.ts
@@ -87,7 +87,8 @@ describe("firestore rules", () => {
       };
       await initRules(setup, cfg, info);
 
-      expect(getRulesetNameStub.calledOnceWith("test-project", "cloud.firestore", releases)).to.be.true;
+      expect(getRulesetNameStub.calledOnceWith("test-project", "cloud.firestore", releases)).to.be
+        .true;
       expect(getRulesetContentStub.calledOnceWith("ruleset-name")).to.be.true;
       expect(writeStub.calledOnceWith("firestore.rules", "console rules")).to.be.true;
       expect(info.rules).to.equal("console rules");

--- a/src/init/features/firestore/rules.ts
+++ b/src/init/features/firestore/rules.ts
@@ -46,7 +46,8 @@ export async function initRules(setup: Setup, config: Config, info: RequiredInfo
 }
 
 async function getRulesFromConsole(projectId: string): Promise<string | null> {
-  const name = await gcp.rules.getLatestRulesetName(projectId, "cloud.firestore");
+  const releases = await gcp.rules.listAllReleases(projectId);
+  const name = await gcp.rules.getLatestRulesetName(projectId, "cloud.firestore", releases);
   if (!name) {
     return null;
   }

--- a/src/init/features/storage/rules.ts
+++ b/src/init/features/storage/rules.ts
@@ -3,7 +3,8 @@ import * as utils from "../../../utils";
 
 export async function getRulesFromConsole(projectId: string): Promise<string | null> {
   const defaultBucket = await gcp.storage.getDefaultBucket(projectId);
-  const name = await gcp.rules.getLatestRulesetName(projectId, "firebase.storage", defaultBucket);
+  const releases = await gcp.rules.listAllReleases(projectId);
+  const name = await gcp.rules.getLatestRulesetName(projectId, "firebase.storage", releases, defaultBucket);
   if (!name) {
     return null;
   }

--- a/src/init/features/storage/rules.ts
+++ b/src/init/features/storage/rules.ts
@@ -4,7 +4,12 @@ import * as utils from "../../../utils";
 export async function getRulesFromConsole(projectId: string): Promise<string | null> {
   const defaultBucket = await gcp.storage.getDefaultBucket(projectId);
   const releases = await gcp.rules.listAllReleases(projectId);
-  const name = await gcp.rules.getLatestRulesetName(projectId, "firebase.storage", releases, defaultBucket);
+  const name = await gcp.rules.getLatestRulesetName(
+    projectId,
+    "firebase.storage",
+    releases,
+    defaultBucket,
+  );
   if (!name) {
     return null;
   }

--- a/src/mcp/tools/core/get_security_rules.ts
+++ b/src/mcp/tools/core/get_security_rules.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { Client } from "../../../apiv2";
 import { tool } from "../../tool";
 import { mcpError, toContent } from "../../util";
-import { getLatestRulesetName, getRulesetContent } from "../../../gcp/rules";
+import { getLatestRulesetName, getRulesetContent, listAllReleases } from "../../../gcp/rules";
 import { getDefaultDatabaseInstance } from "../../../getDefaultDatabaseInstance";
 
 export const get_security_rules = tool(
@@ -52,7 +52,8 @@ export const get_security_rules = tool(
     };
     const { productName, releaseName } = serviceInfo[type];
 
-    const rulesetName = await getLatestRulesetName(projectId, releaseName);
+    const releases = await listAllReleases(projectId);
+    const rulesetName = await getLatestRulesetName(projectId, releaseName, releases);
     if (!rulesetName)
       return mcpError(`No active ${productName} rules were found in project '${projectId}'`);
     const rules = await getRulesetContent(rulesetName);

--- a/src/rulesDeploy.spec.ts
+++ b/src/rulesDeploy.spec.ts
@@ -198,6 +198,9 @@ describe("RulesDeploy", () => {
       sinon
         .stub(gcp.rules, "createRuleset")
         .rejects(new Error("createRuleset behavior unspecified"));
+      sinon
+        .stub(gcp.rules, "listAllReleases")
+        .resolves([]);
     });
 
     afterEach(() => {
@@ -493,7 +496,7 @@ describe("RulesDeploy", () => {
       describe("and a prompt is made", () => {
         beforeEach(() => {
           sinon.stub(prompt, "confirm").rejects(new Error("behavior unspecified"));
-          sinon.stub(gcp.rules, "listAllReleases").rejects(new Error("listAllReleases failing"));
+          (gcp.rules.listAllReleases as sinon.SinonStub).resolves([]);
           sinon.stub(gcp.rules, "deleteRuleset").rejects(new Error("deleteRuleset failing"));
           sinon.stub(gcp.rules, "getRulesetId").throws(new Error("getRulesetId failing"));
         });

--- a/src/rulesDeploy.spec.ts
+++ b/src/rulesDeploy.spec.ts
@@ -223,9 +223,11 @@ describe("RulesDeploy", () => {
         const result = rd.createRulesets(RulesetServiceType.CLOUD_FIRESTORE);
         await expect(result).to.eventually.deep.equal(["compiled"]);
 
-        expect(gcp.rules.createRuleset).calledOnceWithExactly(BASE_OPTIONS.project, [
-          { name: "firestore.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledOnceWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "firestore.rules", content: sinon.match.string }],
+          undefined,
+        );
       });
 
       it("should throw an error if createRuleset fails", async () => {
@@ -249,12 +251,37 @@ describe("RulesDeploy", () => {
         await expect(result).to.eventually.deep.equal(["one", "two"]);
 
         expect(gcp.rules.createRuleset).calledTwice;
-        expect(gcp.rules.createRuleset).calledWithExactly(BASE_OPTIONS.project, [
-          { name: "firestore.rules", content: sinon.match.string },
-        ]);
-        expect(gcp.rules.createRuleset).calledWithExactly(BASE_OPTIONS.project, [
-          { name: "storage.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "firestore.rules", content: sinon.match.string }],
+          undefined,
+        );
+        expect(gcp.rules.createRuleset).calledWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "storage.rules", content: sinon.match.string }],
+          undefined,
+        );
+      });
+    });
+
+    describe("with non-default database", () => {
+      beforeEach(() => {
+        (gcp.rules.getLatestRulesetName as sinon.SinonStub).resolves(null);
+        sinon.stub(projectNumber, "getProjectNumber").resolves("12345");
+      });
+
+      it("should create ruleset with attachment_point", async () => {
+        (gcp.rules.createRuleset as sinon.SinonStub).onFirstCall().resolves("compiled");
+        rd.addFile("firestore.rules", "my-db");
+
+        const result = rd.createRulesets(RulesetServiceType.CLOUD_FIRESTORE);
+        await expect(result).to.eventually.deep.equal(["compiled"]);
+
+        expect(gcp.rules.createRuleset).calledOnceWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "firestore.rules", content: sinon.match.string }],
+          "firestore.googleapis.com/projects/12345/databases/my-db",
+        );
       });
     });
 
@@ -309,9 +336,11 @@ describe("RulesDeploy", () => {
         await expect(result).to.eventually.deep.equal(["created"]);
 
         expect(gcp.rules.createRuleset).calledOnce;
-        expect(gcp.rules.createRuleset).calledOnceWithExactly(BASE_OPTIONS.project, [
-          { name: "storage.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledOnceWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "storage.rules", content: sinon.match.string }],
+          undefined,
+        );
       });
 
       it("should create all rules if none match", async () => {
@@ -328,12 +357,16 @@ describe("RulesDeploy", () => {
         await expect(result).to.eventually.deep.equal(["one", "two"]);
 
         expect(gcp.rules.createRuleset).calledTwice;
-        expect(gcp.rules.createRuleset).calledWithExactly(BASE_OPTIONS.project, [
-          { name: "firestore.rules", content: sinon.match.string },
-        ]);
-        expect(gcp.rules.createRuleset).calledWithExactly(BASE_OPTIONS.project, [
-          { name: "storage.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "firestore.rules", content: sinon.match.string }],
+          undefined,
+        );
+        expect(gcp.rules.createRuleset).calledWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "storage.rules", content: sinon.match.string }],
+          undefined,
+        );
       });
     });
 
@@ -362,9 +395,11 @@ describe("RulesDeploy", () => {
         const result = rd.createRulesets(RulesetServiceType.FIREBASE_STORAGE);
         await expect(result).to.eventually.deep.equal(["compiled"]);
 
-        expect(gcp.rules.createRuleset).calledOnceWithExactly(BASE_OPTIONS.project, [
-          { name: "storage.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledOnceWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "storage.rules", content: sinon.match.string }],
+          undefined,
+        );
         expect(resourceManager.serviceAccountHasRoles).calledOnce;
       });
 
@@ -376,9 +411,11 @@ describe("RulesDeploy", () => {
         const result = rd.createRulesets(RulesetServiceType.FIREBASE_STORAGE);
         await expect(result).to.eventually.deep.equal(["compiled"]);
 
-        expect(gcp.rules.createRuleset).calledOnceWithExactly(BASE_OPTIONS.project, [
-          { name: "storage.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledOnceWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "storage.rules", content: sinon.match.string }],
+          undefined,
+        );
         expect(resourceManager.addServiceAccountToRoles).calledOnceWithExactly(
           "12345",
           "service-12345@gcp-sa-firebasestorage.iam.gserviceaccount.com",
@@ -395,9 +432,11 @@ describe("RulesDeploy", () => {
         const result = rd.createRulesets(RulesetServiceType.FIREBASE_STORAGE);
         await expect(result).to.eventually.deep.equal(["compiled"]);
 
-        expect(gcp.rules.createRuleset).calledOnceWithExactly(BASE_OPTIONS.project, [
-          { name: "storage.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledOnceWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "storage.rules", content: sinon.match.string }],
+          undefined,
+        );
         expect(resourceManager.addServiceAccountToRoles).not.called;
       });
 
@@ -409,9 +448,11 @@ describe("RulesDeploy", () => {
         const result = rd.createRulesets(RulesetServiceType.FIREBASE_STORAGE);
         await expect(result).to.eventually.deep.equal(["compiled"]);
 
-        expect(gcp.rules.createRuleset).calledOnceWithExactly(BASE_OPTIONS.project, [
-          { name: "storage.rules", content: sinon.match.string },
-        ]);
+        expect(gcp.rules.createRuleset).calledOnceWithExactly(
+          BASE_OPTIONS.project,
+          [{ name: "storage.rules", content: sinon.match.string }],
+          undefined,
+        );
         expect(resourceManager.addServiceAccountToRoles).not.called;
         expect(promptSpy).not.called;
       });

--- a/src/rulesDeploy.spec.ts
+++ b/src/rulesDeploy.spec.ts
@@ -198,9 +198,7 @@ describe("RulesDeploy", () => {
       sinon
         .stub(gcp.rules, "createRuleset")
         .rejects(new Error("createRuleset behavior unspecified"));
-      sinon
-        .stub(gcp.rules, "listAllReleases")
-        .resolves([]);
+      sinon.stub(gcp.rules, "listAllReleases").resolves([]);
     });
 
     afterEach(() => {

--- a/src/rulesDeploy.ts
+++ b/src/rulesDeploy.ts
@@ -171,7 +171,6 @@ export class RulesDeploy {
    * @return All the names of the rulesets that were created.
    */
   async createRulesets(service: RulesetServiceType): Promise<string[]> {
-    logger.debug("[rules] createRulesets called for service", service);
     const createdRulesetNames: string[] = [];
     const releases = await gcp.rules.listAllReleases(this.options.project);
 
@@ -180,10 +179,10 @@ export class RulesDeploy {
     const newRulesetsByKey = new Map<string, Promise<string>>();
     for (const entry of this.rulesFiles) {
       const { path: filename, files, databaseId } = entry;
-      
+
       // Normalize databaseId for default database
       const normalizedDatabaseId = databaseId === "(default)" ? undefined : databaseId;
-      
+
       const { latestName: latestRulesetName, latestContent: latestRulesetContent } =
         await this.getCurrentRules(service, releases, normalizedDatabaseId);
 

--- a/src/rulesDeploy.ts
+++ b/src/rulesDeploy.ts
@@ -180,7 +180,10 @@ export class RulesDeploy {
       const { latestName: latestRulesetName, latestContent: latestRulesetContent } =
         await this.getCurrentRules(service, databaseId);
 
-      const key = `${filename}:${databaseId || ""}`;
+      const key =
+        this.type === RulesetServiceType.FIREBASE_STORAGE
+          ? filename
+          : `${filename}:${databaseId || ""}`;
 
       if (latestRulesetName && _.isEqual(files, latestRulesetContent)) {
         utils.logLabeledBullet(
@@ -265,7 +268,10 @@ export class RulesDeploy {
       throw new FirebaseError(`Cannot release resource type "${resourceName}"`);
     }
 
-    const key = `${filename}:${subResourceName || ""}`;
+    const key =
+      this.type === RulesetServiceType.FIREBASE_STORAGE
+        ? filename
+        : `${filename}:${subResourceName || ""}`;
     const releaseName =
       subResourceName && subResourceName !== "(default)"
         ? `${resourceName}/${subResourceName}`

--- a/src/rulesDeploy.ts
+++ b/src/rulesDeploy.ts
@@ -48,8 +48,8 @@ const RulesetType = {
  */
 export class RulesDeploy {
   private project: string;
-  private rulesFiles: { [path: string]: RulesetFile[] };
-  private rulesetNames: { [x: string]: string };
+  private rulesFiles: Array<{ path: string; files: RulesetFile[]; databaseId?: string }>;
+  private rulesetNames: { [key: string]: string };
 
   /**
    * Creates a RulesDeploy instance.
@@ -61,7 +61,7 @@ export class RulesDeploy {
     private type: RulesetServiceType,
   ) {
     this.project = options.project;
-    this.rulesFiles = {};
+    this.rulesFiles = [];
     this.rulesetNames = {};
   }
 
@@ -70,7 +70,7 @@ export class RulesDeploy {
    * deployment for this RulesDeploy.
    * @param path path of file to be included.
    */
-  addFile(path: string): void {
+  addFile(path: string, databaseId?: string): void {
     const fullPath = this.options.config.path(path);
     let src;
     try {
@@ -80,7 +80,7 @@ export class RulesDeploy {
       throw new FirebaseError(`Error reading rules file ${bold(path)}`);
     }
 
-    this.rulesFiles[path] = [{ name: path, content: src }];
+    this.rulesFiles.push({ path, files: [{ name: path, content: src }], databaseId });
   }
 
   /**
@@ -89,8 +89,8 @@ export class RulesDeploy {
    */
   async compile(): Promise<void> {
     await Promise.all(
-      Object.keys(this.rulesFiles).map((filename) => {
-        return this.compileRuleset(filename, this.rulesFiles[filename]);
+      this.rulesFiles.map((entry) => {
+        return this.compileRuleset(entry.path, entry.files);
       }),
     );
   }
@@ -102,8 +102,13 @@ export class RulesDeploy {
    */
   private async getCurrentRules(
     service: RulesetServiceType,
+    databaseId?: string,
   ): Promise<{ latestName: string | null; latestContent: RulesetFile[] | null }> {
-    const latestName = await gcp.rules.getLatestRulesetName(this.options.project, service);
+    const latestName = await gcp.rules.getLatestRulesetName(
+      this.options.project,
+      service,
+      databaseId,
+    );
     let latestContent: RulesetFile[] | null = null;
     if (latestName) {
       latestContent = await gcp.rules.getRulesetContent(latestName);
@@ -164,21 +169,25 @@ export class RulesDeploy {
    * @return All the names of the rulesets that were created.
    */
   async createRulesets(service: RulesetServiceType): Promise<string[]> {
+    logger.debug("[rules] createRulesets called for service", service);
     const createdRulesetNames: string[] = [];
-
-    const { latestName: latestRulesetName, latestContent: latestRulesetContent } =
-      await this.getCurrentRules(service);
 
     // TODO: Make this into a more useful helper method.
     // Gather the files to be uploaded.
-    const newRulesetsByFilename = new Map<string, Promise<string>>();
-    for (const [filename, files] of Object.entries(this.rulesFiles)) {
+    const newRulesetsByKey = new Map<string, Promise<string>>();
+    for (const entry of this.rulesFiles) {
+      const { path: filename, files, databaseId } = entry;
+      const { latestName: latestRulesetName, latestContent: latestRulesetContent } =
+        await this.getCurrentRules(service, databaseId);
+
+      const key = `${filename}:${databaseId || ""}`;
+
       if (latestRulesetName && _.isEqual(files, latestRulesetContent)) {
         utils.logLabeledBullet(
           RulesetType[this.type],
           `latest version of ${bold(filename)} already up to date, skipping upload...`,
         );
-        this.rulesetNames[filename] = latestRulesetName;
+        this.rulesetNames[key] = latestRulesetName;
         continue;
       }
       if (service === RulesetServiceType.FIREBASE_STORAGE) {
@@ -186,14 +195,24 @@ export class RulesDeploy {
       }
 
       utils.logLabeledBullet(RulesetType[this.type], `uploading rules ${bold(filename)}...`);
-      newRulesetsByFilename.set(filename, gcp.rules.createRuleset(this.options.project, files));
+
+      let attachmentPoint: string | undefined;
+      if (databaseId && databaseId !== "(default)") {
+        const projectNumber = await getProjectNumber(this.options);
+        attachmentPoint = `firestore.googleapis.com/projects/${projectNumber}/databases/${databaseId}`;
+      }
+
+      newRulesetsByKey.set(
+        key,
+        gcp.rules.createRuleset(this.options.project, files, attachmentPoint),
+      );
     }
 
     try {
-      await Promise.all(newRulesetsByFilename.values());
+      await Promise.all(newRulesetsByKey.values());
       // All the values are now resolves, so `await` here reads the strings.
-      for (const [filename, rulesetName] of newRulesetsByFilename) {
-        this.rulesetNames[filename] = await rulesetName;
+      for (const [key, rulesetName] of newRulesetsByKey) {
+        this.rulesetNames[key] = await rulesetName;
         createdRulesetNames.push(await rulesetName);
       }
     } catch (err: unknown) {
@@ -245,10 +264,17 @@ export class RulesDeploy {
     if (resourceName === RulesetServiceType.FIREBASE_STORAGE && !subResourceName) {
       throw new FirebaseError(`Cannot release resource type "${resourceName}"`);
     }
+
+    const key = `${filename}:${subResourceName || ""}`;
+    const releaseName =
+      subResourceName && subResourceName !== "(default)"
+        ? `${resourceName}/${subResourceName}`
+        : resourceName;
+
     await gcp.rules.updateOrCreateRelease(
       this.options.project,
-      this.rulesetNames[filename],
-      subResourceName ? `${resourceName}/${subResourceName}` : resourceName,
+      this.rulesetNames[key],
+      releaseName,
     );
     utils.logLabeledSuccess(
       RulesetType[this.type],

--- a/src/rulesDeploy.ts
+++ b/src/rulesDeploy.ts
@@ -102,11 +102,13 @@ export class RulesDeploy {
    */
   private async getCurrentRules(
     service: RulesetServiceType,
+    releases: Release[],
     databaseId?: string,
   ): Promise<{ latestName: string | null; latestContent: RulesetFile[] | null }> {
     const latestName = await gcp.rules.getLatestRulesetName(
       this.options.project,
       service,
+      releases,
       databaseId,
     );
     let latestContent: RulesetFile[] | null = null;
@@ -171,14 +173,19 @@ export class RulesDeploy {
   async createRulesets(service: RulesetServiceType): Promise<string[]> {
     logger.debug("[rules] createRulesets called for service", service);
     const createdRulesetNames: string[] = [];
+    const releases = await gcp.rules.listAllReleases(this.options.project);
 
     // TODO: Make this into a more useful helper method.
     // Gather the files to be uploaded.
     const newRulesetsByKey = new Map<string, Promise<string>>();
     for (const entry of this.rulesFiles) {
       const { path: filename, files, databaseId } = entry;
+      
+      // Normalize databaseId for default database
+      const normalizedDatabaseId = databaseId === "(default)" ? undefined : databaseId;
+      
       const { latestName: latestRulesetName, latestContent: latestRulesetContent } =
-        await this.getCurrentRules(service, databaseId);
+        await this.getCurrentRules(service, releases, normalizedDatabaseId);
 
       const key =
         this.type === RulesetServiceType.FIREBASE_STORAGE
@@ -200,7 +207,11 @@ export class RulesDeploy {
       utils.logLabeledBullet(RulesetType[this.type], `uploading rules ${bold(filename)}...`);
 
       let attachmentPoint: string | undefined;
-      if (databaseId && databaseId !== "(default)") {
+      if (
+        this.type === RulesetServiceType.CLOUD_FIRESTORE &&
+        databaseId &&
+        databaseId !== "(default)"
+      ) {
         const projectNumber = await getProjectNumber(this.options);
         attachmentPoint = `firestore.googleapis.com/projects/${projectNumber}/databases/${databaseId}`;
       }


### PR DESCRIPTION
### Description
Correctly set attachment point when deploying to non-default DBs.

### Scenarios Tested
Deployed rules to a non-default db, made a change in console, and then deployed again. All 3 ruleset show up correctly in history. Also, Gemini referred to itself as Claude, which was odd.
<img width="1393" height="591" alt="Screenshot 2026-04-27 at 3 29 40 PM" src="https://github.com/user-attachments/assets/b30da08f-7aae-4e54-93da-a73add94cfba" />

