### PR TITLE
fix(functions): avoid recreating a deleted task queue on functions:delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed `functions:delete` recreating an already-deleted Cloud Tasks queue for task queue functions. (#9305)

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -90,6 +90,7 @@ describe("Fabricator", () => {
     tasks.upsertQueue.rejects(new Error("unexpected tasks.upsertQueue"));
     tasks.createQueue.rejects(new Error("unexpected tasks.createQueue"));
     tasks.updateQueue.rejects(new Error("unexpected tasks.updateQueue"));
+    tasks.disableQueue.rejects(new Error("unexpected tasks.disableQueue"));
     tasks.deleteQueue.rejects(new Error("unexpected tasks.deleteQueue"));
     tasks.setEnqueuer.rejects(new Error("unexpected tasks.setEnqueuer"));
     tasks.setIamPolicy.rejects(new Error("unexpected tasks.setIamPolicy"));
@@ -1211,19 +1212,16 @@ describe("Fabricator", () => {
       const ep = endpoint({
         taskQueueTrigger: {},
       }) as backend.Endpoint & backend.TaskQueueTriggered;
-      tasks.updateQueue.resolves();
+      tasks.disableQueue.resolves();
       await fab.disableTaskQueue(ep);
-      expect(tasks.updateQueue).to.have.been.calledWith({
-        name: tasks.queueNameForEndpoint(ep),
-        state: "DISABLED",
-      });
+      expect(tasks.disableQueue).to.have.been.calledWith(tasks.queueNameForEndpoint(ep));
     });
 
     it("wraps errors", async () => {
       const ep = endpoint({
         taskQueueTrigger: {},
       }) as backend.Endpoint & backend.TaskQueueTriggered;
-      tasks.updateQueue.rejects(new Error("Not today"));
+      tasks.disableQueue.rejects(new Error("Not today"));
       await expect(fab.disableTaskQueue(ep)).to.eventually.be.rejectedWith(
         reporter.DeploymentError,
         "disable task queue",

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -918,12 +918,8 @@ export class Fabricator {
   }
 
   async disableTaskQueue(endpoint: backend.Endpoint & backend.TaskQueueTriggered): Promise<void> {
-    const update = {
-      name: cloudtasks.queueNameForEndpoint(endpoint),
-      state: "DISABLED" as cloudtasks.State,
-    };
     await this.executor
-      .run(() => cloudtasks.updateQueue(update))
+      .run(() => cloudtasks.disableQueue(cloudtasks.queueNameForEndpoint(endpoint)))
       .catch(rethrowAs(endpoint, "disable task queue"));
   }
 

--- a/src/gcp/cloudtasks.spec.ts
+++ b/src/gcp/cloudtasks.spec.ts
@@ -25,6 +25,7 @@ describe("CloudTasks", () => {
     ct.triggerFromQueue.restore();
     ct.setEnqueuer.restore();
     ct.upsertQueue.restore();
+    ct.disableQueue.restore();
   });
 
   afterEach(() => {
@@ -176,6 +177,38 @@ describe("CloudTasks", () => {
       expect(ct.getQueue).to.have.been.called;
       expect(ct.updateQueue).to.have.been.called;
       expect(ct.purgeQueue).to.have.been.called;
+    });
+  });
+
+  describe("disableQueue", () => {
+    const NAME = "projects/p/locations/r/queues/f";
+
+    it("issues the update only when the queue exists", async () => {
+      ct.getQueue.resolves({ name: NAME, ...cloudtasks.DEFAULT_SETTINGS });
+      ct.updateQueue.resolves({ name: NAME });
+
+      await cloudtasks.disableQueue(NAME);
+
+      // queues.patch cannot actually change `state` (it is output only); we only
+      // assert that the long-standing PATCH is still issued for an existing queue.
+      expect(ct.getQueue).to.have.been.calledWith(NAME);
+      expect(ct.updateQueue).to.have.been.calledWith({ name: NAME, state: "DISABLED" });
+    });
+
+    it("is a no-op when the queue no longer exists", async () => {
+      ct.getQueue.rejects({ context: { response: { statusCode: 404 } } });
+
+      await cloudtasks.disableQueue(NAME);
+
+      expect(ct.getQueue).to.have.been.calledWith(NAME);
+      expect(ct.updateQueue).to.not.have.been.called;
+    });
+
+    it("rethrows non-404 errors without patching", async () => {
+      ct.getQueue.rejects({ context: { response: { statusCode: 500 } } });
+
+      await expect(cloudtasks.disableQueue(NAME)).to.be.rejected;
+      expect(ct.updateQueue).to.not.have.been.called;
     });
   });
 

--- a/src/gcp/cloudtasks.spec.ts
+++ b/src/gcp/cloudtasks.spec.ts
@@ -3,6 +3,7 @@ import * as sinon from "sinon";
 
 import * as iam from "./iam";
 import * as backend from "../deploy/functions/backend";
+import { FirebaseError } from "../error";
 import * as cloudtasks from "./cloudtasks";
 import * as proto from "./proto";
 
@@ -205,9 +206,10 @@ describe("CloudTasks", () => {
     });
 
     it("rethrows non-404 errors without patching", async () => {
-      ct.getQueue.rejects({ context: { response: { statusCode: 500 } } });
+      const err = new FirebaseError("boom", { context: { response: { statusCode: 500 } } });
+      ct.getQueue.rejects(err);
 
-      await expect(cloudtasks.disableQueue(NAME)).to.be.rejected;
+      await expect(cloudtasks.disableQueue(NAME)).to.be.rejectedWith(err);
       expect(ct.updateQueue).to.not.have.been.called;
     });
   });

--- a/src/gcp/cloudtasks.ts
+++ b/src/gcp/cloudtasks.ts
@@ -125,6 +125,31 @@ export async function upsertQueue(queue: Queue): Promise<boolean> {
   }
 }
 
+/**
+ * Best-effort update issued when a task queue triggered function is deleted.
+ * Skips the call when the queue no longer exists: updateQueue issues a PATCH,
+ * which creates the queue if it is absent, so patching an already-deleted queue
+ * would recreate it -- or fail with "existed too recently" when it was just
+ * deleted out of band (issue #9305).
+ *
+ * Note: queues.patch cannot change `state` (it is output only in the Cloud Tasks
+ * API; state changes go through pause/resume or queue.yaml), so this preserves
+ * the long-standing PATCH behavior while no longer resurrecting a queue the user
+ * already removed.
+ */
+export async function disableQueue(name: string): Promise<void> {
+  try {
+    // Here and throughout we use module.exports to ensure late binding & enable stubs in unit tests.
+    await (module.exports.getQueue as typeof getQueue)(name);
+  } catch (err: any) {
+    if (err?.context?.response?.statusCode === 404) {
+      return;
+    }
+    throw err;
+  }
+  await (module.exports.updateQueue as typeof updateQueue)({ name, state: "DISABLED" });
+}
+
 /** Purges all messages in a queue with a given name. */
 export async function purgeQueue(name: string): Promise<void> {
   await client.post(`${name}:purge`);

--- a/src/gcp/cloudtasks.ts
+++ b/src/gcp/cloudtasks.ts
@@ -141,8 +141,9 @@ export async function disableQueue(name: string): Promise<void> {
   try {
     // Here and throughout we use module.exports to ensure late binding & enable stubs in unit tests.
     await (module.exports.getQueue as typeof getQueue)(name);
-  } catch (err: any) {
-    if (err?.context?.response?.statusCode === 404) {
+  } catch (err) {
+    const responseError = err as { context?: { response?: { statusCode?: number } } };
+    if (responseError.context?.response?.statusCode === 404) {
       return;
     }
     throw err;


### PR DESCRIPTION
## Fixes #9305

`firebase functions:delete` fails for a Gen 2 `onTaskDispatched` function when its Cloud Tasks queue has already been deleted out of band:

```
...queues/myTaskFunction?updateMask=name%2Cstate had HTTP Error: 400,
The queue cannot be created because a queue with this name existed too recently.
```

### Root cause

On delete, `Fabricator.disableTaskQueue` calls `cloudtasks.updateQueue`, which issues a `queues.patch`. Per the Cloud Tasks API, `queues.patch` is *create-or-update*, so patching a queue that no longer exists tries to (re)create it — failing with the 400 above when it was deleted too recently, or otherwise silently resurrecting a queue the user intentionally removed.

`upsertQueue` already guards this exact case with a `getQueue` 404 check; the disable path did not.

### Fix

Add a `getQueue` existence check before the patch (mirroring `upsertQueue`): if the queue is already gone (404) the update is skipped; any other error is rethrown.

### Note (out of scope)

`queues.patch` cannot actually change `state` (it is output only — state changes go through `pause`/`resume` or `queue.yaml`), so the pre-existing `{ state: "DISABLED" }` patch is best-effort and is preserved here unchanged. Making delete truly stop dispatch (via `queues.pause`) would also require teaching `upsertQueue` to resume/purge paused queues on redeploy, which looks like a separate change — happy to follow up if you'd prefer that direction.

### Notes

- The delete path now also requires the `cloudtasks.queues.get` permission.
- Tests cover an existing queue (patch preserved), an already-deleted queue (no-op), and non-404 errors (rethrown).
