### PR TITLE
feat: cache cloudbilling API checks to reduce 429 quota issues

### DIFF
--- a/src/extensions/checkProjectBilling.ts
+++ b/src/extensions/checkProjectBilling.ts
@@ -40,7 +40,7 @@ async function openBillingAccount(projectId: string, url: string, open: boolean)
       "Press enter when finished upgrading your project to continue setting up your extension.",
     default: true,
   });
-  return cloudbilling.checkBillingEnabled(projectId);
+  return cloudbilling.checkBillingEnabled(projectId, true);
 }
 
 /**

--- a/src/gcp/cloudbilling.spec.ts
+++ b/src/gcp/cloudbilling.spec.ts
@@ -49,12 +49,13 @@ describe("cloudbilling", () => {
         .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
         .reply(200, { billingEnabled: true });
 
-      const result1 = await cloudbilling.checkBillingEnabled(PROJECT_ID);
+      const [result1, result2] = await Promise.all([
+        cloudbilling.checkBillingEnabled(PROJECT_ID),
+        cloudbilling.checkBillingEnabled(PROJECT_ID),
+      ]);
       expect(result1).to.be.true;
-      expect(nock.isDone()).to.be.true;
-
-      const result2 = await cloudbilling.checkBillingEnabled(PROJECT_ID);
       expect(result2).to.be.true;
+      expect(nock.isDone()).to.be.true;
     });
 
     it("should force refresh if forceRefresh is true", async () => {

--- a/src/gcp/cloudbilling.spec.ts
+++ b/src/gcp/cloudbilling.spec.ts
@@ -9,6 +9,7 @@ const PROJECT_ID = "test-project";
 describe("cloudbilling", () => {
   afterEach(() => {
     nock.cleanAll();
+    cloudbilling.clearCache();
   });
 
   describe("checkBillingEnabled", () => {
@@ -40,6 +41,35 @@ describe("cloudbilling", () => {
         .reply(404, { error: { message: "Not Found" } });
 
       await expect(cloudbilling.checkBillingEnabled(PROJECT_ID)).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should cache the result and not call API again", async () => {
+      nock(cloudbillingOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .reply(200, { billingEnabled: true });
+
+      const result1 = await cloudbilling.checkBillingEnabled(PROJECT_ID);
+      expect(result1).to.be.true;
+      expect(nock.isDone()).to.be.true;
+
+      const result2 = await cloudbilling.checkBillingEnabled(PROJECT_ID);
+      expect(result2).to.be.true;
+    });
+
+    it("should force refresh if forceRefresh is true", async () => {
+      nock(cloudbillingOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .reply(200, { billingEnabled: true });
+
+      await cloudbilling.checkBillingEnabled(PROJECT_ID);
+
+      nock(cloudbillingOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .reply(200, { billingEnabled: false });
+
+      const result2 = await cloudbilling.checkBillingEnabled(PROJECT_ID, true);
+      expect(result2).to.be.false;
       expect(nock.isDone()).to.be.true;
     });
   });
@@ -111,6 +141,20 @@ describe("cloudbilling", () => {
         cloudbilling.setBillingAccount(PROJECT_ID, billingAccountName),
       ).to.be.rejectedWith("Permission Denied");
       expect(nock.isDone()).to.be.true;
+    });
+
+    it("should update the cache", async () => {
+      nock(cloudbillingOrigin())
+        .put(`/v1/projects/${PROJECT_ID}/billingInfo`, {
+          billingAccountName: billingAccountName,
+        })
+        .reply(200, { billingEnabled: true });
+
+      await cloudbilling.setBillingAccount(PROJECT_ID, billingAccountName);
+      expect(nock.isDone()).to.be.true;
+
+      const result = await cloudbilling.checkBillingEnabled(PROJECT_ID);
+      expect(result).to.be.true;
     });
   });
 

--- a/src/gcp/cloudbilling.ts
+++ b/src/gcp/cloudbilling.ts
@@ -29,11 +29,31 @@ export async function isBillingEnabled(setup: Setup): Promise<boolean> {
   return setup.isBillingEnabled;
 }
 
+const billingEnabledCache: Map<string, boolean> = new Map();
+
+/**
+ * Reset the billing enabled cache.
+ * @internal
+ */
+export function clearCache(): void {
+  billingEnabledCache.clear();
+}
+
 /**
  * Returns whether or not project has billing enabled.
- * @param projectId
+ * @param projectId The project ID.
+ * @param forceRefresh Whether to force a refresh by bypassing the cache.
  */
-export async function checkBillingEnabled(projectId: string): Promise<boolean> {
+export async function checkBillingEnabled(
+  projectId: string,
+  forceRefresh = false,
+): Promise<boolean> {
+  if (!forceRefresh) {
+    const cached = billingEnabledCache.get(projectId);
+    if (cached !== undefined) {
+      return cached;
+    }
+  }
   const res = await client.get<{ billingEnabled: boolean }>(
     utils.endpoint(["projects", projectId, "billingInfo"]),
     {
@@ -41,7 +61,9 @@ export async function checkBillingEnabled(projectId: string): Promise<boolean> {
       retryCodes: [429, 500, 503],
     },
   );
-  return res.body.billingEnabled;
+  const enabled = res.body.billingEnabled;
+  billingEnabledCache.set(projectId, enabled);
+  return enabled;
 }
 
 /**
@@ -60,7 +82,9 @@ export async function setBillingAccount(
     },
     { retryCodes: [429, 500, 503] },
   );
-  return res.body.billingEnabled;
+  const enabled = res.body.billingEnabled;
+  billingEnabledCache.set(projectId, enabled);
+  return enabled;
 }
 
 /**

--- a/src/gcp/cloudbilling.ts
+++ b/src/gcp/cloudbilling.ts
@@ -29,7 +29,7 @@ export async function isBillingEnabled(setup: Setup): Promise<boolean> {
   return setup.isBillingEnabled;
 }
 
-const billingEnabledCache: Map<string, boolean> = new Map();
+const billingEnabledCache: Map<string, Promise<boolean>> = new Map();
 
 /**
  * Reset the billing enabled cache.
@@ -44,26 +44,26 @@ export function clearCache(): void {
  * @param projectId The project ID.
  * @param forceRefresh Whether to force a refresh by bypassing the cache.
  */
-export async function checkBillingEnabled(
-  projectId: string,
-  forceRefresh = false,
-): Promise<boolean> {
+export function checkBillingEnabled(projectId: string, forceRefresh = false): Promise<boolean> {
   if (!forceRefresh) {
     const cached = billingEnabledCache.get(projectId);
     if (cached !== undefined) {
       return cached;
     }
   }
-  const res = await client.get<{ billingEnabled: boolean }>(
-    utils.endpoint(["projects", projectId, "billingInfo"]),
-    {
+  const promise = client
+    .get<{ billingEnabled: boolean }>(utils.endpoint(["projects", projectId, "billingInfo"]), {
       retries: 3,
       retryCodes: [429, 500, 503],
-    },
-  );
-  const enabled = res.body.billingEnabled;
-  billingEnabledCache.set(projectId, enabled);
-  return enabled;
+    })
+    .then((res) => res.body.billingEnabled)
+    .catch((err) => {
+      billingEnabledCache.delete(projectId);
+      throw err;
+    });
+
+  billingEnabledCache.set(projectId, promise);
+  return promise;
 }
 
 /**
@@ -83,7 +83,7 @@ export async function setBillingAccount(
     { retryCodes: [429, 500, 503] },
   );
   const enabled = res.body.billingEnabled;
-  billingEnabledCache.set(projectId, enabled);
+  billingEnabledCache.set(projectId, Promise.resolve(enabled));
   return enabled;
 }
 


### PR DESCRIPTION
### Description
Introduce an in-memory cache for `cloudbilling.checkBillingEnabled` calls to reduce the number of outbound API calls during a single CLI command execution. This helps mitigate 429 quota issues.

- Added a module-level `Map` cache in `src/gcp/cloudbilling.ts`.
- Updated `checkBillingEnabled` to use the cache, with an optional `forceRefresh` parameter.
- Updated `setBillingAccount` to update the cache upon success.
- Updated `openBillingAccount` in `src/extensions/checkProjectBilling.ts` to force a refresh after user interaction.
- Added comprehensive unit tests for caching, force-refresh, and cache-updating behaviors.

### Scenarios Tested
- Run `npx mocha src/gcp/cloudbilling.spec.ts` (all passed, including new cache tests).
- Run `npx mocha src/extensions/checkProjectBilling.spec.ts` (all passed).
- Run `npm run lint:changed-files` (completed with 0 errors).

TAG=agy
CONV=f9131a59-a6d0-4092-a025-03350c20fb5a
