### PR TITLE
feat: add firebase ailogic CLI command surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Added Firebase AI Logic CLI commands under the `firebase ailogic` namespace to enable/disable backends, manage consolidated settings configuration, deploy/manage server prompt templates, and register before/after generate-content triggers.
 - Updated Pub/Sub emulator to version 0.8.34

--- a/src/commands/ailogic-config-get.ts
+++ b/src/commands/ailogic-config-get.ts
@@ -1,0 +1,82 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:config:get [path]")
+  .description("read AI Logic configuration")
+  .before(requirePermissions, ["firebasevertexai.config.get", "serviceusage.services.get"])
+  .action(async (path: string | undefined, options: Options) => {
+    const projectId = needProjectId(options);
+
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    const config = await ailogic.getConfig(projectId);
+
+    const authOnly = config.trafficFilter?.firebaseAuthRequired ?? false;
+    const templateOnly = config.trafficFilter?.templateOnly ?? false;
+    const monitoringState = config.telemetryConfig?.mode === "ALL";
+    const sampleRatePercent =
+      config.telemetryConfig?.samplingRate !== undefined
+        ? Math.round(config.telemetryConfig.samplingRate * 100)
+        : 100;
+
+    const enabledProviders = await ailogic.listProviders(projectId);
+    const hasDeveloperApi = enabledProviders.includes("gemini-developer-api");
+    const hasAgentPlatform = enabledProviders.includes("agent-platform-gemini-api");
+
+    const configObj = {
+      providers: {
+        "gemini-developer-api": hasDeveloperApi,
+        "agent-platform-gemini-api": hasAgentPlatform,
+      },
+      security: {
+        "auth-only": authOnly,
+        "template-only": templateOnly,
+      },
+      monitoring: {
+        state: monitoringState,
+        "sample-rate-percentage": sampleRatePercent,
+      },
+    };
+
+    if (path) {
+      const validPaths = [
+        "providers",
+        "providers.gemini-developer-api",
+        "providers.agent-platform-gemini-api",
+        "security",
+        "security.auth-only",
+        "security.template-only",
+        "monitoring",
+        "monitoring.state",
+        "monitoring.sample-rate-percentage",
+      ];
+      if (!validPaths.includes(path)) {
+        throw new FirebaseError(
+          `Unknown configuration path: ${path}\n\nValid paths:\n\n` +
+            [
+              "security.auth-only",
+              "security.template-only",
+              "monitoring.state",
+              "monitoring.sample-rate-percentage",
+            ]
+              .map((p) => `  ${p}`)
+              .join("\n"),
+        );
+      }
+      const parts = path.split(".");
+      let val: any = configObj;
+      for (const part of parts) {
+        val = val[part];
+      }
+      logger.info(typeof val === "object" ? JSON.stringify(val, null, 2) : String(val));
+      return val;
+    } else {
+      logger.info(JSON.stringify(configObj, null, 2));
+      return configObj;
+    }
+  });

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -1,0 +1,122 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import { confirm } from "../prompt";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:config:set <path> <value>")
+  .description("set one configuration value")
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requirePermissions, ["firebasevertexai.config.update", "firebasevertexai.config.get"])
+  .action(async (pathStr: string, value: string, options: Options) => {
+    const projectId = needProjectId(options);
+
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+
+    const validPaths = [
+      "security.auth-only",
+      "security.template-only",
+      "monitoring.state",
+      "monitoring.sample-rate-percentage",
+    ];
+
+    if (!validPaths.includes(pathStr)) {
+      throw new FirebaseError(
+        `Unknown configuration path: ${pathStr}\n\nValid paths:\n\n` +
+          validPaths.map((p) => `  ${p}`).join("\n"),
+      );
+    }
+
+    // Tightening check
+    if (pathStr === "security.auth-only" || pathStr === "security.template-only") {
+      if (value !== "true" && value !== "false") {
+        throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
+      }
+      const boolVal = value === "true";
+
+      if (boolVal) {
+        // Fetch current config to check if it's currently false
+        const currentConfig = await ailogic.getConfig(projectId);
+        const currentVal =
+          pathStr === "security.auth-only"
+            ? currentConfig.trafficFilter?.firebaseAuthRequired ?? false
+            : currentConfig.trafficFilter?.templateOnly ?? false;
+
+        if (!currentVal) {
+          const rejectMsg =
+            pathStr === "security.auth-only"
+              ? "reject requests from unauthenticated users"
+              : "reject requests not using templates";
+
+          const confirmed = await confirm({
+            message: `Enabling ${clc.bold(pathStr)} will ${rejectMsg}. Continue?`,
+            force: options.force,
+            nonInteractive: options.nonInteractive,
+          });
+
+          if (!confirmed) {
+            throw new FirebaseError("Command aborted.", { exit: 1 });
+          }
+        }
+      }
+
+      if (pathStr === "security.auth-only") {
+        await ailogic.updateConfig(
+          projectId,
+          {
+            trafficFilter: { firebaseAuthRequired: boolVal },
+          },
+          ["trafficFilter.firebaseAuthRequired"],
+        );
+      } else {
+        await ailogic.updateConfig(
+          projectId,
+          {
+            trafficFilter: { templateOnly: boolVal },
+          },
+          ["trafficFilter.templateOnly"],
+        );
+      }
+      logger.info(
+        clc.green(`Successfully updated security setting: ${clc.bold(pathStr)} = ${value}`),
+      );
+    } else if (pathStr === "monitoring.state") {
+      if (value !== "true" && value !== "false") {
+        throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
+      }
+      const boolVal = value === "true";
+      await ailogic.updateConfig(
+        projectId,
+        {
+          telemetryConfig: { mode: boolVal ? "ALL" : "NONE" },
+        },
+        ["telemetryConfig.mode"],
+      );
+      logger.info(
+        clc.green(`Successfully updated monitoring state: ${clc.bold(pathStr)} = ${value}`),
+      );
+    } else if (pathStr === "monitoring.sample-rate-percentage") {
+      const numVal = Number(value);
+      if (isNaN(numVal) || numVal <= 0 || numVal > 100) {
+        throw new FirebaseError(
+          `Value for ${clc.bold(pathStr)} must be a number in the range (0, 100].`,
+        );
+      }
+      const samplingRate = numVal / 100;
+      await ailogic.updateConfig(
+        projectId,
+        {
+          telemetryConfig: { samplingRate },
+        },
+        ["telemetryConfig.samplingRate"],
+      );
+      logger.info(
+        clc.green(`Successfully updated monitoring sample rate: ${clc.bold(pathStr)} = ${value}%`),
+      );
+    }
+  });

--- a/src/commands/ailogic-providers-disable.ts
+++ b/src/commands/ailogic-providers-disable.ts
@@ -1,0 +1,34 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import { confirm } from "../prompt";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:disable <providerType>")
+  .description("disable a Gemini API provider service")
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requirePermissions, ["serviceusage.services.disable"])
+  .action(async (providerType: string, options: Options) => {
+    const projectId = needProjectId(options);
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
+      throw new FirebaseError(
+        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
+      );
+    }
+    const confirmed = await confirm({
+      message: `You are about to disable ${clc.bold(providerType)}. This will stop running apps from invoking it. Are you sure?`,
+      force: options.force,
+      nonInteractive: options.nonInteractive,
+    });
+    if (!confirmed) {
+      throw new FirebaseError("Command aborted.", { exit: 1 });
+    }
+    await ailogic.disableProvider(projectId, providerType as ailogic.ProviderType);
+    logger.info(clc.green(`Successfully disabled provider: ${clc.bold(providerType)}`));
+  });

--- a/src/commands/ailogic-providers-enable.ts
+++ b/src/commands/ailogic-providers-enable.ts
@@ -1,0 +1,23 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:enable <providerType>")
+  .description("enable a Gemini API provider service")
+  .before(requirePermissions, ["serviceusage.services.enable", "firebasevertexai.config.update"])
+  .action(async (providerType: string, options: Options) => {
+    const projectId = needProjectId(options);
+    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
+      throw new FirebaseError(
+        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
+      );
+    }
+    await ailogic.enableProvider(projectId, providerType as ailogic.ProviderType);
+    logger.info(clc.green(`Successfully enabled provider: ${clc.bold(providerType)}`));
+  });

--- a/src/commands/ailogic-providers-list.ts
+++ b/src/commands/ailogic-providers-list.ts
@@ -1,0 +1,39 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:list")
+  .description("list which Gemini API providers are enabled")
+  .before(requirePermissions, ["serviceusage.services.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    const enabledProviders = await ailogic.listProviders(projectId);
+
+    if (enabledProviders.length === 0) {
+      logger.info(clc.bold("No Gemini API providers are enabled."));
+      return enabledProviders;
+    }
+
+    const tableHead = ["Provider", "Status"];
+    const table = new Table({ head: tableHead, style: { head: ["green"] } });
+
+    // Show both possible providers, indicating if they are enabled or disabled
+    const allProviders: ailogic.ProviderType[] = [
+      "gemini-developer-api",
+      "agent-platform-gemini-api",
+    ];
+    for (const provider of allProviders) {
+      const isEnabled = enabledProviders.includes(provider);
+      table.push([clc.bold(provider), isEnabled ? clc.green("Enabled") : clc.red("Disabled")]);
+    }
+
+    logger.info(table.toString());
+    return enabledProviders;
+  });

--- a/src/commands/ailogic-templates-delete.ts
+++ b/src/commands/ailogic-templates-delete.ts
@@ -1,0 +1,48 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { confirm } from "../prompt";
+import { FirebaseError } from "../error";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:templates:delete <templateId>")
+  .description("delete a template")
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requirePermissions, ["firebasevertexai.templates.delete"])
+  .action(async (templateId: string, options: Options) => {
+    const projectId = needProjectId(options);
+
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+
+    let template: ailogic.Template;
+    try {
+      template = await ailogic.getTemplate(projectId, "global", templateId);
+    } catch (err: any) {
+      if (err.status === 404) {
+        throw new FirebaseError(`Template ${clc.bold(templateId)} does not exist.`);
+      }
+      throw err;
+    }
+
+    if (template.locked) {
+      throw new FirebaseError(
+        `The following templates are locked and cannot be deleted:\n\n  ${templateId}\n\nUnlock them by running:\n\n  firebase ailogic:templates:unlock <templateId>`,
+      );
+    }
+
+    const confirmed = await confirm({
+      message: `Are you sure you want to delete template ${clc.bold(templateId)}?`,
+      force: options.force,
+      nonInteractive: options.nonInteractive,
+    });
+    if (!confirmed) {
+      throw new FirebaseError("Command aborted.", { exit: 1 });
+    }
+
+    await ailogic.deleteTemplate(projectId, "global", templateId);
+    logger.info(clc.green(`Successfully deleted template: ${clc.bold(templateId)}`));
+  });

--- a/src/commands/ailogic-templates-deploy.spec.ts
+++ b/src/commands/ailogic-templates-deploy.spec.ts
@@ -1,0 +1,163 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { command } from "./ailogic-templates-deploy";
+import * as ailogic from "../gcp/ailogic";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import * as fs from "fs";
+import * as prompt from "../prompt";
+
+describe("ailogic:templates:deploy", () => {
+  const sandbox = sinon.createSandbox();
+  let listTemplatesStub: sinon.SinonStub;
+  let updateTemplateStub: sinon.SinonStub;
+  let deleteTemplateStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+  let existsSyncStub: sinon.SinonStub;
+  let statSyncStub: sinon.SinonStub;
+  let readdirSyncStub: sinon.SinonStub;
+  let readFileSyncStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    listTemplatesStub = sandbox.stub(ailogic, "listTemplates");
+    updateTemplateStub = sandbox.stub(ailogic, "updateTemplate");
+    deleteTemplateStub = sandbox.stub(ailogic, "deleteTemplate");
+    sandbox.stub(ailogic, "ensureAILogicApiEnabled").resolves();
+    confirmStub = sandbox.stub(prompt, "confirm");
+    existsSyncStub = sandbox.stub(fs, "existsSync");
+    statSyncStub = sandbox.stub(fs, "statSync");
+    readdirSyncStub = sandbox.stub(fs, "readdirSync");
+    readFileSyncStub = sandbox.stub(fs, "readFileSync");
+    sandbox.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should fail if validation of a prompt file fails", async () => {
+    const options = { project: "test-project", dir: "prompts" };
+    existsSyncStub.returns(true);
+    statSyncStub.returns({ isDirectory: () => true });
+    readdirSyncStub.returns(["t1.prompt", "t2.prompt"]);
+    readFileSyncStub.onFirstCall().returns(""); // empty file -> invalid
+    readFileSyncStub.onSecondCall().returns("---\nmodel: test\n---\nbody"); // valid
+
+    await expect(command.runner()(options)).to.be.rejectedWith(
+      FirebaseError,
+      "The following prompt files failed validation:\n  t1.prompt: File is empty.",
+    );
+
+    expect(updateTemplateStub).to.not.be.called;
+  });
+
+  it("should fail if local file targets a locked remote template", async () => {
+    const options = { project: "test-project", dir: "prompts" };
+    existsSyncStub.returns(true);
+    statSyncStub.returns({ isDirectory: () => true });
+    readdirSyncStub.returns(["welcome.prompt"]);
+    readFileSyncStub.returns("welcome body");
+
+    // Remote template exists and is locked
+    listTemplatesStub.resolves([
+      {
+        name: "projects/test-project/locations/global/templates/welcome",
+        templateString: "old content",
+        locked: true,
+      },
+    ]);
+
+    await expect(command.runner()(options)).to.be.rejectedWith(
+      FirebaseError,
+      "The following templates are locked and cannot be updated or deleted:\n\n  welcome\n\nUnlock them by running:\n\n  firebase ailogic:templates:unlock <templateId>\n\nThen deploy again. No templates were deployed.",
+    );
+
+    expect(updateTemplateStub).to.not.be.called;
+  });
+
+  it("should deploy templates successfully", async () => {
+    const options = { project: "test-project", dir: "prompts" };
+    existsSyncStub.returns(true);
+    statSyncStub.returns({ isDirectory: () => true });
+    readdirSyncStub.returns(["welcome.prompt"]);
+    readFileSyncStub.returns("welcome body");
+
+    listTemplatesStub.resolves([]);
+    updateTemplateStub.resolves({});
+
+    await command.runner()(options);
+
+    expect(updateTemplateStub).to.have.been.calledOnceWith("test-project", "global", "welcome", {
+      templateString: "welcome body",
+      displayName: "welcome",
+    });
+  });
+
+  it("should prune templates successfully after confirmation", async () => {
+    const options = { project: "test-project", dir: "prompts", prune: true };
+    existsSyncStub.returns(true);
+    statSyncStub.returns({ isDirectory: () => true });
+    readdirSyncStub.returns(["welcome.prompt"]);
+    readFileSyncStub.returns("welcome body");
+
+    // remote has welcome and stale-template
+    listTemplatesStub.resolves([
+      {
+        name: "projects/test-project/locations/global/templates/welcome",
+        templateString: "old content",
+        locked: false,
+      },
+      {
+        name: "projects/test-project/locations/global/templates/stale-template",
+        templateString: "stale content",
+        locked: false,
+      },
+    ]);
+
+    updateTemplateStub.resolves({});
+    deleteTemplateStub.resolves({});
+    confirmStub.resolves(true); // User confirms pruning
+
+    await command.runner()(options);
+
+    expect(updateTemplateStub).to.have.been.calledOnceWith("test-project", "global", "welcome", {
+      templateString: "welcome body",
+      displayName: "welcome",
+    });
+    expect(deleteTemplateStub).to.have.been.calledOnceWith(
+      "test-project",
+      "global",
+      "stale-template",
+    );
+  });
+
+  it("should fail prune if stale remote template is locked", async () => {
+    const options = { project: "test-project", dir: "prompts", prune: true };
+    existsSyncStub.returns(true);
+    statSyncStub.returns({ isDirectory: () => true });
+    readdirSyncStub.returns(["welcome.prompt"]);
+    readFileSyncStub.returns("welcome body");
+
+    // stale template is locked
+    listTemplatesStub.resolves([
+      {
+        name: "projects/test-project/locations/global/templates/welcome",
+        templateString: "old content",
+        locked: false,
+      },
+      {
+        name: "projects/test-project/locations/global/templates/stale-template",
+        templateString: "stale content",
+        locked: true,
+      },
+    ]);
+
+    await expect(command.runner()(options)).to.be.rejectedWith(
+      FirebaseError,
+      "The following templates are locked and cannot be updated or deleted:\n\n  stale-template\n\nUnlock them by running:\n\n  firebase ailogic:templates:unlock <templateId>\n\nThen deploy again. No templates were deployed.",
+    );
+
+    expect(updateTemplateStub).to.not.be.called;
+    expect(deleteTemplateStub).to.not.be.called;
+  });
+});

--- a/src/commands/ailogic-templates-deploy.ts
+++ b/src/commands/ailogic-templates-deploy.ts
@@ -1,0 +1,167 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import * as fs from "fs";
+import * as path from "path";
+import { confirm } from "../prompt";
+import * as yaml from "js-yaml";
+
+import { Options } from "../options";
+
+interface DeployOptions extends Options {
+  dir?: string;
+  prune?: boolean;
+}
+
+function validatePromptFile(content: string): string | null {
+  if (!content.trim()) {
+    return "File is empty.";
+  }
+  if (content.startsWith("---")) {
+    const parts = content.split("---");
+    if (parts.length < 3) {
+      return "Frontmatter block is not closed (missing terminating '---').";
+    }
+    const yamlContent = parts[1];
+    try {
+      yaml.load(yamlContent);
+    } catch (err: any) {
+      return `Invalid YAML in frontmatter: ${err.message || err}`;
+    }
+  }
+  return null;
+}
+
+export const command = new Command("ailogic:templates:deploy")
+  .description("deploy server prompt templates from local files")
+  .option("--dir <path>", "directory containing .prompt files", "prompts")
+  .option("--prune", "delete remote templates with no matching local .prompt file")
+  .before(requirePermissions, ["firebasevertexai.templates.update"])
+  .action(async (options: DeployOptions) => {
+    const projectId = needProjectId(options);
+    const dir = options.dir ?? "prompts";
+
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+
+    if (!fs.existsSync(dir)) {
+      if (options.dir) {
+        throw new FirebaseError(`Directory does not exist: ${dir}`);
+      }
+      logger.info(`Default prompts directory '${dir}' does not exist. No templates to deploy.`);
+      return;
+    }
+    const stat = fs.statSync(dir);
+    if (!stat.isDirectory()) {
+      throw new FirebaseError(`Path is not a directory: ${dir}`);
+    }
+
+    const files = fs.readdirSync(dir);
+    const promptFiles = files.filter((f) => f.endsWith(".prompt"));
+
+    if (promptFiles.length === 0) {
+      logger.info("No .prompt files found to deploy.");
+      return;
+    }
+
+    // 1. Validation pass: validate all local prompt files
+    const validationErrors: { file: string; error: string }[] = [];
+    const contentsMap = new Map<string, string>();
+    for (const file of promptFiles) {
+      const filePath = path.join(dir, file);
+      const content = fs.readFileSync(filePath, "utf-8");
+      const err = validatePromptFile(content);
+      if (err) {
+        validationErrors.push({ file, error: err });
+      } else {
+        contentsMap.set(path.basename(file, ".prompt"), content);
+      }
+    }
+
+    if (validationErrors.length > 0) {
+      const msg = ["The following prompt files failed validation:"]
+        .concat(validationErrors.map((e) => `  ${e.file}: ${e.error}`))
+        .join("\n");
+      throw new FirebaseError(msg);
+    }
+
+    // 2. Fetch remote templates and check for locks
+    const remoteTemplates = await ailogic.listTemplates(projectId, "global");
+    const remoteMap = new Map(remoteTemplates.map((t) => [t.name.split("/").pop()!, t]));
+
+    const lockedTemplatesToModify: string[] = [];
+    for (const file of promptFiles) {
+      const templateId = path.basename(file, ".prompt");
+      const remote = remoteMap.get(templateId);
+      if (remote && remote.locked) {
+        lockedTemplatesToModify.push(templateId);
+      }
+    }
+
+    const templatesToPrune: string[] = [];
+    if (options.prune) {
+      for (const [id, remote] of remoteMap.entries()) {
+        if (!contentsMap.has(id)) {
+          if (remote.locked) {
+            lockedTemplatesToModify.push(id);
+          } else {
+            templatesToPrune.push(id);
+          }
+        }
+      }
+    }
+
+    if (lockedTemplatesToModify.length > 0) {
+      throw new FirebaseError(
+        `The following templates are locked and cannot be updated or deleted:\n\n` +
+          lockedTemplatesToModify.map((id) => `  ${id}`).join("\n") +
+          `\n\nUnlock them by running:\n\n  firebase ailogic:templates:unlock <templateId>\n\nThen deploy again. No templates were deployed.`,
+      );
+    }
+
+    // 3. Confirm pruning if any
+    if (options.prune && templatesToPrune.length > 0) {
+      const confirmed = await confirm({
+        message:
+          `This will delete the following remote templates that do not exist locally:\n\n` +
+          templatesToPrune.map((id) => `  ${id}`).join("\n") +
+          `\n\nAre you sure you want to proceed?`,
+        force: options.force,
+        nonInteractive: options.nonInteractive,
+      });
+      if (!confirmed) {
+        throw new FirebaseError("Command aborted.", { exit: 1 });
+      }
+    }
+
+    // 4. Deploy local templates
+    for (const file of promptFiles) {
+      const templateId = path.basename(file, ".prompt");
+      const content = contentsMap.get(templateId)!;
+      const remote = remoteMap.get(templateId);
+
+      if (remote) {
+        logger.info(`Updating template ${clc.bold(templateId)}...`);
+      } else {
+        logger.info(`Creating template ${clc.bold(templateId)}...`);
+      }
+
+      await ailogic.updateTemplate(projectId, "global", templateId, {
+        templateString: content,
+        displayName: templateId,
+      });
+    }
+
+    // 5. Delete pruned templates
+    if (options.prune && templatesToPrune.length > 0) {
+      for (const templateId of templatesToPrune) {
+        logger.info(`Pruning template ${clc.bold(templateId)}...`);
+        await ailogic.deleteTemplate(projectId, "global", templateId);
+      }
+    }
+
+    logger.info(clc.green("Successfully deployed templates."));
+  });

--- a/src/commands/ailogic-templates-get.ts
+++ b/src/commands/ailogic-templates-get.ts
@@ -1,0 +1,18 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import { logger } from "../logger";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:templates:get <templateId>")
+  .description("print one template")
+  .before(requirePermissions, ["firebasevertexai.templates.get"])
+  .action(async (templateId: string, options: Options) => {
+    const projectId = needProjectId(options);
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    const template = await ailogic.getTemplate(projectId, "global", templateId);
+    logger.info(template.templateString);
+    return template;
+  });

--- a/src/commands/ailogic-templates-list.ts
+++ b/src/commands/ailogic-templates-list.ts
@@ -1,0 +1,41 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:templates:list")
+  .description("list deployed templates")
+  .before(requirePermissions, ["firebasevertexai.templates.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    const templates = await ailogic.listTemplates(projectId, "global");
+
+    if (templates.length === 0) {
+      logger.info(clc.bold("No deployed templates found."));
+      return templates;
+    }
+
+    const tableHead = ["Template ID", "Display Name", "Locked", "Template Preview"];
+    const table = new Table({ head: tableHead, style: { head: ["green"] } });
+
+    for (const t of templates) {
+      const templateId = t.name.split("/").pop() || "";
+      const preview =
+        t.templateString.length > 60 ? t.templateString.substring(0, 57) + "..." : t.templateString;
+      table.push([
+        clc.bold(templateId),
+        t.displayName || "",
+        t.locked ? "Yes" : "No",
+        preview.replace(/\n/g, " "),
+      ]);
+    }
+
+    logger.info(table.toString());
+    return templates;
+  });

--- a/src/commands/ailogic-templates-lock.ts
+++ b/src/commands/ailogic-templates-lock.ts
@@ -1,0 +1,18 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:templates:lock <templateId>")
+  .description("lock a template")
+  .before(requirePermissions, ["firebasevertexai.templates.update"])
+  .action(async (templateId: string, options: Options) => {
+    const projectId = needProjectId(options);
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    await ailogic.lockTemplate(projectId, "global", templateId);
+    logger.info(clc.green(`Successfully locked template: ${clc.bold(templateId)}`));
+  });

--- a/src/commands/ailogic-templates-unlock.ts
+++ b/src/commands/ailogic-templates-unlock.ts
@@ -1,0 +1,18 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:templates:unlock <templateId>")
+  .description("unlock a template")
+  .before(requirePermissions, ["firebasevertexai.templates.update"])
+  .action(async (templateId: string, options: Options) => {
+    const projectId = needProjectId(options);
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    await ailogic.unlockTemplate(projectId, "global", templateId);
+    logger.info(clc.green(`Successfully unlocked template: ${clc.bold(templateId)}`));
+  });

--- a/src/commands/ailogic-triggers-list.ts
+++ b/src/commands/ailogic-triggers-list.ts
@@ -1,0 +1,38 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:triggers:list")
+  .description("list registered triggers")
+  .before(requirePermissions, ["firebasevertexai.triggers.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+    const triggers = await ailogic.listTriggers(projectId, "global");
+
+    if (triggers.length === 0) {
+      logger.info(clc.bold("No registered triggers found."));
+      return triggers;
+    }
+
+    const tableHead = ["Trigger ID", "Function ID", "Function Region"];
+    const table = new Table({ head: tableHead, style: { head: ["green"] } });
+
+    for (const t of triggers) {
+      const triggerId = t.name.split("/").pop() || "";
+      table.push([
+        clc.bold(triggerId),
+        t.cloudFunction?.id || "",
+        t.cloudFunction?.locationId || "",
+      ]);
+    }
+
+    logger.info(table.toString());
+    return triggers;
+  });

--- a/src/commands/help.spec.ts
+++ b/src/commands/help.spec.ts
@@ -1,0 +1,53 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import { command as helpCommand } from "./help";
+import { logger } from "../logger";
+
+describe("help command namespace listing", () => {
+  let loggerStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    loggerStub = sinon.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should show help for namespace subcommands", async () => {
+    const mockEnableCommand = {
+      _name: "ailogic:providers:enable",
+      _description: "enable a provider",
+      outputHelp: sinon.stub(),
+    };
+    const mockDisableCommand = {
+      _name: "ailogic:providers:disable",
+      _description: "disable a provider",
+      outputHelp: sinon.stub(),
+    };
+
+    const mockClient = {
+      cli: {
+        commands: [mockEnableCommand, mockDisableCommand],
+        outputHelp: sinon.stub(),
+      },
+      getCommand: sinon.stub().returns(undefined),
+      ailogic: {
+        providers: {},
+      },
+    };
+
+    // Run help command action with mock context
+    const actionFn = (helpCommand as any).actionFn;
+    await actionFn.call({ client: mockClient }, "ailogic:providers");
+
+    // It should log the subcommands and descriptions
+    expect(loggerStub).to.have.been.called;
+    const allArgs = loggerStub.args.map((a) => a.join(" ")).join("\n");
+    expect(allArgs).to.include("Commands under ailogic:providers:");
+    expect(allArgs).to.include("ailogic:providers:enable");
+    expect(allArgs).to.include("enable a provider");
+    expect(allArgs).to.include("ailogic:providers:disable");
+    expect(allArgs).to.include("disable a provider");
+  });
+});

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -14,7 +14,44 @@ export const command = new Command("help [command]")
     const cmd = commandName ? client.getCommand(commandName) : undefined;
     if (cmd) {
       cmd.outputHelp();
-    } else if (commandName) {
+      return;
+    }
+
+    if (commandName) {
+      const keys = commandName.split(":");
+      let current = client;
+      let matched = true;
+      for (const key of keys) {
+        if (!current || typeof current !== "object") {
+          matched = false;
+          break;
+        }
+        const nextKey = Object.keys(current).find((k) => k.toLowerCase() === key.toLowerCase());
+        if (nextKey) {
+          current = current[nextKey];
+        } else {
+          matched = false;
+          break;
+        }
+      }
+
+      if (matched && current && typeof current === "object") {
+        const prefix = commandName + ":";
+        const subcmds = client.cli.commands.filter((c: any) => c._name.startsWith(prefix));
+        if (subcmds.length > 0) {
+          logger.info();
+          logger.info(clc.bold(`Commands under ${clc.green(commandName)}:`));
+          logger.info();
+          for (const subcmd of subcmds) {
+            logger.info(`  ${clc.bold(subcmd._name.padEnd(45))} ${subcmd._description}`);
+          }
+          logger.info();
+          return;
+        }
+      }
+    }
+
+    if (commandName) {
       logger.warn();
       utils.logWarning(
         clc.bold(commandName) + " is not a valid command. See below for valid commands",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -221,6 +221,27 @@ export function load(client: CLIClient): CLIClient {
       client.apphosting.rollouts.list = loadCommand("apphosting-rollouts-list");
     }
   }
+  client.ailogic = {};
+  client.ailogic.providers = {};
+  client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
+  client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
+  client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+
+  client.ailogic.config = {};
+  client.ailogic.config.get = loadCommand("ailogic-config-get");
+  client.ailogic.config.set = loadCommand("ailogic-config-set");
+
+  client.ailogic.templates = {};
+  client.ailogic.templates.deploy = loadCommand("ailogic-templates-deploy");
+  client.ailogic.templates.list = loadCommand("ailogic-templates-list");
+  client.ailogic.templates.get = loadCommand("ailogic-templates-get");
+  client.ailogic.templates.delete = loadCommand("ailogic-templates-delete");
+  client.ailogic.templates.lock = loadCommand("ailogic-templates-lock");
+  client.ailogic.templates.unlock = loadCommand("ailogic-templates-unlock");
+
+  client.ailogic.triggers = {};
+  client.ailogic.triggers.list = loadCommand("ailogic-triggers-list");
+
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");
   client.login.ci = loadCommand("login-ci");

--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -239,3 +239,14 @@ function cacheEnabledAPI(projectId: string, apiName: string) {
   cache[projectId][apiName] = true;
   configstore.set(API_ENABLEMENT_CACHE_KEY, cache);
 }
+
+export function uncacheEnabledAPI(projectId: string, apiName: string): void {
+  const cache = (configstore.get(API_ENABLEMENT_CACHE_KEY) || {}) as Record<
+    string,
+    Record<string, true>
+  >;
+  if (cache[projectId]) {
+    delete cache[projectId][apiName];
+    configstore.set(API_ENABLEMENT_CACHE_KEY, cache);
+  }
+}

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -1,11 +1,16 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as ailogic from "./ailogic";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as serviceUsage from "./serviceusage";
+import * as rules from "./rules";
+import * as cloudbilling from "./cloudbilling";
 import {
   AI_LOGIC_BEFORE_GENERATE_CONTENT,
   AI_LOGIC_AFTER_GENERATE_CONTENT,
   AILogicEndpoint,
 } from "../deploy/functions/services/ailogic";
+import { FirebaseError } from "../error";
 
 describe("ailogic", () => {
   const mockEndpointBase = {
@@ -139,6 +144,399 @@ describe("ailogic", () => {
             validateOnly: "false",
           },
         },
+      );
+    });
+  });
+
+  describe("getConfig", () => {
+    let getStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      getStub = sinon.stub(ailogic.client, "get");
+    });
+
+    afterEach(() => {
+      getStub.restore();
+    });
+
+    it("should fetch config", async () => {
+      const mockConfig: ailogic.Config = {
+        name: "projects/my-project/locations/global/config",
+        generativeLanguageConfig: { apiKey: "key" },
+      };
+      getStub.resolves({ body: mockConfig });
+
+      const config = await ailogic.getConfig("my-project");
+
+      expect(getStub).to.have.been.calledWithMatch("projects/my-project/locations/global/config");
+      expect(config).to.deep.equal(mockConfig);
+    });
+  });
+
+  describe("updateConfig", () => {
+    let patchStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      patchStub = sinon.stub(ailogic.client, "patch");
+    });
+
+    afterEach(() => {
+      patchStub.restore();
+    });
+
+    it("should update config", async () => {
+      const patchConfig: Partial<ailogic.Config> = {
+        generativeLanguageConfig: { apiKey: "new-key" },
+      };
+      const mockConfig: ailogic.Config = {
+        name: "projects/my-project/locations/global/config",
+        generativeLanguageConfig: { apiKey: "new-key" },
+      };
+      patchStub.resolves({ body: mockConfig });
+
+      const config = await ailogic.updateConfig("my-project", patchConfig, [
+        "generativeLanguageConfig",
+      ]);
+
+      expect(patchStub).to.have.been.calledWithMatch(
+        "projects/my-project/locations/global/config",
+        patchConfig,
+        {
+          queryParams: {
+            updateMask: "generativeLanguageConfig",
+          },
+        },
+      );
+      expect(config).to.deep.equal(mockConfig);
+    });
+  });
+
+  describe("templates", () => {
+    let getStub: sinon.SinonStub;
+    let patchStub: sinon.SinonStub;
+    let deleteStub: sinon.SinonStub;
+    let postStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      getStub = sinon.stub(ailogic.client, "get");
+      patchStub = sinon.stub(ailogic.client, "patch");
+      deleteStub = sinon.stub(ailogic.client, "delete");
+      postStub = sinon.stub(ailogic.client, "post");
+    });
+
+    afterEach(() => {
+      getStub.restore();
+      patchStub.restore();
+      deleteStub.restore();
+      postStub.restore();
+    });
+
+    it("should get template", async () => {
+      const mockTemplate: ailogic.Template = {
+        name: "projects/my-project/locations/global/templates/temp-1",
+        templateString: "hello",
+      };
+      getStub.resolves({ body: mockTemplate });
+
+      const template = await ailogic.getTemplate("my-project", "global", "temp-1");
+
+      expect(getStub).to.have.been.calledWith(
+        "projects/my-project/locations/global/templates/temp-1",
+      );
+      expect(template).to.deep.equal(mockTemplate);
+    });
+
+    it("should update template", async () => {
+      const mockTemplate: ailogic.Template = {
+        name: "projects/my-project/locations/global/templates/temp-1",
+        templateString: "hello",
+      };
+      patchStub.resolves({ body: mockTemplate });
+
+      const template = await ailogic.updateTemplate("my-project", "global", "temp-1", {
+        templateString: "hello",
+      });
+
+      expect(patchStub).to.have.been.calledWithMatch(
+        "projects/my-project/locations/global/templates/temp-1",
+        { templateString: "hello" },
+        {
+          queryParams: {
+            allowMissing: "true",
+          },
+        },
+      );
+      expect(template).to.deep.equal(mockTemplate);
+    });
+
+    it("should delete template", async () => {
+      deleteStub.resolves({});
+
+      await ailogic.deleteTemplate("my-project", "global", "temp-1");
+
+      expect(deleteStub).to.have.been.calledWith(
+        "projects/my-project/locations/global/templates/temp-1",
+      );
+    });
+
+    it("should lock template", async () => {
+      const mockTemplate: ailogic.Template = {
+        name: "projects/my-project/locations/global/templates/temp-1",
+        templateString: "hello",
+        locked: true,
+      };
+      patchStub.resolves({ body: mockTemplate });
+
+      const template = await ailogic.lockTemplate("my-project", "global", "temp-1");
+
+      expect(patchStub).to.have.been.calledWithMatch(
+        "projects/my-project/locations/global/templates/temp-1",
+        { locked: true },
+        {
+          queryParams: {
+            updateMask: "locked",
+          },
+        },
+      );
+      expect(template).to.deep.equal(mockTemplate);
+    });
+
+    it("should unlock template", async () => {
+      const mockTemplate: ailogic.Template = {
+        name: "projects/my-project/locations/global/templates/temp-1",
+        templateString: "hello",
+        locked: false,
+      };
+      patchStub.resolves({ body: mockTemplate });
+
+      const template = await ailogic.unlockTemplate("my-project", "global", "temp-1");
+
+      expect(patchStub).to.have.been.calledWithMatch(
+        "projects/my-project/locations/global/templates/temp-1",
+        { locked: false },
+        {
+          queryParams: {
+            updateMask: "locked",
+          },
+        },
+      );
+      expect(template).to.deep.equal(mockTemplate);
+    });
+
+    it("should list templates slurping all pages", async () => {
+      getStub.onFirstCall().resolves({
+        body: {
+          templates: [{ name: "t1", templateString: "t1" }],
+          nextPageToken: "next",
+        },
+      });
+      getStub.onSecondCall().resolves({
+        body: {
+          templates: [{ name: "t2", templateString: "t2" }],
+        },
+      });
+
+      const templates = await ailogic.listTemplates("my-project", "global");
+
+      expect(getStub).to.have.been.calledTwice;
+      expect(templates).to.deep.equal([
+        { name: "t1", templateString: "t1" },
+        { name: "t2", templateString: "t2" },
+      ]);
+    });
+  });
+
+  describe("providers", () => {
+    let ensureStub: sinon.SinonStub;
+    let disableStub: sinon.SinonStub;
+    let uncacheStub: sinon.SinonStub;
+    let checkStub: sinon.SinonStub;
+    let billingStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      ensureStub = sinon.stub(ensureApiEnabled, "ensure");
+      disableStub = sinon.stub(serviceUsage, "disableServiceAndPoll");
+      uncacheStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
+      checkStub = sinon.stub(ensureApiEnabled, "check");
+      billingStub = sinon.stub(cloudbilling, "checkBillingEnabled");
+    });
+
+    afterEach(() => {
+      ensureStub.restore();
+      disableStub.restore();
+      uncacheStub.restore();
+      checkStub.restore();
+      billingStub.restore();
+    });
+
+    it("should enable gemini-developer-api", async () => {
+      ensureStub.resolves();
+
+      await ailogic.enableProvider("my-project", "gemini-developer-api");
+
+      expect(ensureStub).to.have.been.calledTwice;
+      expect(ensureStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+    });
+
+    it("should enable agent-platform-gemini-api if billing is enabled", async () => {
+      ensureStub.resolves();
+      billingStub.resolves(true);
+
+      await ailogic.enableProvider("my-project", "agent-platform-gemini-api");
+
+      expect(ensureStub).to.have.been.calledTwice;
+      expect(ensureStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "aiplatform.googleapis.com",
+        "ailogic",
+      );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+    });
+
+    it("should reject enabling agent-platform-gemini-api if billing is disabled", async () => {
+      ensureStub.resolves();
+      billingStub.resolves(false);
+
+      await expect(
+        ailogic.enableProvider("my-project", "agent-platform-gemini-api"),
+      ).to.be.rejectedWith(FirebaseError, /must be on the Blaze/);
+
+      expect(ensureStub).to.not.have.been.called;
+    });
+
+    it("should disable gemini-developer-api and disable proxy if agent-platform-gemini-api is also disabled", async () => {
+      disableStub.resolves();
+      checkStub.resolves(false); // agent-platform-gemini-api is disabled
+
+      await ailogic.disableProvider("my-project", "gemini-developer-api");
+
+      expect(disableStub).to.have.been.calledTwice;
+      expect(disableStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(disableStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+      expect(uncacheStub).to.have.been.calledTwice;
+    });
+
+    it("should disable gemini-developer-api but NOT disable proxy if agent-platform-gemini-api is enabled", async () => {
+      disableStub.resolves();
+      checkStub.resolves(true); // agent-platform-gemini-api is enabled
+
+      await ailogic.disableProvider("my-project", "gemini-developer-api");
+
+      expect(disableStub).to.have.been.calledOnce;
+      expect(disableStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(uncacheStub).to.have.been.calledOnce;
+    });
+
+    it("should list enabled providers when billing is disabled", async () => {
+      checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
+      checkStub.onSecondCall().resolves(true); // agent-platform-gemini-api API is enabled
+      billingStub.resolves(false); // billing is disabled
+
+      const enabled = await ailogic.listProviders("my-project");
+
+      expect(enabled).to.deep.equal(["gemini-developer-api"]);
+    });
+
+    it("should list enabled providers when billing is enabled", async () => {
+      checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
+      checkStub.onSecondCall().resolves(true); // agent-platform-gemini-api API is enabled
+      billingStub.resolves(true); // billing is enabled
+
+      const enabled = await ailogic.listProviders("my-project");
+
+      expect(enabled).to.deep.equal(["gemini-developer-api", "agent-platform-gemini-api"]);
+    });
+  });
+
+  describe("securityRules", () => {
+    let listReleasesStub: sinon.SinonStub;
+    let getLatestRulesetNameStub: sinon.SinonStub;
+    let getRulesetContentStub: sinon.SinonStub;
+    let createRulesetStub: sinon.SinonStub;
+    let updateOrCreateReleaseStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      listReleasesStub = sinon.stub(rules, "listAllReleases");
+      getLatestRulesetNameStub = sinon.stub(rules, "getLatestRulesetName");
+      getRulesetContentStub = sinon.stub(rules, "getRulesetContent");
+      createRulesetStub = sinon.stub(rules, "createRuleset");
+      updateOrCreateReleaseStub = sinon.stub(rules, "updateOrCreateRelease");
+    });
+
+    afterEach(() => {
+      listReleasesStub.restore();
+      getLatestRulesetNameStub.restore();
+      getRulesetContentStub.restore();
+      createRulesetStub.restore();
+      updateOrCreateReleaseStub.restore();
+    });
+
+    it("should get rules and parse authOnly and templateOnly", async () => {
+      listReleasesStub.resolves([]);
+      getLatestRulesetNameStub.resolves("ruleset-name");
+      getRulesetContentStub.resolves([
+        {
+          name: "vertexai.rules",
+          content: `rules_version = '2';
+service firebase.vertexai {
+  match /projects/{project}/locations/{location} {
+    match /templates/{template} {
+      allow read: if request.auth != null;
+    }
+    match /models/{model} {
+      allow read: if false;
+    }
+  }
+}`,
+        },
+      ]);
+
+      const config = await ailogic.getSecurityRules("my-project");
+
+      expect(config).to.deep.equal({ authOnly: true, templateOnly: true });
+    });
+
+    it("should deploy rules with generateRulesContent", async () => {
+      createRulesetStub.resolves("new-ruleset");
+      updateOrCreateReleaseStub.resolves("release-name");
+
+      await ailogic.updateSecurityRules("my-project", true, false);
+
+      expect(createRulesetStub).to.have.been.calledWith("my-project", [
+        {
+          name: "vertexai.rules",
+          content: ailogic.generateRulesContent(true, false),
+        },
+      ]);
+      expect(updateOrCreateReleaseStub).to.have.been.calledWith(
+        "my-project",
+        "new-ruleset",
+        "firebase.vertexai",
       );
     });
   });

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -2,7 +2,14 @@ import { Client } from "../apiv2";
 import { aiLogicProxyOrigin } from "../api";
 import { DeepOmit } from "../metaprogramming";
 import type { AILogicEndpoint } from "../deploy/functions/services/ailogic";
-import { getErrStatus } from "../error";
+import { FirebaseError, getErrStatus } from "../error";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as serviceUsage from "./serviceusage";
+import * as rules from "./rules";
+import { bold } from "colorette";
+import * as cloudbilling from "./cloudbilling";
+import { logger } from "../logger";
+import { confirm, select } from "../prompt";
 
 export const API_VERSION = "v1beta";
 
@@ -167,6 +174,9 @@ export async function listTriggers(
   return triggers;
 }
 
+/**
+ *
+ */
 export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise<Trigger> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
@@ -191,10 +201,427 @@ export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise
   }
 }
 
+/**
+ *
+ */
 export async function deleteBlockingFunction(endpoint: AILogicEndpoint): Promise<void> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
   const location = endpoint.blockingTrigger.options?.regionalWebhook ? endpoint.region : "global";
 
   await deleteTrigger(endpoint.project, location, triggerId, true);
+}
+
+export interface GenerativeLanguageConfig {
+  apiKey?: string;
+}
+
+export interface TrafficFilter {
+  templateOnly?: boolean;
+  firebaseAuthRequired?: boolean;
+}
+
+export interface TelemetryConfig {
+  mode?: "MODE_UNSPECIFIED" | "NONE" | "ALL";
+  samplingRate?: number;
+}
+
+export interface Config {
+  name: string;
+  generativeLanguageConfig?: GenerativeLanguageConfig;
+  trafficFilter?: TrafficFilter;
+  telemetryConfig?: TelemetryConfig;
+}
+
+export interface Template {
+  name: string;
+  templateString: string;
+  displayName?: string;
+  etag?: string;
+  locked?: boolean;
+}
+
+export interface ListTemplatesResponse {
+  templates?: Template[];
+  nextPageToken?: string;
+}
+
+export type TemplateOutputOnlyFields = "name" | "etag";
+
+export type ProviderType = "gemini-developer-api" | "agent-platform-gemini-api";
+
+/**
+ * Gets the AI Logic Config singleton.
+ */
+export async function getConfig(projectId: string): Promise<Config> {
+  const name = `projects/${projectId}/locations/global/config`;
+  const res = await client.get<Config>(name);
+  return res.body;
+}
+
+/**
+ * Updates the AI Logic Config singleton.
+ */
+export async function updateConfig(
+  projectId: string,
+  config: Partial<Config>,
+  updateMask?: string[],
+): Promise<Config> {
+  const name = `projects/${projectId}/locations/global/config`;
+  const queryParams: Record<string, string> = {};
+  if (updateMask && updateMask.length > 0) {
+    queryParams.updateMask = updateMask.join(",");
+  }
+  const res = await client.patch<Partial<Config>, Config>(name, config, { queryParams });
+  return res.body;
+}
+
+/**
+ * Gets a Template.
+ */
+export async function getTemplate(
+  projectId: string,
+  location: string,
+  templateId: string,
+): Promise<Template> {
+  const name = `projects/${projectId}/locations/${location}/templates/${templateId}`;
+  const res = await client.get<Template>(name);
+  return res.body;
+}
+
+/**
+ * Updates a Template (upsert).
+ */
+export async function updateTemplate(
+  projectId: string,
+  location: string,
+  templateId: string,
+  template: DeepOmit<Template, TemplateOutputOnlyFields>,
+  allowMissing = true,
+): Promise<Template> {
+  const name = `projects/${projectId}/locations/${location}/templates/${templateId}`;
+  const queryParams: Record<string, string> = {
+    allowMissing: allowMissing ? "true" : "false",
+  };
+  const res = await client.patch<DeepOmit<Template, TemplateOutputOnlyFields>, Template>(
+    name,
+    template,
+    { queryParams },
+  );
+  return res.body;
+}
+
+/**
+ * Deletes a Template.
+ */
+export async function deleteTemplate(
+  projectId: string,
+  location: string,
+  templateId: string,
+): Promise<void> {
+  const name = `projects/${projectId}/locations/${location}/templates/${templateId}`;
+  await client.delete<void>(name);
+}
+
+/**
+ * Locks a Template.
+ */
+export async function lockTemplate(
+  projectId: string,
+  location: string,
+  templateId: string,
+): Promise<Template> {
+  const name = `projects/${projectId}/locations/${location}/templates/${templateId}`;
+  const template = { locked: true };
+  const res = await client.patch<Partial<Template>, Template>(name, template, {
+    queryParams: { updateMask: "locked" },
+  });
+  return res.body;
+}
+
+/**
+ * Unlocks a Template.
+ */
+export async function unlockTemplate(
+  projectId: string,
+  location: string,
+  templateId: string,
+): Promise<Template> {
+  const name = `projects/${projectId}/locations/${location}/templates/${templateId}`;
+  const template = { locked: false };
+  const res = await client.patch<Partial<Template>, Template>(name, template, {
+    queryParams: { updateMask: "locked" },
+  });
+  return res.body;
+}
+
+/**
+ * Lists Templates, slurping all pages.
+ */
+export async function listTemplates(projectId: string, location: string): Promise<Template[]> {
+  const parent = `projects/${projectId}/locations/${location}`;
+  let pageToken: string | undefined;
+  const templates: Template[] = [];
+
+  do {
+    const queryParams: Record<string, string> = pageToken ? { pageToken } : {};
+    const res = await client.get<ListTemplatesResponse>(`${parent}/templates`, { queryParams });
+    if (res.body.templates) {
+      templates.push(...res.body.templates);
+    }
+    pageToken = res.body.nextPageToken;
+  } while (pageToken);
+
+  return templates;
+}
+
+/**
+ * Enables a Gemini API provider service.
+ */
+export async function enableProvider(projectId: string, providerType: ProviderType): Promise<void> {
+  const prefix = "ailogic";
+  if (providerType === "gemini-developer-api") {
+    await ensureApiEnabled.ensure(projectId, "generativelanguage.googleapis.com", prefix);
+    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
+  } else if (providerType === "agent-platform-gemini-api") {
+    const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
+    if (!billingEnabled) {
+      throw new FirebaseError(
+        `Your project ${bold(
+          projectId,
+        )} must be on the Blaze (pay-as-you-go) plan to enable the Agent Platform. To upgrade, visit the following URL:\n\nhttps://console.firebase.google.com/project/${projectId}/usage/details`,
+      );
+    }
+    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", prefix);
+    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
+  } else {
+    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+  }
+}
+
+/**
+ * Disables a Gemini API provider service.
+ */
+export async function disableProvider(
+  projectId: string,
+  providerType: ProviderType,
+): Promise<void> {
+  const prefix = "ailogic";
+  if (providerType === "gemini-developer-api") {
+    await serviceUsage.disableServiceAndPoll(
+      projectId,
+      "generativelanguage.googleapis.com",
+      prefix,
+    );
+    ensureApiEnabled.uncacheEnabledAPI(projectId, "generativelanguage.googleapis.com");
+
+    const isVertexEnabled = await ensureApiEnabled.check(
+      projectId,
+      "aiplatform.googleapis.com",
+      prefix,
+      true,
+    );
+    if (!isVertexEnabled) {
+      await serviceUsage.disableServiceAndPoll(
+        projectId,
+        "firebasevertexai.googleapis.com",
+        prefix,
+      );
+      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
+    }
+  } else if (providerType === "agent-platform-gemini-api") {
+    await serviceUsage.disableServiceAndPoll(projectId, "aiplatform.googleapis.com", prefix);
+    ensureApiEnabled.uncacheEnabledAPI(projectId, "aiplatform.googleapis.com");
+
+    const isDeveloperEnabled = await ensureApiEnabled.check(
+      projectId,
+      "generativelanguage.googleapis.com",
+      prefix,
+      true,
+    );
+    if (!isDeveloperEnabled) {
+      await serviceUsage.disableServiceAndPoll(
+        projectId,
+        "firebasevertexai.googleapis.com",
+        prefix,
+      );
+      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
+    }
+  } else {
+    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+  }
+}
+
+/**
+ *
+ */
+export async function listProviders(projectId: string): Promise<ProviderType[]> {
+  const prefix = "ailogic";
+  const enabled: ProviderType[] = [];
+
+  const isDeveloperEnabled = await ensureApiEnabled.check(
+    projectId,
+    "generativelanguage.googleapis.com",
+    prefix,
+    true,
+  );
+  if (isDeveloperEnabled) {
+    enabled.push("gemini-developer-api");
+  }
+
+  const isVertexEnabled = await ensureApiEnabled.check(
+    projectId,
+    "aiplatform.googleapis.com",
+    prefix,
+    true,
+  );
+  if (isVertexEnabled) {
+    let billingEnabled = false;
+    try {
+      billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
+    } catch (err: any) {
+      logger.debug(`[ailogic] Failed to check billing status for project ${projectId}: ${err}`);
+    }
+    if (billingEnabled) {
+      enabled.push("agent-platform-gemini-api");
+    }
+  }
+
+  return enabled;
+}
+
+/**
+ *
+ */
+export function generateRulesContent(authOnly: boolean, templateOnly: boolean): string {
+  const condition = authOnly ? "request.auth != null" : "true";
+
+  return `rules_version = '2';
+service firebase.vertexai {
+  match /projects/{project}/locations/{location} {
+    match /templates/{template} {
+      allow read: if ${condition};
+    }
+    match /models/{model} {
+      allow read: if ${templateOnly ? "false" : condition};
+    }
+  }
+}`;
+}
+
+export interface SecurityRulesConfig {
+  authOnly: boolean;
+  templateOnly: boolean;
+}
+
+/**
+ * Gets security rules settings by fetching and parsing the active release.
+ */
+export async function getSecurityRules(projectId: string): Promise<SecurityRulesConfig> {
+  const releases = await rules.listAllReleases(projectId);
+  const rulesetName = await rules.getLatestRulesetName(projectId, "firebase.vertexai", releases);
+  if (!rulesetName) {
+    return { authOnly: false, templateOnly: false };
+  }
+  const files = await rules.getRulesetContent(rulesetName);
+  const vertexFile = files.find((f) => f.name === "vertexai.rules");
+  if (!vertexFile) {
+    return { authOnly: false, templateOnly: false };
+  }
+  const content = vertexFile.content;
+  const authOnly = content.includes("request.auth != null");
+  const templateOnly = content.includes("allow read: if false");
+  return { authOnly, templateOnly };
+}
+
+/**
+ * Deploys new security rules.
+ */
+export async function updateSecurityRules(
+  projectId: string,
+  authOnly: boolean,
+  templateOnly: boolean,
+): Promise<void> {
+  const content = generateRulesContent(authOnly, templateOnly);
+  const files = [
+    {
+      name: "vertexai.rules",
+      content,
+    },
+  ];
+  const rulesetName = await rules.createRuleset(projectId, files);
+  await rules.updateOrCreateRelease(projectId, rulesetName, "firebase.vertexai");
+}
+
+/**
+ * Ensures that the Firebase AI Logic API is enabled. If not enabled:
+ * - In non-interactive mode: throws an error with instructions.
+ * - In interactive mode: prompts to enable, and guides the user to choose a provider to enable.
+ */
+export async function ensureAILogicApiEnabled(
+  projectId: string,
+  options: { nonInteractive?: boolean; force?: boolean },
+): Promise<void> {
+  const isEnabled = await ensureApiEnabled.check(
+    projectId,
+    "firebasevertexai.googleapis.com",
+    "ailogic",
+    true,
+  );
+  if (isEnabled) {
+    return;
+  }
+
+  if (options.nonInteractive) {
+    throw new FirebaseError(
+      `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.\n\n` +
+        `Enable Firebase AI Logic with one of the Gemini API providers by running:\n\n` +
+        `  firebase ailogic:providers:enable gemini-developer-api\n` +
+        `  firebase ailogic:providers:enable agent-platform-gemini-api\n\n` +
+        `Then run this command again.`,
+    );
+  }
+
+  logger.info(
+    `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.`,
+  );
+  const proceed = await confirm({
+    message: "Would you like to enable it now?",
+    default: true,
+  });
+  if (!proceed) {
+    throw new FirebaseError("Command aborted.", { exit: 1 });
+  }
+
+  while (true) {
+    const provider = await select<ProviderType>({
+      message: "Which Gemini API provider do you want to enable?",
+      choices: [
+        { name: "gemini-developer-api", value: "gemini-developer-api" },
+        {
+          name: "agent-platform-gemini-api (requires the Blaze plan)",
+          value: "agent-platform-gemini-api",
+        },
+      ],
+    });
+
+    if (provider === "agent-platform-gemini-api") {
+      const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
+      if (!billingEnabled) {
+        logger.info(
+          `\n${bold("Error:")} The agent-platform-gemini-api provider requires the pay-as-you-go (Blaze) plan.\n` +
+            `Project ${projectId} is on the Spark plan.\n\n` +
+            `Upgrade your plan at:\n\n` +
+            `  https://console.firebase.google.com/project/${projectId}/usage/details\n`,
+        );
+        continue;
+      }
+    }
+
+    logger.info(`Enabling firebasevertexai.googleapis.com...`);
+    logger.info(`Enabling provider ${provider}...`);
+    await enableProvider(projectId, provider);
+    logger.info(bold(`Successfully enabled Firebase AI Logic with provider: ${provider}`));
+    break;
+  }
 }

--- a/src/gcp/serviceusage.spec.ts
+++ b/src/gcp/serviceusage.spec.ts
@@ -28,4 +28,22 @@ describe("serviceusage", () => {
       expect(pollerStub).to.not.be.called;
     });
   });
+
+  describe("disableServiceAndPoll", () => {
+    it("does not poll if disableService responds with a completed operation", async () => {
+      postStub.onFirstCall().resolves({ body: { done: true } });
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(pollerStub).to.not.be.called;
+    });
+
+    it("polls if disableService responds with an uncompleted operation", async () => {
+      postStub.onFirstCall().resolves({ body: { done: false, name: "operation-name" } });
+      pollerStub.onFirstCall().resolves({});
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(pollerStub).to.have.been.calledOnce;
+      expect(pollerStub).to.have.been.calledWithMatch({
+        operationResourceName: "operation-name",
+      });
+    });
+  });
 });

--- a/src/gcp/serviceusage.ts
+++ b/src/gcp/serviceusage.ts
@@ -70,3 +70,45 @@ export async function generateServiceIdentityAndPoll(
     headers: { "x-goog-user-project": `${projectNumber}` },
   });
 }
+
+/**
+ * Disables a service on the project.
+ */
+export async function disableService(
+  projectId: string,
+  service: string,
+): Promise<LongRunningOperation<unknown>> {
+  try {
+    const res = await apiClient.post<unknown, unknown>(
+      `projects/${projectId}/services/${service}:disable`,
+      /* body=*/ {},
+      { headers: { "x-goog-user-project": `${projectId}` } },
+    );
+    return res.body as LongRunningOperation<unknown>;
+  } catch (err: unknown) {
+    throw new FirebaseError(`Error disabling service ${service}.`, {
+      original: err as Error,
+    });
+  }
+}
+
+/**
+ * Calls disableService and polls till the operation is complete.
+ */
+export async function disableServiceAndPoll(
+  projectId: string,
+  service: string,
+  prefix: string,
+): Promise<void> {
+  utils.logLabeledBullet(prefix, `disabling service ${bold(service)}...`);
+  const op = await disableService(projectId, service);
+  if (op.done) {
+    return;
+  }
+
+  await poller.pollOperation<void>({
+    ...serviceUsagePollerOptions,
+    operationResourceName: op.name,
+    headers: { "x-goog-user-project": `${projectId}` },
+  });
+}


### PR DESCRIPTION
### Description
Exposes the Firebase AI Logic management command surface under the `firebase ailogic` namespace:
- `providers:enable`, `providers:disable`, `providers:list` to manage Gemini API providers.
- `config:get` and `config:set` to get and set consolidated service settings.
- `templates:deploy`, `templates:list`, `templates:get`, `templates:delete`, `templates:lock`, and `templates:unlock` to version control and manage server prompt templates.
- `triggers:list` to inspect registered before/after generate-content triggers.

### Scenarios Tested
- Enabling/disabling API providers (interactive and non-interactive).
- Correctly validating and prompting for configuration modifications.
- Template validations, lock checks, and pruning configurations.
- Full mocha test suite coverage (47 specs for `ailogic`).

### Sample Commands
- `firebase ailogic:providers:enable gemini-developer-api`
- `firebase ailogic:config:get`
- `firebase ailogic:config:set security.auth-only true`
- `firebase ailogic:templates:deploy --dir ./prompts --prune`
- `firebase ailogic:templates:lock welcome`

