### PR TITLE
test: verify VPC connector path preservation

### DIFF
--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -259,6 +259,35 @@ describe("prepare", () => {
       );
     });
 
+    it("resolves region and preserves pre-formatted VPC connector paths", async () => {
+      const want = build.of({
+        id: {
+          platform: "gcfv2",
+          entryPoint: "entry",
+          project: "project",
+          runtime: latest("nodejs"),
+          httpsTrigger: {},
+          region: [build.REGION_TBD],
+          vpc: {
+            connector: "projects/my-project/locations/us-central1/connectors/my-connector",
+          },
+        },
+      });
+
+      const haveE = { ...ENDPOINT, id: "id", region: "us-east1" };
+      const have = backend.of(haveE);
+
+      await prepare.resolveDefaultRegionsForBuild(want, have);
+      expect(want.endpoints["id"].region).to.deep.equal(["us-east1"]);
+
+      const backendResult = build.toBackend(want, {});
+      const endpointDef = backendResult.endpoints["us-east1"]?.["id"];
+      expect(endpointDef).to.not.be.undefined;
+      expect(endpointDef?.vpc?.connector).to.equal(
+        "projects/my-project/locations/us-central1/connectors/my-connector",
+      );
+    });
+
     it("throws error if ambiguous", async () => {
       const want = build.of({
         id: {


### PR DESCRIPTION
Add a unit test to verify that the VPC connector path is preserved when using the full path.