### PR TITLE
fix(config): allow two dots in path segments

### DIFF
--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -3,6 +3,7 @@ import * as fs from "fs";
 import * as os from "os";
 
 import { expect } from "chai";
+import * as sinon from "sinon";
 
 import { Config } from "./config";
 import { FIREBASE_JSON_PATH as VALID_CONFIG_PATH } from "./test/fixtures/valid-config";
@@ -33,6 +34,10 @@ describe("Config", () => {
   });
 
   describe("#path", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
     it("should skip an absolute path", () => {
       const config = new Config({}, { cwd: SIMPLE_CONFIG_DIR });
       const absPath = "/Users/something";
@@ -54,6 +59,11 @@ describe("Config", () => {
       for (const relativePath of ["..", path.join("..", "outside")]) {
         expect(() => config.path(relativePath)).to.throw("is outside of project directory");
       }
+    });
+    it("should reject an absolute result from path.relative", () => {
+      const config = new Config({}, { cwd: SIMPLE_CONFIG_DIR });
+      sinon.stub(path, "relative").returns(path.resolve("outside"));
+      expect(() => config.path("inside")).to.throw("is outside of project directory");
     });
   });
 

--- a/src/config.spec.ts
+++ b/src/config.spec.ts
@@ -43,6 +43,18 @@ describe("Config", () => {
       const relativePath = "something";
       expect(config.path(relativePath)).to.eq(path.join(SIMPLE_CONFIG_DIR, relativePath));
     });
+    it("should allow path segments containing two dots", () => {
+      const publicDir = "foo..bar";
+      const config = new Config({ hosting: { public: publicDir } }, { cwd: SIMPLE_CONFIG_DIR });
+      const configuredPublicDir = config.get("hosting.public") as string;
+      expect(config.path(configuredPublicDir)).to.eq(path.join(SIMPLE_CONFIG_DIR, publicDir));
+    });
+    it("should reject parent directory traversal", () => {
+      const config = new Config({}, { cwd: SIMPLE_CONFIG_DIR });
+      for (const relativePath of ["..", path.join("..", "outside")]) {
+        expect(() => config.path(relativePath)).to.throw("is outside of project directory");
+      }
+    });
   });
 
   describe("#parseFile", () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -205,7 +205,11 @@ export class Config {
     }
     const outPath = path.normalize(path.join(this.projectDir, pathName));
     const relativePath = path.relative(this.projectDir, outPath);
-    if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`)) {
+    if (
+      path.isAbsolute(relativePath) ||
+      relativePath === ".." ||
+      relativePath.startsWith(`..${path.sep}`)
+    ) {
       throw new FirebaseError(clc.bold(pathName) + " is outside of project directory", { exit: 1 });
     }
     return outPath;

--- a/src/config.ts
+++ b/src/config.ts
@@ -204,7 +204,8 @@ export class Config {
       return pathName;
     }
     const outPath = path.normalize(path.join(this.projectDir, pathName));
-    if (path.relative(this.projectDir, outPath).includes("..")) {
+    const relativePath = path.relative(this.projectDir, outPath);
+    if (relativePath === ".." || relativePath.startsWith(`..${path.sep}`)) {
       throw new FirebaseError(clc.bold(pathName) + " is outside of project directory", { exit: 1 });
     }
     return outPath;


### PR DESCRIPTION
### Description

`Config.path()` previously treated any normalized relative path containing the substring `..` as outside the project directory. This falsely rejected valid in-project segments such as a Hosting `public` directory named `foo..bar`.

This change rejects an exact parent path, a path beginning with the parent-directory segment and platform separator, or an absolute result from `path.relative()` such as a cross-volume result on Windows. This preserves traversal protection while allowing valid two-dot path segments.

### Scenarios Tested

- A configured Hosting `public` path of `foo..bar` resolves inside the project.
- `..` and `../outside` remain rejected.
- An absolute result from `path.relative()` is rejected through a platform-independent regression.
- `path.win32.relative()` cross-volume semantics reject `D:\outside` while allowing `foo..bar`.
- `npx mocha src/config.spec.ts` — passed with 19 tests.
- `npm run lint:changed-files` — passed with no errors.
- `npm run test:compile` — passed.
- `npm ls --depth=0`, `npm run build`, and `npm run prepare` — passed.
- `npm test -- -- --forbid-only` — lint, formatting, and compilation passed; the broad unit phase encountered unrelated environment-sensitive failures locally, including restricted proxy and metadata access.

### Sample Commands

Not applicable; this does not add or change commands or flags.