### PR TITLE
feat: add functions:kits:install command under kits experiment

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -1,0 +1,94 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+
+import { command } from "./functions-kits-install";
+import { Config } from "../config";
+import { FirebaseError } from "../error";
+import * as spawn from "../init/spawn";
+
+describe("functions:kits:install", () => {
+  let sandbox: sinon.SinonSandbox;
+  let configLoadStub: sinon.SinonStub;
+  let wrapSpawnStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    configLoadStub = sandbox.stub(Config, "load");
+    wrapSpawnStub = sandbox.stub(spawn, "wrapSpawn").resolves();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should throw an error if --npm_package is not provided", async () => {
+    await expect(command.runner()({})).to.be.rejectedWith(
+      FirebaseError,
+      /Must specify an npm package/,
+    );
+  });
+
+  it("should throw an error if not in a Firebase project directory", async () => {
+    configLoadStub.returns(null);
+    await expect(command.runner()({ npm_package: "my-package" })).to.be.rejectedWith(
+      FirebaseError,
+      /Must be run from a Firebase project directory/,
+    );
+  });
+
+  it("should initialize codebase matching the package name and install dependencies", async () => {
+    const mockConfig = {
+      src: { functions: [] },
+      defaults: {},
+      projectDir: "/mock/project",
+      set: sinon.spy(),
+      writeProjectFile: sinon.spy(),
+      askWriteProjectFile: sinon.stub().resolves(),
+      readProjectFile: sinon.stub().callsFake((filepath: string) => {
+        if (filepath.endsWith("package.json")) {
+          // Simulate package.json after npm install --save @org/test-package
+          return {
+            dependencies: {
+              "firebase-admin": "^13.6.0",
+              "firebase-functions": "^7.0.0",
+              "@org/test-package": "^1.0.0",
+            },
+          };
+        }
+        return {};
+      }),
+    };
+    configLoadStub.returns(mockConfig);
+
+    await command.runner()({ npm_package: "@org/test-package@^1.0.0" });
+
+    expect(mockConfig.set.calledOnce).to.be.true;
+    expect(mockConfig.set.firstCall.args[0]).to.equal("functions");
+    expect(mockConfig.set.firstCall.args[1]).to.deep.equal([
+      {
+        source: "org-test-package100",
+        codebase: "org-test-package100",
+        predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+        disallowLegacyRuntimeConfig: true,
+      },
+    ]);
+    expect(mockConfig.writeProjectFile.calledWith("firebase.json")).to.be.true;
+    expect(
+      mockConfig.askWriteProjectFile.calledWith(
+        "org-test-package100/src/index.ts",
+        'export * from "@org/test-package";\n',
+      ),
+    ).to.be.true;
+    expect(wrapSpawnStub.calledThrice).to.be.true;
+    expect(wrapSpawnStub.secondCall.args).to.deep.equal([
+      "npm",
+      ["install", "--save", "@org/test-package@^1.0.0"],
+      "/mock/project/org-test-package100",
+    ]);
+    expect(wrapSpawnStub.thirdCall.args).to.deep.equal([
+      "npm",
+      ["run", "build"],
+      "/mock/project/org-test-package100",
+    ]);
+  });
+});

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -1,0 +1,170 @@
+import * as clc from "colorette";
+
+import { Command } from "../command";
+import { Config } from "../config";
+import { FirebaseError } from "../error";
+import { logger } from "../logger";
+import { wrapSpawn } from "../init/spawn";
+import { readTemplateSync } from "../templates";
+import * as supported from "../deploy/functions/runtimes/supported";
+import {
+  assertUnique,
+  normalize,
+  validateCodebase,
+  ValidatedConfig,
+} from "../functions/projectConfig";
+import * as utils from "../utils";
+
+const PACKAGE_NO_LINTING_TEMPLATE = readTemplateSync(
+  "init/functions/typescript/package.nolint.json",
+);
+const TSCONFIG_TEMPLATE = readTemplateSync("init/functions/typescript/tsconfig.json");
+const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/typescript/_gitignore");
+
+function sanitizePackageNameToCodebase(pkgName: string): string {
+  const sanitized = pkgName
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/\//g, "-")
+    .replace(/[^a-z0-9_-]/g, "");
+  if (!sanitized) {
+    return "functions";
+  }
+  return sanitized.slice(0, 63);
+}
+
+export const command = new Command("functions:kits:install")
+  .description("install an npm package filled with Cloud Functions into a new functions codebase")
+  .option("--npm_package <package_name>", "the npm package containing Cloud Functions to install")
+  .option(
+    "--codebase <codebase>",
+    "the codebase name to initialize (defaults to sanitized package name)",
+  )
+  .option("--source <source>", "the directory for the new codebase (defaults to codebase name)")
+  .action(async (options: { npm_package?: string; codebase?: string; source?: string } & any) => {
+    if (!options.npm_package) {
+      throw new FirebaseError(
+        `Must specify an npm package in ${clc.bold("--npm_package <package_name>")} option.`,
+      );
+    }
+
+    const config = Config.load(options, true);
+    if (!config) {
+      throw new FirebaseError(
+        "Must be run from a Firebase project directory. Run 'firebase init' to initialize.",
+      );
+    }
+
+    let existingFunctions: ValidatedConfig | [] = [];
+    if (
+      config.src.functions &&
+      (!Array.isArray(config.src.functions) || config.src.functions.length > 0)
+    ) {
+      try {
+        existingFunctions = normalize(config.src.functions) as ValidatedConfig;
+      } catch (err: any) {
+        throw new FirebaseError(`Invalid existing functions configuration: ${err.message}`);
+      }
+    }
+
+    const codebase = options.codebase || sanitizePackageNameToCodebase(options.npm_package);
+    const source = options.source || codebase;
+
+    try {
+      validateCodebase(codebase);
+      if (existingFunctions.length > 0) {
+        assertUnique(existingFunctions as any, "codebase", codebase);
+        assertUnique(existingFunctions as any, "source", source);
+      }
+    } catch (err: any) {
+      throw new FirebaseError(`Codebase / source validation failed: ${err.message}`);
+    }
+
+    logger.info(
+      `Creating new functions codebase ${clc.bold(codebase)} in directory ${clc.bold(source)}...`,
+    );
+
+    const newFunctionsConfig = {
+      source,
+      codebase,
+      predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+      disallowLegacyRuntimeConfig: true,
+    };
+
+    let updatedFunctionsConfig: any;
+    if (Array.isArray(config.src.functions)) {
+      updatedFunctionsConfig = [...config.src.functions, newFunctionsConfig];
+    } else if (config.src.functions) {
+      updatedFunctionsConfig = [config.src.functions, newFunctionsConfig];
+    } else {
+      updatedFunctionsConfig = [newFunctionsConfig];
+    }
+
+    config.set("functions", updatedFunctionsConfig);
+    config.writeProjectFile("firebase.json", config.src);
+
+    const runtime = supported.latest("nodejs").replace("nodejs", "");
+    const packageJsonContent = PACKAGE_NO_LINTING_TEMPLATE.replace("{{RUNTIME}}", runtime);
+
+    await config.askWriteProjectFile(`${source}/package.json`, packageJsonContent);
+    await config.askWriteProjectFile(`${source}/tsconfig.json`, TSCONFIG_TEMPLATE);
+    await config.askWriteProjectFile(`${source}/.gitignore`, GITIGNORE_TEMPLATE);
+
+    logger.info(`Installing base dependencies in ${clc.bold(source)}...`);
+    try {
+      await wrapSpawn("npm", ["install"], `${config.projectDir}/${source}`);
+    } catch (err: any) {
+      throw new FirebaseError(`Failed to install base dependencies in ${source}: ${err.message}`);
+    }
+
+    const beforePkg = config.readProjectFile(`${source}/package.json`, {
+      json: true,
+      fallback: {},
+    });
+    const initialDeps = new Set([
+      ...Object.keys(beforePkg.dependencies || {}),
+      ...Object.keys(beforePkg.devDependencies || {}),
+    ]);
+
+    logger.info(`Installing kits package ${clc.bold(options.npm_package)}...`);
+    try {
+      await wrapSpawn(
+        "npm",
+        ["install", "--save", options.npm_package],
+        `${config.projectDir}/${source}`,
+      );
+    } catch (err: any) {
+      throw new FirebaseError(
+        `Failed to install package ${options.npm_package} in ${source}: ${err.message}`,
+      );
+    }
+
+    const afterPkg = config.readProjectFile(`${source}/package.json`, { json: true, fallback: {} });
+    const afterDeps = [
+      ...Object.keys(afterPkg.dependencies || {}),
+      ...Object.keys(afterPkg.devDependencies || {}),
+    ];
+    let installedPackageName = afterDeps.find((dep) => !initialDeps.has(dep));
+    if (!installedPackageName) {
+      const raw = options.npm_package as string;
+      if (raw.startsWith("@")) {
+        installedPackageName = "@" + raw.slice(1).split("@")[0];
+      } else {
+        installedPackageName = raw.split("@")[0];
+      }
+    }
+
+    const indexContent = `export * from "${installedPackageName}";\n`;
+    await config.askWriteProjectFile(`${source}/src/index.ts`, indexContent);
+
+    logger.info(`Building TypeScript functions in ${clc.bold(source)}...`);
+    try {
+      await wrapSpawn("npm", ["run", "build"], `${config.projectDir}/${source}`);
+    } catch (err: any) {
+      throw new FirebaseError(`Failed to build TypeScript functions in ${source}: ${err.message}`);
+    }
+
+    utils.logSuccess(
+      `Successfully installed ${clc.bold(options.npm_package)} into functions codebase ${clc.bold(codebase)}!`,
+    );
+  });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -176,6 +176,10 @@ export function load(client: CLIClient): CLIClient {
   client.functions.secrets.set = loadCommand("functions-secrets-set");
   client.functions.artifacts = {};
   client.functions.artifacts.setpolicy = loadCommand("functions-artifacts-setpolicy");
+  if (experiments.isEnabled("kits")) {
+    client.functions.kits = {};
+    client.functions.kits.install = loadCommand("functions-kits-install");
+  }
   client.help = loadCommand("help");
   client.hosting = {};
   client.hosting.channel = {};

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -90,6 +90,11 @@ export const ALL_EXPERIMENTS = experiments({
     public: true,
     default: false,
   },
+  kits: {
+    shortDescription: "Enable Function Kits.",
+    public: false,
+    default: false,
+  },
 
   // Emulator experiments
   emulatoruisnapshot: {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

Introduces the firebase functions:kits:install CLI command, gated behind the kits experiment flag. This command automates initializing a new Cloud Functions codebase and installing an npm package containing pre-built Cloud Functions.

- Validates options and checks for a valid Firebase project directory.
- Auto-sanitizes the package name into a valid codebase/directory name if --codebase or --source are not specified.
- Appends the new codebase configuration to firebase.json.
- Scaffolds configuration files (package.json, tsconfig.json, .gitignore).
- Installs base dependencies and the specified npm package using npm install.
- Generates src/index.ts to re-export functions from the installed kit package (export * from "<package>";).
- Executes npm run build to compile the TypeScript functions.

### Scenarios Tested

- Tested install of local tarball NPM package
- Unit tests

### Sample Commands

```
# Enable the experiment
firebase experiments: enable kits

# Install a kit package (defaults codebase and source to sanitized package name)
firebase functions:kits:install --npm_package @my-org/my-functions-kit

# Install with explicit codebase and source directory
firebase functions:kits:install --npm_package @my-org/my-functions-kit --codebase custom-kit --source functions-custom
```
