### PR TITLE
docs: fix URL of Firebase Agent Sklls in src/mcp/README.md

### DIFF
--- a/src/mcp/README.md
+++ b/src/mcp/README.md
@@ -43,10 +43,10 @@ Here are configuration instructions for popular AI-assistive tools:
 
 #### Gemini CLI
 
-Install the [Firebase extension for Gemini CLI](https://github.com/gemini-cli-extensions/firebase/):
+Install the [Firebase extension for Gemini CLI](https://github.com/firebase/agent-skills):
 
 ```bash
-gemini extensions install https://github.com/gemini-cli-extensions/firebase/
+gemini extensions install https://github.com/firebase/agent-skills
 ```
 
 #### Claude Code


### PR DESCRIPTION
Update the docs to the new URL of the "Firebase extension for Gemini CLI" (a.k.a. "Firebase Agent Skills") from https://github.com/gemini-cli-extensions/firebase to https://github.com/firebase/agent-skills