### PR TITLE
Remove Data Connect service deletion logic on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Fixes `firebase init dataconnect` failing with `ENOEXEC` when creating a new template app on some operating systems. (#10616)
 - Support setting the Google Cloud Storage (GCS) test results bucket in `apptesting:execute` and `appdistribution:distribute`
+- Remove prompt and logic to delete Data Connect services not listed in `firebase.json` during deployment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,2 @@
 - Fixes `firebase init dataconnect` failing with `ENOEXEC` when creating a new template app on some operating systems. (#10616)
 - Support setting the Google Cloud Storage (GCS) test results bucket in `apptesting:execute` and `appdistribution:distribute`
-- Remove prompt and logic to delete Data Connect services not listed in `firebase.json` during deployment.

--- a/src/deploy/dataconnect/context.ts
+++ b/src/deploy/dataconnect/context.ts
@@ -18,7 +18,6 @@ export interface DeployStats {
 
   // deploy.ts
   numServiceCreated: number;
-  numServiceDeleted: number;
 
   // release.ts
   numSchemaMigrated: number;
@@ -36,7 +35,6 @@ export function initDeployStats(): DeployStats {
     numBuildErrors: 0,
     numBuildWarnings: new Map<string, number>(),
     numServiceCreated: 0,
-    numServiceDeleted: 0,
     numSchemaMigrated: 0,
     numConnectorUpdatedBeforeSchema: 0,
     numConnectorUpdatedAfterSchema: 0,
@@ -54,7 +52,6 @@ export function deployStatsParams(stats: DeployStats): AnalyticsParams {
   return {
     missing_billing: (!!stats.missingBilling).toString(),
     num_service_created: stats.numServiceCreated,
-    num_service_deleted: stats.numServiceDeleted,
     num_schema_migrated: stats.numSchemaMigrated,
     num_connector_updated_before_schema: stats.numConnectorUpdatedBeforeSchema,
     num_connector_updated_after_schema: stats.numConnectorUpdatedAfterSchema,

--- a/src/deploy/dataconnect/deploy.spec.ts
+++ b/src/deploy/dataconnect/deploy.spec.ts
@@ -6,7 +6,6 @@ import * as utils from "../../utils";
 import * as projectUtils from "../../projectUtils";
 import * as provisionCloudSql from "../../dataconnect/provisionCloudSql";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
-import * as prompt from "../../prompt";
 import * as poller from "../../operation-poller";
 import { dataconnectOrigin } from "../../api";
 import { initDeployStats } from "./context";
@@ -14,7 +13,6 @@ import { initDeployStats } from "./context";
 describe("dataconnect deploy", () => {
   let sandbox: sinon.SinonSandbox;
   let setupCloudSqlStub: sinon.SinonStub;
-  let confirmStub: sinon.SinonStub;
   let pollOperationStub: sinon.SinonStub;
 
   beforeEach(() => {
@@ -22,7 +20,6 @@ describe("dataconnect deploy", () => {
     setupCloudSqlStub = sandbox.stub(provisionCloudSql, "setupCloudSql").resolves();
     sandbox.stub(projectUtils, "needProjectId").returns("test-project");
     sandbox.stub(ensureApiEnabled, "ensure").resolves();
-    confirmStub = sandbox.stub(prompt, "confirm").resolves(false);
     sandbox.stub(utils, "logLabeledSuccess");
     pollOperationStub = sandbox.stub(poller, "pollOperation").resolves();
   });
@@ -61,43 +58,6 @@ describe("dataconnect deploy", () => {
     expect(nock.isDone()).to.be.true;
   });
 
-  it("should delete an old service if confirmed", async () => {
-    const existingServices = [{ name: "projects/test-project/locations/l/services/s2" }];
-    nock(dataconnectOrigin())
-      .get("/v1/projects/test-project/locations/-/services")
-      .reply(200, { services: existingServices });
-    nock(dataconnectOrigin())
-      .delete("/v1/projects/test-project/locations/l/services/s2?force=true")
-      .reply(200, { name: "op-name" });
-
-    confirmStub.resolves(true);
-    const serviceInfos: any[] = [];
-    const context = { dataconnect: { serviceInfos, deployStats: initDeployStats() } };
-    const options = {} as any;
-
-    await deploy.default(context as any, options);
-
-    expect(pollOperationStub.calledOnce).to.be.true;
-    expect(nock.isDone()).to.be.true;
-  });
-
-  it("should not delete an old service if not confirmed", async () => {
-    const existingServices = [{ name: "projects/test-project/locations/l/services/s2" }];
-    nock(dataconnectOrigin())
-      .get("/v1/projects/test-project/locations/-/services")
-      .reply(200, { services: existingServices });
-
-    confirmStub.resolves(false);
-    const serviceInfos: any[] = [];
-    const context = { dataconnect: { serviceInfos, deployStats: initDeployStats() } };
-    const options = {} as any;
-
-    await deploy.default(context as any, options);
-
-    expect(pollOperationStub.notCalled).to.be.true;
-    expect(nock.isDone()).to.be.true;
-  });
-
   it("should provision cloud sql", async () => {
     nock(dataconnectOrigin())
       .get("/v1/projects/test-project/locations/-/services")
@@ -131,23 +91,5 @@ describe("dataconnect deploy", () => {
     await deploy.default(context as any, options);
 
     expect(setupCloudSqlStub.calledOnce).to.be.true;
-  });
-
-  it("should not delete services if filters are present", async () => {
-    const existingServices = [{ name: "projects/test-project/locations/l/services/s2" }];
-    nock(dataconnectOrigin())
-      .get("/v1/projects/test-project/locations/-/services")
-      .reply(200, { services: existingServices });
-
-    const serviceInfos: any[] = [];
-    const context = {
-      dataconnect: { serviceInfos, filters: [{ serviceId: "s1" }], deployStats: initDeployStats() },
-    };
-    const options = {} as any;
-
-    await deploy.default(context as any, options);
-
-    expect(pollOperationStub.notCalled).to.be.true;
-    expect(nock.isDone()).to.be.true;
   });
 });

--- a/src/deploy/dataconnect/deploy.ts
+++ b/src/deploy/dataconnect/deploy.ts
@@ -8,7 +8,6 @@ import { parseServiceName } from "../../dataconnect/names";
 import { ResourceFilter } from "../../dataconnect/filters";
 import { vertexAIOrigin } from "../../api";
 import * as ensureApiEnabled from "../../ensureApiEnabled";
-import { confirm } from "../../prompt";
 import { Context } from "./context";
 
 /**
@@ -45,10 +44,6 @@ export default async function (context: Context, options: Options): Promise<void
     });
   dataconnect.deployStats.numServiceCreated = servicesToCreate.length;
 
-  const servicesToDelete = filters
-    ? []
-    : services.filter((s) => !serviceInfos.some((si) => matches(si, s)));
-  dataconnect.deployStats.numServiceDeleted = servicesToDelete.length;
   await Promise.all(
     servicesToCreate.map(async (s) => {
       const { projectId, locationId, serviceId } = splitName(s.serviceName);
@@ -56,25 +51,6 @@ export default async function (context: Context, options: Options): Promise<void
       utils.logLabeledSuccess("dataconnect", `Created service ${s.serviceName}`);
     }),
   );
-
-  if (servicesToDelete.length) {
-    const serviceToDeleteList = servicesToDelete.map((s) => " - " + s.name).join("\n");
-    if (
-      await confirm({
-        force: false, // Don't delete anything in --force.
-        nonInteractive: options.nonInteractive,
-        message: `The following services exist on ${projectId} but are not listed in your 'firebase.json'\n${serviceToDeleteList}\nWould you like to delete these services?`,
-        default: false,
-      })
-    ) {
-      await Promise.all(
-        servicesToDelete.map(async (s) => {
-          await client.deleteService(s.name);
-          utils.logLabeledSuccess("dataconnect", `Deleted service ${s.name}`);
-        }),
-      );
-    }
-  }
 
   // Provision CloudSQL resources
   utils.logLabeledBullet("dataconnect", "Checking for CloudSQL resources...");


### PR DESCRIPTION
### Description
Removes the prompt and backend deletion of Data Connect services during `firebase deploy`. It is a common and well-intended usecase to have multiple Data Connect repositories sharing the same Firebase project. Without removing this prompt and deletion behavior, deploying from one repository would attempt to delete the services of the other, or prompt the user unexpectedly.

We don't really have good support to track >1 FDC services in the same local folder, making it very difficult to address this prompt in a proper way.

### Scenarios Tested
- Unit tests in `deploy.spec.ts` updated and run:
  - `npx mocha src/deploy/dataconnect/deploy.spec.ts`

### Sample Commands
- `firebase deploy --only dataconnect`

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
