### PR TITLE
fix(hosting): don't fail deploy when the version is already the active release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
+- Fixed `firebase deploy --only hosting` to the live channel exiting with an error when the deployed version is already the channel's active version. (#10730)

--- a/src/deploy/hosting/release.spec.ts
+++ b/src/deploy/hosting/release.spec.ts
@@ -7,6 +7,7 @@ import * as convertConfigPkg from "./convertConfig";
 
 import { release } from "./release";
 import { last } from "../../utils";
+import { FirebaseError } from "../../error";
 
 describe("release", () => {
   const PROJECT = "fake-project";
@@ -77,6 +78,21 @@ describe("release", () => {
       expect(createReleaseStub).to.have.been.calledOnceWithExactly(SITE, "live", VERSION, {
         message: "hello world",
       });
+    });
+
+    it("should treat a 400 'current active version' response as success (#10730)", async () => {
+      updateVersionStub.resolves({});
+      createReleaseStub.rejects(
+        new FirebaseError(
+          `HTTP Error: 400, ${VERSION} is the current active version of the live channel`,
+          { status: 400 },
+        ),
+      );
+
+      // The deploy has effectively succeeded, so release() should not throw.
+      await release(CONTEXT, {}, {});
+
+      expect(createReleaseStub).to.have.been.calledOnce;
     });
   });
 

--- a/src/deploy/hosting/release.ts
+++ b/src/deploy/hosting/release.ts
@@ -49,13 +49,32 @@ export async function release(
       if (options.message) {
         otherReleaseOpts.message = options.message;
       }
-      const release = await api.createRelease(
-        deploy.config.site,
-        context.hostingChannel || "live",
-        deploy.version,
-        otherReleaseOpts,
-      );
-      logger.debug("[hosting] release:", release);
+      try {
+        const release = await api.createRelease(
+          deploy.config.site,
+          context.hostingChannel || "live",
+          deploy.version,
+          otherReleaseOpts,
+        );
+        logger.debug("[hosting] release:", release);
+      } catch (err: unknown) {
+        // A 400 "<version> is the current active version" means the channel is
+        // already serving this version, so the deploy has effectively succeeded.
+        // Treat it as success instead of failing the whole command (#10730).
+        if (
+          !(
+            err instanceof FirebaseError &&
+            err.status === 400 &&
+            /is the current active version/i.test(err.message)
+          )
+        ) {
+          throw err;
+        }
+        logger.debug(
+          `[hosting] version is already the active release for ${deploy.config.site}, skipping:`,
+          err.message,
+        );
+      }
       utils.logLabeledSuccess(`hosting[${deploy.config.site}]`, "release complete");
     }),
   );


### PR DESCRIPTION
### Description

Fixes #10730.

When deploying to a channel whose active version already matches the version being released, the Hosting API returns:

```
HTTP Error: 400, <version> is the current active version of the <channel> channel
```

`release()` (`src/deploy/hosting/release.ts`) let that error propagate, so `firebase deploy --only hosting` exited 1 even though the deploy effectively succeeded — the site was already serving the deployed content. Multiple users reported this as a 15.22.3 regression.

The fix treats that specific benign 400 as a successful release: `release()` now catches a `FirebaseError` with `status === 400` whose message contains "is the current active version", logs it at debug level, and reports the release complete. Any other error still propagates.

Note: I wasn't able to reproduce the exact 15.22.3 trigger without a live Hosting deploy (the `release()`/`createRelease` code paths haven't changed recently), so this addresses the user-facing symptom by handling the benign response gracefully — arguably correct behavior regardless of the trigger. Happy to iterate if you'd prefer to trace the root-cause change instead.

### Scenarios Tested

- Added a unit test in `src/deploy/hosting/release.spec.ts` that stubs `api.createRelease` to reject with the 400 "current active version" error and asserts `release()` resolves (does not throw). It fails before the change and passes after.
- Existing `release.spec.ts` tests still pass (`6 passing`).
- `prettier --check` and `eslint` are clean on the changed files; added a CHANGELOG entry.

### Sample Commands

```
firebase deploy --only hosting --project <project-id>
```

(run against a Hosting project whose live channel is already serving the version being deployed)
