### PR TITLE
fix(mcp): fix subprocess telemetry leakage and missing agent propagation

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -10,11 +10,16 @@ export function isFirebaseStudio() {
 
 let isFirebaseMcpFlag = false;
 export function isFirebaseMcp() {
-  return isFirebaseMcpFlag;
+  return isFirebaseMcpFlag || process.env.IS_FIREBASE_MCP === "true";
 }
 
 export function setFirebaseMcp(value: boolean) {
   isFirebaseMcpFlag = value;
+  if (value) {
+    process.env.IS_FIREBASE_MCP = "true";
+  } else {
+    delete process.env.IS_FIREBASE_MCP;
+  }
 }
 
 // Detect if the CLI was invoked by a coding agent, based on well-known env vars.

--- a/src/env.ts
+++ b/src/env.ts
@@ -27,8 +27,9 @@ export function setFirebaseMcp(value: boolean) {
 // See: https://github.com/vercel/vercel/tree/main/packages/detect-agent
 export function detectAIAgent(): string {
   // 1. Standardized standard
-  if (process.env.AI_AGENT) {
-    return process.env.AI_AGENT.trim();
+  const aiAgent = process.env.AI_AGENT?.trim();
+  if (aiAgent) {
+    return aiAgent;
   }
 
   // 2. Specific agents (ordered as requested)

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -136,6 +136,9 @@ export class FirebaseMcpServer {
       this.clientInfo = clientInfo;
       if (clientInfo?.name) {
         void this.trackGA4("mcp_client_connected");
+        if (!process.env.AI_AGENT) {
+          process.env.AI_AGENT = clientInfo.name;
+        }
       }
       if (!this.clientInfo?.name) this.clientInfo = { name: "<unknown-client>" };
 

--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -136,7 +136,7 @@ export class FirebaseMcpServer {
       this.clientInfo = clientInfo;
       if (clientInfo?.name) {
         void this.trackGA4("mcp_client_connected");
-        if (!process.env.AI_AGENT) {
+        if (!process.env.AI_AGENT?.trim()) {
           process.env.AI_AGENT = clientInfo.name;
         }
       }


### PR DESCRIPTION
### Description
This PR resolves two telemetry bugs in the Firebase MCP server that were causing data loss and misattribution in downstream analytics dashboards:
1. **Subprocess Telemetry Leakage (CLI Masking):** 
   A previous refactoring (commit `f1a14ed3c`) replaced the `IS_FIREBASE_MCP` environment variable with a local in-memory flag (`isFirebaseMcpFlag`). While this worked for in-process calls, it prevented any spawned child processes from inheriting the MCP context. Consequently, any subprocesses spawned by the CLI (or future extensions) defaulted to logging as `FirebaseCLI` and not FirebaseMCP. 
   * **Fix:** Restored environment-level propagation. When `setFirebaseMcp(true)` is called, it now sets both the local flag and `process.env.IS_FIREBASE_MCP = "true"`, ensuring child processes inherit the telemetry context.

2. **Missing Agent Name**
   Approximately 50% of all `firebase-mcp` requests have an empty `agent_name` (logged as `unknown`). This occurred because GUI clients (like Claude Desktop or Cursor) launch the MCP server in their own isolated environment where standard terminal environment variables (like `CLAUDECODE` or `AI_AGENT`) are missing. Although the MCP server detects the client name during the protocol handshake, it was never propagated to the API client.
   * **Fix:** Dynamic agent propagation. Upon successful MCP initialization, the server now extracts the client name (e.g. `'claude-desktop'`) and dynamically sets `process.env.AI_AGENT = clientInfo.name`. The API client (`apiv2.ts`) will now automatically pick this up and log the correct agent name instead of `unknown`.

---
### Scenarios Tested / Verification
I verified these changes compile cleanly and pass all unit and integration tests.
#### 1. Unit Tests
All main MCP server and tools unit tests pass successfully:
*   `lib/mcp/index.spec.js` (4/4 passing)
*   `lib/mcp/tools/index.spec.js` (8/8 passing)
#### 2. End-to-End Integration Testing
I wrote an automated integration test script to verify the telemetry headers end-to-end. The script:
1. Spawns the compiled MCP server process.
2. Sends an `initialize` JSON-RPC request specifying the client name as `"claude-desktop-test"`.
3. Sends a `tools/call` request for `firebase_list_projects` (which triggers a live API request to Google servers).
4. Inspects the generated `firebase-debug.log` file to verify the outgoing request headers.
**Result:** Both API calls successfully logged the correct `User-Agent` containing the `FirebaseMCP` platform signature and the propagated agent name
