### PR TITLE
Fix Storage Emulator JSON upload limit and body parsing hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
+- Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
 - Support for specifying that the input for a string or string[] param in Functions must be non-empty (#10678)
 - Removed the warning that Dart functions may not yet be visible in the Firebase Console, since they are now shown.

--- a/scripts/storage-emulator-integration/conformance/gcs.endpoints.test.ts
+++ b/scripts/storage-emulator-integration/conformance/gcs.endpoints.test.ts
@@ -176,6 +176,23 @@ describe("GCS endpoint conformance tests", () => {
           .then((res) => res.body);
         expect(String(data)).to.eql("hello world");
       });
+
+      it("should handle large JSON uploads (issue #8355)", async () => {
+        const largeJson = { k: "a".repeat(130000) }; // ~130KB, > 100KB limit
+        await supertest(storageHost)
+          .post(`/upload/storage/v1/b/${storageBucket}/o?name=large.json&uploadType=media`)
+          .set(authHeader)
+          .set("Content-Type", "application/json")
+          .send(JSON.stringify(largeJson))
+          .expect(200);
+
+        const data = await supertest(storageHost)
+          .get(`/storage/v1/b/${storageBucket}/o/large.json?alt=media`)
+          .set(authHeader)
+          .expect(200)
+          .then((res) => res.body);
+        expect(data).to.eql(largeJson);
+      });
     });
 
     describe("resumable upload", () => {

--- a/scripts/storage-emulator-integration/conformance/gcs.endpoints.test.ts
+++ b/scripts/storage-emulator-integration/conformance/gcs.endpoints.test.ts
@@ -177,7 +177,7 @@ describe("GCS endpoint conformance tests", () => {
         expect(String(data)).to.eql("hello world");
       });
 
-      it("should handle large JSON uploads (issue #8355)", async () => {
+      it("should handle large JSON uploads", async () => {
         const largeJson = { k: "a".repeat(130000) }; // ~130KB, > 100KB limit
         await supertest(storageHost)
           .post(`/upload/storage/v1/b/${storageBucket}/o?name=large.json&uploadType=media`)

--- a/src/emulator/downloadableEmulators.ts
+++ b/src/emulator/downloadableEmulators.ts
@@ -260,6 +260,7 @@ const Commands: { [s in DownloadableEmulators]: DownloadableEmulatorCommand } = 
     // separately in ./storage/runtime.ts (not via the start function below).
     binary: "java",
     args: [
+      "-Djava.security.manager=disallow",
       // Required for rules error/warning messages, which are in English only.
       // Attempts to fetch the messages in another language leads to crashes.
       "-Duser.language=en",

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -2,7 +2,8 @@ import { EmulatorLogger } from "../../emulatorLogger";
 import { Emulators } from "../../types";
 import { randomUUID } from "crypto";
 import { IncomingMetadata, OutgoingFirebaseMetadata, StoredFileMetadata } from "../metadata";
-import { Request, Response, Router } from "express";
+import { Request, Response, Router, NextFunction, json } from "express";
+import * as bodyParser from "body-parser";
 import { StorageEmulator } from "../index";
 import { sendFileBytes } from "./shared";
 import { EmulatorRegistry } from "../../registry";
@@ -24,6 +25,23 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
   // eslint-disable-next-line new-cap
   const firebaseStorageAPI = Router();
   const { storageLayer, uploadService } = emulator;
+
+  const firebasePostUploadMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    if (req.method === "PUT" && req.header("x-http-method-override")?.toLowerCase() === "patch") {
+      return json({ limit: "130mb" })(req, res, next);
+    }
+
+    const uploadType = req.header("x-goog-upload-protocol")?.toString();
+    const uploadCommand = req.header("x-goog-upload-command");
+
+    if (uploadCommand === "start") {
+      return json({ limit: "130mb" })(req, res, next);
+    }
+    if (uploadType === "multipart") {
+      return next();
+    }
+    return bodyParser.raw({ type: "*/*", limit: "130mb" })(req, res, next);
+  };
 
   if (process.env.STORAGE_EMULATOR_DEBUG) {
     firebaseStorageAPI.use((req, res, next) => {
@@ -368,6 +386,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
       bucketId: req.params.bucketId,
       objectId: objectId,
       dataRaw: await reqBodyToBuffer(req),
+      contentType: req.header("content-type"),
       authorization: req.header("authorization"),
     });
     return await finalizeOneShotUpload(upload);
@@ -467,8 +486,15 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     return res.json(new OutgoingFirebaseMetadata(metadata));
   };
 
-  firebaseStorageAPI.patch("/b/:bucketId/o/:objectId", handleMetadataUpdate);
-  firebaseStorageAPI.put("/b/:bucketId/o/:objectId?", async (req, res) => {
+  firebaseStorageAPI.patch(
+    "/b/:bucketId/o/:objectId",
+    json({ limit: "130mb" }),
+    handleMetadataUpdate,
+  );
+  firebaseStorageAPI.put(
+    "/b/:bucketId/o/:objectId?",
+    firebasePostUploadMiddleware,
+    async (req, res) => {
     switch (req.header("x-http-method-override")?.toLowerCase()) {
       case "patch":
         return handleMetadataUpdate(req, res);
@@ -477,7 +503,11 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     }
   });
 
-  firebaseStorageAPI.post("/b/:bucketId/o/:objectId?", handleObjectPostRequest);
+  firebaseStorageAPI.post(
+    "/b/:bucketId/o/:objectId?",
+    firebasePostUploadMiddleware,
+    handleObjectPostRequest,
+  );
 
   firebaseStorageAPI.delete("/b/:bucketId/o/:objectId", async (req, res) => {
     try {

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -93,7 +93,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
   }
 
   // Automatically create a bucket for any route which uses a bucket
-  firebaseStorageAPI.use(/.*\/b\/(.+?)\/.*/, (req, res, next) => {
+  firebaseStorageAPI.use(/.*\/b\/(.+?)\/.*/i, (req, res, next) => {
     const bucketId = req.params[0];
     storageLayer.createBucket(bucketId);
     if (!emulator.rulesManager.getRuleset(bucketId)) {

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -26,21 +26,24 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
   const firebaseStorageAPI = Router();
   const { storageLayer, uploadService } = emulator;
 
-  const firebasePostUploadMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  const firebasePostUploadMiddleware = (req: Request, res: Response, next: NextFunction): void => {
     if (req.method === "PUT" && req.header("x-http-method-override")?.toLowerCase() === "patch") {
-      return json({ limit: "130mb" })(req, res, next);
+      json({ limit: "130mb" })(req, res, next);
+      return;
     }
 
     const uploadType = req.header("x-goog-upload-protocol")?.toString();
     const uploadCommand = req.header("x-goog-upload-command");
 
     if (uploadCommand === "start") {
-      return json({ limit: "130mb" })(req, res, next);
+      json({ limit: "130mb" })(req, res, next);
+      return;
     }
     if (uploadType === "multipart") {
-      return next();
+      next();
+      return;
     }
-    return bodyParser.raw({ type: "*/*", limit: "130mb" })(req, res, next);
+    bodyParser.raw({ type: "*/*", limit: "130mb" })(req, res, next);
   };
 
   if (process.env.STORAGE_EMULATOR_DEBUG) {
@@ -154,7 +157,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     let prefix = "";
     if (req.query.prefix) {
       prefix = req.query.prefix.toString();
-      if (prefix.charAt(prefix.length - 1) !== "/") {
+      if (!prefix.endsWith("/")) {
         return res.status(400).json({
           error: {
             code: 400,
@@ -361,7 +364,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
       let dataRaw: Buffer;
       try {
         ({ metadataRaw, dataRaw } = parseObjectUploadMultipartRequest(
-          contentTypeHeader!,
+          contentTypeHeader,
           await reqBodyToBuffer(req),
         ));
       } catch (err) {
@@ -495,13 +498,14 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
     "/b/:bucketId/o/:objectId?",
     firebasePostUploadMiddleware,
     async (req, res) => {
-    switch (req.header("x-http-method-override")?.toLowerCase()) {
-      case "patch":
-        return handleMetadataUpdate(req, res);
-      default:
-        return handleObjectPostRequest(req, res);
-    }
-  });
+      switch (req.header("x-http-method-override")?.toLowerCase()) {
+        case "patch":
+          return handleMetadataUpdate(req, res);
+        default:
+          return handleObjectPostRequest(req, res);
+      }
+    },
+  );
 
   firebaseStorageAPI.post(
     "/b/:bucketId/o/:objectId?",

--- a/src/emulator/storage/apis/firebase.ts
+++ b/src/emulator/storage/apis/firebase.ts
@@ -32,7 +32,7 @@ export function createFirebaseEndpoints(emulator: StorageEmulator): Router {
       return;
     }
 
-    const uploadType = req.header("x-goog-upload-protocol")?.toString();
+    const uploadType = req.header("x-goog-upload-protocol");
     const uploadCommand = req.header("x-goog-upload-command");
 
     if (uploadCommand === "start") {

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -19,9 +19,6 @@ import { ForbiddenError, NotFoundError } from "../errors";
 import { reqBodyToBuffer } from "../../shared/request";
 import type { Query } from "express-serve-static-core";
 
-/**
- *
- */
 export function createCloudEndpoints(emulator: StorageEmulator): Router {
   // eslint-disable-next-line new-cap
   const gcloudStorageAPI = Router();

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -85,7 +85,7 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
   }
 
   // Automatically create a bucket for any route which uses a bucket
-  gcloudStorageAPI.use(/.*\/b\/(.+?)\/.*/, (req, res, next) => {
+  gcloudStorageAPI.use(/.*\/b\/(.+?)\/.*/i, (req, res, next) => {
     adminStorageLayer.createBucket(req.params[0]);
     next();
   });
@@ -234,7 +234,6 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     "/b/:bucketId/o/:objectId/acl",
     json({ limit: "130mb" }),
     async (req, res) => {
-      // TODO(abehaskins) Link to a doc with more info
       EmulatorLogger.forEmulator(Emulators.STORAGE).log(
         "WARN_ONCE",
         "Cloud Storage ACLs are not supported in the Storage Emulator. All related methods will succeed, but have no effect.",

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -19,18 +19,22 @@ import { ForbiddenError, NotFoundError } from "../errors";
 import { reqBodyToBuffer } from "../../shared/request";
 import type { Query } from "express-serve-static-core";
 
+/**
+ *
+ */
 export function createCloudEndpoints(emulator: StorageEmulator): Router {
   // eslint-disable-next-line new-cap
   const gcloudStorageAPI = Router();
   // Use Admin StorageLayer to ensure Firebase Rules validation is skipped.
   const { adminStorageLayer, uploadService } = emulator;
 
-  const postUploadMiddleware = (req: Request, res: Response, next: NextFunction) => {
+  const postUploadMiddleware = (req: Request, res: Response, next: NextFunction): void => {
     const uploadType = req.query.uploadType || req.header("X-Goog-Upload-Protocol");
     if (uploadType === "resumable" && !req.query.upload_id) {
-      return json({ limit: "130mb" })(req, res, next);
+      json({ limit: "130mb" })(req, res, next);
+      return;
     }
-    return bodyParser.raw({ type: "*/*", limit: "130mb" })(req, res, next);
+    bodyParser.raw({ type: "*/*", limit: "130mb" })(req, res, next);
   };
 
   // Debug statements
@@ -123,10 +127,7 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     },
   );
 
-  gcloudStorageAPI.patch(
-    "/b/:bucketId/o/:objectId",
-    json({ limit: "130mb" }),
-    async (req, res) => {
+  gcloudStorageAPI.patch("/b/:bucketId/o/:objectId", json({ limit: "130mb" }), async (req, res) => {
     let updatedMetadata: StoredFileMetadata;
     try {
       updatedMetadata = await adminStorageLayer.updateObjectMetadata({
@@ -197,111 +198,25 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     "/upload/storage/v1/b/:bucketId/o",
     bodyParser.raw({ type: "*/*", limit: "130mb" }),
     async (req, res) => {
-    if (!req.query.upload_id) {
-      res.sendStatus(400);
-      return;
-    }
-
-    const uploadId = req.query.upload_id.toString();
-    let upload: Upload;
-    try {
-      uploadService.continueResumableUpload(uploadId, await reqBodyToBuffer(req));
-      upload = uploadService.finalizeResumableUpload(uploadId);
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return res.sendStatus(404);
-      } else if (err instanceof UploadNotActiveError) {
-        return res.sendStatus(400);
-      }
-      throw err;
-    }
-
-    let metadata: StoredFileMetadata;
-    try {
-      metadata = await adminStorageLayer.uploadObject(upload);
-    } catch (err) {
-      if (err instanceof ForbiddenError) {
-        return res.sendStatus(403);
-      }
-      throw err;
-    }
-    return res.json(new CloudStorageObjectMetadata(metadata));
-  });
-
-  gcloudStorageAPI.post(
-    "/b/:bucketId/o/:objectId/acl",
-    json({ limit: "130mb" }),
-    async (req, res) => {
-    // TODO(abehaskins) Link to a doc with more info
-    EmulatorLogger.forEmulator(Emulators.STORAGE).log(
-      "WARN_ONCE",
-      "Cloud Storage ACLs are not supported in the Storage Emulator. All related methods will succeed, but have no effect.",
-    );
-    let getObjectResponse: GetObjectResponse;
-    try {
-      getObjectResponse = await adminStorageLayer.getObject({
-        bucketId: req.params.bucketId,
-        decodedObjectId: req.params.objectId,
-      });
-    } catch (err) {
-      if (err instanceof NotFoundError) {
-        return sendObjectNotFound(req, res);
-      }
-      if (err instanceof ForbiddenError) {
-        return res.sendStatus(403);
-      }
-      throw err;
-    }
-    const { metadata } = getObjectResponse;
-    // We do an empty update to step metageneration forward;
-    metadata.update({});
-    const selfLink = EmulatorRegistry.url(Emulators.STORAGE);
-    selfLink.pathname = `/storage/v1/b/${metadata.bucket}/o/${encodeURIComponent(
-      metadata.name,
-    )}/acl/allUsers`;
-    return res.json({
-      kind: "storage#objectAccessControl",
-      object: metadata.name,
-      id: `${req.params.bucketId}/${metadata.name}/${metadata.generation}/allUsers`,
-      selfLink: selfLink.toString(),
-      bucket: metadata.bucket,
-      entity: req.body.entity,
-      role: req.body.role,
-      etag: "someEtag",
-      generation: metadata.generation.toString(),
-    } as CloudStorageObjectAccessControlMetadata);
-  });
-
-  gcloudStorageAPI.post(
-    "/upload/storage/v1/b/:bucketId/o",
-    postUploadMiddleware,
-    async (req, res) => {
-    const uploadType = req.query.uploadType || req.header("X-Goog-Upload-Protocol");
-
-    // Resumable upload protocol.
-    if (uploadType === "resumable") {
-      const name = getIncomingFileNameFromRequest(req.query, req.body);
-      if (name === undefined) {
+      if (!req.query.upload_id) {
         res.sendStatus(400);
         return;
       }
-      const contentType = req.header("x-upload-content-type");
-      const upload = uploadService.startResumableUpload({
-        bucketId: req.params.bucketId,
-        objectId: name,
-        metadata: { contentType, ...req.body },
-        authorization: req.header("authorization"),
-      });
 
-      const uploadUrl = EmulatorRegistry.url(Emulators.STORAGE, req);
-      uploadUrl.pathname = `/upload/storage/v1/b/${req.params.bucketId}/o`;
-      uploadUrl.searchParams.set("name", name);
-      uploadUrl.searchParams.set("uploadType", "resumable");
-      uploadUrl.searchParams.set("upload_id", upload.id);
-      return res.header("location", uploadUrl.toString()).sendStatus(200);
-    }
+      const uploadId = req.query.upload_id.toString();
+      let upload: Upload;
+      try {
+        uploadService.continueResumableUpload(uploadId, await reqBodyToBuffer(req));
+        upload = uploadService.finalizeResumableUpload(uploadId);
+      } catch (err) {
+        if (err instanceof NotFoundError) {
+          return res.sendStatus(404);
+        } else if (err instanceof UploadNotActiveError) {
+          return res.sendStatus(400);
+        }
+        throw err;
+      }
 
-    async function finalizeOneShotUpload(upload: Upload) {
       let metadata: StoredFileMetadata;
       try {
         metadata = await adminStorageLayer.uploadObject(upload);
@@ -311,65 +226,154 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
         }
         throw err;
       }
-      return res.status(200).json(new CloudStorageObjectMetadata(metadata));
-    }
+      return res.json(new CloudStorageObjectMetadata(metadata));
+    },
+  );
 
-    // Multipart upload protocol.
-    if (uploadType === "multipart") {
-      const contentTypeHeader = req.header("content-type") || req.header("x-upload-content-type");
-      const contentType = req.header("x-upload-content-type");
-      if (!contentTypeHeader) {
-        return res.sendStatus(400);
-      }
-      let metadataRaw: string;
-      let dataRaw: Buffer;
+  gcloudStorageAPI.post(
+    "/b/:bucketId/o/:objectId/acl",
+    json({ limit: "130mb" }),
+    async (req, res) => {
+      // TODO(abehaskins) Link to a doc with more info
+      EmulatorLogger.forEmulator(Emulators.STORAGE).log(
+        "WARN_ONCE",
+        "Cloud Storage ACLs are not supported in the Storage Emulator. All related methods will succeed, but have no effect.",
+      );
+      let getObjectResponse: GetObjectResponse;
       try {
-        ({ metadataRaw, dataRaw } = parseObjectUploadMultipartRequest(
-          contentTypeHeader,
-          await reqBodyToBuffer(req),
-        ));
+        getObjectResponse = await adminStorageLayer.getObject({
+          bucketId: req.params.bucketId,
+          decodedObjectId: req.params.objectId,
+        });
       } catch (err) {
-        if (err instanceof Error) {
-          return res.status(400).json({
-            error: {
-              code: 400,
-              message: err.message,
-            },
-          });
+        if (err instanceof NotFoundError) {
+          return sendObjectNotFound(req, res);
+        }
+        if (err instanceof ForbiddenError) {
+          return res.sendStatus(403);
         }
         throw err;
       }
+      const { metadata } = getObjectResponse;
+      // We do an empty update to step metageneration forward;
+      metadata.update({});
+      const selfLink = EmulatorRegistry.url(Emulators.STORAGE);
+      selfLink.pathname = `/storage/v1/b/${metadata.bucket}/o/${encodeURIComponent(
+        metadata.name,
+      )}/acl/allUsers`;
+      return res.json({
+        kind: "storage#objectAccessControl",
+        object: metadata.name,
+        id: `${req.params.bucketId}/${metadata.name}/${metadata.generation}/allUsers`,
+        selfLink: selfLink.toString(),
+        bucket: metadata.bucket,
+        entity: req.body.entity,
+        role: req.body.role,
+        etag: "someEtag",
+        generation: metadata.generation.toString(),
+      } as CloudStorageObjectAccessControlMetadata);
+    },
+  );
 
-      const name = getIncomingFileNameFromRequest(req.query, JSON.parse(metadataRaw));
-      if (name === undefined) {
-        res.sendStatus(400);
-        return;
+  gcloudStorageAPI.post(
+    "/upload/storage/v1/b/:bucketId/o",
+    postUploadMiddleware,
+    async (req, res) => {
+      const uploadType = req.query.uploadType || req.header("X-Goog-Upload-Protocol");
+
+      // Resumable upload protocol.
+      if (uploadType === "resumable") {
+        const name = getIncomingFileNameFromRequest(req.query, req.body);
+        if (name === undefined) {
+          res.sendStatus(400);
+          return;
+        }
+        const contentType = req.header("x-upload-content-type");
+        const upload = uploadService.startResumableUpload({
+          bucketId: req.params.bucketId,
+          objectId: name,
+          metadata: { contentType, ...req.body },
+          authorization: req.header("authorization"),
+        });
+
+        const uploadUrl = EmulatorRegistry.url(Emulators.STORAGE, req);
+        uploadUrl.pathname = `/upload/storage/v1/b/${req.params.bucketId}/o`;
+        uploadUrl.searchParams.set("name", name);
+        uploadUrl.searchParams.set("uploadType", "resumable");
+        uploadUrl.searchParams.set("upload_id", upload.id);
+        return res.header("location", uploadUrl.toString()).sendStatus(200);
       }
-      const upload = uploadService.multipartUpload({
+
+      async function finalizeOneShotUpload(upload: Upload) {
+        let metadata: StoredFileMetadata;
+        try {
+          metadata = await adminStorageLayer.uploadObject(upload);
+        } catch (err) {
+          if (err instanceof ForbiddenError) {
+            return res.sendStatus(403);
+          }
+          throw err;
+        }
+        return res.status(200).json(new CloudStorageObjectMetadata(metadata));
+      }
+
+      // Multipart upload protocol.
+      if (uploadType === "multipart") {
+        const contentTypeHeader = req.header("content-type") || req.header("x-upload-content-type");
+        const contentType = req.header("x-upload-content-type");
+        if (!contentTypeHeader) {
+          return res.sendStatus(400);
+        }
+        let metadataRaw: string;
+        let dataRaw: Buffer;
+        try {
+          ({ metadataRaw, dataRaw } = parseObjectUploadMultipartRequest(
+            contentTypeHeader,
+            await reqBodyToBuffer(req),
+          ));
+        } catch (err) {
+          if (err instanceof Error) {
+            return res.status(400).json({
+              error: {
+                code: 400,
+                message: err.message,
+              },
+            });
+          }
+          throw err;
+        }
+
+        const name = getIncomingFileNameFromRequest(req.query, JSON.parse(metadataRaw));
+        if (name === undefined) {
+          res.sendStatus(400);
+          return;
+        }
+        const upload = uploadService.multipartUpload({
+          bucketId: req.params.bucketId,
+          objectId: name,
+          metadata: { contentType, ...JSON.parse(metadataRaw) },
+          dataRaw: dataRaw,
+          authorization: req.header("authorization"),
+        });
+        return await finalizeOneShotUpload(upload);
+      }
+
+      // Default to media (data-only) upload protocol.
+      const name = req.query.name;
+      if (!name) {
+        res.sendStatus(400);
+      }
+
+      const upload = uploadService.mediaUpload({
         bucketId: req.params.bucketId,
-        objectId: name,
-        metadata: { contentType, ...JSON.parse(metadataRaw) },
-        dataRaw: dataRaw,
+        objectId: name!.toString(),
+        dataRaw: await reqBodyToBuffer(req),
+        contentType: req.header("content-type"),
         authorization: req.header("authorization"),
       });
       return await finalizeOneShotUpload(upload);
-    }
-
-    // Default to media (data-only) upload protocol.
-    const name = req.query.name;
-    if (!name) {
-      res.sendStatus(400);
-    }
-
-    const upload = uploadService.mediaUpload({
-      bucketId: req.params.bucketId,
-      objectId: name!.toString(),
-      dataRaw: await reqBodyToBuffer(req),
-      contentType: req.header("content-type"),
-      authorization: req.header("authorization"),
-    });
-    return await finalizeOneShotUpload(upload);
-  });
+    },
+  );
 
   gcloudStorageAPI.get("/:bucketId/:objectId(**)", async (req, res) => {
     let getObjectResponse: GetObjectResponse;

--- a/src/emulator/storage/apis/gcloud.ts
+++ b/src/emulator/storage/apis/gcloud.ts
@@ -1,4 +1,5 @@
-import { Router } from "express";
+import { Router, NextFunction, json } from "express";
+import * as bodyParser from "body-parser";
 import { Emulators } from "../../types";
 import {
   CloudStorageObjectAccessControlMetadata,
@@ -23,6 +24,14 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
   const gcloudStorageAPI = Router();
   // Use Admin StorageLayer to ensure Firebase Rules validation is skipped.
   const { adminStorageLayer, uploadService } = emulator;
+
+  const postUploadMiddleware = (req: Request, res: Response, next: NextFunction) => {
+    const uploadType = req.query.uploadType || req.header("X-Goog-Upload-Protocol");
+    if (uploadType === "resumable" && !req.query.upload_id) {
+      return json({ limit: "130mb" })(req, res, next);
+    }
+    return bodyParser.raw({ type: "*/*", limit: "130mb" })(req, res, next);
+  };
 
   // Debug statements
   if (process.env.STORAGE_EMULATOR_DEBUG) {
@@ -114,7 +123,10 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     },
   );
 
-  gcloudStorageAPI.patch("/b/:bucketId/o/:objectId", async (req, res) => {
+  gcloudStorageAPI.patch(
+    "/b/:bucketId/o/:objectId",
+    json({ limit: "130mb" }),
+    async (req, res) => {
     let updatedMetadata: StoredFileMetadata;
     try {
       updatedMetadata = await adminStorageLayer.updateObjectMetadata({
@@ -181,7 +193,10 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     },
   );
 
-  gcloudStorageAPI.put("/upload/storage/v1/b/:bucketId/o", async (req, res) => {
+  gcloudStorageAPI.put(
+    "/upload/storage/v1/b/:bucketId/o",
+    bodyParser.raw({ type: "*/*", limit: "130mb" }),
+    async (req, res) => {
     if (!req.query.upload_id) {
       res.sendStatus(400);
       return;
@@ -213,7 +228,10 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     return res.json(new CloudStorageObjectMetadata(metadata));
   });
 
-  gcloudStorageAPI.post("/b/:bucketId/o/:objectId/acl", async (req, res) => {
+  gcloudStorageAPI.post(
+    "/b/:bucketId/o/:objectId/acl",
+    json({ limit: "130mb" }),
+    async (req, res) => {
     // TODO(abehaskins) Link to a doc with more info
     EmulatorLogger.forEmulator(Emulators.STORAGE).log(
       "WARN_ONCE",
@@ -254,7 +272,10 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
     } as CloudStorageObjectAccessControlMetadata);
   });
 
-  gcloudStorageAPI.post("/upload/storage/v1/b/:bucketId/o", async (req, res) => {
+  gcloudStorageAPI.post(
+    "/upload/storage/v1/b/:bucketId/o",
+    postUploadMiddleware,
+    async (req, res) => {
     const uploadType = req.query.uploadType || req.header("X-Goog-Upload-Protocol");
 
     // Resumable upload protocol.
@@ -344,6 +365,7 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
       bucketId: req.params.bucketId,
       objectId: name!.toString(),
       dataRaw: await reqBodyToBuffer(req),
+      contentType: req.header("content-type"),
       authorization: req.header("authorization"),
     });
     return await finalizeOneShotUpload(upload);
@@ -441,6 +463,7 @@ export function createCloudEndpoints(emulator: StorageEmulator): Router {
 
   gcloudStorageAPI.post(
     "/b/:bucketId/o/:objectId/:method(rewriteTo|copyTo)/b/:destBucketId/o/:destObjectId",
+    json({ limit: "130mb" }),
     (req, res, next) => {
       if (req.params.method === "rewriteTo" && req.query.rewriteToken) {
         // Don't yet support multi-request copying

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -61,7 +61,6 @@ export function createApp(
   app.use(bodyParser.raw({ limit: "130mb", type: "application/x-www-form-urlencoded" }));
   app.use(bodyParser.raw({ limit: "130mb", type: "multipart/related" }));
 
-
   app.post("/internal/export", express.json({ limit: "130mb" }), async (req, res) => {
     const initiatedBy: string = req.body.initiatedBy || "unknown";
     const path: string = req.body.path;

--- a/src/emulator/storage/server.ts
+++ b/src/emulator/storage/server.ts
@@ -61,13 +61,8 @@ export function createApp(
   app.use(bodyParser.raw({ limit: "130mb", type: "application/x-www-form-urlencoded" }));
   app.use(bodyParser.raw({ limit: "130mb", type: "multipart/related" }));
 
-  app.use(
-    express.json({
-      type: ["application/json"],
-    }),
-  );
 
-  app.post("/internal/export", async (req, res) => {
+  app.post("/internal/export", express.json({ limit: "130mb" }), async (req, res) => {
     const initiatedBy: string = req.body.initiatedBy || "unknown";
     const path: string = req.body.path;
     if (!path) {
@@ -106,7 +101,7 @@ export function createApp(
    * }
    * ```
    */
-  app.put("/internal/setRules", async (req, res) => {
+  app.put("/internal/setRules", express.json({ limit: "130mb" }), async (req, res) => {
     const rulesRaw = req.body.rules;
     if (!(rulesRaw && Array.isArray(rulesRaw.files) && rulesRaw.files.length > 0)) {
       res.status(400).json({

--- a/src/emulator/storage/upload.ts
+++ b/src/emulator/storage/upload.ts
@@ -37,6 +37,7 @@ export type MediaUploadRequest = {
   bucketId: string;
   objectId: string;
   dataRaw: Buffer;
+  contentType?: string;
   authorization?: string;
 };
 
@@ -100,6 +101,7 @@ export class UploadService {
       objectId: request.objectId,
       uploadType: UploadType.MEDIA,
       dataRaw: request.dataRaw,
+      metadata: request.contentType ? { contentType: request.contentType } : undefined,
       authorization: request.authorization,
     });
     this._persistence.deleteFile(upload.path, /* failSilently = */ true);


### PR DESCRIPTION
Addresses issue #8355. Fixes the Storage Emulator to handle large JSON uploads without throwing 413 or hanging due to eager body parsing.