### PR TITLE
Add changelog entry for PR #10619

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Removed the prompt and backend deletion of Data Connect services during `firebase deploy`. (#10619)
 - Fixes `firebase init dataconnect` failing with `ENOEXEC` when creating a new template app on some operating systems. (#10616)
 - Support setting the Google Cloud Storage (GCS) test results bucket in `apptesting:execute` and `appdistribution:distribute`


### PR DESCRIPTION
Prepend `- Removed the prompt and backend deletion of Data Connect services during \`firebase deploy\`. (#10619)` to `CHANGELOG.md` as requested by the user.

---
*PR created automatically by Jules for task [15874458158695641505](https://jules.google.com/task/15874458158695641505) started by @fredzqm*