### PR TITLE
feat: use user project quota for cloudbilling API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Upgrade `zod` to v4 and drop the deprecated `zod-to-json-schema` dependency in favor of zod v4's built-in `z.toJSONSchema()`.
 - Updated the Firebase Data Connect local toolkit to v3.4.14, which includes the following changes:
   - Fix linter warnings in generated Kotlin SDK files.
+- Changed calls to 'cloudbilling.googleapis.com' to use user project quota to avoid shared quota exhaustion issues.

--- a/src/extensions/checkProjectBilling.spec.ts
+++ b/src/extensions/checkProjectBilling.spec.ts
@@ -47,10 +47,10 @@ describe("checkProjectBilling", () => {
       await checkProjectBilling.enableBilling(projectId);
     }
 
-    expect(listBillingAccountsStub.notCalled);
-    expect(setBillingAccountStub.notCalled);
-    expect(confirmStub.notCalled);
-    expect(selectStub.notCalled);
+    expect(listBillingAccountsStub.notCalled).to.be.true;
+    expect(setBillingAccountStub.notCalled).to.be.true;
+    expect(confirmStub.notCalled).to.be.true;
+    expect(selectStub.notCalled).to.be.true;
   });
 
   it("should list accounts if no billing account set, but accounts available.", async () => {
@@ -73,9 +73,11 @@ describe("checkProjectBilling", () => {
       await checkProjectBilling.enableBilling(projectId);
     }
 
-    expect(listBillingAccountsStub.calledOnce);
-    expect(setBillingAccountStub.calledOnce);
-    expect(setBillingAccountStub.calledWith(projectId, "test-cloud-billing-account-name"));
+    expect(listBillingAccountsStub.calledOnce).to.be.true;
+    expect(listBillingAccountsStub.calledWith(projectId)).to.be.true;
+    expect(setBillingAccountStub.calledOnce).to.be.true;
+    expect(setBillingAccountStub.calledWith(projectId, "test-cloud-billing-account-name")).to.be
+      .true;
   });
 
   it("should not list accounts if no billing accounts set or available.", async () => {
@@ -90,8 +92,9 @@ describe("checkProjectBilling", () => {
       await checkProjectBilling.enableBilling(projectId);
     }
 
-    expect(listBillingAccountsStub.calledOnce);
-    expect(setBillingAccountStub.notCalled);
+    expect(listBillingAccountsStub.calledOnce).to.be.true;
+    expect(listBillingAccountsStub.calledWith(projectId)).to.be.true;
+    expect(setBillingAccountStub.notCalled).to.be.true;
     expect(checkBillingEnabledStub.callCount).to.equal(2);
   });
 });

--- a/src/extensions/checkProjectBilling.ts
+++ b/src/extensions/checkProjectBilling.ts
@@ -99,7 +99,7 @@ async function setUpBillingAccount(projectId: string) {
  * @param {string} projectId
  */
 export async function enableBilling(projectId: string): Promise<void> {
-  const billingAccounts = await cloudbilling.listBillingAccounts();
+  const billingAccounts = await cloudbilling.listBillingAccounts(projectId);
   if (billingAccounts) {
     const accounts = billingAccounts.filter((account) => account.open);
     return accounts.length > 0

--- a/src/gcp/cloudbilling.spec.ts
+++ b/src/gcp/cloudbilling.spec.ts
@@ -1,15 +1,24 @@
 import { expect } from "chai";
 import * as nock from "nock";
+import * as sinon from "sinon";
 import * as cloudbilling from "./cloudbilling";
 import { cloudbillingOrigin } from "../api";
 import { Setup } from "../init";
+import * as ensureApiEnabled from "../ensureApiEnabled";
 
 const PROJECT_ID = "test-project";
 
 describe("cloudbilling", () => {
+  let ensureStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    ensureStub = sinon.stub(ensureApiEnabled, "ensure").resolves();
+  });
+
   afterEach(() => {
     nock.cleanAll();
     cloudbilling.clearCache();
+    ensureStub.restore();
   });
 
   describe("checkBillingEnabled", () => {

--- a/src/gcp/cloudbilling.spec.ts
+++ b/src/gcp/cloudbilling.spec.ts
@@ -15,6 +15,7 @@ describe("cloudbilling", () => {
     it("should resolve with true if billing is enabled", async () => {
       nock(cloudbillingOrigin())
         .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .matchHeader("x-goog-user-project", PROJECT_ID)
         .reply(200, { billingEnabled: true });
 
       const result = await cloudbilling.checkBillingEnabled(PROJECT_ID);
@@ -26,6 +27,7 @@ describe("cloudbilling", () => {
     it("should resolve with false if billing is not enabled", async () => {
       nock(cloudbillingOrigin())
         .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .matchHeader("x-goog-user-project", PROJECT_ID)
         .reply(200, { billingEnabled: false });
 
       const result = await cloudbilling.checkBillingEnabled(PROJECT_ID);
@@ -37,6 +39,7 @@ describe("cloudbilling", () => {
     it("should reject if the API call fails", async () => {
       nock(cloudbillingOrigin())
         .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .matchHeader("x-goog-user-project", PROJECT_ID)
         .reply(404, { error: { message: "Not Found" } });
 
       await expect(cloudbilling.checkBillingEnabled(PROJECT_ID)).to.be.rejectedWith("Not Found");
@@ -75,6 +78,7 @@ describe("cloudbilling", () => {
       };
       nock(cloudbillingOrigin())
         .get(`/v1/projects/${PROJECT_ID}/billingInfo`)
+        .matchHeader("x-goog-user-project", PROJECT_ID)
         .reply(200, { billingEnabled: true });
 
       const result = await cloudbilling.isBillingEnabled(setup);
@@ -92,6 +96,7 @@ describe("cloudbilling", () => {
         .put(`/v1/projects/${PROJECT_ID}/billingInfo`, {
           billingAccountName: billingAccountName,
         })
+        .matchHeader("x-goog-user-project", PROJECT_ID)
         .reply(200, { billingEnabled: true });
 
       const result = await cloudbilling.setBillingAccount(PROJECT_ID, billingAccountName);
@@ -105,6 +110,7 @@ describe("cloudbilling", () => {
         .put(`/v1/projects/${PROJECT_ID}/billingInfo`, {
           billingAccountName: billingAccountName,
         })
+        .matchHeader("x-goog-user-project", PROJECT_ID)
         .reply(403, { error: { message: "Permission Denied" } });
 
       await expect(
@@ -148,6 +154,18 @@ describe("cloudbilling", () => {
         .reply(404, { error: { message: "Not Found" } });
 
       await expect(cloudbilling.listBillingAccounts()).to.be.rejectedWith("Not Found");
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("should include x-goog-user-project header when projectId is provided", async () => {
+      nock(cloudbillingOrigin())
+        .get("/v1/billingAccounts")
+        .matchHeader("x-goog-user-project", PROJECT_ID)
+        .reply(200, { billingAccounts: [billingAccount] });
+
+      const result = await cloudbilling.listBillingAccounts(PROJECT_ID);
+
+      expect(result).to.deep.equal([billingAccount]);
       expect(nock.isDone()).to.be.true;
     });
   });

--- a/src/gcp/cloudbilling.ts
+++ b/src/gcp/cloudbilling.ts
@@ -72,15 +72,11 @@ export async function setBillingAccount(
  * @return {!Promise<Object[]>}
  */
 export async function listBillingAccounts(projectId?: string): Promise<BillingAccount[]> {
-  const headers: Record<string, string> = {};
-  if (projectId) {
-    headers["x-goog-user-project"] = projectId;
-  }
   const res = await client.get<{ billingAccounts: BillingAccount[] }>(
     utils.endpoint(["billingAccounts"]),
     {
       retryCodes: [429, 500, 503],
-      headers,
+      headers: projectId ? { "x-goog-user-project": projectId } : undefined,
     },
   );
   return res.body.billingAccounts || [];

--- a/src/gcp/cloudbilling.ts
+++ b/src/gcp/cloudbilling.ts
@@ -2,6 +2,7 @@ import { cloudbillingOrigin } from "../api";
 import { Client } from "../apiv2";
 import { Setup } from "../init";
 import * as utils from "../utils";
+import { ensure } from "../ensureApiEnabled";
 
 const API_VERSION = "v1";
 const client = new Client({ urlPrefix: cloudbillingOrigin(), apiVersion: API_VERSION });
@@ -51,17 +52,21 @@ export function checkBillingEnabled(projectId: string, forceRefresh = false): Pr
       return cached;
     }
   }
-  const promise = client
-    .get<{ billingEnabled: boolean }>(utils.endpoint(["projects", projectId, "billingInfo"]), {
-      retries: 3,
-      retryCodes: [429, 500, 503],
-      headers: { "x-goog-user-project": projectId },
-    })
-    .then((res) => res.body.billingEnabled)
-    .catch((err) => {
-      billingEnabledCache.delete(projectId);
-      throw err;
-    });
+  const promise = (async () => {
+    await ensure(projectId, "cloudbilling.googleapis.com", "billing", true);
+    const res = await client.get<{ billingEnabled: boolean }>(
+      utils.endpoint(["projects", projectId, "billingInfo"]),
+      {
+        retries: 3,
+        retryCodes: [429, 500, 503],
+        headers: { "x-goog-user-project": projectId },
+      },
+    );
+    return res.body.billingEnabled;
+  })().catch((err) => {
+    billingEnabledCache.delete(projectId);
+    throw err;
+  });
 
   billingEnabledCache.set(projectId, promise);
   return promise;
@@ -76,6 +81,7 @@ export async function setBillingAccount(
   projectId: string,
   billingAccountName: string,
 ): Promise<boolean> {
+  await ensure(projectId, "cloudbilling.googleapis.com", "billing", true);
   const res = await client.put<{ billingAccountName: string }, { billingEnabled: boolean }>(
     utils.endpoint(["projects", projectId, "billingInfo"]),
     {
@@ -96,6 +102,9 @@ export async function setBillingAccount(
  * @return {!Promise<Object[]>}
  */
 export async function listBillingAccounts(projectId?: string): Promise<BillingAccount[]> {
+  if (projectId) {
+    await ensure(projectId, "cloudbilling.googleapis.com", "billing", true);
+  }
   const res = await client.get<{ billingAccounts: BillingAccount[] }>(
     utils.endpoint(["billingAccounts"]),
     {

--- a/src/gcp/cloudbilling.ts
+++ b/src/gcp/cloudbilling.ts
@@ -39,6 +39,7 @@ export async function checkBillingEnabled(projectId: string): Promise<boolean> {
     {
       retries: 3,
       retryCodes: [429, 500, 503],
+      headers: { "x-goog-user-project": projectId },
     },
   );
   return res.body.billingEnabled;
@@ -58,7 +59,10 @@ export async function setBillingAccount(
     {
       billingAccountName: billingAccountName,
     },
-    { retryCodes: [429, 500, 503] },
+    {
+      retryCodes: [429, 500, 503],
+      headers: { "x-goog-user-project": projectId },
+    },
   );
   return res.body.billingEnabled;
 }
@@ -67,10 +71,17 @@ export async function setBillingAccount(
  * Lists the billing accounts that the current authenticated user has permission to view.
  * @return {!Promise<Object[]>}
  */
-export async function listBillingAccounts(): Promise<BillingAccount[]> {
+export async function listBillingAccounts(projectId?: string): Promise<BillingAccount[]> {
+  const headers: Record<string, string> = {};
+  if (projectId) {
+    headers["x-goog-user-project"] = projectId;
+  }
   const res = await client.get<{ billingAccounts: BillingAccount[] }>(
     utils.endpoint(["billingAccounts"]),
-    { retryCodes: [429, 500, 503] },
+    {
+      retryCodes: [429, 500, 503],
+      headers,
+    },
   );
   return res.body.billingAccounts || [];
 }


### PR DESCRIPTION
### Description
Modify the API calls to `cloudbilling.googleapis.com` in `cloudbilling.ts` to include the `x-goog-user-project` header. This routes the API quota usage through the user's project instead of the shared CLI quota, preventing quota exhaustion issues.

- Added `x-goog-user-project` to `checkBillingEnabled` and `setBillingAccount`.
- Added an optional `projectId` parameter to `listBillingAccounts` and passed it when available in `enableBilling`.
- Updated unit tests in `cloudbilling.spec.ts` and `checkProjectBilling.spec.ts` to assert that the `x-goog-user-project` header is correctly passed.

### Scenarios Tested
- Ran unit tests for `cloudbilling` and `checkProjectBilling`.
- Verified ESLint/formatting is clean.

### Sample Commands
- `npx mocha src/gcp/cloudbilling.spec.ts src/extensions/checkProjectBilling.spec.ts`
