### PR TITLE
Display a helpful error instead of Unexpected Error for key validation

### DIFF
--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -151,7 +151,7 @@ export function parse(data: string): ParseResult {
   return { envs, errors };
 }
 
-export class KeyValidationError extends Error {
+export class KeyValidationError extends FirebaseError {
   constructor(
     public key: string,
     public message: string,


### PR DESCRIPTION
Because KeyValidationError wasn't instanceof FirebaseError, the catchall error handler in errorOut.ts was just printing "Error: An unexpected error has occurred"