### PR TITLE
Add warning logs for Local Builds + ABIU if using the wrong versions of nodejs

### DIFF
--- a/src/apphosting/localbuilds.spec.ts
+++ b/src/apphosting/localbuilds.spec.ts
@@ -453,7 +453,7 @@ describe("localBuild", () => {
       expect(logWarningStub).to.have.been.calledOnceWith(
         "apphosting",
         sinon.match(
-          "Local Node.js version (v24.10.0) does not match your backend's target ABIU runtime",
+          "Local Node.js version (v24.10.0) does not match your backend's target Node.js version",
         ),
       );
     });

--- a/src/apphosting/localbuilds.spec.ts
+++ b/src/apphosting/localbuilds.spec.ts
@@ -336,7 +336,7 @@ describe("localBuild", () => {
       } as any;
 
       expect(() => validateLocalBuildNodeVersion(backend, "./")).to.throw(
-        "Local builds are only supported for backends with ABIU"
+        "Local builds are only supported for backends with ABIU",
       );
     });
 
@@ -350,7 +350,7 @@ describe("localBuild", () => {
 
       expect(logWarningStub).to.have.been.calledWith(
         "apphosting",
-        sinon.match("Unable to extract Node.js major version from the backend runtime")
+        sinon.match("Unable to extract Node.js major version from the backend runtime"),
       );
       expect(execSyncStub).to.not.have.been.called;
     });
@@ -370,7 +370,7 @@ describe("localBuild", () => {
 
       expect(logWarningStub).to.have.been.calledOnceWith(
         "apphosting",
-        sinon.match("local builds do NOT use the \"engines\" field")
+        sinon.match('local builds do NOT use the "engines" field'),
       );
     });
 
@@ -390,8 +390,53 @@ describe("localBuild", () => {
       expect(logWarningStub).to.have.been.calledTwice;
       expect(logWarningStub.secondCall).to.have.been.calledWith(
         "apphosting",
-        sinon.match("does not satisfy your backend's target ABIU runtime version")
+        sinon.match("does not satisfy your backend's target ABIU runtime version"),
       );
+    });
+
+    it("does not warn on minor/patch constraints in engines if target major is satisfied", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs22" },
+      } as any;
+
+      execSyncStub.returns("v22.15.0");
+      readJsonStub.returns({
+        engines: { node: "^22.15.0" },
+      });
+
+      validateLocalBuildNodeVersion(backend, "./");
+
+      // Should only log the informational "engines not used for local build execution" warning
+      expect(logWarningStub).to.have.been.calledOnce;
+      expect(logWarningStub.firstCall).to.have.been.calledWith(
+        "apphosting",
+        sinon.match('local builds do NOT use the "engines" field'),
+      );
+    });
+
+    it("handles complex logical OR engines ranges correctly", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs22" },
+      } as any;
+
+      execSyncStub.returns("v22.15.0");
+
+      // Case 1: Overlapping OR range (18 || 22) - Should NOT warn
+      readJsonStub.returns({
+        engines: { node: "18 || 22" },
+      });
+      validateLocalBuildNodeVersion(backend, "./");
+      expect(logWarningStub).to.have.been.calledOnce; // Only informational warning
+      logWarningStub.resetHistory();
+
+      // Case 2: Non-overlapping OR range (18 || 20) - Should warn!
+      readJsonStub.returns({
+        engines: { node: "18 || 20" },
+      });
+      validateLocalBuildNodeVersion(backend, "./");
+      expect(logWarningStub).to.have.been.calledTwice; // Informational + mismatch warning
     });
 
     it("warns if local host Node version doesn't match the target version", () => {
@@ -407,7 +452,9 @@ describe("localBuild", () => {
 
       expect(logWarningStub).to.have.been.calledOnceWith(
         "apphosting",
-        sinon.match("Local Node.js version (v24.10.0) does not match your backend's target ABIU runtime")
+        sinon.match(
+          "Local Node.js version (v24.10.0) does not match your backend's target ABIU runtime",
+        ),
       );
     });
 
@@ -438,7 +485,7 @@ describe("localBuild", () => {
 
       expect(logWarningStub).to.have.been.calledOnceWith(
         "apphosting",
-        sinon.match("Unable to detect your local Node.js version")
+        sinon.match("Unable to detect your local Node.js version"),
       );
     });
   });

--- a/src/apphosting/localbuilds.spec.ts
+++ b/src/apphosting/localbuilds.spec.ts
@@ -1,9 +1,10 @@
 import * as sinon from "sinon";
 import { expect } from "chai";
-import { localBuild, runUniversalMaker } from "./localbuilds";
+import { localBuild, runUniversalMaker, validateLocalBuildNodeVersion } from "./localbuilds";
 import * as secrets from "./secrets/index";
 import { EnvMap } from "./yaml";
 import * as childProcess from "child_process";
+import * as utils from "../utils";
 
 import * as universalMakerDownload from "./universalMakerDownload";
 import * as fsExtra from "fs-extra";
@@ -310,6 +311,135 @@ describe("localBuild", () => {
         "Failed to execute the Universal Maker binary at /path/to/universal_maker due to permission constraints. Please assure you have set execution permissions (e.g., chmod +x) on the file.",
       );
       sinon.assert.calledOnce(downloadStub);
+    });
+  });
+
+  describe("validateLocalBuildNodeVersion", () => {
+    let logWarningStub: sinon.SinonStub;
+    let execSyncStub: sinon.SinonStub;
+    let readJsonStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      logWarningStub = sinon.stub(utils, "logLabeledWarning");
+      execSyncStub = sinon.stub(childProcess, "execSync");
+      readJsonStub = sinon.stub(fsExtra, "readJsonSync");
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("throws error if ABIU is disabled", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs" },
+      } as any;
+
+      expect(() => validateLocalBuildNodeVersion(backend, "./")).to.throw(
+        "Local builds are only supported for backends with ABIU"
+      );
+    });
+
+    it("logs warning and exits early if runtime version is not extractable", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "invalid-runtime-string" },
+      } as any;
+
+      validateLocalBuildNodeVersion(backend, "./");
+
+      expect(logWarningStub).to.have.been.calledWith(
+        "apphosting",
+        sinon.match("Unable to extract Node.js major version from the backend runtime")
+      );
+      expect(execSyncStub).to.not.have.been.called;
+    });
+
+    it("warns about package.json engines not being used for local build execution", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs22" },
+      } as any;
+
+      execSyncStub.returns("v22.15.0");
+      readJsonStub.returns({
+        engines: { node: "22" },
+      });
+
+      validateLocalBuildNodeVersion(backend, "./");
+
+      expect(logWarningStub).to.have.been.calledOnceWith(
+        "apphosting",
+        sinon.match("local builds do NOT use the \"engines\" field")
+      );
+    });
+
+    it("warns if package.json engines range does not satisfy the target version", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs22" },
+      } as any;
+
+      execSyncStub.returns("v22.15.0");
+      readJsonStub.returns({
+        engines: { node: "20" },
+      });
+
+      validateLocalBuildNodeVersion(backend, "./");
+
+      expect(logWarningStub).to.have.been.calledTwice;
+      expect(logWarningStub.secondCall).to.have.been.calledWith(
+        "apphosting",
+        sinon.match("does not satisfy your backend's target ABIU runtime version")
+      );
+    });
+
+    it("warns if local host Node version doesn't match the target version", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs22" },
+      } as any;
+
+      execSyncStub.returns("v24.10.0");
+      readJsonStub.returns({});
+
+      validateLocalBuildNodeVersion(backend, "./");
+
+      expect(logWarningStub).to.have.been.calledOnceWith(
+        "apphosting",
+        sinon.match("Local Node.js version (v24.10.0) does not match your backend's target ABIU runtime")
+      );
+    });
+
+    it("does not log warnings when all versions are aligned", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs22" },
+      } as any;
+
+      execSyncStub.returns("v22.15.0");
+      readJsonStub.returns({});
+
+      validateLocalBuildNodeVersion(backend, "./");
+
+      expect(logWarningStub).to.not.have.been.called;
+    });
+
+    it("warns if local Node.js version detection fails (e.g. node not in PATH)", () => {
+      const backend = {
+        name: "projects/my-project/locations/us-central1/backends/foo",
+        runtime: { value: "nodejs22" },
+      } as any;
+
+      execSyncStub.throws(new Error("command not found"));
+      readJsonStub.returns({});
+
+      validateLocalBuildNodeVersion(backend, "./");
+
+      expect(logWarningStub).to.have.been.calledOnceWith(
+        "apphosting",
+        sinon.match("Unable to detect your local Node.js version")
+      );
     });
   });
 });

--- a/src/apphosting/localbuilds.ts
+++ b/src/apphosting/localbuilds.ts
@@ -331,8 +331,8 @@ export function validateLocalBuildNodeVersion(backend: Backend, projectRoot: str
         `and your deployed app will run on the backend's configured ABIU runtime (${runtimeValue}).`,
     );
 
-    const targetVersion = `${targetMajor}.0.0`;
-    if (!semver.satisfies(targetVersion, enginesNode)) {
+    const targetRange = `^${targetMajor}.0.0`;
+    if (!semver.intersects(targetRange, enginesNode)) {
       logLabeledWarning(
         "apphosting",
         `The Node.js version range specified in your package.json engines ("${enginesNode}") ` +

--- a/src/apphosting/localbuilds.ts
+++ b/src/apphosting/localbuilds.ts
@@ -332,7 +332,7 @@ export function validateLocalBuildNodeVersion(backend: Backend, projectRoot: str
     );
 
     const targetRange = `^${targetMajor}.0.0`;
-    if (!semver.intersects(targetRange, enginesNode)) {
+    if (semver.validRange(enginesNode) && !semver.intersects(targetRange, enginesNode)) {
       logLabeledWarning(
         "apphosting",
         `The Node.js version range specified in your package.json engines ("${enginesNode}") ` +

--- a/src/apphosting/localbuilds.ts
+++ b/src/apphosting/localbuilds.ts
@@ -1,14 +1,15 @@
 import * as childProcess from "child_process";
 import * as fs from "fs-extra";
 import * as path from "path";
-import { Availability, BuildConfig, Env } from "../gcp/apphosting";
+import * as semver from "semver";
+import { Availability, Backend, BuildConfig, Env } from "../gcp/apphosting";
 
 import { EnvMap } from "./yaml";
 import { loadSecret } from "./secrets/index";
 import { confirm } from "../prompt";
 import { FirebaseError, getErrMsg } from "../error";
 import { logger } from "../logger";
-import { wrappedSafeLoad } from "../utils";
+import { wrappedSafeLoad, logLabeledWarning } from "../utils";
 import { getOrDownloadUniversalMaker } from "./universalMakerDownload";
 
 interface UniversalMakerOutput {
@@ -265,4 +266,93 @@ async function toProcessEnv(projectId: string, env: EnvMap): Promise<NodeJS.Proc
   );
 
   return Object.fromEntries(resolvedEntries) as NodeJS.ProcessEnv;
+}
+
+/**
+ * Validates that the local Node.js environment and project configuration are
+ * compatible with the target backend's ABIU runtime settings.
+ *
+ * This performs three checks:
+ * 1. Confirms the backend has ABIU enabled (local builds are only supported on ABIU runtimes).
+ * 2. Warns if the host machine's Node.js major version differs from the target ABIU major version.
+ * 3. Warns if the package.json engines.node range does not satisfy the target ABIU version.
+ */
+export function validateLocalBuildNodeVersion(backend: Backend, projectRoot: string): void {
+  const runtimeValue = backend.runtime?.value ?? "";
+  const isLegacyRuntime = runtimeValue === "" || runtimeValue === "nodejs";
+  const abiuEnabled = !isLegacyRuntime && !backend.automaticBaseImageUpdatesDisabled;
+
+  // 1. Block non-ABIU runtimes
+  if (!abiuEnabled) {
+    throw new FirebaseError(
+      `Local builds are only supported for backends with ABIU (Automatic Base Image Updates) enabled. ` +
+        `Your backend is currently configured with a non-ABIU runtime ("${runtimeValue || "unspecified"}"). ` +
+        `Please update your backend to a versioned runtime (e.g., nodejs22) to enable local builds.`,
+      { exit: 1 },
+    );
+  }
+
+  const targetMajorMatch = runtimeValue.match(/^nodejs(\d+)$/);
+  if (!targetMajorMatch) {
+    logLabeledWarning(
+      "apphosting",
+      `Unable to extract Node.js major version from the backend runtime ("${runtimeValue}"). ` +
+        `Skipping local Node.js version compatibility checks.`,
+    );
+    return;
+  }
+
+  const targetMajor = parseInt(targetMajorMatch[1], 10);
+
+  // Get the local Node.js version that will be used to build the app
+  let localNodeVersion: string;
+  try {
+    localNodeVersion = childProcess.execSync("node -v", { encoding: "utf8" }).trim();
+  } catch {
+    logLabeledWarning(
+      "apphosting",
+      `Unable to detect your local Node.js version (is 'node' installed and in your PATH?). ` +
+        `Skipping local Node.js version compatibility checks.`,
+    );
+    return;
+  }
+
+  // Check package.json engines
+  const packageJsonPath = path.join(projectRoot, "package.json");
+  const packageJson = fs.readJsonSync(packageJsonPath, { throws: false });
+  const enginesNode = packageJson?.engines?.node;
+
+  if (enginesNode) {
+    logLabeledWarning(
+      "apphosting",
+      `Your package.json specifies Node.js engine "${enginesNode}". ` +
+        `Please note that local builds do NOT use the "engines" field to resolve or download Node.js. ` +
+        `Instead, your local build uses your host machine's active Node.js version (${localNodeVersion}) to compile the app, ` +
+        `and your deployed app will run on the backend's configured ABIU runtime (${runtimeValue}).`,
+    );
+
+    const targetVersion = `${targetMajor}.0.0`;
+    if (!semver.satisfies(targetVersion, enginesNode)) {
+      logLabeledWarning(
+        "apphosting",
+        `The Node.js version range specified in your package.json engines ("${enginesNode}") ` +
+          `does not satisfy your backend's target ABIU runtime version (Node.js ${targetMajor}). ` +
+          `Please update your package.json engines to align with your backend configuration.`,
+      );
+    }
+  }
+
+  // 2. Check local vs target ABIU runtime version
+  const localMajorMatch = localNodeVersion.match(/^v?(\d+)/);
+  const localMajor = localMajorMatch ? parseInt(localMajorMatch[1], 10) : null;
+
+  if (localMajor !== null && localMajor !== targetMajor) {
+    logLabeledWarning(
+      "apphosting",
+      `Local Node.js version (${localNodeVersion}) does not match your backend's target ABIU runtime major version (Node.js ${targetMajor}). ` +
+        `Because local builds compile code using your host's Node.js version, this mismatch can cause native modules ` +
+        `to be compiled for the wrong version, leading to silent startup crashes in production (running on Node.js ${targetMajor}). ` +
+        `Please switch your local environment to Node.js ${targetMajor} to ensure build-to-run parity.`,
+    );
+  }
 }

--- a/src/apphosting/localbuilds.ts
+++ b/src/apphosting/localbuilds.ts
@@ -349,9 +349,8 @@ export function validateLocalBuildNodeVersion(backend: Backend, projectRoot: str
   if (localMajor !== null && localMajor !== targetMajor) {
     logLabeledWarning(
       "apphosting",
-      `Local Node.js version (${localNodeVersion}) does not match your backend's target ABIU runtime major version (Node.js ${targetMajor}). ` +
-        `Because local builds compile code using your host's Node.js version, this mismatch can cause native modules ` +
-        `to be compiled for the wrong version, leading to silent startup crashes in production (running on Node.js ${targetMajor}). ` +
+      `Local Node.js version (${localNodeVersion}) does not match your backend's target Node.js version (Node.js ${targetMajor}). ` +
+        `This mismatch may cause runtime issues. ` +
         `Please switch your local environment to Node.js ${targetMajor} to ensure build-to-run parity.`,
     );
   }

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -641,6 +641,59 @@ describe("apphosting", () => {
 
       expect(assertEnabledStub).to.not.have.been.calledWith("apphostinglocalbuilds");
     });
+
+    it("dynamically fetches the backend from the API if it is not found in the pre-fetched list (e.g., newly created)", async () => {
+      const optsWithLocalBuild = {
+        ...opts,
+        config: new Config({
+          apphosting: {
+            backendId: "newly-created-backend",
+            rootDir: "/",
+            ignore: [],
+            localBuild: true,
+          },
+        }),
+      };
+      const context = initializeContext();
+
+      const buildConfig = {
+        runCommand: "npm run build:prod",
+        env: [],
+      };
+      sinon.stub(localbuilds, "localBuild").resolves({
+        outputFiles: ["./next/standalone"],
+        buildConfig,
+      });
+
+      listBackendsStub.onFirstCall().resolves({
+        backends: [],
+      });
+
+      doSetupSourceDeployStub.resolves({ location: "us-central1" });
+      confirmStub.resolves(true);
+      checkboxStub.resolves(["newly-created-backend"]);
+
+      const getBackendStub = sinon.stub(apphosting, "getBackend").resolves({
+        name: "projects/my-project/locations/us-central1/backends/newly-created-backend",
+        runtime: { value: "nodejs22" },
+      } as any);
+
+      await prepare(context, optsWithLocalBuild);
+
+      expect(getBackendStub).to.have.been.calledOnceWith(
+        "my-project",
+        "us-central1",
+        "newly-created-backend",
+      );
+      expect(context.backendLocalBuilds["newly-created-backend"]).to.deep.equal({
+        outputFiles: ["./next/standalone"],
+        localBuildScratchDir: path.join(
+          os.tmpdir(),
+          `apphosting-local-build-newly-created-backend-${expectedPathHash}`,
+        ),
+        buildConfig,
+      });
+    });
   });
 
   describe("getBackendConfigs", () => {

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -139,6 +139,7 @@ describe("apphosting", () => {
         backends: [
           {
             name: "projects/my-project/locations/us-central1/backends/foo",
+            runtime: { value: "nodejs22" },
           },
         ],
       });
@@ -240,8 +241,14 @@ describe("apphosting", () => {
 
       listBackendsStub.onFirstCall().resolves({
         backends: [
-          { name: "projects/my-project/locations/us-central1/backends/backend-prod" },
-          { name: "projects/my-project/locations/us-central1/backends/backend-staging" },
+          {
+            name: "projects/my-project/locations/us-central1/backends/backend-prod",
+            runtime: { value: "nodejs22" },
+          },
+          {
+            name: "projects/my-project/locations/us-central1/backends/backend-staging",
+            runtime: { value: "nodejs22" },
+          },
         ],
       });
 
@@ -298,6 +305,7 @@ describe("apphosting", () => {
           {
             name: "projects/my-project/locations/us-central1/backends/foo",
             appId: "my-app-id",
+            runtime: { value: "nodejs22" },
           },
         ],
       });
@@ -357,6 +365,7 @@ describe("apphosting", () => {
         backends: [
           {
             name: "projects/my-project/locations/us-central1/backends/foo",
+            runtime: { value: "nodejs22" },
           },
         ],
       });
@@ -432,6 +441,7 @@ describe("apphosting", () => {
         backends: [
           {
             name: "projects/my-project/locations/us-central1/backends/foo",
+            runtime: { value: "nodejs22" },
           },
         ],
       });
@@ -466,6 +476,7 @@ describe("apphosting", () => {
         backends: [
           {
             name: "projects/my-project/locations/us-central1/backends/foo",
+            runtime: { value: "nodejs22" },
           },
         ],
       });

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -28,7 +28,7 @@ import { needProjectId } from "../../projectUtils";
 import { getProjectNumber } from "../../getProjectNumber";
 import { checkbox, confirm } from "../../prompt";
 import { logLabeledBullet, logLabeledWarning } from "../../utils";
-import { localBuild } from "../../apphosting/localbuilds";
+import { localBuild, validateLocalBuildNodeVersion } from "../../apphosting/localbuilds";
 import { Context } from "./args";
 import { FirebaseError } from "../../error";
 import * as managementApps from "../../management/apps";
@@ -187,6 +187,17 @@ export default async function (context: Context, options: Options): Promise<void
       continue;
     }
     experiments.assertEnabled("apphostinglocalbuilds", "locally build App Hosting backends");
+
+    const backend = backends.find((b) => parseBackendName(b.name).id === cfg.backendId);
+    if (!backend) {
+      throw new FirebaseError(`Backend ${cfg.backendId} not found.`);
+    }
+
+    const rootDir = path.resolve(options.projectRoot || process.cwd());
+    const appDir = path.join(rootDir, cfg.rootDir || "");
+
+    validateLocalBuildNodeVersion(backend, appDir);
+
     logLabeledBullet("apphosting", `Starting local build for backend ${cfg.backendId}`);
 
     await injectEnvVarsFromApphostingConfig(
@@ -196,8 +207,6 @@ export default async function (context: Context, options: Options): Promise<void
       runtimeEnv,
     );
     await injectAutoInitEnvVars(cfg, backends, buildEnv, runtimeEnv);
-
-    const rootDir = path.resolve(options.projectRoot || process.cwd());
     // Generate a static 8-character hash of the Workspace Root directory path to guarantee
     // 100% sibling folder build isolation on the same machine, while preserving predictability.
     const pathHash = crypto.createHash("md5").update(rootDir).digest("hex").substring(0, 8);

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -188,7 +188,18 @@ export default async function (context: Context, options: Options): Promise<void
     }
     experiments.assertEnabled("apphostinglocalbuilds", "locally build App Hosting backends");
 
-    const backend = backends.find((b) => parseBackendName(b.name).id === cfg.backendId);
+    let backend = backends.find((b) => parseBackendName(b.name).id === cfg.backendId);
+    if (!backend) {
+      const location = context.backendLocations[cfg.backendId];
+      if (location) {
+        const apphosting = await import("../../gcp/apphosting");
+        try {
+          backend = await apphosting.getBackend(projectId, location, cfg.backendId);
+        } catch {
+          // Fall through to error handling below
+        }
+      }
+    }
     if (!backend) {
       throw new FirebaseError(`Backend ${cfg.backendId} not found.`);
     }


### PR DESCRIPTION

<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Universal Maker will use the user's own nodejs version installed locally to build the app. It does NOT use package.json#engines nor backend.runtime (the ABIU setting.)

However, for the runtime nodejs version, we DO respect the ABIU setting. That means you can build an app locally with nodejs 22 and then deploy it, using nodejs24 during runtime. In fact, I tested this and it worked. 

This PR adds warning logs to detect if you are using inconsistent nodejs versions. For the most part, we just log warnings so that you are aware if this doesnt work, but we don't block users (unless ABIU is not enabled at all.)

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
