### PR TITLE
feat: add firebase ailogic:providers CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,3 @@
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
 - Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,2 @@
-- Fixed an issue in `apps:create` where App Store ID was always prompted for even when unnecessary.
-- Add `functions:lifecycle:list` and `functions:lifecycle:run` commands to view and run
-  lifecycle hooks in isolation.
-- Updated the Firebase SQL Connect local toolkit to v3.4.15, which supports for 1:1 nested mutations. (#10773)
+- Added `firebase ailogic:providers:*` CLI commands to enable, disable, and list Gemini API providers.
+- Updated Pub/Sub emulator to version 0.8.34

--- a/src/commands/ailogic-providers-disable.ts
+++ b/src/commands/ailogic-providers-disable.ts
@@ -1,0 +1,40 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import { confirm } from "../prompt";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:disable <providerType>")
+  .description("disable a Gemini API provider service")
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requirePermissions, ["serviceusage.services.disable", "firebasevertexai.config.update"])
+  .action(async (providerType: string, options: Options) => {
+    const projectId = needProjectId(options);
+    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
+      throw new FirebaseError(
+        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
+      );
+    }
+    if (options.nonInteractive && !options.force) {
+      throw new FirebaseError(
+        `Disabling provider ${clc.bold(providerType)} requires confirmation.\n\n` +
+          `To proceed in non-interactive mode, rerun with --force:\n\n` +
+          `  firebase ailogic:providers:disable ${providerType} --force`,
+      );
+    }
+    const confirmed = await confirm({
+      message: `You are about to disable ${clc.bold(providerType)}. This will stop running apps from invoking it. Are you sure?`,
+      force: options.force,
+      nonInteractive: options.nonInteractive,
+    });
+    if (!confirmed) {
+      throw new FirebaseError("Command aborted.", { exit: 1 });
+    }
+    await ailogic.disableProvider(projectId, providerType as ailogic.ProviderType);
+    logger.info(clc.green(`Successfully disabled provider: ${clc.bold(providerType)}`));
+  });

--- a/src/commands/ailogic-providers-disable.ts
+++ b/src/commands/ailogic-providers-disable.ts
@@ -15,26 +15,17 @@ export const command = new Command("ailogic:providers:disable <providerType>")
   .before(requirePermissions, ["serviceusage.services.disable", "firebasevertexai.config.update"])
   .action(async (providerType: string, options: Options) => {
     const projectId = needProjectId(options);
-    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
-      throw new FirebaseError(
-        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
-      );
-    }
-    if (options.nonInteractive && !options.force) {
-      throw new FirebaseError(
-        `Disabling provider ${clc.bold(providerType)} requires confirmation.\n\n` +
-          `To proceed in non-interactive mode, rerun with --force:\n\n` +
-          `  firebase ailogic:providers:disable ${providerType} --force`,
-      );
-    }
+    const provider = ailogic.parseProviderType(providerType);
+    // confirm() aborts (throws) in non-interactive mode unless --force is set, so a
+    // separate non-interactive guard is unnecessary here.
     const confirmed = await confirm({
-      message: `You are about to disable ${clc.bold(providerType)}. This will stop running apps from invoking it. Are you sure?`,
+      message: `You are about to disable ${clc.bold(provider)}. This will stop running apps from invoking it. Are you sure?`,
       force: options.force,
       nonInteractive: options.nonInteractive,
     });
     if (!confirmed) {
       throw new FirebaseError("Command aborted.", { exit: 1 });
     }
-    await ailogic.disableProvider(projectId, providerType as ailogic.ProviderType);
-    logger.info(clc.green(`Successfully disabled provider: ${clc.bold(providerType)}`));
+    await ailogic.disableProvider(projectId, provider);
+    logger.info(clc.green(`Successfully disabled provider: ${clc.bold(provider)}`));
   });

--- a/src/commands/ailogic-providers-enable.ts
+++ b/src/commands/ailogic-providers-enable.ts
@@ -1,0 +1,23 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:enable <providerType>")
+  .description("enable a Gemini API provider service")
+  .before(requirePermissions, ["serviceusage.services.enable", "firebasevertexai.config.update"])
+  .action(async (providerType: string, options: Options) => {
+    const projectId = needProjectId(options);
+    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
+      throw new FirebaseError(
+        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
+      );
+    }
+    await ailogic.enableProvider(projectId, providerType as ailogic.ProviderType);
+    logger.info(clc.green(`Successfully enabled provider: ${clc.bold(providerType)}`));
+  });

--- a/src/commands/ailogic-providers-enable.ts
+++ b/src/commands/ailogic-providers-enable.ts
@@ -4,7 +4,6 @@ import { needProjectId } from "../projectUtils";
 import * as ailogic from "../gcp/ailogic";
 import * as clc from "colorette";
 import { logger } from "../logger";
-import { FirebaseError } from "../error";
 
 import { Options } from "../options";
 
@@ -13,11 +12,7 @@ export const command = new Command("ailogic:providers:enable <providerType>")
   .before(requirePermissions, ["serviceusage.services.enable", "firebasevertexai.config.update"])
   .action(async (providerType: string, options: Options) => {
     const projectId = needProjectId(options);
-    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
-      throw new FirebaseError(
-        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
-      );
-    }
-    await ailogic.enableProvider(projectId, providerType as ailogic.ProviderType);
-    logger.info(clc.green(`Successfully enabled provider: ${clc.bold(providerType)}`));
+    const provider = ailogic.parseProviderType(providerType);
+    await ailogic.enableProvider(projectId, provider);
+    logger.info(clc.green(`Successfully enabled provider: ${clc.bold(provider)}`));
   });

--- a/src/commands/ailogic-providers-list.ts
+++ b/src/commands/ailogic-providers-list.ts
@@ -1,0 +1,38 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:list")
+  .description("list which Gemini API providers are enabled")
+  .before(requirePermissions, ["serviceusage.services.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    const enabledProviders = await ailogic.listProviders(projectId);
+
+    if (enabledProviders.length === 0) {
+      logger.info(clc.bold("No Gemini API providers are enabled."));
+      return enabledProviders;
+    }
+
+    const tableHead = ["Provider", "Status"];
+    const table = new Table({ head: tableHead, style: { head: ["green"] } });
+
+    // Show both possible providers, indicating if they are enabled or disabled
+    const allProviders: ailogic.ProviderType[] = [
+      "gemini-developer-api",
+      "agent-platform-gemini-api",
+    ];
+    for (const provider of allProviders) {
+      const isEnabled = enabledProviders.includes(provider);
+      table.push([clc.bold(provider), isEnabled ? clc.green("Enabled") : clc.red("Disabled")]);
+    }
+
+    logger.info(table.toString());
+    return enabledProviders;
+  });

--- a/src/commands/ailogic-providers-list.ts
+++ b/src/commands/ailogic-providers-list.ts
@@ -23,12 +23,8 @@ export const command = new Command("ailogic:providers:list")
     const tableHead = ["Provider", "Status"];
     const table = new Table({ head: tableHead, style: { head: ["green"] } });
 
-    // Show both possible providers, indicating if they are enabled or disabled
-    const allProviders: ailogic.ProviderType[] = [
-      "gemini-developer-api",
-      "agent-platform-gemini-api",
-    ];
-    for (const provider of allProviders) {
+    // Show every possible provider, indicating whether it is enabled or disabled.
+    for (const provider of ailogic.PROVIDER_TYPES) {
       const isEnabled = enabledProviders.includes(provider);
       table.push([clc.bold(provider), isEnabled ? clc.green("Enabled") : clc.red("Disabled")]);
     }

--- a/src/commands/help.spec.ts
+++ b/src/commands/help.spec.ts
@@ -1,0 +1,59 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import { command as helpCommand } from "./help";
+import { logger } from "../logger";
+
+describe("help command namespace listing", () => {
+  let loggerStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    loggerStub = sinon.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should show help for namespace subcommands", async () => {
+    const mockEnableCommand = {
+      name: () => "ailogic:providers:enable",
+      description: () => "enable a provider",
+      outputHelp: sinon.stub(),
+    };
+    const mockDisableCommand = {
+      name: () => "ailogic:providers:disable",
+      description: () => "disable a provider",
+      outputHelp: sinon.stub(),
+    };
+
+    const mockClient = {
+      cli: {
+        commands: [mockEnableCommand, mockDisableCommand],
+        outputHelp: sinon.stub(),
+      },
+      getCommand: sinon.stub().returns(undefined),
+      ailogic: {
+        providers: {},
+      },
+    };
+
+    // Run help command action with mock context
+    // `actionFn` is a private member of Command; cast through `unknown` to invoke it
+    // directly with a mocked command context. The target type is fully specified (no `any`).
+    const actionFn = (
+      helpCommand as unknown as {
+        actionFn: (this: { client: typeof mockClient }, commandName: string) => Promise<void>;
+      }
+    ).actionFn;
+    await actionFn.call({ client: mockClient }, "ailogic:providers");
+
+    // It should log the subcommands and descriptions
+    expect(loggerStub).to.have.been.called;
+    const allArgs = loggerStub.args.map((a) => a.join(" ")).join("\n");
+    expect(allArgs).to.include("Commands under ailogic:providers:");
+    expect(allArgs).to.include("ailogic:providers:enable");
+    expect(allArgs).to.include("enable a provider");
+    expect(allArgs).to.include("ailogic:providers:disable");
+    expect(allArgs).to.include("disable a provider");
+  });
+});

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -19,6 +19,9 @@ export const command = new Command("help [command]")
     }
 
     if (commandName) {
+      // Treat the argument as a command namespace (e.g. "ailogic:providers") and walk
+      // the nested client command tree segment by segment ("ailogic" -> "providers") to
+      // check whether it resolves to a group of subcommands rather than a leaf command.
       const keys = commandName.split(":");
       let current = client;
       let matched = true;
@@ -36,6 +39,8 @@ export const command = new Command("help [command]")
         }
       }
 
+      // If it resolved to a namespace, print every registered command under that prefix
+      // (e.g. `firebase help ailogic:providers` lists enable/disable/list).
       if (matched && current && typeof current === "object") {
         const prefix = commandName + ":";
         const subcmds = (client.cli.commands as CommanderCommand[]).filter((c) =>

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as clc from "colorette";
+import type { Command as CommanderCommand } from "commander";
 
 import { Command } from "../command";
 import { logger } from "../logger";
@@ -14,7 +15,46 @@ export const command = new Command("help [command]")
     const cmd = commandName ? client.getCommand(commandName) : undefined;
     if (cmd) {
       cmd.outputHelp();
-    } else if (commandName) {
+      return;
+    }
+
+    if (commandName) {
+      const keys = commandName.split(":");
+      let current = client;
+      let matched = true;
+      for (const key of keys) {
+        if (!current || typeof current !== "object") {
+          matched = false;
+          break;
+        }
+        const nextKey = Object.keys(current).find((k) => k.toLowerCase() === key.toLowerCase());
+        if (nextKey) {
+          current = current[nextKey];
+        } else {
+          matched = false;
+          break;
+        }
+      }
+
+      if (matched && current && typeof current === "object") {
+        const prefix = commandName + ":";
+        const subcmds = (client.cli.commands as CommanderCommand[]).filter((c) =>
+          c.name().startsWith(prefix),
+        );
+        if (subcmds.length > 0) {
+          logger.info();
+          logger.info(clc.bold(`Commands under ${clc.green(commandName)}:`));
+          logger.info();
+          for (const subcmd of subcmds) {
+            logger.info(`  ${clc.bold(subcmd.name().padEnd(45))} ${subcmd.description()}`);
+          }
+          logger.info();
+          return;
+        }
+      }
+    }
+
+    if (commandName) {
       logger.warn();
       utils.logWarning(
         clc.bold(commandName) + " is not a valid command. See below for valid commands",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -224,11 +224,15 @@ export function load(client: CLIClient): CLIClient {
       client.apphosting.rollouts.list = loadCommand("apphosting-rollouts-list");
     }
   }
-  client.ailogic = {};
-  client.ailogic.providers = {};
-  client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
-  client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
-  client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+  // Gated behind the `ailogic` experiment until the underlying API is API-council
+  // approved, since the surface may still change.
+  if (experiments.isEnabled("ailogic")) {
+    client.ailogic = {};
+    client.ailogic.providers = {};
+    client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
+    client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
+    client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+  }
 
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -224,6 +224,12 @@ export function load(client: CLIClient): CLIClient {
       client.apphosting.rollouts.list = loadCommand("apphosting-rollouts-list");
     }
   }
+  client.ailogic = {};
+  client.ailogic.providers = {};
+  client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
+  client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
+  client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");
   client.login.ci = loadCommand("login-ci");

--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -239,3 +239,18 @@ function cacheEnabledAPI(projectId: string, apiName: string) {
   cache[projectId][apiName] = true;
   configstore.set(API_ENABLEMENT_CACHE_KEY, cache);
 }
+
+/**
+ * Removes a single API from the local "enabled" cache so the next check re-queries the server.
+ * Call this after enabling or disabling an API to keep the cache consistent with the server state.
+ */
+export function uncacheEnabledAPI(projectId: string, apiName: string): void {
+  const cache = (configstore.get(API_ENABLEMENT_CACHE_KEY) || {}) as Record<
+    string,
+    Record<string, true>
+  >;
+  if (cache[projectId]) {
+    delete cache[projectId][apiName];
+    configstore.set(API_ENABLEMENT_CACHE_KEY, cache);
+  }
+}

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -136,6 +136,14 @@ export const ALL_EXPERIMENTS = experiments({
       "without a notice.",
   },
 
+  ailogic: {
+    shortDescription: "Manage Firebase AI Logic from the CLI.",
+    fullDescription:
+      "Enables the `firebase ailogic` command surface for managing Firebase AI Logic, " +
+      "starting with the Gemini API providers. These commands are in preview and may " +
+      "change until the underlying API is finalized.",
+  },
+
   apphosting: {
     shortDescription: "Allow CLI option for Frameworks",
     default: true,

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -1,11 +1,15 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as ailogic from "./ailogic";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as serviceUsage from "./serviceusage";
+import * as cloudbilling from "./cloudbilling";
 import {
   AI_LOGIC_BEFORE_GENERATE_CONTENT,
   AI_LOGIC_AFTER_GENERATE_CONTENT,
   AILogicEndpoint,
 } from "../deploy/functions/services/ailogic";
+import { FirebaseError } from "../error";
 
 describe("ailogic", () => {
   const mockEndpointBase = {
@@ -140,6 +144,122 @@ describe("ailogic", () => {
           },
         },
       );
+    });
+  });
+
+  describe("providers", () => {
+    let ensureStub: sinon.SinonStub;
+    let disableStub: sinon.SinonStub;
+    let uncacheStub: sinon.SinonStub;
+    let checkStub: sinon.SinonStub;
+    let billingStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      ensureStub = sinon.stub(ensureApiEnabled, "ensure");
+      disableStub = sinon.stub(serviceUsage, "disableServiceAndPoll");
+      uncacheStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
+      checkStub = sinon.stub(ensureApiEnabled, "check");
+      billingStub = sinon.stub(cloudbilling, "checkBillingEnabled");
+    });
+
+    afterEach(() => {
+      ensureStub.restore();
+      disableStub.restore();
+      uncacheStub.restore();
+      checkStub.restore();
+      billingStub.restore();
+    });
+
+    it("should enable gemini-developer-api", async () => {
+      ensureStub.resolves();
+
+      await ailogic.enableProvider("my-project", "gemini-developer-api");
+
+      expect(ensureStub).to.have.been.calledTwice;
+      expect(ensureStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+    });
+
+    it("should enable agent-platform-gemini-api if billing is enabled", async () => {
+      ensureStub.resolves();
+      billingStub.resolves(true);
+
+      await ailogic.enableProvider("my-project", "agent-platform-gemini-api");
+
+      expect(ensureStub).to.have.been.calledTwice;
+      expect(ensureStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "aiplatform.googleapis.com",
+        "ailogic",
+      );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+    });
+
+    it("should reject enabling agent-platform-gemini-api if billing is disabled", async () => {
+      ensureStub.resolves();
+      billingStub.resolves(false);
+
+      await expect(
+        ailogic.enableProvider("my-project", "agent-platform-gemini-api"),
+      ).to.be.rejectedWith(FirebaseError, /must be on the Blaze/);
+
+      expect(ensureStub).to.not.have.been.called;
+    });
+
+    it("should disable gemini-developer-api and disable proxy if agent-platform-gemini-api is also disabled", async () => {
+      disableStub.resolves();
+      checkStub.resolves(false); // agent-platform-gemini-api is disabled
+
+      await ailogic.disableProvider("my-project", "gemini-developer-api");
+
+      expect(disableStub).to.have.been.calledTwice;
+      expect(disableStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(disableStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+      expect(uncacheStub).to.have.been.calledTwice;
+    });
+
+    it("should disable gemini-developer-api but NOT disable proxy if agent-platform-gemini-api is enabled", async () => {
+      disableStub.resolves();
+      checkStub.resolves(true); // agent-platform-gemini-api is enabled
+
+      await ailogic.disableProvider("my-project", "gemini-developer-api");
+
+      expect(disableStub).to.have.been.calledOnce;
+      expect(disableStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(uncacheStub).to.have.been.calledOnce;
+    });
+
+    it("should list enabled providers", async () => {
+      checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
+      checkStub.onSecondCall().resolves(true); // agent-platform-gemini-api API is enabled
+
+      const enabled = await ailogic.listProviders("my-project");
+
+      expect(enabled).to.deep.equal(["gemini-developer-api", "agent-platform-gemini-api"]);
     });
   });
 });

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -150,14 +150,14 @@ describe("ailogic", () => {
   describe("providers", () => {
     let ensureStub: sinon.SinonStub;
     let disableStub: sinon.SinonStub;
-    let uncacheStub: sinon.SinonStub;
     let checkStub: sinon.SinonStub;
     let billingStub: sinon.SinonStub;
 
     beforeEach(() => {
       ensureStub = sinon.stub(ensureApiEnabled, "ensure");
+      // disableServiceAndPoll now owns cache invalidation, so it is stubbed here and
+      // that behavior is verified in serviceusage.spec.ts.
       disableStub = sinon.stub(serviceUsage, "disableServiceAndPoll");
-      uncacheStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
       checkStub = sinon.stub(ensureApiEnabled, "check");
       billingStub = sinon.stub(cloudbilling, "checkBillingEnabled");
     });
@@ -165,7 +165,6 @@ describe("ailogic", () => {
     afterEach(() => {
       ensureStub.restore();
       disableStub.restore();
-      uncacheStub.restore();
       checkStub.restore();
       billingStub.restore();
     });
@@ -188,11 +187,11 @@ describe("ailogic", () => {
       );
     });
 
-    it("should enable agent-platform-gemini-api if billing is enabled", async () => {
+    it("should enable gemini-agent-platform-api if billing is enabled", async () => {
       ensureStub.resolves();
       billingStub.resolves(true);
 
-      await ailogic.enableProvider("my-project", "agent-platform-gemini-api");
+      await ailogic.enableProvider("my-project", "gemini-agent-platform-api");
 
       expect(ensureStub).to.have.been.calledTwice;
       expect(ensureStub.firstCall).to.have.been.calledWith(
@@ -207,20 +206,20 @@ describe("ailogic", () => {
       );
     });
 
-    it("should reject enabling agent-platform-gemini-api if billing is disabled", async () => {
+    it("should reject enabling gemini-agent-platform-api if billing is disabled", async () => {
       ensureStub.resolves();
       billingStub.resolves(false);
 
       await expect(
-        ailogic.enableProvider("my-project", "agent-platform-gemini-api"),
+        ailogic.enableProvider("my-project", "gemini-agent-platform-api"),
       ).to.be.rejectedWith(FirebaseError, /must be on the Blaze/);
 
       expect(ensureStub).to.not.have.been.called;
     });
 
-    it("should disable gemini-developer-api and disable proxy if agent-platform-gemini-api is also disabled", async () => {
+    it("should disable gemini-developer-api and disable proxy if gemini-agent-platform-api is also disabled", async () => {
       disableStub.resolves();
-      checkStub.resolves(false); // agent-platform-gemini-api is disabled
+      checkStub.resolves(false); // gemini-agent-platform-api is disabled
 
       await ailogic.disableProvider("my-project", "gemini-developer-api");
 
@@ -235,12 +234,11 @@ describe("ailogic", () => {
         "firebasevertexai.googleapis.com",
         "ailogic",
       );
-      expect(uncacheStub).to.have.been.calledTwice;
     });
 
-    it("should disable gemini-developer-api but NOT disable proxy if agent-platform-gemini-api is enabled", async () => {
+    it("should disable gemini-developer-api but NOT disable proxy if gemini-agent-platform-api is enabled", async () => {
       disableStub.resolves();
-      checkStub.resolves(true); // agent-platform-gemini-api is enabled
+      checkStub.resolves(true); // gemini-agent-platform-api is enabled
 
       await ailogic.disableProvider("my-project", "gemini-developer-api");
 
@@ -250,16 +248,36 @@ describe("ailogic", () => {
         "generativelanguage.googleapis.com",
         "ailogic",
       );
-      expect(uncacheStub).to.have.been.calledOnce;
     });
 
     it("should list enabled providers", async () => {
       checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
-      checkStub.onSecondCall().resolves(true); // agent-platform-gemini-api API is enabled
+      checkStub.onSecondCall().resolves(true); // gemini-agent-platform-api API is enabled
 
       const enabled = await ailogic.listProviders("my-project");
 
-      expect(enabled).to.deep.equal(["gemini-developer-api", "agent-platform-gemini-api"]);
+      expect(enabled).to.deep.equal(["gemini-developer-api", "gemini-agent-platform-api"]);
+    });
+  });
+
+  describe("parseProviderType", () => {
+    it("returns the provider for a valid value", () => {
+      expect(ailogic.parseProviderType("gemini-developer-api")).to.equal("gemini-developer-api");
+      expect(ailogic.parseProviderType("gemini-agent-platform-api")).to.equal(
+        "gemini-agent-platform-api",
+      );
+    });
+
+    it("throws a FirebaseError listing the valid providers for an invalid value", () => {
+      expect(() => ailogic.parseProviderType("agent-platform-gemini-api")).to.throw(
+        FirebaseError,
+        /Invalid provider type/,
+      );
+    });
+
+    it("isProviderType narrows valid values only", () => {
+      expect(ailogic.isProviderType("gemini-developer-api")).to.be.true;
+      expect(ailogic.isProviderType("nope")).to.be.false;
     });
   });
 });

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -169,25 +169,27 @@ describe("ailogic", () => {
       billingStub.restore();
     });
 
-    it("should enable gemini-developer-api", async () => {
+    it("should enable gemini-developer-api, enabling the AI Logic API first", async () => {
       ensureStub.resolves();
 
       await ailogic.enableProvider("my-project", "gemini-developer-api");
 
       expect(ensureStub).to.have.been.calledTwice;
+      // The AI Logic API must be enabled before the provider API so a partial
+      // failure cannot leave a provider on while AI Logic is off.
       expect(ensureStub.firstCall).to.have.been.calledWith(
-        "my-project",
-        "generativelanguage.googleapis.com",
-        "ailogic",
-      );
-      expect(ensureStub.secondCall).to.have.been.calledWith(
         "my-project",
         "firebasevertexai.googleapis.com",
         "ailogic",
       );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
     });
 
-    it("should enable gemini-agent-platform-api if billing is enabled", async () => {
+    it("should enable gemini-agent-platform-api if billing is enabled, enabling the AI Logic API first", async () => {
       ensureStub.resolves();
       billingStub.resolves(true);
 
@@ -196,12 +198,12 @@ describe("ailogic", () => {
       expect(ensureStub).to.have.been.calledTwice;
       expect(ensureStub.firstCall).to.have.been.calledWith(
         "my-project",
-        "aiplatform.googleapis.com",
+        "firebasevertexai.googleapis.com",
         "ailogic",
       );
       expect(ensureStub.secondCall).to.have.been.calledWith(
         "my-project",
-        "firebasevertexai.googleapis.com",
+        "aiplatform.googleapis.com",
         "ailogic",
       );
     });
@@ -251,12 +253,31 @@ describe("ailogic", () => {
     });
 
     it("should list enabled providers", async () => {
-      checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
-      checkStub.onSecondCall().resolves(true); // gemini-agent-platform-api API is enabled
+      checkStub
+        .withArgs("my-project", "firebasevertexai.googleapis.com", "ailogic", true)
+        .resolves(true);
+      checkStub
+        .withArgs("my-project", "generativelanguage.googleapis.com", "ailogic", true)
+        .resolves(true);
+      checkStub.withArgs("my-project", "aiplatform.googleapis.com", "ailogic", true).resolves(true);
 
       const enabled = await ailogic.listProviders("my-project");
 
       expect(enabled).to.deep.equal(["gemini-developer-api", "gemini-agent-platform-api"]);
+    });
+
+    it("should list no providers when the AI Logic API is disabled, even if provider APIs are enabled", async () => {
+      checkStub
+        .withArgs("my-project", "firebasevertexai.googleapis.com", "ailogic", true)
+        .resolves(false);
+      checkStub
+        .withArgs("my-project", "generativelanguage.googleapis.com", "ailogic", true)
+        .resolves(true);
+      checkStub.withArgs("my-project", "aiplatform.googleapis.com", "ailogic", true).resolves(true);
+
+      const enabled = await ailogic.listProviders("my-project");
+
+      expect(enabled).to.deep.equal([]);
     });
   });
 

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -13,6 +13,9 @@ import { confirm, select } from "../prompt";
 
 export const API_VERSION = "v1beta";
 
+/** Label used as the prefix for this module's user-facing progress logging. */
+export const AILOGIC_LOGGING_PREFIX = "ailogic";
+
 export const AI_LOGIC_BEFORE_GENERATE_CONTENT =
   "google.firebase.ailogic.v1.beforeGenerate" as const;
 export const AI_LOGIC_AFTER_GENERATE_CONTENT = "google.firebase.ailogic.v1.afterGenerate" as const;
@@ -212,17 +215,43 @@ export async function deleteBlockingFunction(endpoint: AILogicEndpoint): Promise
   await deleteTrigger(endpoint.project, location, triggerId, true);
 }
 
-export type ProviderType = "gemini-developer-api" | "agent-platform-gemini-api";
+export type ProviderType = "gemini-developer-api" | "gemini-agent-platform-api";
+
+export const PROVIDER_TYPES: ProviderType[] = ["gemini-developer-api", "gemini-agent-platform-api"];
+
+/** Whether the given string is a known Gemini API provider type. */
+export function isProviderType(value: string): value is ProviderType {
+  return PROVIDER_TYPES.some((p) => p === value);
+}
+
+/** Validates and narrows a string to a ProviderType, throwing a FirebaseError otherwise. */
+export function parseProviderType(value: string): ProviderType {
+  if (!isProviderType(value)) {
+    throw new FirebaseError(
+      `Invalid provider type: ${bold(value)}. Must be one of: ${PROVIDER_TYPES.map(
+        (p) => `'${p}'`,
+      ).join(", ")}.`,
+    );
+  }
+  return value;
+}
 
 /**
  * Enables a Gemini API provider service.
  */
 export async function enableProvider(projectId: string, providerType: ProviderType): Promise<void> {
-  const prefix = "ailogic";
   if (providerType === "gemini-developer-api") {
-    await ensureApiEnabled.ensure(projectId, "generativelanguage.googleapis.com", prefix);
-    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
-  } else if (providerType === "agent-platform-gemini-api") {
+    await ensureApiEnabled.ensure(
+      projectId,
+      "generativelanguage.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
+    await ensureApiEnabled.ensure(
+      projectId,
+      "firebasevertexai.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
+  } else if (providerType === "gemini-agent-platform-api") {
     const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
     if (!billingEnabled) {
       throw new FirebaseError(
@@ -231,77 +260,76 @@ export async function enableProvider(projectId: string, providerType: ProviderTy
         )} must be on the Blaze (pay-as-you-go) plan to enable the Agent Platform. To upgrade, visit the following URL:\n\nhttps://console.firebase.google.com/project/${projectId}/usage/details`,
       );
     }
-    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", prefix);
-    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
-  } else {
-    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", AILOGIC_LOGGING_PREFIX);
+    await ensureApiEnabled.ensure(
+      projectId,
+      "firebasevertexai.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
   }
 }
 
 /**
- * Disables a Gemini API provider service.
+ * Disables a Gemini API provider service. `disableServiceAndPoll` invalidates the
+ * enablement cache for each disabled service, so no explicit uncaching is needed here.
  */
 export async function disableProvider(
   projectId: string,
   providerType: ProviderType,
 ): Promise<void> {
-  const prefix = "ailogic";
   if (providerType === "gemini-developer-api") {
     await serviceUsage.disableServiceAndPoll(
       projectId,
       "generativelanguage.googleapis.com",
-      prefix,
+      AILOGIC_LOGGING_PREFIX,
     );
-    ensureApiEnabled.uncacheEnabledAPI(projectId, "generativelanguage.googleapis.com");
 
     const isVertexEnabled = await ensureApiEnabled.check(
       projectId,
       "aiplatform.googleapis.com",
-      prefix,
+      AILOGIC_LOGGING_PREFIX,
       true,
     );
     if (!isVertexEnabled) {
       await serviceUsage.disableServiceAndPoll(
         projectId,
         "firebasevertexai.googleapis.com",
-        prefix,
+        AILOGIC_LOGGING_PREFIX,
       );
-      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
     }
-  } else if (providerType === "agent-platform-gemini-api") {
-    await serviceUsage.disableServiceAndPoll(projectId, "aiplatform.googleapis.com", prefix);
-    ensureApiEnabled.uncacheEnabledAPI(projectId, "aiplatform.googleapis.com");
+  } else if (providerType === "gemini-agent-platform-api") {
+    await serviceUsage.disableServiceAndPoll(
+      projectId,
+      "aiplatform.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
 
     const isDeveloperEnabled = await ensureApiEnabled.check(
       projectId,
       "generativelanguage.googleapis.com",
-      prefix,
+      AILOGIC_LOGGING_PREFIX,
       true,
     );
     if (!isDeveloperEnabled) {
       await serviceUsage.disableServiceAndPoll(
         projectId,
         "firebasevertexai.googleapis.com",
-        prefix,
+        AILOGIC_LOGGING_PREFIX,
       );
-      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
     }
-  } else {
-    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
   }
 }
 
 /**
- *
+ * Lists which Gemini API providers are enabled, derived from underlying API enablement state.
  */
 export async function listProviders(projectId: string): Promise<ProviderType[]> {
-  const prefix = "ailogic";
   const enabled: ProviderType[] = [];
 
   const isDeveloperEnabled = await ensureApiEnabled.check(
     projectId,
     "generativelanguage.googleapis.com",
-    prefix,
+    AILOGIC_LOGGING_PREFIX,
     true,
   );
   if (isDeveloperEnabled) {
@@ -311,13 +339,13 @@ export async function listProviders(projectId: string): Promise<ProviderType[]> 
   const isVertexEnabled = await ensureApiEnabled.check(
     projectId,
     "aiplatform.googleapis.com",
-    prefix,
+    AILOGIC_LOGGING_PREFIX,
     true,
   );
   // aiplatform.googleapis.com cannot be enabled without billing (the Blaze plan),
   // so an enabled Vertex API already implies the agent-platform provider is available.
   if (isVertexEnabled) {
-    enabled.push("agent-platform-gemini-api");
+    enabled.push("gemini-agent-platform-api");
   }
 
   return enabled;
@@ -335,7 +363,7 @@ export async function ensureAILogicApiEnabled(
   const isEnabled = await ensureApiEnabled.check(
     projectId,
     "firebasevertexai.googleapis.com",
-    "ailogic",
+    AILOGIC_LOGGING_PREFIX,
     true,
   );
   if (isEnabled) {
@@ -347,7 +375,7 @@ export async function ensureAILogicApiEnabled(
       `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.\n\n` +
         `Enable Firebase AI Logic with one of the Gemini API providers by running:\n\n` +
         `  firebase ailogic:providers:enable gemini-developer-api\n` +
-        `  firebase ailogic:providers:enable agent-platform-gemini-api\n\n` +
+        `  firebase ailogic:providers:enable gemini-agent-platform-api\n\n` +
         `Then run this command again.`,
     );
   }
@@ -381,17 +409,17 @@ export async function ensureAILogicApiEnabled(
       choices: [
         { name: "gemini-developer-api", value: "gemini-developer-api" },
         {
-          name: "agent-platform-gemini-api (requires the Blaze plan)",
-          value: "agent-platform-gemini-api",
+          name: "gemini-agent-platform-api (requires the Blaze plan)",
+          value: "gemini-agent-platform-api",
         },
       ],
     });
 
-    if (provider === "agent-platform-gemini-api") {
+    if (provider === "gemini-agent-platform-api") {
       const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
       if (!billingEnabled) {
         logger.info(
-          `\n${bold("Error:")} The agent-platform-gemini-api provider requires the pay-as-you-go (Blaze) plan.\n` +
+          `\n${bold("Error:")} The gemini-agent-platform-api provider requires the pay-as-you-go (Blaze) plan.\n` +
             `Project ${projectId} is on the Spark plan.\n\n` +
             `Upgrade your plan at:\n\n` +
             `  https://console.firebase.google.com/project/${projectId}/usage/details\n`,

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -2,7 +2,14 @@ import { Client } from "../apiv2";
 import { aiLogicProxyOrigin } from "../api";
 import { DeepOmit } from "../metaprogramming";
 import type { AILogicEndpoint } from "../deploy/functions/services/ailogic";
-import { getErrStatus } from "../error";
+import { FirebaseError, getErrStatus } from "../error";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as serviceUsage from "./serviceusage";
+import { bold } from "colorette";
+import * as cloudbilling from "./cloudbilling";
+import * as iam from "./iam";
+import { logger } from "../logger";
+import { confirm, select } from "../prompt";
 
 export const API_VERSION = "v1beta";
 
@@ -167,6 +174,9 @@ export async function listTriggers(
   return triggers;
 }
 
+/**
+ *
+ */
 export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise<Trigger> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
@@ -191,10 +201,209 @@ export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise
   }
 }
 
+/**
+ *
+ */
 export async function deleteBlockingFunction(endpoint: AILogicEndpoint): Promise<void> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
   const location = endpoint.blockingTrigger.options?.regionalWebhook ? endpoint.region : "global";
 
   await deleteTrigger(endpoint.project, location, triggerId, true);
+}
+
+export type ProviderType = "gemini-developer-api" | "agent-platform-gemini-api";
+
+/**
+ * Enables a Gemini API provider service.
+ */
+export async function enableProvider(projectId: string, providerType: ProviderType): Promise<void> {
+  const prefix = "ailogic";
+  if (providerType === "gemini-developer-api") {
+    await ensureApiEnabled.ensure(projectId, "generativelanguage.googleapis.com", prefix);
+    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
+  } else if (providerType === "agent-platform-gemini-api") {
+    const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
+    if (!billingEnabled) {
+      throw new FirebaseError(
+        `Your project ${bold(
+          projectId,
+        )} must be on the Blaze (pay-as-you-go) plan to enable the Agent Platform. To upgrade, visit the following URL:\n\nhttps://console.firebase.google.com/project/${projectId}/usage/details`,
+      );
+    }
+    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", prefix);
+    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
+  } else {
+    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+  }
+}
+
+/**
+ * Disables a Gemini API provider service.
+ */
+export async function disableProvider(
+  projectId: string,
+  providerType: ProviderType,
+): Promise<void> {
+  const prefix = "ailogic";
+  if (providerType === "gemini-developer-api") {
+    await serviceUsage.disableServiceAndPoll(
+      projectId,
+      "generativelanguage.googleapis.com",
+      prefix,
+    );
+    ensureApiEnabled.uncacheEnabledAPI(projectId, "generativelanguage.googleapis.com");
+
+    const isVertexEnabled = await ensureApiEnabled.check(
+      projectId,
+      "aiplatform.googleapis.com",
+      prefix,
+      true,
+    );
+    if (!isVertexEnabled) {
+      await serviceUsage.disableServiceAndPoll(
+        projectId,
+        "firebasevertexai.googleapis.com",
+        prefix,
+      );
+      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
+    }
+  } else if (providerType === "agent-platform-gemini-api") {
+    await serviceUsage.disableServiceAndPoll(projectId, "aiplatform.googleapis.com", prefix);
+    ensureApiEnabled.uncacheEnabledAPI(projectId, "aiplatform.googleapis.com");
+
+    const isDeveloperEnabled = await ensureApiEnabled.check(
+      projectId,
+      "generativelanguage.googleapis.com",
+      prefix,
+      true,
+    );
+    if (!isDeveloperEnabled) {
+      await serviceUsage.disableServiceAndPoll(
+        projectId,
+        "firebasevertexai.googleapis.com",
+        prefix,
+      );
+      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
+    }
+  } else {
+    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+  }
+}
+
+/**
+ *
+ */
+export async function listProviders(projectId: string): Promise<ProviderType[]> {
+  const prefix = "ailogic";
+  const enabled: ProviderType[] = [];
+
+  const isDeveloperEnabled = await ensureApiEnabled.check(
+    projectId,
+    "generativelanguage.googleapis.com",
+    prefix,
+    true,
+  );
+  if (isDeveloperEnabled) {
+    enabled.push("gemini-developer-api");
+  }
+
+  const isVertexEnabled = await ensureApiEnabled.check(
+    projectId,
+    "aiplatform.googleapis.com",
+    prefix,
+    true,
+  );
+  // aiplatform.googleapis.com cannot be enabled without billing (the Blaze plan),
+  // so an enabled Vertex API already implies the agent-platform provider is available.
+  if (isVertexEnabled) {
+    enabled.push("agent-platform-gemini-api");
+  }
+
+  return enabled;
+}
+
+/**
+ * Ensures that the Firebase AI Logic API is enabled. If not enabled:
+ * - In non-interactive mode: throws an error with instructions.
+ * - In interactive mode: prompts to enable, and guides the user to choose a provider to enable.
+ */
+export async function ensureAILogicApiEnabled(
+  projectId: string,
+  options: { nonInteractive?: boolean; force?: boolean },
+): Promise<void> {
+  const isEnabled = await ensureApiEnabled.check(
+    projectId,
+    "firebasevertexai.googleapis.com",
+    "ailogic",
+    true,
+  );
+  if (isEnabled) {
+    return;
+  }
+
+  if (options.nonInteractive) {
+    throw new FirebaseError(
+      `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.\n\n` +
+        `Enable Firebase AI Logic with one of the Gemini API providers by running:\n\n` +
+        `  firebase ailogic:providers:enable gemini-developer-api\n` +
+        `  firebase ailogic:providers:enable agent-platform-gemini-api\n\n` +
+        `Then run this command again.`,
+    );
+  }
+
+  // Verify the caller can actually enable the API before prompting, so we fail
+  // with a clear permission error up front instead of midway through the flow.
+  const { missing } = await iam.testIamPermissions(projectId, ["serviceusage.services.enable"]);
+  if (missing.length > 0) {
+    throw new FirebaseError(
+      `You do not have permission to enable the Firebase AI Logic API on project ${projectId}.\n\n` +
+        `Missing permission: ${missing.join(", ")}\n\n` +
+        `This permission is included in the Owner and Editor roles. Ask a project ` +
+        `administrator to enable the API or grant you the permission, then run this command again.`,
+    );
+  }
+
+  logger.info(
+    `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.`,
+  );
+  const proceed = await confirm({
+    message: "Would you like to enable it now?",
+    default: true,
+  });
+  if (!proceed) {
+    throw new FirebaseError("Command aborted.", { exit: 1 });
+  }
+
+  for (;;) {
+    const provider = await select<ProviderType>({
+      message: "Which Gemini API provider do you want to enable?",
+      choices: [
+        { name: "gemini-developer-api", value: "gemini-developer-api" },
+        {
+          name: "agent-platform-gemini-api (requires the Blaze plan)",
+          value: "agent-platform-gemini-api",
+        },
+      ],
+    });
+
+    if (provider === "agent-platform-gemini-api") {
+      const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
+      if (!billingEnabled) {
+        logger.info(
+          `\n${bold("Error:")} The agent-platform-gemini-api provider requires the pay-as-you-go (Blaze) plan.\n` +
+            `Project ${projectId} is on the Spark plan.\n\n` +
+            `Upgrade your plan at:\n\n` +
+            `  https://console.firebase.google.com/project/${projectId}/usage/details\n`,
+        );
+        continue;
+      }
+    }
+
+    logger.info(`Enabling firebasevertexai.googleapis.com...`);
+    logger.info(`Enabling provider ${provider}...`);
+    await enableProvider(projectId, provider);
+    logger.info(bold(`Successfully enabled Firebase AI Logic with provider: ${provider}`));
+    break;
+  }
 }

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -240,18 +240,7 @@ export function parseProviderType(value: string): ProviderType {
  * Enables a Gemini API provider service.
  */
 export async function enableProvider(projectId: string, providerType: ProviderType): Promise<void> {
-  if (providerType === "gemini-developer-api") {
-    await ensureApiEnabled.ensure(
-      projectId,
-      "generativelanguage.googleapis.com",
-      AILOGIC_LOGGING_PREFIX,
-    );
-    await ensureApiEnabled.ensure(
-      projectId,
-      "firebasevertexai.googleapis.com",
-      AILOGIC_LOGGING_PREFIX,
-    );
-  } else if (providerType === "gemini-agent-platform-api") {
+  if (providerType === "gemini-agent-platform-api") {
     const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
     if (!billingEnabled) {
       throw new FirebaseError(
@@ -260,13 +249,21 @@ export async function enableProvider(projectId: string, providerType: ProviderTy
         )} must be on the Blaze (pay-as-you-go) plan to enable the Agent Platform. To upgrade, visit the following URL:\n\nhttps://console.firebase.google.com/project/${projectId}/usage/details`,
       );
     }
-    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", AILOGIC_LOGGING_PREFIX);
-    await ensureApiEnabled.ensure(
-      projectId,
-      "firebasevertexai.googleapis.com",
-      AILOGIC_LOGGING_PREFIX,
-    );
   }
+
+  // Enable the AI Logic API first: a partial failure must not leave a provider's
+  // API enabled while the AI Logic API is off, a state where providers:list would
+  // report the provider as enabled but AI Logic itself is not usable.
+  await ensureApiEnabled.ensure(
+    projectId,
+    "firebasevertexai.googleapis.com",
+    AILOGIC_LOGGING_PREFIX,
+  );
+  const providerApi =
+    providerType === "gemini-developer-api"
+      ? "generativelanguage.googleapis.com"
+      : "aiplatform.googleapis.com";
+  await ensureApiEnabled.ensure(projectId, providerApi, AILOGIC_LOGGING_PREFIX);
 }
 
 /**
@@ -324,24 +321,36 @@ export async function disableProvider(
  * Lists which Gemini API providers are enabled, derived from underlying API enablement state.
  */
 export async function listProviders(projectId: string): Promise<ProviderType[]> {
-  const enabled: ProviderType[] = [];
+  // The three enablement checks are independent, so run them in parallel to keep
+  // read commands responsive on a cold cache.
+  const [isAILogicEnabled, isDeveloperEnabled, isVertexEnabled] = await Promise.all([
+    ensureApiEnabled.check(
+      projectId,
+      "firebasevertexai.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+      true,
+    ),
+    ensureApiEnabled.check(
+      projectId,
+      "generativelanguage.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+      true,
+    ),
+    ensureApiEnabled.check(projectId, "aiplatform.googleapis.com", AILOGIC_LOGGING_PREFIX, true),
+  ]);
 
-  const isDeveloperEnabled = await ensureApiEnabled.check(
-    projectId,
-    "generativelanguage.googleapis.com",
-    AILOGIC_LOGGING_PREFIX,
-    true,
-  );
+  // A provider is only usable through AI Logic when the AI Logic API itself is
+  // enabled. Without this check, a project with (say) generativelanguage enabled
+  // outside the CLI would have its provider reported as enabled even though AI
+  // Logic is off.
+  if (!isAILogicEnabled) {
+    return [];
+  }
+
+  const enabled: ProviderType[] = [];
   if (isDeveloperEnabled) {
     enabled.push("gemini-developer-api");
   }
-
-  const isVertexEnabled = await ensureApiEnabled.check(
-    projectId,
-    "aiplatform.googleapis.com",
-    AILOGIC_LOGGING_PREFIX,
-    true,
-  );
   // aiplatform.googleapis.com cannot be enabled without billing (the Blaze plan),
   // so an enabled Vertex API already implies the agent-platform provider is available.
   if (isVertexEnabled) {

--- a/src/gcp/serviceusage.spec.ts
+++ b/src/gcp/serviceusage.spec.ts
@@ -28,4 +28,22 @@ describe("serviceusage", () => {
       expect(pollerStub).to.not.be.called;
     });
   });
+
+  describe("disableServiceAndPoll", () => {
+    it("does not poll if disableService responds with a completed operation", async () => {
+      postStub.onFirstCall().resolves({ body: { done: true } });
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(pollerStub).to.not.be.called;
+    });
+
+    it("polls if disableService responds with an uncompleted operation", async () => {
+      postStub.onFirstCall().resolves({ body: { done: false, name: "operation-name" } });
+      pollerStub.onFirstCall().resolves({});
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(pollerStub).to.have.been.calledOnce;
+      expect(pollerStub).to.have.been.calledWithMatch({
+        operationResourceName: "operation-name",
+      });
+    });
+  });
 });

--- a/src/gcp/serviceusage.spec.ts
+++ b/src/gcp/serviceusage.spec.ts
@@ -2,10 +2,12 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import * as serviceUsage from "./serviceusage";
 import * as poller from "../operation-poller";
+import * as ensureApiEnabled from "../ensureApiEnabled";
 
 describe("serviceusage", () => {
   let postStub: sinon.SinonStub;
   let pollerStub: sinon.SinonStub;
+  let uncacheStub: sinon.SinonStub;
 
   const projectNumber = "projectNumber";
   const service = "service";
@@ -14,11 +16,13 @@ describe("serviceusage", () => {
   beforeEach(() => {
     postStub = sinon.stub(serviceUsage.apiClient, "post").throws("unexpected post call");
     pollerStub = sinon.stub(poller, "pollOperation").throws("unexpected pollOperation call");
+    uncacheStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
   });
 
   afterEach(() => {
     postStub.restore();
     pollerStub.restore();
+    uncacheStub.restore();
   });
 
   describe("generateServiceIdentityAndPoll", () => {
@@ -34,6 +38,12 @@ describe("serviceusage", () => {
       postStub.onFirstCall().resolves({ body: { done: true } });
       await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
       expect(pollerStub).to.not.be.called;
+    });
+
+    it("invalidates the enablement cache for the disabled service", async () => {
+      postStub.onFirstCall().resolves({ body: { done: true } });
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(uncacheStub).to.have.been.calledOnceWith(projectNumber, service);
     });
 
     it("polls if disableService responds with an uncompleted operation", async () => {

--- a/src/gcp/serviceusage.ts
+++ b/src/gcp/serviceusage.ts
@@ -5,6 +5,7 @@ import { FirebaseError } from "../error";
 import * as utils from "../utils";
 import * as poller from "../operation-poller";
 import { LongRunningOperation } from "../operation-poller";
+import * as ensureApiEnabled from "../ensureApiEnabled";
 
 const API_VERSION = "v1beta1";
 const SERVICE_USAGE_ORIGIN = serviceUsageOrigin();
@@ -98,17 +99,18 @@ export async function disableService(
 export async function disableServiceAndPoll(
   projectId: string,
   service: string,
-  prefix: string,
+  loggingPrefix: string,
 ): Promise<void> {
-  utils.logLabeledBullet(prefix, `disabling service ${bold(service)}...`);
+  utils.logLabeledBullet(loggingPrefix, `disabling service ${bold(service)}...`);
   const op = await disableService(projectId, service);
-  if (op.done) {
-    return;
+  if (!op.done) {
+    await poller.pollOperation<void>({
+      ...serviceUsagePollerOptions,
+      operationResourceName: op.name,
+      headers: { "x-goog-user-project": `${projectId}` },
+    });
   }
-
-  await poller.pollOperation<void>({
-    ...serviceUsagePollerOptions,
-    operationResourceName: op.name,
-    headers: { "x-goog-user-project": `${projectId}` },
-  });
+  // The service is now disabled; invalidate the cached enablement status so that
+  // subsequent checks reflect reality without waiting for the cache to expire.
+  ensureApiEnabled.uncacheEnabledAPI(projectId, service);
 }

--- a/src/gcp/serviceusage.ts
+++ b/src/gcp/serviceusage.ts
@@ -70,3 +70,45 @@ export async function generateServiceIdentityAndPoll(
     headers: { "x-goog-user-project": `${projectNumber}` },
   });
 }
+
+/**
+ * Disables a service on the project.
+ */
+export async function disableService(
+  projectId: string,
+  service: string,
+): Promise<LongRunningOperation<unknown>> {
+  try {
+    const res = await apiClient.post<unknown, unknown>(
+      `projects/${projectId}/services/${service}:disable`,
+      /* body=*/ {},
+      { headers: { "x-goog-user-project": `${projectId}` } },
+    );
+    return res.body as LongRunningOperation<unknown>;
+  } catch (err: unknown) {
+    throw new FirebaseError(`Error disabling service ${service}.`, {
+      original: err as Error,
+    });
+  }
+}
+
+/**
+ * Calls disableService and polls till the operation is complete.
+ */
+export async function disableServiceAndPoll(
+  projectId: string,
+  service: string,
+  prefix: string,
+): Promise<void> {
+  utils.logLabeledBullet(prefix, `disabling service ${bold(service)}...`);
+  const op = await disableService(projectId, service);
+  if (op.done) {
+    return;
+  }
+
+  await poller.pollOperation<void>({
+    ...serviceUsagePollerOptions,
+    operationResourceName: op.name,
+    headers: { "x-goog-user-project": `${projectId}` },
+  });
+}


### PR DESCRIPTION
### Description

Adds the `firebase ailogic:providers:*` command group to manage the Gemini API providers for Firebase AI Logic from the CLI, so developers and CI pipelines can enable, disable, and inspect providers without using the Firebase Console.

- `ailogic:providers:enable <providerType>` — enables the Firebase AI Logic API (`firebasevertexai.googleapis.com`) if needed, then the selected provider's underlying API. `gemini-developer-api` enables `generativelanguage.googleapis.com`; `agent-platform-gemini-api` requires the Blaze (pay-as-you-go) plan and enables `aiplatform.googleapis.com`.
- `ailogic:providers:disable <providerType>` — prompts for confirmation (skippable with `--force`) and turns off the proxy when no providers remain enabled.
- `ailogic:providers:list` — reports which providers are enabled.

Supporting changes:
- A shared interactive enablement flow (`ensureAILogicApiEnabled`) used when the API isn't yet enabled, which checks the `serviceusage.services.enable` permission up front so callers get a clear error before any prompts.
- `firebase help <namespace>` now lists the subcommands under a prefix (e.g. `firebase help ailogic:providers`) for discoverability.
- `ensureApiEnabled.uncacheEnabledAPI` to keep the local API-enablement cache consistent after enabling/disabling an API.

All commands live under the fixed `global` location (no `--location` flag), support `--json` output, and reject client-breaking actions in `--non-interactive` mode unless `--force` is passed. Permissions map to the `firebasevertexai` and `serviceusage` IAM permissions.

This is the first of a series of scoped PRs bringing Firebase AI Logic management (providers, configuration, prompt templates, triggers) to the CLI.

### Scenarios Tested

- `providers:enable gemini-developer-api` on a project with the API disabled — enables the AI Logic API and `generativelanguage.googleapis.com`.
- `providers:enable agent-platform-gemini-api` on a Blaze project succeeds; on a Spark project it fails with an upgrade link and does not change the plan.
- `providers:disable` — confirmation prompt shown; `--force` and `--non-interactive` paths covered; proxy is disabled only when no providers remain.
- `providers:list` — reflects enablement state with and without billing.
- Interactive enablement flow — re-prompts on a Spark billing failure; fails up front when the caller lacks `serviceusage.services.enable`.
- `firebase help ailogic:providers` — lists the namespace subcommands.
- Unit tests added in `src/gcp/ailogic.spec.ts`, `src/gcp/serviceusage.spec.ts`, and `src/commands/help.spec.ts`. `npm test` (lint + compile + mocha) passes.

### Sample Commands

```
firebase ailogic:providers:enable gemini-developer-api
firebase ailogic:providers:list
firebase ailogic:providers:list --json
firebase ailogic:providers:disable gemini-developer-api --force
firebase help ailogic:providers
```
