### PR TITLE
fix: prevent premature caching of API enablement status

### DIFF
--- a/src/ensureApiEnabled.spec.ts
+++ b/src/ensureApiEnabled.spec.ts
@@ -140,7 +140,6 @@ describe("ensureApiEnabled", () => {
         await expect(ensure(FAKE_PROJECT_ID, prefix + FAKE_API, "", true)).to.not.be.rejected;
 
         expect(nock.isDone()).to.be.true;
-        expect(configstoreSetMock.calledWith(FAKE_PROJECT_ID, FAKE_API));
       });
 
       it("should retry enabling the API if it does not enable in time", async () => {

--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -72,7 +72,6 @@ async function enable(projectId: string, apiName: string): Promise<void> {
         skipLog: { resBody: true },
       },
     );
-    cacheEnabledAPI(projectId, apiName);
   } catch (err: any) {
     if (isBillingError(err)) {
       throw new FirebaseError(`Your project ${bold(

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+const { check, ensure, POLL_SETTINGS } = require("./lib/ensureApiEnabled");


### PR DESCRIPTION
Fixes a race condition where the CLI prematurely caches Google Cloud APIs as enabled immediately upon initiating the enablement process, leading to false positives during polling.

---
*PR created automatically by Jules for task [14193484741930371072](https://jules.google.com/task/14193484741930371072) started by @fredzqm*