### PR TITLE
BUG: functions:secrets:prune was not affecting secrets created after apphosting launch

### DIFF
--- a/src/functions/secrets.ts
+++ b/src/functions/secrets.ts
@@ -238,7 +238,10 @@ export async function pruneSecrets(
   const prunedSecrets: Set<string> = new Set();
 
   // Collect all Firebase managed secret versions
-  const haveSecrets = await listSecrets(projectId, `labels.${FIREBASE_MANAGED}=true`);
+  const haveSecrets = await listSecrets(
+    projectId,
+    `labels.${FIREBASE_MANAGED}=true OR labels.${FIREBASE_MANAGED}=functions`,
+  );
   for (const secret of haveSecrets) {
     const versions = await listSecretVersions(projectId, secret.name, `NOT state: DESTROYED`);
     for (const version of versions) {


### PR DESCRIPTION
see: https://github.com/firebase/firebase-tools/blob/16fb909bffb745d39b13678e573006628ca21589/src/gcp/secretManager.ts#L474