### PR TITLE
Add explicit field_mask to Data Connect getConnector call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,5 +6,3 @@
 - Support for specifying that the input for a string or string[] param in Functions must be non-empty (#10678)
 - Removed the warning that Dart functions may not yet be visible in the Firebase Console, since they are now shown.
 - Fixed `dataconnect:execute` command help text. The right env var should be FIREBASE_DATA_CONNECT_EMULATOR_HOST, with an underscore between DATA and CONNECT.
-- Updated the Firebase SQL Connect local toolkit to v3.4.16, which includes the following changes:
-  - Updated the Golang dependency version to 1.25.12.

--- a/src/dataconnect/client.spec.ts
+++ b/src/dataconnect/client.spec.ts
@@ -47,7 +47,9 @@ describe("client", () => {
       const locations = await client.listLocations("project");
 
       expect(locations).to.deep.equal(["us-central1", "us-east1"]);
-      expect(getStub).to.be.calledWith("/projects/project/locations");
+      expect(getStub).to.be.calledWith("/projects/project/locations", {
+        queryParams: { fields: "locations.name,locations.locationId,locations.displayName" },
+      });
     });
 
     it("should return empty list if no locations", async () => {
@@ -66,14 +68,18 @@ describe("client", () => {
       const service = await client.getService("projects/p/locations/l/services/s");
 
       expect(service).to.deep.equal({ name: "service" });
-      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s");
+      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s", {
+        queryParams: { fields: "name" },
+      });
     });
 
     it("listAllServices", async () => {
       getStub.resolves({ body: { services: [{ name: "s1" }, { name: "s2" }] } });
       const services = await client.listAllServices("project");
       expect(services).to.deep.equal([{ name: "s1" }, { name: "s2" }]);
-      expect(getStub).to.be.calledWith("/projects/project/locations/-/services");
+      expect(getStub).to.be.calledWith("/projects/project/locations/-/services", {
+        queryParams: { fields: "services.name" },
+      });
     });
 
     it("createService", async () => {
@@ -121,14 +127,18 @@ describe("client", () => {
       getStub.resolves({ body: { name: "schema" } });
       const schema = await client.getSchema("projects/p/locations/l/services/s");
       expect(schema).to.deep.equal({ name: "schema" });
-      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s/schemas/main");
+      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s/schemas/main", {
+        queryParams: { fields: "name,datasources,source" },
+      });
     });
 
     it("getSchema with schemaId", async () => {
       getStub.resolves({ body: { name: "schema" } });
       const schema = await client.getSchema("projects/p/locations/l/services/s", "schemaId");
       expect(schema).to.deep.equal({ name: "schema" });
-      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s/schemas/schemaId");
+      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s/schemas/schemaId", {
+        queryParams: { fields: "name,datasources,source" },
+      });
     });
 
     it("getSchema returns undefined if not found", async () => {
@@ -146,6 +156,20 @@ describe("client", () => {
       });
       const schemas = await client.listSchemas("projects/p/locations/l/services/s");
       expect(schemas).to.deep.equal([{ name: "s1" }, { name: "s2" }]);
+      expect(getStub.firstCall).to.be.calledWith("projects/p/locations/l/services/s/schemas", {
+        queryParams: {
+          pageSize: 100,
+          pageToken: "",
+          fields: "schemas.name,schemas.datasources,schemas.source",
+        },
+      });
+      expect(getStub.secondCall).to.be.calledWith("projects/p/locations/l/services/s/schemas", {
+        queryParams: {
+          pageSize: 100,
+          pageToken: "next",
+          fields: "schemas.name,schemas.datasources,schemas.source",
+        },
+      });
     });
 
     it("upsertSchema", async () => {
@@ -178,7 +202,11 @@ describe("client", () => {
       getStub.resolves({ body: { name: "connector" } });
       const connector = await client.getConnector("projects/p/locations/l/services/s/connectors/c");
       expect(connector).to.deep.equal({ name: "connector" });
-      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s/connectors/c");
+      expect(getStub).to.be.calledWith("projects/p/locations/l/services/s/connectors/c", {
+        queryParams: {
+          fields: "name,source,client_cache",
+        },
+      });
     });
 
     it("listConnectors", async () => {
@@ -190,6 +218,20 @@ describe("client", () => {
       });
       const connectors = await client.listConnectors("projects/p/locations/l/services/s");
       expect(connectors).to.deep.equal([{ name: "c1" }, { name: "c2" }]);
+      expect(getStub.firstCall).to.be.calledWith("projects/p/locations/l/services/s/connectors", {
+        queryParams: {
+          pageSize: 100,
+          pageToken: "",
+          fields: "connectors.name,connectors.source,connectors.client_cache",
+        },
+      });
+      expect(getStub.secondCall).to.be.calledWith("projects/p/locations/l/services/s/connectors", {
+        queryParams: {
+          pageSize: 100,
+          pageToken: "next",
+          fields: "connectors.name,connectors.source,connectors.client_cache",
+        },
+      });
     });
 
     it("upsertConnector", async () => {

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -158,7 +158,11 @@ export async function deleteSchema(name: string): Promise<void> {
 /** Connector methods */
 
 export async function getConnector(name: string): Promise<types.Connector> {
-  const res = await dataconnectClient().get<types.Connector>(name);
+  const res = await dataconnectClient().get<types.Connector>(name, {
+    queryParams: {
+      fields: "name,source",
+    },
+  });
   return res.body;
 }
 

--- a/src/dataconnect/client.ts
+++ b/src/dataconnect/client.ts
@@ -20,19 +20,32 @@ export async function listLocations(projectId: string): Promise<string[]> {
       locationId: string;
       displayName: string;
     }[];
-  }>(`/projects/${projectId}/locations`);
+  }>(`/projects/${projectId}/locations`, {
+    queryParams: {
+      fields: "locations.name,locations.locationId,locations.displayName",
+    },
+  });
   return res.body?.locations?.map((l) => l.locationId) ?? [];
 }
 
 /** Service methods */
 export async function getService(serviceName: string): Promise<types.Service> {
-  const res = await dataconnectClient().get<types.Service>(serviceName);
+  const res = await dataconnectClient().get<types.Service>(serviceName, {
+    queryParams: {
+      fields: "name",
+    },
+  });
   return res.body;
 }
 
 export async function listAllServices(projectId: string): Promise<types.Service[]> {
   const res = await dataconnectClient().get<{ services: types.Service[] }>(
     `/projects/${projectId}/locations/-/services`,
+    {
+      queryParams: {
+        fields: "services.name",
+      },
+    },
   );
   return res.body.services ?? [];
 }
@@ -88,7 +101,11 @@ export async function getSchema(
   schemaId: string = types.MAIN_SCHEMA_ID,
 ): Promise<types.Schema | undefined> {
   try {
-    const res = await dataconnectClient().get<types.Schema>(`${serviceName}/schemas/${schemaId}`);
+    const res = await dataconnectClient().get<types.Schema>(`${serviceName}/schemas/${schemaId}`, {
+      queryParams: {
+        fields: "name,datasources,source",
+      },
+    });
     return res.body;
   } catch (err: any) {
     if (err.status !== 404) {
@@ -100,7 +117,7 @@ export async function getSchema(
 
 export async function listSchemas(
   serviceName: string,
-  fields: string[] = [],
+  fields: string[] = ["schemas.name", "schemas.datasources", "schemas.source"],
 ): Promise<types.Schema[]> {
   const schemas: types.Schema[] = [];
   const getNextPage = async (pageToken = "") => {
@@ -160,7 +177,7 @@ export async function deleteSchema(name: string): Promise<void> {
 export async function getConnector(name: string): Promise<types.Connector> {
   const res = await dataconnectClient().get<types.Connector>(name, {
     queryParams: {
-      fields: "name,source",
+      fields: "name,source,client_cache",
     },
   });
   return res.body;
@@ -176,7 +193,10 @@ export async function deleteConnector(name: string): Promise<void> {
   return;
 }
 
-export async function listConnectors(serviceName: string, fields: string[] = []) {
+export async function listConnectors(
+  serviceName: string,
+  fields: string[] = ["connectors.name", "connectors.source", "connectors.client_cache"],
+) {
   const connectors: types.Connector[] = [];
   const getNextPage = async (pageToken = "") => {
     const res = await dataconnectClient().get<{

--- a/src/deploy/dataconnect/release.spec.ts
+++ b/src/deploy/dataconnect/release.spec.ts
@@ -42,10 +42,14 @@ describe("dataconnect release", () => {
       .patch("/v1/projects/p/locations/l/services/s1/connectors/c1?allow_missing=true")
       .reply(200, { name: "op-name" });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=connectors.name%2Cconnectors.source%2Cconnectors.client_cache",
+      )
       .reply(200, { connectors: [] });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=schemas.name%2Cschemas.datasources%2Cschemas.source",
+      )
       .reply(200, { schemas: [] });
 
     const serviceInfos = [
@@ -84,10 +88,14 @@ describe("dataconnect release", () => {
       .patch("/v1/projects/p/locations/l/services/s1/connectors/c1?allow_missing=true")
       .reply(200, { name: "op-name" });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=connectors.name%2Cconnectors.source%2Cconnectors.client_cache",
+      )
       .reply(200, { connectors: [] });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=schemas.name%2Cschemas.datasources%2Cschemas.source",
+      )
       .reply(200, { schemas: [] });
     const serviceInfos = [
       {
@@ -120,12 +128,16 @@ describe("dataconnect release", () => {
       .patch("/v1/projects/p/locations/l/services/s1/connectors/c1?allow_missing=true")
       .reply(200, { name: "op-name" });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=connectors.name%2Cconnectors.source%2Cconnectors.client_cache",
+      )
       .reply(200, {
         connectors: [{ name: "projects/p/locations/l/services/s1/connectors/unused-connector" }],
       });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=schemas.name%2Cschemas.datasources%2Cschemas.source",
+      )
       .reply(200, { schemas: [] });
 
     const serviceInfos = [
@@ -164,10 +176,14 @@ describe("dataconnect release", () => {
       .patch("/v1/projects/p/locations/l/services/s1/connectors/c1?allow_missing=true")
       .reply(200, { name: "op-name" });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=connectors.name%2Cconnectors.source%2Cconnectors.client_cache",
+      )
       .reply(200, { connectors: [] });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=schemas.name%2Cschemas.datasources%2Cschemas.source",
+      )
       .reply(200, {
         schemas: [
           { name: "projects/p/locations/l/services/s1/schemas/main" },
@@ -211,12 +227,16 @@ describe("dataconnect release", () => {
       .patch("/v1/projects/p/locations/l/services/s1/connectors/c1?allow_missing=true")
       .reply(200, { name: "op-name" });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=connectors.name%2Cconnectors.source%2Cconnectors.client_cache",
+      )
       .reply(200, {
         connectors: [{ name: "projects/p/locations/l/services/s1/connectors/unused-connector" }],
       });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=schemas.name%2Cschemas.datasources%2Cschemas.source",
+      )
       .reply(200, { schemas: [] });
     const serviceInfos = [
       {
@@ -250,10 +270,14 @@ describe("dataconnect release", () => {
       .patch("/v1/projects/p/locations/l/services/s1/connectors/c1?allow_missing=true")
       .reply(200, { name: "op-name" });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/connectors?pageSize=100&pageToken=&fields=connectors.name%2Cconnectors.source%2Cconnectors.client_cache",
+      )
       .reply(200, { connectors: [] });
     nock(dataconnectOrigin())
-      .get("/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=")
+      .get(
+        "/v1/projects/p/locations/l/services/s1/schemas?pageSize=100&pageToken=&fields=schemas.name%2Cschemas.datasources%2Cschemas.source",
+      )
       .reply(200, {
         schemas: [
           { name: "projects/p/locations/l/services/s1/schemas/main" },

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -54,36 +54,36 @@
   },
   "dataconnect": {
     "darwin": {
-      "version": "3.4.16",
-      "expectedSize": 32877328,
-      "expectedChecksum": "48d472d8a9b009153d127bb0af9c0c77",
-      "expectedChecksumSHA256": "c4764168d79977047a8891ef52a450a4843b36d6d506e35a2147abeee01d7dd0",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-amd64-v3.4.16",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.16"
+      "version": "3.4.15",
+      "expectedSize": 32502016,
+      "expectedChecksum": "00f4b06ef1a6a70fbba7b2b8c1cd8eac",
+      "expectedChecksumSHA256": "8ea50a699023e5464b3306689e464716b8df7c51cadfe4a3db5d346981e1a916",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-amd64-v3.4.15",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.15"
     },
     "darwin_arm64": {
-      "version": "3.4.16",
-      "expectedSize": 30995666,
-      "expectedChecksum": "71055082dbcf0a95451ac63839463a13",
-      "expectedChecksumSHA256": "b31dc5e60046474c66033209ac93105b91195fffa0a4a50bba73fda2cbb14ba7",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-arm64-v3.4.16",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.16"
+      "version": "3.4.15",
+      "expectedSize": 30638050,
+      "expectedChecksum": "5b824b0d725e87f4f1820f8c3d50f2ce",
+      "expectedChecksumSHA256": "563ea6788e2291b82ea1cd0744f2594f0661b79277bc13e4da190b939a99293d",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-macos-arm64-v3.4.15",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.15"
     },
     "win32": {
-      "version": "3.4.16",
-      "expectedSize": 32919040,
-      "expectedChecksum": "d53acc32d9a996d99f8a8ac0abc82b04",
-      "expectedChecksumSHA256": "962f6cbc62d39da102d49c463f225846ce64438bc95bdc28ee8f35b92b7bd6ef",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-amd64-v3.4.16",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.16.exe"
+      "version": "3.4.15",
+      "expectedSize": 32543232,
+      "expectedChecksum": "dbdbdca5482d386a142cd602177e811d",
+      "expectedChecksumSHA256": "01b1408750b2f1612d3a99e89702a600803f9d8f77669e5ad2502651ed560796",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-windows-amd64-v3.4.15",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.15.exe"
     },
     "linux": {
-      "version": "3.4.16",
-      "expectedSize": 32030904,
-      "expectedChecksum": "240d642c408929e609d75eeeefe22689",
-      "expectedChecksumSHA256": "9963b3f1f011bf236a2a9908ebd7a282b79cd44405e77bdf8a566fd1c00dc4c7",
-      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-amd64-v3.4.16",
-      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.16"
+      "version": "3.4.15",
+      "expectedSize": 31654072,
+      "expectedChecksum": "b49d21a4704ddf9420fa58d0c233821d",
+      "expectedChecksumSHA256": "b152edccdf50f3e8e3d6904d6cd1437eb88cb7a447ede3e3dd5092d12262bdc1",
+      "remoteUrl": "https://storage.googleapis.com/firemat-preview-drop/emulator/dataconnect-emulator-linux-amd64-v3.4.15",
+      "downloadPathRelativeToCacheDir": "dataconnect-emulator-3.4.15"
     }
   }
 }


### PR DESCRIPTION
Updated `getConnector` in `src/dataconnect/client.ts` to explicitly specify the `fields` parameter ("name,source"), resolving an issue where the `get` call for Connectors used the default `*` instead of detailing the required fields explicitly.

---
*PR created automatically by Jules for task [4339466892693943361](https://jules.google.com/task/4339466892693943361) started by @fredzqm*