### PR TITLE
fix(apiv2): sanitize domain-scoped project ID in x-goog-user-project header

### DIFF
--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -366,7 +366,11 @@ export class Client {
       process.env.GOOGLE_CLOUD_QUOTA_PROJECT &&
       process.env.GOOGLE_CLOUD_QUOTA_PROJECT !== ""
     ) {
-      reqOptions.headers.set(GOOG_USER_PROJECT_HEADER, process.env.GOOGLE_CLOUD_QUOTA_PROJECT);
+      let quotaProject = process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
+      if (quotaProject.includes(":")) {
+        quotaProject = quotaProject.split(":").pop()!;
+      }
+      reqOptions.headers.set(GOOG_USER_PROJECT_HEADER, quotaProject);
     }
     return reqOptions;
   }

--- a/src/apiv2.ts
+++ b/src/apiv2.ts
@@ -368,9 +368,12 @@ export class Client {
     ) {
       let quotaProject = process.env.GOOGLE_CLOUD_QUOTA_PROJECT;
       if (quotaProject.includes(":")) {
-        quotaProject = quotaProject.split(":").pop()!;
+        const lastColonIndex = quotaProject.lastIndexOf(":");
+        quotaProject = quotaProject.slice(lastColonIndex + 1);
       }
-      reqOptions.headers.set(GOOG_USER_PROJECT_HEADER, quotaProject);
+      if (quotaProject) {
+        reqOptions.headers.set(GOOG_USER_PROJECT_HEADER, quotaProject);
+      }
     }
     return reqOptions;
   }


### PR DESCRIPTION
### Description
Strip domain scope prefix from GOOGLE_CLOUD_QUOTA_PROJECT before setting x-goog-user-project header to prevent API rejections when domain-scoped project IDs are used.

### Scenarios Tested
- Verified apiv2 header generation logic.

### Sample Commands
GOOGLE_CLOUD_QUOTA_PROJECT=domain.com:api-project-123 firebase apptesting:execute

TAG=agy
CONV=107aa4d3-03d0-4299-afcc-27e78b24392e
