### PR TITLE
chore: rename DeploymentEvent to LifecycleEvent to ensure we have consistent naming.

### DIFF
--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -425,6 +425,8 @@ export interface RequiredAPI {
   api: string;
 }
 
+export type LifecycleEvent = "afterFirstDeploy" | "afterRedeploy";
+
 export type LifecycleHook =
   | {
       task: {
@@ -458,7 +460,7 @@ export interface Backend {
   // region -> id -> Endpoint
   endpoints: Record<string, Record<string, Endpoint>>;
   requiredRoles?: string[];
-  lifecycleHooks?: Record<string, LifecycleHook>;
+  lifecycleHooks?: Partial<Record<LifecycleEvent, LifecycleHook>>;
 }
 
 /**

--- a/src/deploy/functions/prompts.ts
+++ b/src/deploy/functions/prompts.ts
@@ -11,7 +11,7 @@ import * as artifacts from "../../functions/artifacts";
 import { Options } from "../../options";
 import { EndpointUpdate } from "./release/planner";
 import * as iam from "../../gcp/iam";
-import { DeploymentEvent } from "./release/lifecycle";
+import { LifecycleEvent } from "./backend";
 
 export interface ActiveSecurityPlan {
   managedServiceAccount: string;
@@ -404,12 +404,12 @@ export async function promptForLifecycleEvent(
   codebase: string,
   wantBackend: backend.Backend,
   options?: Options,
-): Promise<DeploymentEvent | undefined> {
+): Promise<LifecycleEvent | undefined> {
   const hooks = wantBackend.lifecycleHooks || {};
-  const choices: { name: string; value: DeploymentEvent | "skip" }[] = [];
+  const choices: { name: string; value: LifecycleEvent | "skip" }[] = [];
 
   for (const hookName of Object.keys(hooks)) {
-    choices.push({ name: hookName, value: hookName as DeploymentEvent });
+    choices.push({ name: hookName, value: hookName as LifecycleEvent });
   }
 
   if (choices.length === 0) {
@@ -418,7 +418,7 @@ export async function promptForLifecycleEvent(
 
   choices.push({ name: "skip (default)", value: "skip" });
 
-  const selection = await select<DeploymentEvent | "skip">({
+  const selection = await select<LifecycleEvent | "skip">({
     message: `We cannot determine whether this deployment is a first deploy or a redeploy for codebase "${codebase}" because it is recovering from a previous partial failure.`,
     choices,
     default: "skip",

--- a/src/deploy/functions/release/index.ts
+++ b/src/deploy/functions/release/index.ts
@@ -18,7 +18,7 @@ import { FirebaseError } from "../../../error";
 import { getProjectNumber } from "../../../getProjectNumber";
 import { release as extRelease } from "../../extensions";
 import * as artifacts from "../../../functions/artifacts";
-import { determineDeploymentEvent, executeLifecycleHooks } from "./lifecycle";
+import { determineLifecycleEvent, executeLifecycleHooks } from "./lifecycle";
 
 /** Releases new versions of functions and extensions to prod. */
 export async function release(
@@ -144,7 +144,7 @@ export async function release(
     )) {
       const { errors } = getCodebaseDeployStats(codebase, w, h, summary);
       if (errors.length > 0) {
-        const event = determineDeploymentEvent(h);
+        const event = determineLifecycleEvent(h);
         if (w.lifecycleHooks?.[event]) {
           utils.logLabeledWarning(
             "functions",

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import * as backend from "../backend";
 import {
-  determineDeploymentEvent,
+  determineLifecycleEvent,
   executeLifecycleHooks,
   hasLifecycleHooks,
   isRecoveryDeployment,
@@ -137,11 +137,11 @@ describe("lifecycle", () => {
     });
   });
 
-  describe("determineDeploymentEvent", () => {
+  describe("determineLifecycleEvent", () => {
     it("returns afterFirstDeploy when haveBackend has no endpoints", () => {
       const haveBackend = backend.empty();
 
-      const event = determineDeploymentEvent(haveBackend);
+      const event = determineLifecycleEvent(haveBackend);
       expect(event).to.equal("afterFirstDeploy");
     });
 
@@ -156,7 +156,7 @@ describe("lifecycle", () => {
         state: "FAILED",
       });
 
-      const event = determineDeploymentEvent(haveBackend);
+      const event = determineLifecycleEvent(haveBackend);
       expect(event).to.equal("afterFirstDeploy");
     });
 
@@ -170,7 +170,7 @@ describe("lifecycle", () => {
         httpsTrigger: {},
       });
 
-      const event = determineDeploymentEvent(haveBackend);
+      const event = determineLifecycleEvent(haveBackend);
       expect(event).to.equal("afterRedeploy");
     });
   });

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -10,13 +10,11 @@ import { assertExhaustive } from "../../../functional";
 import { Options } from "../../../options";
 import * as prompts from "../prompts";
 
-export type DeploymentEvent = "afterFirstDeploy" | "afterRedeploy";
-
 /**
  * Determines whether the current deployment represents a fresh codebase deployment
  * (afterFirstDeploy) or an update to an existing deployment (afterRedeploy).
  */
-export function determineDeploymentEvent(haveBackend: backend.Backend): DeploymentEvent {
+export function determineLifecycleEvent(haveBackend: backend.Backend): backend.LifecycleEvent {
   // If haveBackend has no existing active endpoints, this is a fresh installation.
   const hasExistingEndpoints = backend.someEndpoint(haveBackend, (ep) => ep.state !== "FAILED");
   if (!hasExistingEndpoints) {
@@ -88,7 +86,7 @@ export async function executeLifecycleHooks(
     return false;
   }
 
-  let event: DeploymentEvent | undefined;
+  let event: backend.LifecycleEvent | undefined;
   if (isRecoveryDeployment(wantBackend, haveBackend)) {
     event = await prompts.promptForLifecycleEvent(codebase ?? "default", wantBackend, options);
     if (!event) {
@@ -99,7 +97,7 @@ export async function executeLifecycleHooks(
       return false;
     }
   } else {
-    event = determineDeploymentEvent(haveBackend);
+    event = determineLifecycleEvent(haveBackend);
   }
 
   const hooks = wantBackend.lifecycleHooks || {};
@@ -216,7 +214,7 @@ function getCloudConsoleLogUrl(endpoint: backend.Endpoint): string {
  * Executes a specific lifecycle hook in isolation.
  */
 export async function executeHook(
-  event: DeploymentEvent,
+  event: backend.LifecycleEvent,
   hook: backend.LifecycleHook,
   backendSpec: backend.Backend,
 ): Promise<backend.Endpoint | undefined> {


### PR DESCRIPTION
### Description

Renaming DeploymentEvent to LifecycleEvent to have consistent naming across hooks & events with new lifecycle features. This also improves the typing of lifecycleHooks in the Backend interface to guarantee the key is always a LifecycleEvent.

### Scenarios Tested

- npm test
