### PR TITLE
chore: update pubsub emulator to 0.8.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## Unreleased
+
+- Updated Pub/Sub emulator to version 0.8.32

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -44,13 +44,13 @@
     }
   },
   "pubsub": {
-    "version": "0.8.31",
-    "expectedSize": 52942385,
-    "expectedChecksum": "04a85aa9873222e9b7a430c6c49cfd9e",
-    "expectedChecksumSHA256": "b474e7d3200f5a8b5f7f467ee3b087c94b939e7d41527e935296a7bcabdbea9a",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.31.zip",
-    "downloadPathRelativeToCacheDir": "pubsub-emulator-0.8.31.zip",
-    "binaryPathRelativeToCacheDir": "pubsub-emulator-0.8.31/pubsub-emulator/bin/cloud-pubsub-emulator"
+    "version": "0.8.32",
+    "expectedSize": 52942305,
+    "expectedChecksum": "b47a3698985bff5f6aedec04fad9354e",
+    "expectedChecksumSHA256": "476d6492718210837f13e64b5b9f54335469381827bad25eda62e36572e47a82",
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.32.zip",
+    "downloadPathRelativeToCacheDir": "pubsub-emulator-0.8.32.zip",
+    "binaryPathRelativeToCacheDir": "pubsub-emulator-0.8.32/pubsub-emulator/bin/cloud-pubsub-emulator"
   },
   "dataconnect": {
     "darwin": {


### PR DESCRIPTION
### Description
Updates the Pub/Sub emulator version to 0.8.32 in `downloadableEmulatorInfo.json`.
Also updates `CHANGELOG.md`.

### Scenarios Tested
- Verified that the emulator starts correctly and downloads the new version.

### Sample Commands
`firebase emulators:start --only pubsub`
