### PR TITLE
Update FDC emulator to v3.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 - Updated Firebase SQL Connect genAI features to use new Agent Service API
+- Updated the Firebase Data Connect local toolkit to v3.4.10, which includes the following changes:
+  - Extended client cache consistency validation to include conflicts with schema field names.

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -54,36 +54,36 @@
   },
   "dataconnect": {
     "darwin": {
-      "version": "3.4.9",
-      "expectedSize": 32423488,
-      "expectedChecksum": "75788cfdb69c2762ac9f78e37714d364",
-      "expectedChecksumSHA256": "af26c22a6fe131b111b4e71eb4c179b2b42a9cf8d334d50e4c2c419bbbb54416",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-amd64-v3.4.9",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.9"
+      "version": "3.4.10",
+      "expectedSize": 32439760,
+      "expectedChecksum": "c3609b01993c1f66d340eda59fa31467",
+      "expectedChecksumSHA256": "257419922a81b4856b1ce7c1ac0684b4690a380072fe132d1960070f7d00941a",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-amd64-v3.4.10",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.10"
     },
     "darwin_arm64": {
-      "version": "3.4.9",
-      "expectedSize": 30554802,
-      "expectedChecksum": "7e64aba6ffc071ef60b8f2a51b3f5683",
-      "expectedChecksumSHA256": "49ba258954b3568e93ef75b4c7e9a50c708a7e15ba9a22697ff967e195a907aa",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-arm64-v3.4.9",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.9"
+      "version": "3.4.10",
+      "expectedSize": 30571186,
+      "expectedChecksum": "fd17de6fb356a5e0c1c67ae7f4adfa08",
+      "expectedChecksumSHA256": "9c6da9eea98ee85b16b6e0c5075d1c757aaa252526470fbe63cfb915e3585361",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-arm64-v3.4.10",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.10"
     },
     "win32": {
-      "version": "3.4.9",
-      "expectedSize": 32464896,
-      "expectedChecksum": "1bc40de5be6bab9280904ee68f849594",
-      "expectedChecksumSHA256": "b0b277ed1efd374099b90a74ebb2994ffa5755c185d8d9d2cf667f49c0c31139",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-amd64-v3.4.9",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.9.exe"
+      "version": "3.4.10",
+      "expectedSize": 32479744,
+      "expectedChecksum": "3ed78e5d74da96e89f385a64fa6151fc",
+      "expectedChecksumSHA256": "bc4bb887b5adbba5b916fa41a091f544aac70f35d5209c483fac90f89abb2c93",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-amd64-v3.4.10",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.10.exe"
     },
     "linux": {
-      "version": "3.4.9",
-      "expectedSize": 31580344,
-      "expectedChecksum": "4de2d7d37652d652d059335a43dc02b4",
-      "expectedChecksumSHA256": "803ec59b5ec1590ed4521df70864a46808f3ec8008756206bf210852e2298291",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-amd64-v3.4.9",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.9"
+      "version": "3.4.10",
+      "expectedSize": 31592632,
+      "expectedChecksum": "a003103017717ddc4ea9967d5820ea51",
+      "expectedChecksumSHA256": "50b22fdaf7bf1c30b5f331ef07a7f19c51309ca9c9897be426e86254e02b514c",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-amd64-v3.4.10",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.10"
     }
   }
 }


### PR DESCRIPTION
- Updated the Firebase Data Connect local toolkit to v3.4.10, which includes the following changes:
  - Extended client cache consistency validation to include conflicts with schema field names.