### PR TITLE
fix(security): default service account sentinel and partial deploy validation

### DIFF
--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1204,7 +1204,6 @@ describe("prepare", () => {
     it("should mutate endpoints to use managed service account when enrolling in declarative security", async () => {
       const e: backend.Endpoint = {
         ...ENDPOINT,
-        serviceAccount: "default",
       };
       const want = backend.of(e);
       want.requiredRoles = ["roles/viewer"];
@@ -1236,7 +1235,7 @@ describe("prepare", () => {
 
       expect(result.existingManagedSA).to.equal("firebase-fn-123@project.iam.gserviceaccount.com");
       expect(result.haveRolesEtag).to.equal("salt-etag");
-      expect(e.serviceAccount).to.equal("default");
+      expect(e.serviceAccount).to.be.null;
       expect(e.labels?.["firebase-declarative-security-etag"]).to.be.undefined;
     });
 
@@ -1269,7 +1268,7 @@ describe("prepare", () => {
       await prepare.discoverSecurityDetails("default", want, have, "project");
 
       expect(eCustom.serviceAccount).to.equal("custom-sa@project.iam.gserviceaccount.com");
-      expect(eManaged.serviceAccount).to.equal("default");
+      expect(eManaged.serviceAccount).to.be.null;
     });
 
     it("should throw error if user combines custom SA and declarative security", async () => {
@@ -1296,7 +1295,6 @@ describe("prepare", () => {
       });
       const e: backend.Endpoint = {
         ...ENDPOINT,
-        serviceAccount: "default",
       };
       const want = backend.of(e);
       want.requiredRoles = ["roles/viewer"];
@@ -1304,6 +1302,48 @@ describe("prepare", () => {
 
       await expect(prepare.discoverSecurityDetails("default", want, have, "project")).to.be
         .rejected;
+    });
+
+    it("should throw error if attempting to enroll during a partially filtered deploy", async () => {
+      const e: backend.Endpoint = {
+        ...ENDPOINT,
+      };
+      const want = backend.of(e);
+      want.requiredRoles = ["roles/viewer"];
+      const have = backend.empty();
+
+      await expect(
+        prepare.discoverSecurityDetails("default", want, have, "project", [
+          { codebase: "default", idChunks: ["myFunc"] },
+        ]),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /Cannot deploy a partial codebase when enrolling or unenrolling from declarative security/,
+      );
+    });
+
+    it("should throw error if attempting to unenroll during a partially filtered deploy", async () => {
+      const e: backend.Endpoint = {
+        ...ENDPOINT,
+        serviceAccount: "firebase-fn-123@project.iam.gserviceaccount.com",
+        labels: {
+          "firebase-declarative-security-etag": "salt-etag",
+        },
+      };
+      const want = backend.of(e);
+      const have = backend.of({
+        ...e,
+        labels: { ...e.labels },
+      });
+
+      await expect(
+        prepare.discoverSecurityDetails("default", want, have, "project", [
+          { codebase: "default", idChunks: ["myFunc"] },
+        ]),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /Cannot deploy a partial codebase when enrolling or unenrolling from declarative security/,
+      );
     });
   });
 });

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1318,7 +1318,7 @@ describe("prepare", () => {
         ]),
       ).to.be.rejectedWith(
         FirebaseError,
-        /Cannot deploy a partial codebase when enrolling or unenrolling from declarative security/,
+        /To ensure a whole codebase is migrated cleanly, you may not deploy only part of a codebase when opting into or out of declarative security/,
       );
     });
 
@@ -1342,7 +1342,7 @@ describe("prepare", () => {
         ]),
       ).to.be.rejectedWith(
         FirebaseError,
-        /Cannot deploy a partial codebase when enrolling or unenrolling from declarative security/,
+        /To ensure a whole codebase is migrated cleanly, you may not deploy only part of a codebase when opting into or out of declarative security/,
       );
     });
   });

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -102,7 +102,8 @@ export async function discoverSecurityDetails(
 
   if (isPartiallyFiltered && (isEnrolling || isUnenrolling)) {
     throw new FirebaseError(
-      `Cannot deploy a partial codebase when enrolling or unenrolling from declarative security`,
+      "To ensure a whole codebase is migrated cleanly, you may not deploy only part of a " +
+      "codebase when opting into or out of declartive secuirty (starting or no longer using `requireRoles`)"
     );
   }
 
@@ -730,11 +731,11 @@ export async function loadCodebases(
     if (firebaseJsonRuntime && !supported.isRuntime(firebaseJsonRuntime as string)) {
       throw new FirebaseError(
         `Functions codebase ${codebase} has invalid runtime ` +
-          `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
-          (Object.keys(supported.RUNTIMES) as supported.Runtime[])
-            .filter((runtime) => !supported.isDecommissioned(runtime))
-            .map((s) => `- ${s}`)
-            .join("\n"),
+        `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
+        (Object.keys(supported.RUNTIMES) as supported.Runtime[])
+          .filter((runtime) => !supported.isDecommissioned(runtime))
+          .map((s) => `- ${s}`)
+          .join("\n"),
       );
     }
     const runtimeDelegate = await runtimes.getRuntimeDelegate(delegateContext);
@@ -787,8 +788,8 @@ function warnIfDartBackendHasUnsupportedTriggers(want: backend.Backend): void {
     logLabeledWarning(
       "functions",
       `The following Dart functions use triggers that are not yet supported for production deployment: ${unsupported.map((ep) => ep.id).join(", ")}. ` +
-        "They will be deployed but may not work as expected. " +
-        "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
+      "They will be deployed but may not work as expected. " +
+      "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
     );
   }
 }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -103,7 +103,7 @@ export async function discoverSecurityDetails(
   if (isPartiallyFiltered && (isEnrolling || isUnenrolling)) {
     throw new FirebaseError(
       "To ensure a whole codebase is migrated cleanly, you may not deploy only part of a " +
-      "codebase when opting into or out of declartive secuirty (starting or no longer using `requireRoles`)"
+        "codebase when opting into or out of declarative security (starting or no longer using `requireRoles`)",
     );
   }
 
@@ -731,11 +731,11 @@ export async function loadCodebases(
     if (firebaseJsonRuntime && !supported.isRuntime(firebaseJsonRuntime as string)) {
       throw new FirebaseError(
         `Functions codebase ${codebase} has invalid runtime ` +
-        `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
-        (Object.keys(supported.RUNTIMES) as supported.Runtime[])
-          .filter((runtime) => !supported.isDecommissioned(runtime))
-          .map((s) => `- ${s}`)
-          .join("\n"),
+          `${firebaseJsonRuntime} specified in firebase.json. Valid values are: \n` +
+          (Object.keys(supported.RUNTIMES) as supported.Runtime[])
+            .filter((runtime) => !supported.isDecommissioned(runtime))
+            .map((s) => `- ${s}`)
+            .join("\n"),
       );
     }
     const runtimeDelegate = await runtimes.getRuntimeDelegate(delegateContext);
@@ -788,8 +788,8 @@ function warnIfDartBackendHasUnsupportedTriggers(want: backend.Backend): void {
     logLabeledWarning(
       "functions",
       `The following Dart functions use triggers that are not yet supported for production deployment: ${unsupported.map((ep) => ep.id).join(", ")}. ` +
-      "They will be deployed but may not work as expected. " +
-      "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
+        "They will be deployed but may not work as expected. " +
+        "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
     );
   }
 }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -72,6 +72,7 @@ export async function discoverSecurityDetails(
   want: backend.Backend,
   have: backend.Backend,
   projectId: string,
+  filters?: EndpointFilter[],
 ): Promise<{
   haveRoles?: string[];
   haveRolesEtag?: string;
@@ -90,6 +91,21 @@ export async function discoverSecurityDetails(
       : undefined;
   }
 
+  const isPartiallyFiltered = !!(
+    filters &&
+    filters.some(
+      (f) => (!f.codebase || f.codebase === codebase) && f.idChunks && f.idChunks.length > 0,
+    )
+  );
+  const isEnrolling = !!requiredRoles && !existingManagedSA;
+  const isUnenrolling = !requiredRoles && !!existingManagedSA && !!haveRolesEtag;
+
+  if (isPartiallyFiltered && (isEnrolling || isUnenrolling)) {
+    throw new FirebaseError(
+      `Cannot deploy a partial codebase when enrolling or unenrolling from declarative security`,
+    );
+  }
+
   if (!requiredRoles && (!existingManagedSA || !haveRolesEtag)) {
     return {};
   }
@@ -98,10 +114,7 @@ export async function discoverSecurityDetails(
     requiredRoles &&
     backend.someEndpoint(
       want,
-      (e) =>
-        typeof e.serviceAccount === "string" &&
-        e.serviceAccount !== "default" &&
-        !e.serviceAccount.startsWith("firebase-fn-"),
+      (e) => typeof e.serviceAccount === "string" && !e.serviceAccount.startsWith("firebase-fn-"),
     )
   ) {
     throw new FirebaseError(
@@ -112,7 +125,7 @@ export async function discoverSecurityDetails(
   if (!requiredRoles && existingManagedSA && haveRolesEtag) {
     for (const endpoint of backend.allEndpoints(want)) {
       if (!endpoint.serviceAccount || endpoint.serviceAccount === existingManagedSA) {
-        endpoint.serviceAccount = "default";
+        endpoint.serviceAccount = null;
       }
       if (endpoint.labels) {
         delete endpoint.labels["firebase-declarative-security-etag"];
@@ -417,7 +430,13 @@ export async function prepare(
   );
   for (const [codebase, wantBackend] of Object.entries(wantBackends)) {
     const haveBackend = haveBackends[codebase] || backend.empty();
-    const security = await discoverSecurityDetails(codebase, wantBackend, haveBackend, projectId);
+    const security = await discoverSecurityDetails(
+      codebase,
+      wantBackend,
+      haveBackend,
+      projectId,
+      context.filters,
+    );
     payload.functions[codebase] = { wantBackend, haveBackend, ...security };
   }
 

--- a/src/deploy/functions/release/planner.spec.ts
+++ b/src/deploy/functions/release/planner.spec.ts
@@ -573,6 +573,24 @@ describe("planner", () => {
       expect(plan.serviceAccountToDelete).to.be.undefined;
     });
 
+    it("deletes the service account when opting out during a codebase-filtered deploy", async () => {
+      const wantBackend = backend.empty();
+      const haveBackend = backend.of(func("id", "region"));
+
+      const plan = await planner.createDeploymentPlan({
+        wantBackend,
+        haveBackend,
+        codebase,
+        projectId: "my-project",
+        filters: [{ codebase }],
+        existingManagedSA: "firebase-fn-123@my-project.iam.gserviceaccount.com",
+      });
+
+      expect(plan.serviceAccountToDelete).to.equal(
+        "firebase-fn-123@my-project.iam.gserviceaccount.com",
+      );
+    });
+
     it("deletes the service account when opting out during an unfiltered deploy", async () => {
       const wantBackend = backend.empty();
       const haveBackend = backend.of(func("id", "region"));

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -174,7 +174,11 @@ export async function createDeploymentPlan(args: PlanArgs): Promise<CodebasePlan
   let serviceAccountToCreate: string | undefined;
   let serviceAccountToDelete: string | undefined;
 
-  const isFiltered = !!(filters && filters.length > 0 && !deleteAll);
+  const isFiltered = !!(
+    filters &&
+    filters.some((f) => f.idChunks && f.idChunks.length > 0) &&
+    !deleteAll
+  );
 
   if (requiredRoles) {
     rolesToAdd = requiredRoles.filter((r) => !roles.includes(r));


### PR DESCRIPTION
### Description
This PR resolves the deployment crash when opting out of declarative security and refines unenrollment safety:
1. Replaces the "default" string sentinel with null to revert to the default service account when unenrolling.
2. Prohibits partial codebase deployments (filtered deploys) when enrolling or unenrolling from declarative security to prevent inconsistent states.
3. Enables unenrollment prompts and cleanup for codebase-level filtered deploys.

### Scenarios Tested
- Ran mocha unit tests: npm run mocha:fast
