### PR TITLE
fix: consume stream response body via streamToString instead of res.response.text()

### DIFF
--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -118,7 +118,7 @@ export const command = new Command("database:get <path>")
 
     if (res.status >= 400) {
       // TODO(bkendall): consider moving stream-handling logic to responseToError.
-      const r = await utils.streamToString(res.body);
+      const r = res.body ? await utils.streamToString(res.body) : "";
       let d;
       try {
         d = JSON.parse(r);

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -118,7 +118,7 @@ export const command = new Command("database:get <path>")
 
     if (res.status >= 400) {
       // TODO(bkendall): consider moving stream-handling logic to responseToError.
-      const r = await res.response.text();
+      const r = await utils.streamToString(res.body);
       let d;
       try {
         d = JSON.parse(r);

--- a/src/commands/database-get.ts
+++ b/src/commands/database-get.ts
@@ -118,7 +118,7 @@ export const command = new Command("database:get <path>")
 
     if (res.status >= 400) {
       // TODO(bkendall): consider moving stream-handling logic to responseToError.
-      const r = res.body ? await utils.streamToString(res.body) : "";
+      const r = await utils.streamToString(res.body);
       let d;
       try {
         d = JSON.parse(r);

--- a/src/deploy/hosting/uploader.spec.ts
+++ b/src/deploy/hosting/uploader.spec.ts
@@ -18,7 +18,7 @@ describe("deploy/hosting/uploader", () => {
       this.handler = options.handler;
     }
     add(item: T) {
-      const p = Promise.resolve(this.handler(item));
+      const p = this.handler(item);
       this.promises.push(p);
     }
     process() {
@@ -122,5 +122,33 @@ describe("deploy/hosting/uploader", () => {
     expect(clientPostStub.firstCall.args[1].files).to.have.property("/file1.txt");
     expect(clientPostStub.firstCall.args[1].files).to.have.property("/file2.txt");
     expect(clientRequestStub.calledTwice).to.be.true;
+  });
+
+  it("should handle error response when uploading a file fails", async () => {
+    const uploader = new Uploader({
+      version: "v1",
+      projectRoot: "root",
+      files: ["file1.txt"],
+      public: "public",
+    });
+    (uploader as any).uploadClient = new Client({ urlPrefix: "https://upload.url" });
+
+    (uploader as any).hashMap = { "/file1.txt": "file1.txt" };
+
+    (fs.createReadStream as sinon.SinonStub).returns(new PassThrough());
+    (zlib.createGzip as sinon.SinonStub).returns(new PassThrough());
+
+    const errStream = new Readable({
+      read() {
+        this.push(Buffer.from("Upload Failed Body"));
+        this.push(null);
+      },
+    });
+    clientRequestStub.resolves({ status: 500, body: errStream, response: { headers: new Map() } });
+
+    await expect((uploader as any).uploadHandler("/file1.txt")).to.be.rejectedWith(
+      Error,
+      /Upload Failed Body/,
+    );
   });
 });

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -246,7 +246,7 @@ export class Uploader {
       logger.debug("[hosting][upload]", this.uploadQueue.stats());
     }
     if (res.status !== 200) {
-      const errorMessage = await streamToString(res.body as NodeJS.ReadableStream);
+      const errorMessage = res.body ? await streamToString(res.body as NodeJS.ReadableStream) : "";
       logger.debug(
         `[hosting][upload] ${this.hashMap[toUpload]} (${toUpload}) HTTP ERROR ${
           res.status

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -11,6 +11,7 @@ import { hostingApiOrigin } from "../../api";
 import { load, dump, HashRecord } from "./hashcache";
 import { logger } from "../../logger";
 import { FirebaseError } from "../../error";
+import { streamToString } from "../../streamUtils";
 
 const MIN_UPLOAD_TIMEOUT = 30000; // 30s
 const MAX_UPLOAD_TIMEOUT = 7200000; // 2h
@@ -245,7 +246,7 @@ export class Uploader {
       logger.debug("[hosting][upload]", this.uploadQueue.stats());
     }
     if (res.status !== 200) {
-      const errorMessage = await res.response.text();
+      const errorMessage = await streamToString(res.body as NodeJS.ReadableStream);
       logger.debug(
         `[hosting][upload] ${this.hashMap[toUpload]} (${toUpload}) HTTP ERROR ${
           res.status

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -233,7 +233,7 @@ export class Uploader {
     const timeout = setTimeout(() => {
       controller.abort();
     }, this.uploadTimeout(this.hashMap[toUpload]));
-    const res = await this.uploadClient.request({
+    const res = await this.uploadClient.request<void, NodeJS.ReadableStream>({
       method: "POST",
       path: `/${toUpload}`,
       body: this.zipStream(this.hashMap[toUpload]),
@@ -246,7 +246,7 @@ export class Uploader {
       logger.debug("[hosting][upload]", this.uploadQueue.stats());
     }
     if (res.status !== 200) {
-      const errorMessage = res.body ? await streamToString(res.body as NodeJS.ReadableStream) : "";
+      const errorMessage = res.body ? await streamToString(res.body) : "";
       logger.debug(
         `[hosting][upload] ${this.hashMap[toUpload]} (${toUpload}) HTTP ERROR ${
           res.status

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -233,7 +233,7 @@ export class Uploader {
     const timeout = setTimeout(() => {
       controller.abort();
     }, this.uploadTimeout(this.hashMap[toUpload]));
-    const res = await this.uploadClient.request<void, NodeJS.ReadableStream>({
+    const res = await this.uploadClient.request<unknown, NodeJS.ReadableStream>({
       method: "POST",
       path: `/${toUpload}`,
       body: this.zipStream(this.hashMap[toUpload]),

--- a/src/deploy/hosting/uploader.ts
+++ b/src/deploy/hosting/uploader.ts
@@ -246,7 +246,7 @@ export class Uploader {
       logger.debug("[hosting][upload]", this.uploadQueue.stats());
     }
     if (res.status !== 200) {
-      const errorMessage = res.body ? await streamToString(res.body) : "";
+      const errorMessage = await streamToString(res.body);
       logger.debug(
         `[hosting][upload] ${this.hashMap[toUpload]} (${toUpload}) HTTP ERROR ${
           res.status

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -338,9 +338,8 @@ export class HubExport {
       resolveOnHTTPError: true,
     });
     if (res.status >= 400) {
-      throw new FirebaseError(
-        `Failed to export storage: ${await streamToString(res.body as NodeJS.ReadableStream)}`,
-      );
+      const errorMsg = res.body ? await streamToString(res.body as NodeJS.ReadableStream) : "";
+      throw new FirebaseError(`Failed to export storage: ${errorMsg}`);
     }
   }
 

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -15,6 +15,7 @@ import { DataConnectEmulator } from "./dataconnectEmulator";
 import { rmSync } from "node:fs";
 import { trackEmulator } from "../track";
 import { dataConnectLocalConnString } from "../api";
+import { streamToString } from "../streamUtils";
 
 export interface FirestoreExportMetadata {
   version: string;
@@ -337,7 +338,9 @@ export class HubExport {
       resolveOnHTTPError: true,
     });
     if (res.status >= 400) {
-      throw new FirebaseError(`Failed to export storage: ${await res.response.text()}`);
+      throw new FirebaseError(
+        `Failed to export storage: ${await streamToString(res.body as NodeJS.ReadableStream)}`,
+      );
     }
   }
 

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -329,7 +329,10 @@ export class HubExport {
       initiatedBy: this.options.initiatedBy,
     };
 
-    const res = await EmulatorRegistry.client(Emulators.STORAGE).request({
+    const res = await EmulatorRegistry.client(Emulators.STORAGE).request<
+      void,
+      NodeJS.ReadableStream
+    >({
       method: "POST",
       path: "/internal/export",
       headers: { "Content-Type": "application/json" },
@@ -338,7 +341,7 @@ export class HubExport {
       resolveOnHTTPError: true,
     });
     if (res.status >= 400) {
-      const errorMsg = res.body ? await streamToString(res.body as NodeJS.ReadableStream) : "";
+      const errorMsg = res.body ? await streamToString(res.body) : "";
       throw new FirebaseError(`Failed to export storage: ${errorMsg}`);
     }
   }

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -330,7 +330,7 @@ export class HubExport {
     };
 
     const res = await EmulatorRegistry.client(Emulators.STORAGE).request<
-      void,
+      unknown,
       NodeJS.ReadableStream
     >({
       method: "POST",

--- a/src/emulator/hubExport.ts
+++ b/src/emulator/hubExport.ts
@@ -341,8 +341,7 @@ export class HubExport {
       resolveOnHTTPError: true,
     });
     if (res.status >= 400) {
-      const errorMsg = res.body ? await streamToString(res.body) : "";
-      throw new FirebaseError(`Failed to export storage: ${errorMsg}`);
+      throw new FirebaseError(`Failed to export storage: ${await streamToString(res.body)}`);
     }
   }
 

--- a/src/init/features/database.ts
+++ b/src/init/features/database.ts
@@ -47,7 +47,7 @@ async function getDBRules(instanceDetails: DatabaseInstance): Promise<string> {
   if (response.status !== 200) {
     throw new FirebaseError(`Failed to fetch current rules. Code: ${response.status}`);
   }
-  return await response.response.text();
+  return await utils.streamToString(response.body);
 }
 
 function writeDBRules(rules: string, filename: string, config: Config): void {

--- a/src/init/features/database.ts
+++ b/src/init/features/database.ts
@@ -47,7 +47,7 @@ async function getDBRules(instanceDetails: DatabaseInstance): Promise<string> {
   if (response.status !== 200) {
     throw new FirebaseError(`Failed to fetch current rules. Code: ${response.status}`);
   }
-  return await utils.streamToString(response.body);
+  return response.body ? await utils.streamToString(response.body) : "";
 }
 
 function writeDBRules(rules: string, filename: string, config: Config): void {

--- a/src/init/features/database.ts
+++ b/src/init/features/database.ts
@@ -47,7 +47,7 @@ async function getDBRules(instanceDetails: DatabaseInstance): Promise<string> {
   if (response.status !== 200) {
     throw new FirebaseError(`Failed to fetch current rules. Code: ${response.status}`);
   }
-  return response.body ? await utils.streamToString(response.body) : "";
+  return await utils.streamToString(response.body);
 }
 
 function writeDBRules(rules: string, filename: string, config: Config): void {

--- a/src/mcp/tools/core/get_security_rules.ts
+++ b/src/mcp/tools/core/get_security_rules.ts
@@ -43,7 +43,7 @@ export const get_security_rules = tool(
         return mcpError(`Failed to fetch current rules. Code: ${response.status}`);
       }
 
-      const rules = await streamToString(response.body);
+      const rules = response.body ? await streamToString(response.body) : "";
       return toContent(rules);
     }
 

--- a/src/mcp/tools/core/get_security_rules.ts
+++ b/src/mcp/tools/core/get_security_rules.ts
@@ -4,6 +4,7 @@ import { tool } from "../../tool";
 import { mcpError, toContent } from "../../util";
 import { getLatestRulesetName, getRulesetContent, listAllReleases } from "../../../gcp/rules";
 import { getDefaultDatabaseInstance } from "../../../getDefaultDatabaseInstance";
+import { streamToString } from "../../../streamUtils";
 
 export const get_security_rules = tool(
   "core",
@@ -42,7 +43,7 @@ export const get_security_rules = tool(
         return mcpError(`Failed to fetch current rules. Code: ${response.status}`);
       }
 
-      const rules = await response.response.text();
+      const rules = await streamToString(response.body);
       return toContent(rules);
     }
 

--- a/src/mcp/tools/core/get_security_rules.ts
+++ b/src/mcp/tools/core/get_security_rules.ts
@@ -43,7 +43,7 @@ export const get_security_rules = tool(
         return mcpError(`Failed to fetch current rules. Code: ${response.status}`);
       }
 
-      const rules = response.body ? await streamToString(response.body) : "";
+      const rules = await streamToString(response.body);
       return toContent(rules);
     }
 

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -69,7 +69,8 @@ export async function profiler(options: any): Promise<unknown> {
   });
 
   if (res.response.status >= 400) {
-    throw responseToError(res.response, await utils.streamToString(res.body));
+    const errorMsg = res.body ? await utils.streamToString(res.body) : "";
+    throw responseToError(res.response, errorMsg);
   }
 
   if (!options.duration) {

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -69,7 +69,7 @@ export async function profiler(options: any): Promise<unknown> {
   });
 
   if (res.response.status >= 400) {
-    throw responseToError(res.response, await res.response.text());
+    throw responseToError(res.response, await utils.streamToString(res.body));
   }
 
   if (!options.duration) {

--- a/src/profiler.ts
+++ b/src/profiler.ts
@@ -69,8 +69,7 @@ export async function profiler(options: any): Promise<unknown> {
   });
 
   if (res.response.status >= 400) {
-    const errorMsg = res.body ? await utils.streamToString(res.body) : "";
-    throw responseToError(res.response, errorMsg);
+    throw responseToError(res.response, await utils.streamToString(res.body));
   }
 
   if (!options.duration) {

--- a/src/streamUtils.ts
+++ b/src/streamUtils.ts
@@ -20,7 +20,10 @@ export function stringToStream(text: string): Readable | undefined {
  * @param s a readable stream.
  * @return a promise resolving to the string'd contents of the stream.
  */
-export function streamToString(s: NodeJS.ReadableStream): Promise<string> {
+export function streamToString(s?: NodeJS.ReadableStream | null): Promise<string> {
+  if (!s) {
+    return Promise.resolve("");
+  }
   return new Promise((resolve, reject) => {
     let b = "";
     s.on("error", reject);

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -289,6 +289,11 @@ describe("utils", () => {
       }
       await expect(utils.streamToString(stream)).to.eventually.equal("hello world");
     });
+
+    it("should return empty string if stream is undefined or null", async () => {
+      await expect(utils.streamToString(undefined)).to.eventually.equal("");
+      await expect(utils.streamToString(null)).to.eventually.equal("");
+    });
   });
 
   describe("allSettled", () => {


### PR DESCRIPTION
Fixes #10809

### Root Cause
When native `fetch` is used with `responseType: "stream"`, `apiv2.ts` converts the Fetch API's `ReadableStream` (`res.body`) into a Node.js `Readable` stream using `Readable.fromWeb(res.body)`. Under Web Streams API semantics, this locks the underlying `ReadableStream`. Subsequent calls to `res.response.text()` on the native `Response` object throw `TypeError: Body is unusable: Body has already been read`.

### Fix
Updated handlers that consume stream responses to read from `res.body` via `streamToString(res.body)` rather than calling `res.response.text()`.

### Verification
- Tested with minimal reproduction script from #10809.
- All unit tests (`npm test`) passed.
- Linter (`npm run lint`) passed cleanly.