### PR TITLE
refactor: replace p-limit with internal pLimit utility

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26207,7 +26207,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.0.0"
+        "ajv": "^8.17.1"
       }
     },
     "ansi-align": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -56,7 +56,6 @@
         "node-fetch": "^2.6.7",
         "open": "^6.3.0",
         "ora": "^5.4.1",
-        "p-limit": "^3.0.1",
         "pg": "^8.11.3",
         "pg-gateway": "^0.3.0-beta.4",
         "pglite-2": "npm:@electric-sql/pglite@0.2.17",
@@ -16667,6 +16666,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -21780,6 +21780,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -26206,7 +26207,7 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
       "requires": {
-        "ajv": "^8.17.1"
+        "ajv": "^8.0.0"
       }
     },
     "ansi-align": {
@@ -33955,6 +33956,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -37705,7 +37707,8 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true
     },
     "yoctocolors-cjs": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "node-fetch": "^2.6.7",
     "open": "^6.3.0",
     "ora": "^5.4.1",
-    "p-limit": "^3.0.1",
     "pg": "^8.11.3",
     "pg-gateway": "^0.3.0-beta.4",
     "pglite-2": "npm:@electric-sql/pglite@0.2.17",

--- a/src/crashlytics/sourcemap.ts
+++ b/src/crashlytics/sourcemap.ts
@@ -1,11 +1,16 @@
 import * as fs from "fs";
 import * as path from "path";
 import { execSync } from "node:child_process";
-import * as pLimit from "p-limit";
 import { Client } from "../apiv2";
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
-import { commandExistsSync, logLabeledBullet, logLabeledWarning, murmurHashV3 } from "../utils";
+import {
+  commandExistsSync,
+  logLabeledBullet,
+  logLabeledWarning,
+  murmurHashV3,
+  pLimit,
+} from "../utils";
 import * as gcs from "../gcp/storage";
 import { archiveFile } from "../archiveFile";
 import { Options } from "../options";

--- a/src/database/import.ts
+++ b/src/database/import.ts
@@ -8,7 +8,7 @@ import { URL } from "url";
 import { Client, ClientResponse } from "../apiv2";
 import { FetchError } from "node-fetch";
 import { FirebaseError } from "../error";
-import * as pLimit from "p-limit";
+import { pLimit, Limit } from "../utils";
 
 type JsonType = { [key: string]: JsonType } | string | number | boolean;
 
@@ -122,7 +122,7 @@ class BatchChunks extends stream.Transform {
  */
 export default class DatabaseImporter {
   private client: Client;
-  private limit: pLimit.Limit;
+  private limit: Limit;
   nonFatalRetryTimeout = 1000; // To be overriden in tests
 
   constructor(

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -669,5 +669,28 @@ describe("utils", () => {
       await Promise.all(tasks);
       expect(maxActive).to.equal(2);
     });
+
+    it("should throw when given invalid concurrency values", () => {
+      expect(() => utils.pLimit(0)).to.throw(FirebaseError);
+      expect(() => utils.pLimit(-5)).to.throw(FirebaseError);
+      expect(() => utils.pLimit(2.5)).to.throw(FirebaseError);
+    });
+
+    it("should recover correctly when a queued task throws synchronously", async () => {
+      const limit = utils.pLimit(1);
+
+      // Task 1 will hang for 20ms
+      const t1 = limit(() => new Promise((res) => setTimeout(res, 20)));
+      // Task 2 will throw synchronously
+      const t2 = limit(() => {
+        throw new Error("Sync error");
+      });
+      // Task 3 should run successfully after t1 and t2 finish
+      const t3 = limit(() => Promise.resolve("Recovered"));
+
+      await expect(t1).to.be.fulfilled;
+      await expect(t2).to.be.rejectedWith("Sync error");
+      await expect(t3).to.eventually.equal("Recovered");
+    });
   });
 });

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -650,4 +650,24 @@ describe("utils", () => {
       expect(utils.formatFilesize(Math.pow(1024, 5) * 2.5)).to.equal("2.5 PB");
     });
   });
+
+  describe("pLimit", () => {
+    it("should limit concurrent promise executions", async () => {
+      const limit = utils.pLimit(2);
+      let active = 0;
+      let maxActive = 0;
+
+      const tasks = Array.from({ length: 5 }, () =>
+        limit(async () => {
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise((res) => setTimeout(res, 10));
+          active--;
+        }),
+      );
+
+      await Promise.all(tasks);
+      expect(maxActive).to.equal(2);
+    });
+  });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1141,3 +1141,35 @@ export function formatFilesize(bytes: number, decimals = 2): string {
   const i = Math.min(Math.floor(Math.log(bytes) / Math.log(k)), sizes.length - 1);
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + " " + sizes[i];
 }
+
+export type Limit = <T>(fn: () => Promise<T>) => Promise<T>;
+
+/**
+ * A lightweight Promise concurrency limiter.
+ */
+export function pLimit(concurrency: number): Limit {
+  const queue: Array<() => void> = [];
+  let activeCount = 0;
+
+  const next = () => {
+    activeCount--;
+    if (queue.length > 0) {
+      queue.shift()?.();
+    }
+  };
+
+  return <T>(fn: () => Promise<T>): Promise<T> => {
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        activeCount++;
+        fn().then(resolve, reject).finally(next);
+      };
+
+      if (activeCount < concurrency) {
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1148,6 +1148,10 @@ export type Limit = <T>(fn: () => Promise<T>) => Promise<T>;
  * A lightweight Promise concurrency limiter.
  */
 export function pLimit(concurrency: number): Limit {
+  if (!Number.isInteger(concurrency) || concurrency <= 0) {
+    throw new FirebaseError(`pLimit concurrency must be a positive integer, got ${concurrency}`);
+  }
+
   const queue: Array<() => void> = [];
   let activeCount = 0;
 
@@ -1162,7 +1166,12 @@ export function pLimit(concurrency: number): Limit {
     return new Promise<T>((resolve, reject) => {
       const run = () => {
         activeCount++;
-        fn().then(resolve, reject).finally(next);
+        try {
+          Promise.resolve(fn()).then(resolve, reject).finally(next);
+        } catch (err) {
+          reject(err);
+          next();
+        }
       };
 
       if (activeCount < concurrency) {


### PR DESCRIPTION
### Description
Eliminated the external third-party `p-limit` dependency and implemented our own premium Promise concurrency limiter function `pLimit` and `Limit` type in `src/utils.ts`. Updated RTDB database importing and Crashlytics sourcemap parallel upload modules to use our native utility.

### Scenarios Tested
- Hermetic unit tests for `pLimit` and `uploadSourceMaps` fully pass (`npx mocha src/utils.spec.ts src/crashlytics/sourcemap.spec.ts`).
- Verified `npm-shrinkwrap.json` regenerated clean and correctly synchronizes.

### Sample Commands
- `npx mocha src/utils.spec.ts src/crashlytics/sourcemap.spec.ts`
