### PR TITLE
chore: update dart template for 0.6.0

### DIFF
--- a/templates/init/functions/dart/pubspec.yaml
+++ b/templates/init/functions/dart/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.9.0
 
 dependencies:
-  firebase_functions: ^0.5.0
+  firebase_functions: ^0.6.0
 
 dev_dependencies:
   build_runner: ^2.4.0

--- a/templates/init/functions/dart/server.dart
+++ b/templates/init/functions/dart/server.dart
@@ -1,7 +1,7 @@
 import 'package:firebase_functions/firebase_functions.dart';
 
-void main(List<String> args) {
-  fireUp(args, (firebase) {
+void main() {
+  runFunctions((firebase) {
     // https://firebase.google.com/docs/functions/http-events
     firebase.https.onRequest(
       name: 'helloWorld',


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

`package:firebase_functions` 0.6.0 was released, which renames `fireUp` to `runFunctions`. This change updates the Dart template to match.

### Scenarios Tested

I used `firebase init`, created a Dart project, and run it using the emulator.
