### PR TITLE
fix(auth): prevent node http.Agent compatibility issue with google-auth-library on Node 22+

### DIFF
--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -28,14 +28,20 @@ function getAuthClient(config: GoogleAuthOptions): GoogleAuth {
     return authClient;
   }
 
+  const nodeMajorVersion = parseInt(process.versions.node.split(".")[0], 10);
+  const isNode22OrHigher = !isNaN(nodeMajorVersion) && nodeMajorVersion >= 22;
+  const transporterOptions = isNode22OrHigher
+    ? config.clientOptions?.transporterOptions
+    : {
+        ...config.clientOptions?.transporterOptions,
+        agent: apiv2.noKeepAliveAgent,
+      };
+
   const authConfig: GoogleAuthOptions = {
     ...config,
     clientOptions: {
       ...config.clientOptions,
-      transporterOptions: {
-        ...config.clientOptions?.transporterOptions,
-        agent: apiv2.noKeepAliveAgent,
-      },
+      ...(transporterOptions ? { transporterOptions } : {}),
     },
   };
 

--- a/src/requireAuth.ts
+++ b/src/requireAuth.ts
@@ -28,7 +28,8 @@ function getAuthClient(config: GoogleAuthOptions): GoogleAuth {
     return authClient;
   }
 
-  const nodeMajorVersion = parseInt(process.versions.node.split(".")[0], 10);
+  const nodeVersion = process.versions?.node;
+  const nodeMajorVersion = nodeVersion ? parseInt(nodeVersion.split(".")[0], 10) : 0;
   const isNode22OrHigher = !isNaN(nodeMajorVersion) && nodeMajorVersion >= 22;
   const transporterOptions = isNode22OrHigher
     ? config.clientOptions?.transporterOptions


### PR DESCRIPTION
### Description
Avoid attaching Node's legacy http.Agent to transporterOptions when running on Node 22 or higher, preventing fetch / undici breakage during STS token exchange under Workload Identity Federation (WIF).

### Scenarios Tested
- Ran mocha unit tests across auth components.

### Sample Commands
firebase apptesting:execute --app 1:123:android:abc

TAG=agy
CONV=107aa4d3-03d0-4299-afcc-27e78b24392e
