### PR TITLE
fix: configure npm registry for firepit-builder in cloudbuild

### DIFF
--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -134,7 +134,7 @@ steps:
         sleep 60
         echo "Package firebase-tools@$(cat /workspace/version_number.txt) is now available on npm."
 
-  # Set up the hub credentials for firepit-builder.
+  # Set up the hub and npm credentials for firepit-builder.
   - name: "gcr.io/$PROJECT_ID/firepit-builder"
     entrypoint: "bash"
     args:
@@ -142,8 +142,9 @@ steps:
       - |
         if [ "${_VERSION}" != "preview" ]; then
           mkdir -vp ~/.config && cp -v hub ~/.config/hub
+          cp -v npmrc ~/.npmrc
         else
-          echo "Skipping hub credentials for firepit-builder for preview."
+          echo "Skipping credentials for firepit-builder for preview."
         fi
 
   # Publish the firepit builds.


### PR DESCRIPTION
### Description
Configures the `firepit-builder` container in the release pipeline to use the decrypted `.npmrc` file (which contains the internal Wombat staging registry configuration).

Previously, `firepit-builder` did not have access to the `.npmrc` file and fell back to the default public npm registry. Due to the propagation delay between publishing to the Wombat staging registry and syncing to the public npm registry, the standalone builder would fail with a "No matching version found" error when trying to install the newly published package.

By copying `.npmrc` to the `firepit-builder` container's home directory, it now installs the package directly from the staging registry, ensuring the standalone binaries are built and published successfully.

### Scenarios Tested
- Reviewed Cloud Build logs where the standalone binary build failed due to registry mismatch (propagation delay) and subsequent builds succeeded once the package propagated to the public registry.
