### PR TITLE
Add --wasm flag to deploy for Flutter Web WebAssembly builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Added a `--wasm` flag to `firebase deploy` to compile Flutter Web to WebAssembly when building for Hosting

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -70,7 +70,8 @@ export const command = new Command("deploy")
     "--dry-run",
     "perform a dry run of your deployment. Validates your changes and builds your code without deploying any changes to your project. " +
       "In order to provide better validation, this may still enable APIs on the target project",
-  );
+  )
+  .option("--wasm", "compile Flutter Web to WebAssembly when building the framework for Hosting");
 
 if (experiments.isEnabled("apphostinglocalbuilds")) {
   command.option(

--- a/src/frameworks/flutter/index.spec.ts
+++ b/src/frameworks/flutter/index.spec.ts
@@ -110,6 +110,30 @@ describe("Flutter", () => {
       });
       sinon.assert.calledWith(stub, "flutter", ["build", "web"], { cwd, stdio: "inherit" });
     });
+
+    it("should pass --wasm when the wasm context is set", async () => {
+      const process = new EventEmitter() as any;
+      process.stdin = new Writable();
+      process.stdout = new EventEmitter();
+      process.stderr = new EventEmitter();
+      process.status = 0;
+
+      sandbox.stub(flutterUtils, "assertFlutterCliExists").returns(undefined);
+
+      const cwd = ".";
+
+      const stub = sandbox.stub(crossSpawn, "sync").returns(process as any);
+
+      const result = build(cwd, undefined, { wasm: true });
+
+      expect(await result).to.deep.equal({
+        wantsBackend: false,
+      });
+      sinon.assert.calledWith(stub, "flutter", ["build", "web", "--wasm"], {
+        cwd,
+        stdio: "inherit",
+      });
+    });
   });
 
   describe("init", () => {

--- a/src/frameworks/flutter/index.spec.ts
+++ b/src/frameworks/flutter/index.spec.ts
@@ -112,17 +112,14 @@ describe("Flutter", () => {
     });
 
     it("should pass --wasm when the wasm context is set", async () => {
-      const process = new EventEmitter() as any;
-      process.stdin = new Writable();
-      process.stdout = new EventEmitter();
-      process.stderr = new EventEmitter();
-      process.status = 0;
-
       sandbox.stub(flutterUtils, "assertFlutterCliExists").returns(undefined);
 
       const cwd = ".";
 
-      const stub = sandbox.stub(crossSpawn, "sync").returns(process as any);
+      const mockResult: Partial<ReturnType<typeof crossSpawn.sync>> = { status: 0 };
+      const stub = sandbox
+        .stub(crossSpawn, "sync")
+        .returns(mockResult as ReturnType<typeof crossSpawn.sync>);
 
       const result = build(cwd, undefined, { wasm: true });
 

--- a/src/frameworks/flutter/index.ts
+++ b/src/frameworks/flutter/index.ts
@@ -2,7 +2,13 @@ import { sync as spawnSync } from "cross-spawn";
 import { copy, pathExists } from "fs-extra";
 import { join } from "path";
 
-import { BuildResult, Discovery, FrameworkType, SupportLevel } from "../interfaces";
+import {
+  BuildResult,
+  Discovery,
+  FrameworkContext,
+  FrameworkType,
+  SupportLevel,
+} from "../interfaces";
 import { FirebaseError } from "../../error";
 import { assertFlutterCliExists, getPubSpec, getAdditionalBuildArgs } from "./utils";
 import { DART_RESERVED_WORDS, FALLBACK_PROJECT_NAME } from "./constants";
@@ -47,12 +53,18 @@ export function init(setup: any, config: any) {
   return Promise.resolve();
 }
 
-export async function build(cwd: string): Promise<BuildResult> {
+export async function build(
+  cwd: string,
+  _target?: string,
+  context?: FrameworkContext,
+): Promise<BuildResult> {
   assertFlutterCliExists();
 
   const pubSpec = await getPubSpec(cwd);
   const otherArgs = getAdditionalBuildArgs(pubSpec);
-  const buildArgs = ["build", "web", ...otherArgs].filter(Boolean);
+  // Compile to WebAssembly when `firebase deploy --wasm` is used.
+  const wasmArgs = context?.wasm ? ["--wasm"] : [];
+  const buildArgs = ["build", "web", ...otherArgs, ...wasmArgs].filter(Boolean);
 
   const build = spawnSync("flutter", buildArgs, { cwd, stdio: "inherit" });
   if (build.status !== 0) throw new FirebaseError("Unable to build your Flutter app");

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -297,6 +297,7 @@ export async function prepareFrameworks(
       projectId: project,
       site: options.site,
       hostingChannel: context?.hostingChannel,
+      wasm: options.wasm,
     };
 
     let codegenFunctionsDirectory: Framework["ɵcodegenFunctionsDirectory"];

--- a/src/frameworks/interfaces.ts
+++ b/src/frameworks/interfaces.ts
@@ -46,12 +46,14 @@ export type FrameworksOptions = HostingOptions &
   Options & {
     frameworksDevModeHandle?: RequestHandler;
     nonInteractive?: boolean;
+    wasm?: boolean;
   };
 
 export type FrameworkContext = {
   projectId?: string;
   hostingChannel?: string;
   site?: string;
+  wasm?: boolean;
 };
 
 export interface Framework {


### PR DESCRIPTION
Adds a --wasm flag to firebase deploy that compiles Flutter Web to WebAssembly. The flag is plumbed from deploy options through FrameworkContext into the Flutter build, which appends --wasm to flutter build web.

Description
The Flutter Web framework integration always runs flutter build web with no way to opt into a WebAssembly (dart2wasm) build, so users who want flutter build web --wasm output have to bypass the framework integration and deploy a pre-built static directory.

This PR adds a --wasm flag to firebase deploy. When set, it is passed from the deploy options through FrameworkContext into the Flutter framework's build(), which appends --wasm to the flutter build web invocation. Without the flag, behavior is unchanged (flutter build web).

A --wasm flag on the shared deploy command is slightly broad given it is currently Flutter-specific, but it matches the standard flutter build web --wasm terminology, is discoverable, and generalizes if other web frameworks add WebAssembly output later.

Related issue: #7554

Scenarios Tested
firebase deploy --only hosting --wasm on a Flutter Web project using hosting.source → confirmed flutter build web --wasm is invoked (verified via --debug output) and the WebAssembly artifacts (.wasm) are deployed and served.
firebase deploy --only hosting (no flag) → unchanged behavior, runs flutter build web.
Unit test added asserting --wasm is forwarded to the Flutter build only when the wasm context is set; existing Flutter build test still passes.
npm test (lint + compile + mocha) passes locally; firebase deploy --help lists the new --wasm flag.
Sample Commands

# Build and deploy a Flutter Web app as WebAssembly
firebase deploy --only hosting --wasm

# Default behavior (unchanged) — standard JS build
firebase deploy --only hosting