### PR TITLE
Resolve VPC Connector region if REGION_TBD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Set region for VPC connector to match function region if not specified. (#10469)

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -257,8 +257,8 @@ export type Endpoint = Triggered & {
   // Defaults to the compute service account when a function is first created as a GCF gen 2 function.
   serviceAccount?: ServiceAccount | Expression<string> | null;
 
-  // defaults to ["us-central1"], overridable in firebase-tools with
-  //  process.env.FIREBASE_FUNCTIONS_DEFAULT_REGION
+  // Defaults to REGION_TBD. The deployment region is resolved dynamically at deploy-time
+  // based on event trigger sources or matching existing functions, falling back to "us-central1".
   region?: ListField;
 
   // The Cloud project associated with this endpoint.

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -484,7 +484,7 @@ describe("prepare", () => {
           retry: false,
         },
         vpc: {
-          connector: "projects/project/locations/REGION_TBD/connectors/my-connector",
+          connector: `projects/project/locations/${build.REGION_TBD}/connectors/my-connector`,
         },
       };
       const want = backend.of(wantE);

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -472,6 +472,33 @@ describe("prepare", () => {
       expect(want.endpoints["us-central1"]?.["id"].region).to.equal("us-central1");
       expect(want.endpoints[build.REGION_TBD]).to.not.exist;
     });
+
+    it("updates VPC connector region if it contains REGION_TBD placeholder when default region is resolved", async () => {
+      const wantE: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        id: "onArchive",
+        region: build.REGION_TBD,
+        eventTrigger: {
+          eventType: "google.cloud.storage.object.v1.archived",
+          eventFilters: { bucket: "my-bucket" },
+          retry: false,
+        },
+        vpc: {
+          connector: "projects/project/locations/REGION_TBD/connectors/my-connector",
+        },
+      };
+      const want = backend.of(wantE);
+      const have = backend.empty();
+
+      getBucketStub.resolves({ location: "us-east1" });
+
+      await prepare.resolveDefaultRegions(want, have);
+
+      expect(want.endpoints["us-east1"]?.["onArchive"]).to.exist;
+      expect(want.endpoints["us-east1"]?.["onArchive"].vpc?.connector).to.equal(
+        "projects/project/locations/us-east1/connectors/my-connector"
+      );
+    });
   });
 
   describe("inferDetailsFromExisting", () => {

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -496,7 +496,7 @@ describe("prepare", () => {
 
       expect(want.endpoints["us-east1"]?.["onArchive"]).to.exist;
       expect(want.endpoints["us-east1"]?.["onArchive"].vpc?.connector).to.equal(
-        "projects/project/locations/us-east1/connectors/my-connector"
+        "projects/project/locations/us-east1/connectors/my-connector",
       );
     });
   });

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -357,11 +357,12 @@ function moveEndpointToRegion(
   endpoint.region = region;
 
   // Update VPC connector region if it was constructed using REGION_TBD
-  if (endpoint.vpc?.connector?.includes("locations/REGION_TBD/")) {
+  if (endpoint.vpc?.connector?.includes(`locations/${build.REGION_TBD}/`)) {
     endpoint.vpc.connector = endpoint.vpc.connector.replace(
-      "locations/REGION_TBD/",
+      `locations/${build.REGION_TBD}/`,
       `locations/${region}/`,
     );
+  }
   }
 
   backend.endpoints[region] = backend.endpoints[region] || {};

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -355,6 +355,15 @@ function moveEndpointToRegion(
   region: string,
 ) {
   endpoint.region = region;
+
+  // Update VPC connector region if it was constructed using REGION_TBD
+  if (endpoint.vpc?.connector?.includes("locations/REGION_TBD/")) {
+    endpoint.vpc.connector = endpoint.vpc.connector.replace(
+      "locations/REGION_TBD/",
+      `locations/${region}/`,
+    );
+  }
+
   backend.endpoints[region] = backend.endpoints[region] || {};
   backend.endpoints[region][endpoint.id] = endpoint;
   delete backend.endpoints[build.REGION_TBD][endpoint.id];

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -363,7 +363,6 @@ function moveEndpointToRegion(
       `locations/${region}/`,
     );
   }
-  }
 
   backend.endpoints[region] = backend.endpoints[region] || {};
   backend.endpoints[region][endpoint.id] = endpoint;


### PR DESCRIPTION
This dynamically resolves the VPC connector region to be the same as the function if not defined.

This also includes a small comment fix for the region field in Endpoint.

### Scenarios Tested
Create function with VPC connector
`firebase deploy --only functions` on 15.16.0
Update function and use local firebase-tools build
`firebase deploy --only functions`
Update was successful.