### PR TITLE
extensions deprecation CLI warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
+- Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.

--- a/src/command.ts
+++ b/src/command.ts
@@ -16,6 +16,8 @@ import { reconcileStudioFirebaseProject } from "./management/studio";
 import { requireAuth } from "./requireAuth";
 import { Options } from "./options";
 import { isFirebaseStudio } from "./env";
+import * as experiments from "./experiments";
+import { showDeprecationWarningBefore, showDeprecationWarningAfter } from "./extensions/warnings";
 
 export interface CommandModule {
   load: () => void;
@@ -474,10 +476,20 @@ export class Command {
       const options = last(args);
       await this.prepare(options);
 
+      if (this.name.startsWith("ext:") && experiments.isEnabled("extdeprecationwarnings")) {
+        showDeprecationWarningBefore(this.name, options);
+      }
+
       for (const before of this.befores) {
         await before.fn(options, ...before.args);
       }
-      return this.actionFn(...args);
+      const result = await this.actionFn(...args);
+
+      if (this.name.startsWith("ext:") && experiments.isEnabled("extdeprecationwarnings")) {
+        showDeprecationWarningAfter(this.name, options);
+      }
+
+      return result;
     };
   }
 }

--- a/src/experiments.spec.ts
+++ b/src/experiments.spec.ts
@@ -26,16 +26,5 @@ describe("experiments", () => {
       expect(isEnabled("experiments")).to.be.true;
       setEnabled("experiments", false);
     });
-
-    it("should disable experiments when prefixed with hyphen in env var", () => {
-      setEnabled("extdeprecationwarnings", true);
-      expect(isEnabled("extdeprecationwarnings")).to.be.true;
-
-      process.env.FIREBASE_CLI_EXPERIMENTS = "-extdeprecationwarnings";
-      enableExperimentsFromCliEnvVariable();
-
-      expect(isEnabled("extdeprecationwarnings")).to.be.false;
-      setEnabled("extdeprecationwarnings", null);
-    });
   });
 });

--- a/src/experiments.spec.ts
+++ b/src/experiments.spec.ts
@@ -26,5 +26,16 @@ describe("experiments", () => {
       expect(isEnabled("experiments")).to.be.true;
       setEnabled("experiments", false);
     });
+
+    it("should disable experiments when prefixed with hyphen in env var", () => {
+      setEnabled("extdeprecationwarnings", true);
+      expect(isEnabled("extdeprecationwarnings")).to.be.true;
+
+      process.env.FIREBASE_CLI_EXPERIMENTS = "-extdeprecationwarnings";
+      enableExperimentsFromCliEnvVariable();
+
+      expect(isEnabled("extdeprecationwarnings")).to.be.false;
+      setEnabled("extdeprecationwarnings", null);
+    });
   });
 });

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -299,14 +299,8 @@ export function setEnabled(name: ExperimentName, to: boolean | null): void {
 export function enableExperimentsFromCliEnvVariable(): void {
   const experiments = process.env.FIREBASE_CLI_EXPERIMENTS || "";
   for (const experiment of experiments.split(",")) {
-    const trimmed = experiment.trim();
-    if (trimmed.startsWith("-")) {
-      const expName = trimmed.slice(1);
-      if (isValidExperiment(expName)) {
-        setEnabled(expName, false);
-      }
-    } else if (isValidExperiment(trimmed)) {
-      setEnabled(trimmed, true);
+    if (isValidExperiment(experiment)) {
+      setEnabled(experiment, true);
     }
   }
 }

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -214,6 +214,11 @@ export const ALL_EXPERIMENTS = experiments({
     default: false,
     public: true,
   },
+  extdeprecationwarnings: {
+    shortDescription: "Show deprecation warnings for Firebase Extensions CLI commands.",
+    default: false,
+    public: true,
+  },
 });
 
 export type ExperimentName = keyof typeof ALL_EXPERIMENTS;
@@ -288,8 +293,14 @@ export function setEnabled(name: ExperimentName, to: boolean | null): void {
 export function enableExperimentsFromCliEnvVariable(): void {
   const experiments = process.env.FIREBASE_CLI_EXPERIMENTS || "";
   for (const experiment of experiments.split(",")) {
-    if (isValidExperiment(experiment)) {
-      setEnabled(experiment, true);
+    const trimmed = experiment.trim();
+    if (trimmed.startsWith("-")) {
+      const expName = trimmed.slice(1);
+      if (isValidExperiment(expName)) {
+        setEnabled(expName, false);
+      }
+    } else if (isValidExperiment(trimmed)) {
+      setEnabled(trimmed, true);
     }
   }
 }

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -216,7 +216,7 @@ export const ALL_EXPERIMENTS = experiments({
   },
   extdeprecationwarnings: {
     shortDescription: "Show deprecation warnings for Firebase Extensions CLI commands.",
-    default: false,
+    default: true,
     public: true,
   },
 });

--- a/src/extensions/warnings.spec.ts
+++ b/src/extensions/warnings.spec.ts
@@ -129,7 +129,6 @@ describe("showDeprecationWarningBefore & showDeprecationWarningAfter", () => {
   afterEach(() => {
     warnStub.restore();
     Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
-    warnings.setPhase2ThresholdForTest(new Date("2026-09-14T00:00:00Z").getTime());
     for (const [k, v] of Object.entries(originalEnv)) {
       if (v !== undefined) {
         process.env[k] = v;
@@ -139,32 +138,17 @@ describe("showDeprecationWarningBefore & showDeprecationWarningAfter", () => {
     }
   });
 
-  it("should hard-error and exit 1 on ext:dev:register in Phase 1 and Phase 2", () => {
-    warnings.setPhase2ThresholdForTest(Date.now() + 100000);
+  it("should hard-error and exit 1 on ext:dev:register", () => {
     expect(() => warnings.showDeprecationWarningBefore("ext:dev:register", {})).to.throw(
       FirebaseError,
       /ext:dev:register is disabled/,
     );
-
-    warnings.setPhase2ThresholdForTest(Date.now() - 100000);
-    expect(() => warnings.showDeprecationWarningBefore("ext:dev:register", {})).to.throw(
-      FirebaseError,
-      /Creating or registering new Firebase Extensions is disabled/,
-    );
   });
 
-  it("should show concise warning for Category 1 in Phase 1 and boxed banner in Phase 2", () => {
-    warnings.setPhase2ThresholdForTest(Date.now() + 100000);
+  it("should show concise warning for Category 1 commands", () => {
     warnings.showDeprecationWarningBefore("ext:install", {});
     expect(warnStub).to.have.been.calledWithMatch(
       /You will not be able to install or edit extensions/,
-    );
-
-    warnStub.resetHistory();
-    warnings.setPhase2ThresholdForTest(Date.now() - 100000);
-    warnings.showDeprecationWarningBefore("ext:install", {});
-    expect(warnStub).to.have.been.calledWithMatch(
-      /We recommend migrating active instances to Function-kits/,
     );
   });
 
@@ -187,7 +171,6 @@ describe("showDeprecationWarningBefore & showDeprecationWarningAfter", () => {
   });
 
   it("should show footer warning in showDeprecationWarningAfter for Category 2 commands", () => {
-    warnings.setPhase2ThresholdForTest(Date.now() + 100000);
     warnings.showDeprecationWarningAfter("ext:list", {});
     expect(warnStub).to.have.been.calledWithMatch(/Notice: Firebase Extensions will shut down/);
   });

--- a/src/extensions/warnings.spec.ts
+++ b/src/extensions/warnings.spec.ts
@@ -108,16 +108,35 @@ describe("showDeprecationWarningBefore & showDeprecationWarningAfter", () => {
   let warnStub: sinon.SinonStub;
   let originalIsTTY: boolean;
 
+  let originalEnv: Record<string, string | undefined>;
+
   beforeEach(() => {
     warnStub = sinon.stub(logger, "warn");
     originalIsTTY = process.stdout.isTTY;
     Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+    originalEnv = {
+      CI: process.env.CI,
+      GITHUB_ACTIONS: process.env.GITHUB_ACTIONS,
+      BUILD_ID: process.env.BUILD_ID,
+      TF_BUILD: process.env.TF_BUILD,
+    };
+    delete process.env.CI;
+    delete process.env.GITHUB_ACTIONS;
+    delete process.env.BUILD_ID;
+    delete process.env.TF_BUILD;
   });
 
   afterEach(() => {
     warnStub.restore();
     Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
     warnings.setPhase2ThresholdForTest(new Date("2026-09-14T00:00:00Z").getTime());
+    for (const [k, v] of Object.entries(originalEnv)) {
+      if (v !== undefined) {
+        process.env[k] = v;
+      } else {
+        delete process.env[k];
+      }
+    }
   });
 
   it("should hard-error and exit 1 on ext:dev:register in Phase 1 and Phase 2", () => {

--- a/src/extensions/warnings.spec.ts
+++ b/src/extensions/warnings.spec.ts
@@ -11,6 +11,8 @@ import {
 } from "./types";
 import { DeploymentInstanceSpec } from "../deploy/extensions/planner";
 import * as utils from "../utils";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
 
 const testExtensionVersion = (listingState: ListingState): ExtensionVersion => {
   return {
@@ -99,5 +101,102 @@ describe("displayWarningsForDeploy", () => {
       "extensions",
       "have not been published to the Firebase Extensions Hub",
     );
+  });
+});
+
+describe("showDeprecationWarningBefore & showDeprecationWarningAfter", () => {
+  let warnStub: sinon.SinonStub;
+  let originalIsTTY: boolean;
+
+  beforeEach(() => {
+    warnStub = sinon.stub(logger, "warn");
+    originalIsTTY = process.stdout.isTTY;
+    Object.defineProperty(process.stdout, "isTTY", { value: true, configurable: true });
+  });
+
+  afterEach(() => {
+    warnStub.restore();
+    Object.defineProperty(process.stdout, "isTTY", { value: originalIsTTY, configurable: true });
+    warnings.setPhase2ThresholdForTest(new Date("2026-09-14T00:00:00Z").getTime());
+  });
+
+  it("should hard-error and exit 1 on ext:dev:register in Phase 1 and Phase 2", () => {
+    warnings.setPhase2ThresholdForTest(Date.now() + 100000);
+    expect(() => warnings.showDeprecationWarningBefore("ext:dev:register", {})).to.throw(
+      FirebaseError,
+      /ext:dev:register is disabled/,
+    );
+
+    warnings.setPhase2ThresholdForTest(Date.now() - 100000);
+    expect(() => warnings.showDeprecationWarningBefore("ext:dev:register", {})).to.throw(
+      FirebaseError,
+      /Creating or registering new Firebase Extensions is disabled/,
+    );
+  });
+
+  it("should show concise warning for Category 1 in Phase 1 and boxed banner in Phase 2", () => {
+    warnings.setPhase2ThresholdForTest(Date.now() + 100000);
+    warnings.showDeprecationWarningBefore("ext:install", {});
+    expect(warnStub).to.have.been.calledWithMatch(
+      /You will not be able to install or edit extensions/,
+    );
+
+    warnStub.resetHistory();
+    warnings.setPhase2ThresholdForTest(Date.now() - 100000);
+    warnings.showDeprecationWarningBefore("ext:install", {});
+    expect(warnStub).to.have.been.calledWithMatch(
+      /We recommend migrating active instances to Function-kits/,
+    );
+  });
+
+  it("should show prominent banner for Category 4 commands", () => {
+    warnings.showDeprecationWarningBefore("ext:dev:upload", {});
+    expect(warnStub).to.have.been.calledWithMatch(
+      /Notice for Publishers: Firebase Extensions will shut down/,
+    );
+  });
+
+  it("should silence warnings when isSilenced returns true", () => {
+    warnings.showDeprecationWarningBefore("ext:install", { json: true });
+    expect(warnStub).to.not.have.been.called;
+
+    warnings.showDeprecationWarningBefore("ext:install", { nonInteractive: true });
+    expect(warnStub).to.not.have.been.called;
+
+    warnings.showDeprecationWarningAfter("ext:list", { quiet: true });
+    expect(warnStub).to.not.have.been.called;
+  });
+
+  it("should show footer warning in showDeprecationWarningAfter for Category 2 commands", () => {
+    warnings.setPhase2ThresholdForTest(Date.now() + 100000);
+    warnings.showDeprecationWarningAfter("ext:list", {});
+    expect(warnStub).to.have.been.calledWithMatch(/Notice: Firebase Extensions will shut down/);
+  });
+
+  it("should hard-error on ext:dev:register even if json flag is true", () => {
+    expect(() =>
+      warnings.showDeprecationWarningBefore("ext:dev:register", { json: true }),
+    ).to.throw(FirebaseError, /ext:dev:register is disabled/);
+  });
+
+  it("should silence warnings when CI or GITHUB_ACTIONS environment variables are set", () => {
+    const origCI = process.env.CI;
+    process.env.CI = "true";
+    try {
+      expect(warnings.isSilenced({})).to.be.true;
+    } finally {
+      if (origCI !== undefined) {
+        process.env.CI = origCI;
+      } else {
+        delete process.env.CI;
+      }
+    }
+  });
+
+  it("should not warn on Category 3 commands", () => {
+    warnings.showDeprecationWarningBefore("ext:export", {});
+    warnings.showDeprecationWarningAfter("ext:export", {});
+    warnings.showDeprecationWarningBefore("ext:uninstall", {});
+    expect(warnStub).to.not.have.been.called;
   });
 });

--- a/src/extensions/warnings.spec.ts
+++ b/src/extensions/warnings.spec.ts
@@ -195,6 +195,20 @@ describe("showDeprecationWarningBefore & showDeprecationWarningAfter", () => {
     }
   });
 
+  it("should not silence warnings when CI is explicitly set to false", () => {
+    const origCI = process.env.CI;
+    process.env.CI = "false";
+    try {
+      expect(warnings.isSilenced({})).to.be.false;
+    } finally {
+      if (origCI !== undefined) {
+        process.env.CI = origCI;
+      } else {
+        delete process.env.CI;
+      }
+    }
+  });
+
   it("should not warn on Category 3 commands", () => {
     warnings.showDeprecationWarningBefore("ext:export", {});
     warnings.showDeprecationWarningAfter("ext:export", {});

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -3,7 +3,9 @@ import * as clc from "colorette";
 import { logPrefix } from "./extensionsHelper";
 import { humanReadable } from "../deploy/extensions/deploymentSummary";
 import { InstanceSpec, getExtensionVersion } from "../deploy/extensions/planner";
+import { FirebaseError } from "../error";
 import { logger } from "../logger";
+import { Options } from "../options";
 import * as utils from "../utils";
 
 const toListEntry = (i: InstanceSpec) => {
@@ -52,4 +54,148 @@ export function outOfBandChangesWarning(instanceIds: string[], isDynamic: boolea
       clc.bold(instanceIds.join("\n\t")) +
       `\nIf you proceed with this deployment, those changes will be overwritten.${extra}`,
   );
+}
+
+const FAQ_URL = "https://firebase.google.com/docs/extensions/faq-and-troubleshooting";
+let phase2ThresholdMs = new Date("2026-09-14T00:00:00Z").getTime();
+
+const NO_WARNING_COMMANDS = new Set(["ext:uninstall", "ext:dev:deprecate", "ext:export"]);
+const LIST_COMMANDS = new Set(["ext:list", "ext:info"]);
+const INSTALL_COMMANDS = new Set(["ext:install", "ext:configure", "ext:update", "ext:sdk:install"]);
+const PUBLISHER_COMMANDS = new Set([
+  "ext:dev:init",
+  "ext:dev:upload",
+  "ext:dev:list",
+  "ext:dev:usage",
+  "ext:dev:undeprecate",
+]);
+
+export function setPhase2ThresholdForTest(thresholdMs: number): void {
+  phase2ThresholdMs = thresholdMs;
+}
+
+function isPhase2(): boolean {
+  return Date.now() >= phase2ThresholdMs;
+}
+
+/**
+ * Checks if deprecation warnings should be silenced (e.g. non-interactive, JSON, non-TTY, quiet mode, or CI).
+ * @param options Command execution options object.
+ */
+export function isSilenced(options: Options | Record<string, unknown>): boolean {
+  const opts = options as Record<string, unknown>;
+  if (
+    opts?.json ||
+    utils.getInheritedOption(options, "json") ||
+    opts?.nonInteractive ||
+    utils.getInheritedOption(options, "nonInteractive") ||
+    !process.stdout.isTTY ||
+    opts?.quiet ||
+    utils.getInheritedOption(options, "quiet")
+  ) {
+    return true;
+  }
+  if (
+    utils.isRunningInGithubAction() ||
+    !!process.env.CI ||
+    !!process.env.BUILD_ID ||
+    !!process.env.TF_BUILD ||
+    !!process.env.GITHUB_ACTIONS
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Displays deprecation warnings or throws hard exit errors before an ext:* command executes.
+ * @param commandName Name of the command being run (e.g. "ext:install").
+ * @param options Command execution options object.
+ */
+export function showDeprecationWarningBefore(
+  commandName: string,
+  options: Options | Record<string, unknown>,
+): void {
+  if (commandName === "ext:dev:register") {
+    if (!isPhase2()) {
+      throw new FirebaseError(
+        `ext:dev:register is disabled. Registering new publisher profile IDs is no longer supported.\n` +
+          `The Firebase Extensions service will shut down on March 31, 2027.\n` +
+          `Learn more: ${FAQ_URL}`,
+        { exit: 1 },
+      );
+    } else {
+      throw new FirebaseError(
+        `Creating or registering new Firebase Extensions is disabled.\n` +
+          `The Firebase Extensions service will shut down on March 31, 2027.\n` +
+          `Learn more: ${FAQ_URL}`,
+        { exit: 1 },
+      );
+    }
+  }
+
+  if (
+    isSilenced(options) ||
+    NO_WARNING_COMMANDS.has(commandName) ||
+    LIST_COMMANDS.has(commandName)
+  ) {
+    return;
+  }
+
+  if (INSTALL_COMMANDS.has(commandName)) {
+    if (!isPhase2()) {
+      logger.warn(
+        clc.yellow(
+          `⚠ Firebase Extensions will shut down on March 31, 2027. You will not be able to install or edit extensions after this date. We will share migration guidance and tools in September 2026. Learn more: ${FAQ_URL}`,
+        ),
+      );
+    } else {
+      logger.warn(
+        clc.yellow(
+          `================================================================================\n` +
+            `⚠ Firebase Extensions will shut down on March 31, 2027.\n` +
+            `We recommend migrating active instances to Function-kits.\n` +
+            `Learn more & view migration steps: ${FAQ_URL}\n` +
+            `================================================================================`,
+        ),
+      );
+    }
+  } else if (PUBLISHER_COMMANDS.has(commandName)) {
+    logger.warn(
+      clc.yellow(
+        `================================================================================\n` +
+          `⚠ Notice for Publishers: Firebase Extensions will shut down on March 31, 2027.\n` +
+          `Learn more & view migration steps: ${FAQ_URL}\n` +
+          `================================================================================`,
+      ),
+    );
+  }
+}
+
+/**
+ * Displays post-execution deprecation warnings (e.g. single-line footer for ext:list and ext:info).
+ * @param commandName Name of the command being run.
+ * @param options Command execution options object.
+ */
+export function showDeprecationWarningAfter(
+  commandName: string,
+  options: Options | Record<string, unknown>,
+): void {
+  if (isSilenced(options) || !LIST_COMMANDS.has(commandName)) {
+    return;
+  }
+
+  if (!isPhase2()) {
+    logger.warn(
+      clc.yellow(
+        `⚠ Notice: Firebase Extensions will shut down on March 31, 2027. Learn more: ${FAQ_URL}`,
+      ),
+    );
+  } else {
+    logger.warn(
+      clc.yellow(
+        `⚠ Notice: Firebase Extensions will shut down on March 31, 2027. Learn more & view migration steps: ${FAQ_URL}`,
+      ),
+    );
+  }
 }

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -58,16 +58,25 @@ export function outOfBandChangesWarning(instanceIds: string[], isDynamic: boolea
 
 const FAQ_URL = "https://firebase.google.com/docs/extensions/faq-and-troubleshooting";
 
-const NO_WARNING_COMMANDS = new Set(["ext:uninstall", "ext:dev:deprecate", "ext:export"]);
-const LIST_COMMANDS = new Set(["ext:list", "ext:info"]);
-const INSTALL_COMMANDS = new Set(["ext:install", "ext:configure", "ext:update", "ext:sdk:install"]);
-const PUBLISHER_COMMANDS = new Set([
+/** Commands that trigger a standard deprecation warning before execution. */
+const WARN_BEFORE_COMMANDS = new Set([
+  "ext:install",
+  "ext:configure",
+  "ext:update",
+  "ext:sdk:install",
+]);
+
+/** Publisher commands that trigger a prominent warning banner before execution. */
+const WARN_STRONGLY_BEFORE_COMMANDS = new Set([
   "ext:dev:init",
   "ext:dev:upload",
   "ext:dev:list",
   "ext:dev:usage",
   "ext:dev:undeprecate",
 ]);
+
+/** Commands that display a post-execution footer warning notice after completion. */
+const WARN_AFTER_COMMANDS = new Set(["ext:list", "ext:info"]);
 
 /**
  * Checks if deprecation warnings should be silenced (e.g. non-interactive, JSON, non-TTY, quiet mode, or CI).
@@ -116,21 +125,17 @@ export function showDeprecationWarningBefore(
     );
   }
 
-  if (
-    isSilenced(options) ||
-    NO_WARNING_COMMANDS.has(commandName) ||
-    LIST_COMMANDS.has(commandName)
-  ) {
+  if (isSilenced(options)) {
     return;
   }
 
-  if (INSTALL_COMMANDS.has(commandName)) {
+  if (WARN_BEFORE_COMMANDS.has(commandName)) {
     logger.warn(
       clc.yellow(
         `⚠ Firebase Extensions will shut down on March 31, 2027. You will not be able to install or edit extensions after this date. Learn more: ${FAQ_URL}`,
       ),
     );
-  } else if (PUBLISHER_COMMANDS.has(commandName)) {
+  } else if (WARN_STRONGLY_BEFORE_COMMANDS.has(commandName)) {
     logger.warn(
       clc.yellow(
         `================================================================================\n` +
@@ -151,7 +156,7 @@ export function showDeprecationWarningAfter(
   commandName: string,
   options: Options | Record<string, unknown>,
 ): void {
-  if (isSilenced(options) || !LIST_COMMANDS.has(commandName)) {
+  if (isSilenced(options) || !WARN_AFTER_COMMANDS.has(commandName)) {
     return;
   }
 

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -80,7 +80,7 @@ export function isSilenced(options: Options | Record<string, unknown>): boolean 
     utils.getInheritedOption(options, "json") ||
     opts?.nonInteractive ||
     utils.getInheritedOption(options, "nonInteractive") ||
-    !process.stdout.isTTY ||
+    !process.stdout?.isTTY ||
     opts?.quiet ||
     utils.getInheritedOption(options, "quiet")
   ) {
@@ -88,7 +88,7 @@ export function isSilenced(options: Options | Record<string, unknown>): boolean 
   }
   if (
     utils.isRunningInGithubAction() ||
-    !!process.env.CI ||
+    (!!process.env.CI && process.env.CI !== "false") ||
     !!process.env.BUILD_ID ||
     !!process.env.TF_BUILD ||
     !!process.env.GITHUB_ACTIONS

--- a/src/extensions/warnings.ts
+++ b/src/extensions/warnings.ts
@@ -57,7 +57,6 @@ export function outOfBandChangesWarning(instanceIds: string[], isDynamic: boolea
 }
 
 const FAQ_URL = "https://firebase.google.com/docs/extensions/faq-and-troubleshooting";
-let phase2ThresholdMs = new Date("2026-09-14T00:00:00Z").getTime();
 
 const NO_WARNING_COMMANDS = new Set(["ext:uninstall", "ext:dev:deprecate", "ext:export"]);
 const LIST_COMMANDS = new Set(["ext:list", "ext:info"]);
@@ -69,14 +68,6 @@ const PUBLISHER_COMMANDS = new Set([
   "ext:dev:usage",
   "ext:dev:undeprecate",
 ]);
-
-export function setPhase2ThresholdForTest(thresholdMs: number): void {
-  phase2ThresholdMs = thresholdMs;
-}
-
-function isPhase2(): boolean {
-  return Date.now() >= phase2ThresholdMs;
-}
 
 /**
  * Checks if deprecation warnings should be silenced (e.g. non-interactive, JSON, non-TTY, quiet mode, or CI).
@@ -117,21 +108,12 @@ export function showDeprecationWarningBefore(
   options: Options | Record<string, unknown>,
 ): void {
   if (commandName === "ext:dev:register") {
-    if (!isPhase2()) {
-      throw new FirebaseError(
-        `ext:dev:register is disabled. Registering new publisher profile IDs is no longer supported.\n` +
-          `The Firebase Extensions service will shut down on March 31, 2027.\n` +
-          `Learn more: ${FAQ_URL}`,
-        { exit: 1 },
-      );
-    } else {
-      throw new FirebaseError(
-        `Creating or registering new Firebase Extensions is disabled.\n` +
-          `The Firebase Extensions service will shut down on March 31, 2027.\n` +
-          `Learn more: ${FAQ_URL}`,
-        { exit: 1 },
-      );
-    }
+    throw new FirebaseError(
+      `ext:dev:register is disabled. Registering new publisher profile IDs is no longer supported.\n` +
+        `The Firebase Extensions service will shut down on March 31, 2027.\n` +
+        `Learn more: ${FAQ_URL}`,
+      { exit: 1 },
+    );
   }
 
   if (
@@ -143,29 +125,17 @@ export function showDeprecationWarningBefore(
   }
 
   if (INSTALL_COMMANDS.has(commandName)) {
-    if (!isPhase2()) {
-      logger.warn(
-        clc.yellow(
-          `⚠ Firebase Extensions will shut down on March 31, 2027. You will not be able to install or edit extensions after this date. We will share migration guidance and tools in September 2026. Learn more: ${FAQ_URL}`,
-        ),
-      );
-    } else {
-      logger.warn(
-        clc.yellow(
-          `================================================================================\n` +
-            `⚠ Firebase Extensions will shut down on March 31, 2027.\n` +
-            `We recommend migrating active instances to Function-kits.\n` +
-            `Learn more & view migration steps: ${FAQ_URL}\n` +
-            `================================================================================`,
-        ),
-      );
-    }
+    logger.warn(
+      clc.yellow(
+        `⚠ Firebase Extensions will shut down on March 31, 2027. You will not be able to install or edit extensions after this date. Learn more: ${FAQ_URL}`,
+      ),
+    );
   } else if (PUBLISHER_COMMANDS.has(commandName)) {
     logger.warn(
       clc.yellow(
         `================================================================================\n` +
           `⚠ Notice for Publishers: Firebase Extensions will shut down on March 31, 2027.\n` +
-          `Learn more & view migration steps: ${FAQ_URL}\n` +
+          `Learn more: ${FAQ_URL}\n` +
           `================================================================================`,
       ),
     );
@@ -185,17 +155,9 @@ export function showDeprecationWarningAfter(
     return;
   }
 
-  if (!isPhase2()) {
-    logger.warn(
-      clc.yellow(
-        `⚠ Notice: Firebase Extensions will shut down on March 31, 2027. Learn more: ${FAQ_URL}`,
-      ),
-    );
-  } else {
-    logger.warn(
-      clc.yellow(
-        `⚠ Notice: Firebase Extensions will shut down on March 31, 2027. Learn more & view migration steps: ${FAQ_URL}`,
-      ),
-    );
-  }
+  logger.warn(
+    clc.yellow(
+      `⚠ Notice: Firebase Extensions will shut down on March 31, 2027. Learn more: ${FAQ_URL}`,
+    ),
+  );
 }


### PR DESCRIPTION
### Description

With the Firebase Extensions managed service scheduled for official decommission on March 31, 2027, this PR introduces the `extdeprecationwarnings` experiment flag (enabled by default) to notify developers across `ext:*` CLI commands without cluttering terminal output or breaking non-interactive CI workflows.

Key features introduced:
1. **Experiment Registration**: Registered `extdeprecationwarnings` in `src/experiments.ts` (default: `true`). Added support for negative opt-out (`FIREBASE_CLI_EXPERIMENTS=-extdeprecationwarnings`).
2. **Categorized Warning Architecture (`src/extensions/warnings.ts`)**:
   - **Category 1 (`ext:install`, `ext:configure`, `ext:update`, `ext:sdk:install`)**: Displays a concise warning before interactive prompts notifying users of the March 31, 2027 decommission.
   - **Category 2 (`ext:list`, `ext:info`)**: Displays a single-line notice as a footer after successful command execution.
   - **Category 3 (`ext:uninstall`, `ext:dev:deprecate`, `ext:export`)**: Silenced (`NO_WARNING_COMMANDS`).
   - **Category 4 (`ext:dev:init`, `ext:dev:upload`, `ext:dev:list`, `ext:dev:usage`, `ext:dev:undeprecate`)**: Displays publisher banner immediately before command execution.
   - **Category 5 (`ext:dev:register`)**: Hard stop throwing `FirebaseError(..., { exit: 1 })`.
3. **Automated Silencing**: Automatically suppresses text warnings when `--json`, `--non-interactive`, `--quiet`, non-TTY stdio, or automated CI environments (`process.env.CI`, `GITHUB_ACTIONS`, `BUILD_ID`, `TF_BUILD`) are present.
4. **CLI Hook**: Intercepts `Command.runner()` in `src/command.ts` to trigger warning hooks before pre-action execution and after completion.

---

### Scenarios Tested

- **Unit Tests**: Added comprehensive Mocha test suites in `src/extensions/warnings.spec.ts` and `src/experiments.spec.ts` verifying Category 1–5 output formatting, hard errors under `--json`, and CI test environment isolation (`12 passing`).
- **Manual Interactive Testing**: Built and tested locally (`./lib/bin/firebase.js`):
  - Verified concise warning appears before `ext:install` interactive prompts.
  - Verified publisher notice banner appears before `ext:dev:upload`.
  - Verified post-execution footer appears after `ext:list`.
  - Verified hard stop failure (`exit 1`) on `ext:dev:register`.
  - Verified clean JSON output when `--json` flag is provided.
  - Verified silencing when running with `FIREBASE_CLI_EXPERIMENTS=-extdeprecationwarnings`.
- **Linting & Formatting**: Verified `npm run format` and `npm run lint:changed-files` pass with 0 errors.

---

### Sample Commands

```bash
# Default behavior (warnings visible)
firebase ext:install

# Test publisher notice banner
firebase ext:dev:upload <ref>

# Test hard exit
firebase ext:dev:register

# Explicit opt-out
FIREBASE_CLI_EXPERIMENTS=-extdeprecationwarnings firebase ext:install
