### PR TITLE
fix-windows-python-init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixes `spawn activate.bat ENOENT` error on Windows when initializing Python functions. (#10608)
 - Updated the Firebase Data Connect local toolkit to v3.4.11, which includes the following changes:
   - [changed] Updated the Golang dependency version to 1.25.11.
 - Fixed issue where `apptesting:execute` command rejects documented `--test-username`, `--test-password`, and `--test-password-file` options.

--- a/src/functions/python.ts
+++ b/src/functions/python.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import * as spawn from "cross-spawn";
+import { spawn } from "cross-spawn";
 import * as cp from "child_process";
 import { logger } from "../logger";
 import { IS_WINDOWS } from "../utils";
@@ -17,7 +17,7 @@ export function virtualEnvCmd(cwd: string, venvDir: string): { command: string; 
   const venvActivate = `"${path.join(cwd, venvDir, ...activateScriptPath)}"`;
   return {
     command: IS_WINDOWS ? venvActivate : ".",
-    args: [IS_WINDOWS ? "" : venvActivate],
+    args: IS_WINDOWS ? [] : [venvActivate],
   };
 }
 
@@ -38,7 +38,7 @@ export function runWithVirtualEnv(
   return spawn(command, args, {
     shell: true,
     cwd,
-    stdio: [/* stdin= */ "pipe", /* stdout= */ "pipe", /* stderr= */ "pipe", "pipe"],
+    stdio: "pipe",
     ...spawnOpts,
     // Linting disabled since internal types expect NODE_ENV which does not apply to Python runtimes.
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any

--- a/src/init/features/functions.spec.ts
+++ b/src/init/features/functions.spec.ts
@@ -8,6 +8,8 @@ import { actuate, askQuestions } from "./functions";
 import { Options } from "../../options";
 import { RC } from "../../rc";
 import * as experiments from "../../experiments";
+import * as spawn from "cross-spawn";
+import * as initSpawn from "../spawn";
 
 const TEST_SOURCE_DEFAULT = "functions";
 const TEST_CODEBASE_DEFAULT = "default";
@@ -128,6 +130,176 @@ describe("functions", () => {
           `${TEST_SOURCE_DEFAULT}/src/index.ts`,
           `${TEST_SOURCE_DEFAULT}/.gitignore`,
         ]);
+      });
+
+      describe("python project", () => {
+        let spawnStub: sinon.SinonStub;
+        let wrapSpawnStub: sinon.SinonStub;
+
+        beforeEach(() => {
+          spawnStub = sandbox.stub(spawn, "spawn");
+          wrapSpawnStub = sandbox.stub(initSpawn, "wrapSpawn");
+        });
+
+        it("creates a new python codebase with the correct configuration", async () => {
+          const config = new Config("{}", { projectDir: "test", cwd: "test" });
+          const setup = { config: { functions: [] }, rcfile: {} };
+          prompt.select.onFirstCall().resolves("python");
+          // do not install dependencies
+          prompt.confirm.onFirstCall().resolves(false);
+          askWriteProjectFileStub = sandbox.stub(config, "askWriteProjectFile");
+          askWriteProjectFileStub.resolves();
+          wrapSpawnStub.resolves();
+
+          await askQuestions(setup, config, options);
+          await actuate(setup, config);
+
+          expect(setup.config.functions[0]).to.deep.equal({
+            source: TEST_SOURCE_DEFAULT,
+            codebase: TEST_CODEBASE_DEFAULT,
+            ignore: ["venv", ".git", "firebase-debug.log", "firebase-debug.*.log", "*.local"],
+            runtime: "python314",
+            disallowLegacyRuntimeConfig: true,
+          });
+          expect(askWriteProjectFileStub.getCalls().map((call) => call.args[0])).to.have.members([
+            `${TEST_SOURCE_DEFAULT}/requirements.txt`,
+            `${TEST_SOURCE_DEFAULT}/.gitignore`,
+            `${TEST_SOURCE_DEFAULT}/main.py`,
+          ]);
+          expect(wrapSpawnStub.callCount).to.equal(1);
+          expect(spawnStub.callCount).to.equal(0);
+        });
+
+        it("throws FirebaseError if venv creation fails", async () => {
+          const config = new Config("{}", { projectDir: "test", cwd: "test" });
+          const setup = { config: { functions: [] }, rcfile: {} };
+          prompt.select.onFirstCall().resolves("python");
+          prompt.confirm.onFirstCall().resolves(false);
+          askWriteProjectFileStub = sandbox.stub(config, "askWriteProjectFile");
+          askWriteProjectFileStub.resolves();
+          wrapSpawnStub.rejects(new Error("Failed to spawn"));
+
+          await askQuestions(setup, config, options);
+          let err: Error | null = null;
+          try {
+            await actuate(setup, config);
+          } catch (e: any) {
+            err = e;
+          }
+          expect(err).to.not.be.null;
+          expect(err!.message).to.contain("Failed to create virtual environment");
+        });
+
+        it("installs dependencies successfully if user confirms", async () => {
+          const config = new Config("{}", { projectDir: "test", cwd: "test" });
+          const setup = { config: { functions: [] }, rcfile: {} };
+          prompt.select.onFirstCall().resolves("python");
+          prompt.confirm.onFirstCall().resolves(true); // install dependencies
+          askWriteProjectFileStub = sandbox.stub(config, "askWriteProjectFile");
+          askWriteProjectFileStub.resolves();
+          wrapSpawnStub.resolves();
+
+          const successProcess = {
+            on: (event: string, callback: (code: number | null) => void) => {
+              if (event === "exit") {
+                setTimeout(() => callback(0), 0);
+              }
+            },
+          };
+          spawnStub.returns(successProcess);
+
+          await askQuestions(setup, config, options);
+          await actuate(setup, config);
+
+          expect(wrapSpawnStub.callCount).to.equal(1);
+          expect(spawnStub.callCount).to.equal(2); // pip upgrade, pip install
+        });
+
+        it("throws FirebaseError if pip upgrade fails", async () => {
+          const config = new Config("{}", { projectDir: "test", cwd: "test" });
+          const setup = { config: { functions: [] }, rcfile: {} };
+          prompt.select.onFirstCall().resolves("python");
+          prompt.confirm.onFirstCall().resolves(true); // install dependencies
+          askWriteProjectFileStub = sandbox.stub(config, "askWriteProjectFile");
+          askWriteProjectFileStub.resolves();
+          wrapSpawnStub.resolves();
+
+          const failProcess = {
+            on: (event: string, callback: (code: number | null) => void) => {
+              if (event === "exit") {
+                setTimeout(() => callback(1), 0);
+              }
+            },
+          };
+          spawnStub.returns(failProcess); // pip upgrade fails
+
+          await askQuestions(setup, config, options);
+          let err: Error | null = null;
+          try {
+            await actuate(setup, config);
+          } catch (e: any) {
+            err = e;
+          }
+          expect(err).to.not.be.null;
+          expect(err!.message).to.contain("Failed to upgrade pip inside virtual environment");
+        });
+
+        it("throws FirebaseError if dependency installation fails", async () => {
+          const config = new Config("{}", { projectDir: "test", cwd: "test" });
+          const setup = { config: { functions: [] }, rcfile: {} };
+          prompt.select.onFirstCall().resolves("python");
+          prompt.confirm.onFirstCall().resolves(true); // install dependencies
+          askWriteProjectFileStub = sandbox.stub(config, "askWriteProjectFile");
+          askWriteProjectFileStub.resolves();
+          wrapSpawnStub.resolves();
+
+          const successProcess = {
+            on: (event: string, callback: (code: number | null) => void) => {
+              if (event === "exit") {
+                setTimeout(() => callback(0), 0);
+              }
+            },
+          };
+          const failProcess = {
+            on: (event: string, callback: (code: number | null) => void) => {
+              if (event === "exit") {
+                setTimeout(() => callback(1), 0);
+              }
+            },
+          };
+          spawnStub.onCall(0).returns(successProcess); // pip upgrade succeeds
+          spawnStub.onCall(1).returns(failProcess); // pip install fails
+
+          await askQuestions(setup, config, options);
+          let err: Error | null = null;
+          try {
+            await actuate(setup, config);
+          } catch (e: any) {
+            err = e;
+          }
+          expect(err).to.not.be.null;
+          expect(err!.message).to.contain("Failed to install dependencies");
+        });
+
+        it("throws FirebaseError if venv creation encounters an error event", async () => {
+          const config = new Config("{}", { projectDir: "test", cwd: "test" });
+          const setup = { config: { functions: [] }, rcfile: {} };
+          prompt.select.onFirstCall().resolves("python");
+          prompt.confirm.onFirstCall().resolves(false);
+          askWriteProjectFileStub = sandbox.stub(config, "askWriteProjectFile");
+          askWriteProjectFileStub.resolves();
+          wrapSpawnStub.rejects(new Error("Spawn error"));
+
+          await askQuestions(setup, config, options);
+          let err: Error | null = null;
+          try {
+            await actuate(setup, config);
+          } catch (e: any) {
+            err = e;
+          }
+          expect(err).to.not.be.null;
+          expect(err!.message).to.contain("Failed to create virtual environment");
+        });
       });
 
       it("does not show Dart as an option when experiments are disabled", async () => {

--- a/src/init/features/functions/python.ts
+++ b/src/init/features/functions/python.ts
@@ -1,4 +1,5 @@
-import * as spawn from "cross-spawn";
+import { ChildProcess } from "child_process";
+import { wrapSpawn } from "../../spawn";
 
 import { Config } from "../../../config";
 import { getPythonBinary } from "../../../deploy/functions/runtimes/python";
@@ -6,15 +7,71 @@ import { runWithVirtualEnv } from "../../../functions/python";
 import { confirm } from "../../../prompt";
 import { latest } from "../../../deploy/functions/runtimes/supported";
 import { readTemplateSync } from "../../../templates";
+import { FirebaseError } from "../../../error";
 
 const MAIN_TEMPLATE = readTemplateSync("init/functions/python/main.py");
 const REQUIREMENTS_TEMPLATE = readTemplateSync("init/functions/python/requirements.txt");
 const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/python/_gitignore");
 
 /**
+ * Helper to wait for a child process to exit.
+ */
+function waitForProcess(p: ChildProcess): Promise<number | null> {
+  return new Promise((resolve) => {
+    p.on("exit", resolve);
+    p.on("error", () => resolve(-1));
+  });
+}
+
+/**
+ * Helper to spawn a process and create a python virtual environment.
+ */
+async function createVirtualEnv(pythonBinary: string, cwd: string): Promise<void> {
+  try {
+    await wrapSpawn(pythonBinary, ["-m", "venv", "venv"], cwd);
+  } catch (err) {
+    throw new FirebaseError(
+      `Failed to create virtual environment. Please make sure Python is installed and in your PATH.`,
+    );
+  }
+}
+
+/**
+ * Helper to upgrade pip and install requirements.txt dependencies inside the virtual environment.
+ */
+async function installDependencies(pythonBinary: string, cwd: string): Promise<void> {
+  // Update pip to support dependencies like pyyaml.
+  // Note: We execute pip using pythonBinary `-m pip` instead of calling `pip3` directly.
+  // Calling `pip3` directly on Windows can cause OS file locking failures since the executable attempts to overwrite itself.
+  const upgradeProcess = runWithVirtualEnv(
+    [pythonBinary, "-m", "pip", "install", "--upgrade", "pip"],
+    cwd,
+    {},
+    { stdio: "inherit" },
+  );
+  const upgradeExitCode = await waitForProcess(upgradeProcess);
+  if (upgradeExitCode !== 0) {
+    throw new FirebaseError("Failed to upgrade pip inside virtual environment.");
+  }
+
+  const installProcess = runWithVirtualEnv(
+    [pythonBinary, "-m", "pip", "install", "-r", "requirements.txt"],
+    cwd,
+    {},
+    { stdio: "inherit" },
+  );
+  const installExitCode = await waitForProcess(installProcess);
+  if (installExitCode !== 0) {
+    throw new FirebaseError("Failed to install dependencies.");
+  }
+}
+
+/**
  * Create a Python Firebase Functions project.
  */
 export async function setup(setup: any, config: Config): Promise<void> {
+  const sourceDir = config.path(setup.functions.source);
+
   await config.askWriteProjectFile(
     `${setup.functions.source}/requirements.txt`,
     REQUIREMENTS_TEMPLATE,
@@ -27,42 +84,16 @@ export async function setup(setup: any, config: Config): Promise<void> {
   // Add python specific ignores to config.
   config.set("functions.ignore", ["venv", "__pycache__"]);
 
-  // Setup VENV.
-  const venvProcess = spawn(getPythonBinary(latest("python")), ["-m", "venv", "venv"], {
-    shell: true,
-    cwd: config.path(setup.functions.source),
-    stdio: [/* stdin= */ "pipe", /* stdout= */ "pipe", /* stderr= */ "pipe", "pipe"],
-  });
-  await new Promise((resolve, reject) => {
-    venvProcess.on("exit", resolve);
-    venvProcess.on("error", reject);
-  });
+  // We resolve the version-specific Python binary (e.g. python3.10) to ensure we execute
+  // the correct version of Python chosen for the functions codebase.
+  const pythonBinary = getPythonBinary(latest("python"));
+  await createVirtualEnv(pythonBinary, sourceDir);
 
   const install = await confirm({
     message: "Do you want to install dependencies now?",
     default: true,
   });
   if (install) {
-    // Update pip to support dependencies like pyyaml.
-    const upgradeProcess = runWithVirtualEnv(
-      ["pip3", "install", "--upgrade", "pip"],
-      config.path(setup.functions.source),
-      {},
-      { stdio: ["inherit", "inherit", "inherit"] },
-    );
-    await new Promise((resolve, reject) => {
-      upgradeProcess.on("exit", resolve);
-      upgradeProcess.on("error", reject);
-    });
-    const installProcess = runWithVirtualEnv(
-      [getPythonBinary(latest("python")), "-m", "pip", "install", "-r", "requirements.txt"],
-      config.path(setup.functions.source),
-      {},
-      { stdio: ["inherit", "inherit", "inherit"] },
-    );
-    await new Promise((resolve, reject) => {
-      installProcess.on("exit", resolve);
-      installProcess.on("error", reject);
-    });
+    await installDependencies(pythonBinary, sourceDir);
   }
 }


### PR DESCRIPTION
This pull request fixes a bug on Windows where initializing Firebase Functions with Python fails during the dependency installation step, throwing a misleading error that says it cannot find the file activate.bat (ENOENT).

The Problem
During investigation, we found that this error is caused by two different issues. First, if a user does not have Python installed or configured in their system PATH, the step to create the virtual environment fails silently because the Firebase CLI does not check its exit code. The CLI then moves on to execute the activation script, which fails because the virtual environment folder was never actually created.

Second, even if a user has Python installed, the installation command tries to run pip3 directly to upgrade pip. On Windows, the operating system locks the pip3 executable while it is running, which causes the upgrade to fail. In both of these failure cases, a quirk in the command-spawning library on Windows translates the failure into a misleading "file not found" error for the activate.bat file, hiding the real root cause.

The Solution
To fix these issues, we updated the virtual environment creation step to output python errors directly to the terminal and to verify the command's exit code. If the virtual environment fails to build (due to a missing Python installation), the CLI now stops immediately and shows a clear error message.

We also changed the dependency commands to use python -m pip instead of calling pip3 directly. This approach is the recommended standard because it runs the command through the Python interpreter, avoiding the Windows file-locking issue. Finally, we added unit tests to ensure that the Python codebase is initialized with the correct configuration and that failures are caught and reported properly.