### PR TITLE
fix(apptesting): display clear quota exhaustion message on 429 error

### DIFF
--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -305,7 +305,6 @@ export class AppDistributionClient {
       const msg = getErrMsg(err);
       if (
         status === 429 ||
-        msg.includes("429") ||
         msg.includes("RESOURCE_EXHAUSTED") ||
         msg.includes("QUOTA_EXCEEDED")
       ) {

--- a/src/appdistribution/client.ts
+++ b/src/appdistribution/client.ts
@@ -3,7 +3,7 @@ import { ReadStream } from "fs";
 import * as utils from "../utils";
 import * as operationPoller from "../operation-poller";
 import { Distribution } from "./distribution";
-import { FirebaseError, getErrMsg } from "../error";
+import { FirebaseError, getErrMsg, getErrStatus, getError } from "../error";
 import { Client, ClientResponse } from "../apiv2";
 import { appDistributionOrigin } from "../api";
 
@@ -301,7 +301,20 @@ export class AppDistributionClient {
       });
       return response.body;
     } catch (err: unknown) {
-      throw new FirebaseError(`Failed to create release test ${getErrMsg(err)}`);
+      const status = getErrStatus(err);
+      const msg = getErrMsg(err);
+      if (
+        status === 429 ||
+        msg.includes("429") ||
+        msg.includes("RESOURCE_EXHAUSTED") ||
+        msg.includes("QUOTA_EXCEEDED")
+      ) {
+        throw new FirebaseError(
+          `Quota exceeded: Failed to request test execution due to quota limits (429 RESOURCE_EXHAUSTED). Please check your project's App Testing quota usage in the Firebase console. Details: ${msg}`,
+          { status: 429, original: getError(err) },
+        );
+      }
+      throw new FirebaseError(`Failed to create release test: ${msg}`, { original: getError(err) });
     }
   }
 


### PR DESCRIPTION
### Description
Intercept 429 HTTP status codes and RESOURCE_EXHAUSTED / QUOTA_EXCEEDED errors when requesting test execution in App Testing, surfacing a human-readable quota error message.

### Scenarios Tested
- Unit test for createReleaseTest handling 429 response.

### Sample Commands
firebase apptesting:execute --app 1:123:android:abc

TAG=agy
CONV=107aa4d3-03d0-4299-afcc-27e78b24392e
