### PR TITLE
fix: generate lcov coverage for codecov v5

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -180,6 +180,8 @@ jobs:
 
       - uses: codecov/codecov-action@v5
         if: matrix.node-version == '20'
+        with:
+          files: ./.coverage/lcov.info
 
   integration:
     needs: unit

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:quiet": "npm run lint:ts -- --quiet && npm run lint:other",
     "lint:ts": "eslint --cache --config .eslintrc.js --ext .ts,.js .",
     "mocha:fast": "mocha 'src/**/*.spec.{ts,js}'",
-    "mocha": "nyc --reporter=html mocha 'src/**/*.spec.{ts,js}'",
+    "mocha": "nyc mocha 'src/**/*.spec.{ts,js}'",
     "prepare": "npm run clean && npm run build:publish",
     "test": "npm run lint:quiet && npm run test:compile && npm run mocha",
     "test:appdistribution": "npm run lint:quiet && npm run test:compile && nyc mocha 'src/appdistribution/*.spec.{ts,js}'",
@@ -91,7 +91,8 @@
     ],
     "reporter": [
       "lcovonly",
-      "text"
+      "text",
+      "html"
     ],
     "report-dir": "./.coverage",
     "extension": [


### PR DESCRIPTION
### Description
Codecov v5 failed to find coverage reports because the `mocha` script was overriding the `nyc` reporter to `html` only. This PR removes the override and updates the `nyc` config to generate both `lcovonly` and `html` reports. It also explicitly points the Codecov action to the generated `lcov.info` file.

### Scenarios Tested
- Verified that `lcov.info` is generated locally when running `npx nyc mocha src/deploy/firestore/prepare.spec.ts`.

### Sample Commands
N/A
