### PR TITLE
Set requiredProjectBindings in AI Logic services

### DIFF
--- a/src/deploy/functions/services/ailogic.spec.ts
+++ b/src/deploy/functions/services/ailogic.spec.ts
@@ -30,6 +30,20 @@ describe("AILogicService", () => {
     sinon.restore();
   });
 
+  describe("requiredProjectBindings", () => {
+    it("should bind the AI logic service account with the Cloud Run invoker role", async () => {
+      const bindings = await service.requiredProjectBindings("123456789");
+      expect(bindings).to.deep.equal([
+        {
+          role: "roles/run.invoker",
+          members: [
+            "serviceAccount:service-123456789@gcp-sa-firebasevertexai.iam.gserviceaccount.com",
+          ],
+        },
+      ]);
+    });
+  });
+
   describe("validateTrigger", () => {
     it("should throw if two regional triggers of same type in same region", () => {
       const ep1: backend.Endpoint = {

--- a/src/deploy/functions/services/ailogic.ts
+++ b/src/deploy/functions/services/ailogic.ts
@@ -2,6 +2,7 @@ import * as backend from "../backend";
 import { FirebaseError, getErrStatus } from "../../../error";
 import { Name, Service } from "./index";
 import * as ailogicApi from "../../../gcp/ailogic";
+import * as iam from "../../../gcp/iam";
 import {
   AI_LOGIC_BEFORE_GENERATE_CONTENT,
   AI_LOGIC_AFTER_GENERATE_CONTENT,
@@ -50,6 +51,22 @@ export class AILogicService implements Service {
 
   ensureTriggerRegion: (ep: backend.Endpoint & backend.EventTriggered) => Promise<void> = () =>
     Promise.resolve();
+
+  /**
+  * The AI logic proxy server uses a service account to invoke functions.
+  * Setting requiredProjectBindings here causes the ensureServiceAgentRoles 
+  * call during prepare phase to upsert the corresponding IAM binding.
+  */
+  async requiredProjectBindings(projectNumber: string): Promise<Array<iam.Binding>> {
+    return [
+      {
+        role: "roles/run.invoker",
+        members: [
+          `serviceAccount:service-${projectNumber}@gcp-sa-firebasevertexai.iam.gserviceaccount.com`,
+        ],
+      },
+    ];
+  }
 
   /**
    * Validate that there are no duplicate AI Logic triggers of the same type.

--- a/src/deploy/functions/services/ailogic.ts
+++ b/src/deploy/functions/services/ailogic.ts
@@ -53,10 +53,10 @@ export class AILogicService implements Service {
     Promise.resolve();
 
   /**
-  * The AI logic proxy server uses a service account to invoke functions.
-  * Setting requiredProjectBindings here causes the ensureServiceAgentRoles 
-  * call during prepare phase to upsert the corresponding IAM binding.
-  */
+   * The AI logic proxy server uses a service account to invoke functions.
+   * Setting requiredProjectBindings here causes the ensureServiceAgentRoles
+   * call during prepare phase to upsert the corresponding IAM binding.
+   */
   async requiredProjectBindings(projectNumber: string): Promise<Array<iam.Binding>> {
     return [
       {


### PR DESCRIPTION
In the prepare phase of function deployment, the CLI calls [ensureServiceAgentRoles](https://github.com/firebase/firebase-tools/blob/0b59f188861ac6e9ccb38c8f44398bacacd44383/src/deploy/functions/checkIam.ts#L239) which checks and upserts all requiredProjectBindings for all Services in the deployed Backend.

Projects containing an AI Logic function must grant the `roles/run.invoker` binding to the AI Logic service account.