### PR TITLE
Adding default timeout for dart functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Updated Pub/Sub emulator to version 0.8.31
 - Resolves undefined regions earlier, during the build to backend resolution phase (#10471)
-- Default timeout for Dart functions is now 60 seconds when not explicitly set (#10506)
+- Default timeout for Dart functions is now 60 seconds when not explicitly set (#10501)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Updated Pub/Sub emulator to version 0.8.31
 - Resolves undefined regions earlier, during the build to backend resolution phase (#10471)
+- Default timeout for Dart functions is now 60 seconds when not explicitly set (#10506)

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -256,6 +256,7 @@ export function memoryToGen2Cpu(memory: MemoryOptions): number {
 
 export const DEFAULT_CONCURRENCY = 80;
 export const DEFAULT_MEMORY: MemoryOptions = 256;
+export const DEFAULT_TIMEOUT_SECONDS = 60;
 export const MIN_CPU_FOR_CONCURRENCY = 1;
 export const SCHEDULED_FUNCTION_LABEL = Object.freeze({ deployment: "firebase-schedule" });
 

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -593,6 +593,18 @@ describe("prepare", () => {
       expect(want.availableMemoryMb).to.equal(512);
     });
 
+    it("fills in timeout from last deploy", () => {
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        httpsTrigger: {},
+      };
+      const have: backend.Endpoint = JSON.parse(JSON.stringify(want));
+      have.timeoutSeconds = 120;
+
+      prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* usedDotEnv= */ false);
+      expect(want.timeoutSeconds).to.equal(120);
+    });
+
     it("downgrades concurrency if necessary (explicit)", () => {
       const have: backend.Endpoint = {
         ...ENDPOINT_BASE,
@@ -644,6 +656,28 @@ describe("prepare", () => {
       prepare.inferDetailsFromExisting(backend.of(want), backend.of(have), /* useDotEnv= */ false);
       prepare.resolveCpuAndConcurrency(backend.of(want));
       expect(want.concurrency).to.equal(1);
+    });
+
+    it("defaults timeout to 60 for run platform functions", () => {
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        platform: "run",
+        httpsTrigger: {},
+      };
+
+      prepare.resolveCpuAndConcurrency(backend.of(want));
+      expect(want.timeoutSeconds).to.equal(60);
+    });
+
+    it("does not default timeout for gcfv2 platform functions", () => {
+      const want: backend.Endpoint = {
+        ...ENDPOINT_BASE,
+        platform: "gcfv2",
+        httpsTrigger: {},
+      };
+
+      prepare.resolveCpuAndConcurrency(backend.of(want));
+      expect(want.timeoutSeconds).to.be.undefined;
     });
   });
 

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -665,7 +665,7 @@ describe("prepare", () => {
         httpsTrigger: {},
       };
 
-      prepare.resolveCpuAndConcurrency(backend.of(want));
+      prepare.resolveDefaultTimeout(backend.of(want));
       expect(want.timeoutSeconds).to.equal(60);
     });
 
@@ -676,7 +676,7 @@ describe("prepare", () => {
         httpsTrigger: {},
       };
 
-      prepare.resolveCpuAndConcurrency(backend.of(want));
+      prepare.resolveDefaultTimeout(backend.of(want));
       expect(want.timeoutSeconds).to.be.undefined;
     });
   });

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -302,6 +302,7 @@ export async function prepare(
     inferDetailsFromExisting(wantBackend, haveBackend, codebaseUsesEnvs.includes(codebase));
     await ensureTriggerRegions(wantBackend);
     resolveCpuAndConcurrency(wantBackend);
+    resolveDefaultTimeout(wantBackend);
     validate.endpointsAreValid(wantBackend);
     inferBlockingDetails(wantBackend);
   }
@@ -651,10 +652,15 @@ export function resolveCpuAndConcurrency(want: backend.Backend): void {
     if (!e.concurrency) {
       e.concurrency = e.cpu >= 1 ? backend.DEFAULT_CONCURRENCY : 1;
     }
+  }
+}
 
-    // Cloud Run defaults to 300s timeout if not specified. For functions deployed
-    // directly to Cloud Run (like Dart), we want to enforce the same 60s default
-    // that GCF enforces for consistency.
+/**
+ * Assigns the default timeout to a function if it is deployed to Cloud Run
+ * and no timeout was specified.
+ */
+export function resolveDefaultTimeout(want: backend.Backend): void {
+  for (const e of backend.allEndpoints(want)) {
     if (e.platform === "run" && e.timeoutSeconds === undefined) {
       e.timeoutSeconds = backend.DEFAULT_TIMEOUT_SECONDS;
     }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -552,6 +552,10 @@ export function inferDetailsFromExisting(
       wantE.cpu = haveE.cpu;
     }
 
+    if (typeof wantE.timeoutSeconds === "undefined" && haveE.timeoutSeconds) {
+      wantE.timeoutSeconds = haveE.timeoutSeconds;
+    }
+
     // N.B. concurrency has different defaults based on CPU. If the customer
     // only specifies CPU and they change that specification to < 1, we should
     // turn off concurrency.
@@ -646,6 +650,13 @@ export function resolveCpuAndConcurrency(want: backend.Backend): void {
 
     if (!e.concurrency) {
       e.concurrency = e.cpu >= 1 ? backend.DEFAULT_CONCURRENCY : 1;
+    }
+
+    // Cloud Run defaults to 300s timeout if not specified. For functions deployed
+    // directly to Cloud Run (like Dart), we want to enforce the same 60s default
+    // that GCF enforces for consistency.
+    if (e.platform === "run" && e.timeoutSeconds === undefined) {
+      e.timeoutSeconds = backend.DEFAULT_TIMEOUT_SECONDS;
     }
   }
 }

--- a/src/deploy/functions/runtimes/dart/index.spec.ts
+++ b/src/deploy/functions/runtimes/dart/index.spec.ts
@@ -17,7 +17,7 @@ describe("Dart Runtime Delegate", () => {
       sinon.restore();
     });
 
-    it("should set default timeout to 60 if undefined", async () => {
+    it("should not set default timeout", async () => {
       const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
 
       const mockBuild: build.Build = {
@@ -38,7 +38,7 @@ describe("Dart Runtime Delegate", () => {
 
       const result = await delegate.discoverBuild({}, {});
 
-      expect(result.endpoints.func1.timeoutSeconds).to.equal(60);
+      expect(result.endpoints.func1.timeoutSeconds).to.be.undefined;
       expect(result.endpoints.func1.platform).to.equal("run");
     });
 

--- a/src/deploy/functions/runtimes/dart/index.spec.ts
+++ b/src/deploy/functions/runtimes/dart/index.spec.ts
@@ -1,0 +1,91 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { Delegate } from "./index";
+import * as discovery from "../discovery";
+import * as backend from "../../backend";
+import * as build from "../../build";
+
+describe("Dart Runtime Delegate", () => {
+  describe("discoverBuild", () => {
+    let detectFromYamlStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      detectFromYamlStub = sinon.stub(discovery, "detectFromYaml");
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should set default timeout to 60 if undefined", async () => {
+      const delegate = new Delegate("project", "sourceDir", "dart" as any);
+      
+      const mockBuild: build.Build = {
+        endpoints: {
+          func1: {
+            platform: "gcfv2",
+            entryPoint: "func1",
+            httpsTrigger: {},
+          } as any,
+        },
+        params: [],
+        requiredAPIs: [],
+      };
+
+      detectFromYamlStub.resolves(mockBuild);
+
+      const result = await delegate.discoverBuild({}, {});
+
+      expect(result.endpoints.func1.timeoutSeconds).to.equal(60);
+      expect(result.endpoints.func1.platform).to.equal("run");
+    });
+
+    it("should preserve user-defined timeout", async () => {
+      const delegate = new Delegate("project", "sourceDir", "dart" as any);
+      
+      const mockBuild: build.Build = {
+        endpoints: {
+          func1: {
+            platform: "gcfv2",
+            entryPoint: "func1",
+            httpsTrigger: {},
+            timeoutSeconds: 120,
+          } as any,
+        },
+        params: [],
+        requiredAPIs: [],
+      };
+
+      detectFromYamlStub.resolves(mockBuild);
+
+      const result = await delegate.discoverBuild({}, {});
+
+      expect(result.endpoints.func1.timeoutSeconds).to.equal(120);
+      expect(result.endpoints.func1.platform).to.equal("run");
+    });
+
+    it("should not apply default timeout in emulator mode", async () => {
+      const delegate = new Delegate("project", "sourceDir", "dart" as any);
+      
+      const mockBuild: build.Build = {
+        endpoints: {
+          func1: {
+            platform: "gcfv2",
+            entryPoint: "func1",
+            httpsTrigger: {},
+          } as any,
+        },
+        params: [],
+        requiredAPIs: [],
+      };
+
+      detectFromYamlStub.resolves(mockBuild);
+
+      const result = await delegate.discoverBuild({}, { FUNCTIONS_EMULATOR: "true" });
+
+      expect(result.endpoints.func1.timeoutSeconds).to.be.undefined;
+      // Platform should not be converted to "run" in emulator mode either
+      expect(result.endpoints.func1.platform).to.equal("gcfv2");
+    });
+  });
+});

--- a/src/deploy/functions/runtimes/dart/index.spec.ts
+++ b/src/deploy/functions/runtimes/dart/index.spec.ts
@@ -2,8 +2,8 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import { Delegate } from "./index";
 import * as discovery from "../discovery";
-import * as backend from "../../backend";
 import * as build from "../../build";
+import * as supported from "../supported";
 
 describe("Dart Runtime Delegate", () => {
   describe("discoverBuild", () => {
@@ -18,15 +18,17 @@ describe("Dart Runtime Delegate", () => {
     });
 
     it("should set default timeout to 60 if undefined", async () => {
-      const delegate = new Delegate("project", "sourceDir", "dart" as any);
-      
+      const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
+
       const mockBuild: build.Build = {
         endpoints: {
           func1: {
             platform: "gcfv2",
             entryPoint: "func1",
+            project: "project",
+            runtime: supported.latest("dart"),
             httpsTrigger: {},
-          } as any,
+          },
         },
         params: [],
         requiredAPIs: [],
@@ -41,16 +43,18 @@ describe("Dart Runtime Delegate", () => {
     });
 
     it("should preserve user-defined timeout", async () => {
-      const delegate = new Delegate("project", "sourceDir", "dart" as any);
-      
+      const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
+
       const mockBuild: build.Build = {
         endpoints: {
           func1: {
             platform: "gcfv2",
             entryPoint: "func1",
+            project: "project",
+            runtime: supported.latest("dart"),
             httpsTrigger: {},
             timeoutSeconds: 120,
-          } as any,
+          },
         },
         params: [],
         requiredAPIs: [],
@@ -65,15 +69,17 @@ describe("Dart Runtime Delegate", () => {
     });
 
     it("should not apply default timeout in emulator mode", async () => {
-      const delegate = new Delegate("project", "sourceDir", "dart" as any);
-      
+      const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
+
       const mockBuild: build.Build = {
         endpoints: {
           func1: {
             platform: "gcfv2",
             entryPoint: "func1",
+            project: "project",
+            runtime: supported.latest("dart"),
             httpsTrigger: {},
-          } as any,
+          },
         },
         params: [],
         requiredAPIs: [],

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -54,6 +54,9 @@ const MIN_DART_SDK_VERSION = "3.9.0";
 /** Default entry point for Dart functions projects. */
 export const DART_ENTRY_POINT = "bin/server.dart";
 
+/** Default timeout for Dart functions in seconds. */
+export const DEFAULT_TIMEOUT_SECONDS = 60;
+
 export class Delegate implements runtimes.RuntimeDelegate {
   public readonly language = "dart";
   public readonly bin = "dart";
@@ -391,7 +394,7 @@ export class Delegate implements runtimes.RuntimeDelegate {
     if (!isEmulator) {
       for (const ep of Object.values(discovered.endpoints)) {
         if (ep.timeoutSeconds === undefined) {
-          ep.timeoutSeconds = 60;
+          ep.timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
         }
         if (ep.platform === "gcfv2") {
           (ep as any).platform = "run";

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -54,8 +54,6 @@ const MIN_DART_SDK_VERSION = "3.9.0";
 /** Default entry point for Dart functions projects. */
 export const DART_ENTRY_POINT = "bin/server.dart";
 
-/** Default timeout for Dart functions in seconds. */
-export const DEFAULT_TIMEOUT_SECONDS = 60;
 
 export class Delegate implements runtimes.RuntimeDelegate {
   public readonly language = "dart";
@@ -393,9 +391,6 @@ export class Delegate implements runtimes.RuntimeDelegate {
     const isEmulator = envs.FUNCTIONS_EMULATOR === "true";
     if (!isEmulator) {
       for (const ep of Object.values(discovered.endpoints)) {
-        if (ep.timeoutSeconds === undefined) {
-          ep.timeoutSeconds = DEFAULT_TIMEOUT_SECONDS;
-        }
         if (ep.platform === "gcfv2") {
           (ep as any).platform = "run";
         }

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -54,7 +54,6 @@ const MIN_DART_SDK_VERSION = "3.9.0";
 /** Default entry point for Dart functions projects. */
 export const DART_ENTRY_POINT = "bin/server.dart";
 
-
 export class Delegate implements runtimes.RuntimeDelegate {
   public readonly language = "dart";
   public readonly bin = "dart";

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -390,6 +390,9 @@ export class Delegate implements runtimes.RuntimeDelegate {
     const isEmulator = envs.FUNCTIONS_EMULATOR === "true";
     if (!isEmulator) {
       for (const ep of Object.values(discovered.endpoints)) {
+        if (ep.timeoutSeconds === undefined) {
+          ep.timeoutSeconds = 60;
+        }
         if (ep.platform === "gcfv2") {
           (ep as any).platform = "run";
         }


### PR DESCRIPTION
Fixes: #10487 

This PR refactors the handling of default timeouts for functions deployed to the Cloud Run platform (such as Dart functions). To improve maintainability, it introduces a dedicated resolveDefaultTimeout method in the Firebase CLI (src/deploy/functions/prepare.ts) to apply a 60-second default timeout to all functions with platform: "run" if not specified, matching the expectation set by Node.js functions.

Additionally, the PR preserves existing timeouts for already deployed functions. If a function is already live in the cloud, the CLI will keep that timeout if the local code does not specify a new one, rather than overriding it with the new default.

Comprehensive unit tests have been added to prepare.spec.ts and updated in index.spec.ts to verify these behaviors, and all existing tests passed successfully.