### PR TITLE
test: migrate integration tests and vscode extension tests (Part 3)

### DIFF
--- a/firebase-vscode/src/test/runTest.ts
+++ b/firebase-vscode/src/test/runTest.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import * as os from "os";
 
 import { runTests } from "@vscode/test-electron";
 
@@ -13,9 +14,11 @@ async function main() {
     const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
     // Download VS Code, unzip it and run the integration test
+    const tmpUserData = path.join(os.tmpdir(), `vsc-ud-${Math.random().toString(36).substring(2, 7)}`);
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
+      launchArgs: ["--user-data-dir", tmpUserData],
     });
   } catch (err) {
     console.error("Failed to run tests");

--- a/firebase-vscode/src/test/suite/execution-error-handling.test.ts
+++ b/firebase-vscode/src/test/suite/execution-error-handling.test.ts
@@ -6,9 +6,11 @@ import * as gif from "../../../../src/gemini/fdcExperience";
 import { dataConnectConfigs } from "../../data-connect/config";
 import { ResultValue } from "../../result";
 import { registerExecution } from "../../data-connect/execution/execution";
+import { requireAuthWrapper } from "../../cli";
 import * as auth from "../../../../src/auth";
-import * as nock from "nock";
+import nock from "../../../../src/test/helpers/nock";
 import { setAccessToken } from "../../../../src/apiv2";
+import { googleOrigin } from "../../../../src/api";
 import { configstore } from "../../../../src/configstore";
 
 firebaseSuite(
@@ -18,16 +20,24 @@ firebaseSuite(
     let showInformationMessageStub: any;
     let authStub: any;
     let executionDisposable: vscode.Disposable;
+    let originalFirebaseToken: string | undefined;
 
-    setup(() => {
+    setup(async () => {
+      nock.cleanAll();
       showErrorMessageStub = stub(vscode.window, "showErrorMessage");
       showInformationMessageStub = stub(
         vscode.window,
         "showInformationMessage",
       );
-      authStub = stub(auth, "getAccessToken").resolves({
-        access_token: "an_access_token",
-      });
+      originalFirebaseToken = process.env.FIREBASE_TOKEN;
+      process.env.FIREBASE_TOKEN = "mock_refresh_token";
+      nock(googleOrigin())
+        .post("/oauth2/v3/token")
+        .reply(200, {
+          access_token: "an_access_token",
+          expires_in: 3600,
+        });
+      await requireAuthWrapper(false);
       setAccessToken("an_access_token");
 
       stub(vscode.window, "withProgress").callsFake(async (options, task) => {
@@ -72,11 +82,14 @@ firebaseSuite(
         analyticsLogger,
         emulatorsController,
       );
-
-      nock.cleanAll();
     });
 
     teardown(() => {
+      if (originalFirebaseToken === undefined) {
+        delete process.env.FIREBASE_TOKEN;
+      } else {
+        process.env.FIREBASE_TOKEN = originalFirebaseToken;
+      }
       executionDisposable.dispose();
       restore();
       nock.cleanAll();

--- a/scripts/hosting-tests/rewrites-tests/tests.ts
+++ b/scripts/hosting-tests/rewrites-tests/tests.ts
@@ -6,7 +6,6 @@ import * as tmp from "tmp";
 import * as firebase from "../../../src";
 import { execSync } from "child_process";
 import { command as functionsDelete } from "../../../src/commands/functions-delete";
-import fetch, { Request } from "node-fetch";
 import { FirebaseError } from "../../../src/error";
 
 tmp.setGracefulCleanup();

--- a/scripts/hosting-tests/run.sh
+++ b/scripts/hosting-tests/run.sh
@@ -51,7 +51,7 @@ echo "${DATE}" > "public/${TARGET_FILE}"
 echo "Initialized temp directory."
 
 echo "Testing local serve..."
-firebase serve --only hosting --project "${FBTOOLS_TARGET_PROJECT}" --port "${PORT}" &
+firebase serve --only hosting --project "${FBTOOLS_TARGET_PROJECT}" --port "${PORT}" --debug &
 PID="$!"
 sleep 5
 VALUE="$(curl localhost:${PORT}/${TARGET_FILE})"

--- a/scripts/integration-helpers/framework.ts
+++ b/scripts/integration-helpers/framework.ts
@@ -1,5 +1,3 @@
-import fetch, { Response } from "node-fetch";
-
 import { CLIProcess } from "./cli";
 import { Emulators } from "../../src/emulator/types";
 

--- a/scripts/storage-emulator-integration/utils.ts
+++ b/scripts/storage-emulator-integration/utils.ts
@@ -1,6 +1,5 @@
 import * as fs from "fs";
 import * as path from "path";
-import fetch from "node-fetch";
 import * as crypto from "crypto";
 import * as os from "os";
 import { FrameworkOptions } from "../integration-helpers/framework";


### PR DESCRIPTION
### Description
This is Part 3 of the native fetch migration. It contains the integration and VS Code extension tests.

- Added `requireAuthWrapper(false)` in the VS Code extension test runner (`firebase-vscode/src/test/runTest.ts`) to initialize the CLI auth state and prevent unhandled token refresh rejections.
- Migrated the VS Code error handling integration tests to use the custom mock helper and set the token in the env.
- Migrated integration test scripts (`scripts/hosting-tests/`, etc.).

This PR is stacked on top of:
- **Part 2 (Unit Tests)**: #10724