### PR TITLE
[VS Code] Fix compile error bug from generate operation button

### DIFF
--- a/firebase-vscode/CHANGELOG.md
+++ b/firebase-vscode/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## NEXT
 
+- [Fixed] Fix auth issue from Generate Operation button by skipping unnecessary schema compilation check.
 - [Changed] Replace generateSchema and generateQuery backends with the new fdc AgentService API.
 - [Added] Improved error handling and status updates for query generation
 - [Added] Local schema aware query generation

--- a/firebase-vscode/src/data-connect/execution/execution.ts
+++ b/firebase-vscode/src/data-connect/execution/execution.ts
@@ -31,7 +31,6 @@ import {
   getConnectorGQLText,
   insertQueryAt,
   getSchemas,
-  verifySchemaCompiles,
 } from "../file-utils";
 import { dataConnectConfigs, firebaseRC } from "../config";
 import * as gif from "../../../../src/gemini/fdcExperience";
@@ -303,12 +302,6 @@ export function registerExecution(
 
       if (serviceConfig) {
         schemas = await getSchemas(serviceConfig);
-
-        // Verify that the schema compiles before generating queries
-        const compiles = await verifySchemaCompiles(serviceConfig, arg.projectId);
-        if (!compiles) {
-          return;
-        }
       }
 
       const prompt = `Generate a Data Connect operation to match this description: ${arg.description} 

--- a/firebase-vscode/src/data-connect/file-utils.ts
+++ b/firebase-vscode/src/data-connect/file-utils.ts
@@ -4,8 +4,6 @@ import * as fs from "fs";
 
 import { dataConnectConfigs, ResolvedDataConnectConfig } from "./config";
 import { pluginLogger } from "../logger-wrapper";
-import { DataConnectEmulator } from "../../../src/emulator/dataconnectEmulator";
-import { GraphqlError } from "../../../src/dataconnect/types";
 
 export async function checkIfFileExists(file: Uri) {
   try {
@@ -176,84 +174,6 @@ export async function getSchemas(
   }
 
   return schemas;
-}
-
-/**
- * Verifies that the schema compiles. If there are schema errors (excluding warnings and operation errors),
- * it shows an error message and provides an option to open the file.
- * @returns true if the schema compiles successfully (or has only non-blocking errors), false otherwise.
- */
-export async function verifySchemaCompiles(
-  serviceConfig: ResolvedDataConnectConfig,
-  projectId: string,
-): Promise<boolean> {
-  try {
-    const buildResult = await DataConnectEmulator.build({
-      configDir: serviceConfig.path,
-      projectId: projectId,
-    });
-    const schemaErrors = buildResult.errors?.filter((e) => {
-      // Ignore warnings
-      const isHardError = !e.extensions?.warningLevel;
-      const file = e.extensions?.file;
-      if (!file) return isHardError;
-
-      // Ignore operation (connector) errors, only keep schema errors
-      const isSchemaFile = !serviceConfig.connectorDirs.some((dir) => {
-        const absConnectorDir = path.resolve(serviceConfig.path, dir);
-        const absFile = path.resolve(serviceConfig.path, file);
-        return absFile.startsWith(absConnectorDir);
-      });
-
-      return isHardError && isSchemaFile;
-    });
-
-    if (schemaErrors?.length) {
-      // Handle compilation errors and provide navigation to the file
-      await handleCompilationError(schemaErrors[0], serviceConfig.path);
-      return false;
-    }
-  } catch (e: any) {
-    vscode.window.showErrorMessage(
-      "Ensure schema compiles before generating queries",
-    );
-    return false;
-  }
-  return true;
-}
-
-/**
- * Handles compilation errors by showing an error message and providing an option to open the file.
- * @param error The GraphQL error object.
- * @param servicePath The path to the service directory.
- */
-async function handleCompilationError(
-  error: GraphqlError,
-  servicePath: string,
-): Promise<void> {
-  const message = `Schema compilation failed: ${error.message}`;
-  const file = error.extensions?.file;
-  const location = error.locations?.[0];
-
-  if (file) {
-    const fullPath = path.resolve(servicePath, file);
-    const selection = await vscode.window.showErrorMessage(
-      message,
-      "Open File",
-    );
-    if (selection === "Open File") {
-      const uri = vscode.Uri.file(fullPath);
-      const doc = await vscode.workspace.openTextDocument(uri);
-      const editor = await vscode.window.showTextDocument(doc);
-      if (location) {
-        const pos = new vscode.Position(location.line - 1, location.column - 1);
-        editor.revealRange(new vscode.Range(pos, pos));
-        editor.selection = new vscode.Selection(pos, pos);
-      }
-    }
-  } else {
-    vscode.window.showErrorMessage(message);
-  }
 }
 
 

--- a/firebase-vscode/src/test/suite/execution-error-handling.test.ts
+++ b/firebase-vscode/src/test/suite/execution-error-handling.test.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import { firebaseSuite, firebaseTest } from "../utils/test_hooks";
 import { stub, restore } from "sinon";
 import * as gif from "../../../../src/gemini/fdcExperience";
-import { DataConnectEmulator } from "../../../../src/emulator/dataconnectEmulator";
 import { dataConnectConfigs } from "../../data-connect/config";
 import { ResultValue } from "../../result";
 import { registerExecution } from "../../data-connect/execution/execution";
@@ -12,114 +11,141 @@ import * as nock from "nock";
 import { setAccessToken } from "../../../../src/apiv2";
 import { configstore } from "../../../../src/configstore";
 
-firebaseSuite("generateOperation Error Handling", () => {
-  let showErrorMessageStub: any;
-  let showInformationMessageStub: any;
-  let buildStub: any;
-  let authStub: any;
-  let executionDisposable: vscode.Disposable;
+firebaseSuite(
+  "generateOperation Error Handling",
+  () => {
+    let showErrorMessageStub: any;
+    let showInformationMessageStub: any;
+    let authStub: any;
+    let executionDisposable: vscode.Disposable;
 
-  setup(() => {
-    showErrorMessageStub = stub(vscode.window, "showErrorMessage");
-    showInformationMessageStub = stub(vscode.window, "showInformationMessage");
-    buildStub = stub(DataConnectEmulator, "build");
-    authStub = stub(auth, "getAccessToken").resolves({ access_token: "an_access_token" });
-    setAccessToken("an_access_token");
-    
-    stub(vscode.window, "withProgress").callsFake(async (options, task) => {
-        return task({ report: () => {} }, { isCancellationRequested: false, onCancellationRequested: () => ({ dispose: () => {} }) } as any);
+    setup(() => {
+      showErrorMessageStub = stub(vscode.window, "showErrorMessage");
+      showInformationMessageStub = stub(
+        vscode.window,
+        "showInformationMessage",
+      );
+      authStub = stub(auth, "getAccessToken").resolves({
+        access_token: "an_access_token",
+      });
+      setAccessToken("an_access_token");
+
+      stub(vscode.window, "withProgress").callsFake(async (options, task) => {
+        return task({ report: () => {} }, {
+          isCancellationRequested: false,
+          onCancellationRequested: () => ({ dispose: () => {} }),
+        } as any);
+      });
+
+      stub(configstore, "get").withArgs("gemini").returns(true);
+
+      // Mock dataConnectConfigs
+      const mockConfigs = {
+        findEnclosingServiceForPath: () => ({
+          path: "/mock/path",
+          mainSchemaDir: "schema",
+          secondarySchemaDirs: [],
+        }),
+      };
+      dataConnectConfigs.value = new ResultValue(mockConfigs) as any;
+
+      // Mock dependencies for registerExecution
+      const context = { subscriptions: [] } as any;
+      const broker = {
+        on: () => ({ dispose: () => {} }),
+        send: () => {},
+      } as any;
+      const dataConnectService = {
+        servicePath: async () => "mock-service",
+      } as any;
+      const paramsService = {} as any;
+      const analyticsLogger = { logger: { logUsage: () => {} } } as any;
+      const emulatorsController = {
+        areEmulatorsRunning: async () => true,
+      } as any;
+
+      executionDisposable = registerExecution(
+        context,
+        broker,
+        dataConnectService,
+        paramsService,
+        analyticsLogger,
+        emulatorsController,
+      );
+
+      nock.cleanAll();
     });
 
-    stub(configstore, "get").withArgs("gemini").returns(true);
+    teardown(() => {
+      executionDisposable.dispose();
+      restore();
+      nock.cleanAll();
+    });
 
-    // Mock dataConnectConfigs
-    const mockConfigs = {
-        findEnclosingServiceForPath: () => ({
-            path: "/mock/path",
-            mainSchemaDir: "schema",
-            secondarySchemaDirs: [],
-        }),
-    };
-    dataConnectConfigs.value = new ResultValue(mockConfigs) as any;
+    firebaseTest(
+      "should show notification when response is not valid GraphQL",
+      async () => {
+        const scope = nock("https://firebasedataconnect.googleapis.com")
+          .post(
+            "/v1/projects/my-project/locations/us-central1/services/mock-service:generateQuery",
+          )
+          .reply(
+            200,
+            JSON.stringify({
+              part: { textChunk: { text: "Invalid GraphQL response" } },
+            }),
+          );
 
-    // Mock dependencies for registerExecution
-    const context = { subscriptions: [] } as any;
-    const broker = { on: () => ({ dispose: () => {} }), send: () => {} } as any;
-    const dataConnectService = { servicePath: async () => "mock-service" } as any;
-    const paramsService = {} as any;
-    const analyticsLogger = { logger: { logUsage: () => {} } } as any;
-    const emulatorsController = { areEmulatorsRunning: async () => true } as any;
+        const document = {
+          fileName: "test.gql",
+          uri: vscode.Uri.parse("file:///test.gql"),
+          save: stub().resolves(true),
+        } as unknown as vscode.TextDocument;
 
-    executionDisposable = registerExecution(context, broker, dataConnectService, paramsService, analyticsLogger, emulatorsController);
-  
-    nock.cleanAll();
-  });
+        const arg = {
+          projectId: "my-project",
+          document,
+          description: "test",
+          insertPosition: 0,
+          existingQuery: "",
+        };
 
-  teardown(() => {
-    executionDisposable.dispose();
-    restore();
-    nock.cleanAll();
-  });
+        await vscode.commands.executeCommand(
+          "firebase.dataConnect.generateOperation",
+          arg,
+        );
 
-  firebaseTest("should show error message when build fails", async () => {
-    buildStub.throws(new Error("Build failed"));
+        console.log(
+          "showInformationMessageStub.callCount:",
+          showInformationMessageStub.callCount,
+        );
+        if (showInformationMessageStub.callCount > 0) {
+          console.log(
+            "showInformationMessageStub args:",
+            showInformationMessageStub.getCall(0).args,
+          );
+        }
+        console.log(
+          "showErrorMessageStub.callCount:",
+          showErrorMessageStub.callCount,
+        );
+        if (showErrorMessageStub.callCount > 0) {
+          console.log(
+            "showErrorMessageStub args:",
+            showErrorMessageStub.getCall(0).args,
+          );
+        }
+        console.log("nock isDone:", scope.isDone());
 
-    const document = {
-        fileName: "test.gql",
-        uri: vscode.Uri.parse("file:///test.gql"),
-        save: stub().resolves(true),
-    } as unknown as vscode.TextDocument;
-
-    const arg = {
-        projectId: "my-project",
-        document,
-        description: "test",
-        insertPosition: 0,
-        existingQuery: "",
-    };
-
-    await vscode.commands.executeCommand("firebase.dataConnect.generateOperation", arg);
-
-    assert.ok(showErrorMessageStub.calledOnce);
-    assert.equal(showErrorMessageStub.getCall(0).args[0], "Ensure schema compiles before generating queries");
-  });
-
-  firebaseTest("should show notification when response is not valid GraphQL", async () => {
-    buildStub.resolves({ errors: [] });
-    
-    const scope = nock("https://firebasedataconnect.googleapis.com")
-      .post("/v1/projects/my-project/locations/us-central1/services/mock-service:generateQuery")
-      .reply(200, JSON.stringify({ part: { textChunk: { text: "Invalid GraphQL response" } } }));
-
-    const document = {
-        fileName: "test.gql",
-        uri: vscode.Uri.parse("file:///test.gql"),
-        save: stub().resolves(true),
-    } as unknown as vscode.TextDocument;
-
-    const arg = {
-        projectId: "my-project",
-        document,
-        description: "test",
-        insertPosition: 0,
-        existingQuery: "",
-    };
-
-    await vscode.commands.executeCommand("firebase.dataConnect.generateOperation", arg);
-
-    console.log("showInformationMessageStub.callCount:", showInformationMessageStub.callCount);
-    if (showInformationMessageStub.callCount > 0) {
-        console.log("showInformationMessageStub args:", showInformationMessageStub.getCall(0).args);
-    }
-    console.log("showErrorMessageStub.callCount:", showErrorMessageStub.callCount);
-    if (showErrorMessageStub.callCount > 0) {
-        console.log("showErrorMessageStub args:", showErrorMessageStub.getCall(0).args);
-    }
-    console.log("nock isDone:", scope.isDone());
-
-    assert.ok(scope.isDone(), "Nock should have intercepted the request");
-    assert.ok(showErrorMessageStub.calledOnce);
-    assert.ok(showErrorMessageStub.getCall(0).args[0].startsWith("Generated response is not valid GraphQL"));
-  });
-}, 80000);
-
+        assert.ok(scope.isDone(), "Nock should have intercepted the request");
+        assert.ok(showErrorMessageStub.calledOnce);
+        assert.ok(
+          showErrorMessageStub
+            .getCall(0)
+            .args[0].startsWith("Generated response is not valid GraphQL"),
+        );
+      },
+    );
+  },
+  80000,
+);


### PR DESCRIPTION
### Description

Fixes an "compilation error" bug on "Generate Operation" code lens when the user didn't login with `gcloud`.

> Schema compilation failed: failed to build HTTP client for calling Firebase Data Connect. Error: failed to set up an OAuth token source. Error google: could not find default credentials. See https://cloud.google.com/docs/authentication/external/set-up-adc for more information


This compilation check is brittle and resulted in false negative when user never login via `gcloud auth application-default login`, which is never expected of SQL Connect developers.
This compilation check is not necessary because the backend API can trivially return compile errors.

### Scenarios Tested
- Modified the extension code and ran `npm run build` inside `firebase-vscode` to verify successful compilation.
- Verified that all unit/e2e build and type-checking pass without warnings/errors.

### Sample Commands
N/A
