### PR TITLE
fix issue where app hosting error logs are cut off in terminal

### DIFF
--- a/src/deploy/apphosting/release.ts
+++ b/src/deploy/apphosting/release.ts
@@ -70,6 +70,7 @@ export default async function (context: Context, options: Options): Promise<void
     `Starting rollout(s) for backend(s) ${backendIds.join(", ")}; this may take a few minutes. It's safe to exit now.\n`,
   ).start();
   const results = await Promise.allSettled(rollouts);
+  rolloutsSpinner.stop();
   let failed = false;
   for (let i = 0; i < results.length; i++) {
     const res = results[i];
@@ -83,7 +84,6 @@ export default async function (context: Context, options: Options): Promise<void
       logLabeledError("apphosting", `${res.reason}`);
     }
   }
-  rolloutsSpinner.stop();
   if (failed) {
     throw new FirebaseError(
       "One or more rollouts failed. Please review the errors above and try again.",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Moved the ora spinner stop to right after the results and right before the success and error logs. For some reason a code like below
```js
 const rolloutsSpinner = ora(
        "Some message with newline in the end\n",
    ).start();
    await new Promise((resolve) => setTimeout(resolve, 1_000)); // Some promise
    
    console.log(`Some log log that is really really long that will mosst likely take up more space that is needed so that is would wrap the line and probably just need another log output? maybe? Some log log that is really really long that will mosst likely take up more space that is needed so that is would wrap the line and probably just need another log output? maybe END`);
    rolloutsSpinner.stop()
```

Will cause `Some log log that is really really long that will...` to be cut off on.

For example, App Hosting error log is cut off so the error link is invalid:

```
$ firebase deploy

=== Deploying to 'PROJECT_ID'...

i  deploying apphosting
i  apphosting: Found backend(s) my-web-app, another-web-app
i  apphosting: Zipped source for backend my-web-app
i  apphosting: Uploading source for backend my-web-app...
i  apphosting: Zipped source for backend another-web-app
i  apphosting: Uploading source for backend another-web-app...
i  apphosting: Uploaded at gs://firebaseapphosting-sources-PROJECT_NUMBER-us-central1/my-web-app--64829-ro4RUkcPt9is-.zip
i  apphosting: Uploaded at gs://firebaseapphosting-sources-PROJECT_NUMBER-us-east4/another-web-app--64829-CQD8tNo8DVaF-.zip
i  apphosting: You may also track the rollout(s) at:
        https://console.firebase.google.com/project/PROJECT_ID/apphosting
⠏ Starting rollout(s) for backend(s) my-web-app, another-web-app; this may take a few minutes. It's safe to exit now.
✔  apphosting: Rollout for backend my-web-app complete!
✔  apphosting: Your backend is now deployed at:
        https://my-web-app--PROJECT_ID.us-central1.hosted.app
⚠  apphosting: Rollout for backend another-web-app failed.
⬢  apphosting: FirebaseError: Failed to build your app. Please inspect the build logs at https://console.cloud.google.com/cloud-build/builds;region=us-east4/84466c59-d941-49

Error: One or more rollouts failed. Please review the errors above and try again.
```



### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->


```
$ firebase deploy

=== Deploying to 'PROJECT_ID'...

i  deploying apphosting
i  apphosting: Found backend(s) my-web-app, another-web-app
i  apphosting: Zipped source for backend my-web-app
i  apphosting: Uploading source for backend my-web-app...
i  apphosting: Zipped source for backend another-web-app
i  apphosting: Uploading source for backend another-web-app...
i  apphosting: Uploaded at gs://firebaseapphosting-sources-PROJECT_NUMBER-us-central1/my-web-app--67218-esG3tiUdoh6I-.zip
i  apphosting: Uploaded at gs://firebaseapphosting-sources-PROJECT_NUMBER-us-east4/another-web-app--67218-g3VBpMnxfgkc-.zip
i  apphosting: You may also track the rollout(s) at:
        https://console.firebase.google.com/project/PROJECT_ID/apphosting
✔  apphosting: Rollout for backend my-web-app complete!
✔  apphosting: Your backend is now deployed at:
        https://my-web-app--PROJECT_ID.us-central1.hosted.app
⚠  apphosting: Rollout for backend another-web-app failed.
⬢  apphosting: FirebaseError: Failed to build your app. Please inspect the build logs at https://console.cloud.google.com/cloud-build/builds;region=us-east4/24ec3a31-5b7b-490e-9d10-a4da80a8c461?project=PROJECT_NUMBER

Error: One or more rollouts failed. Please review the errors above and try again.
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
