### PR TITLE
feat(appcheck): add `appcheck` commands to manage Firebase App Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+- Added `appcheck` commands (preview) to manage Firebase App Check from the CLI: per-service
+  enforcement (`appcheck:services:list|get|set`), attestation providers
+  (`appcheck:providers:list|get|set`), debug tokens (`appcheck:debug:create|list|delete`), and
+  `appcheck:apps:list`.
 - Fixed an issue in `apps:create` where App Store ID was always prompted for even when unnecessary.
 - Add `functions:lifecycle:list` and `functions:lifecycle:run` commands to view and run
   lifecycle hooks in isolation.

--- a/src/api.ts
+++ b/src/api.ts
@@ -167,6 +167,8 @@ export const vertexAIOrigin = () =>
   utils.envOverride("VERTEX_AI_URL", "https://aiplatform.googleapis.com");
 export const aiLogicProxyOrigin = () =>
   utils.envOverride("AI_LOGIC_PROXY_URL", "https://firebasevertexai.googleapis.com");
+export const appCheckOrigin = () =>
+  utils.envOverride("FIREBASE_APP_CHECK_URL", "https://firebaseappcheck.googleapis.com");
 
 export const appTestingOrigin = () =>
   utils.envOverride("FIREBASE_APP_TESTING_URL", "https://firebaseapptesting.googleapis.com");

--- a/src/commands/appcheck-apps-list.ts
+++ b/src/commands/appcheck-apps-list.ts
@@ -6,6 +6,7 @@ import * as ensureApiEnabled from "../ensureApiEnabled";
 import { listFirebaseApps, AppPlatform, AppMetadata } from "../management/apps";
 import * as clc from "colorette";
 import { logger } from "../logger";
+import { getErrMsg } from "../error";
 import * as Table from "cli-table3";
 
 import { Options } from "../options";
@@ -28,8 +29,17 @@ export const command = new Command("appcheck:apps:list")
       if (!appCheckEnabled) {
         return "(App Check not enabled)";
       }
-      const configured = await appcheck.getConfiguredProviders(projectId, app.appId, app.platform);
-      return configured.length > 0 ? configured.join(", ") : "(not configured)";
+      try {
+        const configured = await appcheck.getConfiguredProviders(
+          projectId,
+          app.appId,
+          app.platform,
+        );
+        return configured.length > 0 ? configured.join(", ") : "(not configured)";
+      } catch (err: unknown) {
+        logger.debug(`Failed to get App Check providers for app ${app.appId}: ${getErrMsg(err)}`);
+        return "(unknown)";
+      }
     }
 
     const rows = await Promise.all(

--- a/src/commands/appcheck-apps-list.ts
+++ b/src/commands/appcheck-apps-list.ts
@@ -1,0 +1,53 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import { listFirebaseApps, AppPlatform, AppMetadata } from "../management/apps";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:apps:list")
+  .description("list the project's Firebase apps and their App Check provider status")
+  .before(requirePermissions, ["firebaseappcheck.appCheckConfig.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    const apps = await listFirebaseApps(projectId, AppPlatform.ANY);
+
+    const appCheckEnabled = await ensureApiEnabled.check(
+      projectId,
+      appcheck.APP_CHECK_API,
+      "appcheck",
+      true,
+    );
+
+    async function providerColumn(app: AppMetadata): Promise<string> {
+      if (!appCheckEnabled) {
+        return "(App Check not enabled)";
+      }
+      const configured = await appcheck.getConfiguredProviders(projectId, app.appId, app.platform);
+      return configured.length > 0 ? configured.join(", ") : "(not configured)";
+    }
+
+    const rows = await Promise.all(
+      apps.map(async (app) => ({ app, provider: await providerColumn(app) })),
+    );
+
+    if (rows.length === 0) {
+      logger.info(clc.bold("No Firebase apps found in this project."));
+      return [];
+    }
+
+    const table = new Table({
+      head: ["App ID", "Platform", "Display Name", "App Check Provider"],
+      style: { head: ["green"] },
+    });
+    for (const { app, provider } of rows) {
+      table.push([clc.bold(app.appId), app.platform, app.displayName ?? "", provider]);
+    }
+    logger.info(table.toString());
+    return rows;
+  });

--- a/src/commands/appcheck-debug-create.ts
+++ b/src/commands/appcheck-debug-create.ts
@@ -1,0 +1,35 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as clc from "colorette";
+import * as utils from "../utils";
+import { logger } from "../logger";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:debug:create <appId>")
+  .description("create an App Check debug token for an app")
+  .option("--display-name <name>", "human-readable name for the debug token")
+  .option("--token <uuid>", "supply the debug token value instead of having one generated")
+  .before(requirePermissions, ["firebaseappcheck.debugTokens.create"])
+  .action(async (appId: string, options: Options) => {
+    const projectId = needProjectId(options);
+    await appcheck.ensureAppCheckApiEnabled(projectId, options);
+
+    const displayName =
+      typeof options.displayName === "string" ? options.displayName : "CLI debug token";
+    const token = typeof options.token === "string" ? options.token : undefined;
+    const created = await appcheck.createDebugToken(projectId, appId, displayName, token);
+
+    const tokenId = created.name?.split("/").pop() ?? "";
+    utils.logSuccess(
+      `Created debug token "${created.displayName}"${tokenId ? ` (id: ${tokenId})` : ""}.`,
+    );
+    logger.info(`\n  Debug token: ${clc.bold(created.token ?? "(hidden)")}\n`);
+    utils.logWarning(
+      "Store this value securely; it will not be shown again. It grants access to " +
+        "App Check-enforced backends and must be treated as a secret.",
+    );
+    return created;
+  });

--- a/src/commands/appcheck-debug-delete.spec.ts
+++ b/src/commands/appcheck-debug-delete.spec.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { command } from "./appcheck-debug-delete";
+import * as appcheck from "../gcp/appcheck";
+import * as projectUtils from "../projectUtils";
+import * as prompt from "../prompt";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+
+const PROJECT_ID = "test-project";
+const APP_ID = "1:1234:web:abcd";
+
+describe("appcheck:debug:delete", () => {
+  let deleteStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = []; // bypass pre-action hooks
+    sinon.stub(projectUtils, "needProjectId").returns(PROJECT_ID);
+    sinon.stub(appcheck, "ensureAppCheckApiEnabled").resolves();
+    sinon.stub(utils, "logSuccess");
+    deleteStub = sinon.stub(appcheck, "deleteDebugToken").resolves();
+    confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("deletes after confirmation", async () => {
+    await command.runner()(APP_ID, "tok1", { project: PROJECT_ID, interactive: true });
+    expect(confirmStub).to.have.been.calledOnce;
+    expect(deleteStub).to.have.been.calledWith(PROJECT_ID, APP_ID, "tok1");
+  });
+
+  it("aborts when confirmation is declined", async () => {
+    confirmStub.resolves(false);
+    await expect(
+      command.runner()(APP_ID, "tok1", { project: PROJECT_ID, interactive: true }),
+    ).to.be.rejectedWith(FirebaseError, /aborted/i);
+    expect(deleteStub).to.not.have.been.called;
+  });
+
+  it("errors in non-interactive mode without --force", async () => {
+    await expect(
+      command.runner()(APP_ID, "tok1", { project: PROJECT_ID, nonInteractive: true }),
+    ).to.be.rejectedWith(FirebaseError, /requires confirmation/);
+    expect(deleteStub).to.not.have.been.called;
+  });
+});

--- a/src/commands/appcheck-debug-delete.ts
+++ b/src/commands/appcheck-debug-delete.ts
@@ -1,0 +1,40 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as clc from "colorette";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+import { confirm } from "../prompt";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:debug:delete <appId> <tokenId>")
+  .description("delete an App Check debug token")
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requirePermissions, ["firebaseappcheck.debugTokens.delete"])
+  .action(async (appId: string, tokenId: string, options: Options) => {
+    const projectId = needProjectId(options);
+    await appcheck.ensureAppCheckApiEnabled(projectId, options);
+
+    if (options.nonInteractive && !options.force) {
+      throw new FirebaseError(
+        `Deleting debug token ${clc.bold(tokenId)} requires confirmation.\n\n` +
+          `To proceed in non-interactive mode, rerun with --force:\n\n` +
+          `  firebase appcheck:debug:delete ${appId} ${tokenId} --force`,
+      );
+    }
+    const confirmed = await confirm({
+      message:
+        `You are about to delete debug token ${clc.bold(tokenId)}. Environments relying on it ` +
+        `will lose access to App Check-enforced backends. Are you sure?`,
+      force: options.force,
+      nonInteractive: options.nonInteractive,
+    });
+    if (!confirmed) {
+      throw new FirebaseError("Command aborted.", { exit: 1 });
+    }
+
+    await appcheck.deleteDebugToken(projectId, appId, tokenId);
+    utils.logSuccess(`Deleted debug token: ${clc.bold(tokenId)}`);
+  });

--- a/src/commands/appcheck-debug-list.ts
+++ b/src/commands/appcheck-debug-list.ts
@@ -1,0 +1,41 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:debug:list <appId>")
+  .description("list App Check debug tokens for an app")
+  .before(requirePermissions, ["firebaseappcheck.debugTokens.get"])
+  .action(async (appId: string, options: Options) => {
+    const projectId = needProjectId(options);
+
+    const isEnabled = await ensureApiEnabled.check(
+      projectId,
+      appcheck.APP_CHECK_API,
+      "appcheck",
+      true,
+    );
+    if (!isEnabled) {
+      logger.info(clc.bold(`Firebase App Check is not enabled on project ${projectId}.`));
+      return [];
+    }
+
+    const tokens = await appcheck.listDebugTokens(projectId, appId);
+    if (tokens.length === 0) {
+      logger.info(clc.bold(`No debug tokens are configured for app ${appId}.`));
+      return tokens;
+    }
+
+    const table = new Table({ head: ["Token ID", "Display Name"], style: { head: ["green"] } });
+    for (const token of tokens) {
+      table.push([token.name?.split("/").pop() ?? "", token.displayName]);
+    }
+    logger.info(table.toString());
+    return tokens;
+  });

--- a/src/commands/appcheck-providers-get.ts
+++ b/src/commands/appcheck-providers-get.ts
@@ -3,8 +3,10 @@ import { requirePermissions } from "../requirePermissions";
 import { needProjectId } from "../projectUtils";
 import * as appcheck from "../gcp/appcheck";
 import * as ensureApiEnabled from "../ensureApiEnabled";
+import { listFirebaseApps, AppPlatform } from "../management/apps";
 import * as clc from "colorette";
 import { logger } from "../logger";
+import { FirebaseError } from "../error";
 
 import { Options } from "../options";
 
@@ -24,6 +26,13 @@ export const command = new Command("appcheck:providers:get <appId> <provider>")
     if (!isEnabled) {
       logger.info(clc.bold(`Firebase App Check is not enabled on project ${projectId}.`));
       return null;
+    }
+
+    // getProviderConfig treats a 404 as "not configured", so validate the app
+    // exists first to avoid misreporting an unknown app as unconfigured.
+    const apps = await listFirebaseApps(projectId, AppPlatform.ANY);
+    if (!apps.some((a) => a.appId === appId)) {
+      throw new FirebaseError(`App ${clc.bold(appId)} was not found in project ${projectId}.`);
     }
 
     const config = await appcheck.getProviderConfig(projectId, appId, providerType);

--- a/src/commands/appcheck-providers-get.ts
+++ b/src/commands/appcheck-providers-get.ts
@@ -1,0 +1,36 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as clc from "colorette";
+import { logger } from "../logger";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:providers:get <appId> <provider>")
+  .description("get one App Check attestation provider config for an app")
+  .before(requirePermissions, ["firebaseappcheck.appCheckConfig.get"])
+  .action(async (appId: string, provider: string, options: Options) => {
+    const projectId = needProjectId(options);
+    const providerType = appcheck.parseProviderType(provider);
+
+    const isEnabled = await ensureApiEnabled.check(
+      projectId,
+      appcheck.APP_CHECK_API,
+      "appcheck",
+      true,
+    );
+    if (!isEnabled) {
+      logger.info(clc.bold(`Firebase App Check is not enabled on project ${projectId}.`));
+      return null;
+    }
+
+    const config = await appcheck.getProviderConfig(projectId, appId, providerType);
+    if (!config) {
+      logger.info(clc.bold(`Provider ${providerType} is not configured for app ${appId}.`));
+      return null;
+    }
+    logger.info(JSON.stringify(config, null, 2));
+    return config;
+  });

--- a/src/commands/appcheck-providers-list.ts
+++ b/src/commands/appcheck-providers-list.ts
@@ -1,0 +1,62 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import { listFirebaseApps, AppPlatform } from "../management/apps";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:providers:list")
+  .description("list the configured App Check attestation providers for each app")
+  .option("--app <appId>", "only list providers for one app")
+  .before(requirePermissions, ["firebaseappcheck.appCheckConfig.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+
+    const isEnabled = await ensureApiEnabled.check(
+      projectId,
+      appcheck.APP_CHECK_API,
+      "appcheck",
+      true,
+    );
+    if (!isEnabled) {
+      logger.info(clc.bold(`Firebase App Check is not enabled on project ${projectId}.`));
+      return [];
+    }
+
+    const appFilter = typeof options.app === "string" ? options.app : undefined;
+    let apps = await listFirebaseApps(projectId, AppPlatform.ANY);
+    if (appFilter) {
+      apps = apps.filter((a) => a.appId === appFilter);
+    }
+
+    const table = new Table({
+      head: ["App ID", "Platform", "Provider", "Token TTL"],
+      style: { head: ["green"] },
+    });
+    const results: Array<{ appId: string; provider: appcheck.ProviderType; tokenTtl?: string }> =
+      [];
+    for (const app of apps) {
+      const configured = await appcheck.listConfiguredProviders(projectId, app.appId, app.platform);
+      if (configured.length === 0) {
+        table.push([clc.bold(app.appId), app.platform, clc.dim("(not configured)"), "-"]);
+        continue;
+      }
+      for (const { provider, config } of configured) {
+        results.push({ appId: app.appId, provider, tokenTtl: config.tokenTtl });
+        table.push([
+          clc.bold(app.appId),
+          app.platform,
+          provider,
+          appcheck.formatTokenTtl(config.tokenTtl),
+        ]);
+      }
+    }
+
+    logger.info(table.toString());
+    return results;
+  });

--- a/src/commands/appcheck-providers-list.ts
+++ b/src/commands/appcheck-providers-list.ts
@@ -6,6 +6,7 @@ import * as ensureApiEnabled from "../ensureApiEnabled";
 import { listFirebaseApps, AppPlatform } from "../management/apps";
 import * as clc from "colorette";
 import { logger } from "../logger";
+import { getErrMsg } from "../error";
 import * as Table from "cli-table3";
 
 import { Options } from "../options";
@@ -34,14 +35,37 @@ export const command = new Command("appcheck:providers:list")
       apps = apps.filter((a) => a.appId === appFilter);
     }
 
+    // Probe every app's providers in parallel; a single failing app degrades to
+    // an "(error)" row instead of breaking the whole command.
+    const perApp = await Promise.all(
+      apps.map(async (app) => {
+        try {
+          const configured = await appcheck.listConfiguredProviders(
+            projectId,
+            app.appId,
+            app.platform,
+          );
+          return { app, configured };
+        } catch (err: unknown) {
+          logger.debug(
+            `Failed to list App Check providers for app ${app.appId}: ${getErrMsg(err)}`,
+          );
+          return { app, configured: null };
+        }
+      }),
+    );
+
     const table = new Table({
       head: ["App ID", "Platform", "Provider", "Token TTL"],
       style: { head: ["green"] },
     });
     const results: Array<{ appId: string; provider: appcheck.ProviderType; tokenTtl?: string }> =
       [];
-    for (const app of apps) {
-      const configured = await appcheck.listConfiguredProviders(projectId, app.appId, app.platform);
+    for (const { app, configured } of perApp) {
+      if (configured === null) {
+        table.push([clc.bold(app.appId), app.platform, clc.red("(error)"), "-"]);
+        continue;
+      }
       if (configured.length === 0) {
         table.push([clc.bold(app.appId), app.platform, clc.dim("(not configured)"), "-"]);
         continue;

--- a/src/commands/appcheck-providers-set.spec.ts
+++ b/src/commands/appcheck-providers-set.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { command } from "./appcheck-providers-set";
+import * as appcheck from "../gcp/appcheck";
+import * as apps from "../management/apps";
+import { AppPlatform, AppMetadata } from "../management/apps";
+import * as projectUtils from "../projectUtils";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+
+const PROJECT_ID = "test-project";
+const WEB_APP = "1:1234:web:abcd";
+const IOS_APP = "1:1234:ios:efgh";
+
+function app(appId: string, platform: AppPlatform): AppMetadata {
+  return { name: `projects/${PROJECT_ID}/apps/${appId}`, projectId: PROJECT_ID, appId, platform };
+}
+
+describe("appcheck:providers:set", () => {
+  let setStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = []; // bypass pre-action hooks
+    sinon.stub(projectUtils, "needProjectId").returns(PROJECT_ID);
+    sinon.stub(appcheck, "ensureAppCheckApiEnabled").resolves();
+    sinon.stub(utils, "logSuccess");
+    sinon
+      .stub(apps, "listFirebaseApps")
+      .resolves([app(WEB_APP, AppPlatform.WEB), app(IOS_APP, AppPlatform.IOS)]);
+    setStub = sinon.stub(appcheck, "setProviderConfig").resolves({ siteKey: "key" });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("throws when the app is not found", async () => {
+    await expect(
+      command.runner()("1:1234:web:missing", "recaptcha-enterprise", {
+        project: PROJECT_ID,
+        siteKey: "key",
+      }),
+    ).to.be.rejectedWith(FirebaseError, /was not found/);
+  });
+
+  it("throws on a provider/platform mismatch", async () => {
+    await expect(
+      command.runner()(WEB_APP, "play-integrity", { project: PROJECT_ID }),
+    ).to.be.rejectedWith(FirebaseError, /attests ANDROID apps/);
+  });
+
+  it("throws on an unknown provider", async () => {
+    await expect(command.runner()(WEB_APP, "nope", { project: PROJECT_ID })).to.be.rejectedWith(
+      FirebaseError,
+      /Unknown provider/,
+    );
+  });
+
+  it("requires --site-key for recaptcha-enterprise", async () => {
+    await expect(
+      command.runner()(WEB_APP, "recaptcha-enterprise", { project: PROJECT_ID }),
+    ).to.be.rejectedWith(FirebaseError, /requires --site-key/);
+  });
+
+  it("configures recaptcha-enterprise with a site key", async () => {
+    await command.runner()(WEB_APP, "recaptcha-enterprise", {
+      project: PROJECT_ID,
+      siteKey: "site-key-value",
+    });
+    expect(setStub).to.have.been.calledWith(PROJECT_ID, WEB_APP, "recaptcha-enterprise", {
+      siteKey: "site-key-value",
+    });
+  });
+
+  it("requires both --key-id and --private-key for device-check", async () => {
+    await expect(
+      command.runner()(IOS_APP, "device-check", { project: PROJECT_ID, keyId: "k" }),
+    ).to.be.rejectedWith(FirebaseError, /requires --key-id and --private-key/);
+  });
+
+  it("parses --token-ttl into an API Duration", async () => {
+    await command.runner()(IOS_APP, "app-attest", { project: PROJECT_ID, tokenTtl: "1h" });
+    expect(setStub).to.have.been.calledWith(PROJECT_ID, IOS_APP, "app-attest", {
+      tokenTtl: "3600s",
+    });
+  });
+
+  it("throws when there is nothing to configure", async () => {
+    await expect(
+      command.runner()(IOS_APP, "app-attest", { project: PROJECT_ID }),
+    ).to.be.rejectedWith(FirebaseError, /Nothing to configure/);
+  });
+});

--- a/src/commands/appcheck-providers-set.ts
+++ b/src/commands/appcheck-providers-set.ts
@@ -1,0 +1,87 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import { listFirebaseApps, AppPlatform } from "../management/apps";
+import * as clc from "colorette";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+
+import { Options } from "../options";
+
+/** Reads a command-line flag as a string, or undefined if it was not provided. */
+function stringFlag(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+export const command = new Command("appcheck:providers:set <appId> <provider>")
+  .description(
+    "configure an App Check attestation provider (app-attest | device-check | play-integrity | " +
+      "recaptcha-enterprise | recaptcha-v3) for an app",
+  )
+  .option("--site-key <key>", "reCAPTCHA Enterprise site key")
+  .option("--site-secret <secret>", "reCAPTCHA v3 site secret (or @path/to/file)")
+  .option("--key-id <id>", "Apple DeviceCheck key ID")
+  .option("--private-key <key>", "Apple DeviceCheck private key (or @path/to/file)")
+  .option("--token-ttl <duration>", "App Check token lifetime, e.g. 1h, 30m, 3600s")
+  .before(requirePermissions, ["firebaseappcheck.appCheckConfig.update"])
+  .action(async (appId: string, provider: string, options: Options) => {
+    const projectId = needProjectId(options);
+    const providerType = appcheck.parseProviderType(provider);
+    await appcheck.ensureAppCheckApiEnabled(projectId, options);
+
+    // Ensure the provider matches the app's platform.
+    const apps = await listFirebaseApps(projectId, AppPlatform.ANY);
+    const app = apps.find((a) => a.appId === appId);
+    if (!app) {
+      throw new FirebaseError(`App ${clc.bold(appId)} was not found in project ${projectId}.`);
+    }
+    if (!appcheck.providerSupportsPlatform(providerType, app.platform)) {
+      const valid = appcheck.providersForPlatform(app.platform);
+      const platforms = appcheck.PROVIDER_META[providerType].platforms.join("/");
+      throw new FirebaseError(
+        `Provider ${clc.bold(providerType)} attests ${platforms} apps, but ` +
+          `${appId} is a ${app.platform} app.\n\nValid providers for this app:\n\n` +
+          valid.map((p) => `  ${p}`).join("\n"),
+      );
+    }
+
+    const fields: Record<string, string> = {};
+
+    if (providerType === "recaptcha-enterprise") {
+      const siteKey = stringFlag(options.siteKey);
+      if (!siteKey) {
+        throw new FirebaseError("recaptcha-enterprise requires --site-key.");
+      }
+      fields.siteKey = siteKey;
+    } else if (providerType === "recaptcha-v3") {
+      const siteSecret = stringFlag(options.siteSecret);
+      if (!siteSecret) {
+        throw new FirebaseError("recaptcha-v3 requires --site-secret.");
+      }
+      fields.siteSecret = appcheck.resolveSecretFlag(siteSecret);
+    } else if (providerType === "device-check") {
+      const keyId = stringFlag(options.keyId);
+      const privateKey = stringFlag(options.privateKey);
+      if (!keyId || !privateKey) {
+        throw new FirebaseError("device-check requires --key-id and --private-key.");
+      }
+      fields.keyId = keyId;
+      fields.privateKey = appcheck.resolveSecretFlag(privateKey);
+    }
+
+    const tokenTtl = stringFlag(options.tokenTtl);
+    if (tokenTtl) {
+      fields.tokenTtl = appcheck.parseTokenTtl(tokenTtl);
+    }
+
+    if (Object.keys(fields).length === 0) {
+      throw new FirebaseError(
+        `Nothing to configure for ${providerType}. Provide --token-ttl or a provider-specific flag.`,
+      );
+    }
+
+    const config = await appcheck.setProviderConfig(projectId, appId, providerType, fields);
+    utils.logSuccess(`Configured ${clc.bold(providerType)} for app ${clc.bold(appId)}.`);
+    return config;
+  });

--- a/src/commands/appcheck-services-get.ts
+++ b/src/commands/appcheck-services-get.ts
@@ -1,0 +1,34 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as clc from "colorette";
+import { logger } from "../logger";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:services:get <service>")
+  .description("get the App Check enforcement mode for one Firebase service")
+  .before(requirePermissions, ["firebaseappcheck.services.get"])
+  .action(async (service: string, options: Options) => {
+    const projectId = needProjectId(options);
+    // Validate the alias up front so a bad name fails clearly, even when the
+    // API is not enabled.
+    appcheck.resolveServiceId(service);
+
+    const isEnabled = await ensureApiEnabled.check(
+      projectId,
+      appcheck.APP_CHECK_API,
+      "appcheck",
+      true,
+    );
+    if (!isEnabled) {
+      logger.info(clc.bold(`Firebase App Check is not enabled on project ${projectId}.`));
+      return { enforcement: "off" };
+    }
+
+    const svc = await appcheck.getService(projectId, service);
+    logger.info(svc.enforcement);
+    return svc;
+  });

--- a/src/commands/appcheck-services-list.ts
+++ b/src/commands/appcheck-services-list.ts
@@ -1,0 +1,59 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+function colorMode(mode: appcheck.EnforcementMode): string {
+  switch (mode) {
+    case "enforced":
+      return clc.green("Enforced");
+    case "unenforced":
+      return clc.yellow("Unenforced");
+    default:
+      return clc.red("Off");
+  }
+}
+
+export const command = new Command("appcheck:services:list")
+  .description("list App Check enforcement for each enforceable Firebase service")
+  .before(requirePermissions, ["firebaseappcheck.services.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+
+    const isEnabled = await ensureApiEnabled.check(
+      projectId,
+      appcheck.APP_CHECK_API,
+      "appcheck",
+      true,
+    );
+    if (!isEnabled) {
+      logger.info(
+        clc.bold(
+          `Firebase App Check is not enabled on project ${projectId}. No services are enforced.`,
+        ),
+      );
+      return [];
+    }
+
+    const services = await appcheck.listServices(projectId);
+    if (services.length === 0) {
+      logger.info(clc.bold("No App Check enforcement is configured for any service."));
+      return services;
+    }
+
+    const table = new Table({
+      head: ["Service", "Resource ID", "Enforcement"],
+      style: { head: ["green"] },
+    });
+    for (const svc of services) {
+      table.push([clc.bold(svc.alias), svc.serviceId, colorMode(svc.enforcement)]);
+    }
+    logger.info(table.toString());
+    return services;
+  });

--- a/src/commands/appcheck-services-set.spec.ts
+++ b/src/commands/appcheck-services-set.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { command } from "./appcheck-services-set";
+import * as appcheck from "../gcp/appcheck";
+import * as projectUtils from "../projectUtils";
+import * as prompt from "../prompt";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+
+const PROJECT_ID = "test-project";
+
+describe("appcheck:services:set", () => {
+  let setStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = []; // bypass pre-action hooks
+    sinon.stub(projectUtils, "needProjectId").returns(PROJECT_ID);
+    sinon.stub(appcheck, "ensureAppCheckApiEnabled").resolves();
+    sinon.stub(utils, "logSuccess");
+    setStub = sinon.stub(appcheck, "setServiceEnforcement").resolves({
+      serviceId: "firestore.googleapis.com",
+      alias: "firestore",
+      enforcement: "enforced",
+    });
+    confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("sets a relaxed mode without prompting", async () => {
+    await command.runner()("firestore", "off", { project: PROJECT_ID });
+    expect(confirmStub).to.not.have.been.called;
+    expect(setStub).to.have.been.calledWith(PROJECT_ID, "firestore", "off");
+  });
+
+  it("prompts before enforcing", async () => {
+    await command.runner()("firestore", "enforced", { project: PROJECT_ID, interactive: true });
+    expect(confirmStub).to.have.been.calledOnce;
+    expect(setStub).to.have.been.calledWith(PROJECT_ID, "firestore", "enforced");
+  });
+
+  it("aborts when the enforce confirmation is declined", async () => {
+    confirmStub.resolves(false);
+    await expect(
+      command.runner()("firestore", "enforced", { project: PROJECT_ID, interactive: true }),
+    ).to.be.rejectedWith(FirebaseError, /aborted/i);
+    expect(setStub).to.not.have.been.called;
+  });
+
+  it("errors in non-interactive mode without --force when enforcing", async () => {
+    await expect(
+      command.runner()("firestore", "enforced", { project: PROJECT_ID, nonInteractive: true }),
+    ).to.be.rejectedWith(FirebaseError, /requires confirmation/);
+    expect(setStub).to.not.have.been.called;
+  });
+
+  it("prompts before RELAXING AI Logic, the auto-enforced service", async () => {
+    await command.runner()("ailogic", "unenforced", { project: PROJECT_ID, interactive: true });
+    expect(confirmStub).to.have.been.calledOnce;
+    expect(setStub).to.have.been.calledWith(PROJECT_ID, "ailogic", "unenforced");
+  });
+
+  it("does not prompt when relaxing a normal service", async () => {
+    await command.runner()("firestore", "unenforced", { project: PROJECT_ID });
+    expect(confirmStub).to.not.have.been.called;
+  });
+
+  it("throws on an unknown service", async () => {
+    await expect(
+      command.runner()("firestor", "enforced", { project: PROJECT_ID }),
+    ).to.be.rejectedWith(FirebaseError, /Unknown service/);
+  });
+
+  it("throws on an unknown mode", async () => {
+    await expect(command.runner()("firestore", "on", { project: PROJECT_ID })).to.be.rejectedWith(
+      FirebaseError,
+      /Unknown enforcement mode/,
+    );
+  });
+});

--- a/src/commands/appcheck-services-set.ts
+++ b/src/commands/appcheck-services-set.ts
@@ -1,0 +1,59 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as appcheck from "../gcp/appcheck";
+import * as clc from "colorette";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+import { confirm } from "../prompt";
+
+import { Options } from "../options";
+
+export const command = new Command("appcheck:services:set <service> <mode>")
+  .description("set the App Check enforcement mode (off | unenforced | enforced) for a service")
+  .option("-f, --force", "bypass confirmation prompt when enforcing")
+  .before(requirePermissions, ["firebaseappcheck.services.update"])
+  .action(async (service: string, mode: string, options: Options) => {
+    const projectId = needProjectId(options);
+    appcheck.resolveServiceId(service);
+    const enforcement = appcheck.parseEnforcementMode(mode);
+
+    await appcheck.ensureAppCheckApiEnabled(projectId, options);
+
+    // Two confirmation-gated cases:
+    //  1. Moving any service to `enforced` is client-breaking for clients that
+    //     have not been updated to obtain an App Check token.
+    //  2. Relaxing enforcement on an auto-enforced service (AI Logic) exposes a
+    //     critical, abuse-prone API. That is discouraged, so confirm even though
+    //     it is not "client-breaking".
+    const relaxingAutoEnforced =
+      enforcement !== "enforced" && appcheck.isAutoEnforcedService(service);
+
+    if (enforcement === "enforced" || relaxingAutoEnforced) {
+      const action = enforcement === "enforced" ? "enforced" : enforcement;
+      if (options.nonInteractive && !options.force) {
+        throw new FirebaseError(
+          `Setting App Check on ${clc.bold(service)} to ${action} requires confirmation.\n\n` +
+            `To proceed in non-interactive mode, rerun with --force:\n\n` +
+            `  firebase appcheck:services:set ${service} ${enforcement} --force`,
+        );
+      }
+      const message = relaxingAutoEnforced
+        ? `${clc.bold(service)} is a critical service that Firebase enforces by default to ` +
+          `protect it from abuse. Setting it to ${action} removes that protection. Continue?`
+        : `Enforcing App Check on ${clc.bold(service)} will reject requests without a valid ` +
+          `App Check token from clients that have not been updated to obtain one. Continue?`;
+      const confirmed = await confirm({
+        message,
+        force: options.force,
+        nonInteractive: options.nonInteractive,
+      });
+      if (!confirmed) {
+        throw new FirebaseError("Command aborted.", { exit: 1 });
+      }
+    }
+
+    const svc = await appcheck.setServiceEnforcement(projectId, service, enforcement);
+    utils.logSuccess(`Set ${clc.bold(service)} enforcement to ${enforcement}.`);
+    return svc;
+  });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -224,6 +224,22 @@ export function load(client: CLIClient): CLIClient {
       client.apphosting.rollouts.list = loadCommand("apphosting-rollouts-list");
     }
   }
+  client.appcheck = {};
+  client.appcheck.apps = {};
+  client.appcheck.apps.list = loadCommand("appcheck-apps-list");
+  client.appcheck.services = {};
+  client.appcheck.services.list = loadCommand("appcheck-services-list");
+  client.appcheck.services.get = loadCommand("appcheck-services-get");
+  client.appcheck.services.set = loadCommand("appcheck-services-set");
+  client.appcheck.providers = {};
+  client.appcheck.providers.list = loadCommand("appcheck-providers-list");
+  client.appcheck.providers.get = loadCommand("appcheck-providers-get");
+  client.appcheck.providers.set = loadCommand("appcheck-providers-set");
+  client.appcheck.debug = {};
+  client.appcheck.debug.create = loadCommand("appcheck-debug-create");
+  client.appcheck.debug.list = loadCommand("appcheck-debug-list");
+  client.appcheck.debug.delete = loadCommand("appcheck-debug-delete");
+
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");
   client.login.ci = loadCommand("login-ci");

--- a/src/gcp/appcheck.spec.ts
+++ b/src/gcp/appcheck.spec.ts
@@ -115,6 +115,11 @@ describe("gcp/appcheck", () => {
       expect(appcheck.parseTokenTtl("3600")).to.equal("3600s");
     });
 
+    it("rounds to an integer number of seconds", () => {
+      expect(appcheck.parseTokenTtl("1.5s")).to.equal("2s");
+      expect(appcheck.parseTokenTtl("0.5m")).to.equal("30s");
+    });
+
     it("throws on an invalid duration", () => {
       expect(() => appcheck.parseTokenTtl("soon")).to.throw(FirebaseError, /Invalid token TTL/);
     });

--- a/src/gcp/appcheck.spec.ts
+++ b/src/gcp/appcheck.spec.ts
@@ -1,0 +1,337 @@
+import { expect } from "chai";
+import * as nock from "nock";
+import * as sinon from "sinon";
+import * as fs from "fs";
+
+import * as appcheck from "./appcheck";
+import { appCheckOrigin } from "../api";
+import { FirebaseError } from "../error";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+
+const PROJECT_ID = "test-project";
+const APP_ID = "1:1234:web:abcd";
+
+describe("gcp/appcheck", () => {
+  afterEach(() => {
+    nock.cleanAll();
+    sinon.restore();
+  });
+
+  describe("resolveServiceId", () => {
+    it("resolves a known alias to its resource ID", () => {
+      expect(appcheck.resolveServiceId("firestore")).to.equal("firestore.googleapis.com");
+      expect(appcheck.resolveServiceId("ailogic")).to.equal("firebasevertexai.googleapis.com");
+    });
+
+    it("passes through a known resource ID", () => {
+      expect(appcheck.resolveServiceId("firestore.googleapis.com")).to.equal(
+        "firestore.googleapis.com",
+      );
+    });
+
+    it("throws on an unknown service", () => {
+      expect(() => appcheck.resolveServiceId("firestor")).to.throw(
+        FirebaseError,
+        /Unknown service/,
+      );
+    });
+  });
+
+  describe("aliasForServiceId", () => {
+    it("maps a resource ID back to its alias", () => {
+      expect(appcheck.aliasForServiceId("firebasestorage.googleapis.com")).to.equal("storage");
+    });
+
+    it("falls back to the resource ID when unknown", () => {
+      expect(appcheck.aliasForServiceId("unknown.googleapis.com")).to.equal(
+        "unknown.googleapis.com",
+      );
+    });
+  });
+
+  describe("parseEnforcementMode", () => {
+    it("accepts the three modes, case-insensitively", () => {
+      expect(appcheck.parseEnforcementMode("off")).to.equal("off");
+      expect(appcheck.parseEnforcementMode("UNENFORCED")).to.equal("unenforced");
+      expect(appcheck.parseEnforcementMode("Enforced")).to.equal("enforced");
+    });
+
+    it("throws on an unknown mode", () => {
+      expect(() => appcheck.parseEnforcementMode("on")).to.throw(
+        FirebaseError,
+        /Unknown enforcement mode/,
+      );
+    });
+  });
+
+  describe("isAutoEnforcedService", () => {
+    it("is true for AI Logic and false for others", () => {
+      expect(appcheck.isAutoEnforcedService("ailogic")).to.be.true;
+      expect(appcheck.isAutoEnforcedService("firebasevertexai.googleapis.com")).to.be.true;
+      expect(appcheck.isAutoEnforcedService("firestore")).to.be.false;
+    });
+  });
+
+  describe("parseProviderType", () => {
+    it("accepts a known provider", () => {
+      expect(appcheck.parseProviderType("play-integrity")).to.equal("play-integrity");
+    });
+
+    it("throws on an unknown provider", () => {
+      expect(() => appcheck.parseProviderType("nope")).to.throw(FirebaseError, /Unknown provider/);
+    });
+  });
+
+  describe("providerSupportsPlatform / providersForPlatform", () => {
+    it("treats reCAPTCHA Enterprise as a mobile and web provider", () => {
+      expect(appcheck.providerSupportsPlatform("recaptcha-enterprise", "IOS")).to.be.true;
+      expect(appcheck.providerSupportsPlatform("recaptcha-enterprise", "ANDROID")).to.be.true;
+      expect(appcheck.providerSupportsPlatform("recaptcha-enterprise", "WEB")).to.be.true;
+    });
+
+    it("keeps reCAPTCHA v3 web-only", () => {
+      expect(appcheck.providerSupportsPlatform("recaptcha-v3", "WEB")).to.be.true;
+      expect(appcheck.providerSupportsPlatform("recaptcha-v3", "IOS")).to.be.false;
+    });
+
+    it("lists the providers valid for a platform", () => {
+      expect(appcheck.providersForPlatform("ANDROID")).to.have.members([
+        "play-integrity",
+        "recaptcha-enterprise",
+      ]);
+      expect(appcheck.providersForPlatform("IOS")).to.have.members([
+        "app-attest",
+        "device-check",
+        "recaptcha-enterprise",
+      ]);
+    });
+  });
+
+  describe("parseTokenTtl", () => {
+    it("converts short durations to API Duration strings", () => {
+      expect(appcheck.parseTokenTtl("1h")).to.equal("3600s");
+      expect(appcheck.parseTokenTtl("30m")).to.equal("1800s");
+      expect(appcheck.parseTokenTtl("3600s")).to.equal("3600s");
+      expect(appcheck.parseTokenTtl("3600")).to.equal("3600s");
+    });
+
+    it("throws on an invalid duration", () => {
+      expect(() => appcheck.parseTokenTtl("soon")).to.throw(FirebaseError, /Invalid token TTL/);
+    });
+  });
+
+  describe("formatTokenTtl", () => {
+    it("formats Duration strings into short labels", () => {
+      expect(appcheck.formatTokenTtl("3600s")).to.equal("1h");
+      expect(appcheck.formatTokenTtl("1800s")).to.equal("30m");
+      expect(appcheck.formatTokenTtl("90s")).to.equal("90s");
+      expect(appcheck.formatTokenTtl(undefined)).to.equal("-");
+    });
+  });
+
+  describe("resolveSecretFlag", () => {
+    it("returns a literal value unchanged", () => {
+      expect(appcheck.resolveSecretFlag("my-secret")).to.equal("my-secret");
+    });
+
+    it("reads and trims a value from an @file", () => {
+      sinon.stub(fs, "existsSync").returns(true);
+      sinon.stub(fs, "readFileSync").returns("file-secret\n");
+      expect(appcheck.resolveSecretFlag("@/tmp/secret.txt")).to.equal("file-secret");
+    });
+
+    it("throws when the @file is missing", () => {
+      sinon.stub(fs, "existsSync").returns(false);
+      expect(() => appcheck.resolveSecretFlag("@/tmp/missing.txt")).to.throw(
+        FirebaseError,
+        /Secret file not found/,
+      );
+    });
+  });
+
+  describe("getService", () => {
+    it("maps the API response to an AppCheckService", async () => {
+      nock(appCheckOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/services/firestore.googleapis.com`)
+        .reply(200, {
+          name: `projects/${PROJECT_ID}/services/firestore.googleapis.com`,
+          enforcementMode: "ENFORCED",
+        });
+
+      const svc = await appcheck.getService(PROJECT_ID, "firestore");
+
+      expect(svc).to.deep.equal({
+        serviceId: "firestore.googleapis.com",
+        alias: "firestore",
+        enforcement: "enforced",
+      });
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("listServices", () => {
+    it("maps every service in the response", async () => {
+      nock(appCheckOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/services`)
+        .reply(200, {
+          services: [
+            {
+              name: `projects/${PROJECT_ID}/services/firestore.googleapis.com`,
+              enforcementMode: "ENFORCED",
+            },
+            {
+              name: `projects/${PROJECT_ID}/services/firebasestorage.googleapis.com`,
+              enforcementMode: "UNENFORCED",
+            },
+          ],
+        });
+
+      const services = await appcheck.listServices(PROJECT_ID);
+
+      expect(services).to.deep.equal([
+        { serviceId: "firestore.googleapis.com", alias: "firestore", enforcement: "enforced" },
+        {
+          serviceId: "firebasestorage.googleapis.com",
+          alias: "storage",
+          enforcement: "unenforced",
+        },
+      ]);
+    });
+
+    it("returns an empty array when there are no services", async () => {
+      nock(appCheckOrigin()).get(`/v1/projects/${PROJECT_ID}/services`).reply(200, {});
+      expect(await appcheck.listServices(PROJECT_ID)).to.deep.equal([]);
+    });
+  });
+
+  describe("setServiceEnforcement", () => {
+    it("PATCHes the enforcement mode with an updateMask", async () => {
+      nock(appCheckOrigin())
+        .patch(
+          `/v1/projects/${PROJECT_ID}/services/firestore.googleapis.com`,
+          (body: { enforcementMode?: string }) => body.enforcementMode === "ENFORCED",
+        )
+        .query({ updateMask: "enforcementMode" })
+        .reply(200, {
+          name: `projects/${PROJECT_ID}/services/firestore.googleapis.com`,
+          enforcementMode: "ENFORCED",
+        });
+
+      const svc = await appcheck.setServiceEnforcement(PROJECT_ID, "firestore", "enforced");
+
+      expect(svc.enforcement).to.equal("enforced");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("debug tokens", () => {
+    it("creates a debug token", async () => {
+      nock(appCheckOrigin())
+        .post(
+          `/v1/projects/${PROJECT_ID}/apps/${APP_ID}/debugTokens`,
+          (body: { displayName?: string; token?: string }) =>
+            body.displayName === "CI" && body.token === undefined,
+        )
+        .reply(200, {
+          name: `projects/${PROJECT_ID}/apps/${APP_ID}/debugTokens/tok1`,
+          displayName: "CI",
+          token: "generated-token",
+        });
+
+      const token = await appcheck.createDebugToken(PROJECT_ID, APP_ID, "CI");
+
+      expect(token.token).to.equal("generated-token");
+      expect(nock.isDone()).to.be.true;
+    });
+
+    it("lists debug tokens", async () => {
+      nock(appCheckOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/apps/${APP_ID}/debugTokens`)
+        .reply(200, { debugTokens: [{ name: "a", displayName: "one" }] });
+
+      const tokens = await appcheck.listDebugTokens(PROJECT_ID, APP_ID);
+      expect(tokens).to.have.length(1);
+    });
+
+    it("deletes a debug token", async () => {
+      nock(appCheckOrigin())
+        .delete(`/v1/projects/${PROJECT_ID}/apps/${APP_ID}/debugTokens/tok1`)
+        .reply(200, {});
+
+      await appcheck.deleteDebugToken(PROJECT_ID, APP_ID, "tok1");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("getProviderConfig", () => {
+    it("returns the config when present", async () => {
+      nock(appCheckOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/apps/${APP_ID}/recaptchaEnterpriseConfig`)
+        .reply(200, {
+          name: `projects/${PROJECT_ID}/apps/${APP_ID}/recaptchaEnterpriseConfig`,
+          siteKey: "key",
+          tokenTtl: "1800s",
+        });
+
+      const config = await appcheck.getProviderConfig(PROJECT_ID, APP_ID, "recaptcha-enterprise");
+      expect(config?.siteKey).to.equal("key");
+    });
+
+    it("returns null on a 404", async () => {
+      nock(appCheckOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/apps/${APP_ID}/appAttestConfig`)
+        .reply(404, {});
+
+      const config = await appcheck.getProviderConfig(PROJECT_ID, APP_ID, "app-attest");
+      expect(config).to.be.null;
+    });
+  });
+
+  describe("listConfiguredProviders", () => {
+    it("returns only the platform providers that have a config", async () => {
+      nock(appCheckOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/apps/${APP_ID}/recaptchaEnterpriseConfig`)
+        .reply(200, { siteKey: "key", tokenTtl: "1800s" });
+      nock(appCheckOrigin())
+        .get(`/v1/projects/${PROJECT_ID}/apps/${APP_ID}/recaptchaV3Config`)
+        .reply(404, {});
+
+      const configured = await appcheck.listConfiguredProviders(PROJECT_ID, APP_ID, "WEB");
+
+      expect(configured).to.have.length(1);
+      expect(configured[0].provider).to.equal("recaptcha-enterprise");
+    });
+  });
+
+  describe("setProviderConfig", () => {
+    it("PATCHes the config with an updateMask of the given fields", async () => {
+      nock(appCheckOrigin())
+        .patch(
+          `/v1/projects/${PROJECT_ID}/apps/${APP_ID}/recaptchaEnterpriseConfig`,
+          (body: { siteKey?: string }) => body.siteKey === "key",
+        )
+        .query({ updateMask: "siteKey" })
+        .reply(200, { siteKey: "key" });
+
+      const config = await appcheck.setProviderConfig(PROJECT_ID, APP_ID, "recaptcha-enterprise", {
+        siteKey: "key",
+      });
+      expect(config.siteKey).to.equal("key");
+      expect(nock.isDone()).to.be.true;
+    });
+  });
+
+  describe("ensureAppCheckApiEnabled", () => {
+    it("returns quietly when the API is already enabled", async () => {
+      sinon.stub(ensureApiEnabled, "check").resolves(true);
+      await appcheck.ensureAppCheckApiEnabled(PROJECT_ID, { nonInteractive: true });
+    });
+
+    it("throws with instructions in non-interactive mode when disabled", async () => {
+      sinon.stub(ensureApiEnabled, "check").resolves(false);
+      await expect(
+        appcheck.ensureAppCheckApiEnabled(PROJECT_ID, { nonInteractive: true }),
+      ).to.be.rejectedWith(FirebaseError, /not enabled/);
+    });
+  });
+});

--- a/src/gcp/appcheck.ts
+++ b/src/gcp/appcheck.ts
@@ -1,0 +1,445 @@
+import * as fs from "fs";
+
+import { Client } from "../apiv2";
+import { appCheckOrigin } from "../api";
+import { FirebaseError, getErrStatus } from "../error";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as iam from "./iam";
+import { logger } from "../logger";
+import { confirm } from "../prompt";
+
+export const API_VERSION = "v1";
+export const APP_CHECK_API = "firebaseappcheck.googleapis.com";
+
+const PREFIX = "appcheck";
+
+export const client = new Client({
+  urlPrefix: appCheckOrigin(),
+  auth: true,
+  apiVersion: API_VERSION,
+});
+
+/** Developer-facing enforcement mode, mapped to the API `enforcementMode` enum. */
+export type EnforcementMode = "off" | "unenforced" | "enforced";
+
+const ENFORCEMENT_MODE_TO_API: Record<EnforcementMode, string> = {
+  off: "OFF",
+  unenforced: "UNENFORCED",
+  enforced: "ENFORCED",
+};
+
+const API_TO_ENFORCEMENT_MODE: Record<string, EnforcementMode> = {
+  OFF: "off",
+  UNENFORCED: "unenforced",
+  ENFORCED: "enforced",
+};
+
+/**
+ * Developer-facing service aliases mapped to the underlying App Check service
+ * resource IDs. The alias is what users type; the resource ID is the last path
+ * segment of `projects/{project}/services/{serviceId}`.
+ */
+export const SERVICE_ALIAS_TO_ID: Record<string, string> = {
+  database: "firebasedatabase.googleapis.com",
+  firestore: "firestore.googleapis.com",
+  storage: "firebasestorage.googleapis.com",
+  auth: "identitytoolkit.googleapis.com",
+  ailogic: "firebasevertexai.googleapis.com",
+  functions: "cloudfunctions.googleapis.com",
+};
+
+const SERVICE_ID_TO_ALIAS: Record<string, string> = Object.fromEntries(
+  Object.entries(SERVICE_ALIAS_TO_ID).map(([alias, id]) => [id, alias]),
+);
+
+/** Resolves a service alias (or a raw resource ID) to its resource ID. */
+export function resolveServiceId(service: string): string {
+  if (SERVICE_ALIAS_TO_ID[service]) {
+    return SERVICE_ALIAS_TO_ID[service];
+  }
+  if (SERVICE_ID_TO_ALIAS[service]) {
+    return service; // already a known resource ID
+  }
+  throw new FirebaseError(
+    `Unknown service: ${service}\n\nValid services:\n\n` +
+      Object.keys(SERVICE_ALIAS_TO_ID)
+        .map((a) => `  ${a}`)
+        .join("\n"),
+  );
+}
+
+/** Returns the alias for a resource ID, falling back to the resource ID itself. */
+export function aliasForServiceId(serviceId: string): string {
+  return SERVICE_ID_TO_ALIAS[serviceId] ?? serviceId;
+}
+
+/**
+ * Services that Firebase enforces automatically and that should stay enforced.
+ * As of early July 2026, Firebase auto-enforces App Check for AI Logic during the
+ * guided setup workflow, because it directly protects the Gemini API from abuse.
+ * Relaxing enforcement on these services is discouraged and confirmation-gated.
+ */
+export const AUTO_ENFORCED_SERVICE_IDS = new Set<string>(["firebasevertexai.googleapis.com"]);
+
+/** Whether the service is one Firebase auto-enforces and should stay enforced. */
+export function isAutoEnforcedService(service: string): boolean {
+  return AUTO_ENFORCED_SERVICE_IDS.has(resolveServiceId(service));
+}
+
+/** Parses a developer-facing enforcement mode string, throwing on invalid input. */
+export function parseEnforcementMode(mode: string): EnforcementMode {
+  const normalized = mode.toLowerCase();
+  if (normalized === "off" || normalized === "unenforced" || normalized === "enforced") {
+    return normalized;
+  }
+  throw new FirebaseError(
+    `Unknown enforcement mode: ${mode}\n\nValid modes:\n\n  off\n  unenforced\n  enforced`,
+  );
+}
+
+export interface Service {
+  name: string;
+  enforcementMode: string;
+}
+
+export interface AppCheckService {
+  serviceId: string;
+  alias: string;
+  enforcement: EnforcementMode;
+}
+
+function toAppCheckService(service: Service): AppCheckService {
+  const serviceId = service.name.split("/").pop() ?? service.name;
+  return {
+    serviceId,
+    alias: aliasForServiceId(serviceId),
+    enforcement: API_TO_ENFORCEMENT_MODE[service.enforcementMode] ?? "off",
+  };
+}
+
+/**
+ * Gets the enforcement configuration for a single service.
+ */
+export async function getService(projectId: string, service: string): Promise<AppCheckService> {
+  const serviceId = resolveServiceId(service);
+  const res = await client.get<Service>(`projects/${projectId}/services/${serviceId}`);
+  return toAppCheckService(res.body);
+}
+
+/**
+ * Lists the enforcement configuration for every enforceable service.
+ */
+export async function listServices(projectId: string): Promise<AppCheckService[]> {
+  const res = await client.get<{ services?: Service[] }>(`projects/${projectId}/services`);
+  return (res.body.services ?? []).map(toAppCheckService);
+}
+
+/**
+ * Sets the enforcement mode for a single service.
+ */
+export async function setServiceEnforcement(
+  projectId: string,
+  service: string,
+  mode: EnforcementMode,
+): Promise<AppCheckService> {
+  const serviceId = resolveServiceId(service);
+  const res = await client.patch<Partial<Service>, Service>(
+    `projects/${projectId}/services/${serviceId}`,
+    { enforcementMode: ENFORCEMENT_MODE_TO_API[mode] },
+    { queryParams: { updateMask: "enforcementMode" } },
+  );
+  return toAppCheckService(res.body);
+}
+
+export interface DebugToken {
+  name?: string;
+  displayName: string;
+  token?: string;
+}
+
+/**
+ * Creates a debug token for an app. The returned token value is only available
+ * once, at creation time.
+ */
+export async function createDebugToken(
+  projectId: string,
+  appId: string,
+  displayName: string,
+  token?: string,
+): Promise<DebugToken> {
+  const body: DebugToken = { displayName };
+  if (token) {
+    body.token = token;
+  }
+  const res = await client.post<DebugToken, DebugToken>(
+    `projects/${projectId}/apps/${appId}/debugTokens`,
+    body,
+  );
+  return res.body;
+}
+
+/**
+ * Lists an app's debug tokens. The API never returns the token value.
+ */
+export async function listDebugTokens(projectId: string, appId: string): Promise<DebugToken[]> {
+  const res = await client.get<{ debugTokens?: DebugToken[] }>(
+    `projects/${projectId}/apps/${appId}/debugTokens`,
+  );
+  return res.body.debugTokens ?? [];
+}
+
+/**
+ * Deletes a debug token by its ID.
+ */
+export async function deleteDebugToken(
+  projectId: string,
+  appId: string,
+  tokenId: string,
+): Promise<void> {
+  await client.delete<void>(`projects/${projectId}/apps/${appId}/debugTokens/${tokenId}`);
+}
+
+export type ProviderType =
+  | "app-attest"
+  | "device-check"
+  | "play-integrity"
+  | "recaptcha-enterprise"
+  | "recaptcha-v3";
+
+export type AppCheckPlatform = "IOS" | "ANDROID" | "WEB";
+
+interface ProviderMeta {
+  /** The App Check per-app config sub-resource, e.g. "appAttestConfig". */
+  configResource: string;
+  /** The app platforms this provider can attest. */
+  platforms: AppCheckPlatform[];
+}
+
+// As of June 2026, reCAPTCHA Enterprise is an attestation provider for mobile
+// (iOS, and Android as backend support rolls out) in addition to web, so it is
+// no longer web-only. reCAPTCHA v3 remains web-only.
+export const PROVIDER_META: Record<ProviderType, ProviderMeta> = {
+  "app-attest": { configResource: "appAttestConfig", platforms: ["IOS"] },
+  "device-check": { configResource: "deviceCheckConfig", platforms: ["IOS"] },
+  "play-integrity": { configResource: "playIntegrityConfig", platforms: ["ANDROID"] },
+  "recaptcha-enterprise": {
+    configResource: "recaptchaEnterpriseConfig",
+    platforms: ["IOS", "ANDROID", "WEB"],
+  },
+  "recaptcha-v3": { configResource: "recaptchaV3Config", platforms: ["WEB"] },
+};
+
+/** Parses a provider type string, throwing on an unknown provider. */
+export function parseProviderType(provider: string): ProviderType {
+  if (provider in PROVIDER_META) {
+    return provider as ProviderType;
+  }
+  throw new FirebaseError(
+    `Unknown provider: ${provider}\n\nValid providers:\n\n` +
+      Object.keys(PROVIDER_META)
+        .map((p) => `  ${p}`)
+        .join("\n"),
+  );
+}
+
+export interface ProviderConfig {
+  name?: string;
+  tokenTtl?: string;
+  // recaptcha-enterprise
+  siteKey?: string;
+  // recaptcha-v3
+  siteSecretSet?: boolean;
+  // device-check
+  keyId?: string;
+  privateKeySet?: boolean;
+}
+
+/**
+ * Gets the provider config sub-resource for an app. Returns null if the provider
+ * has not been configured (404).
+ */
+export async function getProviderConfig(
+  projectId: string,
+  appId: string,
+  provider: ProviderType,
+): Promise<ProviderConfig | null> {
+  const { configResource } = PROVIDER_META[provider];
+  try {
+    const res = await client.get<ProviderConfig>(
+      `projects/${projectId}/apps/${appId}/${configResource}`,
+    );
+    return res.body;
+  } catch (err: unknown) {
+    if (getErrStatus(err) === 404) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Registers or updates a provider config for an app. `fields` carries the
+ * provider-specific inputs (siteKey, siteSecret, keyId, privateKey, tokenTtl).
+ */
+export async function setProviderConfig(
+  projectId: string,
+  appId: string,
+  provider: ProviderType,
+  fields: Record<string, string>,
+): Promise<ProviderConfig> {
+  const { configResource } = PROVIDER_META[provider];
+  const updateMask = Object.keys(fields).join(",");
+  const res = await client.patch<Record<string, string>, ProviderConfig>(
+    `projects/${projectId}/apps/${appId}/${configResource}`,
+    fields,
+    { queryParams: { updateMask } },
+  );
+  return res.body;
+}
+
+/** Whether the provider can attest an app of the given platform. */
+export function providerSupportsPlatform(provider: ProviderType, platform: string): boolean {
+  return PROVIDER_META[provider].platforms.some((p) => p === platform);
+}
+
+/** The provider types that can attest an app of the given platform. */
+export function providersForPlatform(platform: string): ProviderType[] {
+  return (Object.keys(PROVIDER_META) as ProviderType[]).filter((p) =>
+    providerSupportsPlatform(p, platform),
+  );
+}
+
+export interface ConfiguredProvider {
+  provider: ProviderType;
+  config: ProviderConfig;
+}
+
+/**
+ * Best-effort probe of which platform-relevant providers have a config for an
+ * app, with each config. Providers are probed in parallel.
+ */
+export async function listConfiguredProviders(
+  projectId: string,
+  appId: string,
+  platform: string,
+): Promise<ConfiguredProvider[]> {
+  const candidates = providersForPlatform(platform);
+  const configs = await Promise.all(
+    candidates.map((provider) => getProviderConfig(projectId, appId, provider)),
+  );
+  const configured: ConfiguredProvider[] = [];
+  candidates.forEach((provider, i) => {
+    const config = configs[i];
+    if (config) {
+      configured.push({ provider, config });
+    }
+  });
+  return configured;
+}
+
+/** The platform-relevant provider types that have a config for an app. */
+export async function getConfiguredProviders(
+  projectId: string,
+  appId: string,
+  platform: string,
+): Promise<ProviderType[]> {
+  const configured = await listConfiguredProviders(projectId, appId, platform);
+  return configured.map((c) => c.provider);
+}
+
+/**
+ * Ensures the Firebase App Check API is enabled.
+ * - Non-interactive mode: throws with instructions.
+ * - Interactive mode: prompts to enable it, checking enablement permission first.
+ * Read-only commands should NOT call this; they should degrade gracefully.
+ */
+export async function ensureAppCheckApiEnabled(
+  projectId: string,
+  options: { nonInteractive?: boolean; force?: boolean },
+): Promise<void> {
+  const isEnabled = await ensureApiEnabled.check(projectId, APP_CHECK_API, PREFIX, true);
+  if (isEnabled) {
+    return;
+  }
+
+  if (options.nonInteractive) {
+    throw new FirebaseError(
+      `The Firebase App Check API (${APP_CHECK_API}) is not enabled on project ${projectId}.\n\n` +
+        `Enable it by rerunning this command in an interactive terminal, or enable the API in ` +
+        `the Google Cloud console:\n\n` +
+        `  https://console.cloud.google.com/apis/library/${APP_CHECK_API}?project=${projectId}\n\n` +
+        `Then run this command again.`,
+    );
+  }
+
+  const { missing } = await iam.testIamPermissions(projectId, ["serviceusage.services.enable"]);
+  if (missing.length > 0) {
+    throw new FirebaseError(
+      `You do not have permission to enable the Firebase App Check API on project ${projectId}.\n\n` +
+        `Missing permission: ${missing.join(", ")}\n\n` +
+        `This permission is included in the Owner and Editor roles. Ask a project ` +
+        `administrator to enable the API or grant you the permission, then run this command again.`,
+    );
+  }
+
+  logger.info(
+    `The Firebase App Check API (${APP_CHECK_API}) is not enabled on project ${projectId}.`,
+  );
+  const proceed = await confirm({ message: "Would you like to enable it now?", default: true });
+  if (!proceed) {
+    throw new FirebaseError("Command aborted.", { exit: 1 });
+  }
+  logger.info(`Enabling ${APP_CHECK_API}...`);
+  await ensureApiEnabled.ensure(projectId, APP_CHECK_API, PREFIX);
+}
+
+/**
+ * Resolves a secret flag value. A value beginning with "@" is read from the file
+ * path that follows (so secrets stay out of shell history and CI logs); any other
+ * value is treated as the literal secret. Surrounding whitespace/newlines from a
+ * file are trimmed.
+ */
+export function resolveSecretFlag(value: string): string {
+  if (!value.startsWith("@")) {
+    return value;
+  }
+  const filePath = value.slice(1);
+  if (!fs.existsSync(filePath)) {
+    throw new FirebaseError(`Secret file not found: ${filePath}`);
+  }
+  return fs.readFileSync(filePath, "utf-8").trim();
+}
+
+/**
+ * Parses a short duration ("1h", "30m", "3600s", "3600") into the API Duration
+ * string form ("3600s").
+ */
+export function parseTokenTtl(ttl: string): string {
+  const match = /^(\d+(?:\.\d+)?)(s|m|h|d)?$/.exec(ttl.trim());
+  if (!match) {
+    throw new FirebaseError(`Invalid token TTL: ${ttl}. Use a value like 1h, 30m, or 3600s.`);
+  }
+  const value = Number(match[1]);
+  const unit = match[2] ?? "s";
+  const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+  return `${value * multipliers[unit]}s`;
+}
+
+/** Formats a Duration string ("3600s") as a short human label ("1h"). */
+export function formatTokenTtl(ttl?: string): string {
+  if (!ttl) {
+    return "-";
+  }
+  const match = /^(\d+(?:\.\d+)?)s$/.exec(ttl);
+  if (!match) {
+    return ttl;
+  }
+  const seconds = Number(match[1]);
+  if (seconds % 3600 === 0) {
+    return `${seconds / 3600}h`;
+  }
+  if (seconds % 60 === 0) {
+    return `${seconds / 60}m`;
+  }
+  return `${seconds}s`;
+}

--- a/src/gcp/appcheck.ts
+++ b/src/gcp/appcheck.ts
@@ -131,7 +131,7 @@ export async function getService(projectId: string, service: string): Promise<Ap
  */
 export async function listServices(projectId: string): Promise<AppCheckService[]> {
   const res = await client.get<{ services?: Service[] }>(`projects/${projectId}/services`);
-  return (res.body.services ?? []).map(toAppCheckService);
+  return (res.body?.services ?? []).map(toAppCheckService);
 }
 
 /**
@@ -185,7 +185,7 @@ export async function listDebugTokens(projectId: string, appId: string): Promise
   const res = await client.get<{ debugTokens?: DebugToken[] }>(
     `projects/${projectId}/apps/${appId}/debugTokens`,
   );
-  return res.body.debugTokens ?? [];
+  return res.body?.debugTokens ?? [];
 }
 
 /**
@@ -422,7 +422,8 @@ export function parseTokenTtl(ttl: string): string {
   const value = Number(match[1]);
   const unit = match[2] ?? "s";
   const multipliers: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
-  return `${value * multipliers[unit]}s`;
+  // The App Check API expects an integer number of seconds.
+  return `${Math.round(value * multipliers[unit])}s`;
 }
 
 /** Formats a Duration string ("3600s") as a short human label ("1h"). */


### PR DESCRIPTION
feat(appcheck): add `appcheck` commands to manage Firebase App Check

### Description

Adds a new `firebase appcheck` command surface (preview) for managing Firebase App Check from the CLI and CI, so developers and coding agents can manage enforcement, attestation providers, and debug tokens without the Firebase Console.

Command groups (API `firebaseappcheck.googleapis.com`, v1):

- `appcheck:services:list|get|set` — per-service App Check enforcement (off | unenforced | enforced) for Realtime Database, Cloud Firestore, Cloud Storage, Authentication, AI Logic, and Cloud Functions.
- `appcheck:providers:list|get|set` — attestation provider configuration per app (App Attest, DeviceCheck, Play Integrity, reCAPTCHA Enterprise, reCAPTCHA v3). reCAPTCHA Enterprise is treated as a mobile + web provider, matching the June 2026 SDKs.
- `appcheck:debug:create|list|delete` — App Check debug tokens for CI runners and simulators.
- `appcheck:apps:list` — inspect apps and their configured provider.

Design: every service should end up enforced. Most services follow the graduated `unenforced → measure → enforced` rollout; AI Logic is the exception, since Firebase auto-enforces it, so the CLI keeps it enforced by default and confirms before relaxing it. Moving any service to `enforced` (client-breaking) and deleting a debug token are confirmation-gated (`--force` to skip; error in non-interactive mode without it).

This is the first step of a larger effort. Follow-ups (not in this PR): Firebase MCP server tools, and verification of the API resource shapes and IAM permission strings against a live project.

### Scenarios Tested

- Unit tests: `src/gcp/appcheck.spec.ts` (32) plus command specs for `services:set`, `providers:set`, and `debug:delete` (19). 51 passing.
- `npm run build`, `npm run lint`, and `tsc --noEmit` are clean.
- `firebase --help` lists all 10 commands, and `--help` on each shows the expected flags.

### Sample Commands

```
firebase appcheck:services:list
firebase appcheck:services:set firestore unenforced
firebase appcheck:services:set firestore enforced
firebase appcheck:providers:set 1:1234:web:xyz recaptcha-enterprise --site-key <KEY>
firebase appcheck:debug:create 1:1234:web:xyz --display-name "CI runner"
firebase appcheck:apps:list
```
