### PR TITLE
Retry without keep-alive after a premature close error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Upgrade `zod` to v4 and drop the deprecated `zod-to-json-schema` dependency in favor of zod v4's built-in `z.toJSONSchema()`.
 - Updated the Firebase Data Connect local toolkit to v3.4.14, which includes the following changes:
   - Fix linter warnings in generated Kotlin SDK files.
+- Fixed an intermittent "Premature close" error during login and API requests by retrying once without keep-alive. (#10692)

--- a/src/apiv2.spec.ts
+++ b/src/apiv2.spec.ts
@@ -2,6 +2,7 @@ import { createServer, Server } from "http";
 import { expect } from "chai";
 import * as nock from "nock";
 import AbortController from "abort-controller";
+import * as FormData from "form-data";
 const proxySetup = require("proxy");
 
 import { Client, CLI_OAUTH_PROJECT_NUMBER } from "./apiv2";
@@ -106,6 +107,79 @@ describe("apiv2", () => {
         retryMaxTimeout: 15,
       });
       expect(r.status).to.equal(503);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should retry without keep-alive after a premature close error", async () => {
+      nock("https://example.com").get("/path/to/foo").once().replyWithError({
+        message:
+          "Invalid response body while trying to fetch https://example.com/path/to/foo: Premature close",
+        code: "ERR_STREAM_PREMATURE_CLOSE",
+      });
+      nock("https://example.com").get("/path/to/foo").once().reply(200, { foo: "bar" });
+
+      const c = new Client({ urlPrefix: "https://example.com" });
+      const r = await c.request({
+        method: "GET",
+        path: "/path/to/foo",
+        retries: 1,
+        retryMinTimeout: 10,
+        retryMaxTimeout: 15,
+      });
+      expect(r.body).to.deep.equal({ foo: "bar" });
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should give up if the connection keeps closing prematurely", async () => {
+      nock("https://example.com").get("/path/to/foo").twice().replyWithError({
+        message:
+          "Invalid response body while trying to fetch https://example.com/path/to/foo: Premature close",
+        code: "ERR_STREAM_PREMATURE_CLOSE",
+      });
+
+      const c = new Client({ urlPrefix: "https://example.com" });
+      const r = c.request({
+        method: "GET",
+        path: "/path/to/foo",
+        retries: 1,
+        retryMinTimeout: 10,
+        retryMaxTimeout: 15,
+      });
+      await expect(r).to.eventually.be.rejectedWith(FirebaseError, /Failed to make request/);
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should resend a multipart body when retrying after a premature close", async () => {
+      const sentBodies: string[] = [];
+      const capture = (b: unknown): boolean => {
+        sentBodies.push(typeof b === "string" ? b : JSON.stringify(b));
+        return true;
+      };
+      nock("https://example.com").post("/upload", capture).once().replyWithError({
+        message:
+          "Invalid response body while trying to fetch https://example.com/upload: Premature close",
+        code: "ERR_STREAM_PREMATURE_CLOSE",
+      });
+      nock("https://example.com").post("/upload", capture).once().reply(200, { ok: true });
+
+      const form = new FormData();
+      form.append("code", "secret-code-123");
+
+      const c = new Client({ urlPrefix: "https://example.com" });
+      const r = await c.request({
+        method: "POST",
+        path: "/upload",
+        body: form,
+        headers: form.getHeaders(),
+        retries: 1,
+        retryMinTimeout: 10,
+        retryMaxTimeout: 15,
+      });
+      expect(r.status).to.equal(200);
+      // Both the original attempt and the retry must carry the full body.
+      expect(sentBodies).to.have.length(2);
+      expect(sentBodies[0]).to.contain("secret-code-123");
+      expect(sentBodies[1]).to.contain("secret-code-123");
       expect(nock.isDone()).to.be.true;
     });
 

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -5,6 +5,8 @@ import { ProxyAgent } from "proxy-agent";
 import * as retry from "retry";
 import AbortController from "abort-controller";
 import fetch, { HeadersInit, Response, RequestInit, Headers } from "node-fetch";
+import * as http from "http";
+import * as https from "https";
 import util from "util";
 
 import * as auth from "./auth";
@@ -155,6 +157,39 @@ function proxyURIFromEnv(): string | undefined {
     process.env.http_proxy ||
     undefined
   );
+}
+
+// Some networks (and recent Node.js security releases) interact badly with
+// node-fetch's keep-alive handling: a reused/closed keep-alive socket surfaces
+// as an "Invalid response body ...: Premature close" error while the response
+// body is being read, even though the response is otherwise valid. Retrying the
+// request once without keep-alive (Connection: close) reliably works around it.
+// See https://github.com/firebase/firebase-tools/issues/10692 and
+// https://github.com/node-fetch/node-fetch/issues/1767.
+const httpAgentNoKeepAlive = new http.Agent({ keepAlive: false });
+const httpsAgentNoKeepAlive = new https.Agent({ keepAlive: false });
+function noKeepAliveAgent(parsedURL: URL): http.Agent | https.Agent {
+  return parsedURL.protocol === "https:" ? httpsAgentNoKeepAlive : httpAgentNoKeepAlive;
+}
+
+function isPrematureCloseError(err: unknown): boolean {
+  for (const candidate of [err, (err as { original?: unknown } | undefined)?.original]) {
+    if (!candidate) {
+      continue;
+    }
+    const e = candidate as { code?: string; errno?: string; message?: string };
+    const code = e.code || e.errno;
+    const message = typeof e.message === "string" ? e.message : "";
+    if (
+      code === "ERR_STREAM_PREMATURE_CLOSE" ||
+      code === "ECONNRESET" ||
+      /premature close/i.test(message) ||
+      /socket hang up/i.test(message)
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export type ClientOptions = {
@@ -408,8 +443,18 @@ export class Client {
       fetchOptions.signal = signal;
     }
 
-    if (typeof options.body === "string" || isStream(options.body)) {
+    // A request can only be safely retried if its body can be sent again.
+    // FormData is a single-use stream, so serialize it to a Buffer up front (the
+    // CLI only sends small string forms this way, e.g. the OAuth token request).
+    // Raw streams cannot be replayed and therefore disable the keep-alive retry.
+    let bodyReplayable = true;
+    if (typeof options.body === "string" || Buffer.isBuffer(options.body)) {
       fetchOptions.body = options.body;
+    } else if (options.body instanceof FormData) {
+      fetchOptions.body = options.body.getBuffer();
+    } else if (isStream(options.body)) {
+      fetchOptions.body = options.body;
+      bodyReplayable = false;
     } else if (options.body !== undefined) {
       fetchOptions.body = JSON.stringify(options.body);
     }
@@ -430,6 +475,10 @@ export class Client {
       operationOptions.maxTimeout = options.retryMaxTimeout;
     }
     const operation = retry.operation(operationOptions);
+
+    // Tracks whether we've already downgraded this request to a non-keep-alive
+    // connection in response to a "Premature close" error (retried at most once).
+    let disabledKeepAlive = false;
 
     return await new Promise<ClientResponse<ResT>>((resolve, reject) => {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -490,6 +539,27 @@ export class Client {
             });
           }
         } catch (err: unknown) {
+          // Work around a node-fetch/Node.js keep-alive bug that surfaces as a
+          // "Premature close" error: retry the request once without keep-alive.
+          if (
+            !disabledKeepAlive &&
+            bodyReplayable &&
+            !proxyURIFromEnv() &&
+            isPrematureCloseError(err)
+          ) {
+            disabledKeepAlive = true;
+            fetchOptions.agent = noKeepAliveAgent;
+            // Use a fresh Headers instance so we don't mutate the shared options.
+            const closeHeaders = new Headers(fetchOptions.headers);
+            closeHeaders.set("Connection", "close");
+            fetchOptions.headers = closeHeaders;
+            logger.debug(
+              `*** [apiv2] retrying ${fetchURL} without keep-alive after a premature close error`,
+            );
+            if (operation.retry(err instanceof Error ? err : new Error(`${err}`))) {
+              return;
+            }
+          }
           return err instanceof FirebaseError ? reject(err) : reject(new FirebaseError(`${err}`));
         }
 


### PR DESCRIPTION
### Description

`firebase login` and other authenticated API calls can fail while exchanging the OAuth code:

```
Token Fetch Error: FetchError: Invalid response body while trying to fetch https://accounts.google.com/o/oauth2/token: Premature close
Authentication Error: Your credentials are no longer valid. Please run firebase login --reauth
Error: Unable to authenticate using the provided code. Please try again.
```

#### Root cause

`apiv2` sends `Connection: keep-alive` and uses Node's global HTTP agent, which defaults to `keepAlive: true` since Node 19. On some networks, and especially on recent Node.js releases that changed keep-alive socket reuse timing (nodejs/node#63989), node-fetch throws a `Premature close` error while reading the response body even though the response is complete. This is a known node-fetch bug in its chunked-response handling when an HTTP agent is involved (node-fetch/node-fetch#1767).

I narrowed it down with a few probes against `https://accounts.google.com/o/oauth2/token`:

- a plain `https` POST and a global `fetch` (undici) POST both return the response (HTTP 401 for a dummy body)
- node-fetch with the default keep-alive agent fails with `Premature close` every time
- node-fetch with `new https.Agent({ keepAlive: false })` works every time

So the cause is not the user's clock, account, Node major version, TLS interception, or a proxy.

#### Fix

If a request fails with a premature close (or `ECONNRESET`) error, `apiv2` retries it once with keep-alive turned off (`Connection: close` and a non-keep-alive agent). Only requests whose body can be sent again are retried: multipart `FormData` bodies, such as the OAuth token request, are serialized to a Buffer up front so the retry can replay them, and raw streams are left untouched. The normal path keeps using keep-alive, so flows like `deploy` are unaffected, and the fallback only runs on that error and only when no proxy is configured.

Fixes #10692. Also reported in #10681.

### Scenarios Tested

- New unit tests in `src/apiv2.spec.ts`:
  - a request that fails once with a `Premature close` error is retried without keep-alive and succeeds
  - a request that keeps closing prematurely is retried once and then rejects (no infinite retry)
  - a multipart body is resent in full on the retry (the OAuth login case)
- `npm run test:compile`, `npm run lint:ts`, `prettier --check`, and `mocha src/apiv2.spec.ts` (40 passing) pass locally
- Verified on Windows 10 / Node v24.17.0 / firebase-tools 15.22.1: `firebase login` and `firebase projects:list` failed consistently with `Premature close` before this change and work after it

### Sample Commands

No command or flag changes. The fix lives in the HTTP client and applies to every `apiv2` request, for example:

```
firebase login
firebase projects:list
```