### PR TITLE
throw error when filter in --only target is invalid

### DIFF
--- a/src/checkValidTargetFilters.spec.ts
+++ b/src/checkValidTargetFilters.spec.ts
@@ -65,4 +65,13 @@ describe("checkValidTargetFilters", () => {
       'Cannot specify "--only functions" and "--only functions:<filter>" at the same time',
     );
   });
+
+  it("should error if a target filter is missing product prefix", async () => {
+    const options = Object.assign(SAMPLE_OPTIONS, {
+      only: "functions:func1,func2",
+    });
+    await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
+      /"func2" is not a valid deploy target/,
+    );
+  });
 });

--- a/src/checkValidTargetFilters.spec.ts
+++ b/src/checkValidTargetFilters.spec.ts
@@ -22,24 +22,27 @@ const UNFILTERABLE_TARGETS = ["remoteconfig", "extensions"];
 
 describe("checkValidTargetFilters", () => {
   it("should resolve", async () => {
-    const options = Object.assign(SAMPLE_OPTIONS, {
+    const options = {
+      ...SAMPLE_OPTIONS,
       only: "functions",
-    });
+    };
     await expect(checkValidTargetFilters(options)).to.be.fulfilled;
   });
 
   it("should resolve if there are no 'only' targets specified", async () => {
-    const options = Object.assign(SAMPLE_OPTIONS, {
-      only: null,
-    });
+    const options = {
+      ...SAMPLE_OPTIONS,
+      only: null as any,
+    };
     await expect(checkValidTargetFilters(options)).to.be.fulfilled;
   });
 
   it("should error if an only option and except option have been provided", async () => {
-    const options = Object.assign(SAMPLE_OPTIONS, {
+    const options = {
+      ...SAMPLE_OPTIONS,
       only: "functions",
       except: "hosting",
-    });
+    };
     await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
       "Cannot specify both --only and --except",
     );
@@ -47,10 +50,10 @@ describe("checkValidTargetFilters", () => {
 
   UNFILTERABLE_TARGETS.forEach((target) => {
     it(`should error if non-filter-type target (${target}) has filters`, async () => {
-      const options = Object.assign(SAMPLE_OPTIONS, {
+      const options = {
+        ...SAMPLE_OPTIONS,
         only: `${target}:filter`,
-        except: null,
-      });
+      };
       await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
         /Filters specified with colons \(e.g. --only functions:func1,functions:func2\) are only supported for .*/,
       );
@@ -58,18 +61,20 @@ describe("checkValidTargetFilters", () => {
   });
 
   it("should error if the same target is specified with and without a filter", async () => {
-    const options = Object.assign(SAMPLE_OPTIONS, {
+    const options = {
+      ...SAMPLE_OPTIONS,
       only: "functions,functions:filter",
-    });
+    };
     await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
       'Cannot specify "--only functions" and "--only functions:<filter>" at the same time',
     );
   });
 
   it("should error if a target filter is missing product prefix", async () => {
-    const options = Object.assign(SAMPLE_OPTIONS, {
+    const options = {
+      ...SAMPLE_OPTIONS,
       only: "functions:func1,func2",
-    });
+    };
     await expect(checkValidTargetFilters(options)).to.be.rejectedWith(
       /"func2" is not a valid deploy target/,
     );

--- a/src/checkValidTargetFilters.ts
+++ b/src/checkValidTargetFilters.ts
@@ -68,6 +68,20 @@ export async function checkValidTargetFilters(options: Options): Promise<void> {
         ),
       );
     }
+
+    for (const target of only) {
+      const baseTarget = target.split(":")[0];
+      if (!VALID_DEPLOY_TARGETS.includes(baseTarget)) {
+        return reject(
+          new FirebaseError(
+            `"${baseTarget}" is not a valid deploy target. Valid target prefixes are: ${VALID_DEPLOY_TARGETS.join(
+              ", ",
+            )}`,
+          ),
+        );
+      }
+    }
+
     return resolve();
   });
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Fixes #6322. #6322 has 2 issues
1. PowerShell parsing - fixed in #10288
2. No errors or warnings are shown when running something like below. `func2` is not a valid target since the expected format is `functions:func2` (`product:target`)
```
firebase deploy --debug --only "functions:func1,func2"
```

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

```
$ firebase deploy --only functions:helloWorld,helloWorld2

Error: "helloWorld2" is not a valid deploy target. Valid target prefixes are: database, storage, firestore, functions, hosting, remoteconfig, extensions, dataconnect, apphosting, auth
```

also verified that `firebase deploy --only functions:helloWorld,functions:helloWorld2` deploys correctly
<details>
<summary>logs</summary>

```
$ firebase deploy --only functions:helloWorld,functions:helloWorld2

=== Deploying to 'PROJECT_ID'...

i  deploying functions
i  functions: preparing codebase default for deployment
i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
i  functions: ensuring required API cloudbuild.googleapis.com is enabled...
i  artifactregistry: ensuring required API artifactregistry.googleapis.com is enabled...
✔  functions: required API cloudfunctions.googleapis.com is enabled
✔  functions: required API cloudbuild.googleapis.com is enabled
✔  artifactregistry: required API artifactregistry.googleapis.com is enabled
i  functions: Loading and analyzing source code for codebase default to determine what to deploy
Serving at port 8804

i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  functions: preparing functions directory for uploading...
i  functions: packaged /Users/PATH/6322/functions (70.22 KB) for uploading
i  functions: ensuring required API run.googleapis.com is enabled...
i  functions: ensuring required API eventarc.googleapis.com is enabled...
i  functions: ensuring required API pubsub.googleapis.com is enabled...
i  functions: ensuring required API storage.googleapis.com is enabled...
✔  functions: required API eventarc.googleapis.com is enabled
✔  functions: required API run.googleapis.com is enabled
✔  functions: required API storage.googleapis.com is enabled
✔  functions: required API pubsub.googleapis.com is enabled
i  functions: generating the service identity for pubsub.googleapis.com...
i  functions: generating the service identity for eventarc.googleapis.com...
✔  functions: functions source uploaded successfully
i  functions: updating Node.js 24 (2nd Gen) function helloWorld(us-central1)...
i  functions: updating Node.js 24 (2nd Gen) function helloWorld2(us-central1)...
✔  functions[helloWorld(us-central1)] Successful update operation.
✔  functions[helloWorld2(us-central1)] Successful update operation.
Function URL (helloWorld(us-central1)): REDACTED
Function URL (helloWorld2(us-central1)): REDACTED

✔  Deploy complete!
```

</details>

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->


### Notes

Is throwing an error too much? If so, we could instead opt for showing a warning message.
