### PR TITLE
Add flags to set credentials with apptesting:execute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Updated the Firebase Data Connect local toolkit to v3.4.11, which includes the following changes:
   - [changed] Updated the Golang dependency version to 1.25.11.
-- [fixed] Fixed issue where `apptesting:execute` command rejects documented `--test-username`, `--test-password`, and `--test-password-file` options.
+- Fixed issue where `apptesting:execute` command rejects documented `--test-username`, `--test-password`, and `--test-password-file` options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Updated the Firebase Data Connect local toolkit to v3.4.11, which includes the following changes:
   - [changed] Updated the Golang dependency version to 1.25.11.
+- [fixed] Fixed issue where `apptesting:execute` command rejects documented `--test-username`, `--test-password`, and `--test-password-file` options.

--- a/src/commands/apptesting.spec.ts
+++ b/src/commands/apptesting.spec.ts
@@ -1,0 +1,98 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import { command as apptestingExecute } from "./apptesting";
+import * as optionsParserUtil from "../appdistribution/options-parser-util";
+import * as parseTestFilesModule from "../apptesting/parseTestFiles";
+import * as fsutils from "../fsutils";
+import { AppDistributionClient } from "../appdistribution/client";
+import * as distributionModule from "../appdistribution/distribution";
+import * as utils from "../utils";
+
+describe("apptesting:execute", () => {
+  let getLoginCredentialSpy: sinon.SinonSpy;
+  let createReleaseTestStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (apptestingExecute as unknown as { befores: unknown[] }).befores = []; // Bypass requireAuth
+    sinon.stub(optionsParserUtil, "getAppName").returns("projects/123/apps/1:123:android:abc");
+    sinon.stub(optionsParserUtil, "getResultsBucket").returns(undefined);
+    sinon.stub(optionsParserUtil, "parseTestDevices").returns([]);
+    getLoginCredentialSpy = sinon.spy(optionsParserUtil, "getLoginCredential");
+    sinon.stub(fsutils, "dirExistsSync").returns(true);
+    sinon.stub(parseTestFilesModule, "parseTestFiles").resolves([
+      {
+        testCase: {
+          displayName: "Login smoke test",
+          steps: [{ goal: "Log in" }],
+        },
+        testExecution: [],
+      },
+    ]);
+    const mockRelease = {
+      name: "projects/123/apps/1:123:android:abc/releases/version1",
+      displayVersion: "1.0.0",
+      buildVersion: "1a",
+      createTime: new Date("2026-06-11T12:00:00Z"),
+      releaseNotes: { text: "Notes" },
+      firebaseConsoleUri: "https://console.firebase.google.com/foo",
+      testingUri: "https://testing.uri",
+      binaryDownloadUri: "https://download.uri",
+    };
+    sinon.stub(AppDistributionClient.prototype, "getLatestRelease").resolves(mockRelease);
+    createReleaseTestStub = sinon
+      .stub(AppDistributionClient.prototype, "createReleaseTest")
+      .resolves({
+        name: "projects/123/apps/1:123:android:abc/releases/version1/tests/test1",
+        deviceExecutions: [],
+      });
+    sinon.stub(distributionModule, "upload").resolves(mockRelease);
+    sinon.stub(distributionModule, "awaitTestResults").resolves();
+    sinon.stub(utils, "logBullet");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should define --test-username, --test-password, and --test-password-file options", () => {
+    const optionNames = (apptestingExecute as any).options.map((opt: any) => opt[0]);
+    expect(optionNames).to.include("--test-username <string>");
+    expect(optionNames).to.include("--test-password <string>");
+    expect(optionNames).to.include("--test-password-file <string>");
+  });
+
+  it("should call getLoginCredential with the correct arguments", async () => {
+    await apptestingExecute.runner()(undefined, {
+      app: "1:123:android:abc",
+      testUsername: "tester@example.com",
+      testPassword: "dummy-password",
+      testPasswordFile: "./password.txt",
+    });
+
+    expect(getLoginCredentialSpy).to.have.been.calledWith({
+      username: "tester@example.com",
+      password: "dummy-password",
+      passwordFile: "./password.txt",
+    });
+  });
+
+  it("should pass the parsed LoginCredential to AppDistributionClient.createReleaseTest", async () => {
+    await apptestingExecute.runner()(undefined, {
+      app: "1:123:android:abc",
+      testUsername: "tester@example.com",
+      testPassword: "dummy-password",
+    });
+
+    expect(createReleaseTestStub).to.have.been.calledWith(
+      "projects/123/apps/1:123:android:abc/releases/version1",
+      sinon.match.any,
+      sinon.match({
+        loginCredential: {
+          username: "tester@example.com",
+          password: "dummy-password",
+          fieldHints: undefined,
+        },
+      }),
+    );
+  });
+});

--- a/src/commands/apptesting.spec.ts
+++ b/src/commands/apptesting.spec.ts
@@ -9,15 +9,13 @@ import * as distributionModule from "../appdistribution/distribution";
 import * as utils from "../utils";
 
 describe("apptesting:execute", () => {
-  let getLoginCredentialSpy: sinon.SinonSpy;
   let createReleaseTestStub: sinon.SinonStub;
 
   beforeEach(() => {
-    (apptestingExecute as unknown as { befores: unknown[] }).befores = []; // Bypass requireAuth
+    (apptestingExecute as unknown as { befores: unknown[] }).befores = []; // Bypass pre-action hooks for unit testing action
     sinon.stub(optionsParserUtil, "getAppName").returns("projects/123/apps/1:123:android:abc");
     sinon.stub(optionsParserUtil, "getResultsBucket").returns(undefined);
     sinon.stub(optionsParserUtil, "parseTestDevices").returns([]);
-    getLoginCredentialSpy = sinon.spy(optionsParserUtil, "getLoginCredential");
     sinon.stub(fsutils, "dirExistsSync").returns(true);
     sinon.stub(parseTestFilesModule, "parseTestFiles").resolves([
       {
@@ -52,28 +50,6 @@ describe("apptesting:execute", () => {
 
   afterEach(() => {
     sinon.restore();
-  });
-
-  it("should define --test-username, --test-password, and --test-password-file options", () => {
-    const optionNames = (apptestingExecute as any).options.map((opt: any) => opt[0]);
-    expect(optionNames).to.include("--test-username <string>");
-    expect(optionNames).to.include("--test-password <string>");
-    expect(optionNames).to.include("--test-password-file <string>");
-  });
-
-  it("should call getLoginCredential with the correct arguments", async () => {
-    await apptestingExecute.runner()(undefined, {
-      app: "1:123:android:abc",
-      testUsername: "tester@example.com",
-      testPassword: "dummy-password",
-      testPasswordFile: "./password.txt",
-    });
-
-    expect(getLoginCredentialSpy).to.have.been.calledWith({
-      username: "tester@example.com",
-      password: "dummy-password",
-      passwordFile: "./password.txt",
-    });
   });
 
   it("should pass the parsed LoginCredential to AppDistributionClient.createReleaseTest", async () => {

--- a/src/commands/apptesting.ts
+++ b/src/commands/apptesting.ts
@@ -87,6 +87,11 @@ export const command = new Command("apptesting:execute [release-binary-file]")
       options.testNamePattern,
     );
     const testDevices = parseTestDevices(options.testDevices, options.testDevicesFile);
+    const loginCredential = getLoginCredential({
+      username: options.testUsername,
+      password: options.testPassword,
+      passwordFile: options.testPasswordFile,
+    });
 
     if (!tests.length) {
       throw new FirebaseError(`No tests found under test directory ${testDir}`);
@@ -114,12 +119,6 @@ export const command = new Command("apptesting:execute [release-binary-file]")
         release = latestRelease;
         utils.logBullet(`Using release ${release.displayVersion} created at ${release.createTime}`);
       }
-
-      const loginCredential = getLoginCredential({
-        username: options.testUsername,
-        password: options.testPassword,
-        passwordFile: options.testPasswordFile,
-      });
 
       invokeSpinner.start();
       releaseTests = await invokeTests(

--- a/src/commands/apptesting.ts
+++ b/src/commands/apptesting.ts
@@ -6,11 +6,18 @@ import { TestCaseInvocation } from "../apptesting/types";
 import { FirebaseError, getError } from "../error";
 import { AppDistributionClient } from "../appdistribution/client";
 import { awaitTestResults, Distribution, upload } from "../appdistribution/distribution";
-import { AiInstructions, ReleaseTest, TestDevice, Release } from "../appdistribution/types";
+import {
+  AiInstructions,
+  ReleaseTest,
+  TestDevice,
+  Release,
+  LoginCredential,
+} from "../appdistribution/types";
 import {
   getAppName,
   parseTestDevices,
   getResultsBucket,
+  getLoginCredential,
 } from "../appdistribution/options-parser-util";
 import * as utils from "../utils";
 import { dirExistsSync } from "../fsutils";
@@ -56,6 +63,12 @@ export const command = new Command("apptesting:execute [release-binary-file]")
     "--results-bucket <bucket>",
     "The name of a Google Cloud Storage bucket where raw test results will be stored. If this flag is not set, Firebase creates a default bucket for you. Note that the bucket must be owned by a billing-enabled project, and that using a non-default bucket will result in billing charges for the storage used.",
   )
+  .option("--test-username <string>", "username for automatic login")
+  .option(
+    "--test-password <string>",
+    "password for automatic login. If using a real password, use --test-password-file instead to avoid putting sensitive info in history and logs.",
+  )
+  .option("--test-password-file <string>", "path to file containing password for automatic login")
   .before(requireAuth)
   .action(async (target: string | undefined, options: any) => {
     const appName = getAppName(options);
@@ -102,6 +115,12 @@ export const command = new Command("apptesting:execute [release-binary-file]")
         utils.logBullet(`Using release ${release.displayVersion} created at ${release.createTime}`);
       }
 
+      const loginCredential = getLoginCredential({
+        username: options.testUsername,
+        password: options.testPassword,
+        passwordFile: options.testPasswordFile,
+      });
+
       invokeSpinner.start();
       releaseTests = await invokeTests(
         client,
@@ -109,6 +128,7 @@ export const command = new Command("apptesting:execute [release-binary-file]")
         tests,
         !testDevices.length ? defaultDevices : testDevices,
         resultsBucket,
+        loginCredential,
       );
       invokeSpinner.text = `${pluralizeTests(releaseTests.length)} started successfully!`;
       invokeSpinner.succeed();
@@ -135,6 +155,7 @@ async function invokeTests(
   testDefs: TestCaseInvocation[],
   devices: TestDevice[],
   resultsBucket?: string,
+  loginCredential?: LoginCredential,
 ): Promise<ReleaseTest[]> {
   try {
     const releaseTests: ReleaseTest[] = [];
@@ -147,6 +168,7 @@ async function invokeTests(
           aiInstructions,
           displayName: testDef.testCase.displayName,
           resultsBucket,
+          loginCredential,
         }),
       );
     }


### PR DESCRIPTION
### Description

The `--test-username`, `--test-password`, and `--test-password-file` flags were documented for `apptesting:execute` but not actually hooked up to that action.

See https://github.com/firebase/firebase-tools/issues/10620.

### Scenarios Tested

- No credentials
- Username and password
- Username and password from file
- Also added a new unit test for the command

### Sample Commands

```
firebase apptesting:execute --app=1:12345:android:deadbeef --test-dir=./tests --test-username=myusername --test-password=mypassword build/app/outputs/apk/release/app-release.apk
```
