### PR TITLE
feat(mcp): add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).

--- a/src/mcp/onemcp/onemcp_server.spec.ts
+++ b/src/mcp/onemcp/onemcp_server.spec.ts
@@ -5,6 +5,7 @@ import { Client } from "../../apiv2";
 import * as ensureModule from "../../ensureApiEnabled";
 import { FirebaseError } from "../../error";
 import { ServerFeature } from "../types";
+import { LATEST_PROTOCOL_VERSION } from "@modelcontextprotocol/sdk/types.js";
 
 describe("OneMcpServer", () => {
   let sandbox: sinon.SinonSandbox;
@@ -52,6 +53,10 @@ describe("OneMcpServer", () => {
         feature: "auth",
       });
       expect(clientRequestStub).to.have.been.calledOnce;
+      expect(clientRequestStub.firstCall.args[0].headers).to.deep.include({
+        "MCP-Protocol-Version": LATEST_PROTOCOL_VERSION,
+        "Mcp-Method": "tools/list",
+      });
     });
 
     it("should throw FirebaseError if fetch fails", async () => {
@@ -115,6 +120,9 @@ describe("OneMcpServer", () => {
         },
       });
       expect(clientRequestStub.secondCall.args[0].headers).to.deep.include({
+        "MCP-Protocol-Version": LATEST_PROTOCOL_VERSION,
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "test_tool",
         "x-goog-user-project": "test-project",
       });
     });
@@ -135,6 +143,11 @@ describe("OneMcpServer", () => {
       await tool.fn({ arg: "val" }, { ...mockContext, projectId: undefined });
 
       expect(clientRequestStub.secondCall.args[0].headers?.["x-goog-user-project"]).to.be.undefined;
+      expect(clientRequestStub.secondCall.args[0].headers).to.deep.equal({
+        "MCP-Protocol-Version": LATEST_PROTOCOL_VERSION,
+        "Mcp-Method": "tools/call",
+        "Mcp-Name": "test_tool",
+      });
     });
 
     it("should handle remote tool error results", async () => {

--- a/src/mcp/onemcp/onemcp_server.ts
+++ b/src/mcp/onemcp/onemcp_server.ts
@@ -6,6 +6,7 @@ import {
   JSONRPCRequest,
   ListToolsRequest,
   CallToolRequest,
+  LATEST_PROTOCOL_VERSION,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Client } from "../../apiv2";
 import { ServerTool, ServerToolMeta } from "../tool";
@@ -47,11 +48,20 @@ export class OneMcpServer {
       const res = await this.listClient.post<
         JSONRPCRequest & ListToolsRequest,
         JSONRPCResultResponse
-      >("/mcp", {
-        method: "tools/list",
-        jsonrpc: "2.0",
-        id: 1,
-      });
+      >(
+        "/mcp",
+        {
+          method: "tools/list",
+          jsonrpc: "2.0",
+          id: 1,
+        },
+        {
+          headers: {
+            "MCP-Protocol-Version": LATEST_PROTOCOL_VERSION,
+            "Mcp-Method": "tools/list",
+          },
+        },
+      );
 
       const parsed = ListToolsResultSchema.parse(res.body.result);
       return parsed.tools.map((mcpTool) => ({
@@ -102,13 +112,14 @@ export class OneMcpServer {
           jsonrpc: "2.0",
           id: 1,
         },
-        ctx.projectId
-          ? {
-              headers: {
-                "x-goog-user-project": ctx.projectId,
-              },
-            }
-          : {},
+        {
+          headers: {
+            "MCP-Protocol-Version": LATEST_PROTOCOL_VERSION,
+            "Mcp-Method": "tools/call",
+            "Mcp-Name": toolName,
+            ...(ctx.projectId ? { "x-goog-user-project": ctx.projectId } : {}),
+          },
+        },
       );
       return CallToolResultSchema.parse(res.body.result);
     } catch (error) {


### PR DESCRIPTION
### Description
Adds `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers for proxy requests issued by `OneMcpServer`, adhering to the MCP 0728 standard release candidate specification and SEP-2243:
- https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/
- https://modelcontextprotocol.io/seps/2243-http-standardization

### Scenarios Tested
- Unit tests in src/mcp/onemcp/onemcp_server.spec.ts verifying listTools sends `MCP-Protocol-Version` and `Mcp-Method`.
- Unit tests in src/mcp/onemcp/onemcp_server.spec.ts verifying callTool sends `MCP-Protocol-Version`, `Mcp-Method`, `Mcp-Name`, and `x-goog-user-project` headers.

### Sample Commands
npx mocha --require ts-node/register src/mcp/onemcp/onemcp_server.spec.ts

