### PR TITLE
refactor: move default region resolution to service interface

### DIFF
--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -5,6 +5,9 @@ import * as prepare from "./prepare";
 import * as runtimes from "./runtimes";
 import * as backend from "./backend";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
+import * as firestore from "../../gcp/firestore";
+import * as storage from "../../gcp/storage";
+import * as database from "../../management/database";
 import * as firestoreService from "./services/firestore";
 import * as storageService from "./services/storage";
 import * as databaseService from "./services/database";
@@ -194,9 +197,12 @@ describe("prepare", () => {
 
     beforeEach(() => {
       sandbox = sinon.createSandbox();
-      getDatabaseStub = sandbox.stub(firestoreService, "getDatabase");
-      getBucketStub = sandbox.stub(storageService, "getBucket");
-      getDatabaseInstanceDetailsStub = sandbox.stub(databaseService, "getDatabaseInstanceDetails");
+      firestoreService.clearCache();
+      storageService.clearCache();
+      databaseService.clearCache();
+      getDatabaseStub = sandbox.stub(firestore, "getDatabase");
+      getBucketStub = sandbox.stub(storage, "getBucket");
+      getDatabaseInstanceDetailsStub = sandbox.stub(database, "getDatabaseInstanceDetails");
     });
 
     afterEach(() => {

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -522,6 +522,87 @@ describe("prepare", () => {
 
       expect(want.endpoints["id"].region).to.deep.equal(["us-central1"]);
     });
+
+    it("resolves us-east1 for global AI Logic triggers", async () => {
+      const want = build.of({
+        globalAI: {
+          platform: "gcfv2",
+          entryPoint: "entry",
+          project: "project",
+          runtime: latest("nodejs"),
+          blockingTrigger: {
+            eventType: "google.firebase.ailogic.v1.beforeGenerate",
+          },
+          region: [build.REGION_TBD],
+        },
+      });
+      const have = backend.empty();
+
+      await prepare.resolveDefaultRegionsForBuild(want, have);
+
+      expect(want.endpoints["globalAI"].region).to.deep.equal(["us-east1"]);
+    });
+
+    it("resolves us-central1 for regional AI Logic triggers", async () => {
+      const want = build.of({
+        regionalAI: {
+          platform: "gcfv2",
+          entryPoint: "entry",
+          project: "project",
+          runtime: latest("nodejs"),
+          blockingTrigger: {
+            eventType: "google.firebase.ailogic.v1.beforeGenerate",
+            options: {
+              regionalWebhook: true,
+            },
+          },
+          region: [build.REGION_TBD],
+        },
+      });
+      const have = backend.empty();
+
+      await prepare.resolveDefaultRegionsForBuild(want, have);
+
+      expect(want.endpoints["regionalAI"].region).to.deep.equal(["us-central1"]);
+    });
+
+    it("falls back to us-central1 when getDatabase or getBucket throws an API error during region resolution", async () => {
+      const want = build.of({
+        firestoreTrigger: {
+          platform: "gcfv2",
+          entryPoint: "entry",
+          project: "project",
+          runtime: latest("nodejs"),
+          eventTrigger: {
+            eventType: "google.cloud.firestore.document.v1.created",
+            eventFilters: { database: "(default)" },
+            retry: false,
+          },
+          region: [build.REGION_TBD],
+        },
+        storageTrigger: {
+          platform: "gcfv2",
+          entryPoint: "entry",
+          project: "project",
+          runtime: latest("nodejs"),
+          eventTrigger: {
+            eventType: "google.cloud.storage.object.v1.archived",
+            eventFilters: { bucket: "my-bucket" },
+            retry: false,
+          },
+          region: [build.REGION_TBD],
+        },
+      });
+      const have = backend.empty();
+
+      getDatabaseStub.rejects(new Error("API Error fetching database location"));
+      getBucketStub.rejects(new Error("API Error fetching bucket location"));
+
+      await prepare.resolveDefaultRegionsForBuild(want, have);
+
+      expect(want.endpoints["firestoreTrigger"].region).to.deep.equal(["us-central1"]);
+      expect(want.endpoints["storageTrigger"].region).to.deep.equal(["us-central1"]);
+    });
   });
 
   describe("inferDetailsFromExisting", () => {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -12,7 +12,7 @@ import * as runtimes from "./runtimes";
 import * as supported from "./runtimes/supported";
 import * as validate from "./validate";
 import * as ensure from "./ensure";
-import { serviceForEndpoint } from "./services";
+import { serviceForEndpoint, FALLBACK_DEPLOYMENT_REGION } from "./services";
 import {
   functionsOrigin,
   artifactRegistryDomain,
@@ -59,7 +59,6 @@ import { DeployOptions } from "..";
 import * as prompt from "../../prompt";
 
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
-export const DEFAULT_FUNCTION_REGION = "us-central1";
 
 /**
  * Prepare functions codebases for deploy.
@@ -356,7 +355,7 @@ export async function resolveDefaultRegionsForBuild(
 ): Promise<void> {
   for (const [id, endpoint] of Object.entries(buildObj.endpoints)) {
     if (!endpoint.region?.length || endpoint.region.includes(build.REGION_TBD)) {
-      let resolvedRegion = DEFAULT_FUNCTION_REGION;
+      let resolvedRegion = FALLBACK_DEPLOYMENT_REGION;
 
       // Match existing endpoints.
       let matching: backend.Endpoint | undefined;
@@ -379,7 +378,7 @@ export async function resolveDefaultRegionsForBuild(
           resolvedRegion = await resolveRegionForTrigger(endpoint);
         } catch (err: any) {
           logger.debug(
-            `Failed to resolve region for endpoint ${id}. Defaulting to ${DEFAULT_FUNCTION_REGION}.`,
+            `Failed to resolve region for endpoint ${id}. Defaulting to ${FALLBACK_DEPLOYMENT_REGION}.`,
             getErrStack(err),
           );
         }
@@ -392,10 +391,7 @@ export async function resolveDefaultRegionsForBuild(
 
 async function resolveRegionForTrigger(endpoint: build.Endpoint): Promise<string> {
   const service = serviceForEndpoint(endpoint);
-  if (service.getDefaultRegion) {
-    return await service.getDefaultRegion(endpoint);
-  }
-  return DEFAULT_FUNCTION_REGION;
+  return await service.getDefaultRegion(endpoint);
 }
 
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -12,12 +12,7 @@ import * as runtimes from "./runtimes";
 import * as supported from "./runtimes/supported";
 import * as validate from "./validate";
 import * as ensure from "./ensure";
-import * as events from "../../functions/events/v1";
-import { getDatabase } from "./services/firestore";
-import { getBucket } from "./services/storage";
-import { getDatabaseInstanceDetails } from "./services/database";
-import { isGlobalAILogicTrigger } from "./services/ailogic";
-import { parseServiceName, parseConnectorName } from "../../dataconnect/names";
+import { serviceForEndpoint } from "./services";
 import {
   functionsOrigin,
   artifactRegistryDomain,
@@ -381,14 +376,7 @@ export async function resolveDefaultRegionsForBuild(
       } else {
         // Match triggers.
         try {
-          if (build.isBlockingTriggered(endpoint)) {
-            resolvedRegion = resolveRegionForBlockingTrigger(endpoint.blockingTrigger);
-          } else if (build.isEventTriggered(endpoint)) {
-            resolvedRegion = await resolveRegionForEventTrigger(
-              endpoint.project,
-              endpoint.eventTrigger,
-            );
-          }
+          resolvedRegion = await resolveRegionForTrigger(endpoint);
         } catch (err: any) {
           logger.debug(
             `Failed to resolve region for endpoint ${id}. Defaulting to ${DEFAULT_FUNCTION_REGION}.`,
@@ -402,114 +390,11 @@ export async function resolveDefaultRegionsForBuild(
   }
 }
 
-function resolveRegionForBlockingTrigger(blockingTrigger: build.BlockingTrigger): string {
-  const eventType = blockingTrigger.eventType;
-  if ((events.AUTH_BLOCKING_EVENTS as readonly string[]).includes(eventType)) {
-    return "us-east1";
+async function resolveRegionForTrigger(endpoint: build.Endpoint): Promise<string> {
+  const service = serviceForEndpoint(endpoint);
+  if (service.getDefaultRegion) {
+    return await service.getDefaultRegion(endpoint);
   }
-
-  if (isGlobalAILogicTrigger(blockingTrigger)) {
-    return "us-east1";
-  }
-
-  return DEFAULT_FUNCTION_REGION;
-}
-
-async function resolveRegionForEventTrigger(
-  project: string,
-  eventTrigger: build.EventTrigger,
-): Promise<string> {
-  const eventType = eventTrigger.eventType;
-
-  // Global functions should be deployed to us-east1.
-  if (
-    eventType.startsWith("google.cloud.pubsub.") ||
-    eventType.startsWith("providers/cloud.auth/eventTypes/") ||
-    eventType.startsWith("providers/firebase.auth/eventTypes/") ||
-    eventType.startsWith("google.firebase.testlab.") ||
-    eventType.startsWith("google.firebase.remoteconfig.") ||
-    eventType.startsWith("google.firebase.firebasealerts.")
-  ) {
-    return "us-east1";
-  }
-
-  // Firestore functions should be deployed to the same region as the database.
-  // In multi-region locations, we default to:
-  // * nam5 -> us-central1
-  // * nam7 -> us-central1
-  // * eur3 -> europe-west1
-  if (eventType.startsWith("google.cloud.firestore.")) {
-    try {
-      const databaseId = eventTrigger.eventFilters?.database || "(default)";
-      const db = await getDatabase(project, databaseId);
-      const locationId = db.locationId.toLowerCase();
-
-      if (locationId === "nam5" || locationId === "nam7") return "us-central1";
-      if (locationId === "eur3") return "europe-west1";
-      return locationId;
-    } catch (err: any) {
-      logger.debug("Failed to resolve Firestore database location", getErrStack(err));
-    }
-  }
-
-  // Cloud Storage functions should be deployed to the same region as the bucket.
-  // In multi-region locations, we default to:
-  // * us -> us-east1
-  // * eu -> europe-west1
-  // * asia -> asia-east1
-  if (eventType.startsWith("google.cloud.storage.")) {
-    try {
-      const bucketName = eventTrigger.eventFilters?.bucket;
-      if (bucketName) {
-        const bucket = await getBucket(bucketName);
-        const locationId = bucket.location.toLowerCase();
-
-        if (locationId === "us") return "us-east1";
-        if (locationId === "eu") return "europe-west1";
-        if (locationId === "asia") return "asia-east1";
-        return locationId;
-      }
-    } catch (err: any) {
-      logger.debug("Failed to resolve Cloud Storage bucket location", getErrStack(err));
-    }
-  }
-
-  // Realtime Database functions should be deployed to the same region as the database.
-  if (eventType.startsWith("google.firebase.database.")) {
-    if (eventTrigger.region) return eventTrigger.region;
-
-    try {
-      const instanceName = eventTrigger.eventFilters?.instance;
-      if (instanceName) {
-        const details = await getDatabaseInstanceDetails(project, instanceName);
-        if (details.location && details.location !== "-") {
-          return details.location.toLowerCase();
-        }
-      }
-    } catch (err: any) {
-      logger.debug("Failed to resolve Realtime Database instance location", getErrStack(err));
-    }
-  }
-
-  // DataConnect functions should be deployed to the same region as the service.
-  if (eventType.startsWith("google.firebase.dataconnect.")) {
-    if (eventTrigger.region) return eventTrigger.region;
-
-    try {
-      const service = eventTrigger.eventFilters?.service;
-      if (service) {
-        return parseServiceName(service).location;
-      }
-
-      const connector = eventTrigger.eventFilters?.connector;
-      if (connector) {
-        return parseConnectorName(connector).location;
-      }
-    } catch (err: any) {
-      logger.debug("Failed to resolve DataConnect location", getErrStack(err));
-    }
-  }
-
   return DEFAULT_FUNCTION_REGION;
 }
 

--- a/src/deploy/functions/services/ailogic.ts
+++ b/src/deploy/functions/services/ailogic.ts
@@ -134,4 +134,11 @@ export class AILogicService implements Service {
       }
     }
   }
+
+  async getDefaultRegion(endpoint: build.Endpoint): Promise<string> {
+    if (build.isBlockingTriggered(endpoint) && isGlobalAILogicTrigger(endpoint.blockingTrigger)) {
+      return "us-east1";
+    }
+    return "us-central1";
+  }
 }

--- a/src/deploy/functions/services/auth.ts
+++ b/src/deploy/functions/services/auth.ts
@@ -1,7 +1,6 @@
 import * as backend from "../backend";
 import * as identityPlatform from "../../../gcp/identityPlatform";
 import * as events from "../../../functions/events";
-import * as build from "../build";
 import { FirebaseError } from "../../../error";
 import { cloneDeep } from "../../../utils";
 import { Name, noop, Service } from "./index";
@@ -182,8 +181,7 @@ export class AuthBlockingService implements Service {
     return this.triggerQueue;
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async getDefaultRegion(endpoint: build.Endpoint): Promise<string> {
+  async getDefaultRegion(): Promise<string> {
     return "us-east1";
   }
 }

--- a/src/deploy/functions/services/auth.ts
+++ b/src/deploy/functions/services/auth.ts
@@ -1,6 +1,7 @@
 import * as backend from "../backend";
 import * as identityPlatform from "../../../gcp/identityPlatform";
 import * as events from "../../../functions/events";
+import * as build from "../build";
 import { FirebaseError } from "../../../error";
 import { cloneDeep } from "../../../utils";
 import { Name, noop, Service } from "./index";
@@ -179,5 +180,10 @@ export class AuthBlockingService implements Service {
     }
     this.triggerQueue = this.triggerQueue.then(() => this.unregisterTriggerLocked(ep));
     return this.triggerQueue;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getDefaultRegion(endpoint: build.Endpoint): Promise<string> {
+    return "us-east1";
   }
 }

--- a/src/deploy/functions/services/database.ts
+++ b/src/deploy/functions/services/database.ts
@@ -1,5 +1,6 @@
 import * as backend from "../backend";
 import { FirebaseError } from "../../../error";
+import * as build from "../build";
 import {
   getDatabaseInstanceDetails as getDetails,
   DatabaseInstance,
@@ -50,4 +51,25 @@ export function ensureDatabaseTriggerRegion(
     throw new FirebaseError("A database trigger location must match the function region.");
   }
   return Promise.resolve();
+}
+
+/**
+ * Get the default region for a Realtime Database event trigger.
+ */
+export async function getDefaultRegion(endpoint: build.Endpoint): Promise<string> {
+  if (!build.isEventTriggered(endpoint)) {
+    throw new FirebaseError("Database getDefaultRegion requires an event-triggered endpoint");
+  }
+  if (endpoint.eventTrigger.region) {
+    return endpoint.eventTrigger.region;
+  }
+
+  const instanceName = endpoint.eventTrigger.eventFilters?.instance;
+  if (instanceName) {
+    const details = await getDatabaseInstanceDetails(endpoint.project, instanceName);
+    if (details.location && details.location !== "-") {
+      return details.location.toLowerCase();
+    }
+  }
+  throw new FirebaseError("Could not resolve database instance location");
 }

--- a/src/deploy/functions/services/dataconnect.ts
+++ b/src/deploy/functions/services/dataconnect.ts
@@ -1,6 +1,8 @@
 import * as backend from "../backend";
 import { dataconnectOrigin } from "../../../api";
 import { FirebaseError } from "../../../error";
+import * as build from "../build";
+import { parseServiceName, parseConnectorName } from "../../../dataconnect/names";
 
 const AUTOPUSH_DATACONNECT_SA_DOMAIN = "gcp-sa-autopush-dataconnect.iam.gserviceaccount.com";
 const STAGING_DATACONNECT_SA_DOMAIN = "gcp-sa-staging-dataconnect.iam.gserviceaccount.com";
@@ -37,4 +39,28 @@ export function getDataConnectP4SA(projectNumber: string): string {
     return `service-${projectNumber}@${STAGING_DATACONNECT_SA_DOMAIN}`;
   }
   return `service-${projectNumber}@${PROD_DATACONNECT_SA_DOMAIN}`;
+}
+
+/**
+ * Get the default region for a DataConnect event trigger.
+ */
+export async function getDefaultRegion(endpoint: build.Endpoint): Promise<string> {
+  if (!build.isEventTriggered(endpoint)) {
+    throw new FirebaseError("DataConnect getDefaultRegion requires an event-triggered endpoint");
+  }
+  if (endpoint.eventTrigger.region) {
+    return endpoint.eventTrigger.region;
+  }
+
+  const service = endpoint.eventTrigger.eventFilters?.service;
+  if (service) {
+    return parseServiceName(service).location;
+  }
+
+  const connector = endpoint.eventTrigger.eventFilters?.connector;
+  if (connector) {
+    return parseConnectorName(connector).location;
+  }
+
+  throw new FirebaseError("Could not resolve DataConnect location");
 }

--- a/src/deploy/functions/services/firestore.ts
+++ b/src/deploy/functions/services/firestore.ts
@@ -1,6 +1,8 @@
 import * as backend from "../backend";
 import * as firestore from "../../../gcp/firestore";
 import { FirebaseError } from "../../../error";
+import * as build from "../build";
+import { FIRESTORE_MULTI_REGION_MAPPING } from "../../../gcp/location";
 
 const dbCache = new Map<string, firestore.Database>();
 const dbPromiseCache = new Map<string, Promise<firestore.Database>>();
@@ -71,4 +73,17 @@ export async function ensureFirestoreTriggerRegion(
       "A firestore trigger location must match the firestore database region.",
     );
   }
+}
+
+/**
+ * Get the default region for a Firestore event trigger.
+ */
+export async function getDefaultRegion(endpoint: build.Endpoint): Promise<string> {
+  if (!build.isEventTriggered(endpoint)) {
+    throw new FirebaseError("Firestore getDefaultRegion requires an event-triggered endpoint");
+  }
+  const databaseId = endpoint.eventTrigger.eventFilters?.database || "(default)";
+  const db = await getDatabase(endpoint.project, databaseId);
+  const locationId = db.locationId.toLowerCase();
+  return FIRESTORE_MULTI_REGION_MAPPING[locationId] || locationId;
 }

--- a/src/deploy/functions/services/firestore.ts
+++ b/src/deploy/functions/services/firestore.ts
@@ -2,7 +2,7 @@ import * as backend from "../backend";
 import * as firestore from "../../../gcp/firestore";
 import { FirebaseError } from "../../../error";
 import * as build from "../build";
-import { FIRESTORE_MULTI_REGION_MAPPING } from "../../../gcp/location";
+import { FIRESTORE_DUAL_REGION_TO_REGION_MAPPING } from "../../../gcp/location";
 
 const dbCache = new Map<string, firestore.Database>();
 const dbPromiseCache = new Map<string, Promise<firestore.Database>>();
@@ -85,5 +85,5 @@ export async function getDefaultRegion(endpoint: build.Endpoint): Promise<string
   const databaseId = endpoint.eventTrigger.eventFilters?.database || "(default)";
   const db = await getDatabase(endpoint.project, databaseId);
   const locationId = db.locationId.toLowerCase();
-  return FIRESTORE_MULTI_REGION_MAPPING[locationId] || locationId;
+  return FIRESTORE_DUAL_REGION_TO_REGION_MAPPING[locationId] || locationId;
 }

--- a/src/deploy/functions/services/index.ts
+++ b/src/deploy/functions/services/index.ts
@@ -31,6 +31,12 @@ export const noop = (): Promise<void> => Promise.resolve();
 /** A No Op that's useful for Services that don't have specific bindings but should still try to set default bindings */
 export const noopProjectBindings = (): Promise<Array<iam.Binding>> => Promise.resolve([]);
 
+/** The default region for global triggers. */
+export const DEFAULT_GLOBAL_TRIGGER_REGION = "us-east1";
+
+/** The fallback region to deploy new functions from. */
+export const FALLBACK_DEPLOYMENT_REGION = "us-central1";
+
 /** A name of a service */
 export type Name =
   | "noop"
@@ -57,7 +63,7 @@ export interface Service {
   registerTrigger: (ep: backend.Endpoint) => Promise<void>;
   unregisterTrigger: (ep: backend.Endpoint) => Promise<void>;
 
-  getDefaultRegion?: (endpoint: build.Endpoint) => Promise<string>;
+  getDefaultRegion: (endpoint: build.Endpoint) => Promise<string>;
 }
 
 /** A noop service object, useful for v1 events */
@@ -68,6 +74,7 @@ const noOpService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: () => Promise.resolve(FALLBACK_DEPLOYMENT_REGION),
 };
 
 /** A pubsub service object */
@@ -79,7 +86,7 @@ const pubSubService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
-  getDefaultRegion: () => Promise.resolve("us-east1"),
+  getDefaultRegion: () => Promise.resolve(DEFAULT_GLOBAL_TRIGGER_REGION),
 };
 
 /** A storage service object */
@@ -103,7 +110,7 @@ const firebaseAlertsService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
-  getDefaultRegion: () => Promise.resolve("us-east1"),
+  getDefaultRegion: () => Promise.resolve(DEFAULT_GLOBAL_TRIGGER_REGION),
 };
 
 /** A auth blocking service object */
@@ -131,7 +138,7 @@ const remoteConfigService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
-  getDefaultRegion: () => Promise.resolve("us-east1"),
+  getDefaultRegion: () => Promise.resolve(DEFAULT_GLOBAL_TRIGGER_REGION),
 };
 
 /** A test lab service object */
@@ -143,7 +150,7 @@ const testLabService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
-  getDefaultRegion: () => Promise.resolve("us-east1"),
+  getDefaultRegion: () => Promise.resolve(DEFAULT_GLOBAL_TRIGGER_REGION),
 };
 
 /** A firestore service object */

--- a/src/deploy/functions/services/index.ts
+++ b/src/deploy/functions/services/index.ts
@@ -204,11 +204,10 @@ const EVENT_SERVICE_MAPPING: Record<events.Event, Service> = {
 
 export function serviceForEndpoint(endpoint: backend.Endpoint | build.Endpoint): Service {
   let eventType: string | undefined;
-  const ep = endpoint as any;
-  if (ep.eventTrigger?.eventType) {
-    eventType = ep.eventTrigger.eventType;
-  } else if (ep.blockingTrigger?.eventType) {
-    eventType = ep.blockingTrigger.eventType;
+  if ("eventTrigger" in endpoint && endpoint.eventTrigger?.eventType) {
+    eventType = endpoint.eventTrigger.eventType;
+  } else if ("blockingTrigger" in endpoint && endpoint.blockingTrigger?.eventType) {
+    eventType = endpoint.blockingTrigger.eventType;
   }
 
   return eventType ? EVENT_SERVICE_MAPPING[eventType as events.Event] || noOpService : noOpService;

--- a/src/deploy/functions/services/index.ts
+++ b/src/deploy/functions/services/index.ts
@@ -1,14 +1,28 @@
 import * as backend from "../backend";
 import * as iam from "../../../gcp/iam";
 import * as events from "../../../functions/events";
+import * as build from "../build";
 import { AuthBlockingService } from "./auth";
-import { obtainStorageBindings, ensureStorageTriggerRegion } from "./storage";
+import {
+  obtainStorageBindings,
+  ensureStorageTriggerRegion,
+  getDefaultRegion as ensureStorageDefaultRegion,
+} from "./storage";
 import { ensureFirebaseAlertsTriggerRegion } from "./firebaseAlerts";
-import { ensureDatabaseTriggerRegion } from "./database";
+import {
+  ensureDatabaseTriggerRegion,
+  getDefaultRegion as ensureDatabaseDefaultRegion,
+} from "./database";
 import { ensureRemoteConfigTriggerRegion } from "./remoteConfig";
 import { ensureTestLabTriggerRegion } from "./testLab";
-import { ensureFirestoreTriggerRegion } from "./firestore";
-import { ensureDataConnectTriggerRegion } from "./dataconnect";
+import {
+  ensureFirestoreTriggerRegion,
+  getDefaultRegion as ensureFirestoreDefaultRegion,
+} from "./firestore";
+import {
+  ensureDataConnectTriggerRegion,
+  getDefaultRegion as ensureDataConnectDefaultRegion,
+} from "./dataconnect";
 import { AILogicService } from "./ailogic";
 
 /** A standard void No Op */
@@ -42,6 +56,8 @@ export interface Service {
   validateTrigger: (ep: backend.Endpoint, want: backend.Backend) => void;
   registerTrigger: (ep: backend.Endpoint) => Promise<void>;
   unregisterTrigger: (ep: backend.Endpoint) => Promise<void>;
+
+  getDefaultRegion?: (endpoint: build.Endpoint) => Promise<string>;
 }
 
 /** A noop service object, useful for v1 events */
@@ -63,6 +79,7 @@ const pubSubService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: () => Promise.resolve("us-east1"),
 };
 
 /** A storage service object */
@@ -74,6 +91,7 @@ const storageService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: ensureStorageDefaultRegion,
 };
 
 /** A firebase alerts service object */
@@ -85,6 +103,7 @@ const firebaseAlertsService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: () => Promise.resolve("us-east1"),
 };
 
 /** A auth blocking service object */
@@ -100,6 +119,7 @@ const databaseService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: ensureDatabaseDefaultRegion,
 };
 
 /** A remote config service object */
@@ -111,6 +131,7 @@ const remoteConfigService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: () => Promise.resolve("us-east1"),
 };
 
 /** A test lab service object */
@@ -122,6 +143,7 @@ const testLabService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: () => Promise.resolve("us-east1"),
 };
 
 /** A firestore service object */
@@ -133,6 +155,7 @@ const firestoreService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: ensureFirestoreDefaultRegion,
 };
 
 /** A Firebase SQL Connect service object */
@@ -144,6 +167,7 @@ const dataconnectService: Service = {
   validateTrigger: noop,
   registerTrigger: noop,
   unregisterTrigger: noop,
+  getDefaultRegion: ensureDataConnectDefaultRegion,
 };
 
 /** Mapping from event type string to service object */
@@ -178,19 +202,14 @@ const EVENT_SERVICE_MAPPING: Record<events.Event, Service> = {
   "google.firebase.ailogic.v1.afterGenerate": aiLogicService,
 };
 
-/**
- * Find the Service object for the given endpoint
- * @param endpoint the endpoint that we want the service for
- * @return a Service object that corresponds to the event type of the endpoint or noop
- */
-export function serviceForEndpoint(endpoint: backend.Endpoint): Service {
-  if (backend.isEventTriggered(endpoint)) {
-    return EVENT_SERVICE_MAPPING[endpoint.eventTrigger.eventType as events.Event] || noOpService;
+export function serviceForEndpoint(endpoint: backend.Endpoint | build.Endpoint): Service {
+  let eventType: string | undefined;
+  const ep = endpoint as any;
+  if (ep.eventTrigger?.eventType) {
+    eventType = ep.eventTrigger.eventType;
+  } else if (ep.blockingTrigger?.eventType) {
+    eventType = ep.blockingTrigger.eventType;
   }
 
-  if (backend.isBlockingTriggered(endpoint)) {
-    return EVENT_SERVICE_MAPPING[endpoint.blockingTrigger.eventType as events.Event] || noOpService;
-  }
-
-  return noOpService;
+  return eventType ? EVENT_SERVICE_MAPPING[eventType as events.Event] || noOpService : noOpService;
 }

--- a/src/deploy/functions/services/storage.ts
+++ b/src/deploy/functions/services/storage.ts
@@ -3,7 +3,8 @@ import * as backend from "../backend";
 import * as iam from "../../../gcp/iam";
 import { logger } from "../../../logger";
 import { FirebaseError } from "../../../error";
-import { regionInLocation } from "../../../gcp/location";
+import { regionInLocation, STORAGE_MULTI_REGION_MAPPING } from "../../../gcp/location";
+import * as build from "../build";
 
 const PUBSUB_PUBLISHER_ROLE = "roles/pubsub.publisher";
 
@@ -87,4 +88,20 @@ export async function ensureStorageTriggerRegion(
       `A function in region ${endpoint.region} cannot listen to a bucket in region ${eventTrigger.region}`,
     );
   }
+}
+
+/**
+ * Get the default region for a Storage event trigger.
+ */
+export async function getDefaultRegion(endpoint: build.Endpoint): Promise<string> {
+  if (!build.isEventTriggered(endpoint)) {
+    throw new FirebaseError("Storage getDefaultRegion requires an event-triggered endpoint");
+  }
+  const bucketName = endpoint.eventTrigger.eventFilters?.bucket;
+  if (!bucketName) {
+    throw new FirebaseError("Could not find bucket name in event trigger filters");
+  }
+  const bucket = await getBucket(bucketName);
+  const locationId = bucket.location.toLowerCase();
+  return STORAGE_MULTI_REGION_MAPPING[locationId] || locationId;
 }

--- a/src/deploy/functions/services/storage.ts
+++ b/src/deploy/functions/services/storage.ts
@@ -3,7 +3,7 @@ import * as backend from "../backend";
 import * as iam from "../../../gcp/iam";
 import { logger } from "../../../logger";
 import { FirebaseError } from "../../../error";
-import { regionInLocation, STORAGE_MULTI_REGION_MAPPING } from "../../../gcp/location";
+import { regionInLocation, STORAGE_MULTI_REGION_TO_REGION_MAPPING } from "../../../gcp/location";
 import * as build from "../build";
 
 const PUBSUB_PUBLISHER_ROLE = "roles/pubsub.publisher";
@@ -103,5 +103,5 @@ export async function getDefaultRegion(endpoint: build.Endpoint): Promise<string
   }
   const bucket = await getBucket(bucketName);
   const locationId = bucket.location.toLowerCase();
-  return STORAGE_MULTI_REGION_MAPPING[locationId] || locationId;
+  return STORAGE_MULTI_REGION_TO_REGION_MAPPING[locationId] || locationId;
 }

--- a/src/deploy/functions/triggerRegionHelper.ts
+++ b/src/deploy/functions/triggerRegionHelper.ts
@@ -5,6 +5,7 @@ import * as utils from "../../utils";
 import { getBucket } from "./services/storage";
 import { getDatabase } from "./services/firestore";
 import { getDatabaseInstanceDetails } from "./services/database";
+import { isUSRegion } from "../../gcp/location";
 
 /**
  * Ensures the trigger regions are set and correct
@@ -136,8 +137,4 @@ function extractInstanceName(resource: string | undefined): string | null {
   if (match) return match[1];
   if (!resource.includes("/")) return resource;
   return null;
-}
-
-function isUSRegion(region: string): boolean {
-  return region === "us" || region.startsWith("nam") || region.startsWith("us-");
 }

--- a/src/gcp/location.ts
+++ b/src/gcp/location.ts
@@ -40,15 +40,15 @@ export const DUAL_REGION_MAPPING: Record<string, string> = {
   "us-east1": "nam4",
 };
 
-/** Firestore multi-region mapping (https://cloud.google.com/firestore/docs/locations#multi-region) */
-export const FIRESTORE_MULTI_REGION_MAPPING: Record<string, string> = {
+/** Firestore dual-region to default function region mapping. */
+export const FIRESTORE_DUAL_REGION_TO_REGION_MAPPING: Record<string, string> = {
   nam5: "us-central1",
   nam7: "us-central1",
   eur3: "europe-west1",
 };
 
-/** Google Cloud Storage multi-region location to default region mapping (https://cloud.google.com/storage/docs/locations#multi-region) */
-export const STORAGE_MULTI_REGION_MAPPING: Record<string, string> = {
+/** Google Cloud Storage multi-region to default function region mapping. */
+export const STORAGE_MULTI_REGION_TO_REGION_MAPPING: Record<string, string> = {
   us: "us-east1",
   eu: "europe-west1",
   asia: "asia-east1",

--- a/src/gcp/location.ts
+++ b/src/gcp/location.ts
@@ -40,6 +40,20 @@ export const DUAL_REGION_MAPPING: Record<string, string> = {
   "us-east1": "nam4",
 };
 
+/** Firestore multi-region mapping (https://cloud.google.com/firestore/docs/locations#multi-region) */
+export const FIRESTORE_MULTI_REGION_MAPPING: Record<string, string> = {
+  nam5: "us-central1",
+  nam7: "us-central1",
+  eur3: "europe-west1",
+};
+
+/** Google Cloud Storage multi-region location to default region mapping (https://cloud.google.com/storage/docs/locations#multi-region) */
+export const STORAGE_MULTI_REGION_MAPPING: Record<string, string> = {
+  us: "us-east1",
+  eu: "europe-west1",
+  asia: "asia-east1",
+};
+
 /**
  * Helper function to determine if the given region is inside the multi-region or dual-region location.
  * This is helpful for determining if a specific region maps to a Google Cloud Storage location.
@@ -56,4 +70,12 @@ export function regionInLocation(region: string, location: string): boolean {
     return true;
   }
   return false;
+}
+
+/**
+ * Helper function to check if a region is a US region.
+ */
+export function isUSRegion(region: string): boolean {
+  const lower = region.toLowerCase();
+  return lower === "us" || lower.startsWith("nam") || lower.startsWith("us-");
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This PR refactors the trigger default region resolution logic during Cloud Functions deployment to make it less brittle, easier to maintain, and more scalable.

Previously, prepare.ts contained complex service-specific logic and switch/if blocks to inspect different event types (Firestore, Cloud Storage, Realtime Database, etc.) and look up their corresponding default regions. This was highly brittle: if a new service or event type is added, developers would have to manually update prepare.ts, which could be easy to miss.
