### PR TITLE
Show login:*, target:*, and ext:* subcommands in firebase --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed an issue where `login:*`, `target:*`, and `ext:*` subcommands were missing from `firebase --help`.
 - Functions can declare additional API dependencies (#10621)
 - Added mock Passkey (WebAuthn) support to the Auth emulator. (#10636)
 - Fixes `spawn activate.bat ENOENT` error on Windows when initializing Python functions. (#10608)

--- a/src/bin/cli.spec.ts
+++ b/src/bin/cli.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { loadAllCommands } from "./cli";
+
+function makeCommand(): any {
+  const fn: any = function () {
+    return undefined;
+  };
+  fn.load = sinon.stub();
+  return fn;
+}
+
+describe("cli loadAllCommands", () => {
+  it("loads commands nested under a plain namespace object", () => {
+    const authExport = makeCommand();
+    const client: any = {
+      cli: {},
+      auth: { export: authExport },
+    };
+
+    loadAllCommands(client);
+
+    expect(authExport.load.calledOnce).to.be.true;
+  });
+
+  it("loads subcommands attached to a command that is also a namespace parent", () => {
+    // `login`/`target`/`ext` are command functions that also carry their
+    // subcommands as attached properties. All of them must be registered.
+    const login = makeCommand();
+    login.add = makeCommand();
+    login.list = makeCommand();
+
+    const client: any = {
+      cli: {},
+      login,
+    };
+
+    loadAllCommands(client);
+
+    expect(login.load.calledOnce, "bare login command loaded").to.be.true;
+    expect(login.add.load.calledOnce, "login:add loaded").to.be.true;
+    expect(login.list.load.calledOnce, "login:list loaded").to.be.true;
+  });
+
+  it("does not traverse the `cli` property and ignores arrays", () => {
+    const open = makeCommand();
+    const client: any = {
+      cli: { commands: [makeCommand()] }, // cli is intentionally not traversed
+      list: [makeCommand()], // arrays are not traversed
+      open,
+    };
+
+    loadAllCommands(client);
+
+    expect(open.load.calledOnce).to.be.true;
+    expect(client.cli.commands[0].load.called, "cli subtree skipped").to.be.false;
+    expect(client.list[0].load.called, "array entries skipped").to.be.false;
+  });
+});

--- a/src/bin/cli.spec.ts
+++ b/src/bin/cli.spec.ts
@@ -3,10 +3,16 @@ import * as sinon from "sinon";
 
 import { loadAllCommands } from "./cli";
 
-function makeCommand(): any {
-  const fn: any = function () {
+interface MockCommand {
+  (): void;
+  load: sinon.SinonStub;
+  [key: string]: unknown;
+}
+
+function makeCommand(): MockCommand {
+  const fn = function () {
     return undefined;
-  };
+  } as MockCommand;
   fn.load = sinon.stub();
   return fn;
 }
@@ -14,7 +20,7 @@ function makeCommand(): any {
 describe("cli loadAllCommands", () => {
   it("loads commands nested under a plain namespace object", () => {
     const authExport = makeCommand();
-    const client: any = {
+    const client: Record<string, unknown> = {
       cli: {},
       auth: { export: authExport },
     };
@@ -28,10 +34,12 @@ describe("cli loadAllCommands", () => {
     // `login`/`target`/`ext` are command functions that also carry their
     // subcommands as attached properties. All of them must be registered.
     const login = makeCommand();
-    login.add = makeCommand();
-    login.list = makeCommand();
+    const loginAdd = makeCommand();
+    const loginList = makeCommand();
+    login.add = loginAdd;
+    login.list = loginList;
 
-    const client: any = {
+    const client: Record<string, unknown> = {
       cli: {},
       login,
     };
@@ -39,22 +47,24 @@ describe("cli loadAllCommands", () => {
     loadAllCommands(client);
 
     expect(login.load.calledOnce, "bare login command loaded").to.be.true;
-    expect(login.add.load.calledOnce, "login:add loaded").to.be.true;
-    expect(login.list.load.calledOnce, "login:list loaded").to.be.true;
+    expect(loginAdd.load.calledOnce, "login:add loaded").to.be.true;
+    expect(loginList.load.calledOnce, "login:list loaded").to.be.true;
   });
 
   it("does not traverse the `cli` property and ignores arrays", () => {
     const open = makeCommand();
-    const client: any = {
-      cli: { commands: [makeCommand()] }, // cli is intentionally not traversed
-      list: [makeCommand()], // arrays are not traversed
+    const cliCommand = makeCommand();
+    const arrayCommand = makeCommand();
+    const client: Record<string, unknown> = {
+      cli: { commands: [cliCommand] }, // cli is intentionally not traversed
+      list: [arrayCommand], // arrays are not traversed
       open,
     };
 
     loadAllCommands(client);
 
     expect(open.load.calledOnce).to.be.true;
-    expect(client.cli.commands[0].load.called, "cli subtree skipped").to.be.false;
-    expect(client.list[0].load.called, "array entries skipped").to.be.false;
+    expect(cliCommand.load.called, "cli subtree skipped").to.be.false;
+    expect(arrayCommand.load.called, "array entries skipped").to.be.false;
   });
 });

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -32,9 +32,9 @@ import { detectAIAgent } from "../env";
  * attached as properties. We therefore load command functions *and* recurse
  * into them so the nested subcommands are not skipped.
  */
-export function loadAllCommands(client: any): void {
-  const seen = new Set();
-  const loadAll = (obj: any) => {
+export function loadAllCommands(client: Record<string, unknown>): void {
+  const seen = new Set<unknown>();
+  const loadAll = (obj: Record<string, unknown>) => {
     if (seen.has(obj)) return;
     seen.add(obj);
     for (const [key, value] of Object.entries(obj)) {
@@ -49,7 +49,7 @@ export function loadAllCommands(client: any): void {
         value !== null &&
         !Array.isArray(value)
       ) {
-        loadAll(value);
+        loadAll(value as Record<string, unknown>);
       }
     }
   };
@@ -159,7 +159,7 @@ export function cli(pkg: any) {
   }
 
   if (isHelp) {
-    loadAllCommands(client);
+    loadAllCommands(client as Record<string, unknown>);
   }
   // If there are no args, display help
   if (!args.length) {

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -23,6 +23,39 @@ import { fetchMOTD } from "../fetchMOTD";
 import { isCommandModule } from "../command";
 import { detectAIAgent } from "../env";
 
+/**
+ * Recursively registers every command in the client tree so that they all
+ * appear in `firebase --help`.
+ *
+ * A node can be both a leaf command and a namespace parent (e.g. `login`,
+ * `target`, `ext`): these are command functions that have their subcommands
+ * attached as properties. We therefore load command functions *and* recurse
+ * into them so the nested subcommands are not skipped.
+ */
+export function loadAllCommands(client: any): void {
+  const seen = new Set();
+  const loadAll = (obj: any) => {
+    if (seen.has(obj)) return;
+    seen.add(obj);
+    for (const [key, value] of Object.entries(obj)) {
+      if (key === "cli") {
+        continue;
+      }
+      if (isCommandModule(value)) {
+        value.load();
+      }
+      if (
+        (typeof value === "object" || typeof value === "function") &&
+        value !== null &&
+        !Array.isArray(value)
+      ) {
+        loadAll(value);
+      }
+    }
+  };
+  loadAll(client);
+}
+
 export function cli(pkg: any) {
   const updateNotifier = updateNotifierPkg({ pkg });
 
@@ -126,24 +159,7 @@ export function cli(pkg: any) {
   }
 
   if (isHelp) {
-    const seen = new Set();
-    const loadAll = (obj: any) => {
-      if (seen.has(obj)) return;
-      seen.add(obj);
-      for (const [key, value] of Object.entries(obj)) {
-        if (isCommandModule(value)) {
-          value.load();
-        } else if (
-          typeof value === "object" &&
-          value !== null &&
-          !Array.isArray(value) &&
-          key !== "cli"
-        ) {
-          loadAll(value);
-        }
-      }
-    };
-    loadAll(client);
+    loadAllCommands(client);
   }
   // If there are no args, display help
   if (!args.length) {


### PR DESCRIPTION
## Bug

Fixes #10652. The `login:*`, `target:*`, and `ext:*` subcommands don't appear in `firebase --help`, even though they work at runtime (e.g. `firebase login:list` runs fine and `firebase login:list --help` shows usage). Other namespaced commands like `auth:*` and `apps:*` show up correctly.

## Cause

The help-time loader in `src/bin/cli.ts` walked the command tree with an `if/else if`: a value was either loaded as a command *or* recursed into as a namespace, never both. `login`, `target`, and `ext` are command functions that also carry their subcommands as attached properties, so the loader registered the bare command and then skipped the recursion that would have registered the subcommands. They stayed reachable only through the lazy resolver at runtime.

## Fix

I pulled the loader out into `loadAllCommands` and made it load command functions *and* recurse into objects and functions alike, so subcommands attached to a command that is also a namespace parent get registered for help too.

## Testing

- Added `src/bin/cli.spec.ts` covering the both-leaf-and-parent case (fails on `main`, passes with this change), plus the plain-namespace and `cli`/array-skipping cases.
- `firebase --help` now lists `login:add/ci/list/use`, `target:apply/clear/remove`, and the `ext:*` subcommands; bare commands and other namespaces are unchanged.
- `npm run test:compile`, eslint (`--quiet`), prettier, and the `src/bin` + `src/commands` test suites all pass.