### PR TITLE
support nested .gitignore files in source deploys

### DIFF
--- a/src/archiveDirectory.ts
+++ b/src/archiveDirectory.ts
@@ -78,7 +78,7 @@ async function zipDirectory(
   try {
     files = await fsAsync.readdirRecursive({
       path: sourceDirectory,
-      ignore: options.ignore,
+      ignoreStrings: options.ignore,
       ignoreSymlinks: true,
     });
   } catch (err: any) {

--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -31,8 +31,8 @@ export async function createLocalBuildTarArchive(
   const ignore = ["firebase-debug.log", "firebase-debug.*.log", ".git"];
   const rdrFiles = await fsAsync.readdirRecursive({
     path: targetDir,
-    ignore: ignore,
-    isGitIgnore: true,
+    ignoreStrings: ignore,
+    supportGitIgnore: true,
   });
   const allFiles: string[] = rdrFiles.map((rdrf) => path.relative(rootDir, rdrf.name));
 
@@ -92,13 +92,11 @@ export async function createSourceDeployArchive(
   // We must ignore firebase-debug.log or weird things happen if you're in the public dir when you deploy.
   const ignore = config.ignore || ["node_modules", ".git"];
   ignore.push("firebase-debug.log", "firebase-debug.*.log");
-  const gitIgnorePatterns = parseGitIgnorePatterns(targetDir);
-  ignore.push(...gitIgnorePatterns);
   try {
     const files = await fsAsync.readdirRecursive({
       path: targetDir,
-      ignore: ignore,
-      isGitIgnore: true,
+      ignoreStrings: ignore,
+      supportGitIgnore: true,
     });
     for (const file of files) {
       const name = path.relative(rootDir, file.name);
@@ -115,20 +113,6 @@ export async function createSourceDeployArchive(
     );
   }
   return tmpFile;
-}
-
-function parseGitIgnorePatterns(projectRoot: string, gitIgnorePath = ".gitignore"): string[] {
-  const absoluteFilePath = path.resolve(projectRoot, gitIgnorePath);
-  if (!fs.existsSync(absoluteFilePath)) {
-    return [];
-  }
-  const lines = fs
-    .readFileSync(absoluteFilePath)
-    .toString() // Buffer -> string
-    .split("\n") // split into lines
-    .map((line) => line.trim())
-    .filter((line) => !line.startsWith("#") && !(line === "")); // remove comments and empty lines
-  return lines;
 }
 
 async function pipeAsync(from: archiver.Archiver, to: fs.WriteStream): Promise<void> {

--- a/src/deploy/functions/prepareFunctionsUpload.ts
+++ b/src/deploy/functions/prepareFunctionsUpload.ts
@@ -114,7 +114,7 @@ async function packageSource(
     CONFIG_DEST_FILE /* .runtimeconfig.json */,
   );
   try {
-    const files = await fsAsync.readdirRecursive({ path: sourceDir, ignore: ignore });
+    const files = await fsAsync.readdirRecursive({ path: sourceDir, ignoreStrings: ignore });
     hashes.push(...(await addFilesToArchive(archive, files, sourceDir, options?.executablePaths)));
     for (const name of additionalSources) {
       const absPath = utils.resolveWithin(projectDir, name);

--- a/src/fsAsync.spec.ts
+++ b/src/fsAsync.spec.ts
@@ -61,7 +61,10 @@ describe("fsAsync", () => {
     });
 
     it("can ignore directories", async () => {
-      const results = await fsAsync.readdirRecursive({ path: baseDir, ignore: ["node_modules"] });
+      const results = await fsAsync.readdirRecursive({
+        path: baseDir,
+        ignoreStrings: ["node_modules"],
+      });
 
       const gotFileNames = results.map((r) => r.name).sort();
       const expectFiles = files
@@ -74,7 +77,7 @@ describe("fsAsync", () => {
     it("supports blob rules", async () => {
       const results = await fsAsync.readdirRecursive({
         path: baseDir,
-        ignore: ["**/node_modules/**"],
+        ignoreStrings: ["**/node_modules/**"],
       });
 
       const gotFileNames = results.map((r) => r.name).sort();
@@ -86,7 +89,10 @@ describe("fsAsync", () => {
     });
 
     it("should support negation rules", async () => {
-      const results = await fsAsync.readdirRecursive({ path: baseDir, ignore: ["!visible"] });
+      const results = await fsAsync.readdirRecursive({
+        path: baseDir,
+        ignoreStrings: ["!visible"],
+      });
 
       const gotFileNames = results.map((r) => r.name).sort();
       const expectFiles = files
@@ -99,8 +105,8 @@ describe("fsAsync", () => {
     it("should support .gitignore rules via options", async () => {
       const results = await fsAsync.readdirRecursive({
         path: baseDir,
-        ignore: ["subdir/nesteddir/*", "!subdir/nesteddir/nestedfile"],
-        isGitIgnore: true,
+        ignoreStrings: ["subdir/nesteddir/*", "!subdir/nesteddir/nestedfile"],
+        supportGitIgnore: true,
       });
 
       const gotFileNames = results.map((r) => r.name).sort();
@@ -109,6 +115,102 @@ describe("fsAsync", () => {
         .filter((file) => file !== path.join(baseDir, "subdir/nesteddir/nestedfile2"))
         .sort();
       return expect(gotFileNames).to.deep.equal(expectFiles);
+    });
+
+    it("should support .gitignore files in subdirectories dynamically", async () => {
+      const testDir = path.join(os.tmpdir(), crypto.randomBytes(10).toString("hex"));
+      fs.mkdirSync(testDir);
+      fs.mkdirSync(path.join(testDir, "a"));
+      fs.mkdirSync(path.join(testDir, "b"));
+
+      fs.writeFileSync(path.join(testDir, "b.txt"), "b.txt");
+      fs.writeFileSync(path.join(testDir, "a", "foo.txt"), "foo.txt");
+      fs.writeFileSync(path.join(testDir, "a", ".env"), ".env");
+      fs.writeFileSync(path.join(testDir, "b", "bar.txt"), "bar.txt");
+
+      fs.writeFileSync(path.join(testDir, ".gitignore"), "b.txt");
+      fs.writeFileSync(path.join(testDir, "a", ".gitignore"), ".env");
+
+      try {
+        const results = await fsAsync.readdirRecursive({
+          path: testDir,
+          supportGitIgnore: true,
+          ignoreStrings: ["node_modules", ".git", "b.txt"],
+        });
+
+        const gotFileNames = results.map((r) => path.relative(testDir, r.name)).sort();
+        const expectedFiles = [".gitignore", "a/.gitignore", "a/foo.txt", "b/bar.txt"].sort();
+
+        expect(gotFileNames).to.deep.equal(expectedFiles);
+      } finally {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should respect nested subdirectory overrides and path scoping", async () => {
+      const testDir = path.join(os.tmpdir(), crypto.randomBytes(10).toString("hex"));
+      fs.mkdirSync(testDir);
+      fs.mkdirSync(path.join(testDir, "subdir"));
+      fs.mkdirSync(path.join(testDir, "subdir", "nested"));
+
+      fs.writeFileSync(path.join(testDir, "subdir", "foo.txt"), "foo");
+      fs.writeFileSync(path.join(testDir, "subdir", "bar.txt"), "bar");
+      fs.writeFileSync(path.join(testDir, "subdir", "nested", "foo.txt"), "nested foo");
+      fs.writeFileSync(path.join(testDir, "subdir", "nested", "baz.txt"), "nested baz");
+
+      fs.writeFileSync(path.join(testDir, ".gitignore"), "*.txt");
+      fs.writeFileSync(
+        path.join(testDir, "subdir", ".gitignore"),
+        ["!foo.txt", "/nested/baz.txt"].join("\n"),
+      );
+
+      try {
+        const results = await fsAsync.readdirRecursive({
+          path: testDir,
+          supportGitIgnore: true,
+        });
+
+        const gotFileNames = results.map((r) => path.relative(testDir, r.name)).sort();
+        const expectedFiles = [
+          ".gitignore",
+          "subdir/.gitignore",
+          "subdir/foo.txt",
+          "subdir/nested/foo.txt",
+        ].sort();
+
+        expect(gotFileNames).to.deep.equal(expectedFiles);
+      } finally {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    });
+
+    it("should handle subdirectories without .gitignore and directories named .gitignore gracefully", async () => {
+      const testDir = path.join(os.tmpdir(), crypto.randomBytes(10).toString("hex"));
+      fs.mkdirSync(testDir);
+
+      fs.mkdirSync(path.join(testDir, "a"));
+      fs.writeFileSync(path.join(testDir, "a", "keep.log"), "keep");
+      fs.writeFileSync(path.join(testDir, "a", "ignore.log"), "ignore");
+
+      fs.mkdirSync(path.join(testDir, "b"));
+      fs.mkdirSync(path.join(testDir, "b", ".gitignore"));
+      fs.writeFileSync(path.join(testDir, "b", "file.txt"), "file");
+
+      fs.writeFileSync(path.join(testDir, ".gitignore"), "ignore.log");
+
+      try {
+        const results = await fsAsync.readdirRecursive({
+          path: testDir,
+          supportGitIgnore: true,
+        });
+
+        const gotFileNames = results.map((r) => path.relative(testDir, r.name)).sort();
+        const expectedFiles = [".gitignore", "a/keep.log", "b/file.txt"].sort();
+
+        expect(gotFileNames).to.deep.equal(expectedFiles);
+      } finally {
+        rmSync(testDir, { recursive: true, force: true });
+      }
     });
 
     it("should support maximum recursion depth", async () => {

--- a/src/fsAsync.ts
+++ b/src/fsAsync.ts
@@ -1,15 +1,20 @@
-import { readdirSync, statSync } from "fs-extra";
+import { readdirSync, statSync, readFileSync } from "fs-extra";
 import ignorePkg from "ignore";
 import * as _ from "lodash";
 import * as minimatch from "minimatch";
 import { join, relative } from "path";
+import { logger } from "./logger";
 
 export interface ReaddirRecursiveOpts {
   // The directory to recurse.
   path: string;
-  // Files to ignore.
-  ignore?: string[];
-  isGitIgnore?: boolean;
+  // Array of glob patterns representing files and folders to ignore.
+  // Note: The matching behavior changes depending on the supportGitIgnore option.
+  ignoreStrings?: string[];
+  // When true, ignoreStrings are matched using the GitIgnore spec rules (supporting negations and scope priorities)
+  // and local nested .gitignore files are discovered and stacked automatically.
+  // When false or undefined, ignoreStrings are matched flatly using simple minimatch wildcard globs.
+  supportGitIgnore?: boolean;
   // Files in the ignore array to include.
   include?: string[];
   // Maximum depth to recurse.
@@ -23,17 +28,49 @@ export interface ReaddirRecursiveFile {
   mode: number;
 }
 
+export interface GitIgnoreState {
+  dirPath: string;
+  ignore: ReturnType<typeof ignorePkg>;
+}
+
 async function readdirRecursiveHelper(options: {
   path: string;
-  filter: (p: string) => boolean;
+  filter: (p: string, gitIgnoreStack?: GitIgnoreState[]) => boolean;
   maxDepth: number;
   ignoreSymlinks: boolean;
+  supportGitIgnore?: boolean;
+  gitIgnoreStack?: GitIgnoreState[];
 }): Promise<ReaddirRecursiveFile[]> {
   const dirContents = readdirSync(options.path, { withFileTypes: true });
+
+  let currentGitIgnoreStack = options.gitIgnoreStack || [];
+  // Load and stack directory-specific .gitignore rules if supportGitIgnore is enabled
+  if (options.supportGitIgnore) {
+    if (dirContents.find((n) => n.name === ".gitignore")?.isFile()) {
+      const localGitIgnore = join(options.path, ".gitignore");
+      try {
+        const lines = readFileSync(localGitIgnore)
+          .toString()
+          .split("\n")
+          .map((line) => line.trim())
+          .filter((line) => !line.startsWith("#") && line !== "");
+        const subIgnore = ignorePkg().add(lines);
+        currentGitIgnoreStack = [
+          ...currentGitIgnoreStack,
+          {
+            dirPath: options.path,
+            ignore: subIgnore,
+          },
+        ];
+      } catch (e: unknown) {
+        logger.debug(`Error reading .gitignore file at ${localGitIgnore}:`, e);
+      }
+    }
+  }
   const fullPaths = dirContents
     .filter((n) => !options.ignoreSymlinks || !n.isSymbolicLink())
     .map((n) => join(options.path, n.name));
-  const filteredPaths = fullPaths.filter((p) => !options.filter(p));
+  const filteredPaths = fullPaths.filter((p) => !options.filter(p, currentGitIgnoreStack));
   const filePromises: Array<Promise<ReaddirRecursiveFile | ReaddirRecursiveFile[]>> = [];
   for (const p of filteredPaths) {
     const fstat = statSync(p);
@@ -50,6 +87,8 @@ async function readdirRecursiveHelper(options: {
           filter: options.filter,
           maxDepth: options.maxDepth - 1,
           ignoreSymlinks: options.ignoreSymlinks,
+          supportGitIgnore: options.supportGitIgnore,
+          gitIgnoreStack: currentGitIgnoreStack,
         }),
       );
     }
@@ -70,28 +109,50 @@ export async function readdirRecursive(
   options: ReaddirRecursiveOpts,
 ): Promise<ReaddirRecursiveFile[]> {
   const mmopts = { matchBase: true, dot: true };
-  const rules = (options.ignore || []).map((glob) => {
+  const ignoreRules = (options.ignoreStrings || []).map((glob) => {
     return (p: string) => minimatch(p, glob, mmopts);
   });
-  const gitIgnoreRules = ignorePkg()
-    .add(options.ignore || [])
-    .createFilter();
-
-  const filter = (t: string): boolean => {
-    if (options.isGitIgnore) {
-      // the git ignore filter will return true if given path should be included,
-      // so we need to negative that return false to avoid filtering it.
-      return !gitIgnoreRules(relative(options.path, t));
+  const filter = (targetPath: string, gitIgnoreStack: GitIgnoreState[] = []): boolean => {
+    if (options.supportGitIgnore) {
+      let ignored = false;
+      // Loop in reverse (from deepest subdirectory to root) so that local subdirectory
+      // rules take precedence and override any parent directory rules.
+      // Loop using a decrementing index to avoid allocating array copies or reversing in the hot path.
+      for (let i = gitIgnoreStack.length - 1; i >= 0; i--) {
+        const state = gitIgnoreStack[i];
+        const relPath = relative(state.dirPath, targetPath);
+        const result = state.ignore.test(relPath);
+        // Check both properties since:
+        // - result.ignored = true means the path is explicitly ignored (e.g. matches "*.txt").
+        // - result.unignored = true means the path is explicitly un-ignored via a negation rule (e.g. matches "!foo.txt").
+        // - both = false means no rules matched in this scope (so we should proceed to check parent directories).
+        if (result.ignored || result.unignored) {
+          ignored = result.ignored;
+          break;
+        }
+      }
+      return ignored;
     }
-    return rules.some((rule) => {
-      return rule(t);
+    return ignoreRules.some((rule) => {
+      return rule(targetPath);
     });
   };
+
+  const initialGitIgnoreStack: GitIgnoreState[] = [];
+  if (options.supportGitIgnore) {
+    initialGitIgnoreStack.push({
+      dirPath: options.path,
+      ignore: ignorePkg().add(options.ignoreStrings || []),
+    });
+  }
+
   const maxDepth = options.maxDepth && options.maxDepth > 0 ? options.maxDepth : Infinity;
   return await readdirRecursiveHelper({
     path: options.path,
     filter: filter,
     maxDepth,
     ignoreSymlinks: !!options.ignoreSymlinks,
+    supportGitIgnore: options.supportGitIgnore,
+    gitIgnoreStack: initialGitIgnoreStack,
   });
 }

--- a/src/fsAsync.ts
+++ b/src/fsAsync.ts
@@ -117,7 +117,6 @@ export async function readdirRecursive(
       let ignored = false;
       // Loop in reverse (from deepest subdirectory to root) so that local subdirectory
       // rules take precedence and override any parent directory rules.
-      // Loop using a decrementing index to avoid allocating array copies or reversing in the hot path.
       for (let i = gitIgnoreStack.length - 1; i >= 0; i--) {
         const state = gitIgnoreStack[i];
         const relPath = relative(state.dirPath, targetPath);


### PR DESCRIPTION
### Description
Enables dynamic cascading discovery and stacked processing of nested `.gitignore` files during recursive directory scanning in `fsAsync.readdirRecursive`. This ensures nested directories respect local `.gitignore` definitions, negation overrides, and scoped anchored rules inside child directories, aligning exactly with Git's standard specifications.

Also performs extensive code cleanups:
- Renamed `isGitIgnore` to `supportGitIgnore` for clear intent.
- Renamed `ignore` to `ignoreStrings` to avoid confusion with ignore engines.
- Renamed `rules` to `ignoreRules` for explicit matching clarity.
- Unified all GitIgnore matching logic into a single stack-based traversal, removing redundant parallel checks and obsolete manual parsers from callers.

### Scenarios Tested
- Discovered and parsed `.gitignore` files dynamically inside nested subdirectories.
- Scoped subdirectory paths and matched anchored rules correctly.
- Evaluated nested negation rules (`!file`) and prioritize child directory rules over parent ignores correctly.
- Handled subdirectories without `.gitignore` files and directory-named `.gitignore` folders gracefully.

### Sample Commands
`npm test`
`npx mocha src/fsAsync.spec.ts`

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
