### PR TITLE
Rename lifecycle events to match functions vocabulary

### DIFF
--- a/src/commands/functions-lifecycle-run.ts
+++ b/src/commands/functions-lifecycle-run.ts
@@ -12,9 +12,9 @@ export const command = new Command("functions:lifecycle:run <hookName> <codebase
   .description("run a specific lifecycle hook in isolation")
   .before(requirePermissions, ["cloudfunctions.functions.list", "run.services.list"])
   .action(async (hookName: string, codebase: string, options: Options) => {
-    if (hookName !== "afterInstall" && hookName !== "afterUpdate") {
+    if (hookName !== "afterFirstDeploy" && hookName !== "afterRedeploy") {
       throw new FirebaseError(
-        `Invalid hook name "${hookName}". Supported hooks are "afterInstall" and "afterUpdate".`,
+        `Invalid hook name "${hookName}". Supported hooks are "afterFirstDeploy" and "afterRedeploy".`,
       );
     }
 

--- a/src/commands/functions-lifecycle.spec.ts
+++ b/src/commands/functions-lifecycle.spec.ts
@@ -53,7 +53,7 @@ describe("functions:lifecycle commands", () => {
         endpoints: {},
         params: [],
         lifecycleHooks: {
-          afterInstall: {
+          afterFirstDeploy: {
             task: {
               function: "myTask",
             },
@@ -78,7 +78,7 @@ describe("functions:lifecycle commands", () => {
       };
       const mockBackend = backend.empty();
 
-      await expect(lifecycle.executeHook("afterInstall", hook, mockBackend)).to.be.rejectedWith(
+      await expect(lifecycle.executeHook("afterFirstDeploy", hook, mockBackend)).to.be.rejectedWith(
         FirebaseError,
         'Lifecycle hook action type "call" is not supported.',
       );
@@ -106,7 +106,7 @@ describe("functions:lifecycle commands", () => {
         const loggerStub = sandbox.stub(logger, "info");
         const mockBuild = {
           lifecycleHooks: {
-            afterInstall: {
+            afterFirstDeploy: {
               task: {
                 function: "myTask",
                 body: { foo: "bar" },
@@ -119,7 +119,7 @@ describe("functions:lifecycle commands", () => {
         const { command: listCommand } = require("./functions-lifecycle-list");
         await listCommand.runner()("my-codebase", options);
 
-        expect(loggerStub).to.have.been.calledWith(sinon.match("Event: afterInstall"));
+        expect(loggerStub).to.have.been.calledWith(sinon.match("Event: afterFirstDeploy"));
         expect(loggerStub).to.have.been.calledWith(sinon.match("Action: Task"));
         expect(loggerStub).to.have.been.calledWith(sinon.match("Target Function: myTask"));
       });
@@ -142,7 +142,7 @@ describe("functions:lifecycle commands", () => {
         const { command: runCommand } = require("./functions-lifecycle-run");
         await expect(runCommand.runner()("invalidHook", "my-codebase", options)).to.be.rejectedWith(
           FirebaseError,
-          'Invalid hook name "invalidHook". Supported hooks are "afterInstall" and "afterUpdate".',
+          'Invalid hook name "invalidHook". Supported hooks are "afterFirstDeploy" and "afterRedeploy".',
         );
       });
 
@@ -151,10 +151,10 @@ describe("functions:lifecycle commands", () => {
 
         const { command: runCommand } = require("./functions-lifecycle-run");
         await expect(
-          runCommand.runner()("afterInstall", "my-codebase", options),
+          runCommand.runner()("afterFirstDeploy", "my-codebase", options),
         ).to.be.rejectedWith(
           FirebaseError,
-          'No lifecycle hook "afterInstall" configured for codebase "my-codebase".',
+          'No lifecycle hook "afterFirstDeploy" configured for codebase "my-codebase".',
         );
       });
 
@@ -162,7 +162,7 @@ describe("functions:lifecycle commands", () => {
         const mockHook = { task: { function: "myTask" } };
         loadCodebaseBuildStub.resolves({
           lifecycleHooks: {
-            afterInstall: mockHook,
+            afterFirstDeploy: mockHook,
           },
         });
 
@@ -171,10 +171,10 @@ describe("functions:lifecycle commands", () => {
         const executeHookStub = sandbox.stub(lifecycle, "executeHook").resolves();
 
         const { command: runCommand } = require("./functions-lifecycle-run");
-        await runCommand.runner()("afterInstall", "my-codebase", options);
+        await runCommand.runner()("afterFirstDeploy", "my-codebase", options);
 
         expect(executeHookStub).to.have.been.calledWith(
-          "afterInstall",
+          "afterFirstDeploy",
           mockHook,
           mockExistingBackend,
         );

--- a/src/deploy/functions/build.spec.ts
+++ b/src/deploy/functions/build.spec.ts
@@ -520,13 +520,13 @@ describe("applyPrefix", () => {
       params: [],
       requiredAPIs: [],
       lifecycleHooks: {
-        afterInstall: {
+        afterFirstDeploy: {
           task: {
             function: "func1",
             body: { foo: "bar" },
           },
         },
-        afterUpdate: {
+        afterRedeploy: {
           call: {
             function: "func1",
           },
@@ -537,13 +537,13 @@ describe("applyPrefix", () => {
     build.applyPrefix(testBuild, "staging");
 
     expect(testBuild.lifecycleHooks).to.deep.equal({
-      afterInstall: {
+      afterFirstDeploy: {
         task: {
           function: "staging-func1",
           body: { foo: "bar" },
         },
       },
-      afterUpdate: {
+      afterRedeploy: {
         call: {
           function: "staging-func1",
         },

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as backend from "../backend";
-import { determineDeploymentDelta, executeLifecycleHooks } from "./lifecycle";
+import { determineDeploymentEvent, executeLifecycleHooks } from "./lifecycle";
 import * as cloudtasks from "../../../gcp/cloudtasks";
 import { logger } from "../../../logger";
 import * as projects from "../../../management/projects";
@@ -23,15 +23,15 @@ describe("lifecycle", () => {
     sandbox.restore();
   });
 
-  describe("determineDeploymentDelta", () => {
-    it("returns afterInstall when haveBackend has no endpoints", () => {
+  describe("determineDeploymentEvent", () => {
+    it("returns afterFirstDeploy when haveBackend has no endpoints", () => {
       const haveBackend = backend.empty();
 
-      const delta = determineDeploymentDelta(haveBackend);
-      expect(delta).to.equal("afterInstall");
+      const event = determineDeploymentEvent(haveBackend);
+      expect(event).to.equal("afterFirstDeploy");
     });
 
-    it("returns afterUpdate when haveBackend has existing endpoints", () => {
+    it("returns afterRedeploy when haveBackend has existing endpoints", () => {
       const haveBackend = backend.of({
         id: "myFunc",
         project: "myProj",
@@ -41,8 +41,8 @@ describe("lifecycle", () => {
         httpsTrigger: {},
       });
 
-      const delta = determineDeploymentDelta(haveBackend);
-      expect(delta).to.equal("afterUpdate");
+      const event = determineDeploymentEvent(haveBackend);
+      expect(event).to.equal("afterRedeploy");
     });
   });
 
@@ -55,7 +55,7 @@ describe("lifecycle", () => {
       expect(executed).to.be.false;
     });
 
-    it("enqueues task when afterInstall TaskQueue hook is configured on fresh install", async () => {
+    it("enqueues task when afterFirstDeploy TaskQueue hook is configured on fresh install", async () => {
       const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
       const loggerStub = sandbox.stub(logger, "info");
       const wantBackend = backend.of({
@@ -68,7 +68,7 @@ describe("lifecycle", () => {
         taskQueueTrigger: {},
       });
       wantBackend.lifecycleHooks = {
-        afterInstall: {
+        afterFirstDeploy: {
           task: {
             function: "installHookTask",
             body: { setupVersion: 1 },
@@ -93,7 +93,7 @@ describe("lifecycle", () => {
       });
       expect(loggerStub).to.have.been.calledWith(
         sinon.match.any,
-        "View logs for afterInstall at: https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.service_name%3D%22installHookTask%22%0Aresource.labels.location%3D%22us-east1%22;project=myProj",
+        "View logs for afterFirstDeploy at: https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.service_name%3D%22installHookTask%22%0Aresource.labels.location%3D%22us-east1%22;project=myProj",
       );
     });
 
@@ -110,7 +110,7 @@ describe("lifecycle", () => {
         taskQueueTrigger: {},
       });
       wantBackend.lifecycleHooks = {
-        afterInstall: {
+        afterFirstDeploy: {
           task: {
             function: "installHookTask",
           },
@@ -128,7 +128,7 @@ describe("lifecycle", () => {
       });
     });
 
-    it("enqueues task when afterUpdate TaskQueue hook is configured on subsequent update", async () => {
+    it("enqueues task when afterRedeploy TaskQueue hook is configured on subsequent update", async () => {
       const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
       const wantBackend = backend.of({
         id: "updateHookTask",
@@ -140,7 +140,7 @@ describe("lifecycle", () => {
         taskQueueTrigger: {},
       });
       wantBackend.lifecycleHooks = {
-        afterUpdate: {
+        afterRedeploy: {
           task: {
             function: "updateHookTask",
             body: { migrationStep: 2 },
@@ -172,7 +172,7 @@ describe("lifecycle", () => {
       });
     });
 
-    it("skips afterUpdate hook when deployment plan contains no resource modifications", async () => {
+    it("skips afterRedeploy hook when deployment plan contains no resource modifications", async () => {
       const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
       const wantBackend = backend.of({
         id: "updateHookTask",
@@ -184,7 +184,7 @@ describe("lifecycle", () => {
         taskQueueTrigger: {},
       });
       wantBackend.lifecycleHooks = {
-        afterUpdate: {
+        afterRedeploy: {
           task: {
             function: "updateHookTask",
           },
@@ -229,7 +229,7 @@ describe("lifecycle", () => {
         codebase: "my-codebase",
       });
       wantBackend.lifecycleHooks = {
-        afterInstall: {
+        afterFirstDeploy: {
           task: {
             function: "installHookTask",
           },
@@ -246,11 +246,11 @@ describe("lifecycle", () => {
       expect(executed).to.be.false;
       expect(warningStub).to.have.been.calledWith(
         "functions",
-        "Failed to execute afterInstall lifecycle hook: Queue full",
+        "Failed to execute afterFirstDeploy lifecycle hook: Queue full",
       );
       expect(bulletStub).to.have.been.calledWith(
         "functions",
-        "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterInstall my-codebase",
+        "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterFirstDeploy my-codebase",
       );
     });
   });

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -8,19 +8,19 @@ import * as computeEngine from "../../../gcp/computeEngine";
 import { getProject } from "../../../management/projects";
 import { assertExhaustive } from "../../../functional";
 
-export type LifecycleDelta = "afterInstall" | "afterUpdate";
+export type DeploymentEvent = "afterFirstDeploy" | "afterRedeploy";
 
 /**
  * Determines whether the current deployment represents a fresh codebase deployment
- * (afterInstall) or an update to an existing deployment (afterUpdate).
+ * (afterFirstDeploy) or an update to an existing deployment (afterRedeploy).
  */
-export function determineDeploymentDelta(haveBackend: backend.Backend): LifecycleDelta {
+export function determineDeploymentEvent(haveBackend: backend.Backend): DeploymentEvent {
   // If haveBackend has no existing endpoints, this is a fresh installation.
   const hasExistingEndpoints = backend.someEndpoint(haveBackend, () => true);
   if (!hasExistingEndpoints) {
-    return "afterInstall";
+    return "afterFirstDeploy";
   }
-  return "afterUpdate";
+  return "afterRedeploy";
 }
 
 /**
@@ -33,16 +33,16 @@ export async function executeLifecycleHooks(
   plan?: planner.DeploymentPlan,
   codebase?: string,
 ): Promise<boolean> {
-  const delta = determineDeploymentDelta(haveBackend);
+  const event = determineDeploymentEvent(haveBackend);
   const hooks = wantBackend.lifecycleHooks || {};
-  const hook = hooks[delta];
+  const hook = hooks[event];
 
   if (!hook) {
-    logger.debug(`No lifecycle hook configured for event: ${delta}`);
+    logger.debug(`No lifecycle hook configured for event: ${event}`);
     return false;
   }
 
-  if (delta === "afterUpdate" && plan) {
+  if (event === "afterRedeploy" && plan) {
     // Filter the deployment plan to only include changesets relevant to the codebase being released.
     // Changeset keys in the plan are prefixed with the codebase name (e.g. "mycodebase-").
     // If the codebase is "default", the key may just start with "-" (e.g. "-endpointId").
@@ -63,23 +63,23 @@ export async function executeLifecycleHooks(
     if (!hasResourceModifications) {
       logLabeledBullet(
         "functions",
-        `No resources modified for codebase: ${codebase ?? "default"}. Skipping afterUpdate lifecycle hook.`,
+        `No resources modified for codebase: ${codebase ?? "default"}. Skipping afterRedeploy lifecycle hook.`,
       );
       return false;
     }
   }
 
   try {
-    await executeHook(delta, hook, wantBackend);
+    await executeHook(event, hook, wantBackend);
     return true;
   } catch (err: unknown) {
     // We treat lifecycle hook failures as warnings. We don't want to fail
     // the entire deploy command if a post-deploy hook fails to enqueue.
     const errorMsg = err instanceof Error ? err.message : String(err);
-    logLabeledWarning("functions", `Failed to execute ${delta} lifecycle hook: ${errorMsg}`);
+    logLabeledWarning("functions", `Failed to execute ${event} lifecycle hook: ${errorMsg}`);
     logLabeledBullet(
       "functions",
-      `You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run ${delta} ${codebase ?? "default"}`,
+      `You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run ${event} ${codebase ?? "default"}`,
     );
     return false;
   }
@@ -156,7 +156,7 @@ function getCloudConsoleLogUrl(endpoint: backend.Endpoint): string {
  * Executes a specific lifecycle hook in isolation.
  */
 export async function executeHook(
-  delta: string,
+  event: DeploymentEvent,
   hook: backend.LifecycleHook,
   backendSpec: backend.Backend,
 ): Promise<backend.Endpoint | undefined> {
@@ -164,7 +164,7 @@ export async function executeHook(
   if ("task" in hook) {
     logLabeledBullet(
       "functions",
-      `Executing ${delta} lifecycle hook targeting: ${hook.task.function}...`,
+      `Executing ${event} lifecycle hook targeting: ${hook.task.function}...`,
     );
     executedEndpoint = await executeTaskQueueHook(hook.task, backendSpec);
   } else if ("call" in hook) {
@@ -178,7 +178,7 @@ export async function executeHook(
   if (executedEndpoint) {
     logLabeledBullet(
       "functions",
-      `View logs for ${delta} at: ${getCloudConsoleLogUrl(executedEndpoint)}`,
+      `View logs for ${event} at: ${getCloudConsoleLogUrl(executedEndpoint)}`,
     );
   }
   return executedEndpoint;

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.spec.ts
@@ -1109,7 +1109,7 @@ describe("buildFromV1Alpha", () => {
         specVersion: "v1alpha1",
         endpoints: {},
         lifecycleHooks: {
-          afterInstall: {
+          afterFirstDeploy: {
             task: {
               function: "myTaskFunc",
               body: { key: "value" },
@@ -1121,7 +1121,7 @@ describe("buildFromV1Alpha", () => {
       const parsed = v1alpha1.buildFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
       const expected: build.Build = build.empty();
       expected.lifecycleHooks = {
-        afterInstall: {
+        afterFirstDeploy: {
           task: {
             function: "myTaskFunc",
             body: { key: "value" },
@@ -1136,7 +1136,7 @@ describe("buildFromV1Alpha", () => {
         specVersion: "v1alpha1",
         endpoints: {},
         lifecycleHooks: {
-          afterUpdate: {
+          afterRedeploy: {
             call: {
               function: "myCallFunc",
               params: { foo: "bar" },
@@ -1148,7 +1148,7 @@ describe("buildFromV1Alpha", () => {
       const parsed = v1alpha1.buildFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
       const expected: build.Build = build.empty();
       expected.lifecycleHooks = {
-        afterUpdate: {
+        afterRedeploy: {
           call: {
             function: "myCallFunc",
             params: { foo: "bar" },
@@ -1163,7 +1163,7 @@ describe("buildFromV1Alpha", () => {
         specVersion: "v1alpha1",
         endpoints: {},
         lifecycleHooks: {
-          afterInstall: {
+          afterFirstDeploy: {
             http: {
               url: "https://example.com/hook",
               body: "some-body",
@@ -1175,7 +1175,7 @@ describe("buildFromV1Alpha", () => {
       const parsed = v1alpha1.buildFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME);
       const expected: build.Build = build.empty();
       expected.lifecycleHooks = {
-        afterInstall: {
+        afterFirstDeploy: {
           http: {
             url: "https://example.com/hook",
             body: "some-body",
@@ -1209,7 +1209,7 @@ describe("buildFromV1Alpha", () => {
         specVersion: "v1alpha1",
         endpoints: {},
         lifecycleHooks: {
-          afterInstall: {
+          afterFirstDeploy: {
             task: {},
           },
         },
@@ -1217,7 +1217,7 @@ describe("buildFromV1Alpha", () => {
 
       expect(() => v1alpha1.buildFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME)).to.throw(
         FirebaseError,
-        /Invalid target "" for lifecycle hook "afterInstall"/,
+        /Invalid target "" for lifecycle hook "afterFirstDeploy"/,
       );
     });
 
@@ -1226,13 +1226,13 @@ describe("buildFromV1Alpha", () => {
         specVersion: "v1alpha1",
         endpoints: {},
         lifecycleHooks: {
-          afterInstall: {},
+          afterFirstDeploy: {},
         },
       };
 
       expect(() => v1alpha1.buildFromV1Alpha1(yaml, PROJECT, REGION, RUNTIME)).to.throw(
         FirebaseError,
-        /No action \(task, call, or http\) specified for lifecycle hook "afterInstall"/,
+        /No action \(task, call, or http\) specified for lifecycle hook "afterFirstDeploy"/,
       );
     });
   });

--- a/src/deploy/functions/runtimes/discovery/v1alpha1.ts
+++ b/src/deploy/functions/runtimes/discovery/v1alpha1.ts
@@ -157,7 +157,7 @@ export function buildFromV1Alpha1(
   if (manifest.lifecycleHooks) {
     bd.lifecycleHooks = {};
     for (const id of Object.keys(manifest.lifecycleHooks)) {
-      if (id !== "afterInstall" && id !== "afterUpdate") {
+      if (id !== "afterFirstDeploy" && id !== "afterRedeploy") {
         throw new FirebaseError(`Invalid eventType "${id}" for lifecycle hook.`);
       }
       const hook: WireLifecycleHook = manifest.lifecycleHooks[id];

--- a/src/deploy/functions/validate.spec.ts
+++ b/src/deploy/functions/validate.spec.ts
@@ -512,7 +512,7 @@ describe("validate", () => {
         };
         const want = backend.of(taskEp);
         want.lifecycleHooks = {
-          afterInstall: {
+          afterFirstDeploy: {
             task: {
               function: "mytaskfunc",
             },
@@ -527,14 +527,14 @@ describe("validate", () => {
           id: "myfunc",
         });
         want.lifecycleHooks = {
-          afterInstall: {
+          afterFirstDeploy: {
             task: {
               function: "nonexistent",
             },
           },
         };
         expect(() => validate.endpointsAreValid(want)).to.throw(
-          /Target endpoint "nonexistent" not found in backend for lifecycle hook "afterInstall"/,
+          /Target endpoint "nonexistent" not found in backend for lifecycle hook "afterFirstDeploy"/,
         );
       });
 
@@ -546,14 +546,14 @@ describe("validate", () => {
         };
         const want = backend.of(nonTaskEp);
         want.lifecycleHooks = {
-          afterInstall: {
+          afterFirstDeploy: {
             task: {
               function: "nontaskfunc",
             },
           },
         };
         expect(() => validate.endpointsAreValid(want)).to.throw(
-          /Lifecycle hook "afterInstall" expects a task queue function\./,
+          /Lifecycle hook "afterFirstDeploy" expects a task queue function\./,
         );
       });
 
@@ -566,7 +566,7 @@ describe("validate", () => {
         };
         const want = backend.of(v1Ep);
         want.lifecycleHooks = {
-          afterInstall: {
+          afterFirstDeploy: {
             task: {
               function: "v1func",
             },
@@ -583,7 +583,7 @@ describe("validate", () => {
           id: "myfunc",
         });
         want.lifecycleHooks = {
-          afterInstall: {
+          afterFirstDeploy: {
             call: {
               function: "myfunc",
             },
@@ -600,7 +600,7 @@ describe("validate", () => {
           id: "myfunc",
         });
         want.lifecycleHooks = {
-          afterInstall: {
+          afterFirstDeploy: {
             http: {
               url: "https://example.com/hook",
             },


### PR DESCRIPTION
### Description

This PR refactors lifecycle hook event naming and helper structures to better mirror Cloud Functions terminology and move away from Extensions terms (`afterInstall`, `afterUpdate`).

- **Renamed event strings:**
  - `afterInstall` is renamed to `afterFirstDeploy`
  - `afterUpdate` is renamed to `afterRedeploy`
- **Renamed types and methods:**
  - Type `LifecycleDelta` is renamed to `DeploymentEvent`
  - Helper function `determineDeploymentDelta` is renamed to `determineDeploymentEvent`
- **Internal variable renaming:**
  - Updated occurrences of `delta` variables/parameters to `event` to correspond with `DeploymentEvent`.

### Scenarios Tested

- Ran functions lifecycle unit tests to verify behavior and string parsing.
- Manually tested that hooks run as intended with https://github.com/firebase/firebase-functions/pull/1920

### Sample Commands

- `firebase functions:lifecycle:run afterFirstDeploy default`
- `firebase functions:lifecycle:run afterRedeploy default`
- `firebase functions:lifecycle:list default`