### PR TITLE
emulator: validate Host header to mitigate DNS-rebinding

### DIFF
--- a/src/emulator/ExpressBasedEmulator.ts
+++ b/src/emulator/ExpressBasedEmulator.ts
@@ -6,6 +6,7 @@ import * as utils from "../utils";
 import { Emulators, EmulatorInstance, EmulatorInfo, ListenSpec } from "./types";
 import { createServer } from "node:http";
 import { IPV4_UNSPECIFIED, IPV6_UNSPECIFIED } from "./dns";
+import { hostValidationMiddleware } from "./hostValidation";
 import { ListenOptions } from "node:net";
 
 export interface ExpressBasedEmulatorOptions {
@@ -32,6 +33,11 @@ export abstract class ExpressBasedEmulator implements EmulatorInstance {
 
   protected createExpressApp(): Promise<express.Express> {
     const app = express();
+
+    // Reject requests with an untrusted Host header to mitigate DNS-rebinding.
+    // Only enforced when bound to loopback (see hostValidationMiddleware).
+    app.use(hostValidationMiddleware(this.options.listen.map((s) => s.address)));
+
     if (!this.options.noCors) {
       // Enable CORS for all APIs, all origins (reflected), and all headers (reflected).
       // This is enabled by default since most emulators are cookieless.

--- a/src/emulator/auth/index.ts
+++ b/src/emulator/auth/index.ts
@@ -33,7 +33,9 @@ export class AuthEmulator implements EmulatorInstance {
 
   async start(): Promise<void> {
     const { host, port } = this.getInfo();
-    const app = await createApp(this.args.projectId, this.args.singleProjectMode);
+    const app = await createApp(this.args.projectId, this.args.singleProjectMode, undefined, [
+      host,
+    ]);
     const server = app.listen(port, host);
     this.destroyServer = utils.createDestroyer(server);
   }

--- a/src/emulator/auth/server.ts
+++ b/src/emulator/auth/server.ts
@@ -32,6 +32,7 @@ import {
 import { logError } from "./utils";
 import { camelCase } from "lodash";
 import { registerHandlers } from "./handlers";
+import { hostValidationMiddleware } from "../hostValidation";
 import * as bodyParser from "body-parser";
 import { URLSearchParams } from "url";
 import { decode, JwtHeader } from "jsonwebtoken";
@@ -114,14 +115,21 @@ function specWithEmulatorServer(protocol: string, host: string | undefined): Ope
  * accepted by the target endpoint), it assumes ALL keys / tokens map to this
  * default project ID.
  * @param projectStateForId a map from projectId to state, injectable for tests
+ * @param listenHosts the address(es) the emulator is bound to, used to reject
+ * untrusted Host headers when bound to loopback (mitigates DNS-rebinding)
  */
 export async function createApp(
   defaultProjectId: string,
   singleProjectMode = SingleProjectMode.NO_WARNING,
   projectStateForId = new Map<string, AgentProjectState>(),
+  listenHosts: string[] = [],
 ): Promise<express.Express> {
   const app = express();
   app.set("json spaces", 2);
+
+  // Reject requests with an untrusted Host header to mitigate DNS-rebinding.
+  // Only enforced when bound to loopback (see hostValidationMiddleware).
+  app.use(hostValidationMiddleware(listenHosts));
 
   // Return access-control-allow-private-network heder if requested
   // Enables accessing locahost when site is exposed via tunnel see https://github.com/firebase/firebase-tools/issues/4227

--- a/src/emulator/eventarcEmulator.ts
+++ b/src/emulator/eventarcEmulator.ts
@@ -9,6 +9,7 @@ import { CloudEvent } from "./events/types";
 import { EmulatorRegistry } from "./registry";
 import { FirebaseError } from "../error";
 import { cloudEventFromProtoToJson } from "./eventarcEmulatorUtils";
+import { hostValidationMiddleware } from "./hostValidation";
 import * as cors from "cors";
 
 interface EmulatedEventTrigger {
@@ -148,6 +149,7 @@ export class EventarcEmulator implements EmulatorInstance {
     };
 
     const hub = express();
+    hub.use(hostValidationMiddleware([this.getInfo().host]));
     hub.post([registerTriggerRoute], dataMiddleware, registerTriggerHandler);
     hub.post([publishEventsRoute], dataMiddleware, publishEventsHandler);
     hub.post(

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -38,6 +38,7 @@ import {
 } from "./functionsEmulatorShared";
 import { EmulatorRegistry } from "./registry";
 import { EmulatorLogger, Verbosity } from "./emulatorLogger";
+import { hostValidationMiddleware } from "./hostValidation";
 import { RuntimeWorker, RuntimeWorkerPool } from "./functionsRuntimeWorker";
 import { PubsubEmulator } from "./pubsubEmulator";
 import { FirebaseError } from "../error";
@@ -311,6 +312,7 @@ export class FunctionsEmulator implements EmulatorInstance {
     this.workQueue.start();
 
     const hub = express();
+    hub.use(hostValidationMiddleware([this.getInfo().host]));
 
     const dataMiddleware: express.RequestHandler = (req, res, next) => {
       const chunks: Buffer[] = [];

--- a/src/emulator/hostValidation.ts
+++ b/src/emulator/hostValidation.ts
@@ -1,0 +1,90 @@
+import * as express from "express";
+
+/**
+ * Returns true if the given address refers to the loopback interface (and is
+ * therefore only reachable from the local machine).
+ *
+ * Note: "0.0.0.0" (and IPv6 "::") mean "all interfaces" and are NOT loopback —
+ * binding to them opts into remote access, so they are treated as non-loopback.
+ */
+export function isLoopbackAddress(addr: string): boolean {
+  const normalized = addr.trim().toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "::1" ||
+    normalized === "[::1]" ||
+    normalized.startsWith("127.")
+  );
+}
+
+/**
+ * Strip the trailing ":port" from a Host header value, returning the bare
+ * hostname (lowercased). Handles bracketed IPv6 hosts like "[::1]:5000".
+ */
+function bareHostname(host: string): string {
+  const trimmed = host.trim().toLowerCase();
+  if (trimmed.startsWith("[")) {
+    // Bracketed IPv6 host, e.g. "[::1]" or "[::1]:5000".
+    const closing = trimmed.indexOf("]");
+    if (closing !== -1) {
+      return trimmed.substring(0, closing + 1);
+    }
+    return trimmed;
+  }
+  // IPv4 / hostname: only strip the port if there's a single colon. A bare
+  // unbracketed IPv6 address (multiple colons) has no port suffix to strip.
+  const firstColon = trimmed.indexOf(":");
+  if (firstColon !== -1 && trimmed.indexOf(":", firstColon + 1) === -1) {
+    return trimmed.substring(0, firstColon);
+  }
+  return trimmed;
+}
+
+/**
+ * Express middleware that rejects requests with an untrusted Host header to
+ * mitigate DNS-rebinding attacks against the (unauthenticated) emulator APIs.
+ *
+ * Enforcement only happens when the emulator is bound exclusively to loopback
+ * addresses. If the operator bound to a non-loopback address (e.g. "0.0.0.0"
+ * or a specific public host) they have opted into remote access (such as tunnel
+ * support, see https://github.com/firebase/firebase-tools/issues/4227) and the
+ * middleware becomes a no-op so as not to break those setups.
+ *
+ * @param bindAddresses the address(es) the emulator is listening on.
+ */
+export function hostValidationMiddleware(bindAddresses: string[]): express.RequestHandler {
+  // Cannot determine the bind address(es) — don't break anything.
+  if (bindAddresses.length === 0) {
+    return (req, res, next) => next();
+  }
+
+  // Operator opted into remote access by binding to a non-loopback address.
+  if (!bindAddresses.every((addr) => isLoopbackAddress(addr))) {
+    return (req, res, next) => next();
+  }
+
+  const allowedHosts = new Set(["localhost", "::1", "[::1]"]);
+  for (const addr of bindAddresses) {
+    allowedHosts.add(addr.trim().toLowerCase());
+  }
+
+  return (req, res, next) => {
+    const hostHeader = req.headers.host;
+    if (!hostHeader) {
+      // No Host header — nothing to validate against.
+      return next();
+    }
+
+    const host = bareHostname(hostHeader);
+    if (host.startsWith("127.") || allowedHosts.has(host)) {
+      return next();
+    }
+
+    res.status(403).json({
+      error:
+        `Request blocked due to an untrusted Host header "${host}". ` +
+        `The Firebase Emulator Suite only accepts requests with a loopback Host header to ` +
+        `mitigate DNS-rebinding; bind the emulator to a non-loopback host to allow remote access.`,
+    });
+  };
+}

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -8,6 +8,7 @@ import { RulesConfig, StorageEmulator } from "./index";
 import { createFirebaseEndpoints } from "./apis/firebase";
 import { InvalidArgumentError } from "../auth/errors";
 import { SourceFile } from "./rules/types";
+import { hostValidationMiddleware } from "../hostValidation";
 
 /**
  * @param defaultProjectId
@@ -24,6 +25,10 @@ export function createApp(
     "DEBUG",
     `Temp file directory for storage emulator: ${storageLayer.dirPath}`,
   );
+
+  // Reject requests with an untrusted Host header to mitigate DNS-rebinding.
+  // Only enforced when bound to loopback (see hostValidationMiddleware).
+  app.use(hostValidationMiddleware([emulator.getInfo().host]));
 
   // Return access-control-allow-private-network header if requested
   // Enables accessing locahost when site is exposed via tunnel see https://github.com/firebase/firebase-tools/issues/4227

--- a/src/emulator/tasksEmulator.ts
+++ b/src/emulator/tasksEmulator.ts
@@ -5,6 +5,7 @@ import { EmulatorInfo, EmulatorInstance, Emulators } from "./types";
 import { createDestroyer } from "../utils";
 import { EmulatorLogger } from "./emulatorLogger";
 import { TaskQueue } from "./taskQueue";
+import { hostValidationMiddleware } from "./hostValidation";
 import * as cors from "cors";
 
 export interface TasksEmulatorArgs {
@@ -196,6 +197,7 @@ export class TasksEmulator implements EmulatorInstance {
   }
   createHubServer(): express.Application {
     const hub = express();
+    hub.use(hostValidationMiddleware([this.getInfo().host]));
 
     const createTaskQueueRoute = `/projects/:project_id/locations/:location_id/queues/:queue_name`;
     const createTaskQueueHandler: express.Handler = (req, res) => {


### PR DESCRIPTION
## Description

The local emulator HTTP servers all use `cors({ origin: true })` and perform no `Host`-header validation. A web page open in a developer's browser can therefore reach the (unauthenticated) emulator APIs via **DNS-rebinding** — rebind an attacker-controlled domain to `127.0.0.1`, after which requests are same-origin so CORS no longer applies — and drive the emulator endpoints (read/modify/delete local emulator data, toggle Cloud Functions triggers, etc.).

## Fix

Add a small `hostValidationMiddleware` (`src/emulator/hostValidation.ts`) that rejects requests whose `Host` header is not a loopback/configured host, wired as the first middleware on every emulator's express app — Hub/UI via `ExpressBasedEmulator`, plus Auth, Storage, Eventarc, Tasks, and Functions.

Enforcement happens **only when the emulator is bound exclusively to loopback addresses** (the rebinding-vulnerable default). If the operator bound to a non-loopback address (`0.0.0.0`, `::`, or a specific host) they have opted into remote access — e.g. the tunnel support from #4227 — so the middleware becomes a no-op and those setups keep working.

The legitimate callers (the `HubClient` node client, the CLI, and the Emulator UI) send loopback `Host` headers and requests without a `Host` header are allowed, so they are unaffected.

## Testing

- Typecheck (`tsc --noEmit`) passes; files are prettier-clean.
- Middleware behavior verified: under a loopback bind it allows `Host: localhost` / `127.0.0.1` / `::1` / `[::1]` / the configured host (and requests with no `Host`), and returns `403` for an untrusted host (e.g. a rebound attacker domain); under a non-loopback bind it is a pass-through.
