### PR TITLE
test: run functions-discover test on Node 24

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -207,7 +207,6 @@ jobs:
           - npm run test:emulator
           - npm run test:extensions-emulator
           - npm run test:frameworks
-          - npm run test:functions-discover
           - npm run test:hosting
           # - npm run test:hosting-rewrites # Long-running test that might conflict across test runs. Run this manually.
           - npm run test:import-export
@@ -217,6 +216,9 @@ jobs:
           - npm run test:triggers-end-to-end:inspect
           # - npm run test:dataconnect-deploy
           - npm run test:dataconnect-emulator
+        include:
+          - node-version: "24"
+            script: "npm run test:functions-discover"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -276,7 +278,6 @@ jobs:
           - npm run test:emulator
           # - npm run test:import-export # Fails becuase port 4000 is taken after first run - hub not shutting down?
           # - npm run test:extensions-emulator # Fails due to cannot find module sharp (not waiting for npm install?)
-          - npm run test:functions-discover
           # - npm run test:triggers-end-to-end
           - npm run test:triggers-end-to-end:inspect
           - npm run test:storage-deploy
@@ -284,6 +285,9 @@ jobs:
           # - npm run test:dataconnect-deploy #  TODO (joehanley): Reenable this - it should be safe to run in parallel
           # - npm run test:dataconnect-emulator # TODO (joehanley): Figure out why this is failing
           # - npm run test:frameworks
+        include:
+          - node-version: "24"
+            script: "npm run test:functions-discover"
     steps:
       - name: Setup Java JDK
         uses: actions/setup-java@v3.3.0

--- a/scripts/functions-discover-tests/fixtures/pnpm/functions/package.json
+++ b/scripts/functions-discover-tests/fixtures/pnpm/functions/package.json
@@ -2,5 +2,11 @@
   "name": "pnpm",
   "dependencies": {
     "firebase-functions": "^6.4.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@firebase/util",
+      "protobufjs"
+    ]
   }
 }

--- a/scripts/functions-discover-tests/fixtures/pnpm/install.sh
+++ b/scripts/functions-discover-tests/fixtures/pnpm/install.sh
@@ -2,4 +2,4 @@
 set -euxo pipefail # bash strict mode
 IFS=$'\n\t'
 
-cd functions && pnpm install
+cd functions && pnpm install --ignore-scripts


### PR DESCRIPTION
### Description
The test:functions-discover test was failing on Node 20 because the latest pnpm requires Node 22+ (due to node:sqlite). This PR updates the CI workflow to run this specific test on Node 24 instead.

### Scenarios Tested
- Verified that the workflow file syntax is correct.
- Verified that run.sh is restored to use the latest pnpm.

### Sample Commands
npm run test:functions-discover
