### PR TITLE
feat: add firebase functions:lifecycle commands and refactor hook error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Add `functions:lifecycle:list` and `functions:lifecycle:run` commands to view and run
+  lifecycle hooks in isolation.

--- a/src/commands/functions-lifecycle-list.ts
+++ b/src/commands/functions-lifecycle-list.ts
@@ -14,6 +14,9 @@ import * as self from "./functions-lifecycle-list";
 
 export async function loadCodebaseBuild(codebase: string, options: Options): Promise<build.Build> {
   const projectId = needProjectId(options);
+  if (!options.config) {
+    throw new FirebaseError("Not in a Firebase project directory (firebase.json not found).");
+  }
   const fnConfig = normalizeAndValidate(options.config.src.functions);
 
   const hasCodebase = fnConfig.some((c) => c.codebase === codebase);

--- a/src/commands/functions-lifecycle-list.ts
+++ b/src/commands/functions-lifecycle-list.ts
@@ -1,0 +1,116 @@
+import { Command } from "../command";
+import { Options } from "../options";
+import { logger } from "../logger";
+import { loadCodebases } from "../deploy/functions/prepare";
+import { normalizeAndValidate, shouldUseRuntimeConfig } from "../functions/projectConfig";
+import { getProjectAdminSdkConfigOrCached } from "../emulator/adminSdkConfig";
+import { needProjectId } from "../projectUtils";
+import { FirebaseError } from "../error";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import { runtimeconfigOrigin } from "../api";
+import { getFunctionsConfig } from "../deploy/functions/prepareFunctionsUpload";
+import * as build from "../deploy/functions/build";
+import * as self from "./functions-lifecycle-list";
+
+export async function loadCodebaseBuild(codebase: string, options: Options): Promise<build.Build> {
+  const projectId = needProjectId(options);
+  const fnConfig = normalizeAndValidate(options.config.src.functions);
+
+  const hasCodebase = fnConfig.some((c) => c.codebase === codebase);
+  if (!hasCodebase) {
+    throw new FirebaseError(`Codebase "${codebase}" is not defined in firebase.json.`);
+  }
+
+  const firebaseConfig = await getProjectAdminSdkConfigOrCached(projectId);
+  if (!firebaseConfig) {
+    throw new FirebaseError(
+      "Admin SDK config unexpectedly undefined - have you run firebase init?",
+    );
+  }
+
+  let runtimeConfig: Record<string, unknown> = { firebase: firebaseConfig };
+
+  if (fnConfig.some(shouldUseRuntimeConfig)) {
+    try {
+      const runtimeConfigApiEnabled = await ensureApiEnabled.check(
+        projectId,
+        runtimeconfigOrigin(),
+        "runtimeconfig",
+        /* silent=*/ true,
+      );
+
+      if (runtimeConfigApiEnabled) {
+        runtimeConfig = { ...runtimeConfig, ...(await getFunctionsConfig(projectId)) };
+      }
+    } catch (err) {
+      logger.debug("Could not check Runtime Config API status, assuming disabled:", err);
+    }
+  }
+
+  const wantBuilds = await loadCodebases(
+    fnConfig,
+    options,
+    firebaseConfig,
+    runtimeConfig,
+    undefined, // no filters
+  );
+
+  const codebaseBuild = wantBuilds[codebase];
+  if (!codebaseBuild) {
+    throw new FirebaseError(`Failed to load build for codebase "${codebase}".`);
+  }
+
+  return codebaseBuild;
+}
+
+export const command = new Command("functions:lifecycle:list <codebase>")
+  .description("list all the lifecycle hooks defined in a codebase")
+  .action(async (codebase: string, options: Options) => {
+    const codebaseBuild = await self.loadCodebaseBuild(codebase, options);
+    const hooks = codebaseBuild.lifecycleHooks || {};
+
+    if (Object.keys(hooks).length === 0) {
+      logger.info(`No lifecycle hooks configured for codebase "${codebase}".`);
+      return hooks;
+    }
+
+    for (const [event, hook] of Object.entries(hooks)) {
+      logger.info(`\nEvent: ${event}`);
+      if ("task" in hook) {
+        logger.info(`  Action: Task`);
+        logger.info(`  Target Function: ${hook.task.function}`);
+        if (hook.task.body) {
+          logger.info(`  Body: ${JSON.stringify(hook.task.body, null, 2).replace(/\n/g, "\n  ")}`);
+        }
+      } else if ("call" in hook) {
+        logger.info(`  Action: Call`);
+        logger.info(`  Target Function: ${hook.call.function}`);
+        if (hook.call.params) {
+          logger.info(
+            `  Params: ${JSON.stringify(hook.call.params, null, 2).replace(/\n/g, "\n  ")}`,
+          );
+        }
+      } else if ("http" in hook) {
+        logger.info(`  Action: HTTP`);
+        if (hook.http.function) {
+          logger.info(`  Target Function: ${hook.http.function}`);
+        }
+        if (hook.http.url) {
+          logger.info(`  URL: ${hook.http.url}`);
+        }
+        if (hook.http.method) {
+          logger.info(`  Method: ${hook.http.method}`);
+        }
+        if (hook.http.headers) {
+          logger.info(
+            `  Headers: ${JSON.stringify(hook.http.headers, null, 2).replace(/\n/g, "\n  ")}`,
+          );
+        }
+        if (hook.http.body) {
+          logger.info(`  Body: ${JSON.stringify(hook.http.body, null, 2).replace(/\n/g, "\n  ")}`);
+        }
+      }
+    }
+
+    return hooks;
+  });

--- a/src/commands/functions-lifecycle-run.ts
+++ b/src/commands/functions-lifecycle-run.ts
@@ -1,0 +1,38 @@
+import { Command } from "../command";
+import { Options } from "../options";
+import { needProjectId } from "../projectUtils";
+import { requirePermissions } from "../requirePermissions";
+import { FirebaseError } from "../error";
+import { loadCodebaseBuild } from "./functions-lifecycle-list";
+import * as backend from "../deploy/functions/backend";
+import { executeHook } from "../deploy/functions/release/lifecycle";
+import { Context } from "../deploy/functions/args";
+
+export const command = new Command("functions:lifecycle:run <hookName> <codebase>")
+  .description("run a specific lifecycle hook in isolation")
+  .before(requirePermissions, ["cloudfunctions.functions.list", "run.services.list"])
+  .action(async (hookName: string, codebase: string, options: Options) => {
+    if (hookName !== "afterInstall" && hookName !== "afterUpdate") {
+      throw new FirebaseError(
+        `Invalid hook name "${hookName}". Supported hooks are "afterInstall" and "afterUpdate".`,
+      );
+    }
+
+    const projectId = needProjectId(options);
+    const codebaseBuild = await loadCodebaseBuild(codebase, options);
+    const hook = codebaseBuild.lifecycleHooks?.[hookName];
+
+    if (!hook) {
+      throw new FirebaseError(
+        `No lifecycle hook "${hookName}" configured for codebase "${codebase}".`,
+      );
+    }
+
+    const context = {
+      projectId,
+    } as Context;
+
+    const existingBackend = await backend.existingBackend(context);
+
+    await executeHook(hookName, hook, existingBackend);
+  });

--- a/src/commands/functions-lifecycle.spec.ts
+++ b/src/commands/functions-lifecycle.spec.ts
@@ -1,0 +1,184 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { logger } from "../logger";
+import { loadCodebaseBuild } from "./functions-lifecycle-list";
+import * as prepare from "../deploy/functions/prepare";
+import * as projectUtils from "../projectUtils";
+import * as adminSdkConfig from "../emulator/adminSdkConfig";
+import * as backend from "../deploy/functions/backend";
+import * as lifecycle from "../deploy/functions/release/lifecycle";
+import { FirebaseError } from "../error";
+import { Options } from "../options";
+import * as requirePermissions from "../requirePermissions";
+
+describe("functions:lifecycle commands", () => {
+  let sandbox: sinon.SinonSandbox;
+  let options: any;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    options = {
+      projectId: "test-project",
+      config: {
+        src: {
+          functions: [{ codebase: "my-codebase", source: "functions" }],
+        },
+        path: (p: string) => p,
+        projectDir: "/path/to/project",
+      },
+    } as any as Options;
+
+    sandbox.stub(projectUtils, "needProjectId").returns("test-project");
+    sandbox.stub(adminSdkConfig, "getProjectAdminSdkConfigOrCached").resolves({
+      projectId: "test-project",
+      storageBucket: "test-bucket",
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("loadCodebaseBuild", () => {
+    it("should throw FirebaseError if codebase is not defined in firebase.json", async () => {
+      await expect(loadCodebaseBuild("non-existent", options)).to.be.rejectedWith(
+        FirebaseError,
+        'Codebase "non-existent" is not defined in firebase.json.',
+      );
+    });
+
+    it("should load codebase build successfully", async () => {
+      const mockBuild = {
+        requiredAPIs: [],
+        endpoints: {},
+        params: [],
+        lifecycleHooks: {
+          afterInstall: {
+            task: {
+              function: "myTask",
+            },
+          },
+        },
+      };
+      sandbox.stub(prepare, "loadCodebases").resolves({
+        "my-codebase": mockBuild,
+      });
+
+      const build = await loadCodebaseBuild("my-codebase", options);
+      expect(build).to.deep.equal(mockBuild);
+    });
+  });
+
+  describe("executeHook", () => {
+    it("should throw FirebaseError for non-task hook", async () => {
+      const hook: backend.LifecycleHook = {
+        call: {
+          function: "myCall",
+        },
+      };
+      const mockBackend = backend.empty();
+
+      await expect(lifecycle.executeHook("afterInstall", hook, mockBackend)).to.be.rejectedWith(
+        FirebaseError,
+        'Lifecycle hook action type "call" is not supported.',
+      );
+    });
+  });
+
+  describe("CLI Commands", () => {
+    let loadCodebaseBuildStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      // Stub Command.prototype.prepare to avoid framework-level setup (like project root detection)
+      const { Command } = require("../command");
+      sandbox.stub(Command.prototype, "prepare").resolves();
+
+      // Stub requirePermissions to avoid network calls
+      sandbox.stub(requirePermissions, "requirePermissions").resolves();
+
+      // Stub loadCodebaseBuild to avoid loading actual codebases in command tests
+      const listModule = require("./functions-lifecycle-list");
+      loadCodebaseBuildStub = sandbox.stub(listModule, "loadCodebaseBuild");
+    });
+
+    describe("functions:lifecycle:list", () => {
+      it("should list hooks if configured", async () => {
+        const loggerStub = sandbox.stub(logger, "info");
+        const mockBuild = {
+          lifecycleHooks: {
+            afterInstall: {
+              task: {
+                function: "myTask",
+                body: { foo: "bar" },
+              },
+            },
+          },
+        };
+        loadCodebaseBuildStub.resolves(mockBuild);
+
+        const { command: listCommand } = require("./functions-lifecycle-list");
+        await listCommand.runner()("my-codebase", options);
+
+        expect(loggerStub).to.have.been.calledWith(sinon.match("Event: afterInstall"));
+        expect(loggerStub).to.have.been.calledWith(sinon.match("Action: Task"));
+        expect(loggerStub).to.have.been.calledWith(sinon.match("Target Function: myTask"));
+      });
+
+      it("should log message if no hooks configured", async () => {
+        const loggerStub = sandbox.stub(logger, "info");
+        loadCodebaseBuildStub.resolves({ lifecycleHooks: {} });
+
+        const { command: listCommand } = require("./functions-lifecycle-list");
+        await listCommand.runner()("my-codebase", options);
+
+        expect(loggerStub).to.have.been.calledWith(
+          'No lifecycle hooks configured for codebase "my-codebase".',
+        );
+      });
+    });
+
+    describe("functions:lifecycle:run", () => {
+      it("should throw error for invalid hook name", async () => {
+        const { command: runCommand } = require("./functions-lifecycle-run");
+        await expect(runCommand.runner()("invalidHook", "my-codebase", options)).to.be.rejectedWith(
+          FirebaseError,
+          'Invalid hook name "invalidHook". Supported hooks are "afterInstall" and "afterUpdate".',
+        );
+      });
+
+      it("should throw error if hook is not configured", async () => {
+        loadCodebaseBuildStub.resolves({ lifecycleHooks: {} });
+
+        const { command: runCommand } = require("./functions-lifecycle-run");
+        await expect(
+          runCommand.runner()("afterInstall", "my-codebase", options),
+        ).to.be.rejectedWith(
+          FirebaseError,
+          'No lifecycle hook "afterInstall" configured for codebase "my-codebase".',
+        );
+      });
+
+      it("should execute hook successfully", async () => {
+        const mockHook = { task: { function: "myTask" } };
+        loadCodebaseBuildStub.resolves({
+          lifecycleHooks: {
+            afterInstall: mockHook,
+          },
+        });
+
+        const mockExistingBackend = backend.empty();
+        sandbox.stub(backend, "existingBackend").resolves(mockExistingBackend);
+        const executeHookStub = sandbox.stub(lifecycle, "executeHook").resolves();
+
+        const { command: runCommand } = require("./functions-lifecycle-run");
+        await runCommand.runner()("afterInstall", "my-codebase", options);
+
+        expect(executeHookStub).to.have.been.calledWith(
+          "afterInstall",
+          mockHook,
+          mockExistingBackend,
+        );
+      });
+    });
+  });
+});

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -161,6 +161,9 @@ export function load(client: CLIClient): CLIClient {
   client.functions.log = loadCommand("functions-log");
   client.functions.shell = loadCommand("functions-shell");
   client.functions.list = loadCommand("functions-list");
+  client.functions.lifecycle = {};
+  client.functions.lifecycle.list = loadCommand("functions-lifecycle-list");
+  client.functions.lifecycle.run = loadCommand("functions-lifecycle-run");
   if (experiments.isEnabled("deletegcfartifacts")) {
     client.functions.deletegcfartifacts = loadCommand("functions-deletegcfartifacts");
   }

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -95,10 +95,6 @@ describe("lifecycle", () => {
         sinon.match.any,
         "View logs for afterInstall at: https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.service_name%3D%22installHookTask%22%0Aresource.labels.location%3D%22us-east1%22;project=myProj",
       );
-      expect(loggerStub).to.have.been.calledWith(
-        sinon.match.any,
-        "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterInstall default",
-      );
     });
 
     it("enqueues task using the endpoint's configured service account when present", async () => {

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -6,6 +6,7 @@ import * as cloudtasks from "../../../gcp/cloudtasks";
 import { logger } from "../../../logger";
 import * as projects from "../../../management/projects";
 import * as computeEngine from "../../../gcp/computeEngine";
+import * as utils from "../../../utils";
 
 describe("lifecycle", () => {
   let sandbox: sinon.SinonSandbox;
@@ -92,7 +93,11 @@ describe("lifecycle", () => {
       });
       expect(loggerStub).to.have.been.calledWith(
         sinon.match.any,
-        "View logs for installHookTask at: https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.service_name%3D%22installHookTask%22%0Aresource.labels.location%3D%22us-east1%22;project=myProj",
+        "View logs for afterInstall at: https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.service_name%3D%22installHookTask%22%0Aresource.labels.location%3D%22us-east1%22;project=myProj",
+      );
+      expect(loggerStub).to.have.been.calledWith(
+        sinon.match.any,
+        "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterInstall default",
       );
     });
 
@@ -211,6 +216,46 @@ describe("lifecycle", () => {
       const executed = await executeLifecycleHooks(wantBackend, haveBackend, emptyPlan, "default");
       expect(executed).to.be.false;
       expect(enqueueStub).to.not.have.been.called;
+    });
+
+    it("logs a warning and suggest run command when task enqueue fails", async () => {
+      sandbox.stub(cloudtasks, "enqueueTask").rejects(new Error("Queue full"));
+      const warningStub = sandbox.stub(utils, "logLabeledWarning");
+      const bulletStub = sandbox.stub(utils, "logLabeledBullet");
+      const wantBackend = backend.of({
+        id: "installHookTask",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "installHookTask",
+        platform: "gcfv2",
+        uri: "https://installhooktask-12345.a.run.app",
+        taskQueueTrigger: {},
+        codebase: "my-codebase",
+      });
+      wantBackend.lifecycleHooks = {
+        afterInstall: {
+          task: {
+            function: "installHookTask",
+          },
+        },
+      };
+      const haveBackend = backend.empty();
+
+      const executed = await executeLifecycleHooks(
+        wantBackend,
+        haveBackend,
+        undefined,
+        "my-codebase",
+      );
+      expect(executed).to.be.false;
+      expect(warningStub).to.have.been.calledWith(
+        "functions",
+        "Failed to execute afterInstall lifecycle hook: Queue full",
+      );
+      expect(bulletStub).to.have.been.calledWith(
+        "functions",
+        "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterInstall my-codebase",
+      );
     });
   });
 });

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -69,21 +69,20 @@ export async function executeLifecycleHooks(
     }
   }
 
-  let success = false;
   try {
     await executeHook(delta, hook, wantBackend);
-    success = true;
+    return true;
   } catch (err: unknown) {
     // We treat lifecycle hook failures as warnings. We don't want to fail
     // the entire deploy command if a post-deploy hook fails to enqueue.
-    success = false;
-  } finally {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    logLabeledWarning("functions", `Failed to execute ${delta} lifecycle hook: ${errorMsg}`);
     logLabeledBullet(
       "functions",
       `You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run ${delta} ${codebase ?? "default"}`,
     );
+    return false;
   }
-  return success;
 }
 
 /**
@@ -162,31 +161,25 @@ export async function executeHook(
   backendSpec: backend.Backend,
 ): Promise<backend.Endpoint | undefined> {
   let executedEndpoint: backend.Endpoint | undefined;
-  try {
-    if ("task" in hook) {
-      logLabeledBullet(
-        "functions",
-        `Executing ${delta} lifecycle hook targeting: ${hook.task.function}...`,
-      );
-      executedEndpoint = await executeTaskQueueHook(hook.task, backendSpec);
-    } else if ("call" in hook) {
-      throw new FirebaseError(`Lifecycle hook action type "call" is not supported.`);
-    } else if ("http" in hook) {
-      throw new FirebaseError(`Lifecycle hook action type "http" is not supported.`);
-    } else {
-      assertExhaustive(hook);
-    }
+  if ("task" in hook) {
+    logLabeledBullet(
+      "functions",
+      `Executing ${delta} lifecycle hook targeting: ${hook.task.function}...`,
+    );
+    executedEndpoint = await executeTaskQueueHook(hook.task, backendSpec);
+  } else if ("call" in hook) {
+    throw new FirebaseError(`Lifecycle hook action type "call" is not supported.`);
+  } else if ("http" in hook) {
+    throw new FirebaseError(`Lifecycle hook action type "http" is not supported.`);
+  } else {
+    assertExhaustive(hook);
+  }
 
-    if (executedEndpoint) {
-      logLabeledBullet(
-        "functions",
-        `View logs for ${delta} at: ${getCloudConsoleLogUrl(executedEndpoint)}`,
-      );
-    }
-  } catch (err: unknown) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
-    logLabeledWarning("functions", `Failed to execute ${delta} lifecycle hook: ${errorMsg}`);
-    throw err;
+  if (executedEndpoint) {
+    logLabeledBullet(
+      "functions",
+      `View logs for ${delta} at: ${getCloudConsoleLogUrl(executedEndpoint)}`,
+    );
   }
   return executedEndpoint;
 }

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -63,26 +63,27 @@ export async function executeLifecycleHooks(
     if (!hasResourceModifications) {
       logLabeledBullet(
         "functions",
-        "No resources modified in codebase. Skipping afterUpdate lifecycle hook.",
+        `No resources modified for codebase: ${codebase ?? "default"}. Skipping afterUpdate lifecycle hook.`,
       );
       return false;
     }
   }
 
-  if ("task" in hook) {
+  let success = false;
+  try {
+    await executeHook(delta, hook, wantBackend);
+    success = true;
+  } catch (err: unknown) {
+    // We treat lifecycle hook failures as warnings. We don't want to fail
+    // the entire deploy command if a post-deploy hook fails to enqueue.
+    success = false;
+  } finally {
     logLabeledBullet(
       "functions",
-      `Executing ${delta} lifecycle hook targeting: ${hook.task.function}...`,
+      `You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run ${delta} ${codebase ?? "default"}`,
     );
-    await executeTaskQueueHook(hook.task, wantBackend);
-    return true;
-  } else if ("call" in hook) {
-    throw new FirebaseError(`Lifecycle hook action type "call" is not supported.`);
-  } else if ("http" in hook) {
-    throw new FirebaseError(`Lifecycle hook action type "http" is not supported.`);
-  } else {
-    assertExhaustive(hook);
   }
+  return success;
 }
 
 /**
@@ -91,7 +92,7 @@ export async function executeLifecycleHooks(
 async function executeTaskQueueHook(
   taskHook: { function: string; body?: Record<string, unknown> },
   wantBackend: backend.Backend,
-): Promise<void> {
+): Promise<backend.Endpoint> {
   const targetEndpoint = backend.findEndpoint(wantBackend, (ep) => ep.id === taskHook.function);
   if (!targetEndpoint) {
     throw new FirebaseError(
@@ -134,25 +135,12 @@ async function executeTaskQueueHook(
     task.httpRequest.body = body;
   }
 
-  try {
-    await cloudtasks.enqueueTask(queueName, task);
-    logLabeledSuccess(
-      "functions",
-      `Successfully queued task for lifecycle hook ${taskHook.function} in queue ${queueName}.`,
-    );
-    logLabeledBullet(
-      "functions",
-      `View logs for ${taskHook.function} at: ${getCloudConsoleLogUrl(targetEndpoint)}`,
-    );
-  } catch (err: unknown) {
-    // We treat lifecycle hook failures as warnings. We don't want to fail
-    // the entire deploy command if a post-deploy hook fails to enqueue.
-    const errorMsg = err instanceof Error ? err.message : String(err);
-    logLabeledWarning(
-      "functions",
-      `Failed to enqueue task for lifecycle hook ${taskHook.function}: ${errorMsg}`,
-    );
-  }
+  await cloudtasks.enqueueTask(queueName, task);
+  logLabeledSuccess(
+    "functions",
+    `Successfully queued task for lifecycle hook ${taskHook.function} in queue ${queueName}.`,
+  );
+  return targetEndpoint;
 }
 
 /**
@@ -163,4 +151,42 @@ function getCloudConsoleLogUrl(endpoint: backend.Endpoint): string {
   const serviceName = endpoint.runServiceId || id;
   const query = `resource.type="cloud_run_revision"\nresource.labels.service_name="${serviceName}"\nresource.labels.location="${region}"`;
   return `https://console.cloud.google.com/logs/query;query=${encodeURIComponent(query)};project=${project}`;
+}
+
+/**
+ * Executes a specific lifecycle hook in isolation.
+ */
+export async function executeHook(
+  delta: string,
+  hook: backend.LifecycleHook,
+  backendSpec: backend.Backend,
+): Promise<backend.Endpoint | undefined> {
+  let executedEndpoint: backend.Endpoint | undefined;
+  try {
+    if ("task" in hook) {
+      logLabeledBullet(
+        "functions",
+        `Executing ${delta} lifecycle hook targeting: ${hook.task.function}...`,
+      );
+      executedEndpoint = await executeTaskQueueHook(hook.task, backendSpec);
+    } else if ("call" in hook) {
+      throw new FirebaseError(`Lifecycle hook action type "call" is not supported.`);
+    } else if ("http" in hook) {
+      throw new FirebaseError(`Lifecycle hook action type "http" is not supported.`);
+    } else {
+      assertExhaustive(hook);
+    }
+
+    if (executedEndpoint) {
+      logLabeledBullet(
+        "functions",
+        `View logs for ${delta} at: ${getCloudConsoleLogUrl(executedEndpoint)}`,
+      );
+    }
+  } catch (err: unknown) {
+    const errorMsg = err instanceof Error ? err.message : String(err);
+    logLabeledWarning("functions", `Failed to execute ${delta} lifecycle hook: ${errorMsg}`);
+    throw err;
+  }
+  return executedEndpoint;
 }


### PR DESCRIPTION
### Description
This PR introduces new CLI commands to interact with lifecycle hooks, and refactors the hook execution pipeline inside `src/deploy/functions/release/lifecycle.ts` to be more generic.

Key changes:
1. **New commands**:
   - `firebase functions:lifecycle:list <codebase>`: Lists all configured lifecycle hooks for a codebase.
   - `firebase functions:lifecycle:run <hookName> <codebase>`: Executes a specific lifecycle hook manually in isolation.
2. **Centralized Logging & Error Handling**:
   - Refactored `executeLifecycleHooks` and `executeHook` to centrally manage logs and warnings.
   - On hook execution completion, the system logs the target Cloud Console query log URL (`View logs for <hookName> at: ...`).
   - On execution failure, a warning is logged generically and a call-to-action is printed suggesting the corresponding retry CLI command.
   - Hook action execution runners (like `executeTaskQueueHook`) now throw errors upwards to let manual command runs exit with a non-zero code on failures, while letting deployments handle the failures gracefully as warnings.

---

### Scenarios Tested
- **Unit Testing**:
  - `npx mocha src/commands/functions-lifecycle.spec.ts`
  - `npx mocha src/deploy/functions/release/lifecycle.spec.ts`
- **Manual Verification**:
  - Checked console log URLs and formatting output formats under success scenarios.

---

### Sample Commands
```bash
# List all configured lifecycle hooks
firebase functions:lifecycle:list my-codebase

# Run a lifecycle hook in isolation (e.g., afterInstall)
firebase functions:lifecycle:run afterInstall my-codebase
```