### PR TITLE
fix: disable keep-alive on GoogleAuth transporter to avoid Premature …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Disable 'keep-alive' in `google-auth-library` calls to avoid `Premature close` errors on some Node versions (#10716).

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -168,7 +168,7 @@ function proxyURIFromEnv(): string | undefined {
 // https://github.com/node-fetch/node-fetch/issues/1767.
 const httpAgentNoKeepAlive = new http.Agent({ keepAlive: false });
 const httpsAgentNoKeepAlive = new https.Agent({ keepAlive: false });
-function noKeepAliveAgent(parsedURL: URL): http.Agent | https.Agent {
+export function noKeepAliveAgent(parsedURL: URL): http.Agent | https.Agent {
   return parsedURL.protocol === "https:" ? httpsAgentNoKeepAlive : httpAgentNoKeepAlive;
 }
 

--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -28,7 +28,18 @@ function getAuthClient(config: GoogleAuthOptions): GoogleAuth {
     return authClient;
   }
 
-  authClient = new GoogleAuth(config);
+  const authConfig: GoogleAuthOptions = {
+    ...config,
+    clientOptions: {
+      ...config.clientOptions,
+      transporterOptions: {
+        ...config.clientOptions?.transporterOptions,
+        agent: apiv2.noKeepAliveAgent,
+      },
+    },
+  };
+
+  authClient = new GoogleAuth(authConfig);
   return authClient;
 }
 


### PR DESCRIPTION
### Description
Disables HTTP keep-alive on the transporter utilized by `google-auth-library` to fetch and exchange auth tokens (e.g. via WIF or ADC). This works around a Node.js keep-alive socket reuse regression shipped in security updates for Node 22.23.0 and Node 24.17.0 (referenced in nodejs/node#63989) which causes token exchange requests to fail with `Premature close`.

Fixes #10716

### Scenarios Tested
Wrote up a minimal reproduction script `scripts/repro.ts` under Node v24.17.0 using Application Default Credentials:
- Verified it fails on v15.22.1 and v15.22.2 (without the fix) with a `Premature close` GaxiosError.
- Verified it successfully passes after applying the fix, making the Google API call and receiving a standard API response.

