### PR TITLE
refactor: replace leven with internal stringDistance helper

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -44,7 +44,6 @@
         "ignore": "^7.0.4",
         "js-yaml": "^3.14.2",
         "jsonwebtoken": "^9.0.2",
-        "leven": "^3.1.0",
         "libsodium-wrappers": "^0.7.10",
         "lodash": "^4.18.0",
         "lsofi": "^2.0.0",
@@ -13438,14 +13437,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/leven": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -26207,7 +26198,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.17.1"
+        "ajv": "^8.0.0"
       }
     },
     "ansi-align": {
@@ -31631,11 +31622,6 @@
           }
         }
       }
-    },
-    "leven": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
     },
     "levn": {
       "version": "0.3.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26198,7 +26198,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.0.0"
+        "ajv": "^8.17.1"
       }
     },
     "ansi-align": {

--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "ignore": "^7.0.4",
     "js-yaml": "^3.14.2",
     "jsonwebtoken": "^9.0.2",
-    "leven": "^3.1.0",
     "libsodium-wrappers": "^0.7.10",
     "lodash": "^4.18.0",
     "lsofi": "^2.0.0",

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -1,9 +1,8 @@
 import { bold, italic } from "colorette";
-import * as leven from "leven";
 import { basename } from "path";
 import { configstore } from "./configstore";
 import { FirebaseError } from "./error";
-import { isRunningInGithubAction } from "./utils";
+import { isRunningInGithubAction, stringDistance } from "./utils";
 
 export interface Experiment {
   shortDescription: string;
@@ -242,7 +241,7 @@ export function experimentNameAutocorrect(malformed: string): string[] {
   // but this logic matches src/index.ts. I neither want to change something
   // with such potential impact nor to create divergent behavior.
   return Object.keys(ALL_EXPERIMENTS).filter(
-    (name) => leven(name, malformed) < malformed.length * 0.4,
+    (name) => stringDistance(name, malformed) < malformed.length * 0.4,
   );
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import * as program from "commander";
 import * as clc from "colorette";
-import * as leven from "leven";
+import { stringDistance } from "./utils";
 
 import { logger, useConsoleLoggers } from "./logger";
 import { isCommandModule, CLIClient } from "./command";
@@ -69,7 +69,7 @@ require("./commands").load(client);
  */
 function suggestCommands(cmd: string, cmdList: string[]): string | undefined {
   const suggestion = cmdList.find((c) => {
-    return leven(c, cmd) < c.length * 0.4;
+    return stringDistance(c, cmd) < c.length * 0.4;
   });
   if (suggestion) {
     logger.error();

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -693,4 +693,15 @@ describe("utils", () => {
       await expect(t3).to.eventually.equal("Recovered");
     });
   });
+
+  describe("stringDistance", () => {
+    it("should correctly compute Levenshtein distance between two strings", () => {
+      expect(utils.stringDistance("", "")).to.equal(0);
+      expect(utils.stringDistance("a", "")).to.equal(1);
+      expect(utils.stringDistance("", "a")).to.equal(1);
+      expect(utils.stringDistance("abc", "abc")).to.equal(0);
+      expect(utils.stringDistance("kitten", "sitting")).to.equal(3);
+      expect(utils.stringDistance("flaw", "lawn")).to.equal(2);
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1186,23 +1186,33 @@ export function pLimit(concurrency: number): Limit {
  * Calculates the Levenshtein distance between two strings.
  */
 export function stringDistance(a: string, b: string): number {
+  if (a === b) return 0;
   if (a.length === 0) return b.length;
   if (b.length === 0) return a.length;
-  const matrix = Array.from({ length: b.length + 1 }, (_, i) => [i]);
-  for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
 
-  for (let i = 1; i <= b.length; i++) {
-    for (let j = 1; j <= a.length; j++) {
-      if (b.charAt(i - 1) === a.charAt(j - 1)) {
-        matrix[i][j] = matrix[i - 1][j - 1];
-      } else {
-        matrix[i][j] = Math.min(
-          matrix[i - 1][j - 1] + 1, // substitution
-          matrix[i][j - 1] + 1, // insertion
-          matrix[i - 1][j] + 1, // deletion
-        );
-      }
+  // Make 's1' the shorter string to optimize space
+  const [s1, s2] = a.length <= b.length ? [a, b] : [b, a];
+  const v0 = new Array<number>(s1.length + 1);
+  const v1 = new Array<number>(s1.length + 1);
+
+  for (let i = 0; i <= s1.length; i++) {
+    v0[i] = i;
+  }
+
+  for (let i = 0; i < s2.length; i++) {
+    v1[0] = i + 1;
+    for (let j = 0; j < s1.length; j++) {
+      const cost = s1[j] === s2[i] ? 0 : 1;
+      v1[j + 1] = Math.min(
+        v1[j] + 1, // Insertion
+        v0[j + 1] + 1, // Deletion
+        v0[j] + cost, // Substitution
+      );
+    }
+    for (let j = 0; j <= s1.length; j++) {
+      v0[j] = v1[j];
     }
   }
-  return matrix[b.length][a.length];
+
+  return v0[s1.length];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1181,6 +1181,7 @@ export function pLimit(concurrency: number): Limit {
       }
     });
   };
+}
 
 /**
  * Calculates the Levenshtein distance between two strings.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1181,4 +1181,28 @@ export function pLimit(concurrency: number): Limit {
       }
     });
   };
+
+/**
+ * Calculates the Levenshtein distance between two strings.
+ */
+export function stringDistance(a: string, b: string): number {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const matrix = Array.from({ length: b.length + 1 }, (_, i) => [i]);
+  for (let j = 0; j <= a.length; j++) matrix[0][j] = j;
+
+  for (let i = 1; i <= b.length; i++) {
+    for (let j = 1; j <= a.length; j++) {
+      if (b.charAt(i - 1) === a.charAt(j - 1)) {
+        matrix[i][j] = matrix[i - 1][j - 1];
+      } else {
+        matrix[i][j] = Math.min(
+          matrix[i - 1][j - 1] + 1, // substitution
+          matrix[i][j - 1] + 1, // insertion
+          matrix[i - 1][j] + 1, // deletion
+        );
+      }
+    }
+  }
+  return matrix[b.length][a.length];
 }


### PR DESCRIPTION
### Description
Removed the external third-party `leven` string distance dependency and implemented our own lightweight Levenshtein distance helper function `stringDistance` in `src/utils.ts`. Updated call sites in command and experiment suggestions.

### Scenarios Tested
- Unit tests for `stringDistance` and `experiments` fully pass (`npx mocha src/experiments.spec.ts src/utils.spec.ts`).
- Verified `npm-shrinkwrap.json` regenerated clean and correctly synchronizes.

### Sample Commands
- `npx mocha src/experiments.spec.ts src/utils.spec.ts`
