### PR TITLE
security: drop symlinks from Hosting deploy upload list

### DIFF
--- a/src/listFiles.spec.ts
+++ b/src/listFiles.spec.ts
@@ -1,9 +1,8 @@
 import { expect } from "chai";
-import * as crypto from "crypto";
-import * as fs from "fs";
-import * as os from "os";
-import * as path from "path";
-import { rmSync } from "node:fs";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
 
 import { listFiles } from "./listFiles";
 import { FIXTURE_DIR } from "./test/fixtures/ignores";
@@ -53,8 +52,12 @@ describe("listFiles", () => {
     });
 
     after(() => {
-      rmSync(tmpRoot, { recursive: true, force: true });
-      rmSync(outsideTarget, { force: true });
+      if (tmpRoot) {
+        fs.rmSync(tmpRoot, { recursive: true, force: true });
+      }
+      if (outsideTarget) {
+        fs.rmSync(outsideTarget, { force: true });
+      }
     });
 
     it("excludes a symlink-to-file at the top level (security: prevents leaking files outside source tree)", () => {
@@ -111,7 +114,7 @@ describe("listFiles", () => {
         } catch {
           /* ignore */
         }
-        rmSync(outsideDir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
       }
     });
   });

--- a/src/listFiles.spec.ts
+++ b/src/listFiles.spec.ts
@@ -1,4 +1,9 @@
 import { expect } from "chai";
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { rmSync } from "node:fs";
 
 import { listFiles } from "./listFiles";
 import { FIXTURE_DIR } from "./test/fixtures/ignores";
@@ -29,5 +34,85 @@ describe("listFiles", () => {
       "index.html",
       "present/index.html",
     ]);
+  });
+
+  describe("symlink handling", () => {
+    let tmpRoot = "";
+    let outsideTarget = "";
+
+    before(() => {
+      tmpRoot = path.join(os.tmpdir(), "fb-tools-listFiles-" + crypto.randomBytes(6).toString("hex"));
+      fs.mkdirSync(tmpRoot, { recursive: true });
+      // Two regular files inside the public dir.
+      fs.writeFileSync(path.join(tmpRoot, "index.html"), "<!doctype html>");
+      fs.mkdirSync(path.join(tmpRoot, "static"));
+      fs.writeFileSync(path.join(tmpRoot, "static", "app.js"), "// app");
+      // A target outside the public dir to simulate the credential-leak case.
+      outsideTarget = path.join(os.tmpdir(), "fb-tools-listFiles-leak-" + crypto.randomBytes(6).toString("hex"));
+      fs.writeFileSync(outsideTarget, "SECRET-CONTENT");
+    });
+
+    after(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+      rmSync(outsideTarget, { force: true });
+    });
+
+    it("excludes a symlink-to-file at the top level (security: prevents leaking files outside source tree)", () => {
+      const linkPath = path.join(tmpRoot, "leak");
+      try {
+        fs.symlinkSync(outsideTarget, linkPath);
+        const result = listFiles(tmpRoot);
+        expect(result.sort()).to.have.members(["index.html", "static/app.js"]);
+        expect(result).to.not.include("leak");
+      } finally {
+        try {
+          fs.unlinkSync(linkPath);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    it("excludes a symlink-to-file nested inside the source tree", () => {
+      const linkPath = path.join(tmpRoot, "static", "leak");
+      try {
+        fs.symlinkSync(outsideTarget, linkPath);
+        const result = listFiles(tmpRoot);
+        expect(result.sort()).to.have.members(["index.html", "static/app.js"]);
+        expect(result).to.not.include("static/leak");
+      } finally {
+        try {
+          fs.unlinkSync(linkPath);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    it("does not descend into symlinked directories", () => {
+      const outsideDir = path.join(
+        os.tmpdir(),
+        "fb-tools-listFiles-leakdir-" + crypto.randomBytes(6).toString("hex"),
+      );
+      fs.mkdirSync(outsideDir);
+      fs.writeFileSync(path.join(outsideDir, "secret"), "SECRET-CONTENT");
+      const linkDirPath = path.join(tmpRoot, "linked-dir");
+      try {
+        fs.symlinkSync(outsideDir, linkDirPath, "dir");
+        const result = listFiles(tmpRoot);
+        expect(result.sort()).to.have.members(["index.html", "static/app.js"]);
+        // No file from the linked dir should appear, regardless of stat behavior.
+        for (const r of result) {
+          expect(r.startsWith("linked-dir")).to.equal(false);
+        }
+      } finally {
+        try {
+          fs.unlinkSync(linkDirPath);
+        } catch {
+          /* ignore */
+        }
+        rmSync(outsideDir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/listFiles.ts
+++ b/src/listFiles.ts
@@ -1,12 +1,58 @@
+import { lstatSync } from "fs";
+import { join } from "path";
 import { sync } from "glob";
 
+import { logger } from "./logger";
+
+/**
+ * Recursively list deployable files under `cwd`.
+ *
+ * **Security: symlinks are excluded by default.**
+ *
+ * Hosting deploys take this list, read each entry with `fs.readFile*`
+ * (which follows symlinks at the OS layer), and uploads the bytes to a
+ * Firebase Hosting site. If the source tree contains a symlink such as
+ * `public/leak -> /proc/self/environ` or
+ * `public/leak -> ~/.config/gcloud/application_default_credentials.json`,
+ * the target's contents would otherwise end up published on a
+ * Firebase-hosted public URL.
+ *
+ * The largest exposure is CI workflows that extract attacker-supplied
+ * tarballs into the public directory before invoking `firebase deploy`
+ * (e.g. PR-preview deploy actions). Both `glob({ follow: true })` and
+ * `glob({ follow: false })` would return symlink-to-file entries in
+ * the result (`follow` only controls whether symlinked *directories*
+ * are descended into); the explicit `lstatSync` filter below drops
+ * symlinks of either kind.
+ */
 export function listFiles(cwd: string, ignore: string[] = []): string[] {
-  return sync("**/*", {
+  const matched = sync("**/*", {
     cwd,
     dot: true,
-    follow: true,
+    follow: false,
     ignore: ["**/firebase-debug.log", "**/firebase-debug.*.log", ".firebase/*"].concat(ignore),
     nodir: true,
     posix: true,
   });
+  const out: string[] = [];
+  for (const rel of matched) {
+    let stats;
+    try {
+      // `lstat` does NOT follow symlinks, so we can detect them and skip.
+      stats = lstatSync(join(cwd, rel));
+    } catch {
+      // Stat error: skip the entry rather than risk uploading something
+      // we can't classify.
+      continue;
+    }
+    if (stats.isSymbolicLink()) {
+      logger.debug(
+        `[hosting] dropping symlink \`${rel}\` from upload list ` +
+          `(security: prevents symlink-following from exposing files outside the source tree)`,
+      );
+      continue;
+    }
+    out.push(rel);
+  }
+  return out;
 }


### PR DESCRIPTION
﻿## Summary

`src/listFiles.ts` enumerates the files that `firebase deploy --only hosting` (and `firebase hosting:channel:deploy`) uploads to the Firebase Hosting CDN. It used `glob({ follow: true })`, and even with `follow: false` `glob` still returns symlink-to-file entries because `follow` only controls whether symlinked *directories* are descended into. `Uploader` then calls `fs.readFile*` on each entry, which follows symlinks at the OS layer, so a symlink under the public dir ends up uploading the bytes of its target.

This PR sets `follow: false` and adds an explicit `lstatSync` filter that drops any entry whose `lstat` reports `isSymbolicLink()`.

## Threat model

The largest exposure is CI workflows that extract attacker-supplied tarballs into the public dir before invoking `firebase deploy` (the classic PR-preview deploy pattern; see [GitHub Security Lab on pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). A tarball entry like

- `public/leak -> /proc/self/environ`
- `public/leak -> ~/.config/gcloud/application_default_credentials.json`
- `public/leak -> ~/.ssh/id_rsa`
- `public/leak -> /run/secrets/<anything>`

would otherwise end up uploaded under a path the attacker chose, on a Firebase-hosted public URL accessible to the world.

## What this PR does

- `src/listFiles.ts`:
  - `follow: true` -> `follow: false` so `glob` does not descend into symlinked directories.
  - Adds an `lstatSync`-based filter that drops any entry whose `lstat` reports `isSymbolicLink()`. This catches the symlink-to-file entries `glob` still returns under `follow: false`.
  - Logs a `debug`-level entry when a symlink is dropped so users who legitimately rely on symlinks can see what was skipped.
  - Documents the threat model and the `lstat`-vs-`stat` rationale in JSDoc.
- `src/listFiles.spec.ts`:
  - Adds tests for symlink-to-file rejection at the top level and nested in subdirectories, and a symlinked-directory case.
  - The existing fixture-based tests are unchanged.

## Backward compatibility

Behavior changes only for users whose Hosting public directory contains symlinks they want followed during deploy. That population is small; the typical `public/`, `dist/`, `build/` directory contains regular files only. Users who need symlink-following can bypass `listFiles` by copying the dereferenced files into a real directory before deploy (e.g. `cp -L`), which is also the more predictable thing to do for a CDN upload.

## Why this is a separate PR from #10477

PR #10477 flips the default of `fsAsync.readdirRecursive`. That function is used by Cloud Functions deploy and App Hosting deploy. Hosting deploy uses `listFiles`, which is a different module backed by `glob`. Both paths need symlink protection; the two fixes don't overlap.

## Testing

`npm run test:compile && npm test -- --grep listFiles` — three new tests pass, existing fixture-based tests unchanged.
