### PR TITLE
fix: support exporting and importing mfaInfo in auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixes `auth:export` and `auth:import` dropping `mfaInfo` data for users with Multi-Factor Authentication enabled.
 - Upgrade `zod` to v4 and drop the deprecated `zod-to-json-schema` dependency in favor of zod v4's built-in `z.toJSONSchema()`.
 - Updated the Firebase Data Connect local toolkit to v3.4.14, which includes the following changes:
   - Fix linter warnings in generated Kotlin SDK files.

--- a/src/accountExporter.spec.ts
+++ b/src/accountExporter.spec.ts
@@ -35,6 +35,7 @@ describe("accountExporter", () => {
       displayName: string;
       disabled: boolean;
       customAttributes?: string;
+      mfaInfo?: any[];
       providerUserInfo?: {
         providerId: string;
         rawId: string;
@@ -288,6 +289,38 @@ describe("accountExporter", () => {
       userList[0].customAttributes =
         '{ "customBoolean": true, "customString": "test", "customInt": 99 }';
       userList[1].customAttributes = '{ "customBoolean": true }';
+      nock("https://www.googleapis.com")
+        .post("/identitytoolkit/v3/relyingparty/downloadAccount", {
+          maxResults: 3,
+          targetProjectId: "test-project-id",
+        })
+        .reply(200, {
+          users: userList.slice(0, 3),
+        });
+      await serialExportUsers("test-project-id", {
+        format: "JSON",
+        batchSize: 3,
+        writeStream: writeStream,
+      });
+      expect(spyWrite.getCall(0).args[0]).to.eq(JSON.stringify(userList[0], null, 2));
+      expect(spyWrite.getCall(1).args[0]).to.eq(
+        "," + os.EOL + JSON.stringify(userList[1], null, 2),
+      );
+      expect(spyWrite.getCall(2).args[0]).to.eq(
+        "," + os.EOL + JSON.stringify(userList[2], null, 2),
+      );
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should export a user's mfaInfo for JSON formats", async () => {
+      userList[0].mfaInfo = [
+        {
+          mfaEnrollmentId: "enrollment-id-1",
+          displayName: "My SMS MFA",
+          phoneInfo: "+11111111111",
+          enrolledAt: "2026-06-24T00:00:00Z",
+        },
+      ];
       nock("https://www.googleapis.com")
         .post("/identitytoolkit/v3/relyingparty/downloadAccount", {
           maxResults: 3,

--- a/src/accountExporter.spec.ts
+++ b/src/accountExporter.spec.ts
@@ -39,7 +39,12 @@ describe("accountExporter", () => {
       displayName: string;
       disabled: boolean;
       customAttributes?: string;
-      mfaInfo?: unknown[];
+      mfaInfo?: {
+        mfaEnrollmentId: string;
+        displayName?: string;
+        phoneInfo?: string;
+        enrolledAt?: string;
+      }[];
       providerUserInfo?: {
         providerId: string;
         rawId: string;

--- a/src/accountExporter.ts
+++ b/src/accountExporter.ts
@@ -11,7 +11,6 @@ const apiClient = new Client({
   urlPrefix: googleOrigin(),
 });
 
-// TODO: support for MFA at runtime was added in PR #3173, but this exporter currently ignores `mfaInfo` and loses the data on export.
 const EXPORTED_JSON_KEYS = [
   "localId",
   "email",
@@ -25,6 +24,7 @@ const EXPORTED_JSON_KEYS = [
   "phoneNumber",
   "disabled",
   "customAttributes",
+  "mfaInfo",
 ];
 const EXPORTED_JSON_KEYS_RENAMING: Record<string, string> = {
   lastLoginAt: "lastSignedInAt",

--- a/src/accountImporter.spec.ts
+++ b/src/accountImporter.spec.ts
@@ -148,6 +148,23 @@ describe("accountImporter", () => {
         }),
       ).to.not.have.property("error");
     });
+
+    it("should not reject when mfaInfo is present in user json", () => {
+      expect(
+        validateUserJson({
+          localId: "123",
+          email: "test@test.org",
+          mfaInfo: [
+            {
+              mfaEnrollmentId: "enrollment-id-1",
+              displayName: "My SMS MFA",
+              phoneInfo: "+11111111111",
+              enrolledAt: "2026-06-24T00:00:00Z",
+            },
+          ],
+        }),
+      ).to.not.have.property("error");
+    });
   });
 
   describe("serialImportUsers", () => {

--- a/src/accountImporter.ts
+++ b/src/accountImporter.ts
@@ -10,7 +10,6 @@ const apiClient = new Client({
   urlPrefix: googleOrigin(),
 });
 
-// TODO: support for MFA at runtime was added in PR #3173, but this importer currently ignores `mfaInfo` and loses the data on import.
 const ALLOWED_JSON_KEYS = [
   "localId",
   "email",
@@ -25,6 +24,7 @@ const ALLOWED_JSON_KEYS = [
   "phoneNumber",
   "disabled",
   "customAttributes",
+  "mfaInfo",
 ];
 const ALLOWED_JSON_KEYS_RENAMING = {
   lastSignedInAt: "lastLoginAt",


### PR DESCRIPTION
Fixes auth:export and auth:import silently discarding MFA user data (mfaInfo) by explicitly including the 'mfaInfo' key in the allowed JSON extraction and validation fields.

### Scenarios Tested

- JSON auth export correctly contains `mfaInfo` array (verified with unit tests).
- JSON auth import successfully parses and validates `mfaInfo` (verified with unit tests).

### Sample Commands

firebase auth:export accounts.json --format=json
firebase auth:import accounts.json --hash-algo=scrypt --hash-key=xxx --salt-separator=xxx --rounds=8 --mem-cost=14

Fixes #10704
