### PR TITLE
update the init functions python flow to find available python runtimes on user's machine

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "lint:ts": "eslint --cache --config .eslintrc.js --ext .ts,.js .",
     "mocha:fast": "mocha 'src/**/*.spec.{ts,js}'",
     "mocha": "nyc mocha 'src/**/*.spec.{ts,js}'",
-    "test:custom": "nyc mocha 'src/init/features/functions.spec.ts'",
     "prepare": "npm run clean && npm run build:publish",
     "test": "npm run lint:quiet && npm run test:compile && npm run mocha",
     "test:appdistribution": "npm run lint:quiet && npm run test:compile && nyc mocha 'src/appdistribution/*.spec.{ts,js}'",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint:ts": "eslint --cache --config .eslintrc.js --ext .ts,.js .",
     "mocha:fast": "mocha 'src/**/*.spec.{ts,js}'",
     "mocha": "nyc mocha 'src/**/*.spec.{ts,js}'",
+    "test:custom": "nyc mocha 'src/init/features/functions.spec.ts'",
     "prepare": "npm run clean && npm run build:publish",
     "test": "npm run lint:quiet && npm run test:compile && npm run mocha",
     "test:appdistribution": "npm run lint:quiet && npm run test:compile && nyc mocha 'src/appdistribution/*.spec.{ts,js}'",

--- a/src/functions/python.ts
+++ b/src/functions/python.ts
@@ -3,6 +3,8 @@ import { spawn } from "cross-spawn";
 import * as cp from "child_process";
 import { logger } from "../logger";
 import { IS_WINDOWS } from "../utils";
+import * as supported from "../deploy/functions/runtimes/supported";
+import { getPythonBinary } from "../deploy/functions/runtimes/python";
 
 /**
  * Default directory for python virtual environment.
@@ -44,4 +46,52 @@ export function runWithVirtualEnv(
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
     env: envs as any,
   });
+}
+
+/**
+ * Check if a python binary is available and return its version.
+ */
+export async function checkPythonVersion(binary: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    const child = spawn(binary, ["--version"], { stdio: "pipe" });
+    let output = "";
+    child.stdout?.on("data", (data: Buffer) => {
+      output += data.toString();
+    });
+    child.stderr?.on("data", (data: Buffer) => {
+      output += data.toString();
+    });
+    child.on("close", (code: number) => {
+      if (code === 0) {
+        resolve(output.trim());
+      } else {
+        resolve(undefined);
+      }
+    });
+    child.on("error", () => {
+      resolve(undefined);
+    });
+  });
+}
+
+/**
+ * Get all available python runtimes on the user machine.
+ */
+export async function getAvailablePythonRuntimes(): Promise<
+  { runtime: supported.Runtime & supported.RuntimeOf<"python">; binary: string; version: string }[]
+> {
+  const pythonRuntimes = (Object.keys(supported.RUNTIMES) as supported.Runtime[]).filter(
+    (runtime): runtime is supported.Runtime & supported.RuntimeOf<"python"> =>
+      runtime.startsWith("python"),
+  );
+
+  const results = await Promise.all(
+    pythonRuntimes.map(async (runtime) => {
+      const binary = getPythonBinary(runtime);
+      const version = await checkPythonVersion(binary);
+      return version ? { runtime, binary, version } : undefined;
+    }),
+  );
+
+  return results.filter((r): r is NonNullable<typeof r> => !!r);
 }

--- a/src/init/features/functions.spec.ts
+++ b/src/init/features/functions.spec.ts
@@ -10,6 +10,7 @@ import { RC } from "../../rc";
 import * as experiments from "../../experiments";
 import * as spawn from "cross-spawn";
 import * as initSpawn from "../spawn";
+import * as pythonUtils from "../../functions/python";
 
 const TEST_SOURCE_DEFAULT = "functions";
 const TEST_CODEBASE_DEFAULT = "default";
@@ -135,16 +136,22 @@ describe("functions", () => {
       describe("python project", () => {
         let spawnStub: sinon.SinonStub;
         let wrapSpawnStub: sinon.SinonStub;
+        let getAvailablePythonRuntimesStub: sinon.SinonStub;
 
         beforeEach(() => {
           spawnStub = sandbox.stub(spawn, "spawn");
           wrapSpawnStub = sandbox.stub(initSpawn, "wrapSpawn");
+          getAvailablePythonRuntimesStub = sandbox.stub(pythonUtils, "getAvailablePythonRuntimes");
+          getAvailablePythonRuntimesStub.resolves([
+            { runtime: "python314", binary: "python3.14", version: "Python 3.14.0" },
+          ]);
         });
 
         it("creates a new python codebase with the correct configuration", async () => {
           const config = new Config("{}", { projectDir: "test", cwd: "test" });
           const setup = { config: { functions: [] }, rcfile: {} };
           prompt.select.onFirstCall().resolves("python");
+          prompt.select.onSecondCall().resolves("python314");
           // do not install dependencies
           prompt.confirm.onFirstCall().resolves(false);
           askWriteProjectFileStub = sandbox.stub(config, "askWriteProjectFile");

--- a/src/init/features/functions/python.ts
+++ b/src/init/features/functions/python.ts
@@ -1,13 +1,16 @@
 import { ChildProcess } from "child_process";
+import * as ora from "ora";
 import { wrapSpawn } from "../../spawn";
 
 import { Config } from "../../../config";
 import { getPythonBinary } from "../../../deploy/functions/runtimes/python";
-import { runWithVirtualEnv } from "../../../functions/python";
-import { confirm } from "../../../prompt";
-import { latest } from "../../../deploy/functions/runtimes/supported";
+import { getAvailablePythonRuntimes, runWithVirtualEnv } from "../../../functions/python";
+import { confirm, select } from "../../../prompt";
+import { latest, Runtime, RuntimeOf } from "../../../deploy/functions/runtimes/supported";
 import { readTemplateSync } from "../../../templates";
 import { FirebaseError } from "../../../error";
+import { logger } from "../../../logger";
+import { configForCodebase } from "../../../functions/projectConfig";
 
 const MAIN_TEMPLATE = readTemplateSync("init/functions/python/main.py");
 const REQUIREMENTS_TEMPLATE = readTemplateSync("init/functions/python/requirements.txt");
@@ -27,9 +30,12 @@ function waitForProcess(p: ChildProcess): Promise<number | null> {
  * Helper to spawn a process and create a python virtual environment.
  */
 async function createVirtualEnv(pythonBinary: string, cwd: string): Promise<void> {
+  const spinner = ora("Creating Python virtual environment...").start();
   try {
     await wrapSpawn(pythonBinary, ["-m", "venv", "venv"], cwd);
+    spinner.succeed("Created Python virtual environment.");
   } catch (err) {
+    spinner.fail("Failed to create Python virtual environment.");
     throw new FirebaseError(
       `Failed to create virtual environment. Please make sure Python is installed and in your PATH.`,
     );
@@ -67,6 +73,47 @@ async function installDependencies(pythonBinary: string, cwd: string): Promise<v
 }
 
 /**
+ * Prompt the user to select a Python runtime if multiple runtimes are available, or if the latest runtime is not available.
+ */
+async function promptSelectRuntime(
+  availableRuntimes: { runtime: Runtime & RuntimeOf<"python">; version: string }[],
+): Promise<Runtime & RuntimeOf<"python">> {
+  const latestPythonRuntime = latest("python");
+  let selectedRuntime: Runtime & RuntimeOf<"python">;
+
+  const isLatestRuntimeAvailable = availableRuntimes.some((r) => r.runtime === latestPythonRuntime);
+  // If the latest runtime is available, use it by default
+  if (isLatestRuntimeAvailable) {
+    selectedRuntime = latestPythonRuntime;
+  } else if (availableRuntimes.length >= 1) {
+    const choices = availableRuntimes.map((r) => ({
+      name: `${r.runtime} (${r.version})`,
+      value: r.runtime,
+    }));
+    if (!choices.some((c) => c.value === latestPythonRuntime)) {
+      choices.push({
+        name: `${latestPythonRuntime} (not available on your machine)`,
+        value: latestPythonRuntime,
+      });
+    }
+    const runtime = await select({
+      message: "Which Python runtime would you like to use for this codebase?",
+      default: choices[0].value,
+      choices,
+    });
+
+    selectedRuntime = runtime;
+  } else {
+    logger.warn(
+      "No Python runtimes were detected on your machine. " +
+        `The latest supported runtime ${latestPythonRuntime} will be set in your config, but you may encounter issues deploying or emulating functions.`,
+    );
+    selectedRuntime = latestPythonRuntime;
+  }
+  return selectedRuntime;
+}
+
+/**
  * Create a Python Firebase Functions project.
  */
 export async function setup(setup: any, config: Config): Promise<void> {
@@ -79,21 +126,32 @@ export async function setup(setup: any, config: Config): Promise<void> {
   await config.askWriteProjectFile(`${setup.functions.source}/.gitignore`, GITIGNORE_TEMPLATE);
   await config.askWriteProjectFile(`${setup.functions.source}/main.py`, MAIN_TEMPLATE);
 
-  // Write the latest supported runtime version to the config.
-  config.set("functions.runtime", latest("python"));
+  const availableRuntimes = await getAvailablePythonRuntimes();
+  const selectedRuntime = await promptSelectRuntime(availableRuntimes);
+  const cbconfig = configForCodebase(setup.config.functions, setup.functions.codebase);
+  cbconfig.runtime = selectedRuntime;
+
+  // Write the selected runtime version to the config.
+  config.set("functions.runtime", selectedRuntime);
   // Add python specific ignores to config.
   config.set("functions.ignore", ["venv", "__pycache__"]);
 
   // We resolve the version-specific Python binary (e.g. python3.10) to ensure we execute
   // the correct version of Python chosen for the functions codebase.
-  const pythonBinary = getPythonBinary(latest("python"));
-  await createVirtualEnv(pythonBinary, sourceDir);
-
-  const install = await confirm({
-    message: "Do you want to install dependencies now?",
-    default: true,
-  });
-  if (install) {
-    await installDependencies(pythonBinary, sourceDir);
+  const pythonBinary = getPythonBinary(selectedRuntime);
+  const runtimeDetected = availableRuntimes.some((r) => r.runtime === selectedRuntime);
+  if (runtimeDetected) {
+    await createVirtualEnv(pythonBinary, sourceDir);
+    const install = await confirm({
+      message: "Do you want to install dependencies now?",
+      default: true,
+    });
+    if (install) {
+      await installDependencies(pythonBinary, sourceDir);
+    }
+  } else {
+    logger.info(
+      `Skipping virtual environment creation because ${selectedRuntime} is not available on your machine.`,
+    );
   }
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

- [ ] Test on Windows

We currently always try to use the latest python runtime when we set up functions
https://github.com/firebase/firebase-tools/blob/33ff901ac4b2c44af4b5e0dc0c853113b07583da/src/init/features/functions/python.ts#L83

For machines that don't have the latest version of python installed, venv creation and dependency installation will fail because that python version isn't available.
<img width="2258" height="932" alt="image" src="https://github.com/user-attachments/assets/bc5d651c-913d-4edb-bf08-302f473849d7" />

This PR introduces an additional prompt to allow users to set up with older version of python on their machine(if latest is not available). 
<img width="982" height="504" alt="image" src="https://github.com/user-attachments/assets/246f1803-2d5b-4400-acf6-ea4411f45501" />

If latest version of python is available on their machine, no prompts occur and we default to using the latest
<img width="1000" height="408" alt="image" src="https://github.com/user-attachments/assets/748388e1-54c9-4b8a-a109-908cea6c926f" />

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

`firebase init functions` - No Python3.14
- Shows a list of old version of Python I have and sets up using the selected version

`firebase init functions` - With Python3.14
- Skips the prompt and defaults setting up with Python3.14

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
