### PR TITLE
add flag to override host/port for the emulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
 - Add `functions:lifecycle:list` and `functions:lifecycle:run` commands to view and run
   lifecycle hooks in isolation.
+- Add `--host-overrides` flag to dynamically override host and port for `emulators:start`
+  and `emulators:exec`.

--- a/src/commands/emulators-exec.ts
+++ b/src/commands/emulators-exec.ts
@@ -14,6 +14,7 @@ export const command = new Command("emulators:exec <script>")
   .option(commandUtils.FLAG_EXPORT_ON_EXIT, commandUtils.DESC_EXPORT_ON_EXIT)
   .option(commandUtils.FLAG_VERBOSITY, commandUtils.DESC_VERBOSITY)
   .option(commandUtils.FLAG_UI, commandUtils.DESC_UI)
+  .option(commandUtils.FLAG_HOST, commandUtils.DESC_HOST)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   .action((script: string, options: any) => {
     return Promise.race([shutdownWhenKilled(options), emulatorExec(script, options)]);

--- a/src/commands/emulators-start.ts
+++ b/src/commands/emulators-start.ts
@@ -25,6 +25,7 @@ export const command = new Command("emulators:start")
   .option(commandUtils.FLAG_IMPORT, commandUtils.DESC_IMPORT)
   .option(commandUtils.FLAG_EXPORT_ON_EXIT, commandUtils.DESC_EXPORT_ON_EXIT)
   .option(commandUtils.FLAG_VERBOSITY, commandUtils.DESC_VERBOSITY)
+  .option(commandUtils.FLAG_HOST, commandUtils.DESC_HOST)
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   .action((options: Options) => {
     const killSignalPromise = commandUtils.shutdownWhenKilled(options);

--- a/src/emulator/commandUtils.spec.ts
+++ b/src/emulator/commandUtils.spec.ts
@@ -194,5 +194,16 @@ describe("commandUtils", () => {
         "Port must be a number",
       );
     });
+
+    it("should throw error on zero, negative, or out-of-range port", () => {
+      expect(() => commandUtils.parseHostOverrides("firestore:0")).to.throw(
+        FirebaseError,
+        "Port must be a valid number between 1 and 65535",
+      );
+      expect(() => commandUtils.parseHostOverrides("firestore:65536")).to.throw(
+        FirebaseError,
+        "Port must be a valid number between 1 and 65535",
+      );
+    });
   });
 });

--- a/src/emulator/commandUtils.spec.ts
+++ b/src/emulator/commandUtils.spec.ts
@@ -195,7 +195,7 @@ describe("commandUtils", () => {
       );
     });
 
-    it("should throw error on zero, negative, or out-of-range port", () => {
+    it("should throw error on zero or out-of-range port", () => {
       expect(() => commandUtils.parseHostOverrides("firestore:0")).to.throw(
         FirebaseError,
         "Port must be a valid number between 1 and 65535",

--- a/src/emulator/commandUtils.spec.ts
+++ b/src/emulator/commandUtils.spec.ts
@@ -120,4 +120,79 @@ describe("commandUtils", () => {
       }).someUnrelatedOption,
     ).to.eql("isHere");
   });
+
+  describe("parseHostOverrides", () => {
+    it("should throw error on missing colon or empty override", () => {
+      expect(() => commandUtils.parseHostOverrides("firestore")).to.throw(
+        FirebaseError,
+        "Emulator overrides must be in the format <emulator>:<port> or <emulator>:<host>:<port>",
+      );
+      expect(() => commandUtils.parseHostOverrides("firestore:")).to.throw(
+        FirebaseError,
+        "Emulator overrides must be in the format <emulator>:<port> or <emulator>:<host>:<port>",
+      );
+    });
+
+    it("should parse single host override with port only", () => {
+      expect(commandUtils.parseHostOverrides("firestore:8080")).to.deep.equal({
+        firestore: { port: 8080 },
+      });
+    });
+
+    it("should parse single host override with host and port", () => {
+      expect(commandUtils.parseHostOverrides("firestore:127.0.0.1:8080")).to.deep.equal({
+        firestore: { host: "127.0.0.1", port: 8080 },
+      });
+      expect(commandUtils.parseHostOverrides("firestore:localhost:8080")).to.deep.equal({
+        firestore: { host: "localhost", port: 8080 },
+      });
+    });
+
+    it("should parse multiple host overrides", () => {
+      expect(
+        commandUtils.parseHostOverrides(
+          "firestore:8080,auth:127.0.0.1:9199,database:localhost:8085",
+        ),
+      ).to.deep.equal({
+        firestore: { port: 8080 },
+        auth: { host: "127.0.0.1", port: 9199 },
+        database: { host: "localhost", port: 8085 },
+      });
+    });
+
+    it("should parse IPv6 addresses enclosed in brackets with port", () => {
+      expect(commandUtils.parseHostOverrides("firestore:[::1]:8080")).to.deep.equal({
+        firestore: { host: "::1", port: 8080 },
+      });
+    });
+
+    it("should throw error on host-only override without a port", () => {
+      expect(() => commandUtils.parseHostOverrides("firestore:127.0.0.1")).to.throw(
+        FirebaseError,
+        "Port must be a number, or specify host and port as <emulator>:<host>:<port>",
+      );
+      expect(() => commandUtils.parseHostOverrides("firestore:localhost")).to.throw(
+        FirebaseError,
+        "Port must be a number, or specify host and port as <emulator>:<host>:<port>",
+      );
+    });
+
+    it("should throw error on invalid emulator name", () => {
+      expect(() => commandUtils.parseHostOverrides("non_existent_emulator:8080")).to.throw(
+        FirebaseError,
+        "is not a valid emulator name",
+      );
+    });
+
+    it("should throw error on non-numeric port", () => {
+      expect(() => commandUtils.parseHostOverrides("firestore:not_a_number")).to.throw(
+        FirebaseError,
+        "Port must be a number",
+      );
+      expect(() => commandUtils.parseHostOverrides("firestore:localhost:not_a_number")).to.throw(
+        FirebaseError,
+        "Port must be a number",
+      );
+    });
+  });
 });

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -9,7 +9,7 @@ import * as path from "path";
 import { Constants } from "./constants";
 import { requireAuth } from "../requireAuth";
 import { requireConfig } from "../requireConfig";
-import { Emulators, ALL_SERVICE_EMULATORS } from "./types";
+import { Emulators, ALL_SERVICE_EMULATORS, isEmulator } from "./types";
 import { FirebaseError } from "../error";
 import { getError } from "../error";
 import { EmulatorRegistry } from "./registry";
@@ -64,6 +64,10 @@ export const DESC_TEST_CONFIG =
 export const FLAG_TEST_PARAMS = "--test-params <params.env file>";
 export const DESC_TEST_PARAMS =
   "A .env file containing test param values for your emulated extension.";
+
+export const FLAG_HOST = "--host-overrides <hosts>";
+export const DESC_HOST =
+  'emulator specific host/port overrides (e.g. "--host-overrides firestore:8080,auth:127.0.0.1:9199")';
 
 export const DEFAULT_CONFIG = new Config(
   {
@@ -151,6 +155,9 @@ export async function errorMissingProject(options: any): Promise<void> {
  * uses the emulator suite.
  */
 export async function beforeEmulatorCommand(options: any): Promise<any> {
+  if (options.hostOverrides) {
+    options.hostOverrides = parseHostOverrides(options.hostOverrides);
+  }
   const optionsWithDefaultConfig = {
     ...options,
     config: DEFAULT_CONFIG,
@@ -255,6 +262,84 @@ export function setExportOnExitOptions(options: ExportOnExitOptions): void {
     }
   }
   return;
+}
+
+export interface EmulatorHostOverrides {
+  [emulator: string]: { host?: string; port?: number };
+}
+
+export function parseHostOverrides(hostOverrides: string): EmulatorHostOverrides {
+  const emulatorHostOverrides: EmulatorHostOverrides = {};
+
+  const overrides = hostOverrides.split(",");
+  for (const override of overrides) {
+    const colonIndex = override.indexOf(":");
+    if (colonIndex === -1) {
+      throw new FirebaseError(
+        `Invalid --host-overrides value "${override}". Emulator overrides must be in the format <emulator>:<port> or <emulator>:<host>:<port>.`,
+      );
+    }
+
+    const emulatorName = override.substring(0, colonIndex);
+    if (!isEmulator(emulatorName)) {
+      throw new FirebaseError(
+        `Invalid --host-overrides value. "${emulatorName}" is not a valid emulator name. Valid emulators are: ${Object.values(
+          Emulators,
+        ).join(", ")}`,
+      );
+    }
+
+    const hostOverride = override.substring(colonIndex + 1);
+    if (hostOverride.length === 0) {
+      throw new FirebaseError(
+        `Invalid --host-overrides value "${override}". Emulator overrides must be in the format <emulator>:<port> or <emulator>:<host>:<port>.`,
+      );
+    }
+
+    let host: string | undefined;
+    let port: number;
+
+    const colonCount = (hostOverride.match(/:/g) || []).length;
+    if (colonCount > 1) {
+      // IPv6 with host:port
+      const ipv6WHostPortMatch = hostOverride.match(/^\[(.*)\]:(\d+)$/);
+      if (!ipv6WHostPortMatch) {
+        throw new FirebaseError(
+          `Invalid --host-overrides value "${override}". IPv6 addresses must be enclosed in brackets with a port (e.g. [::1]:8080)`,
+        );
+      }
+      host = ipv6WHostPortMatch[1];
+      port = parseInt(ipv6WHostPortMatch[2], 10);
+    } else if (colonCount === 1) {
+      // host:port
+      const [hostString, portString] = hostOverride.split(":");
+      if (!/^\d+$/.test(portString)) {
+        throw new FirebaseError(
+          `Invalid --host-overrides value "${override}". Port must be a number.`,
+        );
+      }
+      host = hostString;
+      port = parseInt(portString, 10);
+    } else {
+      // Only a port
+      if (!/^\d+$/.test(hostOverride)) {
+        throw new FirebaseError(
+          `Invalid --host-overrides value "${override}". Port must be a number, or specify host and port as <emulator>:<host>:<port>.`,
+        );
+      }
+      port = parseInt(hostOverride, 10);
+    }
+
+    if (isNaN(port)) {
+      throw new FirebaseError(
+        `Invalid --host-overrides value "${override}". Port must be a number.`,
+      );
+    }
+
+    emulatorHostOverrides[emulatorName] = host ? { host, port } : { port };
+  }
+
+  return emulatorHostOverrides;
 }
 
 function processKillSignal(

--- a/src/emulator/commandUtils.ts
+++ b/src/emulator/commandUtils.ts
@@ -155,7 +155,7 @@ export async function errorMissingProject(options: any): Promise<void> {
  * uses the emulator suite.
  */
 export async function beforeEmulatorCommand(options: any): Promise<any> {
-  if (options.hostOverrides) {
+  if (typeof options.hostOverrides === "string") {
     options.hostOverrides = parseHostOverrides(options.hostOverrides);
   }
   const optionsWithDefaultConfig = {
@@ -271,7 +271,10 @@ export interface EmulatorHostOverrides {
 export function parseHostOverrides(hostOverrides: string): EmulatorHostOverrides {
   const emulatorHostOverrides: EmulatorHostOverrides = {};
 
-  const overrides = hostOverrides.split(",");
+  const overrides = hostOverrides
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
   for (const override of overrides) {
     const colonIndex = override.indexOf(":");
     if (colonIndex === -1) {
@@ -280,7 +283,7 @@ export function parseHostOverrides(hostOverrides: string): EmulatorHostOverrides
       );
     }
 
-    const emulatorName = override.substring(0, colonIndex);
+    const emulatorName = override.substring(0, colonIndex).trim();
     if (!isEmulator(emulatorName)) {
       throw new FirebaseError(
         `Invalid --host-overrides value. "${emulatorName}" is not a valid emulator name. Valid emulators are: ${Object.values(
@@ -289,7 +292,7 @@ export function parseHostOverrides(hostOverrides: string): EmulatorHostOverrides
       );
     }
 
-    const hostOverride = override.substring(colonIndex + 1);
+    const hostOverride = override.substring(colonIndex + 1).trim();
     if (hostOverride.length === 0) {
       throw new FirebaseError(
         `Invalid --host-overrides value "${override}". Emulator overrides must be in the format <emulator>:<port> or <emulator>:<host>:<port>.`,
@@ -312,7 +315,7 @@ export function parseHostOverrides(hostOverrides: string): EmulatorHostOverrides
       port = parseInt(ipv6WHostPortMatch[2], 10);
     } else if (colonCount === 1) {
       // host:port
-      const [hostString, portString] = hostOverride.split(":");
+      const [hostString, portString] = hostOverride.split(":").map((s) => s.trim());
       if (!/^\d+$/.test(portString)) {
         throw new FirebaseError(
           `Invalid --host-overrides value "${override}". Port must be a number.`,
@@ -330,9 +333,9 @@ export function parseHostOverrides(hostOverrides: string): EmulatorHostOverrides
       port = parseInt(hostOverride, 10);
     }
 
-    if (isNaN(port)) {
+    if (isNaN(port) || port < 1 || port > 65535) {
       throw new FirebaseError(
-        `Invalid --host-overrides value "${override}". Port must be a number.`,
+        `Invalid --host-overrides value "${override}". Port must be a valid number between 1 and 65535.`,
       );
     }
 

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -32,6 +32,7 @@ import { EmulatorLogger, Verbosity } from "./emulatorLogger";
 import { EmulatorHubClient } from "./hubClient";
 import { confirm } from "../prompt";
 import {
+  EmulatorHostOverrides,
   FLAG_EXPORT_ON_EXIT_NAME,
   JAVA_DEPRECATION_WARNING,
   MIN_SUPPORTED_JAVA_MAJOR_VERSION,
@@ -263,6 +264,7 @@ function findExportMetadata(importPath: string): ExportMetadata | undefined {
 interface EmulatorOptions extends Options {
   extDevEnv?: Record<string, string>;
   logVerbosity?: "DEBUG" | "INFO" | "QUIET" | "SILENT";
+  hostOverrides?: EmulatorHostOverrides;
 }
 
 /**
@@ -1069,7 +1071,10 @@ function getListenConfig(
   options: EmulatorOptions,
   emulator: Exclude<Emulators, Emulators.EXTENSIONS>,
 ): EmulatorListenConfig {
-  let host = options.config.src.emulators?.[emulator]?.host || Constants.getDefaultHost();
+  let host =
+    options?.hostOverrides?.[emulator]?.host ||
+    options.config.src.emulators?.[emulator]?.host ||
+    Constants.getDefaultHost();
   if (host === "localhost" && utils.isRunningInWSL()) {
     // HACK(https://github.com/firebase/firebase-tools-ui/issues/332): Use IPv4
     // 127.0.0.1 instead of localhost. This, combined with the hack in
@@ -1081,9 +1086,13 @@ function getListenConfig(
   }
 
   const portVal = options.config.src.emulators?.[emulator]?.port;
+  const overridePort = options?.hostOverrides?.[emulator]?.port;
   let port: number;
   let portFixed: boolean;
-  if (portVal) {
+  if (overridePort !== undefined) {
+    port = overridePort;
+    portFixed = true;
+  } else if (portVal) {
     port = parseInt(`${portVal}`, 10);
     portFixed = true;
   } else {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

Proposed fix for #10756. Adding a flag for each emulator might make it difficult to maintain since we would have to add a flag whenever a new emulator is added, so opt for using a single flag to override host/port for the emulators. Usage: `firebase emulators:start --host-overrides "functions:[::1]:8082,auth:9098"`.

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

<details>
<summary>ipv6 address - works</summary>

```
$ firebase emulators:start --host-overrides "functions:[::1]:8082,auth:9098"
i  emulators: Starting emulators: auth, functions, firestore, extensions
i  emulators: Detected demo project ID "demo-no-project", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
i  functions: Watching "/Users/PATH/issues/10756/functions" for Cloud Functions...
⚠  functions: Your requested "node" version "24" doesn't match your global version "20". Using node@20 from host.
Serving at port 8163

✔  functions: Loaded functions definitions from source: helloWorld.
✔  functions[us-central1-helloWorld]: http function initialized (http://[::1]:8082/demo-no-project/us-central1/helloWorld).

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://127.0.0.1:4000/               │
└─────────────────────────────────────────────────────────────┘

┌────────────────┬────────────────┬──────────────────────────────────┐
│ Emulator       │ Host:Port      │ View in Emulator UI              │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Authentication │ 127.0.0.1:9098 │ http://127.0.0.1:4000/auth       │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Functions      │ [::1]:8082     │ http://127.0.0.1:4000/functions  │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Firestore      │ 127.0.0.1:8080 │ http://127.0.0.1:4000/firestore  │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Extensions     │ [::1]:8082     │ http://127.0.0.1:4000/extensions │
└────────────────┴────────────────┴──────────────────────────────────┘
  Emulator Hub host: 127.0.0.1 port: 4400
  Other reserved ports: 4500, 9150
┌─────────────────────────┬───────────────┬─────────────────────┐
│ Extension Instance Name │ Extension Ref │ View in Emulator UI │
└─────────────────────────┴───────────────┴─────────────────────┘
Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
 
 ```
 </details>

<details>
<summary>ipv4 address - works</summary>

```
$ firebase emulators:start --host-overrides functions:127.0.0.1:8082,auth:9098
i  emulators: Starting emulators: auth, functions, firestore, extensions
i  emulators: Detected demo project ID "demo-no-project", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
i  functions: Watching "/Users/PATH/firebase-tools/issues/10756/functions" for Cloud Functions...
⚠  functions: Your requested "node" version "24" doesn't match your global version "20". Using node@20 from host.
Serving at port 8615

✔  functions: Loaded functions definitions from source: helloWorld.
✔  functions[us-central1-helloWorld]: http function initialized (http://127.0.0.1:8082/demo-no-project/us-central1/helloWorld).

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://127.0.0.1:4000/               │
└─────────────────────────────────────────────────────────────┘

┌────────────────┬────────────────┬──────────────────────────────────┐
│ Emulator       │ Host:Port      │ View in Emulator UI              │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Authentication │ 127.0.0.1:9098 │ http://127.0.0.1:4000/auth       │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Functions      │ 127.0.0.1:8082 │ http://127.0.0.1:4000/functions  │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Firestore      │ 127.0.0.1:8080 │ http://127.0.0.1:4000/firestore  │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Extensions     │ 127.0.0.1:8082 │ http://127.0.0.1:4000/extensions │
└────────────────┴────────────────┴──────────────────────────────────┘
  Emulator Hub host: 127.0.0.1 port: 4400
  Other reserved ports: 4500, 9150
┌─────────────────────────┬───────────────┬─────────────────────┐
│ Extension Instance Name │ Extension Ref │ View in Emulator UI │
└─────────────────────────┴───────────────┴─────────────────────┘
Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
```
</details>

<details>
<summary>emulator:port - works</summary>

```
$ firebase emulators:start --host-overrides functions:9098
i  emulators: Starting emulators: auth, functions, firestore, extensions
i  emulators: Detected demo project ID "demo-no-project", emulated services will use a demo configuration and attempts to access non-emulated services for this project will fail.
i  firestore: Firestore Emulator logging to firestore-debug.log
✔  firestore: Firestore Emulator was started in standard edition.
✔  firestore: Firestore Emulator UI websocket is running on 9150.
i  functions: Watching "/Users/PATH/firebase-tools/issues/10756/functions" for Cloud Functions...
⚠  functions: Your requested "node" version "24" doesn't match your global version "20". Using node@20 from host.
Serving at port 8594

✔  functions: Loaded functions definitions from source: helloWorld.
✔  functions[us-central1-helloWorld]: http function initialized (http://127.0.0.1:9098/demo-no-project/us-central1/helloWorld).

┌─────────────────────────────────────────────────────────────┐
│ ✔  All emulators ready! It is now safe to connect your app. │
│ i  View Emulator UI at http://127.0.0.1:4000/               │
└─────────────────────────────────────────────────────────────┘

┌────────────────┬────────────────┬──────────────────────────────────┐
│ Emulator       │ Host:Port      │ View in Emulator UI              │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Authentication │ 127.0.0.1:9099 │ http://127.0.0.1:4000/auth       │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Functions      │ 127.0.0.1:9098 │ http://127.0.0.1:4000/functions  │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Firestore      │ 127.0.0.1:8080 │ http://127.0.0.1:4000/firestore  │
├────────────────┼────────────────┼──────────────────────────────────┤
│ Extensions     │ 127.0.0.1:9098 │ http://127.0.0.1:4000/extensions │
└────────────────┴────────────────┴──────────────────────────────────┘
  Emulator Hub host: 127.0.0.1 port: 4400
  Other reserved ports: 4500, 9150
┌─────────────────────────┬───────────────┬─────────────────────┐
│ Extension Instance Name │ Extension Ref │ View in Emulator UI │
└─────────────────────────┴───────────────┴─────────────────────┘
Issues? Report them at https://github.com/firebase/firebase-tools/issues and attach the *-debug.log files.
```
</details>

invalid format - correctly throws error

```
$ firebase emulators:start --host-overrides functions:

Error: Invalid --host-overrides value "functions:". Emulator overrides must be in the format <emulator>:<port> or <emulator>:<host>:<port>.
```

```
$ firebase emulators:start --host-overrides functions

Error: Invalid --host-overrides value "functions". Emulator overrides must be in the format <emulator>:<port> or <emulator>:<host>:<port>.
```

```
$ firebase emulators:start --host-overrides functions:not-a-port

Error: Invalid --host-overrides value "functions:not-a-port". Port must be a number, or specify host and port as <emulator>:<host>:<port>.
```

```
$ firebase emulators:start --host-overrides invalid-emulator:9098

Error: Invalid --host-overrides value. "invalid-emulator" is not a valid emulator name. Valid emulators are: auth, hub, functions, firestore, database, hosting, apphosting, pubsub, ui, logging, storage, extensions, eventarc, dataconnect, tasks
```

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->

`firebase emulators:start --host-overrides functions:127.0.0.1:8082,auth:9098`