### PR TITLE
Integrate .env secret bindings with param prompting

### DIFF
--- a/src/deploy/functions/build.spec.ts
+++ b/src/deploy/functions/build.spec.ts
@@ -474,6 +474,88 @@ describe("applyEnvSecretBindings", () => {
     );
   });
 
+  it("merges resourceID and version fields into the SecretParam", () => {
+    const testBuild: build.Build = {
+      endpoints: {
+        func: {
+          region: "us-central1",
+          project: "test-project",
+          platform: "gcfv2",
+          runtime: "nodejs18",
+          entryPoint: "func1",
+          httpsTrigger: {},
+          secretEnvironmentVariables: [
+            {
+              key: "foo",
+              secret: "foo",
+              projectId: "test-project",
+            },
+          ],
+        },
+      },
+      params: [{ type: "secret", name: "FOO" }],
+      requiredAPIs: [],
+    };
+    const testSecretRefs: Record<string, build.ParsedSecretRef> = {
+      FOO: {
+        projectId: "test-project",
+        secretId: "bar",
+        version: "2",
+      },
+    };
+    build.applyEnvSecretBindings(testBuild, testSecretRefs);
+    expect(testBuild.params).to.deep.equal([
+      {
+        type: "secret",
+        name: "FOO",
+        resourceId: "bar",
+        version: "2",
+        inLocalEnvironment: true,
+      },
+    ]);
+  });
+
+  it("is case-insensitive when matching SecretParam name and .env file key", () => {
+    const testBuild: build.Build = {
+      endpoints: {
+        func: {
+          region: "us-central1",
+          project: "test-project",
+          platform: "gcfv2",
+          runtime: "nodejs18",
+          entryPoint: "func1",
+          httpsTrigger: {},
+          secretEnvironmentVariables: [
+            {
+              key: "foo",
+              secret: "foo",
+              projectId: "test-project",
+            },
+          ],
+        },
+      },
+      params: [{ type: "secret", name: "foo" }],
+      requiredAPIs: [],
+    };
+    const testSecretRefs: Record<string, build.ParsedSecretRef> = {
+      FOO: {
+        projectId: "test-project",
+        secretId: "bar",
+        version: "2",
+      },
+    };
+    build.applyEnvSecretBindings(testBuild, testSecretRefs);
+    expect(testBuild.params).to.deep.equal([
+      {
+        type: "secret",
+        name: "foo",
+        resourceId: "bar",
+        version: "2",
+        inLocalEnvironment: true,
+      },
+    ]);
+  });
+
   it("should not add the referenced secret to secretEnvironmentVariables if not present", () => {
     const testBuildEmpty: build.Build = {
       endpoints: {

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -819,11 +819,11 @@ export function applyEnvSecretBindings(
     const secretRef = envSecrets[key];
     const { projectId, secretId, version } = secretRef;
 
-    for (const secret of build.params.filter((param) => param.type === "secret")) {
-      if (secret.name === key) {
-        secret.resourceId = secretId;
-        secret.version = version;
-        secret.inLocalEnvironment = true;
+    for (const secretParam of build.params.filter((param) => param.type === "secret")) {
+      if (secretParam.name.toUpperCase() === key) {
+        secretParam.resourceId = secretId;
+        secretParam.version = version;
+        secretParam.inLocalEnvironment = true;
       }
     }
 

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -347,7 +347,7 @@ interface ResolveBackendOpts {
  */
 export async function resolveBackend(
   opts: ResolveBackendOpts,
-): Promise<{ backend: backend.Backend; envs: Record<string, params.ParamValue> }> {
+): Promise<{ backend: backend.Backend; envs: Record<string, params.ParamValue>, newSecretRefs: Record<string, string> }> {
   const paramValues = await params.resolveParams(
     opts.build.params,
     opts.firebaseConfig,
@@ -356,7 +356,7 @@ export async function resolveBackend(
     opts.isEmulator,
   );
 
-  return { backend: toBackend(opts.build, paramValues), envs: paramValues };
+  return { backend: toBackend(opts.build, paramValues), envs: paramValues, newSecretRefs: {} };
 }
 
 /**
@@ -806,6 +806,14 @@ export function applyEnvSecretBindings(build: Build, envSecrets: Record<string, 
     const secretRef = envSecrets[key];
     const { projectId, secretId, version } = secretRef;
     const secretPinsVersion = typeof secretRef.version !== "undefined";
+
+    for (const secret of build.params.filter(param => param.type === "secret")) {
+      if (secret.name.toLowerCase() === key.toLowerCase()) {
+        secret.resourceId = secretId;
+        secret.version = version;
+        secret.inLocalEnvironment = true;
+      }
+    }
 
     for (const endpointName of Object.keys(build.endpoints)) {
       const endpoint = build.endpoints[endpointName];

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -341,6 +341,7 @@ interface ResolveBackendOpts {
   userEnvs: Record<string, string>;
   nonInteractive?: boolean;
   isEmulator?: boolean;
+  force?: boolean;
 }
 
 /**
@@ -358,6 +359,7 @@ export async function resolveBackend(opts: ResolveBackendOpts): Promise<{
     envWithTypes(opts.build.params, opts.userEnvs),
     opts.nonInteractive,
     opts.isEmulator,
+    opts.force,
   );
 
   return { backend: toBackend(opts.build, paramValues), envs: paramValues, secretRefs: secretRefs };

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -345,10 +345,12 @@ interface ResolveBackendOpts {
  * Resolves user-defined parameters inside a Build and generates a Backend.
  * Callers are responsible for persisting resolved env vars.
  */
-export async function resolveBackend(
-  opts: ResolveBackendOpts,
-): Promise<{ backend: backend.Backend; envs: Record<string, params.ParamValue>, newSecretRefs: Record<string, string> }> {
-  const paramValues = await params.resolveParams(
+export async function resolveBackend(opts: ResolveBackendOpts): Promise<{
+  backend: backend.Backend;
+  envs: Record<string, params.ParamValue>;
+  secretRefs: Record<string, string>;
+}> {
+  const { paramValues: paramValues, secretRefs: secretRefs } = await params.resolveParams(
     opts.build.params,
     opts.firebaseConfig,
     envWithTypes(opts.build.params, opts.userEnvs),
@@ -356,7 +358,7 @@ export async function resolveBackend(
     opts.isEmulator,
   );
 
-  return { backend: toBackend(opts.build, paramValues), envs: paramValues, newSecretRefs: {} };
+  return { backend: toBackend(opts.build, paramValues), envs: paramValues, secretRefs: secretRefs };
 }
 
 /**
@@ -807,8 +809,8 @@ export function applyEnvSecretBindings(build: Build, envSecrets: Record<string, 
     const { projectId, secretId, version } = secretRef;
     const secretPinsVersion = typeof secretRef.version !== "undefined";
 
-    for (const secret of build.params.filter(param => param.type === "secret")) {
-      if (secret.name.toLowerCase() === key.toLowerCase()) {
+    for (const secret of build.params.filter((param) => param.type === "secret")) {
+      if (secret.name === key) {
         secret.resourceId = secretId;
         secret.version = version;
         secret.inLocalEnvironment = true;

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -13,7 +13,7 @@ export const REGION_TBD = "REGION_TBD";
 export const SECRET_REF_PREFIX = "FIREBASE_SECRET_REF_";
 // prettier-ignore
 const GCP_PROJECT_ID_PATTERN = "([a-z][-a-z0-9]{4,28}[a-z0-9])";
-const GCP_SECRET_ID_PATTERN = "([a-zA-Z0-9-_]+)";
+export const GCP_SECRET_ID_PATTERN = "([a-zA-Z0-9-_]+)";
 export const SECRET_REF_SHORT_RE = new RegExp(
   "^" + // start of string
     GCP_SECRET_ID_PATTERN + // capture secret ID

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -813,8 +813,14 @@ export function applyEnvSecretBindings(
     return;
   }
   logger.debug(
-    `Attempting to merge .env secret bindings ${JSON.stringify(envSecrets)} into declared secrets...`,
+    `Attempting to merge .env secret bindings ${JSON.stringify(envSecrets)} into declared secrets...)}`,
   );
+  for (const endpointName of Object.keys(build.endpoints)) {
+    logger.debug(
+      `${endpointName} declared secrets: ${JSON.stringify(build.endpoints[endpointName].secretEnvironmentVariables)}`,
+    );
+  }
+
   for (const key of Object.keys(envSecrets)) {
     const secretRef = envSecrets[key];
     const { projectId, secretId, version } = secretRef;

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -819,11 +819,11 @@ export function applyEnvSecretBindings(
     const secretRef = envSecrets[key];
     const { projectId, secretId, version } = secretRef;
 
-    for (const secretParam of build.params.filter((param) => param.type === "secret")) {
-      if (secretParam.name.toUpperCase() === key) {
-        secretParam.resourceId = secretId;
-        secretParam.version = version;
-        secretParam.inLocalEnvironment = true;
+    for (const param of build.params) {
+      if (param.type === "secret" && param.name.toUpperCase() === key) {
+        param.resourceId = secretId;
+        param.version = version;
+        param.inLocalEnvironment = true;
       }
     }
 

--- a/src/deploy/functions/params.spec.ts
+++ b/src/deploy/functions/params.spec.ts
@@ -90,9 +90,9 @@ describe("resolveParams", () => {
   it("always contains the precanned internal param values", async () => {
     const paramsToResolve: params.Param[] = [];
     const userEnv: Record<string, params.ParamValue> = {};
-    await expect(
-      params.resolveParams(paramsToResolve, fakeConfig, userEnv),
-    ).to.eventually.deep.equal(expectedInternalParams);
+    expect(
+      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv)).paramValues,
+    ).to.deep.equal(expectedInternalParams);
   });
 
   it("can pull a literal value out of the dotenvs", async () => {
@@ -111,9 +111,9 @@ describe("resolveParams", () => {
       bar: new params.ParamValue("24", false, { string: false, number: true, boolean: false }),
       baz: new params.ParamValue("true", false, { string: false, number: false, boolean: true }),
     };
-    await expect(
-      params.resolveParams(paramsToResolve, fakeConfig, userEnv),
-    ).to.eventually.deep.equal(
+    expect(
+      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv)).paramValues,
+    ).to.deep.equal(
       Object.assign(
         {
           foo: new params.ParamValue("bar", false, { string: true, number: false, boolean: false }),
@@ -138,9 +138,9 @@ describe("resolveParams", () => {
         boolean: false,
       }),
     };
-    await expect(
-      params.resolveParams(paramsToResolve, fakeConfig, userEnv),
-    ).to.eventually.deep.equal({
+    expect(
+      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv)).paramValues,
+    ).to.deep.equal({
       DATABASE_URL: new params.ParamValue(fakeConfig.databaseURL, true, {
         string: true,
         boolean: false,
@@ -167,13 +167,15 @@ describe("resolveParams", () => {
   it("does not create the corresponding internal params if database url/storage bucket are not configured", async () => {
     const paramsToResolve: params.Param[] = [];
     const userEnv: Record<string, params.ParamValue> = {};
-    await expect(
-      params.resolveParams(
-        paramsToResolve,
-        { locationId: "", projectId: "foo", storageBucket: "", databaseURL: "" },
-        userEnv,
-      ),
-    ).to.eventually.deep.equal({
+    expect(
+      (
+        await params.resolveParams(
+          paramsToResolve,
+          { locationId: "", projectId: "foo", storageBucket: "", databaseURL: "" },
+          userEnv,
+        )
+      ).paramValues,
+    ).to.deep.equal({
       GCLOUD_PROJECT: expectedInternalParams.GCLOUD_PROJECT,
       PROJECT_ID: expectedInternalParams.PROJECT_ID,
     });
@@ -189,7 +191,7 @@ describe("resolveParams", () => {
       },
     ];
     input.resolves("bar");
-    await expect(params.resolveParams(paramsToResolve, fakeConfig, {})).to.eventually.deep.equal(
+    expect((await params.resolveParams(paramsToResolve, fakeConfig, {})).paramValues).to.deep.equal(
       Object.assign(
         {
           foo: new params.ParamValue("bar", false, { string: true }),

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -489,7 +489,7 @@ async function ensureSecret(
   nonInteractive?: boolean,
   force?: boolean,
 ): Promise<string> {
-  let resourceId = secretParam.resourceId || secretParam.name;
+  const resourceId = secretParam.resourceId || secretParam.name;
   const version = secretParam.version || "latest";
   let secretAlreadyExisted = false;
 
@@ -504,12 +504,11 @@ async function ensureSecret(
     }
     if (experiments.isEnabled("secretEnvParams") && typeof secretParam.resourceId === "undefined") {
       if (force) {
-        logger.info(
-          `--force: Using default resource ID while creating secreat ${secretParam.name}`,
-        );
+        logger.info(`--force: Using default resource ID for secret ${secretParam.name}`);
+        secretParam.resourceId = secretParam.name;
       } else {
         // TODO: Move the explanation and link to Cloud Secret Manager in the next prompt here once this makes it out of experimental.
-        resourceId = await input({
+        secretParam.resourceId = await input({
           default: secretParam.name,
           message: `What resource ID do you want to use for the backing Secret resource for secret param ${secretParam.name}?`,
           validate: (id) => {
@@ -520,6 +519,7 @@ async function ensureSecret(
           },
         });
       }
+      return ensureSecret(secretParam, projectId, nonInteractive, force);
     }
     const promptMessage = `The value for this secret (${secretParam.name}) will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${resourceId}. Enter ${secretParam.format === "json" ? "a JSON value" : "a value"} for ${
       secretParam.label || secretParam.name

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -542,8 +542,7 @@ async function ensureSecret(
     secretAlreadyExisted = true;
   }
 
-  const secretRefString =
-    typeof version === "undefined" ? resourceId : `${resourceId}:${version}`;
+  const secretRefString = typeof version === "undefined" ? resourceId : `${resourceId}:${version}`;
   if (experiments.isEnabled("secretEnvParams")) {
     if (!secretParam.inLocalEnvironment && secretAlreadyExisted) {
       logger.info(

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -490,7 +490,7 @@ async function ensureSecret(
   const version = secretParam.version || "latest";
   let secretAlreadyExisted = false;
 
-  const metadata = await secretManager.getSecretMetadata(projectId, resourceId, "latest");
+  const metadata = await secretManager.getSecretMetadata(projectId, resourceId, version);
   if (!metadata.secret) {
     if (nonInteractive) {
       throw new FirebaseError(

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -395,6 +395,7 @@ export async function resolveParams(
   firebaseConfig: FirebaseConfig,
   userEnvs: Record<string, ParamValue>,
   nonInteractive?: boolean,
+  force?: boolean,
   isEmulator = false,
 ): Promise<{ paramValues: Record<string, ParamValue>; secretRefs: Record<string, string> }> {
   const paramValues: Record<string, ParamValue> = populateDefaultParams(firebaseConfig);
@@ -417,6 +418,7 @@ export async function resolveParams(
         param as SecretParam,
         firebaseConfig.projectId,
         nonInteractive,
+        force,
       );
     }
   }
@@ -485,6 +487,7 @@ async function ensureSecret(
   secretParam: SecretParam,
   projectId: string,
   nonInteractive?: boolean,
+  force?: boolean,
 ): Promise<string> {
   let resourceId = secretParam.resourceId || secretParam.name;
   const version = secretParam.version || "latest";
@@ -499,18 +502,24 @@ async function ensureSecret(
           `\tfirebase functions:secrets:set ${resourceId}${secretParam.format === "json" ? " --format=json --data-file <file.json>" : ""}`,
       );
     }
-    if (experiments.isEnabled("secretEnvParams")) {
-      // TODO: Move the explanation and link to Cloud Secret Manager in the next prompt here once this makes it out of experimental.
-      resourceId = await input({
-        default: secretParam.name,
-        message: `What resource ID do you want to use for the backing Secret resource for secret param ${secretParam.name}?`,
-        validate: (id) => {
-          if (new RegExp(`^${build.GCP_SECRET_ID_PATTERN}$`).test(id)) {
-            return true;
-          }
-          return "GCP Secret identifiers must contain only letters, numbers, underscores, and hyphens.";
-        },
-      });
+    if (experiments.isEnabled("secretEnvParams") && typeof secretParam.resourceId === "undefined") {
+      if (force) {
+        logger.info(
+          `--force: Using default resource ID while creating secreat ${secretParam.name}`,
+        );
+      } else {
+        // TODO: Move the explanation and link to Cloud Secret Manager in the next prompt here once this makes it out of experimental.
+        resourceId = await input({
+          default: secretParam.name,
+          message: `What resource ID do you want to use for the backing Secret resource for secret param ${secretParam.name}?`,
+          validate: (id) => {
+            if (new RegExp(`^${build.GCP_SECRET_ID_PATTERN}$`).test(id)) {
+              return true;
+            }
+            return "GCP Secret identifiers must contain only letters, numbers, underscores, and hyphens.";
+          },
+        });
+      }
     }
     const promptMessage = `The value for this secret (${secretParam.name}) will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${resourceId}. Enter ${secretParam.format === "json" ? "a JSON value" : "a value"} for ${
       secretParam.label || secretParam.name

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -543,7 +543,7 @@ async function ensureSecret(
   }
 
   const secretRefString =
-    typeof version === "undefined" ? "resourceId" : `${resourceId}:${version}`;
+    typeof version === "undefined" ? resourceId : `${resourceId}:${version}`;
   if (experiments.isEnabled("secretEnvParams")) {
     if (!secretParam.inLocalEnvironment && secretAlreadyExisted) {
       logger.info(

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -477,7 +477,7 @@ function populateDefaultParams(config: FirebaseConfig): Record<string, ParamValu
 
 /**
  * Handles a SecretParam by checking for the presence of a corresponding secret
- * in Cloud Secrets Manager.
+ * in Cloud Secrets Manager. Assist the user with secret creation if not present.
  * @return a Functions-formatted reference (e.g "foo:latest") to a Secret
  * resource which has been verified to exist/have just been created
  */
@@ -486,7 +486,7 @@ async function ensureSecret(
   projectId: string,
   nonInteractive?: boolean,
 ): Promise<string> {
-  const resourceId = secretParam.resourceId || secretParam.name;
+  let resourceId = secretParam.resourceId || secretParam.name;
   const version = secretParam.version || "latest";
   let secretAlreadyExisted = false;
 
@@ -499,10 +499,22 @@ async function ensureSecret(
           `\tfirebase functions:secrets:set ${resourceId}${secretParam.format === "json" ? " --format=json --data-file <file.json>" : ""}`,
       );
     }
+    if (experiments.isEnabled("secretEnvParams")) {
+      // TODO: Move the explanation and link to Cloud Secret Manager in the next prompt here once this makes it out of experimental.
+      resourceId = await input({
+        default: secretParam.name,
+        message: `What resource ID do you want to use for the backing Secret resource for secret param ${secretParam.name}?`,
+        validate: (id) => {
+          if (new RegExp(`^${build.GCP_SECRET_ID_PATTERN}$`).test(id)) {
+            return true;
+          }
+          return "GCP Secret identifiers must contain only letters, numbers, underscores, and hyphens.";
+        },
+      });
+    }
     const promptMessage = `The value for this secret (${secretParam.name}) will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${resourceId}. Enter ${secretParam.format === "json" ? "a JSON value" : "a value"} for ${
       secretParam.label || secretParam.name
     }:`;
-
     const secretValue = await password({
       message: promptMessage,
     });
@@ -530,7 +542,8 @@ async function ensureSecret(
     secretAlreadyExisted = true;
   }
 
-  const secretRefString = `${resourceId}:${version}`;
+  const secretRefString =
+    typeof version === "undefined" ? "resourceId" : `${resourceId}:${version}`;
   if (experiments.isEnabled("secretEnvParams")) {
     if (!secretParam.inLocalEnvironment && secretAlreadyExisted) {
       logger.info(

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -9,6 +9,7 @@ import { listBuckets } from "../../gcp/storage";
 import { isCelExpression, resolveExpression } from "./cel";
 import { FirebaseConfig } from "./args";
 import { labels as secretLabels } from "../../gcp/secretManager";
+import * as experiments from "../../experiments";
 
 // A convenience type containing options for Prompt's select
 interface ListItem {
@@ -229,7 +230,7 @@ interface SecretParam {
   // The format of the secret, e.g. "json"
   format?: string;
 
-  // The resource name of the backing Secret in Cloud Secret Manager. 
+  // The resource name of the backing Secret in Cloud Secret Manager.
   // Defaults to `name` if not present.
   resourceId?: string;
 
@@ -395,7 +396,7 @@ export async function resolveParams(
   userEnvs: Record<string, ParamValue>,
   nonInteractive?: boolean,
   isEmulator = false,
-): Promise<{paramValues: Record<string, ParamValue>, secretRefs: Record<string, string>}> {
+): Promise<{ paramValues: Record<string, ParamValue>; secretRefs: Record<string, string> }> {
   const paramValues: Record<string, ParamValue> = populateDefaultParams(firebaseConfig);
   const secretRefs: Record<string, string> = {};
 
@@ -412,7 +413,11 @@ export async function resolveParams(
   // The functions emulator will handle secrets
   if (!isEmulator) {
     for (const param of needSecret) {
-      secretRefs[param.name] = await ensureSecret(param as SecretParam, firebaseConfig.projectId, nonInteractive);
+      secretRefs[param.name] = await ensureSecret(
+        param as SecretParam,
+        firebaseConfig.projectId,
+        nonInteractive,
+      );
     }
   }
 
@@ -438,7 +443,7 @@ export async function resolveParams(
     paramValues[param.name] = await promptParam(param, firebaseConfig.projectId, paramDefault);
   }
 
-  return {paramValues: paramValues, secretRefs: secretRefs};
+  return { paramValues: paramValues, secretRefs: secretRefs };
 }
 
 function populateDefaultParams(config: FirebaseConfig): Record<string, ParamValue> {
@@ -473,8 +478,7 @@ function populateDefaultParams(config: FirebaseConfig): Record<string, ParamValu
 /**
  * Handles a SecretParam by checking for the presence of a corresponding secret
  * in Cloud Secrets Manager.
- * 
- * @returns a Functions-formatted reference (e.g "foo:latest") to a Secret
+ * @return a Functions-formatted reference (e.g "foo:latest") to a Secret
  * resource which has been verified to exist/have just been created
  */
 async function ensureSecret(
@@ -486,18 +490,16 @@ async function ensureSecret(
   const version = secretParam.version || "latest";
   let secretAlreadyExisted = false;
 
-  const metadata = await secretManager.getSecretMetadata(projectId, secretParam.name, "latest");
+  const metadata = await secretManager.getSecretMetadata(projectId, resourceId, "latest");
   if (!metadata.secret) {
     if (nonInteractive) {
       throw new FirebaseError(
-        `In non-interactive mode but have no value for the secret: ${secretParam.name}\n\n` +
+        `In non-interactive mode but have no value for the secret ${secretParam.name}: ${resourceId}\n\n` +
           "Set this secret before deploying:\n" +
-          `\tfirebase functions:secrets:set ${secretParam.name}${secretParam.format === "json" ? " --format=json --data-file <file.json>" : ""}`,
+          `\tfirebase functions:secrets:set ${resourceId}${secretParam.format === "json" ? " --format=json --data-file <file.json>" : ""}`,
       );
     }
-    const promptMessage = `This secret will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${
-      secretParam.name
-    }. Enter ${secretParam.format === "json" ? "a JSON value" : "a value"} for ${
+    const promptMessage = `The value for this secret (${secretParam.name}) will be stored in Cloud Secret Manager (https://cloud.google.com/secret-manager/pricing) as ${resourceId}. Enter ${secretParam.format === "json" ? "a JSON value" : "a value"} for ${
       secretParam.label || secretParam.name
     }:`;
 
@@ -507,8 +509,8 @@ async function ensureSecret(
     if (secretParam.format === "json") {
       validateJsonSecret(secretParam.name, secretValue);
     }
-    await secretManager.createSecret(projectId, secretParam.name, secretLabels());
-    await secretManager.addVersion(projectId, secretParam.name, secretValue);
+    await secretManager.createSecret(projectId, resourceId, secretLabels());
+    await secretManager.addVersion(projectId, resourceId, secretValue);
   } else if (!metadata.secretVersion) {
     throw new FirebaseError(
       `Cloud Secret Manager has no latest version of the secret defined by param ${
@@ -528,11 +530,16 @@ async function ensureSecret(
     secretAlreadyExisted = true;
   }
 
-  if (!secretParam.inLocalEnvironment && secretAlreadyExisted) {
-
+  const secretRefString = `${resourceId}:${version}`;
+  if (experiments.isEnabled("secretEnvParams")) {
+    if (!secretParam.inLocalEnvironment && secretAlreadyExisted) {
+      logger.info(
+        `Onetime (firebase-tools x.y.z+): storing a reference to existing secret ${secretParam.name}=${secretRefString} in .env files.`,
+      );
+    }
   }
 
-  return `${resourceId}:${version}`;
+  return secretRefString;
 }
 
 /**

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -228,6 +228,19 @@ interface SecretParam {
 
   // The format of the secret, e.g. "json"
   format?: string;
+
+  // The resource name of the backing Secret in Cloud Secret Manager. 
+  // Defaults to `name` if not present.
+  resourceId?: string;
+
+  // The version of the backing Secret to use. Can be an index, "latest",
+  // or a previously configured version alias. Functions will resolve the version to
+  // the current latest version if not present.
+  version?: string;
+
+  // Internal use only. Populated with whether or not a corresponding FIREBASE_SECRET_REF_
+  // key was found in the local .env files.
+  inLocalEnvironment?: boolean;
 }
 
 export type Param = StringParam | IntParam | BooleanParam | ListParam | SecretParam;
@@ -382,8 +395,9 @@ export async function resolveParams(
   userEnvs: Record<string, ParamValue>,
   nonInteractive?: boolean,
   isEmulator = false,
-): Promise<Record<string, ParamValue>> {
+): Promise<{paramValues: Record<string, ParamValue>, secretRefs: Record<string, string>}> {
   const paramValues: Record<string, ParamValue> = populateDefaultParams(firebaseConfig);
+  const secretRefs: Record<string, string> = {};
 
   // TODO(vsfan@): should we ever reject param values from .env files based on the appearance of the string?
   const [resolved, outstanding] = partition(params, (param) => {
@@ -398,7 +412,7 @@ export async function resolveParams(
   // The functions emulator will handle secrets
   if (!isEmulator) {
     for (const param of needSecret) {
-      await handleSecret(param as SecretParam, firebaseConfig.projectId, nonInteractive);
+      secretRefs[param.name] = await ensureSecret(param as SecretParam, firebaseConfig.projectId, nonInteractive);
     }
   }
 
@@ -424,7 +438,7 @@ export async function resolveParams(
     paramValues[param.name] = await promptParam(param, firebaseConfig.projectId, paramDefault);
   }
 
-  return paramValues;
+  return {paramValues: paramValues, secretRefs: secretRefs};
 }
 
 function populateDefaultParams(config: FirebaseConfig): Record<string, ParamValue> {
@@ -458,18 +472,20 @@ function populateDefaultParams(config: FirebaseConfig): Record<string, ParamValu
 
 /**
  * Handles a SecretParam by checking for the presence of a corresponding secret
- * in Cloud Secrets Manager. If not present, we currently ask the user to
- * create a corresponding one using functions:secret:set.
- * Firebase-tools is not responsible for providing secret values to the Functions
- * runtime environment, since having viewer permissions on a function is enough
- * to read its environment variables. They are instead provided through GCF's own
- * Secret Manager integration.
+ * in Cloud Secrets Manager.
+ * 
+ * @returns a Functions-formatted reference (e.g "foo:latest") to a Secret
+ * resource which has been verified to exist/have just been created
  */
-async function handleSecret(
+async function ensureSecret(
   secretParam: SecretParam,
   projectId: string,
   nonInteractive?: boolean,
-): Promise<void> {
+): Promise<string> {
+  const resourceId = secretParam.resourceId || secretParam.name;
+  const version = secretParam.version || "latest";
+  let secretAlreadyExisted = false;
+
   const metadata = await secretManager.getSecretMetadata(projectId, secretParam.name, "latest");
   if (!metadata.secret) {
     if (nonInteractive) {
@@ -493,7 +509,6 @@ async function handleSecret(
     }
     await secretManager.createSecret(projectId, secretParam.name, secretLabels());
     await secretManager.addVersion(projectId, secretParam.name, secretValue);
-    return;
   } else if (!metadata.secretVersion) {
     throw new FirebaseError(
       `Cloud Secret Manager has no latest version of the secret defined by param ${
@@ -509,7 +524,15 @@ async function handleSecret(
         secretParam.label || secretParam.name
       } is in illegal state ${metadata.secretVersion.state}`,
     );
+  } else {
+    secretAlreadyExisted = true;
   }
+
+  if (!secretParam.inLocalEnvironment && secretAlreadyExisted) {
+
+  }
+
+  return `${resourceId}:${version}`;
 }
 
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -297,7 +297,9 @@ export async function prepare(
     });
 
     functionsEnv.writeResolvedParams(resolvedEnvs, userEnvs, userEnvOpt);
-    functionsEnv.writeResolvedSecretRefs(resolvedSecretRefs, secretRefs, userEnvOpt);
+    if (experiments.isEnabled("secretEnvParams")) {
+      functionsEnv.writeResolvedSecretRefs(resolvedSecretRefs, secretRefs, userEnvOpt);
+    }
 
     let hasEnvsFromParams = false;
     wantBackend.environmentVariables = envs;

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -293,6 +293,7 @@ export async function prepare(
       firebaseConfig,
       userEnvs,
       nonInteractive: options.nonInteractive,
+      force: options.force,
       isEmulator: false,
     });
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -286,7 +286,11 @@ export async function prepare(
       build.applyEnvSecretBindings(wantBuild, parsedSecretRefs);
     }
 
-    const { backend: wantBackend, envs: resolvedEnvs } = await build.resolveBackend({
+    const {
+      backend: wantBackend,
+      envs: resolvedEnvs,
+      secretRefs: resolvedSecretRefs,
+    } = await build.resolveBackend({
       build: wantBuild,
       firebaseConfig,
       userEnvs,
@@ -295,6 +299,7 @@ export async function prepare(
     });
 
     functionsEnv.writeResolvedParams(resolvedEnvs, userEnvs, userEnvOpt);
+    functionsEnv.writeResolvedSecretRefs(resolvedSecretRefs, secretRefs, userEnvOpt);
 
     let hasEnvsFromParams = false;
     wantBackend.environmentVariables = envs;

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -214,6 +214,12 @@ export const ALL_EXPERIMENTS = experiments({
     default: false,
     public: true,
   },
+  secretEnvParams: {
+    shortDescription:
+      "Enable writing the backing resource binding for a Functions secret param to .env",
+    default: false,
+    public: false,
+  },
 });
 
 export type ExperimentName = keyof typeof ALL_EXPERIMENTS;

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -459,9 +459,10 @@ export function writeResolvedSecretRefs(
   const toWrite: Record<string, string> = {};
 
   for (const secretName of Object.keys(resolvedSecretRefs)) {
-    const resolvedRef = resolvedSecretRefs[secretName];
-    if (!Object.prototype.hasOwnProperty.call(haveSecretRefs, secretName)) {
-      const reservedKey = "FIREBASE_SECRET_REF_" + secretName.toUpperCase();
+    const uppercaseName = secretName.toUpperCase();
+    const resolvedRef = resolvedSecretRefs[uppercaseName];
+    if (!Object.prototype.hasOwnProperty.call(haveSecretRefs, uppercaseName)) {
+      const reservedKey = "FIREBASE_SECRET_REF_" + uppercaseName;
       toWrite[reservedKey] = resolvedRef;
     }
   }

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -445,3 +445,24 @@ export function writeResolvedParams(
 
   writeUserEnvs(toWrite, userEnvOpt);
 }
+
+/**
+ * Writes newly defined secret bindings to the appropriate env file.
+ */
+export function writeResolvedSecretRefs(
+  resolvedSecretRefs: Readonly<Record<string, string>>,
+  haveSecretRefs: Readonly<Record<string, string>>,
+  userEnvOpt: UserEnvsOpts,
+): void {
+  const toWrite: Record<string, string> = {};
+
+  for (const secretName of Object.keys(resolvedSecretRefs)) {
+    const resolvedRef = resolvedSecretRefs[secretName];
+    if (!Object.prototype.hasOwnProperty.call(haveSecretRefs, secretName)) {
+      const reservedKey = "FIREBASE_SECRET_REF_" + secretName.toUpperCase();
+      toWrite[reservedKey] = resolvedRef;
+    }
+  }
+
+  writeUserEnvs(toWrite, userEnvOpt);
+}

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -94,25 +94,24 @@ interface ParseResult {
  *
  * Each line should contain key, value pairs, e.g.:
  *
- *   SERVICE_URL=https://example.com
+ * SERVICE_URL=https://example.com
  *
  * Values can be double quoted, e.g.:
  *
- *   SERVICE_URL="https://example.com"
+ * SERVICE_URL="https://example.com"
  *
  * Double quoted values can include newlines, e.g.:
  *
- *   PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nABC\nEFG\n-----BEGIN PUBLIC KEY-----""
+ * PUBLIC_KEY="-----BEGIN PUBLIC KEY-----\nABC\nEFG\n-----BEGIN PUBLIC KEY-----""
  *
  * or span multiple lines, e.g.:
  *
- *   PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
- *   ABC
- *   EFG
- *   -----BEGIN PUBLIC KEY-----"
+ * PUBLIC_KEY="-----BEGIN PUBLIC KEY-----
+ * ABC
+ * EFG
+ * -----BEGIN PUBLIC KEY-----"
  *
  * See test for more examples.
- *
  * @return {ParseResult} Result containing parsed key, value pairs and errored lines.
  */
 export function parse(data: string): ParseResult {
@@ -258,7 +257,6 @@ export interface UserEnvsOpts {
 
 /**
  * Checks if user has specified any environment variables for their functions.
- *
  * @return True if there are any user-specified environment variables
  */
 export function hasUserEnvs(opts: UserEnvsOpts): boolean {
@@ -364,11 +362,10 @@ function formatUserEnvForWrite(key: string, value: string): string {
  *
  * .env files are searched and merged in the following order:
  *
- *   1. .env
- *   2. .env.<project or alias>
+ * 1. .env
+ * 2. .env.<project or alias>
  *
  * If both .env.<project> and .env.<alias> files are found, an error is thrown.
- *
  * @return {Record<string, string>} Environment variables for the project.
  */
 export function loadUserEnvs(opts: UserEnvsOpts): Record<string, string> {
@@ -412,7 +409,6 @@ export function loadUserEnvs(opts: UserEnvsOpts): Record<string, string> {
 
 /**
  * Load Firebase-set environment variables.
- *
  * @return Environment varibles for functions.
  */
 export function loadFirebaseEnvs(
@@ -448,6 +444,7 @@ export function writeResolvedParams(
 
 /**
  * Writes newly defined secret bindings to the appropriate env file.
+ * Does not overwrite secrets that already exist anywhere in the .env chain.
  */
 export function writeResolvedSecretRefs(
   resolvedSecretRefs: Readonly<Record<string, string>>,


### PR DESCRIPTION
This PR centers around changes made to the handleSecret()/now ensureSecret() method invoked during param resolution. Formerly, handleSecret() only made sure that a Cloud Secret with a resource name matching the name of the Secret Param existed with a readable latest version.

Now:
1) It can use an alternative resource name and version identifier from the Secret Param, which has been merged into the Param object earlier in deployment by applyEnvSecretBindings().
2) It emits a string representing the secret binding which should be written to .env files. These strings are propagated up the call chain to prepare.ts, which has them inserted to .env files only if not present using the same mechanisms that currently write other params.
3) It logs an INFO-level notification in the case where the backing Cloud Secret already existed but no matching record in .env files existed, in which case we are basically "importing" a secret that already existed. Open to wording suggestions here, especially if we should specifically advise users to commit to version control.

Intended behavior after merging this PR on deploy:
- Secret Param exists, .env secret exists: applyEnvSecretBindings seamlessly overrides the Secret to look in the place specified by .env, which satisfies ensureSecret().
- Secret Param missing, .env secret exists: no-op; since defineSecret() was never called during discovery, no corresponding record exists in build.SecretEnvVars and applyEnvSecretBindings skips the .env secret.
- Secret Param exists, .env secret missing: ensureSecret() checks to see whether a Secret resource exists at the "default" secret location. If so, it logs a warning and writes that default secret to .envs. Otherwise, it helps the user create a secret and upon success writes it to .env files.