### PR TITLE
Fix: Add `schemas` property to `dataconnect.yaml` JSON schema

### DIFF
--- a/schema/dataconnect-yaml.json
+++ b/schema/dataconnect-yaml.json
@@ -80,6 +80,13 @@
     },
     "schema": {
       "$ref": "#/definitions/schema"
+    },
+    "schemas": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/schema"
+      },
+      "description": "A list of schema configurations."
     }
   }
 }


### PR DESCRIPTION
This patch updates `schema/dataconnect-yaml.json` to include the `schemas` property as an array of `schema` items. This resolves validation issues in VS Code for dataconnect apps that specify an array of schema configurations using `schemas`.

---
*PR created automatically by Jules for task [4144845718607347064](https://jules.google.com/task/4144845718607347064) started by @fredzqm*