### PR TITLE
fix(auth): use 127.0.0.1 for OAuth loopback redirect instead of localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
+- Fixed `firebase login` hanging on some dual-stack hosts by using the `127.0.0.1` IP literal for the OAuth loopback redirect instead of `localhost`. (#10750)

--- a/src/auth.spec.ts
+++ b/src/auth.spec.ts
@@ -5,6 +5,7 @@ import {
   assertAccount,
   getAdditionalAccounts,
   getAllAccounts,
+  getCallbackUrl,
   getGlobalDefaultAccount,
   getProjectDefaultAccount,
   selectAccount,
@@ -37,6 +38,24 @@ describe("auth", () => {
   afterEach(() => {
     fakeConfigStore = {};
     sandbox.restore();
+  });
+
+  describe("getCallbackUrl", () => {
+    it("uses the provided host for the loopback redirect", () => {
+      // The Google login flow passes 127.0.0.1: an IP literal is expected by
+      // Google's OAuth loopback flow, and on dual-stack hosts "localhost" can
+      // resolve to ::1 while the listener holds the port on 127.0.0.1, hanging
+      // `firebase login`.
+      expect(getCallbackUrl(9005, "127.0.0.1")).to.equal("http://127.0.0.1:9005");
+    });
+
+    it("defaults to localhost when no host is provided", () => {
+      expect(getCallbackUrl(9005)).to.equal("http://localhost:9005");
+    });
+
+    it("falls back to the OOB redirect when no port is provided", () => {
+      expect(getCallbackUrl()).to.equal("urn:ietf:wg:oauth:2.0:oob");
+    });
   });
 
   describe("no accounts", () => {

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -546,7 +546,6 @@ async function loginWithLocalhostGoogle(port: number, userHint?: string): Promis
   const successHtml = await readTemplate("loginSuccess.html");
   const tokens = await loginWithLocalhost(
     port,
-    GOOGLE_LOOPBACK_HOST,
     callbackUrl,
     authUrl,
     successHtml,
@@ -571,7 +570,6 @@ async function loginWithLocalhostGitHub(port: number): Promise<string> {
   const successHtml = await readTemplate("loginSuccessGithub.html");
   const tokens = await loginWithLocalhost(
     port,
-    "localhost",
     callbackUrl,
     authUrl,
     successHtml,
@@ -583,7 +581,6 @@ async function loginWithLocalhostGitHub(port: number): Promise<string> {
 
 async function loginWithLocalhost<ResultType>(
   port: number,
-  host: string,
   callbackUrl: string,
   authUrl: string,
   successHtml: string,
@@ -616,7 +613,9 @@ async function loginWithLocalhost<ResultType>(
       return;
     });
 
-    server.listen(port, host, () => {
+    // Bind all interfaces so both 127.0.0.1 (Google redirect) and localhost/::1
+    // (GitHub redirect) can reach the callback server on dual-stack hosts.
+    server.listen(port, () => {
       logger.info();
       logger.info("Visit this URL on this device to log in:");
       logger.info(clc.bold(clc.underline(authUrl)));

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -283,11 +283,14 @@ const getPort = portfinder.getPortPromise;
 // in-memory cache, so we have it for successive calls
 let lastAccessToken: TokensWithExpiration | undefined;
 
-function getCallbackUrl(port?: number): string {
+// Google's OAuth 2.0 loopback flow expects an IP literal rather than "localhost".
+const GOOGLE_LOOPBACK_HOST = "127.0.0.1";
+
+export function getCallbackUrl(port?: number, host = "localhost"): string {
   if (typeof port === "undefined") {
     return "urn:ietf:wg:oauth:2.0:oob";
   }
-  return `http://localhost:${port}`;
+  return `http://${host}:${port}`;
 }
 
 function queryParamString(args: { [key: string]: string | undefined }) {
@@ -534,11 +537,16 @@ async function loginRemotely(): Promise<UserCredentials> {
 }
 
 async function loginWithLocalhostGoogle(port: number, userHint?: string): Promise<UserCredentials> {
-  const callbackUrl = getCallbackUrl(port);
+  // Use the 127.0.0.1 IP literal (not "localhost") for the Google OAuth loopback.
+  // Google's OAuth 2.0 loopback flow expects an IP literal, and on dual-stack
+  // hosts "localhost" can resolve to ::1 while the listener holds the port on
+  // 127.0.0.1 (or vice versa), which leaves `firebase login` hanging.
+  const callbackUrl = getCallbackUrl(port, GOOGLE_LOOPBACK_HOST);
   const authUrl = getLoginUrl(callbackUrl, userHint);
   const successHtml = await readTemplate("loginSuccess.html");
   const tokens = await loginWithLocalhost(
     port,
+    GOOGLE_LOOPBACK_HOST,
     callbackUrl,
     authUrl,
     successHtml,
@@ -556,11 +564,14 @@ async function loginWithLocalhostGoogle(port: number, userHint?: string): Promis
 }
 
 async function loginWithLocalhostGitHub(port: number): Promise<string> {
+  // GitHub's OAuth app validates the redirect_uri host against its registered
+  // callback URL, so keep the existing "localhost" host here.
   const callbackUrl = getCallbackUrl(port);
   const authUrl = getGithubLoginUrl(callbackUrl);
   const successHtml = await readTemplate("loginSuccessGithub.html");
   const tokens = await loginWithLocalhost(
     port,
+    "localhost",
     callbackUrl,
     authUrl,
     successHtml,
@@ -572,6 +583,7 @@ async function loginWithLocalhostGitHub(port: number): Promise<string> {
 
 async function loginWithLocalhost<ResultType>(
   port: number,
+  host: string,
   callbackUrl: string,
   authUrl: string,
   successHtml: string,
@@ -604,7 +616,7 @@ async function loginWithLocalhost<ResultType>(
       return;
     });
 
-    server.listen(port, () => {
+    server.listen(port, host, () => {
       logger.info();
       logger.info("Visit this URL on this device to log in:");
       logger.info(clc.bold(clc.underline(authUrl)));


### PR DESCRIPTION
## Description

`firebase login` builds the Google OAuth loopback redirect as `http://localhost:${port}` (`getCallbackUrl` in `src/auth.ts`).

On dual-stack hosts, the browser can resolve `localhost` to `::1` while the OAuth redirect never reaches the CLI, and login hangs on `Waiting for authentication...`.

This uses the `127.0.0.1` IP literal for the **Google** redirect URI so it matches [Google's OAuth 2.0 loopback requirement](https://developers.google.com/identity/protocols/oauth2/native-app#redirect-uri_loopback) (IP literal, not `localhost`).

The **GitHub** login flow stays on `localhost`, since GitHub validates `redirect_uri` against its registered OAuth callback URL.

The local callback server still binds with `server.listen(port)` (all interfaces), so both `127.0.0.1` (Google) and `localhost`/`::1` (GitHub) can reach it on dual-stack hosts.

Fixes #10750.

## Scenarios Tested

- Unit tests: `getCallbackUrl(port, "127.0.0.1")` → `http://127.0.0.1:${port}`, default host stays `localhost`, no port yields the OOB URN.
- `npm run mocha -- src/auth.spec.ts` passes.

## Sample Commands

`firebase login`