### PR TITLE
feat: extend wire protocol and add requiredRoles to manifest discovery (PR 1)

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -434,9 +434,11 @@ export interface Backend {
   environmentVariables: EnvironmentVariables;
   // region -> id -> Endpoint
   endpoints: Record<string, Record<string, Endpoint>>;
+  requiredRoles?: string[];
 }
 
 /**
+
  * A helper utility to create an empty backend.
  * Tests that verify the behavior of one possible resource in a Backend can use
  * this method to avoid compiler errors when new fields are added to Backend.
@@ -474,6 +476,7 @@ export function merge(...backends: Backend[]): Backend {
 
   // Merge all APIs
   const apiToReasons: Record<string, Set<string>> = {};
+  const requiredRoles = new Set<string>();
   for (const b of backends) {
     for (const { api, reason } of b.requiredAPIs) {
       const reasons = apiToReasons[api] || new Set();
@@ -482,11 +485,21 @@ export function merge(...backends: Backend[]): Backend {
       }
       apiToReasons[api] = reasons;
     }
-    // Mere all environment variables.
+    // Merge all environment variables.
     merged.environmentVariables = { ...merged.environmentVariables, ...b.environmentVariables };
+
+    // Merge requiredRoles
+    if (b.requiredRoles) {
+      for (const role of b.requiredRoles) {
+        requiredRoles.add(role);
+      }
+    }
   }
   for (const [api, reasons] of Object.entries(apiToReasons)) {
     merged.requiredAPIs.push({ api, reason: Array.from(reasons).join(" ") });
+  }
+  if (requiredRoles.size > 0) {
+    merged.requiredRoles = Array.from(requiredRoles);
   }
   return merged;
 }

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -514,7 +514,9 @@ export function merge(...backends: Backend[]): Backend {
 
     // Merge requiredRoles
     if (b.requiredRoles) {
-      requiredRoles.push(...b.requiredRoles);
+      for (const role of b.requiredRoles) {
+        requiredRoles.add(role);
+      }
     }
     if (b.lifecycleHooks) {
       merged.lifecycleHooks = { ...(merged.lifecycleHooks || {}), ...b.lifecycleHooks };

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -17,6 +17,7 @@ export interface Build {
   params: params.Param[];
   runtime?: Runtime;
   extensions?: Record<string, DynamicExtension>;
+  requiredRoles?: string[];
 }
 
 /**
@@ -588,6 +589,9 @@ export function toBackend(
 
   const bkend = backend.of(...bkEndpoints);
   bkend.requiredAPIs = build.requiredAPIs;
+  if (build.requiredRoles) {
+    bkend.requiredRoles = build.requiredRoles;
+  }
   return bkend;
 }
 

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -91,6 +91,7 @@ export interface WireManifest {
   specVersion: string;
   params?: params.Param[];
   requiredAPIs?: build.RequiredApi[];
+  requiredRoles?: string[];
   endpoints: Record<string, WireEndpoint>;
   extensions?: Record<string, WireExtension>;
 }
@@ -108,12 +109,16 @@ export function buildFromV1Alpha1(
     specVersion: "string",
     params: "array",
     requiredAPIs: "array",
+    requiredRoles: "array",
     endpoints: "object",
     extensions: "object",
   });
   const bd: build.Build = build.empty();
   bd.params = manifest.params || [];
   bd.requiredAPIs = parseRequiredAPIs(manifest);
+  if (manifest.requiredRoles) {
+    bd.requiredRoles = parseRequiredRoles(manifest);
+  }
   for (const id of Object.keys(manifest.endpoints)) {
     const me: WireEndpoint = manifest.endpoints[id];
     assertBuildEndpoint(me, id);
@@ -132,8 +137,24 @@ export function buildFromV1Alpha1(
   return bd;
 }
 
+const ROLE_REGEX = /^((projects|organizations)\/[a-zA-Z0-9_-]+\/)?roles\/[a-zA-Z0-9_.-]+$/;
+
+function parseRequiredRoles(manifest: WireManifest): string[] {
+  const roles: string[] = manifest.requiredRoles || [];
+  for (const role of roles) {
+    if (typeof role !== "string") {
+      throw new FirebaseError(`Invalid role "${JSON.stringify(role)}". Expected string`);
+    }
+    if (!ROLE_REGEX.test(role)) {
+      throw new FirebaseError(`Invalid IAM role format "${role}".`);
+    }
+  }
+  return Array.from(new Set(roles)); // Deduplicate as requested
+}
+
 function parseRequiredAPIs(manifest: WireManifest): build.RequiredApi[] {
   const requiredAPIs: build.RequiredApi[] = manifest.requiredAPIs || [];
+
   for (const { api, reason } of requiredAPIs) {
     if (typeof api !== "string") {
       throw new FirebaseError(`Invalid api "${JSON.stringify(api)}. Expected string`);

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -193,7 +193,8 @@ export function buildFromV1Alpha1(
   return bd;
 }
 
-const ROLE_REGEX = /^((projects|organizations)\/[a-zA-Z0-9_-]+\/)?roles\/[a-zA-Z0-9_.-]+$/;
+const ROLE_REGEX =
+  /^(roles\/[a-zA-Z0-9_\.\-]+|projects\/[a-zA-Z0-9\-]+\/roles\/[a-zA-Z0-9_\.\-]+|organizations\/[0-9]+\/roles\/[a-zA-Z0-9_\.\-]+)$/;
 
 function parseRequiredRoles(manifest: WireManifest): string[] {
   const roles: string[] = manifest.requiredRoles || [];


### PR DESCRIPTION
### Description
This is PR 1 in the requiresRole PR chain.
It extends the wire protocol to include declared required roles for 2nd generation Cloud Functions, enabling manifest discovery to parse and validate them.

### Scenarios Tested
- Run npm test
- Run npm run build & npm run lint

### Sample Commands
N/A