### PR TITLE
feat: Support creating search indexes for Firestore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Added support for creating search indexes for Firestore. (#10431)
 - Fixed an issue where some MCP tools would error with "Invalid input: expected record, received array". (#10437)
 - Increase supported range for Next.js to version 16.0 (#9463)

--- a/src/firestore/api-sort.spec.ts
+++ b/src/firestore/api-sort.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 
+import { Index, Order, QueryScope, TextIndexType, TextMatchType } from "./api-types";
 import { Backup, BackupSchedule, DayOfWeek } from "../gcp/firestore";
 import { durationFromSeconds } from "../gcp/proto";
 import * as sort from "./api-sort";
@@ -74,5 +75,99 @@ describe("compareApiBackupSchedule", () => {
     };
     expect(sort.compareApiBackupSchedule(dailySchedule1, dailySchedule2)).to.lessThanOrEqual(-1);
     expect(sort.compareApiBackupSchedule(dailySchedule2, dailySchedule1)).to.greaterThanOrEqual(1);
+  });
+});
+
+describe("compareApiIndex", () => {
+  it("should compare indexes by searchConfig", () => {
+    const indexNoSearch: Index = {
+      queryScope: QueryScope.COLLECTION,
+      fields: [{ fieldPath: "foo", order: Order.ASCENDING }],
+    };
+    const indexWithSearch1: Index = {
+      queryScope: QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "foo",
+          searchConfig: {
+            textSpec: {
+              indexSpecs: [
+                { indexType: TextIndexType.TOKENIZED, matchType: TextMatchType.MATCH_GLOBALLY },
+              ],
+            },
+          },
+        },
+      ],
+    };
+    const indexWithSearch2: Index = {
+      queryScope: QueryScope.COLLECTION,
+      fields: [{ fieldPath: "foo", searchConfig: { geoSpec: { geoJsonIndexingDisabled: true } } }],
+    };
+
+    // Index without searchConfig should come before one with searchConfig
+    expect(sort.compareApiIndex(indexNoSearch, indexWithSearch1)).to.be.lessThan(0);
+    expect(sort.compareApiIndex(indexWithSearch1, indexNoSearch)).to.be.greaterThan(0);
+
+    // Indexes with a text search spec should compare based on the number of index specs within
+    // indexWithSearch1 has 1 text spec
+    // indexWithSearch2 has 0 text specs
+    expect(sort.compareApiIndex(indexWithSearch2, indexWithSearch1)).to.be.lessThan(0);
+    expect(sort.compareApiIndex(indexWithSearch1, indexWithSearch2)).to.be.greaterThan(0);
+
+    const indexWithSearch3: Index = {
+      queryScope: QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "foo",
+          searchConfig: {
+            textSpec: {
+              indexSpecs: [
+                { indexType: TextIndexType.TOKENIZED, matchType: TextMatchType.MATCH_GLOBALLY },
+                { indexType: TextIndexType.TOKENIZED, matchType: TextMatchType.MATCH_GLOBALLY },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    // indexWithSearch3 has 2 text specs, indexWithSearch1 has 1
+    expect(sort.compareApiIndex(indexWithSearch1, indexWithSearch3)).to.be.lessThan(0);
+    expect(sort.compareApiIndex(indexWithSearch3, indexWithSearch1)).to.be.greaterThan(0);
+
+    // Otherwise, just consider them equal
+    const indexWithSearch4: Index = {
+      queryScope: QueryScope.COLLECTION,
+      fields: [
+        {
+          fieldPath: "foo",
+          searchConfig: {
+            textSpec: {
+              indexSpecs: [
+                {
+                  indexType: TextIndexType.TOKENIZED,
+                  matchType: TextMatchType.TEXT_MATCH_TYPE_UNSPECIFIED,
+                },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    // indexWithSearch1 and indexWithSearch4 both have 1 text spec, different content
+    // They should be considered equal
+    expect(sort.compareApiIndex(indexWithSearch1, indexWithSearch4)).to.equal(0);
+    expect(sort.compareApiIndex(indexWithSearch4, indexWithSearch1)).to.equal(0);
+
+    const indexWithSearch5: Index = {
+      queryScope: QueryScope.COLLECTION,
+      fields: [{ fieldPath: "foo", searchConfig: { geoSpec: { geoJsonIndexingDisabled: false } } }],
+    };
+
+    // indexWithSearch2 and indexWithSearch5 both have 0 text specs, different geoSpec
+    // They should be considered equal
+    expect(sort.compareApiIndex(indexWithSearch2, indexWithSearch5)).to.equal(0);
+    expect(sort.compareApiIndex(indexWithSearch5, indexWithSearch2)).to.equal(0);
   });
 });

--- a/src/firestore/api-sort.ts
+++ b/src/firestore/api-sort.ts
@@ -244,6 +244,7 @@ export function compareFieldOverride(a: Spec.FieldOverride, b: Spec.FieldOverrid
  *   2) Sort order (if it exists).
  *   3) Array config (if it exists).
  *   4) Vector config (if it exists).
+ *   5) Search config (if it exists).
  */
 function compareIndexField(a: API.IndexField, b: API.IndexField): number {
   if (a.fieldPath !== b.fieldPath) {
@@ -260,6 +261,10 @@ function compareIndexField(a: API.IndexField, b: API.IndexField): number {
 
   if (a.vectorConfig !== b.vectorConfig) {
     return compareVectorConfig(a.vectorConfig, b.vectorConfig);
+  }
+
+  if (a.searchConfig !== b.searchConfig) {
+    return compareSearchConfig(a.searchConfig, b.searchConfig);
   }
 
   return 0;
@@ -358,6 +363,26 @@ function compareVectorConfig(a?: API.VectorConfig, b?: API.VectorConfig): number
     return -1;
   }
   return a.dimension - b.dimension;
+}
+
+function compareSearchConfig(a?: API.SearchConfig, b?: API.SearchConfig): number {
+  if (!a) {
+    if (!b) {
+      return 0;
+    } else {
+      return 1;
+    }
+  } else if (!b) {
+    return -1;
+  }
+  const aTextSpecs = a?.textSpec?.indexSpecs?.length || 0;
+  const bTextSpecs = b?.textSpec?.indexSpecs?.length || 0;
+
+  if (aTextSpecs !== bTextSpecs) {
+    return aTextSpecs - bTextSpecs;
+  }
+
+  return 0;
 }
 
 /**

--- a/src/firestore/api-types.ts
+++ b/src/firestore/api-types.ts
@@ -39,6 +39,28 @@ export enum ArrayConfig {
   CONTAINS = "CONTAINS",
 }
 
+export enum TextIndexType {
+  TEXT_INDEX_TYPE_UNSPECIFIED = "TEXT_INDEX_TYPE_UNSPECIFIED",
+  TOKENIZED = "TOKENIZED",
+}
+
+export enum TextMatchType {
+  TEXT_MATCH_TYPE_UNSPECIFIED = "TEXT_MATCH_TYPE_UNSPECIFIED",
+  MATCH_GLOBALLY = "MATCH_GLOBALLY",
+}
+
+export interface SearchConfig {
+  textSpec?: {
+    indexSpecs: {
+      indexType: TextIndexType;
+      matchType: TextMatchType;
+    }[];
+  };
+  geoSpec?: {
+    geoJsonIndexingDisabled?: boolean;
+  };
+}
+
 export interface VectorConfig {
   dimension: number;
   flat?: {};
@@ -57,7 +79,7 @@ export enum StateTtl {
 }
 
 /**
- * An Index as it is represented in the Firestore v1beta2 indexes API.
+ * An Index as it is represented in the Firestore indexes API.
  */
 export interface Index {
   name?: string;
@@ -77,6 +99,7 @@ export interface IndexField {
   fieldPath: string;
   order?: Order;
   arrayConfig?: ArrayConfig;
+  searchConfig?: SearchConfig;
   vectorConfig?: VectorConfig;
 }
 

--- a/src/firestore/api.ts
+++ b/src/firestore/api.ts
@@ -24,7 +24,7 @@ export class FirestoreApi {
   /**
    * Process indexes by appending the implicit __name__ fields with default order for STANDARD edition database.
    * No-op if exists __name__ field at the end.
-   * No-op is ENTERPRISE edition databases.
+   * Not called on ENTERPRISE edition databases.
    * @param index Spec index to process
    * @return Processed spec index with potential additional __name__ suffix
    */
@@ -364,7 +364,7 @@ export class FirestoreApi {
 
     index.fields.forEach((field: any) => {
       validator.assertHas(field, "fieldPath");
-      validator.assertHasOneOf(field, ["order", "arrayConfig", "vectorConfig"]);
+      validator.assertHasOneOf(field, ["order", "arrayConfig", "searchConfig", "vectorConfig"]);
 
       if (field.order) {
         validator.assertEnum(field, "order", Object.keys(types.Order));
@@ -377,6 +377,26 @@ export class FirestoreApi {
       if (field.vectorConfig) {
         validator.assertType("vectorConfig.dimension", field.vectorConfig.dimension, "number");
         validator.assertHas(field.vectorConfig, "flat");
+      }
+
+      if (field.searchConfig) {
+        if (field.searchConfig.textSpec) {
+          validator.assertHas(field.searchConfig.textSpec, "indexSpecs");
+          for (const spec of field.searchConfig.textSpec.indexSpecs as unknown[]) {
+            validator.assertHas(spec, "indexType");
+            validator.assertEnum(spec, "indexType", Object.keys(types.TextIndexType));
+            validator.assertHas(spec, "matchType");
+            validator.assertEnum(spec, "matchType", Object.keys(types.TextMatchType));
+          }
+        }
+        // all fields under field.searchConfig.geoSpec are optional
+        if (field.searchConfig.geoSpec?.geoJsonIndexingDisabled !== undefined) {
+          validator.assertType(
+            "searchConfig.geoSpec.geoJsonIndexingDisabled",
+            field.searchConfig.geoSpec.geoJsonIndexingDisabled,
+            "boolean",
+          );
+        }
       }
     });
   }
@@ -609,8 +629,12 @@ export class FirestoreApi {
         return false;
       }
 
-      // Note: vectorConfig is an object, and using '!==' should not be used.
+      // Note: vectorConfig and searchConfig are objects, and '!==' should not be used.
       if (!utils.deepEqual(iField.vectorConfig, sField.vectorConfig)) {
+        return false;
+      }
+
+      if (!utils.deepEqual(iField.searchConfig, sField.searchConfig)) {
         return false;
       }
 
@@ -728,6 +752,8 @@ export class FirestoreApi {
             f.arrayConfig = field.arrayConfig;
           } else if (field.vectorConfig) {
             f.vectorConfig = field.vectorConfig;
+          } else if (field.searchConfig) {
+            f.searchConfig = field.searchConfig;
           } else if (field.mode === types.Mode.ARRAY_CONTAINS) {
             f.arrayConfig = types.ArrayConfig.CONTAINS;
           } else {

--- a/src/firestore/indexes.spec.ts
+++ b/src/firestore/indexes.spec.ts
@@ -269,6 +269,167 @@ describe("IndexValidation", () => {
     }).to.throw(FirebaseError, /Must contain "flat"/);
   });
 
+  it("should accept a valid searchConfig index", () => {
+    idx.validateSpec(
+      idx.upgradeOldSpec({
+        indexes: [
+          {
+            collectionGroup: "collection",
+            queryScope: "COLLECTION",
+            fields: [
+              {
+                fieldPath: "foo",
+                searchConfig: {
+                  textSpec: {
+                    indexSpecs: [
+                      {
+                        indexType: "TOKENIZED",
+                        matchType: "MATCH_GLOBALLY",
+                      },
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+  });
+
+  it("should accept a valid searchConfig index with geoSpec", () => {
+    idx.validateSpec(
+      idx.upgradeOldSpec({
+        indexes: [
+          {
+            collectionGroup: "collection",
+            queryScope: "COLLECTION",
+            fields: [
+              {
+                fieldPath: "foo",
+                searchConfig: {
+                  geoSpec: {
+                    geoJsonIndexingDisabled: true,
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      }),
+    );
+  });
+
+  it("should reject invalid searchConfig missing indexType", () => {
+    expect(() => {
+      idx.validateSpec({
+        indexes: [
+          {
+            collectionGroup: "collection",
+            queryScope: "COLLECTION",
+            fields: [
+              {
+                fieldPath: "foo",
+                searchConfig: {
+                  textSpec: {
+                    indexSpecs: [
+                      {
+                        matchType: "MATCH_GLOBALLY",
+                      } as any,
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    }).to.throw(FirebaseError, /Must contain "indexType"/);
+  });
+
+  it("should reject invalid searchConfig missing matchType", () => {
+    expect(() => {
+      idx.validateSpec({
+        indexes: [
+          {
+            collectionGroup: "collection",
+            queryScope: "COLLECTION",
+            fields: [
+              {
+                fieldPath: "foo",
+                searchConfig: {
+                  textSpec: {
+                    indexSpecs: [
+                      {
+                        indexType: "TOKENIZED",
+                      } as any,
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    }).to.throw(FirebaseError, /Must contain "matchType"/);
+  });
+
+  it("should reject invalid searchConfig with invalid indexType", () => {
+    expect(() => {
+      idx.validateSpec({
+        indexes: [
+          {
+            collectionGroup: "collection",
+            queryScope: "COLLECTION",
+            fields: [
+              {
+                fieldPath: "foo",
+                searchConfig: {
+                  textSpec: {
+                    indexSpecs: [
+                      {
+                        indexType: "INVALID",
+                        matchType: "MATCH_GLOBALLY",
+                      } as any,
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    }).to.throw(FirebaseError, /Field "indexType" must be one of/);
+  });
+
+  it("should reject invalid searchConfig with invalid matchType", () => {
+    expect(() => {
+      idx.validateSpec({
+        indexes: [
+          {
+            collectionGroup: "collection",
+            queryScope: "COLLECTION",
+            fields: [
+              {
+                fieldPath: "foo",
+                searchConfig: {
+                  textSpec: {
+                    indexSpecs: [
+                      {
+                        indexType: "TOKENIZED",
+                        matchType: "INVALID",
+                      } as any,
+                    ],
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      });
+    }).to.throw(FirebaseError, /Field "matchType" must be one of/);
+  });
+
   it("should reject an incomplete index spec", () => {
     expect(() => {
       idx.validateSpec({
@@ -299,7 +460,10 @@ describe("IndexValidation", () => {
           },
         ],
       });
-    }).to.throw(FirebaseError, /Must contain exactly one of "order,arrayConfig,vectorConfig"/);
+    }).to.throw(
+      FirebaseError,
+      /Must contain exactly one of "order,arrayConfig,searchConfig,vectorConfig"/,
+    );
   });
 });
 describe("IndexSpecMatching", () => {
@@ -323,6 +487,19 @@ describe("IndexSpecMatching", () => {
         { fieldPath: "foo", order: API.Order.ASCENDING },
         { fieldPath: "bar", arrayConfig: API.ArrayConfig.CONTAINS },
         { fieldPath: "baz", vectorConfig: { dimension: 384, flat: {} } },
+        {
+          fieldPath: "qux",
+          searchConfig: {
+            textSpec: {
+              indexSpecs: [
+                {
+                  indexType: API.TextIndexType.TOKENIZED,
+                  matchType: API.TextMatchType.MATCH_GLOBALLY,
+                },
+              ],
+            },
+          },
+        },
         { fieldPath: "__name__", order: API.Order.ASCENDING },
       ],
       state: API.State.READY,
@@ -335,6 +512,19 @@ describe("IndexSpecMatching", () => {
         { fieldPath: "foo", order: "ASCENDING" },
         { fieldPath: "bar", arrayConfig: "CONTAINS" },
         { fieldPath: "baz", vectorConfig: { dimension: 384, flat: {} } },
+        {
+          fieldPath: "qux",
+          searchConfig: {
+            textSpec: {
+              indexSpecs: [
+                {
+                  indexType: "TOKENIZED",
+                  matchType: "MATCH_GLOBALLY",
+                },
+              ],
+            },
+          },
+        },
         { fieldPath: "__name__", order: API.Order.ASCENDING },
       ],
     } as Spec.Index;
@@ -356,6 +546,41 @@ describe("IndexSpecMatching", () => {
 
     expect(idx.indexMatchesSpec(apiIndex, specIndex, DatabaseEdition.STANDARD)).to.eql(false);
     expect(idx.indexMatchesSpec(apiIndex, specIndex, DatabaseEdition.ENTERPRISE)).to.eql(false);
+  });
+
+  it("should identify a negative index spec match with different search config", () => {
+    const apiIndex = {
+      ...baseApiIndex,
+      fields: [
+        {
+          fieldPath: "foo",
+          searchConfig: {
+            textSpec: {
+              indexSpecs: [
+                {
+                  indexType: API.TextIndexType.TOKENIZED,
+                  matchType: API.TextMatchType.MATCH_GLOBALLY,
+                },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    const specIndex = {
+      ...baseSpecIndex,
+      fields: [
+        {
+          fieldPath: "foo",
+          searchConfig: {
+            geoSpec: { geoJsonIndexingDisabled: true },
+          },
+        },
+      ],
+    } as Spec.Index;
+
+    expect(idx.indexMatchesSpec(apiIndex, specIndex, DatabaseEdition.STANDARD)).to.eql(false);
   });
 
   it("should identify a positive index spec match with apiScope, density, multikey, and unique", () => {

--- a/src/firestore/pretty-print.spec.ts
+++ b/src/firestore/pretty-print.spec.ts
@@ -67,6 +67,35 @@ describe("prettyIndexString", () => {
       ),
     ).to.contain("(foo,ASCENDING) (bar,VECTOR<200>) ");
   });
+
+  it("should correctly print a search type Index", () => {
+    expect(
+      printer.prettyIndexString(
+        {
+          name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+          queryScope: API.QueryScope.COLLECTION,
+          fields: [{ fieldPath: "foo", searchConfig: {} }],
+        },
+        false,
+      ),
+    ).to.contain("(foo,SEARCH) ");
+  });
+
+  it("should correctly print a search type Index with other fields", () => {
+    expect(
+      printer.prettyIndexString(
+        {
+          name: "/projects/project/databases/(default)/collectionGroups/collectionB/indexes/a",
+          queryScope: API.QueryScope.COLLECTION,
+          fields: [
+            { fieldPath: "foo", order: API.Order.ASCENDING },
+            { fieldPath: "bar", searchConfig: {} },
+          ],
+        },
+        false,
+      ),
+    ).to.contain("(foo,ASCENDING) (bar,SEARCH) ");
+  });
 });
 
 describe("firebaseConsoleDatabaseUrl", () => {

--- a/src/firestore/pretty-print.ts
+++ b/src/firestore/pretty-print.ts
@@ -331,14 +331,17 @@ export class PrettyPrint {
         return;
       }
 
-      // Normal field indexes have an "order", array indexes have an
-      // "arrayConfig", and vector indexes have a "vectorConfig" we want to
-      // display whichever one is present.
+      /* Normal field indexes have an "order", array indexes have an
+      "arrayConfig", search indexes have a "searchConfig"
+      and vector indexes have a "vectorConfig". We want to
+      display whichever one is present. */
       let configString;
       if (field.order) {
         configString = field.order;
       } else if (field.arrayConfig) {
         configString = field.arrayConfig;
+      } else if (field.searchConfig) {
+        configString = "SEARCH";
       } else if (field.vectorConfig) {
         configString = `VECTOR<${field.vectorConfig.dimension}>`;
       }


### PR DESCRIPTION
### Description

Adds support for creating Firestore search indexes

### Scenarios Tested

Tested search configs with and without other existing index field types.


### Sample Commands

firebase deploy --only firestore