### PR TITLE
feat: prompt user before executing lifecycle hooks when recovering from partially failed deployments

### DIFF
--- a/src/deploy/functions/prompts.ts
+++ b/src/deploy/functions/prompts.ts
@@ -406,20 +406,19 @@ export async function promptForLifecycleEvent(
 ): Promise<DeploymentEvent | undefined> {
   const hooks = wantBackend.lifecycleHooks || {};
   const choices: { name: string; value: DeploymentEvent | "skip" }[] = [];
-  if (hooks.afterFirstDeploy) {
-    choices.push({ name: "afterFirstDeploy", value: "afterFirstDeploy" });
-  }
-  if (hooks.afterRedeploy) {
-    choices.push({ name: "afterRedeploy", value: "afterRedeploy" });
-  }
-  choices.push({ name: "skip (default)", value: "skip" });
 
-  if (choices.length === 1) {
+  for (const hookName of Object.keys(hooks)) {
+    choices.push({ name: hookName, value: hookName as DeploymentEvent });
+  }
+
+  if (choices.length === 0) {
     return undefined;
   }
 
+  choices.push({ name: "skip (default)", value: "skip" });
+
   const selection = await select<DeploymentEvent | "skip">({
-    message: `We detected a partially failed deployment for codebase "${codebase}". Which lifecycle hook would you like to run?`,
+    message: `We cannot determine whether this deployment is a first deploy or a redeploy for codebase "${codebase}" because it is recovering from a previous partial failure.`,
     choices,
     default: "skip",
     nonInteractive: options?.nonInteractive,

--- a/src/deploy/functions/prompts.ts
+++ b/src/deploy/functions/prompts.ts
@@ -398,6 +398,7 @@ export async function promptForSecurityChanges(
 
 /**
  * Prompts the user to select which lifecycle hook to execute when a partial deployment retry is detected.
+ * If no hooks are defined, then the prompt will be skipped.
  */
 export async function promptForLifecycleEvent(
   codebase: string,

--- a/src/deploy/functions/prompts.ts
+++ b/src/deploy/functions/prompts.ts
@@ -398,7 +398,7 @@ export async function promptForSecurityChanges(
 
 /**
  * Prompts the user to select which lifecycle hook to execute when a partial deployment retry is detected.
- * If no hooks are defined, then the prompt will be skipped.
+ * If no lifecycle hooks are defined in wantBackend, the prompt is skipped and returns undefined.
  */
 export async function promptForLifecycleEvent(
   codebase: string,

--- a/src/deploy/functions/prompts.ts
+++ b/src/deploy/functions/prompts.ts
@@ -2,7 +2,7 @@ import * as clc from "colorette";
 
 import { getFunctionLabel } from "./functionsDeployHelper";
 import { FirebaseError } from "../../error";
-import { confirm, number } from "../../prompt";
+import { confirm, number, select } from "../../prompt";
 import { logger } from "../../logger";
 import * as backend from "./backend";
 import * as pricing from "./pricing";
@@ -11,6 +11,7 @@ import * as artifacts from "../../functions/artifacts";
 import { Options } from "../../options";
 import { EndpointUpdate } from "./release/planner";
 import * as iam from "../../gcp/iam";
+import { DeploymentEvent } from "./release/lifecycle";
 
 export interface ActiveSecurityPlan {
   managedServiceAccount: string;
@@ -393,4 +394,36 @@ export async function promptForSecurityChanges(
       }
     }
   }
+}
+
+/**
+ * Prompts the user to select which lifecycle hook to execute when a partial deployment retry is detected.
+ */
+export async function promptForLifecycleEvent(
+  codebase: string,
+  wantBackend: backend.Backend,
+  options?: Options,
+): Promise<DeploymentEvent | undefined> {
+  const hooks = wantBackend.lifecycleHooks || {};
+  const choices: { name: string; value: DeploymentEvent | "skip" }[] = [];
+  if (hooks.afterFirstDeploy) {
+    choices.push({ name: "afterFirstDeploy", value: "afterFirstDeploy" });
+  }
+  if (hooks.afterRedeploy) {
+    choices.push({ name: "afterRedeploy", value: "afterRedeploy" });
+  }
+  choices.push({ name: "skip (default)", value: "skip" });
+
+  if (choices.length === 1) {
+    return undefined;
+  }
+
+  const selection = await select<DeploymentEvent | "skip">({
+    message: `We detected a partially failed deployment for codebase "${codebase}". Which lifecycle hook would you like to run?`,
+    choices,
+    default: "skip",
+    nonInteractive: options?.nonInteractive,
+  });
+
+  return selection === "skip" ? undefined : selection;
 }

--- a/src/deploy/functions/release/index.spec.ts
+++ b/src/deploy/functions/release/index.spec.ts
@@ -212,4 +212,77 @@ describe("release/index", () => {
       'Lifecycle hook "afterFirstDeploy" for codebase "codebase1" was configured but not executed because one or more function deployments failed.',
     );
   });
+
+  it("should run lifecycle hooks with isPartialFailure=true when only SOME deployments fail", async () => {
+    const context = {
+      projectId: "test-project",
+      config: {},
+      sources: {},
+      firebaseConfig: { locationId: "us-central1" },
+    } as any;
+
+    const options = {
+      projectId: "test-project",
+      projectNumber: "123456",
+    } as any;
+
+    const wantBackend = backend.of(
+      {
+        id: "fn1",
+        region: "us-central1",
+        project: "test-project",
+        platform: "gcfv2",
+        entryPoint: "fn1",
+        httpsTrigger: {},
+      },
+      {
+        id: "fn2",
+        region: "us-central1",
+        project: "test-project",
+        platform: "gcfv2",
+        entryPoint: "fn2",
+        httpsTrigger: {},
+      },
+    );
+
+    const payload = {
+      functions: {
+        codebase1: {
+          wantBackend,
+          haveBackend: backend.empty(),
+        },
+      },
+    } as any;
+
+    // Simulate partial failure (1 succeeded, 1 failed out of 2)
+    fabricatorStub.resolves({
+      totalTime: 120,
+      results: [
+        {
+          endpoint: payload.functions.codebase1.wantBackend.endpoints["us-central1"]["fn1"],
+          durationMs: 120,
+        },
+        {
+          endpoint: payload.functions.codebase1.wantBackend.endpoints["us-central1"]["fn2"],
+          durationMs: 120,
+          error: new Error("Failed to deploy function fn2"),
+        },
+      ],
+    });
+
+    await expect(release(context, options, payload)).to.be.rejectedWith(
+      FirebaseError,
+      "There was an error deploying functions",
+    );
+
+    // Assert that lifecycle hooks WERE executed with isPartialFailure=true
+    expect(executeLifecycleHooksStub).to.have.been.calledOnceWith(
+      wantBackend,
+      backend.empty(),
+      sinon.match.any,
+      "codebase1",
+      options,
+      true,
+    );
+  });
 });

--- a/src/deploy/functions/release/index.spec.ts
+++ b/src/deploy/functions/release/index.spec.ts
@@ -213,7 +213,7 @@ describe("release/index", () => {
     );
   });
 
-  it("should run lifecycle hooks with isPartialFailure=true when only SOME deployments fail", async () => {
+  it("should NOT run lifecycle hooks when only SOME deployments fail", async () => {
     const context = {
       projectId: "test-project",
       config: {},
@@ -275,14 +275,7 @@ describe("release/index", () => {
       "There was an error deploying functions",
     );
 
-    // Assert that lifecycle hooks WERE executed with isPartialFailure=true
-    expect(executeLifecycleHooksStub).to.have.been.calledOnceWith(
-      wantBackend,
-      backend.empty(),
-      sinon.match.any,
-      "codebase1",
-      options,
-      true,
-    );
+    // Assert that lifecycle hooks were NOT executed
+    expect(executeLifecycleHooksStub).to.not.have.been.called;
   });
 });

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -124,13 +124,9 @@ export async function release(
   const wantBackend = backend.merge(...Object.values(payload.functions).map((p) => p.wantBackend));
   printTriggerUrls(wantBackend, projectNumber);
 
-  const allErrors = summary.results.filter((r) => r.error).map((r) => r.error) as Error[];
-  const isPartialFailure = allErrors.length > 0 && allErrors.length < summary.results.length;
-
-  if (allErrors.length === 0 || isPartialFailure) {
-    for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(
-      payload.functions,
-    )) {
+  for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(payload.functions)) {
+    const { errors, isPartialFailure } = getCodebaseDeployStats(codebase, w, h, summary);
+    if (errors.length === 0 || isPartialFailure) {
       await executeLifecycleHooks(w, h, plan, codebase, options, isPartialFailure);
     }
   }
@@ -141,11 +137,13 @@ export async function release(
     Object.keys(wantBackend.endpoints),
   );
 
+  const allErrors = summary.results.filter((r) => r.error).map((r) => r.error) as Error[];
   if (allErrors.length) {
-    if (!isPartialFailure) {
-      for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(
-        payload.functions,
-      )) {
+    for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(
+      payload.functions,
+    )) {
+      const { results, errors } = getCodebaseDeployStats(codebase, w, h, summary);
+      if (errors.length > 0 && errors.length === results.length) {
         const event = determineDeploymentEvent(h);
         if (w.lifecycleHooks?.[event]) {
           utils.logLabeledWarning(
@@ -193,6 +191,31 @@ export function printTriggerUrls(results: backend.Backend, projectNumber: string
     }
     logger.info(clc.bold("Function URL"), `(${getFunctionLabel(httpsFunc)}):`, httpsFunc.uri);
   }
+}
+
+interface CodebaseDeployStats {
+  results: reporter.DeployResult[];
+  errors: reporter.DeployResult[];
+  isPartialFailure: boolean;
+}
+
+function getCodebaseDeployStats(
+  codebase: string,
+  wantBackend: backend.Backend,
+  haveBackend: backend.Backend,
+  summary: reporter.Summary,
+): CodebaseDeployStats {
+  const cb = codebase || "default";
+  const results = summary.results.filter(
+    (r) =>
+      (r.endpoint.codebase ?? "default") === cb ||
+      !!wantBackend.endpoints[r.endpoint.region]?.[r.endpoint.id] ||
+      !!haveBackend.endpoints[r.endpoint.region]?.[r.endpoint.id],
+  );
+  const errors = results.filter((r) => r.error);
+  const isPartialFailure = errors.length > 0 && errors.length < results.length;
+
+  return { results, errors, isPartialFailure };
 }
 
 /**

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -125,9 +125,9 @@ export async function release(
   printTriggerUrls(wantBackend, projectNumber);
 
   for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(payload.functions)) {
-    const { errors, isPartialFailure } = getCodebaseDeployStats(codebase, w, h, summary);
-    if (errors.length === 0 || isPartialFailure) {
-      await executeLifecycleHooks(w, h, plan, codebase, options, isPartialFailure);
+    const { errors } = getCodebaseDeployStats(codebase, w, h, summary);
+    if (errors.length === 0) {
+      await executeLifecycleHooks(w, h, plan, codebase, options);
     }
   }
 
@@ -142,8 +142,8 @@ export async function release(
     for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(
       payload.functions,
     )) {
-      const { results, errors } = getCodebaseDeployStats(codebase, w, h, summary);
-      if (errors.length > 0 && errors.length === results.length) {
+      const { errors } = getCodebaseDeployStats(codebase, w, h, summary);
+      if (errors.length > 0) {
         const event = determineDeploymentEvent(h);
         if (w.lifecycleHooks?.[event]) {
           utils.logLabeledWarning(
@@ -196,7 +196,6 @@ export function printTriggerUrls(results: backend.Backend, projectNumber: string
 interface CodebaseDeployStats {
   results: reporter.DeployResult[];
   errors: reporter.DeployResult[];
-  isPartialFailure: boolean;
 }
 
 function getCodebaseDeployStats(
@@ -213,9 +212,8 @@ function getCodebaseDeployStats(
       !!haveBackend.endpoints[r.endpoint.region]?.[r.endpoint.id],
   );
   const errors = results.filter((r) => r.error);
-  const isPartialFailure = errors.length > 0 && errors.length < results.length;
 
-  return { results, errors, isPartialFailure };
+  return { results, errors };
 }
 
 /**

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -125,13 +125,13 @@ export async function release(
   printTriggerUrls(wantBackend, projectNumber);
 
   const allErrors = summary.results.filter((r) => r.error).map((r) => r.error) as Error[];
+  const isPartialFailure = allErrors.length > 0 && allErrors.length < summary.results.length;
 
-  // Only execute lifecycle hooks when all deployments are successful.
-  if (allErrors.length === 0) {
+  if (allErrors.length === 0 || isPartialFailure) {
     for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(
       payload.functions,
     )) {
-      await executeLifecycleHooks(w, h, plan, codebase);
+      await executeLifecycleHooks(w, h, plan, codebase, options, isPartialFailure);
     }
   }
 
@@ -142,15 +142,17 @@ export async function release(
   );
 
   if (allErrors.length) {
-    for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(
-      payload.functions,
-    )) {
-      const event = determineDeploymentEvent(h);
-      if (w.lifecycleHooks?.[event]) {
-        utils.logLabeledWarning(
-          "functions",
-          `Lifecycle hook "${event}" for codebase "${codebase}" was configured but not executed because one or more function deployments failed.`,
-        );
+    if (!isPartialFailure) {
+      for (const [codebase, { wantBackend: w, haveBackend: h }] of Object.entries(
+        payload.functions,
+      )) {
+        const event = determineDeploymentEvent(h);
+        if (w.lifecycleHooks?.[event]) {
+          utils.logLabeledWarning(
+            "functions",
+            `Lifecycle hook "${event}" for codebase "${codebase}" was configured but not executed because one or more function deployments failed.`,
+          );
+        }
       }
     }
     const opts = allErrors.length === 1 ? { original: allErrors[0] } : { children: allErrors };

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -411,5 +411,118 @@ describe("lifecycle", () => {
         "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterFirstDeploy my-codebase",
       );
     });
+
+    it("prompts user and executes selected hook when recovering from a partial deployment", async () => {
+      const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
+      const promptStub = sandbox
+        .stub(prompts, "promptForLifecycleEvent")
+        .resolves("afterFirstDeploy");
+      const wantBackend = backend.of(
+        {
+          id: "fn1",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "fn1",
+          platform: "gcfv2" as const,
+          httpsTrigger: {},
+          hash: "shared-hash",
+        },
+        {
+          id: "installHookTask",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "installHookTask",
+          platform: "gcfv2" as const,
+          uri: "https://installhooktask-12345.a.run.app",
+          taskQueueTrigger: {},
+          hash: "shared-hash",
+        },
+      );
+      wantBackend.lifecycleHooks = {
+        afterFirstDeploy: {
+          task: {
+            function: "installHookTask",
+          },
+        },
+      };
+      const haveBackend = backend.of({
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "shared-hash",
+      });
+
+      const executed = await executeLifecycleHooks(
+        wantBackend,
+        haveBackend,
+        undefined,
+        "default",
+        undefined,
+      );
+      expect(promptStub).to.have.been.calledOnceWith("default", wantBackend, sinon.match.any);
+      expect(executed).to.be.true;
+      expect(enqueueStub).to.have.been.calledOnce;
+    });
+
+    it("skips execution when user selects skip in partial deployment recovery prompt", async () => {
+      const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
+      const promptStub = sandbox.stub(prompts, "promptForLifecycleEvent").resolves(undefined);
+      const bulletStub = sandbox.stub(utils, "logLabeledBullet");
+      const wantBackend = backend.of(
+        {
+          id: "fn1",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "fn1",
+          platform: "gcfv2" as const,
+          httpsTrigger: {},
+          hash: "shared-hash",
+        },
+        {
+          id: "installHookTask",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "installHookTask",
+          platform: "gcfv2" as const,
+          uri: "https://installhooktask-12345.a.run.app",
+          taskQueueTrigger: {},
+          hash: "shared-hash",
+        },
+      );
+      wantBackend.lifecycleHooks = {
+        afterFirstDeploy: {
+          task: {
+            function: "installHookTask",
+          },
+        },
+      };
+      const haveBackend = backend.of({
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "shared-hash",
+      });
+
+      const executed = await executeLifecycleHooks(
+        wantBackend,
+        haveBackend,
+        undefined,
+        "default",
+        undefined,
+      );
+      expect(promptStub).to.have.been.calledOnce;
+      expect(executed).to.be.false;
+      expect(enqueueStub).to.not.have.been.called;
+      expect(bulletStub).to.have.been.calledWith(
+        "functions",
+        sinon.match(/Skipping lifecycle hooks for codebase "default"/),
+      );
+    });
   });
 });

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -367,7 +367,12 @@ describe("lifecycle", () => {
         },
       };
 
-      const executed = await executeLifecycleHooks(wantBackend, haveBackend, emptyPlan, "default");
+      const executed = await executeLifecycleHooks(
+        wantBackend,
+        haveBackend,
+        emptyPlan /* plan */,
+        "default" /* codebase */,
+      );
       expect(executed).to.be.false;
       expect(enqueueStub).to.not.have.been.called;
     });
@@ -398,8 +403,8 @@ describe("lifecycle", () => {
       const executed = await executeLifecycleHooks(
         wantBackend,
         haveBackend,
-        undefined,
-        "my-codebase",
+        undefined /* plan */,
+        "my-codebase" /* codebase */,
       );
       expect(executed).to.be.false;
       expect(warningStub).to.have.been.calledWith(
@@ -458,9 +463,9 @@ describe("lifecycle", () => {
       const executed = await executeLifecycleHooks(
         wantBackend,
         haveBackend,
-        undefined,
-        "default",
-        undefined,
+        undefined /* plan */,
+        "default" /* codebase */,
+        undefined /* options */,
       );
       expect(promptStub).to.have.been.calledOnceWith("default", wantBackend, sinon.match.any);
       expect(executed).to.be.true;
@@ -512,9 +517,9 @@ describe("lifecycle", () => {
       const executed = await executeLifecycleHooks(
         wantBackend,
         haveBackend,
-        undefined,
-        "default",
-        undefined,
+        undefined /* plan */,
+        "default" /* codebase */,
+        undefined /* options */,
       );
       expect(promptStub).to.have.been.calledOnce;
       expect(executed).to.be.false;

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -5,7 +5,7 @@ import {
   determineDeploymentEvent,
   executeLifecycleHooks,
   hasLifecycleHooks,
-  isRecoveredFromPartialDeploy,
+  isRecoveryDeployment,
 } from "./lifecycle";
 import * as prompts from "../prompts";
 import * as cloudtasks from "../../../gcp/cloudtasks";
@@ -29,7 +29,7 @@ describe("lifecycle", () => {
     sandbox.restore();
   });
 
-  describe("isRecoveredFromPartialDeploy", () => {
+  describe("isRecoveryDeployment", () => {
     it("returns false if wantBackend endpoints have no hashes", () => {
       const wantBackend = backend.of({
         id: "fn1",
@@ -40,7 +40,7 @@ describe("lifecycle", () => {
         httpsTrigger: {},
       });
       const haveBackend = backend.empty();
-      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.false;
+      expect(isRecoveryDeployment(wantBackend, haveBackend)).to.be.false;
     });
 
     it("returns false if haveBackend does not include the same hash", () => {
@@ -56,7 +56,7 @@ describe("lifecycle", () => {
       const haveEndpoint: backend.Endpoint = { ...wantEndpoint, hash: "hash-old" };
       const wantBackend = backend.of(wantEndpoint);
       const haveBackend = backend.of(haveEndpoint);
-      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.false;
+      expect(isRecoveryDeployment(wantBackend, haveBackend)).to.be.false;
     });
 
     it("returns false if haveBackend includes the same hash but there are no net new functions", () => {
@@ -82,7 +82,7 @@ describe("lifecycle", () => {
       const haveEndpoint2: backend.Endpoint = { ...wantEndpoint2, hash: "hash-old" };
       const wantBackend = backend.of(wantEndpoint1, wantEndpoint2);
       const haveBackend = backend.of(haveEndpoint1, haveEndpoint2);
-      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.false;
+      expect(isRecoveryDeployment(wantBackend, haveBackend)).to.be.false;
     });
 
     it("returns true if haveBackend includes the same hash and there are net new functions", () => {
@@ -107,7 +107,7 @@ describe("lifecycle", () => {
       const haveEndpoint1: backend.Endpoint = { ...wantEndpoint1 };
       const wantBackend = backend.of(wantEndpoint1, wantEndpoint2);
       const haveBackend = backend.of(haveEndpoint1);
-      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.true;
+      expect(isRecoveryDeployment(wantBackend, haveBackend)).to.be.true;
     });
 
     it("returns true if haveBackend includes the same hash and net new function exists in haveBackend only in FAILED state", () => {
@@ -133,7 +133,7 @@ describe("lifecycle", () => {
       const haveEndpoint2: backend.Endpoint = { ...wantEndpoint2, state: "FAILED" };
       const wantBackend = backend.of(wantEndpoint1, wantEndpoint2);
       const haveBackend = backend.of(haveEndpoint1, haveEndpoint2);
-      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.true;
+      expect(isRecoveryDeployment(wantBackend, haveBackend)).to.be.true;
     });
   });
 

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -1,7 +1,12 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as backend from "../backend";
-import { determineDeploymentEvent, executeLifecycleHooks, hasLifecycleHooks } from "./lifecycle";
+import {
+  determineDeploymentEvent,
+  executeLifecycleHooks,
+  hasLifecycleHooks,
+  isRecoveredFromPartialDeploy,
+} from "./lifecycle";
 import * as prompts from "../prompts";
 import * as cloudtasks from "../../../gcp/cloudtasks";
 import { logger } from "../../../logger";
@@ -24,9 +29,132 @@ describe("lifecycle", () => {
     sandbox.restore();
   });
 
+  describe("isRecoveredFromPartialDeploy", () => {
+    it("returns false if wantBackend endpoints have no hashes", () => {
+      const wantBackend = backend.of({
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+      });
+      const haveBackend = backend.empty();
+      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.false;
+    });
+
+    it("returns false if haveBackend does not include the same hash", () => {
+      const wantEndpoint: backend.Endpoint = {
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "hash-new",
+      };
+      const haveEndpoint: backend.Endpoint = { ...wantEndpoint, hash: "hash-old" };
+      const wantBackend = backend.of(wantEndpoint);
+      const haveBackend = backend.of(haveEndpoint);
+      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.false;
+    });
+
+    it("returns false if haveBackend includes the same hash but there are no net new functions", () => {
+      const wantEndpoint1: backend.Endpoint = {
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "hash-shared",
+      };
+      const wantEndpoint2: backend.Endpoint = {
+        id: "fn2",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn2",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "hash-shared",
+      };
+      const haveEndpoint1: backend.Endpoint = { ...wantEndpoint1 };
+      const haveEndpoint2: backend.Endpoint = { ...wantEndpoint2, hash: "hash-old" };
+      const wantBackend = backend.of(wantEndpoint1, wantEndpoint2);
+      const haveBackend = backend.of(haveEndpoint1, haveEndpoint2);
+      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.false;
+    });
+
+    it("returns true if haveBackend includes the same hash and there are net new functions", () => {
+      const wantEndpoint1: backend.Endpoint = {
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "hash-shared",
+      };
+      const wantEndpoint2: backend.Endpoint = {
+        id: "fn2",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn2",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "hash-shared",
+      };
+      const haveEndpoint1: backend.Endpoint = { ...wantEndpoint1 };
+      const wantBackend = backend.of(wantEndpoint1, wantEndpoint2);
+      const haveBackend = backend.of(haveEndpoint1);
+      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.true;
+    });
+
+    it("returns true if haveBackend includes the same hash and net new function exists in haveBackend only in FAILED state", () => {
+      const wantEndpoint1: backend.Endpoint = {
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "hash-shared",
+      };
+      const wantEndpoint2: backend.Endpoint = {
+        id: "fn2",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn2",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+        hash: "hash-shared",
+      };
+      const haveEndpoint1: backend.Endpoint = { ...wantEndpoint1 };
+      const haveEndpoint2: backend.Endpoint = { ...wantEndpoint2, state: "FAILED" };
+      const wantBackend = backend.of(wantEndpoint1, wantEndpoint2);
+      const haveBackend = backend.of(haveEndpoint1, haveEndpoint2);
+      expect(isRecoveredFromPartialDeploy(wantBackend, haveBackend)).to.be.true;
+    });
+  });
+
   describe("determineDeploymentEvent", () => {
     it("returns afterFirstDeploy when haveBackend has no endpoints", () => {
       const haveBackend = backend.empty();
+
+      const event = determineDeploymentEvent(haveBackend);
+      expect(event).to.equal("afterFirstDeploy");
+    });
+
+    it("returns afterFirstDeploy when haveBackend has only FAILED endpoints", () => {
+      const haveBackend = backend.of({
+        id: "myFunc",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "myFunc",
+        platform: "gcfv2",
+        httpsTrigger: {},
+        state: "FAILED",
+      });
 
       const event = determineDeploymentEvent(haveBackend);
       expect(event).to.equal("afterFirstDeploy");
@@ -281,101 +409,6 @@ describe("lifecycle", () => {
       expect(bulletStub).to.have.been.calledWith(
         "functions",
         "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterFirstDeploy my-codebase",
-      );
-    });
-
-    it("prompts user and executes selected hook when partial deployment failure is flagged", async () => {
-      const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
-      const promptStub = sandbox
-        .stub(prompts, "promptForLifecycleEvent")
-        .resolves("afterFirstDeploy");
-      const wantBackend = backend.of(
-        {
-          id: "fn1",
-          project: "myProj",
-          region: "us-east1",
-          entryPoint: "fn1",
-          platform: "gcfv2",
-          httpsTrigger: {},
-        },
-        {
-          id: "installHookTask",
-          project: "myProj",
-          region: "us-east1",
-          entryPoint: "installHookTask",
-          platform: "gcfv2",
-          uri: "https://installhooktask-12345.a.run.app",
-          taskQueueTrigger: {},
-        },
-      );
-      wantBackend.lifecycleHooks = {
-        afterFirstDeploy: {
-          task: {
-            function: "installHookTask",
-          },
-        },
-      };
-      const haveBackend = backend.empty();
-
-      const executed = await executeLifecycleHooks(
-        wantBackend,
-        haveBackend,
-        undefined,
-        "default",
-        undefined,
-        true,
-      );
-      expect(promptStub).to.have.been.calledOnceWith("default", wantBackend, sinon.match.any);
-      expect(executed).to.be.true;
-      expect(enqueueStub).to.have.been.calledOnce;
-    });
-
-    it("skips execution when user selects skip in partial deployment failure prompt", async () => {
-      const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
-      const promptStub = sandbox.stub(prompts, "promptForLifecycleEvent").resolves(undefined);
-      const bulletStub = sandbox.stub(utils, "logLabeledBullet");
-      const wantBackend = backend.of(
-        {
-          id: "fn1",
-          project: "myProj",
-          region: "us-east1",
-          entryPoint: "fn1",
-          platform: "gcfv2",
-          httpsTrigger: {},
-        },
-        {
-          id: "installHookTask",
-          project: "myProj",
-          region: "us-east1",
-          entryPoint: "installHookTask",
-          platform: "gcfv2",
-          uri: "https://installhooktask-12345.a.run.app",
-          taskQueueTrigger: {},
-        },
-      );
-      wantBackend.lifecycleHooks = {
-        afterFirstDeploy: {
-          task: {
-            function: "installHookTask",
-          },
-        },
-      };
-      const haveBackend = backend.empty();
-
-      const executed = await executeLifecycleHooks(
-        wantBackend,
-        haveBackend,
-        undefined,
-        "default",
-        undefined,
-        true,
-      );
-      expect(promptStub).to.have.been.calledOnce;
-      expect(executed).to.be.false;
-      expect(enqueueStub).to.not.have.been.called;
-      expect(bulletStub).to.have.been.calledWith(
-        "functions",
-        sinon.match(/Skipping lifecycle hooks for codebase "default"/),
       );
     });
   });

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -1,7 +1,8 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as backend from "../backend";
-import { determineDeploymentEvent, executeLifecycleHooks } from "./lifecycle";
+import { determineDeploymentEvent, executeLifecycleHooks, hasLifecycleHooks } from "./lifecycle";
+import * as prompts from "../prompts";
 import * as cloudtasks from "../../../gcp/cloudtasks";
 import { logger } from "../../../logger";
 import * as projects from "../../../management/projects";
@@ -43,6 +44,31 @@ describe("lifecycle", () => {
 
       const event = determineDeploymentEvent(haveBackend);
       expect(event).to.equal("afterRedeploy");
+    });
+  });
+
+  describe("hasLifecycleHooks", () => {
+    it("returns false when lifecycleHooks is undefined", () => {
+      const b = backend.empty();
+      expect(hasLifecycleHooks(b)).to.be.false;
+    });
+
+    it("returns false when lifecycleHooks is empty", () => {
+      const b = backend.empty();
+      b.lifecycleHooks = {};
+      expect(hasLifecycleHooks(b)).to.be.false;
+    });
+
+    it("returns true when lifecycleHooks has configured hooks", () => {
+      const b = backend.empty();
+      b.lifecycleHooks = {
+        afterFirstDeploy: {
+          task: {
+            function: "myTask",
+          },
+        },
+      };
+      expect(hasLifecycleHooks(b)).to.be.true;
     });
   });
 
@@ -255,6 +281,101 @@ describe("lifecycle", () => {
       expect(bulletStub).to.have.been.calledWith(
         "functions",
         "You can retry the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterFirstDeploy my-codebase",
+      );
+    });
+
+    it("prompts user and executes selected hook when partial deployment failure is flagged", async () => {
+      const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
+      const promptStub = sandbox
+        .stub(prompts, "promptForLifecycleEvent")
+        .resolves("afterFirstDeploy");
+      const wantBackend = backend.of(
+        {
+          id: "fn1",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "fn1",
+          platform: "gcfv2",
+          httpsTrigger: {},
+        },
+        {
+          id: "installHookTask",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "installHookTask",
+          platform: "gcfv2",
+          uri: "https://installhooktask-12345.a.run.app",
+          taskQueueTrigger: {},
+        },
+      );
+      wantBackend.lifecycleHooks = {
+        afterFirstDeploy: {
+          task: {
+            function: "installHookTask",
+          },
+        },
+      };
+      const haveBackend = backend.empty();
+
+      const executed = await executeLifecycleHooks(
+        wantBackend,
+        haveBackend,
+        undefined,
+        "default",
+        undefined,
+        true,
+      );
+      expect(promptStub).to.have.been.calledOnceWith("default", wantBackend, sinon.match.any);
+      expect(executed).to.be.true;
+      expect(enqueueStub).to.have.been.calledOnce;
+    });
+
+    it("skips execution when user selects skip in partial deployment failure prompt", async () => {
+      const enqueueStub = sandbox.stub(cloudtasks, "enqueueTask").resolves();
+      const promptStub = sandbox.stub(prompts, "promptForLifecycleEvent").resolves(undefined);
+      const bulletStub = sandbox.stub(utils, "logLabeledBullet");
+      const wantBackend = backend.of(
+        {
+          id: "fn1",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "fn1",
+          platform: "gcfv2",
+          httpsTrigger: {},
+        },
+        {
+          id: "installHookTask",
+          project: "myProj",
+          region: "us-east1",
+          entryPoint: "installHookTask",
+          platform: "gcfv2",
+          uri: "https://installhooktask-12345.a.run.app",
+          taskQueueTrigger: {},
+        },
+      );
+      wantBackend.lifecycleHooks = {
+        afterFirstDeploy: {
+          task: {
+            function: "installHookTask",
+          },
+        },
+      };
+      const haveBackend = backend.empty();
+
+      const executed = await executeLifecycleHooks(
+        wantBackend,
+        haveBackend,
+        undefined,
+        "default",
+        undefined,
+        true,
+      );
+      expect(promptStub).to.have.been.calledOnce;
+      expect(executed).to.be.false;
+      expect(enqueueStub).to.not.have.been.called;
+      expect(bulletStub).to.have.been.calledWith(
+        "functions",
+        sinon.match(/Skipping lifecycle hooks for codebase "default"/),
       );
     });
   });

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -43,9 +43,7 @@ export function isRecoveredFromPartialDeploy(
   const wantEndpoints = backend.allEndpoints(wantBackend);
   const haveEndpoints = backend.allEndpoints(haveBackend);
 
-  const wantHashes = new Set(
-    wantEndpoints.map((ep) => ep.hash).filter((h): h is string => !!h),
-  );
+  const wantHashes = new Set(wantEndpoints.map((ep) => ep.hash).filter((h): h is string => !!h));
   if (!wantHashes.size) {
     return false;
   }

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -33,10 +33,11 @@ export function hasLifecycleHooks(backendSpec: backend.Backend): boolean {
 }
 
 /**
- * Detects if the codebase is recovering from a previous partially successful deploy
- * that requires prompting the user to select the appropriate lifecycle event.
+ * Detects if this deployment is a redeploy of a partially successful but identical previous deployment.
+ * This will be true only if the hashes for both backends are the same but the specified endpoints are different.
+ * Note: If any code or comment modification was made between deploys, the hash will change, so this check won't detect it as an identical recovery deployment.
  */
-export function isRecoveredFromPartialDeploy(
+export function isRecoveryDeployment(
   wantBackend: backend.Backend,
   haveBackend: backend.Backend,
 ): boolean {
@@ -45,6 +46,8 @@ export function isRecoveredFromPartialDeploy(
 
   const wantHashes = new Set(wantEndpoints.map((ep) => ep.hash).filter((h): h is string => !!h));
   if (!wantHashes.size) {
+    // If there are no endpoint hashes in wantBackend (e.g. deleting all functions or missing hashes),
+    // we cannot reliably compare hashes to detect recovery, so we return false.
     return false;
   }
 
@@ -55,9 +58,9 @@ export function isRecoveredFromPartialDeploy(
     return false;
   }
 
-  // 2. If there are no net new functions, we know this was an update.
-  // If there are net new functions we know this might be a first deploy (it could also be
-  // an update if the user defined new functions and had a partial failure deploying them).
+  // 2. If we have existing endpoints in haveBackend with matching hashes, but wantBackend contains net new functions,
+  // we know the current deployment is re-attempting a previous deployment with the same source code specification
+  // that failed to deploy all endpoints successfully.
   const hasNetNewFunctions = wantEndpoints.some(
     (wantEp) =>
       !backend.findEndpoint(
@@ -86,7 +89,7 @@ export async function executeLifecycleHooks(
   }
 
   let event: DeploymentEvent | undefined;
-  if (isRecoveredFromPartialDeploy(wantBackend, haveBackend)) {
+  if (isRecoveryDeployment(wantBackend, haveBackend)) {
     event = await prompts.promptForLifecycleEvent(codebase ?? "default", wantBackend, options);
     if (!event) {
       logLabeledBullet(

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -54,7 +54,7 @@ export async function executeLifecycleHooks(
     if (!event) {
       logLabeledBullet(
         "functions",
-        `Skipping lifecycle hooks for codebase "${codebase ?? "default"}". You can retry a lifecycle hook in isolation by running: firebase functions:lifecycle:run <event> ${codebase ?? "default"}`,
+        `Skipping lifecycle hooks for codebase "${codebase ?? "default"}".`,
       );
       return false;
     }

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -7,6 +7,8 @@ import * as cloudtasks from "../../../gcp/cloudtasks";
 import * as computeEngine from "../../../gcp/computeEngine";
 import { getProject } from "../../../management/projects";
 import { assertExhaustive } from "../../../functional";
+import { Options } from "../../../options";
+import * as prompts from "../prompts";
 
 export type DeploymentEvent = "afterFirstDeploy" | "afterRedeploy";
 
@@ -24,6 +26,13 @@ export function determineDeploymentEvent(haveBackend: backend.Backend): Deployme
 }
 
 /**
+ * Checks if the backend specification has any lifecycle hooks configured.
+ */
+export function hasLifecycleHooks(backendSpec: backend.Backend): boolean {
+  return !!(backendSpec.lifecycleHooks && Object.keys(backendSpec.lifecycleHooks).length > 0);
+}
+
+/**
  * Validates and executes matching lifecycle hooks for the deployed codebase.
  * Returns true if a hook was executed, false otherwise.
  */
@@ -32,8 +41,27 @@ export async function executeLifecycleHooks(
   haveBackend: backend.Backend,
   plan?: planner.DeploymentPlan,
   codebase?: string,
+  options?: Options,
+  isPartialFailure?: boolean,
 ): Promise<boolean> {
-  const event = determineDeploymentEvent(haveBackend);
+  if (!hasLifecycleHooks(wantBackend)) {
+    return false;
+  }
+
+  let event: DeploymentEvent | undefined;
+  if (isPartialFailure) {
+    event = await prompts.promptForLifecycleEvent(codebase ?? "default", wantBackend, options);
+    if (!event) {
+      logLabeledBullet(
+        "functions",
+        `Skipping lifecycle hooks for codebase "${codebase ?? "default"}". You can retry a lifecycle hook in isolation by running: firebase functions:lifecycle:run <event> ${codebase ?? "default"}`,
+      );
+      return false;
+    }
+  } else {
+    event = determineDeploymentEvent(haveBackend);
+  }
+
   const hooks = wantBackend.lifecycleHooks || {};
   const hook = hooks[event];
 

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -17,8 +17,8 @@ export type DeploymentEvent = "afterFirstDeploy" | "afterRedeploy";
  * (afterFirstDeploy) or an update to an existing deployment (afterRedeploy).
  */
 export function determineDeploymentEvent(haveBackend: backend.Backend): DeploymentEvent {
-  // If haveBackend has no existing endpoints, this is a fresh installation.
-  const hasExistingEndpoints = backend.someEndpoint(haveBackend, () => true);
+  // If haveBackend has no existing active endpoints, this is a fresh installation.
+  const hasExistingEndpoints = backend.someEndpoint(haveBackend, (ep) => ep.state !== "FAILED");
   if (!hasExistingEndpoints) {
     return "afterFirstDeploy";
   }
@@ -33,6 +33,46 @@ export function hasLifecycleHooks(backendSpec: backend.Backend): boolean {
 }
 
 /**
+ * Detects if the codebase is recovering from a previous partially successful deploy
+ * that requires prompting the user to select the appropriate lifecycle event.
+ */
+export function isRecoveredFromPartialDeploy(
+  wantBackend: backend.Backend,
+  haveBackend: backend.Backend,
+): boolean {
+  const wantEndpoints = backend.allEndpoints(wantBackend);
+  const haveEndpoints = backend.allEndpoints(haveBackend);
+
+  const wantHashes = new Set(
+    wantEndpoints.map((ep) => ep.hash).filter((h): h is string => !!h),
+  );
+  if (!wantHashes.size) {
+    return false;
+  }
+
+  // 1. We know a previous deploy was a partial success if haveBackend includes the same hash
+  // but wantBackend includes different functions.
+  const hasSameHash = haveEndpoints.some((ep) => ep.hash && wantHashes.has(ep.hash));
+  if (!hasSameHash) {
+    return false;
+  }
+
+  // 2. If there are no net new functions, we know this was an update.
+  // If there are net new functions we know this might be a first deploy (it could also be
+  // an update if the user defined new functions and had a partial failure deploying them).
+  const hasNetNewFunctions = wantEndpoints.some(
+    (wantEp) =>
+      !backend.findEndpoint(
+        haveBackend,
+        (haveEp) =>
+          haveEp.id === wantEp.id && haveEp.region === wantEp.region && haveEp.state !== "FAILED",
+      ),
+  );
+
+  return hasNetNewFunctions;
+}
+
+/**
  * Validates and executes matching lifecycle hooks for the deployed codebase.
  * Returns true if a hook was executed, false otherwise.
  */
@@ -42,14 +82,13 @@ export async function executeLifecycleHooks(
   plan?: planner.DeploymentPlan,
   codebase?: string,
   options?: Options,
-  isPartialFailure?: boolean,
 ): Promise<boolean> {
   if (!hasLifecycleHooks(wantBackend)) {
     return false;
   }
 
   let event: DeploymentEvent | undefined;
-  if (isPartialFailure) {
+  if (isRecoveredFromPartialDeploy(wantBackend, haveBackend)) {
     event = await prompts.promptForLifecycleEvent(codebase ?? "default", wantBackend, options);
     if (!event) {
       logLabeledBullet(


### PR DESCRIPTION
### Description

This PR introduces recovery detection for partial deployment failures and interactive user prompting:
- **`isRecoveredFromPartialDeploy` helper**: Evaluates whether a successful deploy is recovering from a previous partial failure by checking if `haveBackend` contains functions with a matching bundle hash (or in a `FAILED` state) while `wantBackend` introduces net new functions (excluding `FAILED` resources in `haveBackend`).
- **Interactive Lifecycle Prompting**: When `isRecoveredFromPartialDeploy` returns `true`, the user is prompted to clarify which lifecycle hook (`afterFirstDeploy`, `afterRedeploy`, or `skip`) should be executed.

### Scenarios Tested
- Unit tests