### PR TITLE
Pin to node 24.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fixed various issues with Data Connect emulator / deploy by updating binary to version 3.4.13.
+- Temporarily pinned firebase-docker-image to Node 24.16.0 to mitigate https://github.com/nodejs/node/issues/63989.

--- a/scripts/publish/firebase-docker-image/Dockerfile
+++ b/scripts/publish/firebase-docker-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:lts-alpine AS app-env
 
 # Make sure to get the latest version of npm before doing anything else, to avoid vulnerabilities in npm's bundled dependencies.
-RUN npm install -g npm@latest
+RUN npm install -g npm@24.16.0
 
 # Install Python (for Cloud Functions) and Java (for emulators) and pre-cache emulator dependencies.
 RUN apk update && \

--- a/scripts/publish/firebase-docker-image/Dockerfile
+++ b/scripts/publish/firebase-docker-image/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:lts-alpine AS app-env
+FROM node:24.16-alpine AS app-env
 
 # Make sure to get the latest version of npm before doing anything else, to avoid vulnerabilities in npm's bundled dependencies.
-RUN npm install -g npm@24.16.0
+RUN npm install -g npm@latest
 
 # Install Python (for Cloud Functions) and Java (for emulators) and pre-cache emulator dependencies.
 RUN apk update && \


### PR DESCRIPTION
### Description
Temporarily ipnning our Docker image to node 24.16.0 to address https://github.com/nodejs/node/issues/63989. Once a new version of node releases, we'll revert this.
