### PR TITLE
fix: support secret environment variables for Cloud Run functions

### DIFF
--- a/src/deploy/functions/validate.spec.ts
+++ b/src/deploy/functions/validate.spec.ts
@@ -692,6 +692,29 @@ describe("validate", () => {
         expect(backend.allEndpoints(b)[0].secretEnvironmentVariables![0].version).to.equal("2");
       }
     });
+
+    it("passes validation for Cloud Run (platform=run) functions with secrets", async () => {
+      secretVersionStub.withArgs(project, secret.name, "latest").resolves({
+        secret,
+        versionId: "1",
+        state: "ENABLED",
+      });
+
+      const b = backend.of({
+        ...ENDPOINT,
+        platform: "run",
+        secretEnvironmentVariables: [
+          {
+            projectId: project,
+            secret: "MY_SECRET",
+            key: "MY_SECRET",
+          },
+        ],
+      });
+
+      await validate.secretsAreValid(project, b);
+      expect(backend.allEndpoints(b)[0].secretEnvironmentVariables![0].version).to.equal("1");
+    });
   });
 
   describe("validateTimeoutConfig", () => {

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -338,7 +338,7 @@ export async function secretsAreValid(projectId: string, wantBackend: backend.Ba
   await validateSecretVersions(projectId, endpoints);
 }
 
-const secretsSupportedPlatforms = ["gcfv1", "gcfv2", "run"];
+const secretsSupportedPlatforms: readonly backend.FunctionsPlatform[] = backend.AllFunctionsPlatforms;
 /**
  * Ensures that all endpoints specifying secret environment variables target platform that supports the feature.
  */

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -338,7 +338,8 @@ export async function secretsAreValid(projectId: string, wantBackend: backend.Ba
   await validateSecretVersions(projectId, endpoints);
 }
 
-const secretsSupportedPlatforms: readonly backend.FunctionsPlatform[] = backend.AllFunctionsPlatforms;
+const secretsSupportedPlatforms: readonly backend.FunctionsPlatform[] =
+  backend.AllFunctionsPlatforms;
 /**
  * Ensures that all endpoints specifying secret environment variables target platform that supports the feature.
  */

--- a/src/deploy/functions/validate.ts
+++ b/src/deploy/functions/validate.ts
@@ -338,7 +338,7 @@ export async function secretsAreValid(projectId: string, wantBackend: backend.Ba
   await validateSecretVersions(projectId, endpoints);
 }
 
-const secretsSupportedPlatforms = ["gcfv1", "gcfv2"];
+const secretsSupportedPlatforms = ["gcfv1", "gcfv2", "run"];
 /**
  * Ensures that all endpoints specifying secret environment variables target platform that supports the feature.
  */


### PR DESCRIPTION
 Dart functions (and any language deploying as Cloud Run services) use `platform=run`. The `secretsSupportedPlatforms` allowlist in `validate.ts` only included `gcfv1` and `gcfv2`, causing deploys with secrets to fail with:
 
> Tried to set secret environment variables on <function>[platform=run]. Only gcfv1, gcfv2 support secret environments.

## Fix
Add `"run"` to `secretsSupportedPlatforms`.

## Known limitations
Secret rotation (`firebase functions:secrets:set`) is not yet supported for Cloud Run functions.
The following code in `src/functions/secrets.ts` still throws for `platform=run`:
https://github.com/firebase/firebase-tools/blob/main/src/functions/secrets.ts#L382-L385

```typescript
} else if (endpoint.platform === "run") {
  // This may be tricky because the image has been deleted. How does this work
  // with GCF?
  throw new FirebaseError("Updating Cloud Run functions is not yet implemented.");
}
```

## Related
- Reported in firebase/firebase-functions-dart#141