### PR TITLE
Remove unused framework parameter from local build code

### DIFF
--- a/src/apphosting/localbuilds.spec.ts
+++ b/src/apphosting/localbuilds.spec.ts
@@ -55,7 +55,6 @@ describe("localBuild", () => {
     const expectedAnnotations = {
       language: "nodejs",
       runtime: "nodejs22",
-      framework: "nextjs",
     };
     const expectedOutputFiles = [".next/standalone"];
     const expectedBuildConfig = {
@@ -70,11 +69,7 @@ describe("localBuild", () => {
       stderr: "mock stderr",
       signal: null,
     });
-    const { outputFiles, annotations, buildConfig } = await localBuild(
-      "test-project",
-      "./",
-      "nextjs",
-    );
+    const { outputFiles, annotations, buildConfig } = await localBuild("test-project", "./");
     expect(annotations).to.deep.equal(expectedAnnotations);
     expect(buildConfig).to.deep.equal(expectedBuildConfig);
     expect(outputFiles).to.deep.equal(expectedOutputFiles);
@@ -103,7 +98,7 @@ describe("localBuild", () => {
       MY_PLAIN_VAR: { value: "plain-value" },
     };
 
-    await localBuild("test-project", "./", "nextjs", envMap, {
+    await localBuild("test-project", "./", envMap, {
       nonInteractive: true,
       allowLocalBuildSecrets: true,
     });
@@ -136,7 +131,7 @@ describe("localBuild", () => {
       ANOTHER_VAR: { value: "another-value" },
     };
 
-    await localBuild("test-project", "./", "nextjs", envMap);
+    await localBuild("test-project", "./", envMap);
 
     expect(loadSecretStub).to.not.have.been.called;
     // We expect the original process.env to not have these injected globally after run completes,
@@ -158,7 +153,7 @@ describe("localBuild", () => {
       };
 
       await expect(
-        localBuild("test-project", "./", "nextjs", envMap, { nonInteractive: true }),
+        localBuild("test-project", "./", envMap, { nonInteractive: true }),
       ).to.be.rejectedWith(
         "Using build-available secrets during a local build in non-interactive mode requires the --allow-local-build-secrets flag.",
       );
@@ -179,7 +174,7 @@ describe("localBuild", () => {
         MY_BUILD_SECRET: { secret: "my-secret-id", availability: ["BUILD"] },
       };
 
-      await localBuild("test-project", "./", "nextjs", envMap, {
+      await localBuild("test-project", "./", envMap, {
         nonInteractive: true,
         allowLocalBuildSecrets: true,
       });
@@ -195,7 +190,7 @@ describe("localBuild", () => {
       };
 
       await expect(
-        localBuild("test-project", "./", "nextjs", envMap, { nonInteractive: false }),
+        localBuild("test-project", "./", envMap, { nonInteractive: false }),
       ).to.be.rejectedWith("Cancelled local build due to BUILD-available secrets.");
       expect(confirmStub).to.have.been.calledOnce;
     });
@@ -216,7 +211,7 @@ describe("localBuild", () => {
         MY_BUILD_SECRET: { secret: "my-secret-id", availability: ["BUILD"] },
       };
 
-      await localBuild("test-project", "./", "nextjs", envMap, { nonInteractive: false });
+      await localBuild("test-project", "./", envMap, { nonInteractive: false });
       expect(confirmStub).to.have.been.calledOnce;
     });
   });
@@ -232,13 +227,12 @@ describe("localBuild", () => {
         signal: null,
       });
 
-      const output = await runUniversalMaker("./", "nextjs");
+      const output = await runUniversalMaker("./");
 
       expect(output).to.deep.equal({
         metadata: {
           language: "nodejs",
           runtime: "nodejs22",
-          framework: "nextjs",
         },
         runConfig: {
           runCommand: "npm run start",

--- a/src/apphosting/localbuilds.ts
+++ b/src/apphosting/localbuilds.ts
@@ -22,13 +22,10 @@ interface UniversalMakerOutput {
 /**
  * Runs the Universal Maker binary to build the project.
  */
-export async function runUniversalMaker(
-  projectRoot: string,
-  framework?: string,
-): Promise<AppHostingBuildOutput> {
+export async function runUniversalMaker(projectRoot: string): Promise<AppHostingBuildOutput> {
   const universalMakerBinary = await getOrDownloadUniversalMaker();
   executeUniversalMakerBinary(universalMakerBinary, projectRoot);
-  return processUniversalMakerOutput(projectRoot, framework);
+  return processUniversalMakerOutput(projectRoot);
 }
 
 /**
@@ -118,10 +115,7 @@ function parseBundleYaml(
  * This includes resolving the final run command and artifact paths from the
  * generated bundle.yaml, as well as cleaning up temporary metadata files.
  */
-function processUniversalMakerOutput(
-  projectRoot: string,
-  framework?: string,
-): AppHostingBuildOutput {
+function processUniversalMakerOutput(projectRoot: string): AppHostingBuildOutput {
   const outputFilePath = path.join(projectRoot, "build_output.json");
   if (!fs.existsSync(outputFilePath)) {
     throw new FirebaseError(
@@ -166,7 +160,6 @@ function processUniversalMakerOutput(
     metadata: {
       language: umOutput.language,
       runtime: umOutput.runtime,
-      framework: framework || "nextjs",
     },
     runConfig: {
       runCommand: finalRunCommand,
@@ -213,7 +206,6 @@ export interface AppHostingBuildOutput {
  * generates the necessary build artifacts, and returns metadata about the build.
  * @param projectId - The project ID to use for resolving secrets.
  * @param projectRoot - The root directory of the project to build.
- * @param framework - The framework to use for the build (e.g., 'nextjs').
  * @param env - The environment configuration map to resolve and inject into the build.
  * @return A promise that resolves to the build output, including:
  *          - `outputFiles`: Paths to the generated build artifacts.
@@ -223,7 +215,6 @@ export interface AppHostingBuildOutput {
 export async function localBuild(
   projectId: string,
   projectRoot: string,
-  framework: string,
   env: EnvMap = {},
   options?: { nonInteractive?: boolean; allowLocalBuildSecrets?: boolean },
 ): Promise<{
@@ -264,7 +255,7 @@ export async function localBuild(
 
   let apphostingBuildOutput: AppHostingBuildOutput;
   try {
-    apphostingBuildOutput = await runUniversalMaker(projectRoot, framework);
+    apphostingBuildOutput = await runUniversalMaker(projectRoot);
   } finally {
     for (const key in process.env) {
       if (!(key in originalEnv)) {

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -298,7 +298,6 @@ describe("apphosting", () => {
       expect(localBuildStub).to.be.calledWithMatch(
         "my-project",
         sinon.match.any,
-        "nextjs",
         sinon.match({
           FIREBASE_WEBAPP_CONFIG: { value: JSON.stringify(webAppConfig) },
           FIREBASE_CONFIG: {
@@ -359,14 +358,13 @@ describe("apphosting", () => {
       expect(localBuildStub).to.have.been.calledWithMatch(
         "my-project",
         sinon.match.any,
-        "nextjs",
         sinon.match({
           BUILD_VAR: { secret: "build-secret", availability: ["BUILD"] },
           SHARED_VAR: { secret: "shared-secret", availability: ["BUILD", "RUNTIME"] },
         }),
       );
       // RUNTIME_VAR should definitely NOT be present in match
-      expect(localBuildStub.firstCall.args[3]).to.not.have.property("RUNTIME_VAR");
+      expect(localBuildStub.firstCall.args[2]).to.not.have.property("RUNTIME_VAR");
     });
 
     it("should fail if localBuild is specified but experiment is disabled", async () => {

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -205,7 +205,6 @@ export default async function (context: Context, options: Options): Promise<void
       const { outputFiles, annotations, buildConfig } = await localBuild(
         projectId,
         localBuildScratchDir,
-        "nextjs",
         buildEnv[cfg.backendId] || {},
         {
           nonInteractive: options.nonInteractive,


### PR DESCRIPTION

### Description
This is no longer needed since we use Universal Maker 

### Scenarios Tested

Testing local build and source deploy

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
