### PR TITLE
chore: remove warning about dart functions not being shown in Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Removed the warning that Dart functions may not yet be visible in the Firebase Console, since they are now shown.

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -18,7 +18,6 @@ import { FirebaseError } from "../../../error";
 import { getProjectNumber } from "../../../getProjectNumber";
 import { release as extRelease } from "../../extensions";
 import * as artifacts from "../../../functions/artifacts";
-import { runtimeIsLanguage } from "../runtimes/supported";
 import { determineDeploymentEvent, executeLifecycleHooks } from "./lifecycle";
 
 /** Releases new versions of functions and extensions to prod. */
@@ -124,17 +123,6 @@ export async function release(
   // trigger URLs by calling existingBackend again.
   const wantBackend = backend.merge(...Object.values(payload.functions).map((p) => p.wantBackend));
   printTriggerUrls(wantBackend, projectNumber);
-
-  // TODO: Remove once the Firebase console has support.
-  if (
-    backend.someEndpoint(wantBackend, (endpoint) => runtimeIsLanguage(endpoint.runtime, "dart"))
-  ) {
-    utils.logLabeledBullet(
-      "functions",
-      "Dart functions may not yet be visible in the Firebase Console. " +
-        `View them in the Cloud Console at https://console.cloud.google.com/run/services?project=${context.projectId}`,
-    );
-  }
 
   const allErrors = summary.results.filter((r) => r.error).map((r) => r.error) as Error[];
 


### PR DESCRIPTION
### Scenarios Tested
- npm test
- npm run lint:changed-files
- firebase deploy --only functions (with Dart functions)
