### PR TITLE
fix: wrap MCP tool array outputs in objects to satisfy SDK schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,4 @@
 
 ## Unreleased
 
-- Fix MCP server error 'Invalid input: expected record, received array' by wrapping arrays in objects at call sites and adding a safety check in `toContent`.
+- Fixed an issue where some MCP tools would error with "Invalid input: expected record, received array". (#10437)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Fix MCP server error 'Invalid input: expected record, received array' by wrapping arrays in objects at call sites and adding a safety check in `toContent`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,1 @@
-# Changelog
-
-## Unreleased
-
 - Fixed an issue where some MCP tools would error with "Invalid input: expected record, received array". (#10437)

--- a/src/mcp/tools/auth/get_users.spec.ts
+++ b/src/mcp/tools/auth/get_users.spec.ts
@@ -33,7 +33,7 @@ describe("get_users tool", () => {
       listUsersStub.resolves(users);
       const result = await get_users.fn({}, { projectId } as McpContext);
       expect(listUsersStub).to.be.calledWith(projectId, 100);
-      expect(result).to.deep.equal(toContent(prunedUsers));
+      expect(result).to.deep.equal(toContent({ users: prunedUsers }));
     });
   });
 
@@ -44,7 +44,7 @@ describe("get_users tool", () => {
       const result = await get_users.fn({ uids: ["uid1", "uid2"] }, { projectId } as McpContext);
       expect(findUserStub).to.be.calledWith(projectId, undefined, undefined, "uid1");
       expect(findUserStub).to.be.calledWith(projectId, undefined, undefined, "uid2");
-      expect(result).to.deep.equal(toContent(prunedUsers));
+      expect(result).to.deep.equal(toContent({ users: prunedUsers }));
     });
 
     it("should handle not found users", async () => {
@@ -53,7 +53,7 @@ describe("get_users tool", () => {
       const result = await get_users.fn({ uids: ["uid1", "uid2"] }, { projectId } as McpContext);
       expect(findUserStub).to.be.calledWith(projectId, undefined, undefined, "uid1");
       expect(findUserStub).to.be.calledWith(projectId, undefined, undefined, "uid2");
-      expect(result).to.deep.equal(toContent([prunedUsers[0]]));
+      expect(result).to.deep.equal(toContent({ users: [prunedUsers[0]] }));
     });
   });
 
@@ -66,7 +66,7 @@ describe("get_users tool", () => {
       } as McpContext);
       expect(findUserStub).to.be.calledWith(projectId, "user1@example.com", undefined, undefined);
       expect(findUserStub).to.be.calledWith(projectId, "user2@example.com", undefined, undefined);
-      expect(result).to.deep.equal(toContent(prunedUsers));
+      expect(result).to.deep.equal(toContent({ users: prunedUsers }));
     });
   });
 
@@ -79,7 +79,7 @@ describe("get_users tool", () => {
       } as McpContext);
       expect(findUserStub).to.be.calledWith(projectId, undefined, "+11111111111", undefined);
       expect(findUserStub).to.be.calledWith(projectId, undefined, "+22222222222", undefined);
-      expect(result).to.deep.equal(toContent(prunedUsers));
+      expect(result).to.deep.equal(toContent({ users: prunedUsers }));
     });
   });
 });

--- a/src/mcp/tools/auth/get_users.ts
+++ b/src/mcp/tools/auth/get_users.ts
@@ -59,6 +59,6 @@ export const get_users = tool(
     if (!uids?.length && !emails?.length && !phone_numbers?.length) {
       users = await listUsers(projectId, limit || 100);
     }
-    return toContent(users.map(prune));
+    return toContent({ users: users.map(prune) });
   },
 );

--- a/src/mcp/tools/firestore/query_collection.ts
+++ b/src/mcp/tools/firestore/query_collection.ts
@@ -145,7 +145,7 @@ export const query_collection = tool(
 
     const docs = documents.map(firestoreDocumentToJson);
 
-    const docsContent = toContent(docs);
+    const docsContent = toContent({ documents: docs });
 
     return docsContent;
   },

--- a/src/mcp/tools/functions/list_functions.ts
+++ b/src/mcp/tools/functions/list_functions.ts
@@ -44,12 +44,15 @@ export const list_functions = tool(
       }));
 
       if (!formattedList.length) {
-        return toContent([], {
-          contentPrefix: "No functions found in this project.\n\n",
-        });
+        return toContent(
+          { functions: [] },
+          {
+            contentPrefix: "No functions found in this project.\n\n",
+          },
+        );
       }
 
-      return toContent(formattedList);
+      return toContent({ functions: formattedList });
     } catch (err) {
       const errMsg = getErrMsg((err as any)?.original || err, "Failed to list functions.");
       return mcpError(errMsg);

--- a/src/mcp/util.spec.ts
+++ b/src/mcp/util.spec.ts
@@ -514,7 +514,7 @@ describe("toContent", () => {
     const result = toContent(data);
     expect(result.content).to.have.lengthOf(1);
     expect(result.content[0].type).to.equal("text");
-    expect((result as any).structuredContent).to.deep.equal(data);
+    expect(result.structuredContent).to.deep.equal(data);
   });
 
   it("should NOT return structuredContent for array data", () => {
@@ -522,7 +522,7 @@ describe("toContent", () => {
     const result = toContent(data);
     expect(result.content).to.have.lengthOf(1);
     expect(result.content[0].type).to.equal("text");
-    expect((result as any).structuredContent).to.be.undefined;
+    expect(result.structuredContent).to.be.undefined;
   });
 
   it("should return content for string data", () => {

--- a/src/mcp/util.spec.ts
+++ b/src/mcp/util.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import * as experiments from "../experiments";
-import { cleanSchema, applyAppMeta } from "./util";
+import { cleanSchema, applyAppMeta, toContent } from "./util";
 
 interface TestCase {
   desc: string;
@@ -505,5 +505,30 @@ describe("applyAppMeta", () => {
     const result: CallToolResult = { content: [{ type: "text", text: "hello" }] };
     const uri = "ui://test";
     expect(applyAppMeta(result, uri)).to.deep.equal(result);
+  });
+});
+
+describe("toContent", () => {
+  it("should return content and structuredContent for object data", () => {
+    const data = { foo: "bar" };
+    const result = toContent(data);
+    expect(result.content).to.have.lengthOf(1);
+    expect(result.content[0].type).to.equal("text");
+    expect((result as any).structuredContent).to.deep.equal(data);
+  });
+
+  it("should NOT return structuredContent for array data", () => {
+    const data = ["foo", "bar"];
+    const result = toContent(data);
+    expect(result.content).to.have.lengthOf(1);
+    expect(result.content[0].type).to.equal("text");
+    expect((result as any).structuredContent).to.be.undefined;
+  });
+
+  it("should return content for string data", () => {
+    const data = "hello";
+    const result = toContent(data);
+    expect(result.content).to.deep.equal([{ type: "text", text: "hello" }]);
+    expect((result as any).structuredContent).to.be.undefined;
   });
 });

--- a/src/mcp/util.ts
+++ b/src/mcp/util.ts
@@ -44,7 +44,7 @@ export function toContent(
     content: [{ type: "text", text: `${prefix}${text}${suffix}` }],
   };
   if (typeof data === "object" && data !== null && !Array.isArray(data)) {
-    (result as any).structuredContent = data as Record<string, unknown>;
+    result.structuredContent = data as Record<string, unknown>;
   }
   return result;
 }

--- a/src/mcp/util.ts
+++ b/src/mcp/util.ts
@@ -40,10 +40,13 @@ export function toContent(
   }
   const prefix = options?.contentPrefix || "";
   const suffix = options?.contentSuffix || "";
-  return {
+  const result: CallToolResult = {
     content: [{ type: "text", text: `${prefix}${text}${suffix}` }],
-    structuredContent: data as { [key: string]: unknown },
   };
+  if (typeof data === "object" && data !== null && !Array.isArray(data)) {
+    (result as any).structuredContent = data as Record<string, unknown>;
+  }
+  return result;
 }
 
 /**


### PR DESCRIPTION
### Description
Fixes an issue where some MCP tools fail with 'Invalid input: expected record, received array' due to SDK upgrade enforcing record type for structuredContent.

Wrapped arrays in objects at call sites and added safety check in toContent.

### Scenarios Tested
- Unit tests for get_users and util.ts passed.

### Sample Commands
npx mocha src/mcp/tools/auth/get_users.spec.ts
npx mocha src/mcp/util.spec.ts

Fixes #10437
