### PR TITLE
inject default Angular SSR environment variables for local builds

### DIFF
--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -822,20 +822,20 @@ describe("apphosting", () => {
       readFileSyncStub = sinon.stub(fs, "readFileSync");
     });
 
-    it("should do nothing for non-Angular applications", () => {
+    it("should do nothing for non-Angular applications", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = { foo: {} };
 
       existsStub.returns(false);
 
-      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
 
       expect(buildEnv["foo"]).to.be.empty;
       expect(runtimeEnv["foo"]).to.be.empty;
     });
 
-    it("should inject defaults for Angular applications when headers are missing", () => {
+    it("should inject defaults for Angular applications when headers are missing", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = { foo: {} };
@@ -849,19 +849,19 @@ describe("apphosting", () => {
         }),
       );
 
-      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
 
       expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
         value: "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for",
         availability: ["RUNTIME"],
       });
       expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
-        value: "*.hosted.app,*.run.app,*.firestack.app,localhost",
+        value: "foo-123456789.us-central1.run.app,foo--my-project.us-central1.hosted.app,foo--my-project.web.app,foo--my-project.firebaseapp.com",
         availability: ["RUNTIME"],
       });
     });
 
-    it("should accept valid NG_TRUST_PROXY_HEADERS overrides", () => {
+    it("should accept valid NG_TRUST_PROXY_HEADERS overrides", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
@@ -880,14 +880,14 @@ describe("apphosting", () => {
         }),
       );
 
-      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
 
       expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]?.value).to.equal(
         "X-Forwarded-Host,X-Forwarded-Proto",
       );
     });
 
-    it("should throw an error for invalid NG_TRUST_PROXY_HEADERS values", () => {
+    it("should throw an error for invalid NG_TRUST_PROXY_HEADERS values", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
@@ -906,12 +906,12 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() => {
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
-      }).to.throw(FirebaseError, "invalid value for NG_TRUST_PROXY_HEADERS");
+      await expect(
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+      ).to.be.rejectedWith(FirebaseError, "invalid value for NG_TRUST_PROXY_HEADERS");
     });
 
-    it("should throw an error if NG_TRUST_PROXY_HEADERS explicitly omits RUNTIME availability", () => {
+    it("should throw an error if NG_TRUST_PROXY_HEADERS explicitly omits RUNTIME availability", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
@@ -930,12 +930,12 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() => {
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
-      }).to.throw(FirebaseError, "must include RUNTIME in its availability");
+      await expect(
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+      ).to.be.rejectedWith(FirebaseError, "must include RUNTIME in its availability");
     });
 
-    it("should throw an error if NG_ALLOWED_HOSTS explicitly omits RUNTIME availability", () => {
+    it("should throw an error if NG_ALLOWED_HOSTS explicitly omits RUNTIME availability", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
@@ -954,15 +954,15 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() => {
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
-      }).to.throw(
+      await expect(
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+      ).to.be.rejectedWith(
         FirebaseError,
         "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
       );
     });
 
-    it("should throw an error if NG_ALLOWED_HOSTS omits availability entirely (replicating the Go preparer slices.Contains(nil) quirk)", () => {
+    it("should throw an error if NG_ALLOWED_HOSTS omits availability entirely (replicating the Go preparer slices.Contains(nil) quirk)", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
@@ -981,15 +981,15 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() => {
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
-      }).to.throw(
+      await expect(
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+      ).to.be.rejectedWith(
         FirebaseError,
         "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
       );
     });
 
-    it("should pass if NG_ALLOWED_HOSTS has explicit RUNTIME availability", () => {
+    it("should pass if NG_ALLOWED_HOSTS has explicit RUNTIME availability", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
@@ -1008,7 +1008,7 @@ describe("apphosting", () => {
         }),
       );
 
-      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
 
       expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]?.value).to.equal("my.domain.com");
     });

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -852,7 +852,7 @@ describe("apphosting", () => {
       injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
 
       expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
-        value: "X-Forwarded-Host,X-Forwarded-Port,X-Forwarded-Proto,X-Forwarded-For",
+        value: "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for",
         availability: ["RUNTIME"],
       });
       expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
@@ -906,9 +906,9 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() =>
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
-      ).to.throw(FirebaseError, "invalid value for NG_TRUST_PROXY_HEADERS");
+      expect(() => {
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      }).to.throw(FirebaseError, "invalid value for NG_TRUST_PROXY_HEADERS");
     });
 
     it("should throw an error if NG_TRUST_PROXY_HEADERS explicitly omits RUNTIME availability", () => {
@@ -930,9 +930,9 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() =>
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
-      ).to.throw(FirebaseError, "must include RUNTIME in its availability");
+      expect(() => {
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      }).to.throw(FirebaseError, "must include RUNTIME in its availability");
     });
 
     it("should throw an error if NG_ALLOWED_HOSTS explicitly omits RUNTIME availability", () => {
@@ -954,9 +954,12 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() =>
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
-      ).to.throw(FirebaseError, "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability");
+      expect(() => {
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      }).to.throw(
+        FirebaseError,
+        "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
+      );
     });
 
     it("should throw an error if NG_ALLOWED_HOSTS omits availability entirely (replicating the Go preparer slices.Contains(nil) quirk)", () => {
@@ -978,9 +981,12 @@ describe("apphosting", () => {
         }),
       );
 
-      expect(() =>
-        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
-      ).to.throw(FirebaseError, "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability");
+      expect(() => {
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+      }).to.throw(
+        FirebaseError,
+        "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
+      );
     });
 
     it("should pass if NG_ALLOWED_HOSTS has explicit RUNTIME availability", () => {

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -829,7 +829,14 @@ describe("apphosting", () => {
 
       existsStub.returns(false);
 
-      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(
+        cfg,
+        "/app-dir",
+        "my-project",
+        "us-central1",
+        buildEnv,
+        runtimeEnv,
+      );
 
       expect(buildEnv["foo"]).to.be.empty;
       expect(runtimeEnv["foo"]).to.be.empty;
@@ -849,14 +856,22 @@ describe("apphosting", () => {
         }),
       );
 
-      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(
+        cfg,
+        "/app-dir",
+        "my-project",
+        "us-central1",
+        buildEnv,
+        runtimeEnv,
+      );
 
       expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
         value: "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for",
         availability: ["RUNTIME"],
       });
       expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
-        value: "foo-123456789.us-central1.run.app,foo--my-project.us-central1.hosted.app,foo--my-project.web.app,foo--my-project.firebaseapp.com",
+        value:
+          "foo-123456789.us-central1.run.app,foo--my-project.us-central1.hosted.app,foo--my-project.web.app,foo--my-project.firebaseapp.com",
         availability: ["RUNTIME"],
       });
     });
@@ -880,7 +895,14 @@ describe("apphosting", () => {
         }),
       );
 
-      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(
+        cfg,
+        "/app-dir",
+        "my-project",
+        "us-central1",
+        buildEnv,
+        runtimeEnv,
+      );
 
       expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]?.value).to.equal(
         "X-Forwarded-Host,X-Forwarded-Proto",
@@ -907,7 +929,7 @@ describe("apphosting", () => {
       );
 
       await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
       ).to.be.rejectedWith(FirebaseError, "invalid value for NG_TRUST_PROXY_HEADERS");
     });
 
@@ -931,7 +953,7 @@ describe("apphosting", () => {
       );
 
       await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
       ).to.be.rejectedWith(FirebaseError, "must include RUNTIME in its availability");
     });
 
@@ -955,7 +977,7 @@ describe("apphosting", () => {
       );
 
       await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
       ).to.be.rejectedWith(
         FirebaseError,
         "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
@@ -982,7 +1004,7 @@ describe("apphosting", () => {
       );
 
       await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv)
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
       ).to.be.rejectedWith(
         FirebaseError,
         "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
@@ -1008,7 +1030,14 @@ describe("apphosting", () => {
         }),
       );
 
-      await injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv);
+      await injectAngularEnvVars(
+        cfg,
+        "/app-dir",
+        "my-project",
+        "us-central1",
+        buildEnv,
+        runtimeEnv,
+      );
 
       expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]?.value).to.equal("my.domain.com");
     });

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -678,7 +678,7 @@ describe("apphosting", () => {
       const getBackendStub = sinon.stub(apphosting, "getBackend").resolves({
         name: "projects/my-project/locations/us-central1/backends/newly-created-backend",
         runtime: { value: "nodejs22" },
-      } as any);
+      } as unknown as apphosting.Backend);
 
       await prepare(context, optsWithLocalBuild);
 

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -30,6 +30,7 @@ import { Options } from "../../options";
 import { AppHostingSingle } from "../../firebaseConfig";
 import * as fs from "fs";
 import * as fsAsync from "../../fsAsync";
+import * as utils from "../../utils";
 
 const BASE_OPTS = {
   cwd: "/",
@@ -876,13 +877,95 @@ describe("apphosting", () => {
       });
     });
 
-    it("should accept valid NG_TRUST_PROXY_HEADERS overrides", async () => {
+    it("should override user-defined NG_TRUST_PROXY_HEADERS and log a warning if defined as RUNTIME variable", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
         foo: {
           NG_TRUST_PROXY_HEADERS: {
-            value: "X-Forwarded-Host,X-Forwarded-Proto",
+            value: "x-forwarded-host,x-forwarded-proto",
+            availability: ["RUNTIME"],
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      const warningSpy = sinon.spy(utils, "logLabeledWarning");
+
+      await injectAngularEnvVars(
+        cfg,
+        "/app-dir",
+        "my-project",
+        "us-central1",
+        buildEnv,
+        runtimeEnv,
+      );
+
+      expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
+        value: "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for",
+        availability: ["RUNTIME"],
+      });
+      expect(buildEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.be.undefined;
+      expect(warningSpy).to.have.been.calledWith(
+        "apphosting",
+        sinon.match("Overriding user-defined RUNTIME environment variable NG_TRUST_PROXY_HEADERS"),
+      );
+    });
+
+    it("should override user-defined NG_TRUST_PROXY_HEADERS but NOT log a warning if defined as BUILD-only variable", async () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_TRUST_PROXY_HEADERS: {
+            value: "x-forwarded-host,x-forwarded-proto",
+            availability: ["BUILD"],
+          },
+        },
+      };
+      const runtimeEnv: Record<string, EnvMap> = { foo: {} };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      const warningSpy = sinon.spy(utils, "logLabeledWarning");
+
+      await injectAngularEnvVars(
+        cfg,
+        "/app-dir",
+        "my-project",
+        "us-central1",
+        buildEnv,
+        runtimeEnv,
+      );
+
+      expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
+        value: "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for",
+        availability: ["RUNTIME"],
+      });
+      expect(buildEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
+        value: "x-forwarded-host,x-forwarded-proto",
+        availability: ["BUILD"],
+      });
+      expect(warningSpy).to.not.have.been.called;
+    });
+
+    it("should merge user-defined RUNTIME NG_ALLOWED_HOSTS with default hosts, deduplicating case-insensitively, preserving the first casing, and leaving buildEnv untouched", async () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_ALLOWED_HOSTS: {
+            value: "MY-CUSTOM-DOMAIN.COM,foo-123456789.us-central1.run.app,Another-Domain.com,my-custom-domain.com,MY-CUSTOM-DOMAIN.COM",
             availability: ["RUNTIME"],
           },
         },
@@ -904,124 +987,25 @@ describe("apphosting", () => {
         runtimeEnv,
       );
 
-      expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]?.value).to.equal(
-        "X-Forwarded-Host,X-Forwarded-Proto",
-      );
+      expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
+        value:
+          "foo-123456789.us-central1.run.app,foo--my-project.us-central1.hosted.app,foo--my-project.web.app,foo--my-project.firebaseapp.com,MY-CUSTOM-DOMAIN.COM,Another-Domain.com",
+        availability: ["RUNTIME"],
+      });
+      expect(buildEnv["foo"]["NG_ALLOWED_HOSTS"]).to.be.undefined;
     });
 
-    it("should throw an error for invalid NG_TRUST_PROXY_HEADERS values", async () => {
+    it("should NOT merge user-defined BUILD-only NG_ALLOWED_HOSTS with default hosts, and should leave buildEnv untouched", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
-      const buildEnv: Record<string, EnvMap> = { foo: {} };
-      const runtimeEnv: Record<string, EnvMap> = {
+      const buildEnv: Record<string, EnvMap> = {
         foo: {
-          NG_TRUST_PROXY_HEADERS: {
-            value: "X-Forwarded-Host,X-Invalid-Header",
-            availability: ["RUNTIME"],
-          },
-        },
-      };
-
-      existsStub.withArgs(sinon.match("package.json")).returns(true);
-      readFileSyncStub.returns(
-        JSON.stringify({
-          dependencies: { "@angular/core": "^19.0.0" },
-        }),
-      );
-
-      await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
-      ).to.be.rejectedWith(FirebaseError, "invalid value for NG_TRUST_PROXY_HEADERS");
-    });
-
-    it("should throw an error if NG_TRUST_PROXY_HEADERS explicitly omits RUNTIME availability", async () => {
-      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
-      const buildEnv: Record<string, EnvMap> = { foo: {} };
-      const runtimeEnv: Record<string, EnvMap> = {
-        foo: {
-          NG_TRUST_PROXY_HEADERS: {
-            value: "X-Forwarded-Host",
+          NG_ALLOWED_HOSTS: {
+            value: "MY-CUSTOM-DOMAIN.COM,foo-123456789.us-central1.run.app,Another-Domain.com",
             availability: ["BUILD"],
           },
         },
       };
-
-      existsStub.withArgs(sinon.match("package.json")).returns(true);
-      readFileSyncStub.returns(
-        JSON.stringify({
-          dependencies: { "@angular/core": "^19.0.0" },
-        }),
-      );
-
-      await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
-      ).to.be.rejectedWith(FirebaseError, "must include RUNTIME in its availability");
-    });
-
-    it("should throw an error if NG_ALLOWED_HOSTS explicitly omits RUNTIME availability", async () => {
-      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
-      const buildEnv: Record<string, EnvMap> = { foo: {} };
-      const runtimeEnv: Record<string, EnvMap> = {
-        foo: {
-          NG_ALLOWED_HOSTS: {
-            value: "my.domain.com",
-            availability: ["BUILD"],
-          },
-        },
-      };
-
-      existsStub.withArgs(sinon.match("package.json")).returns(true);
-      readFileSyncStub.returns(
-        JSON.stringify({
-          dependencies: { "@angular/core": "^19.0.0" },
-        }),
-      );
-
-      await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
-      ).to.be.rejectedWith(
-        FirebaseError,
-        "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
-      );
-    });
-
-    it("should throw an error if NG_ALLOWED_HOSTS omits availability entirely (replicating the Go preparer slices.Contains(nil) quirk)", async () => {
-      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
-      const buildEnv: Record<string, EnvMap> = { foo: {} };
-      const runtimeEnv: Record<string, EnvMap> = {
-        foo: {
-          NG_ALLOWED_HOSTS: {
-            value: "my.domain.com",
-            // availability is completely omitted (undefined)
-          },
-        },
-      };
-
-      existsStub.withArgs(sinon.match("package.json")).returns(true);
-      readFileSyncStub.returns(
-        JSON.stringify({
-          dependencies: { "@angular/core": "^19.0.0" },
-        }),
-      );
-
-      await expect(
-        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
-      ).to.be.rejectedWith(
-        FirebaseError,
-        "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability",
-      );
-    });
-
-    it("should pass if NG_ALLOWED_HOSTS has explicit RUNTIME availability", async () => {
-      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
-      const buildEnv: Record<string, EnvMap> = { foo: {} };
-      const runtimeEnv: Record<string, EnvMap> = {
-        foo: {
-          NG_ALLOWED_HOSTS: {
-            value: "my.domain.com",
-            availability: ["RUNTIME"],
-          },
-        },
-      };
+      const runtimeEnv: Record<string, EnvMap> = { foo: {} };
 
       existsStub.withArgs(sinon.match("package.json")).returns(true);
       readFileSyncStub.returns(
@@ -1039,7 +1023,15 @@ describe("apphosting", () => {
         runtimeEnv,
       );
 
-      expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]?.value).to.equal("my.domain.com");
+      expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
+        value:
+          "foo-123456789.us-central1.run.app,foo--my-project.us-central1.hosted.app,foo--my-project.web.app,foo--my-project.firebaseapp.com",
+        availability: ["RUNTIME"],
+      });
+      expect(buildEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
+        value: "MY-CUSTOM-DOMAIN.COM,foo-123456789.us-central1.run.app,Another-Domain.com",
+        availability: ["BUILD"],
+      });
     });
   });
 });

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -965,7 +965,8 @@ describe("apphosting", () => {
       const runtimeEnv: Record<string, EnvMap> = {
         foo: {
           NG_ALLOWED_HOSTS: {
-            value: "MY-CUSTOM-DOMAIN.COM,foo-123456789.us-central1.run.app,Another-Domain.com,my-custom-domain.com,MY-CUSTOM-DOMAIN.COM",
+            value:
+              "MY-CUSTOM-DOMAIN.COM,foo-123456789.us-central1.run.app,Another-Domain.com,my-custom-domain.com,MY-CUSTOM-DOMAIN.COM",
             availability: ["RUNTIME"],
           },
         },

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -877,7 +877,7 @@ describe("apphosting", () => {
       });
     });
 
-    it("should override user-defined NG_TRUST_PROXY_HEADERS and log a warning if defined as RUNTIME variable", async () => {
+    it("should NOT override user-defined NG_TRUST_PROXY_HEADERS if it is a subset of allowed values", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
@@ -908,13 +908,36 @@ describe("apphosting", () => {
       );
 
       expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
-        value: "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for",
+        value: "x-forwarded-host,x-forwarded-proto",
         availability: ["RUNTIME"],
       });
-      expect(buildEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.be.undefined;
-      expect(warningSpy).to.have.been.calledWith(
-        "apphosting",
-        sinon.match("Overriding user-defined RUNTIME environment variable NG_TRUST_PROXY_HEADERS"),
+      expect(warningSpy).to.not.have.been.called;
+    });
+
+    it("should throw a FirebaseError if user-defined NG_TRUST_PROXY_HEADERS contains invalid headers", async () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_TRUST_PROXY_HEADERS: {
+            value: "x-forwarded-host,invalid-header",
+            availability: ["RUNTIME"],
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      await expect(
+        injectAngularEnvVars(cfg, "/app-dir", "my-project", "us-central1", buildEnv, runtimeEnv),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /User-defined RUNTIME environment variable NG_TRUST_PROXY_HEADERS contains invalid headers/,
       );
     });
 
@@ -959,14 +982,13 @@ describe("apphosting", () => {
       expect(warningSpy).to.not.have.been.called;
     });
 
-    it("should merge user-defined RUNTIME NG_ALLOWED_HOSTS with default hosts, deduplicating case-insensitively, preserving the first casing, and leaving buildEnv untouched", async () => {
+    it("should NOT inject default NG_ALLOWED_HOSTS if user has defined it as RUNTIME variable", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = { foo: {} };
       const runtimeEnv: Record<string, EnvMap> = {
         foo: {
           NG_ALLOWED_HOSTS: {
-            value:
-              "MY-CUSTOM-DOMAIN.COM,foo-123456789.us-central1.run.app,Another-Domain.com,my-custom-domain.com,MY-CUSTOM-DOMAIN.COM",
+            value: "MY-CUSTOM-DOMAIN.COM",
             availability: ["RUNTIME"],
           },
         },
@@ -989,14 +1011,13 @@ describe("apphosting", () => {
       );
 
       expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
-        value:
-          "foo-123456789.us-central1.run.app,foo--my-project.us-central1.hosted.app,foo--my-project.web.app,foo--my-project.firebaseapp.com,MY-CUSTOM-DOMAIN.COM,Another-Domain.com",
+        value: "MY-CUSTOM-DOMAIN.COM",
         availability: ["RUNTIME"],
       });
       expect(buildEnv["foo"]["NG_ALLOWED_HOSTS"]).to.be.undefined;
     });
 
-    it("should NOT merge user-defined BUILD-only NG_ALLOWED_HOSTS with default hosts, and should leave buildEnv untouched", async () => {
+    it("should inject default NG_ALLOWED_HOSTS into runtimeEnv if user defined it as a BUILD-only variable", async () => {
       const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
       const buildEnv: Record<string, EnvMap> = {
         foo: {

--- a/src/deploy/apphosting/prepare.spec.ts
+++ b/src/deploy/apphosting/prepare.spec.ts
@@ -16,6 +16,7 @@ import prepare, {
   getBackendConfigs,
   injectEnvVarsFromApphostingConfig,
   injectAutoInitEnvVars,
+  injectAngularEnvVars,
 } from "./prepare";
 import * as localbuilds from "../../apphosting/localbuilds";
 import * as managementApps from "../../management/apps";
@@ -809,6 +810,201 @@ describe("apphosting", () => {
 
       expect(runtimeEnv["foo"]["USER_VAR_1"]?.value).to.equal("user_defined_value");
       expect(runtimeEnv["foo"]["AUTO_VAR_1"]?.value).to.equal("auto1");
+    });
+  });
+
+  describe("injectAngularEnvVars", () => {
+    let existsStub: sinon.SinonStub;
+    let readFileSyncStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      existsStub = fs.existsSync as sinon.SinonStub;
+      readFileSyncStub = sinon.stub(fs, "readFileSync");
+    });
+
+    it("should do nothing for non-Angular applications", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = { foo: {} };
+
+      existsStub.returns(false);
+
+      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+
+      expect(buildEnv["foo"]).to.be.empty;
+      expect(runtimeEnv["foo"]).to.be.empty;
+    });
+
+    it("should inject defaults for Angular applications when headers are missing", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = { foo: {} };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.withArgs(sinon.match("package.json")).returns(
+        JSON.stringify({
+          dependencies: {
+            "@angular/core": "^19.0.0",
+          },
+        }),
+      );
+
+      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+
+      expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]).to.deep.equal({
+        value: "X-Forwarded-Host,X-Forwarded-Port,X-Forwarded-Proto,X-Forwarded-For",
+        availability: ["RUNTIME"],
+      });
+      expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]).to.deep.equal({
+        value: "*.hosted.app,*.run.app,*.firestack.app,localhost",
+        availability: ["RUNTIME"],
+      });
+    });
+
+    it("should accept valid NG_TRUST_PROXY_HEADERS overrides", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_TRUST_PROXY_HEADERS: {
+            value: "X-Forwarded-Host,X-Forwarded-Proto",
+            availability: ["RUNTIME"],
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+
+      expect(runtimeEnv["foo"]["NG_TRUST_PROXY_HEADERS"]?.value).to.equal(
+        "X-Forwarded-Host,X-Forwarded-Proto",
+      );
+    });
+
+    it("should throw an error for invalid NG_TRUST_PROXY_HEADERS values", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_TRUST_PROXY_HEADERS: {
+            value: "X-Forwarded-Host,X-Invalid-Header",
+            availability: ["RUNTIME"],
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      expect(() =>
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
+      ).to.throw(FirebaseError, "invalid value for NG_TRUST_PROXY_HEADERS");
+    });
+
+    it("should throw an error if NG_TRUST_PROXY_HEADERS explicitly omits RUNTIME availability", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_TRUST_PROXY_HEADERS: {
+            value: "X-Forwarded-Host",
+            availability: ["BUILD"],
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      expect(() =>
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
+      ).to.throw(FirebaseError, "must include RUNTIME in its availability");
+    });
+
+    it("should throw an error if NG_ALLOWED_HOSTS explicitly omits RUNTIME availability", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_ALLOWED_HOSTS: {
+            value: "my.domain.com",
+            availability: ["BUILD"],
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      expect(() =>
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
+      ).to.throw(FirebaseError, "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability");
+    });
+
+    it("should throw an error if NG_ALLOWED_HOSTS omits availability entirely (replicating the Go preparer slices.Contains(nil) quirk)", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_ALLOWED_HOSTS: {
+            value: "my.domain.com",
+            // availability is completely omitted (undefined)
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      expect(() =>
+        injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv),
+      ).to.throw(FirebaseError, "NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability");
+    });
+
+    it("should pass if NG_ALLOWED_HOSTS has explicit RUNTIME availability", () => {
+      const cfg: AppHostingSingle = { backendId: "foo", rootDir: "/", ignore: [] };
+      const buildEnv: Record<string, EnvMap> = { foo: {} };
+      const runtimeEnv: Record<string, EnvMap> = {
+        foo: {
+          NG_ALLOWED_HOSTS: {
+            value: "my.domain.com",
+            availability: ["RUNTIME"],
+          },
+        },
+      };
+
+      existsStub.withArgs(sinon.match("package.json")).returns(true);
+      readFileSyncStub.returns(
+        JSON.stringify({
+          dependencies: { "@angular/core": "^19.0.0" },
+        }),
+      );
+
+      injectAngularEnvVars(cfg, "/app-dir", buildEnv, runtimeEnv);
+
+      expect(runtimeEnv["foo"]["NG_ALLOWED_HOSTS"]?.value).to.equal("my.domain.com");
     });
   });
 });

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -428,16 +428,29 @@ async function prepareLocalBuildScratchDirectory(
 /**
  * Checks if the application in a directory is an Angular application.
  */
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+}
+
+/**
+ * Returns true if the directory contains an Angular application.
+ */
 function isAngularApplication(appDir: string): boolean {
   const packageJsonPath = path.join(appDir, "package.json");
   if (fs.existsSync(packageJsonPath)) {
     try {
-      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
-      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-      if (deps["@angular/core"] || deps["@angular/ssr"] || deps["@angular/platform-server"]) {
-        return true;
+      const parsed: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      if (parsed && typeof parsed === "object") {
+        const pkg = parsed as PackageJson;
+        const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+        if (deps["@angular/core"] || deps["@angular/ssr"] || deps["@angular/platform-server"]) {
+          return true;
+        }
       }
-    } catch {}
+    } catch (e) {
+      // Ignore JSON parsing or read errors
+    }
   }
   const angularJsonPath = path.join(appDir, "angular.json");
   if (fs.existsSync(angularJsonPath)) {
@@ -465,7 +478,8 @@ export function injectAngularEnvVars(
   buildEnv[backendId] ??= {};
 
   const ngTrustProxyHeaders = "NG_TRUST_PROXY_HEADERS";
-  const allowedProxyHeadersValue = "X-Forwarded-Host,X-Forwarded-Port,X-Forwarded-Proto,X-Forwarded-For";
+  const allowedProxyHeadersValue =
+    "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for";
   const allowedProxyHeaders = new Set([
     "x-forwarded-host",
     "x-forwarded-port",
@@ -474,7 +488,8 @@ export function injectAngularEnvVars(
   ]);
 
   // 1. Validate or Inject NG_TRUST_PROXY_HEADERS
-  const userTrustProxy = runtimeEnv[backendId][ngTrustProxyHeaders];
+  const userTrustProxy =
+    runtimeEnv[backendId][ngTrustProxyHeaders] || buildEnv[backendId][ngTrustProxyHeaders];
   if (userTrustProxy) {
     const userVal = userTrustProxy.value || "";
     // Validate the value of the user provided NG_TRUST_PROXY_HEADERS
@@ -505,11 +520,8 @@ export function injectAngularEnvVars(
   }
 
   // 2. Validate or Inject NG_ALLOWED_HOSTS
-  // Replicate the Go buildpack preparer's validateAngularEnv behavior exactly:
-  // If the user explicitly defined NG_ALLOWED_HOSTS in their configuration (either BUILD or RUNTIME),
-  // they MUST have explicitly set its availability to include "RUNTIME". If availability was omitted (undefined),
-  // the Go preparer fails the build because slices.Contains(nil, "RUNTIME") evaluates to false!
-  const userAllowedHosts = runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] || buildEnv[backendId]["NG_ALLOWED_HOSTS"];
+  const userAllowedHosts =
+    runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] || buildEnv[backendId]["NG_ALLOWED_HOSTS"];
   if (userAllowedHosts) {
     if (!userAllowedHosts.availability || !userAllowedHosts.availability.includes("RUNTIME")) {
       throw new FirebaseError(

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -27,7 +27,7 @@ import { Options } from "../../options";
 import { needProjectId } from "../../projectUtils";
 import { getProjectNumber } from "../../getProjectNumber";
 import { checkbox, confirm } from "../../prompt";
-import { logLabeledBullet, logLabeledWarning } from "../../utils";
+import { logLabeledBullet, logLabeledWarning, logLabeledError } from "../../utils";
 import { localBuild } from "../../apphosting/localbuilds";
 import { Context } from "./args";
 import { FirebaseError } from "../../error";
@@ -444,15 +444,15 @@ function isAngularApplication(appDir: string): boolean {
       const parsed: unknown = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
       if (parsed && typeof parsed === "object") {
         const pkg = parsed as PackageJson;
-        const deps = { ...pkg.dependencies, ...pkg.devDependencies };
-        if (deps["@angular/core"] || deps["@angular/ssr"] || deps["@angular/platform-server"]) {
+        const angularDeps = ["@angular/core", "@angular/ssr", "@angular/platform-server"];
+        if (angularDeps.some((d) => pkg.dependencies?.[d] || pkg.devDependencies?.[d])) {
           return true;
         }
       }
     } catch (e: unknown) {
-      logLabeledWarning(
+      logLabeledError(
         "apphosting",
-        `Failed to parse package.json in ${appDir}: ${e instanceof Error ? e.message : String(e)}`,
+        `error when checking if application is angular: ${e instanceof Error ? e.message : String(e)}`,
       );
     }
   }
@@ -487,52 +487,59 @@ export async function injectAngularEnvVars(
   runtimeEnv[backendId] ??= {};
   buildEnv[backendId] ??= {};
 
-  const allowedProxyHeadersValue =
-    "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for";
+  const allowedProxyHeaders = [
+    "x-forwarded-host",
+    "x-forwarded-port",
+    "x-forwarded-proto",
+    "x-forwarded-for",
+  ];
+  const allowedProxyHeadersValue = allowedProxyHeaders.join(",");
 
   // 1. Inject NG_TRUST_PROXY_HEADERS
-  // If they have defined RUNTIME env vars for the proxy header though we will log a warning that we're overriding it.
+  let shouldInjectProxyHeaders = true;
   if (runtimeEnv[backendId]["NG_TRUST_PROXY_HEADERS"]) {
-    logLabeledWarning(
-      "apphosting",
-      `Overriding user-defined RUNTIME environment variable NG_TRUST_PROXY_HEADERS with default value: ${allowedProxyHeadersValue}`,
-    );
+    const userProxyHeadersStr = runtimeEnv[backendId]["NG_TRUST_PROXY_HEADERS"].value;
+    const userProxyHeaders = userProxyHeadersStr
+      ? userProxyHeadersStr
+          .split(",")
+          .map((h) => h.trim().toLowerCase())
+          .filter(Boolean)
+      : [];
+
+    const isSubset =
+      userProxyHeaders.length > 0 && userProxyHeaders.every((h) => allowedProxyHeaders.includes(h));
+
+    if (isSubset) {
+      shouldInjectProxyHeaders = false;
+    } else {
+      throw new FirebaseError(
+        `User-defined RUNTIME environment variable NG_TRUST_PROXY_HEADERS contains invalid headers. Allowed values: ${allowedProxyHeadersValue}`,
+      );
+    }
   }
 
-  runtimeEnv[backendId]["NG_TRUST_PROXY_HEADERS"] = {
-    value: allowedProxyHeadersValue,
-    availability: ["RUNTIME"],
-  };
+  if (shouldInjectProxyHeaders) {
+    runtimeEnv[backendId]["NG_TRUST_PROXY_HEADERS"] = {
+      value: allowedProxyHeadersValue,
+      availability: ["RUNTIME"],
+    };
+  }
 
-  // 2. Inject/Merge NG_ALLOWED_HOSTS
-  const projectNumber = await getProjectNumber({ project: projectId });
-  const sharedDomain = "hosted.app";
-  const defaultHosts = [
-    `${backendId}-${projectNumber}.${location}.run.app`,
-    `${backendId}--${projectId}.${location}.${sharedDomain}`,
-    `${backendId}--${projectId}.web.app`,
-    `${backendId}--${projectId}.firebaseapp.com`,
-  ];
+  // 2. Inject NG_ALLOWED_HOSTS
+  if (!runtimeEnv[backendId]["NG_ALLOWED_HOSTS"]) {
+    const projectNumber = await getProjectNumber({ project: projectId });
+    const sharedDomain = "hosted.app";
+    // TODO: This is missing the custom domains retrieved dynamically by the control plane during Cloud Build creation.
+    const defaultHosts = [
+      `${backendId}-${projectNumber}.${location}.run.app`,
+      `${backendId}--${projectId}.${location}.${sharedDomain}`,
+      `${backendId}--${projectId}.web.app`,
+      `${backendId}--${projectId}.firebaseapp.com`,
+    ];
 
-  const defaultHostsLower = new Set(defaultHosts.map((h) => h.toLowerCase()));
-  const userAllowedHosts = runtimeEnv[backendId]["NG_ALLOWED_HOSTS"];
-  const userHosts =
-    userAllowedHosts?.value
-      ?.split(",")
-      .map((h) => h.trim())
-      .filter(Boolean) || [];
-
-  const additionalHosts = userHosts.filter((h) => {
-    const lower = h.toLowerCase();
-    if (defaultHostsLower.has(lower)) return false;
-    defaultHostsLower.add(lower);
-    return true;
-  });
-
-  const allowedHostsValue = [...defaultHosts, ...additionalHosts].join(",");
-
-  runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] = {
-    value: allowedHostsValue,
-    availability: ["RUNTIME"],
-  };
+    runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] = {
+      value: defaultHosts.join(","),
+      availability: ["RUNTIME"],
+    };
+  }
 }

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -448,8 +448,11 @@ function isAngularApplication(appDir: string): boolean {
           return true;
         }
       }
-    } catch (e) {
-      // Ignore JSON parsing or read errors
+    } catch (e: unknown) {
+      logLabeledWarning(
+        "apphosting",
+        `Failed to parse package.json in ${appDir}: ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
   const angularJsonPath = path.join(appDir, "angular.json");

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -490,70 +490,50 @@ export async function injectAngularEnvVars(
   const ngTrustProxyHeaders = "NG_TRUST_PROXY_HEADERS";
   const allowedProxyHeadersValue =
     "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for";
-  const allowedProxyHeaders = new Set([
-    "x-forwarded-host",
-    "x-forwarded-port",
-    "x-forwarded-proto",
-    "x-forwarded-for",
-  ]);
 
-  // 1. Validate or Inject NG_TRUST_PROXY_HEADERS
-  const userTrustProxy =
-    runtimeEnv[backendId][ngTrustProxyHeaders] || buildEnv[backendId][ngTrustProxyHeaders];
-  if (userTrustProxy) {
-    const userVal = userTrustProxy.value || "";
-    // Validate the value of the user provided NG_TRUST_PROXY_HEADERS
-    const userList = userVal.split(",");
-    for (const h of userList) {
-      const trimmed = h.trim().toLowerCase();
-      if (trimmed !== "" && !allowedProxyHeaders.has(trimmed)) {
-        throw new FirebaseError(
-          `invalid value for ${ngTrustProxyHeaders} (Angular trust proxy headers): got ${JSON.stringify(userVal)}, must be a subset of ${JSON.stringify(allowedProxyHeadersValue)}`,
-        );
-      }
-    }
-
-    if (userTrustProxy.availability && !userTrustProxy.availability.includes("RUNTIME")) {
-      throw new FirebaseError(
-        `user-defined environment variable ${ngTrustProxyHeaders} must include RUNTIME in its availability`,
-      );
-    }
-  } else {
-    logLabeledBullet(
+  // 1. Inject NG_TRUST_PROXY_HEADERS
+  // If they have defined RUNTIME env vars for the proxy header though we will log a warning that we're overriding it.
+  if (runtimeEnv[backendId][ngTrustProxyHeaders]) {
+    logLabeledWarning(
       "apphosting",
-      `Angular SSR application detected. Injecting default ${ngTrustProxyHeaders}=${allowedProxyHeadersValue}`,
+      `Overriding user-defined RUNTIME environment variable ${ngTrustProxyHeaders} with default value: ${allowedProxyHeadersValue}`,
     );
-    runtimeEnv[backendId][ngTrustProxyHeaders] = {
-      value: allowedProxyHeadersValue,
-      availability: ["RUNTIME"],
-    };
   }
 
-  // 2. Validate or Inject NG_ALLOWED_HOSTS
-  const userAllowedHosts =
-    runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] || buildEnv[backendId]["NG_ALLOWED_HOSTS"];
-  if (userAllowedHosts) {
-    if (!userAllowedHosts.availability || !userAllowedHosts.availability.includes("RUNTIME")) {
-      throw new FirebaseError(
-        `NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability`,
-      );
-    }
-  } else {
-    const projectNumber = await getProjectNumber({ project: projectId });
-    const sharedDomain = "hosted.app";
-    const allowedHostsValue = [
-      `${backendId}-${projectNumber}.${location}.run.app`,
-      `${backendId}--${projectId}.${location}.${sharedDomain}`,
-      `${backendId}--${projectId}.web.app`,
-      `${backendId}--${projectId}.firebaseapp.com`,
-    ].join(",");
-    logLabeledBullet(
-      "apphosting",
-      `Angular SSR application detected. Injecting default NG_ALLOWED_HOSTS=${allowedHostsValue}`,
-    );
-    runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] = {
-      value: allowedHostsValue,
-      availability: ["RUNTIME"],
-    };
-  }
+  runtimeEnv[backendId][ngTrustProxyHeaders] = {
+    value: allowedProxyHeadersValue,
+    availability: ["RUNTIME"],
+  };
+
+  // 2. Inject/Merge NG_ALLOWED_HOSTS
+  const projectNumber = await getProjectNumber({ project: projectId });
+  const sharedDomain = "hosted.app";
+  const defaultHosts = [
+    `${backendId}-${projectNumber}.${location}.run.app`,
+    `${backendId}--${projectId}.${location}.${sharedDomain}`,
+    `${backendId}--${projectId}.web.app`,
+    `${backendId}--${projectId}.firebaseapp.com`,
+  ];
+
+  const defaultHostsLower = new Set(defaultHosts.map((h) => h.toLowerCase()));
+  const userAllowedHosts = runtimeEnv[backendId]["NG_ALLOWED_HOSTS"];
+  const userHosts =
+    userAllowedHosts?.value
+      ?.split(",")
+      .map((h) => h.trim())
+      .filter(Boolean) || [];
+
+  const additionalHosts = userHosts.filter((h) => {
+    const lower = h.toLowerCase();
+    if (defaultHostsLower.has(lower)) return false;
+    defaultHostsLower.add(lower);
+    return true;
+  });
+
+  const allowedHostsValue = [...defaultHosts, ...additionalHosts].join(",");
+
+  runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] = {
+    value: allowedHostsValue,
+    availability: ["RUNTIME"],
+  };
 }

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -487,20 +487,19 @@ export async function injectAngularEnvVars(
   runtimeEnv[backendId] ??= {};
   buildEnv[backendId] ??= {};
 
-  const ngTrustProxyHeaders = "NG_TRUST_PROXY_HEADERS";
   const allowedProxyHeadersValue =
     "x-forwarded-host,x-forwarded-port,x-forwarded-proto,x-forwarded-for";
 
   // 1. Inject NG_TRUST_PROXY_HEADERS
   // If they have defined RUNTIME env vars for the proxy header though we will log a warning that we're overriding it.
-  if (runtimeEnv[backendId][ngTrustProxyHeaders]) {
+  if (runtimeEnv[backendId]["NG_TRUST_PROXY_HEADERS"]) {
     logLabeledWarning(
       "apphosting",
-      `Overriding user-defined RUNTIME environment variable ${ngTrustProxyHeaders} with default value: ${allowedProxyHeadersValue}`,
+      `Overriding user-defined RUNTIME environment variable NG_TRUST_PROXY_HEADERS with default value: ${allowedProxyHeadersValue}`,
     );
   }
 
-  runtimeEnv[backendId][ngTrustProxyHeaders] = {
+  runtimeEnv[backendId]["NG_TRUST_PROXY_HEADERS"] = {
     value: allowedProxyHeadersValue,
     availability: ["RUNTIME"],
   };

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -199,9 +199,6 @@ export default async function (context: Context, options: Options): Promise<void
 
     const rootDir = path.resolve(options.projectRoot || process.cwd());
     const location = context.backendLocations[cfg.backendId];
-    if (!location) {
-      throw new FirebaseError(`Failed to find location for backend ${cfg.backendId}.`);
-    }
     await injectAngularEnvVars(cfg, rootDir, projectId, location, buildEnv, runtimeEnv);
     // Generate a static 8-character hash of the Workspace Root directory path to guarantee
     // 100% sibling folder build isolation on the same machine, while preserving predictability.
@@ -473,13 +470,17 @@ export async function injectAngularEnvVars(
   cfg: AppHostingSingle,
   projectRoot: string,
   projectId: string,
-  location: string,
+  location: string | undefined,
   buildEnv: Record<string, EnvMap>,
   runtimeEnv: Record<string, EnvMap>,
 ): Promise<void> {
   const appDir = path.join(projectRoot, cfg.rootDir || "");
   if (!isAngularApplication(appDir)) {
     return;
+  }
+
+  if (!location) {
+    throw new FirebaseError(`Failed to find location for backend ${cfg.backendId}.`);
   }
 
   const backendId = cfg.backendId;

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -198,6 +198,7 @@ export default async function (context: Context, options: Options): Promise<void
     await injectAutoInitEnvVars(cfg, backends, buildEnv, runtimeEnv);
 
     const rootDir = path.resolve(options.projectRoot || process.cwd());
+    injectAngularEnvVars(cfg, rootDir, buildEnv, runtimeEnv);
     // Generate a static 8-character hash of the Workspace Root directory path to guarantee
     // 100% sibling folder build isolation on the same machine, while preserving predictability.
     const pathHash = crypto.createHash("md5").update(rootDir).digest("hex").substring(0, 8);
@@ -421,5 +422,108 @@ async function prepareLocalBuildScratchDirectory(
     const destPath = path.join(localBuildScratchDir, relativePath);
     fs.mkdirSync(path.dirname(destPath), { recursive: true });
     fs.copyFileSync(file.name, destPath);
+  }
+}
+
+/**
+ * Checks if the application in a directory is an Angular application.
+ */
+function isAngularApplication(appDir: string): boolean {
+  const packageJsonPath = path.join(appDir, "package.json");
+  if (fs.existsSync(packageJsonPath)) {
+    try {
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+      if (deps["@angular/core"] || deps["@angular/ssr"] || deps["@angular/platform-server"]) {
+        return true;
+      }
+    } catch {}
+  }
+  const angularJsonPath = path.join(appDir, "angular.json");
+  if (fs.existsSync(angularJsonPath)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Replicates the Go buildpack preparer's Angular environment variable injection and validation.
+ */
+export function injectAngularEnvVars(
+  cfg: AppHostingSingle,
+  projectRoot: string,
+  buildEnv: Record<string, EnvMap>,
+  runtimeEnv: Record<string, EnvMap>,
+): void {
+  const appDir = path.join(projectRoot, cfg.rootDir || "");
+  if (!isAngularApplication(appDir)) {
+    return;
+  }
+
+  const backendId = cfg.backendId;
+  runtimeEnv[backendId] ??= {};
+  buildEnv[backendId] ??= {};
+
+  const ngTrustProxyHeaders = "NG_TRUST_PROXY_HEADERS";
+  const allowedProxyHeadersValue = "X-Forwarded-Host,X-Forwarded-Port,X-Forwarded-Proto,X-Forwarded-For";
+  const allowedProxyHeaders = new Set([
+    "x-forwarded-host",
+    "x-forwarded-port",
+    "x-forwarded-proto",
+    "x-forwarded-for",
+  ]);
+
+  // 1. Validate or Inject NG_TRUST_PROXY_HEADERS
+  const userTrustProxy = runtimeEnv[backendId][ngTrustProxyHeaders];
+  if (userTrustProxy) {
+    const userVal = userTrustProxy.value || "";
+    // Validate the value of the user provided NG_TRUST_PROXY_HEADERS
+    const userList = userVal.split(",");
+    for (const h of userList) {
+      const trimmed = h.trim().toLowerCase();
+      if (trimmed !== "" && !allowedProxyHeaders.has(trimmed)) {
+        throw new FirebaseError(
+          `invalid value for ${ngTrustProxyHeaders} (Angular trust proxy headers): got ${JSON.stringify(userVal)}, must be a subset of ${JSON.stringify(allowedProxyHeadersValue)}`,
+        );
+      }
+    }
+
+    if (userTrustProxy.availability && !userTrustProxy.availability.includes("RUNTIME")) {
+      throw new FirebaseError(
+        `user-defined environment variable ${ngTrustProxyHeaders} must include RUNTIME in its availability`,
+      );
+    }
+  } else {
+    logLabeledBullet(
+      "apphosting",
+      `Angular SSR application detected. Injecting default ${ngTrustProxyHeaders}=${allowedProxyHeadersValue}`,
+    );
+    runtimeEnv[backendId][ngTrustProxyHeaders] = {
+      value: allowedProxyHeadersValue,
+      availability: ["RUNTIME"],
+    };
+  }
+
+  // 2. Validate or Inject NG_ALLOWED_HOSTS
+  // Replicate the Go buildpack preparer's validateAngularEnv behavior exactly:
+  // If the user explicitly defined NG_ALLOWED_HOSTS in their configuration (either BUILD or RUNTIME),
+  // they MUST have explicitly set its availability to include "RUNTIME". If availability was omitted (undefined),
+  // the Go preparer fails the build because slices.Contains(nil, "RUNTIME") evaluates to false!
+  const userAllowedHosts = runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] || buildEnv[backendId]["NG_ALLOWED_HOSTS"];
+  if (userAllowedHosts) {
+    if (!userAllowedHosts.availability || !userAllowedHosts.availability.includes("RUNTIME")) {
+      throw new FirebaseError(
+        `NG_ALLOWED_HOSTS environment variable must be set with RUNTIME availability`,
+      );
+    }
+  } else {
+    logLabeledBullet(
+      "apphosting",
+      `Angular SSR application detected. Injecting default NG_ALLOWED_HOSTS=*.hosted.app,*.run.app,*.firestack.app,localhost`,
+    );
+    runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] = {
+      value: "*.hosted.app,*.run.app,*.firestack.app,localhost",
+      availability: ["RUNTIME"],
+    };
   }
 }

--- a/src/deploy/apphosting/prepare.ts
+++ b/src/deploy/apphosting/prepare.ts
@@ -198,7 +198,11 @@ export default async function (context: Context, options: Options): Promise<void
     await injectAutoInitEnvVars(cfg, backends, buildEnv, runtimeEnv);
 
     const rootDir = path.resolve(options.projectRoot || process.cwd());
-    injectAngularEnvVars(cfg, rootDir, buildEnv, runtimeEnv);
+    const location = context.backendLocations[cfg.backendId];
+    if (!location) {
+      throw new FirebaseError(`Failed to find location for backend ${cfg.backendId}.`);
+    }
+    await injectAngularEnvVars(cfg, rootDir, projectId, location, buildEnv, runtimeEnv);
     // Generate a static 8-character hash of the Workspace Root directory path to guarantee
     // 100% sibling folder build isolation on the same machine, while preserving predictability.
     const pathHash = crypto.createHash("md5").update(rootDir).digest("hex").substring(0, 8);
@@ -465,12 +469,14 @@ function isAngularApplication(appDir: string): boolean {
 /**
  * Replicates the Go buildpack preparer's Angular environment variable injection and validation.
  */
-export function injectAngularEnvVars(
+export async function injectAngularEnvVars(
   cfg: AppHostingSingle,
   projectRoot: string,
+  projectId: string,
+  location: string,
   buildEnv: Record<string, EnvMap>,
   runtimeEnv: Record<string, EnvMap>,
-): void {
+): Promise<void> {
   const appDir = path.join(projectRoot, cfg.rootDir || "");
   if (!isAngularApplication(appDir)) {
     return;
@@ -532,12 +538,20 @@ export function injectAngularEnvVars(
       );
     }
   } else {
+    const projectNumber = await getProjectNumber({ project: projectId });
+    const sharedDomain = "hosted.app";
+    const allowedHostsValue = [
+      `${backendId}-${projectNumber}.${location}.run.app`,
+      `${backendId}--${projectId}.${location}.${sharedDomain}`,
+      `${backendId}--${projectId}.web.app`,
+      `${backendId}--${projectId}.firebaseapp.com`,
+    ].join(",");
     logLabeledBullet(
       "apphosting",
-      `Angular SSR application detected. Injecting default NG_ALLOWED_HOSTS=*.hosted.app,*.run.app,*.firestack.app,localhost`,
+      `Angular SSR application detected. Injecting default NG_ALLOWED_HOSTS=${allowedHostsValue}`,
     );
     runtimeEnv[backendId]["NG_ALLOWED_HOSTS"] = {
-      value: "*.hosted.app,*.run.app,*.firestack.app,localhost",
+      value: allowedHostsValue,
       availability: ["RUNTIME"],
     };
   }


### PR DESCRIPTION


<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

This adds NG_ALLOWED_HOSTS and NG_ALLOWED_PROXY_HEADERS similar to Firebase App Hosting Source Deploys. This is required for Angular SSR to work with Firebase Deployments. 

### Scenarios Tested

I tested Angular v19 through v22 with local vs source deploys and confirmed that the results were correct and the same (not falling back to CSR for local builds.)

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
