### PR TITLE
fix: remove duplicate find endpoint function

### DIFF
--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -92,7 +92,7 @@ async function executeTaskQueueHook(
   taskHook: { function: string; body?: Record<string, unknown> },
   wantBackend: backend.Backend,
 ): Promise<void> {
-  const targetEndpoint = findTargetEndpoint(wantBackend, taskHook.function);
+  const targetEndpoint = backend.findEndpoint(wantBackend, (ep) => ep.id === taskHook.function);
   if (!targetEndpoint) {
     throw new FirebaseError(
       `Target endpoint "${taskHook.function}" not found in backend for lifecycle hook.`,
@@ -153,18 +153,6 @@ async function executeTaskQueueHook(
       `Failed to enqueue task for lifecycle hook ${taskHook.function}: ${errorMsg}`,
     );
   }
-}
-
-function findTargetEndpoint(
-  backendSpec: backend.Backend,
-  targetId: string,
-): backend.Endpoint | undefined {
-  for (const endpoint of backend.allEndpoints(backendSpec)) {
-    if (endpoint.id === targetId) {
-      return endpoint;
-    }
-  }
-  return undefined;
 }
 
 /**


### PR DESCRIPTION
### Description
`findTargetEndpoint` is a redundant utility function to discover an endpoint. We could simply reuse `backend.findEndpoint` and use the same predicate to discover based on id.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

`npx mocha src/deploy/functions/release/lifecycle.spec.ts`
