### PR TITLE
emulator: reject cross-origin calls to Hub state-changing endpoints

### DIFF
--- a/src/emulator/hub.ts
+++ b/src/emulator/hub.ts
@@ -109,6 +109,7 @@ export class EmulatorHub extends ExpressBasedEmulator {
         res.status(403).json({
           message: `Export cannot be triggered by external callers.`,
         });
+        return;
       }
       const path: string = req.body.path;
       const initiatedBy: string = req.body.initiatedBy || "unknown";
@@ -134,6 +135,12 @@ export class EmulatorHub extends ExpressBasedEmulator {
     });
 
     app.put(EmulatorHub.PATH_DISABLE_FUNCTIONS, async (req, res) => {
+      if (req.headers.origin) {
+        res.status(403).json({
+          message: `Cloud Functions triggers cannot be toggled by external callers.`,
+        });
+        return;
+      }
       utils.logLabeledBullet(
         "emulators",
         `Disabling Cloud Functions triggers, non-HTTP functions will not execute.`,
@@ -151,6 +158,12 @@ export class EmulatorHub extends ExpressBasedEmulator {
     });
 
     app.put(EmulatorHub.PATH_ENABLE_FUNCTIONS, async (req, res) => {
+      if (req.headers.origin) {
+        res.status(403).json({
+          message: `Cloud Functions triggers cannot be toggled by external callers.`,
+        });
+        return;
+      }
       utils.logLabeledBullet(
         "emulators",
         `Enabling Cloud Functions triggers, non-HTTP functions will execute.`,
@@ -172,6 +185,7 @@ export class EmulatorHub extends ExpressBasedEmulator {
         res.status(403).json({
           message: `Clear SQL Connect cannot be triggered by external callers.`,
         });
+        return;
       }
       utils.logLabeledBullet("emulators", `Clearing data from SQL Connect data sources.`);
 


### PR DESCRIPTION
## Description

The Emulator Hub's state-changing endpoints can be driven cross-site from a page open in the developer's browser.

`POST /_admin/export` and `POST /dataconnect/clearData` already try to block browser callers with an `if (req.headers.origin)` 403, but the guard is **missing a `return`** — the 403 is sent, yet execution falls through and the side effect (full emulator data export / Data Connect wipe) runs anyway. The trailing `res.status(200)` then throws `ERR_HTTP_HEADERS_SENT`, which crashes the `emulators:start` process.

`PUT /functions/disableBackgroundTriggers` and `/functions/enableBackgroundTriggers` have no origin guard at all.

## Fix

- Add the missing `return` after the 403 in `/_admin/export` and `/dataconnect/clearData` so the guard actually stops execution.
- Apply the same origin guard to the two `BackgroundTriggers` endpoints.

The legitimate caller (`HubClient`, a server-side `apiv2` node client) does not send an `Origin` header, so the CLI and the Emulator UI are unaffected — only browser-originated cross-site requests are rejected.

## Note (defense-in-depth, not in this PR)

The broader exposure — `cors({ origin: true })` on the data emulators (cross-origin reads) and the absence of Host-header validation (DNS-rebinding) — is a larger design question that interacts with the Emulator UI and the tunnel support added in #4227. Happy to follow up separately if that's useful; this PR fixes the clear control-bypass bug.
