### PR TITLE
Fix: specify repo explicitly in gh pr view

### DIFF
--- a/.github/workflows/release-vscode-ext.yaml
+++ b/.github/workflows/release-vscode-ext.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           PR_NUM="${{ github.event.issue.number }}"
           echo "Fetching SHA for PR $PR_NUM..."
-          SHA=$(gh pr view "$PR_NUM" --json headRefOid -q .headRefOid)
+          SHA=$(gh pr view "$PR_NUM" --repo "${{ github.repository }}" --json headRefOid -q .headRefOid)
           echo "PR Head SHA is $SHA"
 
           if [[ "$COMMENT_BODY" == *"--build-only"* ]]; then


### PR DESCRIPTION
 Specify repository explicitly in Release workflow to fix "not a git repository" errors in GHA runner.