### PR TITLE
ci: pin github actions runner node version to 24.18

### DIFF
--- a/.github/workflows/agent-evals.yaml
+++ b/.github/workflows/agent-evals.yaml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24"
+          - "24.18"
     env:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
     steps:

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: "24"
+          node-version: "24.18"
 
       - uses: google-github-actions/auth@v0
         with:

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24.18"
+          - "24"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +50,7 @@ jobs:
       matrix:
         node-version:
           - "22"
-          - "24.18"
+          - "24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -68,7 +68,7 @@ jobs:
       - run: npm run test:unit
         working-directory: firebase-vscode
       - uses: codecov/codecov-action@v5
-        if: matrix.node-version == '24.18'
+        if: matrix.node-version == '24'
 
   # vscode_integration:
   #   runs-on: macos-latest
@@ -133,7 +133,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24.18"
+          - "24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -155,7 +155,7 @@ jobs:
       matrix:
         node-version:
           - "22"
-          - "24.18"
+          - "24"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -177,7 +177,7 @@ jobs:
       - run: npm test -- -- --forbid-only
 
       - uses: codecov/codecov-action@v5
-        if: matrix.node-version == '24.18'
+        if: matrix.node-version == '24'
         with:
           files: ./.coverage/lcov.info
 
@@ -322,7 +322,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24.18"
+          - "24"
 
     steps:
       - uses: actions/checkout@v4
@@ -341,7 +341,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24.18"
+          - "24"
 
     steps:
       - uses: actions/checkout@v4
@@ -360,7 +360,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24.18"
+          - "24"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24"
+          - "24.18"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,7 +50,7 @@ jobs:
       matrix:
         node-version:
           - "22"
-          - "24"
+          - "24.18"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -68,14 +68,14 @@ jobs:
       - run: npm run test:unit
         working-directory: firebase-vscode
       - uses: codecov/codecov-action@v5
-        if: matrix.node-version == '24'
+        if: matrix.node-version == '24.18'
 
   # vscode_integration:
   #   runs-on: macos-latest
   #   strategy:
   #     matrix:
   #       node-version:
-  #         - "24"
+  #         - "24.18"
 
   #   env:
   #     FIREBASE_EMULATORS_PATH: ${{ github.workspace }}/emulator-cache
@@ -126,14 +126,14 @@ jobs:
   #         path: firebase-vscode/src/test/screenshots
 
   #     - uses: codecov/codecov-action@v5
-  #       if: matrix.node-version == '24'
+  #       if: matrix.node-version == '24.18'
 
   agent_evals_build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         node-version:
-          - "24"
+          - "24.18"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -155,7 +155,7 @@ jobs:
       matrix:
         node-version:
           - "22"
-          - "24"
+          - "24.18"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
@@ -177,7 +177,7 @@ jobs:
       - run: npm test -- -- --forbid-only
 
       - uses: codecov/codecov-action@v5
-        if: matrix.node-version == '24'
+        if: matrix.node-version == '24.18'
         with:
           files: ./.coverage/lcov.info
 
@@ -199,7 +199,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - "24"
+          - "24.18"
         script:
           - npm run test:client-integration
           - npm run test:emulator
@@ -268,7 +268,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - "24"
+          - "24.18"
         script:
           - npm run test:hosting
           # - npm run test:hosting-rewrites # Long-running test that might conflict across test runs. Run this manually.
@@ -284,7 +284,7 @@ jobs:
           # - npm run test:dataconnect-emulator # TODO (joehanley): Figure out why this is failing
           # - npm run test:frameworks
         include:
-          - node-version: "24"
+          - node-version: "24.18"
             script: "npm run test:functions-discover"
     steps:
       - name: Setup Java JDK
@@ -322,7 +322,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24"
+          - "24.18"
 
     steps:
       - uses: actions/checkout@v4
@@ -341,7 +341,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24"
+          - "24.18"
 
     steps:
       - uses: actions/checkout@v4
@@ -360,7 +360,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - "24"
+          - "24.18"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Description
Reverts unit, lint, and static verification checks in .github/workflows/node-test.yml back to Node 24 while keeping integration tests (Linux and Windows) pinned to 24.18.

### Scenarios Tested
Verified YAML formatting with prettier and CI execution.

### Sample Commands
N/A