### PR TITLE
Add --results-bucket flag for starting ATA tests

### DIFF
--- a/src/appdistribution/client.spec.ts
+++ b/src/appdistribution/client.spec.ts
@@ -484,10 +484,33 @@ describe("distribution", () => {
 
     it("should resolve with ReleaseTest when request succeeds", async () => {
       nock(appDistributionOrigin())
-        .post(`/v1alpha/${releaseName}/tests`)
+        .post(`/v1alpha/${releaseName}/tests`, {
+          deviceExecutions: mockDevices.map((device) => ({ device })),
+        } as any)
         .reply(200, mockReleaseTest);
       await expect(
         appDistributionClient.createReleaseTest(releaseName, mockDevices),
+      ).to.be.eventually.deep.eq(mockReleaseTest);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should include resultsBucket in request body if specified", async () => {
+      nock(appDistributionOrigin())
+        .post(`/v1alpha/${releaseName}/tests`, {
+          deviceExecutions: mockDevices.map((device) => ({ device })),
+          resultsBucket: "projects/123/buckets/my-bucket",
+        } as any)
+        .reply(200, mockReleaseTest);
+      await expect(
+        appDistributionClient.createReleaseTest(
+          releaseName,
+          mockDevices,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          "projects/123/buckets/my-bucket",
+        ),
       ).to.be.eventually.deep.eq(mockReleaseTest);
       expect(nock.isDone()).to.be.true;
     });

--- a/src/appdistribution/client.spec.ts
+++ b/src/appdistribution/client.spec.ts
@@ -486,7 +486,7 @@ describe("distribution", () => {
       nock(appDistributionOrigin())
         .post(`/v1alpha/${releaseName}/tests`, {
           deviceExecutions: mockDevices.map((device) => ({ device })),
-        } as any)
+        })
         .reply(200, mockReleaseTest);
       await expect(
         appDistributionClient.createReleaseTest(releaseName, mockDevices),
@@ -499,18 +499,12 @@ describe("distribution", () => {
         .post(`/v1alpha/${releaseName}/tests`, {
           deviceExecutions: mockDevices.map((device) => ({ device })),
           resultsBucket: "projects/123/buckets/my-bucket",
-        } as any)
+        })
         .reply(200, mockReleaseTest);
       await expect(
-        appDistributionClient.createReleaseTest(
-          releaseName,
-          mockDevices,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          "projects/123/buckets/my-bucket",
-        ),
+        appDistributionClient.createReleaseTest(releaseName, mockDevices, {
+          resultsBucket: "projects/123/buckets/my-bucket",
+        }),
       ).to.be.eventually.deep.eq(mockReleaseTest);
       expect(nock.isDone()).to.be.true;
     });

--- a/src/appdistribution/client.spec.ts
+++ b/src/appdistribution/client.spec.ts
@@ -483,29 +483,39 @@ describe("distribution", () => {
     });
 
     it("should resolve with ReleaseTest when request succeeds", async () => {
+      let capturedRequestBody: nock.Body | undefined;
       nock(appDistributionOrigin())
-        .post(`/v1alpha/${releaseName}/tests`, {
-          deviceExecutions: mockDevices.map((device) => ({ device })),
-        })
-        .reply(200, mockReleaseTest);
+        .post(`/v1alpha/${releaseName}/tests`)
+        .reply(200, (uri, requestBody) => {
+          capturedRequestBody = requestBody;
+          return mockReleaseTest;
+        });
       await expect(
         appDistributionClient.createReleaseTest(releaseName, mockDevices),
       ).to.be.eventually.deep.eq(mockReleaseTest);
+      expect(capturedRequestBody).to.deep.equal({
+        deviceExecutions: mockDevices.map((device) => ({ device })),
+      });
       expect(nock.isDone()).to.be.true;
     });
 
     it("should include resultsBucket in request body if specified", async () => {
+      let capturedRequestBody: nock.Body | undefined;
       nock(appDistributionOrigin())
-        .post(`/v1alpha/${releaseName}/tests`, {
-          deviceExecutions: mockDevices.map((device) => ({ device })),
-          resultsBucket: "projects/123/buckets/my-bucket",
-        })
-        .reply(200, mockReleaseTest);
+        .post(`/v1alpha/${releaseName}/tests`)
+        .reply(200, (uri, requestBody) => {
+          capturedRequestBody = requestBody;
+          return mockReleaseTest;
+        });
       await expect(
         appDistributionClient.createReleaseTest(releaseName, mockDevices, {
           resultsBucket: "projects/123/buckets/my-bucket",
         }),
       ).to.be.eventually.deep.eq(mockReleaseTest);
+      expect(capturedRequestBody).to.deep.equal({
+        deviceExecutions: mockDevices.map((device) => ({ device })),
+        resultsBucket: "projects/123/buckets/my-bucket",
+      });
       expect(nock.isDone()).to.be.true;
     });
   });

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -278,11 +278,13 @@ export class AppDistributionClient {
   async createReleaseTest(
     releaseName: string,
     devices: TestDevice[],
-    aiInstructions?: AiInstructions,
-    loginCredential?: LoginCredential,
-    testCaseName?: string,
-    displayName?: string,
-    resultsBucket?: string,
+    options: {
+      aiInstructions?: AiInstructions;
+      loginCredential?: LoginCredential;
+      testCaseName?: string;
+      displayName?: string;
+      resultsBucket?: string;
+    } = {},
   ): Promise<ReleaseTest> {
     try {
       const response = await this.appDistroV1AlphaClient.request<ReleaseTest, ReleaseTest>({
@@ -290,11 +292,11 @@ export class AppDistributionClient {
         path: `${releaseName}/tests`,
         body: {
           deviceExecutions: devices.map((device) => ({ device })),
-          loginCredential,
-          testCase: testCaseName,
-          aiInstructions: aiInstructions,
-          displayName: displayName,
-          resultsBucket: resultsBucket,
+          loginCredential: options.loginCredential,
+          testCase: options.testCaseName,
+          aiInstructions: options.aiInstructions,
+          displayName: options.displayName,
+          resultsBucket: options.resultsBucket,
         },
       });
       return response.body;

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -282,6 +282,7 @@ export class AppDistributionClient {
     loginCredential?: LoginCredential,
     testCaseName?: string,
     displayName?: string,
+    resultsBucket?: string,
   ): Promise<ReleaseTest> {
     try {
       const response = await this.appDistroV1AlphaClient.request<ReleaseTest, ReleaseTest>({
@@ -293,6 +294,7 @@ export class AppDistributionClient {
           testCase: testCaseName,
           aiInstructions: aiInstructions,
           displayName: displayName,
+          resultsBucket: resultsBucket,
         },
       });
       return response.body;

--- a/src/appdistribution/options-parser-util.spec.ts
+++ b/src/appdistribution/options-parser-util.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { getLoginCredential, parseTestDevices } from "./options-parser-util";
+import { getLoginCredential, parseTestDevices, getResultsBucket } from "./options-parser-util";
 import { FirebaseError } from "../error";
 import * as fs from "fs-extra";
 import { rmSync } from "node:fs";
@@ -200,6 +200,48 @@ describe("options-parser-util", () => {
           passwordResourceName: "password_resource_id",
         }),
       ).to.throw(FirebaseError, "Must specify username and password");
+    });
+  });
+
+  describe("getResultsBucket", () => {
+    const appName = "projects/123456789/apps/1:123456789:android:abcdef";
+
+    it("returns undefined if bucket is not provided", () => {
+      expect(getResultsBucket(undefined, appName)).to.be.undefined;
+    });
+
+    it("returns the formatted bucket name when simple name provided", () => {
+      expect(getResultsBucket("my-bucket", appName)).to.equal(
+        "projects/123456789/buckets/my-bucket",
+      );
+    });
+
+    it("strips gs:// prefix and formats correctly", () => {
+      expect(getResultsBucket("gs://my-bucket", appName)).to.equal(
+        "projects/123456789/buckets/my-bucket",
+      );
+    });
+
+    it("throws FirebaseError if bucket name contains invalid characters", () => {
+      expect(() => getResultsBucket("my_Bucket", appName)).to.throw(
+        FirebaseError,
+        "Invalid results bucket format: my_Bucket",
+      );
+      expect(() => getResultsBucket("gs://my-bucket/", appName)).to.throw(
+        FirebaseError,
+        "Invalid results bucket format: gs://my-bucket/",
+      );
+      expect(() => getResultsBucket("projects/123456789/buckets/my-bucket", appName)).to.throw(
+        FirebaseError,
+        "Invalid results bucket format: projects/123456789/buckets/my-bucket",
+      );
+    });
+
+    it("throws FirebaseError if appName is not valid format", () => {
+      expect(() => getResultsBucket("my-bucket", "invalid-app-name")).to.throw(
+        FirebaseError,
+        "Invalid app name: invalid-app-name",
+      );
     });
   });
 });

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -187,3 +187,29 @@ export function getLoginCredential(args: {
 function isPresenceMismatched(value1?: string, value2?: string) {
   return (value1 && !value2) || (!value1 && value2);
 }
+
+const APP_NAME_REGEX = /^projects\/(?<projectNumber>[^\/]+)\/apps\/(?<appId>[^\/]+)$/;
+const BUCKET_NAME_FORMAT_REGEX = /^[a-z0-9-_.]+$/;
+
+/**
+ * Parses and returns the custom GCS results bucket resource name path format:
+ * `projects/{project_number}/buckets/{bucket}`.
+ */
+export function getResultsBucket(bucket: string | undefined, appName: string): string | undefined {
+  if (!bucket) {
+    return undefined;
+  }
+  let bucketName = bucket;
+  if (bucketName.startsWith("gs://")) {
+    bucketName = bucketName.substring(5);
+  }
+  if (!BUCKET_NAME_FORMAT_REGEX.test(bucketName)) {
+    throw new FirebaseError(`Invalid results bucket format: ${bucket}`);
+  }
+  const match = APP_NAME_REGEX.exec(appName);
+  if (!match || typeof match.groups === "undefined") {
+    throw new FirebaseError(`Invalid app name: ${appName}`);
+  }
+  const { projectNumber } = match.groups;
+  return `projects/${projectNumber}/buckets/${bucketName}`;
+}

--- a/src/appdistribution/options-parser-util.ts
+++ b/src/appdistribution/options-parser-util.ts
@@ -189,7 +189,7 @@ function isPresenceMismatched(value1?: string, value2?: string) {
 }
 
 const APP_NAME_REGEX = /^projects\/(?<projectNumber>[^\/]+)\/apps\/(?<appId>[^\/]+)$/;
-const BUCKET_NAME_FORMAT_REGEX = /^[a-z0-9-_.]+$/;
+const BUCKET_NAME_FORMAT_REGEX = /^[a-z0-9_.-]+$/;
 
 /**
  * Parses and returns the custom GCS results bucket resource name path format:

--- a/src/appdistribution/types.ts
+++ b/src/appdistribution/types.ts
@@ -123,6 +123,7 @@ export interface ReleaseTest {
   testCase?: string;
   aiInstructions?: AiInstructions;
   displayName?: string;
+  resultsBucket?: string;
 }
 
 export interface AiStep {

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -15,6 +15,7 @@ import {
   getLoginCredential,
   parseTestDevices,
   parseIntoStringArray,
+  getResultsBucket,
 } from "../appdistribution/options-parser-util";
 import {
   AabInfo,
@@ -85,9 +86,14 @@ export const command = new Command("appdistribution:distribute <release-binary-f
     "--test-case-ids-file <file>",
     "path to file with a comma- or newline-separated list of test case IDs.",
   )
+  .option(
+    "--results-bucket <bucket>",
+    "The name of a Google Cloud Storage bucket where raw results of any automated tests will be stored. If this flag is not set, Firebase creates a bucket for you. Note that the bucket must be owned by a billing-enabled project, and that using a non-default bucket will result in billing charges for the storage used.",
+  )
   .before(requireAuth)
   .action(async (file: string, options: any) => {
     const appName = getAppName(options);
+    const resultsBucket = getResultsBucket(options.resultsBucket, appName);
     const distribution = new Distribution(file);
     const releaseNotes = getReleaseNotes(options.releaseNotes, options.releaseNotesFile);
     const testers = parseIntoStringArray(options.testers, options.testersFile);
@@ -117,6 +123,7 @@ export const command = new Command("appdistribution:distribute <release-binary-f
       groups,
       options.testNonBlocking,
       loginCredential,
+      resultsBucket,
     );
   });
 
@@ -133,6 +140,7 @@ async function distribute(
   groups?: string[],
   testNonBlocking?: boolean,
   loginCredential?: LoginCredential,
+  resultsBucket?: string,
 ) {
   const requests = new AppDistributionClient();
   let aabInfo: AabInfo | undefined;
@@ -210,7 +218,15 @@ async function distribute(
     if (!testCases.length) {
       // fallback to basic automated test
       releaseTestPromises.push(
-        requests.createReleaseTest(release.name, testDevices, undefined, loginCredential),
+        requests.createReleaseTest(
+          release.name,
+          testDevices,
+          undefined,
+          loginCredential,
+          undefined,
+          undefined,
+          resultsBucket,
+        ),
       );
     } else {
       for (const testCaseId of testCases) {
@@ -221,6 +237,8 @@ async function distribute(
             undefined,
             loginCredential,
             `${appName}/testCases/${testCaseId}`,
+            undefined,
+            resultsBucket,
           ),
         );
       }

--- a/src/commands/appdistribution-distribute.ts
+++ b/src/commands/appdistribution-distribute.ts
@@ -218,28 +218,19 @@ async function distribute(
     if (!testCases.length) {
       // fallback to basic automated test
       releaseTestPromises.push(
-        requests.createReleaseTest(
-          release.name,
-          testDevices,
-          undefined,
+        requests.createReleaseTest(release.name, testDevices, {
           loginCredential,
-          undefined,
-          undefined,
           resultsBucket,
-        ),
+        }),
       );
     } else {
       for (const testCaseId of testCases) {
         releaseTestPromises.push(
-          requests.createReleaseTest(
-            release.name,
-            testDevices,
-            undefined,
+          requests.createReleaseTest(release.name, testDevices, {
             loginCredential,
-            `${appName}/testCases/${testCaseId}`,
-            undefined,
+            testCaseName: `${appName}/testCases/${testCaseId}`,
             resultsBucket,
-          ),
+          }),
         );
       }
     }

--- a/src/commands/apptesting.ts
+++ b/src/commands/apptesting.ts
@@ -7,7 +7,11 @@ import { FirebaseError, getError } from "../error";
 import { AppDistributionClient } from "../appdistribution/client";
 import { awaitTestResults, Distribution, upload } from "../appdistribution/distribution";
 import { AiInstructions, ReleaseTest, TestDevice, Release } from "../appdistribution/types";
-import { getAppName, parseTestDevices } from "../appdistribution/options-parser-util";
+import {
+  getAppName,
+  parseTestDevices,
+  getResultsBucket,
+} from "../appdistribution/options-parser-util";
 import * as utils from "../utils";
 import { dirExistsSync } from "../fsutils";
 import * as path from "path";
@@ -48,9 +52,14 @@ export const command = new Command("apptesting:execute [release-binary-file]")
     "--test-non-blocking",
     "Run automated tests without waiting for them to complete. Visit the Firebase console for the test results.",
   )
+  .option(
+    "--results-bucket <bucket>",
+    "The name of a Google Cloud Storage bucket where raw test results will be stored. If this flag is not set, Firebase creates a default bucket for you. Note that the bucket must be owned by a billing-enabled project, and that using a non-default bucket will result in billing charges for the storage used.",
+  )
   .before(requireAuth)
   .action(async (target: string | undefined, options: any) => {
     const appName = getAppName(options);
+    const resultsBucket = getResultsBucket(options.resultsBucket, appName);
 
     const testDir = path.resolve(options.testDir || "tests");
     if (!dirExistsSync(testDir)) {
@@ -99,6 +108,7 @@ export const command = new Command("apptesting:execute [release-binary-file]")
         release.name,
         tests,
         !testDevices.length ? defaultDevices : testDevices,
+        resultsBucket,
       );
       invokeSpinner.text = `${pluralizeTests(releaseTests.length)} started successfully!`;
       invokeSpinner.succeed();
@@ -124,6 +134,7 @@ async function invokeTests(
   releaseName: string,
   testDefs: TestCaseInvocation[],
   devices: TestDevice[],
+  resultsBucket?: string,
 ): Promise<ReleaseTest[]> {
   try {
     const releaseTests: ReleaseTest[] = [];
@@ -139,6 +150,7 @@ async function invokeTests(
           undefined,
           undefined,
           testDef.testCase.displayName,
+          resultsBucket,
         ),
       );
     }

--- a/src/commands/apptesting.ts
+++ b/src/commands/apptesting.ts
@@ -143,15 +143,11 @@ async function invokeTests(
         steps: testDef.testCase.steps,
       };
       releaseTests.push(
-        await client.createReleaseTest(
-          releaseName,
-          devices,
+        await client.createReleaseTest(releaseName, devices, {
           aiInstructions,
-          undefined,
-          undefined,
-          testDef.testCase.displayName,
+          displayName: testDef.testCase.displayName,
           resultsBucket,
-        ),
+        }),
       );
     }
     return releaseTests;

--- a/src/mcp/tools/apptesting/tests.spec.ts
+++ b/src/mcp/tools/apptesting/tests.spec.ts
@@ -73,7 +73,9 @@ describe("mcp/tools/apptesting/tests", () => {
 
       expect(uploadStub.called).to.be.true;
       expect(
-        clientStub.createReleaseTest.calledWith(releaseName, input.testDevices, input.testCase),
+        clientStub.createReleaseTest.calledWith(releaseName, input.testDevices, {
+          aiInstructions: input.testCase,
+        }),
       ).to.be.true;
 
       const resultText = (result.content[0] as any).text;

--- a/src/mcp/tools/apptesting/tests.ts
+++ b/src/mcp/tools/apptesting/tests.ts
@@ -69,7 +69,11 @@ export const run_tests = tool(
     const devices = testDevices || defaultDevices;
     const client = new AppDistributionClient();
     const release = await upload(client, toAppName(appId), new Distribution(releaseBinaryFile));
-    return toContent(await client.createReleaseTest(release.name, devices, testCase));
+    return toContent(
+      await client.createReleaseTest(release.name, devices, {
+        aiInstructions: testCase,
+      }),
+    );
   },
 );
 


### PR DESCRIPTION
### Description

This PR adds the `--results-bucket` flag to both the `apptesting:execute` and `appdistribution:distribute` commands. This allows users to specify a custom Google Cloud Storage (GCS) bucket when starting automated tests, matching the behavior of the `--results-bucket` flag in the `gcloud` CLI.

Under the hood:
- The bucket name is parsed and validated using a simplified regex pattern (`/^[a-z0-9-_.]+$/`).
- An optional `gs://` prefix is automatically stripped before validation.
- If the bucket name format is invalid, a `FirebaseError` is thrown.
- The project number is extracted from the application's resource name and combined with the parsed bucket name to construct the full GCS bucket resource name: `projects/{projectNumber}/buckets/{bucketName}`.

### Scenarios Tested

- **Unit tests** added in [options-parser-util.spec.ts](file:///usr/local/google/home/lkellogg/dev/firebase-tools/src/appdistribution/options-parser-util.spec.ts) covering:
  - Valid bucket names (e.g. `my-bucket` -> `projects/123456789/buckets/my-bucket`).
  - Validation of names with `gs://` prefix (e.g. `gs://my-bucket` -> `projects/123456789/buckets/my-bucket`).
  - Rejection of invalid characters/names (e.g. containing uppercase letters, trailing slashes, or already formatted resource paths).
  - Rejection of invalid app name formats.

### Sample Commands

```bash
# Execute tests from YAML using a simple bucket name
firebase apptesting:execute \
  --app 1:1234567890:android:0a1b2c3d4e5f67890 \
  --test-dir ./mytests \
  --results-bucket my-custom-bucket
  ./app/build/outputs/apk/debug/app-debug.apk

# Distribute and run tests using a bucket with a gs:// prefix
firebase appdistribution:distribute app.apk \
  --app 1:1234567890:android:0a1b2c3d4e5f67890  \
  --test-devices "model=shiba,version=34,locale=en,orientation=portrait" \
  --test-case-ids "my-test-case" \
  --results-bucket gs://my-custom-bucket
```