### PR TITLE
feat(mcp): add `allowedTools` filtering support to `OneMcpServer`

### DIFF
--- a/src/mcp/onemcp/onemcp_server.spec.ts
+++ b/src/mcp/onemcp/onemcp_server.spec.ts
@@ -77,6 +77,30 @@ describe("OneMcpServer", () => {
 
       await expect(server.listTools()).to.be.rejected;
     });
+
+    it("should filter tools if allowedTools option is provided", async () => {
+      const serverWithFilter = new OneMcpServer(
+        feature,
+        serverUrl,
+        { requiresAuth: false, requiresProject: true },
+        { allowedTools: ["allowed_tool"] },
+      );
+      clientRequestStub.resolves({
+        body: {
+          result: {
+            tools: [
+              { name: "allowed_tool", inputSchema: { type: "object" } },
+              { name: "disallowed_tool", inputSchema: { type: "object" } },
+            ],
+          },
+        },
+      });
+
+      const tools = await serverWithFilter.listTools();
+
+      expect(tools).to.have.length(1);
+      expect(tools[0].mcp.name).to.equal("auth_allowed_tool");
+    });
   });
 
   describe("callTool", () => {
@@ -204,6 +228,22 @@ describe("OneMcpServer", () => {
       });
 
       await expect(tool.fn({}, mockContext)).to.be.rejected;
+    });
+
+    it("should throw FirebaseError when calling a tool not in allowedTools", async () => {
+      const serverWithFilter = new OneMcpServer(
+        feature,
+        serverUrl,
+        { requiresAuth: false, requiresProject: true },
+        { allowedTools: ["allowed_tool"] },
+      );
+
+      const fn = (serverWithFilter as any).callTool.bind(serverWithFilter);
+
+      await expect(fn("disallowed_tool", {}, mockContext)).to.be.rejectedWith(
+        FirebaseError,
+        /is not allowed on remote server/,
+      );
     });
   });
 });

--- a/src/mcp/onemcp/onemcp_server.ts
+++ b/src/mcp/onemcp/onemcp_server.ts
@@ -14,6 +14,15 @@ import { McpContext, ServerFeature } from "../types";
 import { FirebaseError } from "../../error";
 import { ensure } from "../../ensureApiEnabled";
 
+export interface OneMcpServerOptions {
+  /**
+   * Optional allowlist of tool names. If provided, only tools matching
+   * these names (original remote tool name or prefixed name) will be surfaced in listTools()
+   * and permitted in callTool().
+   */
+  allowedTools?: string[];
+}
+
 /**
  * OneMcpServer encapsulates the logic for interacting with a remote MCP server.
  */
@@ -24,11 +33,13 @@ export class OneMcpServer {
    * @param feature The Firebase feature this server belongs to.
    * @param serverUrl The base URL of the remote MCP server.
    * @param meta Metadata to be attached to every tool from this server.
+   * @param options Additional options, including tool filtering.
    */
   constructor(
     private readonly feature: ServerFeature,
     private readonly serverUrl: string,
     private readonly meta: ServerToolMeta,
+    private readonly options: OneMcpServerOptions = {},
   ) {
     this.listClient = new Client({
       urlPrefix: this.serverUrl,
@@ -64,7 +75,17 @@ export class OneMcpServer {
       );
 
       const parsed = ListToolsResultSchema.parse(res.body.result);
-      return parsed.tools.map((mcpTool) => ({
+      const tools = parsed.tools.filter((mcpTool) => {
+        if (!this.options.allowedTools?.length) {
+          return true;
+        }
+        return (
+          this.options.allowedTools.includes(mcpTool.name) ||
+          this.options.allowedTools.includes(`${this.feature}_${mcpTool.name}`)
+        );
+      });
+
+      return tools.map((mcpTool) => ({
         mcp: {
           ...mcpTool,
           name: `${this.feature}_${mcpTool.name}`,
@@ -95,6 +116,16 @@ export class OneMcpServer {
     },
     ctx: McpContext,
   ): Promise<CallToolResult> {
+    if (
+      this.options.allowedTools?.length &&
+      !this.options.allowedTools.includes(toolName) &&
+      !this.options.allowedTools.includes(`${this.feature}_${toolName}`)
+    ) {
+      throw new FirebaseError(
+        `Tool '${toolName}' is not allowed on remote server for feature '${this.feature}'.`,
+      );
+    }
+
     // TODO: Optimize this to not call ensure on every tool call.
     await ensure(ctx.projectId, this.serverUrl, this.feature, /* silent=*/ true);
     try {


### PR DESCRIPTION
### Description
Adds support for tool filtering in `OneMcpServer` via an optional `allowedTools?: string[]` parameter in `OneMcpServerOptions` (addressing b/535744232).
- `listTools()` filters remote tool list responses against `allowedTools`.
- `callTool()` guards against invoking tools not present in `allowedTools`.

### Scenarios Tested
- Unit tests in src/mcp/onemcp/onemcp_server.spec.ts verifying `listTools` filters tools when `allowedTools` is configured.
- Unit tests in src/mcp/onemcp/onemcp_server.spec.ts verifying `callTool` throws a `FirebaseError` for unallowed tools.
- Unit tests verifying backward compatibility when `allowedTools` is omitted or empty.

### Sample Commands
npx mocha --require ts-node/register src/mcp/onemcp/onemcp_server.spec.ts
