### PR TITLE
Update AGY env var

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -19,7 +19,7 @@ export function setFirebaseMcp(value: boolean) {
 
 // Detect if the CLI was invoked by a coding agent, based on well-known env vars.
 export function detectAIAgent(): string {
-  if (process.env.ANTIGRAVITY_CLI_ALIAS) return "antigravity";
+  if (process.env.ANTIGRAVITY_AGENT) return "antigravity";
   if (process.env.CLAUDECODE) return "claude_code";
   if (process.env.CLINE_ACTIVE) return "cline";
   if (process.env.CODEX_SANDBOX) return "codex_cli";


### PR DESCRIPTION
### Description
Use a more reliable env var to detect when the AGY agent calls the CLI.

Validated this by having the agent run `env` in all the places we'd want to detect this from (AGY chat, AGY hub, Jetski hub). The `ANTIGRAVITY_AGENT=1` env var was set in all locations.