### PR TITLE
ci: fix storage emulator integration tests on Node 24

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -213,9 +213,8 @@ jobs:
           - npm run test:triggers-end-to-end:inspect
           # - npm run test:dataconnect-deploy
           - npm run test:dataconnect-emulator
+          - npm run test:functions-discover
         include:
-          - node-version: "24"
-            script: "npm run test:functions-discover"
           - node-version: "22"
             script: "npm run test:storage-emulator-integration"
     steps:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -199,7 +199,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - "22"
+          - "24"
         script:
           - npm run test:client-integration
           - npm run test:emulator
@@ -209,14 +209,15 @@ jobs:
           # - npm run test:hosting-rewrites # Long-running test that might conflict across test runs. Run this manually.
           - npm run test:import-export
           - npm run test:storage-deploy
-          - npm run test:storage-emulator-integration
           - npm run test:triggers-end-to-end
           - npm run test:triggers-end-to-end:inspect
           # - npm run test:dataconnect-deploy
           - npm run test:dataconnect-emulator
         include:
-          - node-version: "22"
+          - node-version: "24"
             script: "npm run test:functions-discover"
+          - node-version: "22"
+            script: "npm run test:storage-emulator-integration"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -268,7 +269,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - "22"
+          - "24"
         script:
           - npm run test:hosting
           # - npm run test:hosting-rewrites # Long-running test that might conflict across test runs. Run this manually.
@@ -284,7 +285,7 @@ jobs:
           # - npm run test:dataconnect-emulator # TODO (joehanley): Figure out why this is failing
           # - npm run test:frameworks
         include:
-          - node-version: "22"
+          - node-version: "24"
             script: "npm run test:functions-discover"
     steps:
       - name: Setup Java JDK

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -199,7 +199,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - "24"
+          - "22"
         script:
           - npm run test:client-integration
           - npm run test:emulator
@@ -215,7 +215,7 @@ jobs:
           # - npm run test:dataconnect-deploy
           - npm run test:dataconnect-emulator
         include:
-          - node-version: "24"
+          - node-version: "22"
             script: "npm run test:functions-discover"
     steps:
       - uses: actions/checkout@v4
@@ -268,7 +268,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - "24"
+          - "22"
         script:
           - npm run test:hosting
           # - npm run test:hosting-rewrites # Long-running test that might conflict across test runs. Run this manually.
@@ -284,7 +284,7 @@ jobs:
           # - npm run test:dataconnect-emulator # TODO (joehanley): Figure out why this is failing
           # - npm run test:frameworks
         include:
-          - node-version: "24"
+          - node-version: "22"
             script: "npm run test:functions-discover"
     steps:
       - name: Setup Java JDK


### PR DESCRIPTION
### Description
The storage emulator test was broken on Node 24 due to a puppeteer incompatibility. We'll need to update our version of puppeteer eventually to address this, but for now, we can just stick this on node 22
