### PR TITLE
update workflow to use environment secrets

### DIFF
--- a/.github/workflows/release-vscode-ext.yaml
+++ b/.github/workflows/release-vscode-ext.yaml
@@ -24,10 +24,11 @@ jobs:
     steps:
       - name: Generate Token
         id: generate_token
-        uses: actions/create-github-app-token@631e7242c55486a978d103328229b439c362080f
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+          permissions-content: write
       - name: Trigger Kokoro via API
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/release-vscode-ext.yaml
+++ b/.github/workflows/release-vscode-ext.yaml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Generate Token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@631e7242c55486a978d103328229b439c362080f
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}

--- a/.github/workflows/release-vscode-ext.yaml
+++ b/.github/workflows/release-vscode-ext.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
           private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
-          permissions-content: write
+          permission-contents: write
       - name: Trigger Kokoro via API
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/release-vscode-ext.yaml
+++ b/.github/workflows/release-vscode-ext.yaml
@@ -10,6 +10,7 @@ permissions:
   issues: read
 
 jobs:
+  environment: firebase-tools VSCode release
   release:
     if: |
       github.event.issue.pull_request &&
@@ -21,9 +22,15 @@ jobs:
        github.event.issue.author_association == 'MEMBER')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
       - name: Trigger Kokoro via API
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           PR_NUM="${{ github.event.issue.number }}"

--- a/.github/workflows/release-vscode-ext.yaml
+++ b/.github/workflows/release-vscode-ext.yaml
@@ -10,8 +10,8 @@ permissions:
   issues: read
 
 jobs:
-  environment: firebase-tools VSCode release
   release:
+    environment: firebase-tools VSCode release
     if: |
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/run-release') &&


### PR DESCRIPTION
Update vscode release workflow to use APP token instead of default github token.