### PR TITLE
feat: inject FUNCTION_REGION env var for gcfv2 and run platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Inject FUNCTION_REGION environment variable for gcfv2 and run platforms, and resolve it per-region

--- a/scripts/emulator-tests/functionsEmulator.spec.ts
+++ b/scripts/emulator-tests/functionsEmulator.spec.ts
@@ -8,6 +8,7 @@ import * as express from "express";
 import * as sinon from "sinon";
 import * as supertest from "supertest";
 import * as winston from "winston";
+// eslint-disable-next-line brikke/no-undeclared-imports
 import * as logform from "logform";
 
 import { EmulatedTriggerDefinition } from "../../src/emulator/functionsEmulatorShared";
@@ -688,6 +689,7 @@ describe("FunctionsEmulator", function () {
                   databaseHost: process.env.FIREBASE_DATABASE_EMULATOR_HOST,
                   firestoreHost: process.env.FIRESTORE_EMULATOR_HOST,
                   authHost: process.env.FIREBASE_AUTH_EMULATOR_HOST,
+                  region: process.env.FUNCTION_REGION,
                 });
               },
             ),
@@ -701,6 +703,7 @@ describe("FunctionsEmulator", function () {
             expect(res.body.databaseHost).to.eql(`${database.host}:${database.port}`);
             expect(res.body.firestoreHost).to.eql(`${firestore.host}:${firestore.port}`);
             expect(res.body.authHost).to.eql(`${auth.host}:${auth.port}`);
+            expect(res.body.region).to.eql("us-central1");
           });
       }).timeout(TIMEOUT_MED);
 

--- a/src/deploy/functions/build.spec.ts
+++ b/src/deploy/functions/build.spec.ts
@@ -93,6 +93,29 @@ describe("toBackend", () => {
     expect(Object.keys(backend.endpoints).length).to.equal(0);
   });
 
+  it("interpolates FUNCTION_REGION correctly in per-region endpoint resolution", () => {
+    const desiredBuild: build.Build = build.of({
+      func: {
+        platform: "gcfv2",
+        region: ["us-central1", "europe-west1"],
+        project: "project",
+        runtime: "nodejs16",
+        entryPoint: "func",
+        httpsTrigger: {},
+        minInstances: '{{ params.FUNCTION_REGION == "us-central1" ? 1 : 0 }}',
+      },
+    });
+    const backend = build.toBackend(desiredBuild, {
+      FUNCTION_REGION: new ParamValue("", true, { string: true }),
+    });
+    const ep1 = backend.endpoints["us-central1"]?.["func"];
+    const ep2 = backend.endpoints["europe-west1"]?.["func"];
+    expect(ep1).to.not.be.undefined;
+    expect(ep2).to.not.be.undefined;
+    expect(ep1.minInstances).to.equal(1);
+    expect(ep2.minInstances).to.equal(0);
+  });
+
   it("populates multiple specified https invokers correctly", () => {
     const desiredBuild: build.Build = build.of({
       func: {

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -563,14 +563,14 @@ export function toBackend(
       if (bdEndpoint.vpc) {
         bkEndpoint.vpc = {};
         if (typeof bdEndpoint.vpc.connector !== "undefined" && bdEndpoint.vpc.connector !== null) {
-          const connector = params.resolveString(bdEndpoint.vpc.connector, regionParamValues);
+          const connector = r.resolveString(bdEndpoint.vpc.connector);
           bkEndpoint.vpc.connector =
             connector.includes("/") || connector === ""
               ? connector
               : `projects/${bdEndpoint.project}/locations/${region}/connectors/${connector}`;
         }
         if (bdEndpoint.vpc.egressSettings) {
-          const egress = params.resolveString(bdEndpoint.vpc.egressSettings, regionParamValues);
+          const egress = r.resolveString(bdEndpoint.vpc.egressSettings);
           if (!backend.AllVpcEgressSettings.includes(egress as backend.VpcEgressSettings)) {
             throw new FirebaseError(`Value "${egress}" is an invalid egress setting.`);
           }
@@ -579,11 +579,10 @@ export function toBackend(
         if (bdEndpoint.vpc.networkInterfaces) {
           bkEndpoint.vpc.networkInterfaces = bdEndpoint.vpc.networkInterfaces.map((ni) => {
             const resolved: { network?: string; subnetwork?: string; tags?: string[] } = {};
-            if (ni.network) resolved.network = params.resolveString(ni.network, regionParamValues);
-            if (ni.subnetwork)
-              resolved.subnetwork = params.resolveString(ni.subnetwork, regionParamValues);
+            if (ni.network) resolved.network = r.resolveString(ni.network);
+            if (ni.subnetwork) resolved.subnetwork = r.resolveString(ni.subnetwork);
             if (ni.tags) {
-              resolved.tags = ni.tags.map((tag) => params.resolveString(tag, regionParamValues));
+              resolved.tags = ni.tags.map((tag) => r.resolveString(tag));
             }
             return resolved;
           });

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -496,6 +496,11 @@ export function toBackend(
       }
     }
     for (const region of regions) {
+      const regionParamValues = {
+        ...paramValues,
+        FUNCTION_REGION: new params.ParamValue(region, true, { string: true }),
+      };
+      const r = new Resolver(regionParamValues);
       const trigger = discoverTrigger(bdEndpoint, region, r);
 
       if (typeof bdEndpoint.platform === "undefined") {
@@ -558,14 +563,14 @@ export function toBackend(
       if (bdEndpoint.vpc) {
         bkEndpoint.vpc = {};
         if (typeof bdEndpoint.vpc.connector !== "undefined" && bdEndpoint.vpc.connector !== null) {
-          const connector = params.resolveString(bdEndpoint.vpc.connector, paramValues);
+          const connector = params.resolveString(bdEndpoint.vpc.connector, regionParamValues);
           bkEndpoint.vpc.connector =
             connector.includes("/") || connector === ""
               ? connector
               : `projects/${bdEndpoint.project}/locations/${region}/connectors/${connector}`;
         }
         if (bdEndpoint.vpc.egressSettings) {
-          const egress = params.resolveString(bdEndpoint.vpc.egressSettings, paramValues);
+          const egress = params.resolveString(bdEndpoint.vpc.egressSettings, regionParamValues);
           if (!backend.AllVpcEgressSettings.includes(egress as backend.VpcEgressSettings)) {
             throw new FirebaseError(`Value "${egress}" is an invalid egress setting.`);
           }
@@ -574,11 +579,11 @@ export function toBackend(
         if (bdEndpoint.vpc.networkInterfaces) {
           bkEndpoint.vpc.networkInterfaces = bdEndpoint.vpc.networkInterfaces.map((ni) => {
             const resolved: { network?: string; subnetwork?: string; tags?: string[] } = {};
-            if (ni.network) resolved.network = params.resolveString(ni.network, paramValues);
+            if (ni.network) resolved.network = params.resolveString(ni.network, regionParamValues);
             if (ni.subnetwork)
-              resolved.subnetwork = params.resolveString(ni.subnetwork, paramValues);
+              resolved.subnetwork = params.resolveString(ni.subnetwork, regionParamValues);
             if (ni.tags) {
-              resolved.tags = ni.tags.map((tag) => params.resolveString(tag, paramValues));
+              resolved.tags = ni.tags.map((tag) => params.resolveString(tag, regionParamValues));
             }
             return resolved;
           });

--- a/src/deploy/functions/params.spec.ts
+++ b/src/deploy/functions/params.spec.ts
@@ -34,6 +34,11 @@ const expectedInternalParams = {
     boolean: false,
     number: false,
   }),
+  FUNCTION_REGION: new params.ParamValue("", true, {
+    string: true,
+    boolean: false,
+    number: false,
+  }),
 };
 
 describe("CEL resolution", () => {
@@ -161,6 +166,11 @@ describe("resolveParams", () => {
         boolean: false,
         number: false,
       }),
+      FUNCTION_REGION: new params.ParamValue("", true, {
+        string: true,
+        boolean: false,
+        number: false,
+      }),
     });
   });
 
@@ -176,6 +186,7 @@ describe("resolveParams", () => {
     ).to.eventually.deep.equal({
       GCLOUD_PROJECT: expectedInternalParams.GCLOUD_PROJECT,
       PROJECT_ID: expectedInternalParams.PROJECT_ID,
+      FUNCTION_REGION: expectedInternalParams.FUNCTION_REGION,
     });
   });
 

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -456,6 +456,11 @@ function populateDefaultParams(config: FirebaseConfig): Record<string, ParamValu
       number: false,
     });
   }
+  defaultParams["FUNCTION_REGION"] = new ParamValue("", true, {
+    string: true,
+    boolean: false,
+    number: false,
+  });
   return defaultParams;
 }
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -327,6 +327,7 @@ export async function prepare(
         // more restrictive character set). We'll need to reimplement that here.
         // BUG BUG BUG. This has happened and we need to fix it.
         resource = `projects/${endpoint.project}/locations/${endpoint.region}/services/${endpoint.id}`;
+        endpoint.environmentVariables["FUNCTION_REGION"] = endpoint.region;
       } else {
         assertExhaustive(endpoint.platform);
       }

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -1506,6 +1506,9 @@ export class FunctionsEmulator implements EmulatorInstance {
       envs.FUNCTION_TARGET = target;
       envs.FUNCTION_SIGNATURE_TYPE = getSignatureType(trigger);
       envs.K_SERVICE = trigger.name;
+      if (trigger.region) {
+        envs.FUNCTION_REGION = trigger.region;
+      }
     }
     return envs;
   }


### PR DESCRIPTION
### Description
GCF v2 / Cloud Run platforms do not include the `FUNCTION_REGION` environment variable by default, which can break some workflows. In particular, Firebase Extensions may depend on this variable to target callable or task queue functions in the same region.

This change:
1. Injects the `FUNCTION_REGION` environment variable in the CLI (`firebase-tools`) for functions with `gcfv2` or `run` platforms during deployment.
2. Injects the `FUNCTION_REGION` environment variable in the functions emulator for all platforms when the trigger is present.
3. Correctly resolves the `FUNCTION_REGION` parameter per-region when translating the multi-region build to backend representations.

### Scenarios Tested
- Unit tests verifying per-region CEL evaluation of `FUNCTION_REGION` in `toBackend`.
- Integration tests in the emulator verifying `FUNCTION_REGION` is correctly injected in emulated processes.

### Sample Commands
- `firebase deploy --only functions`
- `firebase emulators:start --only functions`