### PR TITLE
feat: unify database edition and type logic

### DIFF
--- a/src/firestore/pretty-print.spec.ts
+++ b/src/firestore/pretty-print.spec.ts
@@ -95,7 +95,7 @@ describe("prettyStringArray", () => {
   });
 });
 
-describe("prettyPrintDatabase", () => {
+describe("database:get", () => {
   let loggerInfoStub: sinon.SinonStub;
 
   const BASE_DATABASE: API.DatabaseResp = {
@@ -169,5 +169,94 @@ describe("prettyPrintDatabase", () => {
 
     expect(loggerInfoStub.firstCall.args[0]).to.include("Edition");
     expect(loggerInfoStub.firstCall.args[0]).to.include("STANDARD");
+  });
+});
+
+describe("database:list", () => {
+  let loggerInfoStub: sinon.SinonStub;
+
+  const BASE_DATABASE: API.DatabaseResp = {
+    name: "projects/my-project/databases/(default)",
+    uid: "uid",
+    createTime: "2020-01-01T00:00:00Z",
+    updateTime: "2020-01-01T00:00:00Z",
+    locationId: "us-central1",
+    type: API.DatabaseType.FIRESTORE_NATIVE,
+    concurrencyMode: "OPTIMISTIC",
+    appEngineIntegrationMode: "ENABLED",
+    keyPrefix: "prefix",
+    deleteProtectionState: API.DatabaseDeleteProtectionState.DISABLED,
+    pointInTimeRecoveryEnablement: API.PointInTimeRecoveryEnablement.DISABLED,
+    etag: "etag",
+    versionRetentionPeriod: "1h",
+    earliestVersionTime: "2020-01-01T00:00:00Z",
+    realtimeUpdatesMode: API.RealtimeUpdatesMode.ENABLED,
+    firestoreDataAccessMode: API.DataAccessMode.ENABLED,
+    mongodbCompatibleDataAccessMode: API.DataAccessMode.DISABLED,
+  };
+
+  beforeEach(() => {
+    loggerInfoStub = sinon.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    loggerInfoStub.restore();
+  });
+
+  it("should display columns for Name, Edition, and Type", () => {
+    const databases: API.DatabaseResp[] = [
+      {
+        ...BASE_DATABASE,
+        name: "projects/my-project/databases/db1",
+        databaseEdition: API.DatabaseEdition.STANDARD,
+      },
+    ];
+
+    printer.prettyPrintDatabases(databases);
+
+    expect(loggerInfoStub.firstCall.args[0]).to.include("Database Name");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("Edition");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("Type");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("db1");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("STANDARD");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("FIRESTORE_NATIVE");
+  });
+
+  it("should sort databases by name", () => {
+    const databases: API.DatabaseResp[] = [
+      {
+        ...BASE_DATABASE,
+        name: "projects/my-project/databases/z-database",
+      },
+      {
+        ...BASE_DATABASE,
+        name: "projects/my-project/databases/a-database",
+      },
+    ];
+
+    printer.prettyPrintDatabases(databases);
+
+    const logOutput = loggerInfoStub.firstCall.args[0] as string;
+    expect(logOutput.indexOf("a-database")).to.be.lessThan(logOutput.indexOf("z-database"));
+  });
+
+  it("should show No databases found when list is empty", () => {
+    printer.prettyPrintDatabases([]);
+    expect(loggerInfoStub.firstCall.args[0]).to.include("No databases found.");
+  });
+
+  it("should display DATASTORE_MODE when type is DATASTORE_MODE", () => {
+    const databases: API.DatabaseResp[] = [
+      {
+        ...BASE_DATABASE,
+        name: "projects/my-project/databases/db-datastore",
+        type: API.DatabaseType.DATASTORE_MODE,
+      },
+    ];
+
+    printer.prettyPrintDatabases(databases);
+
+    expect(loggerInfoStub.firstCall.args[0]).to.include("db-datastore");
+    expect(loggerInfoStub.firstCall.args[0]).to.include("DATASTORE_MODE");
   });
 });

--- a/src/firestore/pretty-print.ts
+++ b/src/firestore/pretty-print.ts
@@ -26,6 +26,17 @@ export class PrettyPrint {
     });
   }
 
+  getDatabaseEdition(database: types.DatabaseResp): string {
+    return !database.databaseEdition ||
+      database.databaseEdition === types.DatabaseEdition.DATABASE_EDITION_UNSPECIFIED
+      ? types.DatabaseEdition.STANDARD
+      : database.databaseEdition;
+  }
+
+  getDatabaseApiType(database: types.DatabaseResp): string {
+    return database.type;
+  }
+
   /**
    * Print an array of databases to the console as an ASCII table.
    * @param databases the array of Firestore databases.
@@ -37,11 +48,21 @@ export class PrettyPrint {
     }
     const sortedDatabases: types.DatabaseResp[] = databases.sort(sort.compareApiDatabase);
     const table = new Table({
-      head: ["Database Name"],
-      colWidths: [Math.max(...sortedDatabases.map((database) => database.name.length + 5), 20)],
+      head: ["Database Name", "Edition", "Type"],
+      colWidths: [
+        Math.max(...sortedDatabases.map((database) => database.name.length + 5), 20),
+        20,
+        20,
+      ],
     });
 
-    table.push(...sortedDatabases.map((database) => [this.prettyDatabaseString(database)]));
+    table.push(
+      ...sortedDatabases.map((database) => {
+        const edition = this.getDatabaseEdition(database);
+        const apiType = this.getDatabaseApiType(database);
+        return [this.prettyDatabaseString(database), edition, apiType];
+      }),
+    );
     logger.info(table.toString());
   }
 
@@ -60,16 +81,13 @@ export class PrettyPrint {
       colWidths: [30, colValueWidth],
     });
 
-    const edition =
-      !database.databaseEdition ||
-      database.databaseEdition === types.DatabaseEdition.DATABASE_EDITION_UNSPECIFIED
-        ? types.DatabaseEdition.STANDARD
-        : database.databaseEdition;
+    const edition = this.getDatabaseEdition(database);
+    const apiType = this.getDatabaseApiType(database);
     table.push(
       ["Name", clc.yellow(database.name)],
       ["Create Time", clc.yellow(database.createTime)],
       ["Last Update Time", clc.yellow(database.updateTime)],
-      ["Type", clc.yellow(database.type)],
+      ["Type", clc.yellow(apiType)],
       ["Edition", clc.yellow(edition)],
       ["Location", clc.yellow(database.locationId)],
       ["Delete Protection State", clc.yellow(database.deleteProtectionState)],


### PR DESCRIPTION
### Description
Extracts shared helper methods for resolving a Firestore database's edition and type. Ensures that both 'firestore:databases:list' and 'firestore:databases:get' use the same underlying logic for formatting their output and display consistent headers.

### Scenarios Tested
- All unit tests in pretty-print.spec.ts pass successfully.
- Added new tests for database:list to verify alphabetical sorting, handling of empty lists, and checking the correctness of database mode configurations (e.g., DATASTORE_MODE).
- Renamed test suites in pretty-print.spec.ts to 'database:get' and 'database:list' for better clarity.
- Checks for building and linting the repository completed without errors.

### Sample Commands
- npx mocha src/firestore/pretty-print.spec.ts
- npm run build
- npm run lint:changed-files