### PR TITLE
tests: Fix wrong method called in api-sort tests

### DIFF
--- a/src/firestore/api-sort.spec.ts
+++ b/src/firestore/api-sort.spec.ts
@@ -58,7 +58,7 @@ describe("compareApiBackupSchedule", () => {
       retention: durationFromSeconds(60 * 60 * 24 * 7),
     };
     expect(sort.compareApiBackupSchedule(weeklySchedule, dailySchedule)).to.greaterThanOrEqual(1);
-    expect(sort.compareApiBackup(dailySchedule, weeklySchedule)).to.lessThanOrEqual(-1);
+    expect(sort.compareApiBackupSchedule(dailySchedule, weeklySchedule)).to.lessThanOrEqual(-1);
   });
 
   it("should compare schedules with the same recurrence by name", () => {
@@ -73,6 +73,6 @@ describe("compareApiBackupSchedule", () => {
       retention: durationFromSeconds(60 * 60 * 24),
     };
     expect(sort.compareApiBackupSchedule(dailySchedule1, dailySchedule2)).to.lessThanOrEqual(-1);
-    expect(sort.compareApiBackup(dailySchedule2, dailySchedule1)).to.greaterThanOrEqual(1);
+    expect(sort.compareApiBackupSchedule(dailySchedule2, dailySchedule1)).to.greaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
### Description

This corrects two tests that were previously calling the wrong method (a method that compares Backups on two BackupSchedules; I don't get why the TypeScript compiler didn't catch this mistake years ago)
