### PR TITLE
handle powershell parsing commas for --except

### DIFF
--- a/src/command.spec.ts
+++ b/src/command.spec.ts
@@ -211,6 +211,24 @@ describe("Command", () => {
     const run = command
       .action((options) => {
         return {
+          except: options.except,
+        };
+      })
+      .runner();
+
+    const result = await run({
+      except: "firestore, hosting,  auth",
+    });
+
+    expect(result).to.deep.eq({
+      except: "firestore,hosting,auth",
+    });
+  });
+
+  it("should normalize space and commas separated values in 'only' options", async () => {
+    const run = command
+      .action((options) => {
+        return {
           only: options.only,
         };
       })

--- a/src/command.spec.ts
+++ b/src/command.spec.ts
@@ -211,24 +211,6 @@ describe("Command", () => {
     const run = command
       .action((options) => {
         return {
-          except: options.except,
-        };
-      })
-      .runner();
-
-    const result = await run({
-      except: "firestore, hosting,  auth",
-    });
-
-    expect(result).to.deep.eq({
-      except: "firestore,hosting,auth",
-    });
-  });
-
-  it("should normalize space and commas separated values in 'only' options", async () => {
-    const run = command
-      .action((options) => {
-        return {
           only: options.only,
         };
       })
@@ -240,6 +222,24 @@ describe("Command", () => {
 
     expect(result).to.deep.eq({
       only: "firestore,hosting,auth",
+    });
+  });
+
+  it("should normalize space and commas separated values in 'except' options", async () => {
+    const run = command
+      .action((options) => {
+        return {
+          except: options.except,
+        };
+      })
+      .runner();
+
+    const result = await run({
+      except: "firestore, hosting,  auth",
+    });
+
+    expect(result).to.deep.eq({
+      except: "firestore,hosting,auth",
     });
   });
 });

--- a/src/command.ts
+++ b/src/command.ts
@@ -349,6 +349,16 @@ export class Command {
         .join(",");
     }
 
+    const exceptOption = getInheritedOption(options, "except");
+    if (exceptOption) {
+      // Handle cases where PowerShell replaces commas with spaces.
+      // see https://github.com/firebase/firebase-tools/issues/7506
+      options.except = exceptOption
+        .split(/[\s,]+/)
+        .filter(Boolean)
+        .join(",");
+    }
+
     try {
       options.config = Config.load(options);
     } catch (e: any) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Similar idea to #10288. TIL we have an `--except` flag

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

With functions, firestore, and hosting set up - verified that ` --except "firestore hosting"` only deploys `functions`
```
$ firebase deploy --except "firestore hosting" --dry-run

=== Deploying to 'PROJECT_ID'...

i  deploying functions
i  functions: preparing codebase default for deployment
i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
i  functions: ensuring required API cloudbuild.googleapis.com is enabled...
i  artifactregistry: ensuring required API artifactregistry.googleapis.com is enabled...
✔  functions: required API cloudbuild.googleapis.com is enabled
✔  functions: required API cloudfunctions.googleapis.com is enabled
✔  artifactregistry: required API artifactregistry.googleapis.com is enabled
i  functions: Loading and analyzing source code for codebase default to determine what to deploy
Serving at port 8630

i  extensions: ensuring required API firebaseextensions.googleapis.com is enabled...
✔  extensions: required API firebaseextensions.googleapis.com is enabled
i  functions: preparing functions directory for uploading...
i  functions: packaged /Users/PATH/7506/functions (70.22 KB) for uploading
i  functions: ensuring required API run.googleapis.com is enabled...
i  functions: ensuring required API eventarc.googleapis.com is enabled...
i  functions: ensuring required API pubsub.googleapis.com is enabled...
i  functions: ensuring required API storage.googleapis.com is enabled...
✔  functions: required API run.googleapis.com is enabled
✔  functions: required API eventarc.googleapis.com is enabled
✔  functions: required API storage.googleapis.com is enabled
✔  functions: required API pubsub.googleapis.com is enabled
i  functions: generating the service identity for pubsub.googleapis.com...
i  functions: generating the service identity for eventarc.googleapis.com...

✔  Dry run complete!
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
