### PR TITLE
chore: remove temporary Dart console warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Fixed an issue where Cloud Run rewrites in the Hosting emulator would always hit the live Cloud Run API instead of routing to the local functions emulator. (#10588)
+- Removed temporary warning directing Dart functions users to Cloud Console, as Firebase Console now supports Dart functions. (#10584)
 - Updated the Firebase Data Connect local toolkit to v3.4.11, which includes the following changes:
   - [changed] Updated the Golang dependency version to 1.25.11.
 - Fixed issue where `apptesting:execute` command rejects documented `--test-username`, `--test-password`, and `--test-password-file` options.

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -115,17 +115,6 @@ export async function release(
   const wantBackend = backend.merge(...Object.values(payload.functions).map((p) => p.wantBackend));
   printTriggerUrls(wantBackend, projectNumber);
 
-  // TODO: Remove once the Firebase console has support.
-  if (
-    backend.someEndpoint(wantBackend, (endpoint) => runtimeIsLanguage(endpoint.runtime, "dart"))
-  ) {
-    utils.logLabeledBullet(
-      "functions",
-      "Dart functions may not yet be visible in the Firebase Console. " +
-        `View them in the Cloud Console at https://console.cloud.google.com/run/services?project=${context.projectId}`,
-    );
-  }
-
   await setupArtifactCleanupPolicies(
     options,
     options.projectId!,

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -17,7 +17,6 @@ import { FirebaseError } from "../../../error";
 import { getProjectNumber } from "../../../getProjectNumber";
 import { release as extRelease } from "../../extensions";
 import * as artifacts from "../../../functions/artifacts";
-import { runtimeIsLanguage } from "../runtimes/supported";
 
 /** Releases new versions of functions and extensions to prod. */
 export async function release(


### PR DESCRIPTION
The Firebase Console now supports Dart functions, so the temporary warning directing users to the Cloud Console is no longer needed.