### PR TITLE
Fix shared scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Added SSE mode support to `firebase mcp`. To use it, run `firebase mcp --mode=sse --port=3000`, and connect your client on `http://localhost:3000`.
 - Update the valid Python runtimes for functions. Default Python runtime is now Python 3.14.
 - Fix CLI non-interactive mode for dataconnect init (#10401)
+- Fix an issue where deploying multi-codebase functions failed due to a shared source token scraper (#10428)

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -1782,6 +1782,37 @@ describe("Fabricator", () => {
       expect(createEndpoint).to.have.been.calledOnce;
       expect(deleteEndpoint).to.have.been.calledOnce;
     });
+
+    it("isolates source token scrapers across changesets", async () => {
+      const ep1 = endpoint({ httpsTrigger: {} }, { id: "A", region: "us-central1" });
+      const ep2 = endpoint({ httpsTrigger: {} }, { id: "B", region: "us-west1" });
+      const plan: planner.DeploymentPlan = {
+        "us-central1": {
+          endpointsToCreate: [ep1],
+          endpointsToUpdate: [],
+          endpointsToDelete: [],
+          endpointsToSkip: [],
+        },
+        "us-west1": {
+          endpointsToCreate: [ep2],
+          endpointsToUpdate: [],
+          endpointsToDelete: [],
+          endpointsToSkip: [],
+        },
+      };
+
+      const scrapers: scraper.SourceTokenScraper[] = [];
+      const createEndpoint = sinon.stub(fab, "createEndpoint").callsFake(
+        (unused: backend.Endpoint, s: scraper.SourceTokenScraper) => {
+          scrapers.push(s);
+          return Promise.resolve();
+        },
+      );
+
+      await fab.applyPlan(plan);
+      expect(scrapers).to.have.lengthOf(2);
+      expect(scrapers[0]).to.not.equal(scrapers[1]);
+    });
   });
 
   describe("createRunFunction", () => {

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -1802,12 +1802,12 @@ describe("Fabricator", () => {
       };
 
       const scrapers: scraper.SourceTokenScraper[] = [];
-      const createEndpoint = sinon.stub(fab, "createEndpoint").callsFake(
-        (unused: backend.Endpoint, s: scraper.SourceTokenScraper) => {
+      sinon
+        .stub(fab, "createEndpoint")
+        .callsFake((unused: backend.Endpoint, s: scraper.SourceTokenScraper) => {
           scrapers.push(s);
           return Promise.resolve();
-        },
-      );
+        });
 
       await fab.applyPlan(plan);
       expect(scrapers).to.have.lengthOf(2);

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -99,9 +99,9 @@ export class Fabricator {
     const changesets = Object.values(plan);
 
     // Phase 1: Creates and Updates
-    const scraperV1 = new SourceTokenScraper();
-    const scraperV2 = new SourceTokenScraper();
     const createAndUpdatePromises = changesets.map((changes) => {
+      const scraperV1 = new SourceTokenScraper();
+      const scraperV2 = new SourceTokenScraper();
       return this.applyUpserts(changes, scraperV1, scraperV2);
     });
     const createAndUpdateResultsArray = await Promise.allSettled(createAndUpdatePromises);


### PR DESCRIPTION
This pull request fixes a regression introduced in the function rename deletion sequence refactor  #10317 where a single shared instance of SourceTokenScraper was used across all changesets. Because Cloud Functions source and build tokens are unique to a specific codebase and region, sharing a single scraper caused a source token from the first codebase to be incorrectly reused during the deployment of functions from a second codebase, leading to build mismatches and container health check failures.

To resolve this issue, we isolate the scraper instances within each regional changeset during the initial create and update phase. This restores the original isolation model so that only functions within the exact same region and codebase reuse the same build token, while retaining the correct deployment deletion sequence. We also added unit test coverage in the deployment fabricator spec to ensure that each changeset maintains independent scrapers and prevents any token leakage across changesets.

Fixes #10428 