### PR TITLE
feat(ailogic): add ailogic:config CLI commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - Added `firebase ailogic:providers:*` CLI commands to enable, disable, and list Gemini API providers.
+- Added `firebase ailogic:config:*` CLI commands to read and modify AI Logic configuration settings.
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
 - Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,3 @@
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
 - Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,2 @@
-- Fixed an issue in `apps:create` where App Store ID was always prompted for even when unnecessary.
-- Add `functions:lifecycle:list` and `functions:lifecycle:run` commands to view and run
-  lifecycle hooks in isolation.
-- Updated the Firebase SQL Connect local toolkit to v3.4.15, which supports for 1:1 nested mutations. (#10773)
+- Added `firebase ailogic:providers:*` CLI commands to enable, disable, and list Gemini API providers.
+- Updated Pub/Sub emulator to version 0.8.34

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
-- Added `firebase ailogic:providers:*` CLI commands to enable, disable, and list Gemini API providers.
-- Added `firebase ailogic:config:*` CLI commands to read and modify AI Logic configuration settings.
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
 - Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.

--- a/src/commands/ailogic-config-get.spec.ts
+++ b/src/commands/ailogic-config-get.spec.ts
@@ -1,0 +1,52 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { command } from "./ailogic-config-get";
+import * as ailogic from "../gcp/ailogic";
+import * as projectUtils from "../projectUtils";
+import { FirebaseError } from "../error";
+
+const PROJECT_ID = "test-project";
+
+describe("ailogic:config:get", () => {
+  beforeEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = []; // bypass pre-action hooks
+    sinon.stub(projectUtils, "needProjectId").returns(PROJECT_ID);
+    sinon.stub(ailogic, "isAILogicApiEnabled").resolves(true);
+    sinon.stub(ailogic, "listProviders").resolves(["gemini-developer-api"]);
+    sinon.stub(ailogic, "getConfig").resolves({
+      name: "config",
+      trafficFilter: { firebaseAuthRequired: true, templateOnly: false },
+      telemetryConfig: { mode: "ALL", samplingRate: 0.5 },
+    });
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("returns a structured config with mapped values", async () => {
+    expect(await command.runner()(undefined, { project: PROJECT_ID })).to.deep.equal({
+      providers: {
+        "gemini-developer-api": true,
+        "gemini-agent-platform-api": false,
+      },
+      security: { "auth-only": true, "template-only": false },
+      monitoring: { state: true, "sample-rate-percentage": 50 },
+    });
+  });
+
+  it("returns a single value for a valid path", async () => {
+    expect(await command.runner()("security.auth-only", { project: PROJECT_ID })).to.equal(true);
+  });
+
+  it("throws on an unknown path", async () => {
+    await expect(command.runner()("security.authonly", { project: PROJECT_ID })).to.be.rejectedWith(
+      FirebaseError,
+      /Unknown configuration path/,
+    );
+  });
+
+  it("returns early when AI Logic is not enabled", async () => {
+    (ailogic.isAILogicApiEnabled as sinon.SinonStub).resolves(false);
+    expect(await command.runner()(undefined, { project: PROJECT_ID })).to.be.undefined;
+  });
+});

--- a/src/commands/ailogic-config-get.spec.ts
+++ b/src/commands/ailogic-config-get.spec.ts
@@ -38,6 +38,13 @@ describe("ailogic:config:get", () => {
     expect(await command.runner()("security.auth-only", { project: PROJECT_ID })).to.equal(true);
   });
 
+  it("returns a nested object for a group path", async () => {
+    expect(await command.runner()("monitoring", { project: PROJECT_ID })).to.deep.equal({
+      state: true,
+      "sample-rate-percentage": 50,
+    });
+  });
+
   it("throws on an unknown path", async () => {
     await expect(command.runner()("security.authonly", { project: PROJECT_ID })).to.be.rejectedWith(
       FirebaseError,

--- a/src/commands/ailogic-config-get.spec.ts
+++ b/src/commands/ailogic-config-get.spec.ts
@@ -9,12 +9,16 @@ import { FirebaseError } from "../error";
 const PROJECT_ID = "test-project";
 
 describe("ailogic:config:get", () => {
+  let enabledStub: sinon.SinonStub;
+  let listProvidersStub: sinon.SinonStub;
+  let getConfigStub: sinon.SinonStub;
+
   beforeEach(() => {
     (command as unknown as { befores: unknown[] }).befores = []; // bypass pre-action hooks
     sinon.stub(projectUtils, "needProjectId").returns(PROJECT_ID);
-    sinon.stub(ailogic, "isAILogicApiEnabled").resolves(true);
-    sinon.stub(ailogic, "listProviders").resolves(["gemini-developer-api"]);
-    sinon.stub(ailogic, "getConfig").resolves({
+    enabledStub = sinon.stub(ailogic, "isAILogicApiEnabled").resolves(true);
+    listProvidersStub = sinon.stub(ailogic, "listProviders").resolves(["gemini-developer-api"]);
+    getConfigStub = sinon.stub(ailogic, "getConfig").resolves({
       name: "config",
       trafficFilter: { firebaseAuthRequired: true, templateOnly: false },
       telemetryConfig: { mode: "ALL", samplingRate: 0.5 },
@@ -45,15 +49,26 @@ describe("ailogic:config:get", () => {
     });
   });
 
-  it("throws on an unknown path", async () => {
+  it("only checks provider enablement when the path needs it", async () => {
+    await command.runner()("security.auth-only", { project: PROJECT_ID });
+    expect(listProvidersStub).to.not.have.been.called;
+
+    await command.runner()("providers.gemini-developer-api", { project: PROJECT_ID });
+    expect(listProvidersStub).to.have.been.calledOnce;
+  });
+
+  it("throws on an unknown path before making any API calls", async () => {
     await expect(command.runner()("security.authonly", { project: PROJECT_ID })).to.be.rejectedWith(
       FirebaseError,
       /Unknown configuration path/,
     );
+    expect(enabledStub).to.not.have.been.called;
+    expect(getConfigStub).to.not.have.been.called;
+    expect(listProvidersStub).to.not.have.been.called;
   });
 
   it("returns early when AI Logic is not enabled", async () => {
-    (ailogic.isAILogicApiEnabled as sinon.SinonStub).resolves(false);
+    enabledStub.resolves(false);
     expect(await command.runner()(undefined, { project: PROJECT_ID })).to.be.undefined;
   });
 });

--- a/src/commands/ailogic-config-get.ts
+++ b/src/commands/ailogic-config-get.ts
@@ -1,0 +1,85 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:config:get [path]")
+  .description("read AI Logic configuration")
+  .before(requirePermissions, ["firebasevertexai.config.get", "serviceusage.services.get"])
+  .action(async (path: string | undefined, options: Options) => {
+    const projectId = needProjectId(options);
+
+    if (!(await ailogic.isAILogicApiEnabled(projectId))) {
+      logger.info("Firebase AI Logic is not enabled on this project.");
+      return;
+    }
+    const config = await ailogic.getConfig(projectId);
+
+    const authOnly = config.trafficFilter?.firebaseAuthRequired ?? false;
+    const templateOnly = config.trafficFilter?.templateOnly ?? false;
+    const monitoringState = config.telemetryConfig?.mode === "ALL";
+    const sampleRatePercent =
+      config.telemetryConfig?.samplingRate !== undefined
+        ? Math.round(config.telemetryConfig.samplingRate * 100)
+        : 100;
+
+    const enabledProviders = await ailogic.listProviders(projectId);
+    const hasDeveloperApi = enabledProviders.includes("gemini-developer-api");
+    const hasAgentPlatform = enabledProviders.includes("agent-platform-gemini-api");
+
+    const configObj = {
+      providers: {
+        "gemini-developer-api": hasDeveloperApi,
+        "agent-platform-gemini-api": hasAgentPlatform,
+      },
+      security: {
+        "auth-only": authOnly,
+        "template-only": templateOnly,
+      },
+      monitoring: {
+        state: monitoringState,
+        "sample-rate-percentage": sampleRatePercent,
+      },
+    };
+
+    if (path) {
+      const validPaths = [
+        "providers",
+        "providers.gemini-developer-api",
+        "providers.agent-platform-gemini-api",
+        "security",
+        "security.auth-only",
+        "security.template-only",
+        "monitoring",
+        "monitoring.state",
+        "monitoring.sample-rate-percentage",
+      ];
+      if (!validPaths.includes(path)) {
+        throw new FirebaseError(
+          `Unknown configuration path: ${path}\n\nValid paths:\n\n` +
+            [
+              "security.auth-only",
+              "security.template-only",
+              "monitoring.state",
+              "monitoring.sample-rate-percentage",
+            ]
+              .map((p) => `  ${p}`)
+              .join("\n"),
+        );
+      }
+      const parts = path.split(".");
+      let val: unknown = configObj;
+      for (const part of parts) {
+        val = val && typeof val === "object" ? (val as Record<string, unknown>)[part] : undefined;
+      }
+      logger.info(typeof val === "object" ? JSON.stringify(val, null, 2) : String(val));
+      return val;
+    } else {
+      logger.info(JSON.stringify(configObj, null, 2));
+      return configObj;
+    }
+  });

--- a/src/commands/ailogic-config-get.ts
+++ b/src/commands/ailogic-config-get.ts
@@ -7,6 +7,20 @@ import { FirebaseError } from "../error";
 
 import { Options } from "../options";
 
+// Developer-facing config paths that `config:get` can read. Used both to validate
+// the requested path and to list the valid paths in the error message.
+const READABLE_CONFIG_PATHS = [
+  "providers",
+  "providers.gemini-developer-api",
+  "providers.gemini-agent-platform-api",
+  "security",
+  "security.auth-only",
+  "security.template-only",
+  "monitoring",
+  "monitoring.state",
+  "monitoring.sample-rate-percentage",
+];
+
 export const command = new Command("ailogic:config:get [path]")
   .description("read AI Logic configuration")
   .before(requirePermissions, ["firebasevertexai.config.get", "serviceusage.services.get"])
@@ -22,6 +36,8 @@ export const command = new Command("ailogic:config:get [path]")
     const authOnly = config.trafficFilter?.firebaseAuthRequired ?? false;
     const templateOnly = config.trafficFilter?.templateOnly ?? false;
     const monitoringState = config.telemetryConfig?.mode === "ALL";
+    // The API stores the sampling rate as a fraction in (0,1]; the CLI exposes it
+    // as an integer percentage (1-100).
     const sampleRatePercent =
       config.telemetryConfig?.samplingRate !== undefined
         ? Math.round(config.telemetryConfig.samplingRate * 100)
@@ -29,12 +45,12 @@ export const command = new Command("ailogic:config:get [path]")
 
     const enabledProviders = await ailogic.listProviders(projectId);
     const hasDeveloperApi = enabledProviders.includes("gemini-developer-api");
-    const hasAgentPlatform = enabledProviders.includes("agent-platform-gemini-api");
+    const hasAgentPlatform = enabledProviders.includes("gemini-agent-platform-api");
 
     const configObj = {
       providers: {
         "gemini-developer-api": hasDeveloperApi,
-        "agent-platform-gemini-api": hasAgentPlatform,
+        "gemini-agent-platform-api": hasAgentPlatform,
       },
       security: {
         "auth-only": authOnly,
@@ -46,40 +62,22 @@ export const command = new Command("ailogic:config:get [path]")
       },
     };
 
-    if (path) {
-      const validPaths = [
-        "providers",
-        "providers.gemini-developer-api",
-        "providers.agent-platform-gemini-api",
-        "security",
-        "security.auth-only",
-        "security.template-only",
-        "monitoring",
-        "monitoring.state",
-        "monitoring.sample-rate-percentage",
-      ];
-      if (!validPaths.includes(path)) {
-        throw new FirebaseError(
-          `Unknown configuration path: ${path}\n\nValid paths:\n\n` +
-            [
-              "security.auth-only",
-              "security.template-only",
-              "monitoring.state",
-              "monitoring.sample-rate-percentage",
-            ]
-              .map((p) => `  ${p}`)
-              .join("\n"),
-        );
-      }
-      const parts = path.split(".");
-      let val: unknown = configObj;
-      for (const part of parts) {
-        val = val && typeof val === "object" ? (val as Record<string, unknown>)[part] : undefined;
-      }
-      logger.info(typeof val === "object" ? JSON.stringify(val, null, 2) : String(val));
-      return val;
-    } else {
+    if (!path) {
       logger.info(JSON.stringify(configObj, null, 2));
       return configObj;
     }
+
+    if (!READABLE_CONFIG_PATHS.includes(path)) {
+      throw new FirebaseError(
+        `Unknown configuration path: ${path}\n\nValid paths:\n\n` +
+          READABLE_CONFIG_PATHS.map((p) => `  ${p}`).join("\n"),
+      );
+    }
+
+    let val: unknown = configObj;
+    for (const part of path.split(".")) {
+      val = val && typeof val === "object" ? (val as Record<string, unknown>)[part] : undefined;
+    }
+    logger.info(typeof val === "object" ? JSON.stringify(val, null, 2) : String(val));
+    return val;
   });

--- a/src/commands/ailogic-config-get.ts
+++ b/src/commands/ailogic-config-get.ts
@@ -3,22 +3,18 @@ import { requirePermissions } from "../requirePermissions";
 import { needProjectId } from "../projectUtils";
 import * as ailogic from "../gcp/ailogic";
 import { logger } from "../logger";
-import { FirebaseError } from "../error";
 
 import { Options } from "../options";
 
-// Developer-facing config paths that `config:get` can read. Provider sub-paths are
-// derived from the canonical provider list so they stay in sync. Used both to
-// validate the requested path and to list the valid paths in the error message.
+// Everything `config:get` can read: the writable paths plus their group prefixes
+// and the read-only provider status derived from API enablement.
 const READABLE_CONFIG_PATHS = [
   "providers",
   ...ailogic.PROVIDER_TYPES.map((p) => `providers.${p}`),
   "security",
-  "security.auth-only",
-  "security.template-only",
+  ...ailogic.WRITABLE_CONFIG_PATHS.filter((p) => p.startsWith("security.")),
   "monitoring",
-  "monitoring.state",
-  "monitoring.sample-rate-percentage",
+  ...ailogic.WRITABLE_CONFIG_PATHS.filter((p) => p.startsWith("monitoring.")),
 ];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -31,31 +27,38 @@ export const command = new Command("ailogic:config:get [path]")
   .action(async (path: string | undefined, options: Options) => {
     const projectId = needProjectId(options);
 
+    // Validate the path up front so bad input fails fast, before any API calls.
+    if (path) {
+      ailogic.assertKnownConfigPath(path, READABLE_CONFIG_PATHS);
+    }
+
     if (!(await ailogic.isAILogicApiEnabled(projectId))) {
       logger.info("Firebase AI Logic is not enabled on this project.");
       return;
     }
     const config = await ailogic.getConfig(projectId);
 
-    const authOnly = config.trafficFilter?.firebaseAuthRequired ?? false;
-    const templateOnly = config.trafficFilter?.templateOnly ?? false;
     const monitoringState = config.telemetryConfig?.mode === "ALL";
-    // The API stores the sampling rate as a fraction in (0,1]; the CLI exposes it
-    // as an integer percentage (1-100).
+    // An unset samplingRate is displayed as 100% (full sampling).
     const sampleRatePercent =
       config.telemetryConfig?.samplingRate !== undefined
-        ? Math.round(config.telemetryConfig.samplingRate * 100)
+        ? ailogic.samplingRateToPercent(config.telemetryConfig.samplingRate)
         : 100;
 
-    const enabledProviders = await ailogic.listProviders(projectId);
+    // Provider status needs extra Service Usage checks, so fetch it only when the
+    // requested path is under `providers` (or the whole config was requested).
+    const needsProviders = !path || path === "providers" || path.startsWith("providers.");
+    const enabledProviders = needsProviders ? await ailogic.listProviders(projectId) : [];
 
     const configObj = {
-      providers: Object.fromEntries(
-        ailogic.PROVIDER_TYPES.map((p) => [p, enabledProviders.includes(p)]),
-      ),
+      ...(needsProviders && {
+        providers: Object.fromEntries(
+          ailogic.PROVIDER_TYPES.map((p) => [p, enabledProviders.includes(p)]),
+        ),
+      }),
       security: {
-        "auth-only": authOnly,
-        "template-only": templateOnly,
+        "auth-only": config.trafficFilter?.firebaseAuthRequired ?? false,
+        "template-only": config.trafficFilter?.templateOnly ?? false,
       },
       monitoring: {
         state: monitoringState,
@@ -66,13 +69,6 @@ export const command = new Command("ailogic:config:get [path]")
     if (!path) {
       logger.info(JSON.stringify(configObj, null, 2));
       return configObj;
-    }
-
-    if (!READABLE_CONFIG_PATHS.includes(path)) {
-      throw new FirebaseError(
-        `Unknown configuration path: ${path}\n\nValid paths:\n\n` +
-          READABLE_CONFIG_PATHS.map((p) => `  ${p}`).join("\n"),
-      );
     }
 
     let val: unknown = configObj;

--- a/src/commands/ailogic-config-get.ts
+++ b/src/commands/ailogic-config-get.ts
@@ -7,12 +7,12 @@ import { FirebaseError } from "../error";
 
 import { Options } from "../options";
 
-// Developer-facing config paths that `config:get` can read. Used both to validate
-// the requested path and to list the valid paths in the error message.
+// Developer-facing config paths that `config:get` can read. Provider sub-paths are
+// derived from the canonical provider list so they stay in sync. Used both to
+// validate the requested path and to list the valid paths in the error message.
 const READABLE_CONFIG_PATHS = [
   "providers",
-  "providers.gemini-developer-api",
-  "providers.gemini-agent-platform-api",
+  ...ailogic.PROVIDER_TYPES.map((p) => `providers.${p}`),
   "security",
   "security.auth-only",
   "security.template-only",
@@ -20,6 +20,10 @@ const READABLE_CONFIG_PATHS = [
   "monitoring.state",
   "monitoring.sample-rate-percentage",
 ];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
 
 export const command = new Command("ailogic:config:get [path]")
   .description("read AI Logic configuration")
@@ -44,14 +48,11 @@ export const command = new Command("ailogic:config:get [path]")
         : 100;
 
     const enabledProviders = await ailogic.listProviders(projectId);
-    const hasDeveloperApi = enabledProviders.includes("gemini-developer-api");
-    const hasAgentPlatform = enabledProviders.includes("gemini-agent-platform-api");
 
     const configObj = {
-      providers: {
-        "gemini-developer-api": hasDeveloperApi,
-        "gemini-agent-platform-api": hasAgentPlatform,
-      },
+      providers: Object.fromEntries(
+        ailogic.PROVIDER_TYPES.map((p) => [p, enabledProviders.includes(p)]),
+      ),
       security: {
         "auth-only": authOnly,
         "template-only": templateOnly,
@@ -76,7 +77,11 @@ export const command = new Command("ailogic:config:get [path]")
 
     let val: unknown = configObj;
     for (const part of path.split(".")) {
-      val = val && typeof val === "object" ? (val as Record<string, unknown>)[part] : undefined;
+      if (!isRecord(val)) {
+        val = undefined;
+        break;
+      }
+      val = val[part];
     }
     logger.info(typeof val === "object" ? JSON.stringify(val, null, 2) : String(val));
     return val;

--- a/src/commands/ailogic-config-get.ts
+++ b/src/commands/ailogic-config-get.ts
@@ -23,6 +23,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 export const command = new Command("ailogic:config:get [path]")
   .description("read AI Logic configuration")
+  .help(
+    `prints the full AI Logic configuration for the active project as JSON. If [path] is given, prints only that section or value.
+
+Valid values for [path]:
+
+${READABLE_CONFIG_PATHS.map((p) => `  ${p}`).join("\n")}
+
+For example, to check whether requests are restricted to authenticated users:
+
+  firebase ailogic:config:get security.auth-only`,
+  )
   .before(requirePermissions, ["firebasevertexai.config.get", "serviceusage.services.get"])
   .action(async (path: string | undefined, options: Options) => {
     const projectId = needProjectId(options);
@@ -39,10 +50,11 @@ export const command = new Command("ailogic:config:get [path]")
     const config = await ailogic.getConfig(projectId);
 
     const monitoringState = config.telemetryConfig?.mode === "ALL";
-    // An unset samplingRate is displayed as 100% (full sampling).
+    // The API stores samplingRate as a fraction in (0,1]; the CLI displays an
+    // integer percentage. An unset samplingRate is displayed as 100% (full sampling).
     const sampleRatePercent =
       config.telemetryConfig?.samplingRate !== undefined
-        ? ailogic.samplingRateToPercent(config.telemetryConfig.samplingRate)
+        ? Math.round(config.telemetryConfig.samplingRate * 100)
         : 100;
 
     // Provider status needs extra Service Usage checks, so fetch it only when the

--- a/src/commands/ailogic-config-set.spec.ts
+++ b/src/commands/ailogic-config-set.spec.ts
@@ -1,0 +1,110 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { command } from "./ailogic-config-set";
+import * as ailogic from "../gcp/ailogic";
+import * as projectUtils from "../projectUtils";
+import * as prompt from "../prompt";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+
+const PROJECT_ID = "test-project";
+
+describe("ailogic:config:set", () => {
+  let updateStub: sinon.SinonStub;
+  let getConfigStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = []; // bypass pre-action hooks
+    sinon.stub(projectUtils, "needProjectId").returns(PROJECT_ID);
+    sinon.stub(ailogic, "ensureAILogicApiEnabled").resolves();
+    sinon.stub(utils, "logSuccess");
+    getConfigStub = sinon.stub(ailogic, "getConfig").resolves({ name: "config" });
+    updateStub = sinon.stub(ailogic, "updateConfig").resolves({ name: "config" });
+    confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("throws on an unknown path listing the writable paths", async () => {
+    await expect(
+      command.runner()("security.authonly", "true", { project: PROJECT_ID }),
+    ).to.be.rejectedWith(FirebaseError, /Unknown configuration path/);
+  });
+
+  it("rejects a non-boolean value for a security path", async () => {
+    await expect(
+      command.runner()("security.auth-only", "yes", { project: PROJECT_ID }),
+    ).to.be.rejectedWith(FirebaseError, /must be 'true' or 'false'/);
+  });
+
+  it("prompts when tightening auth-only from false to true, then updates", async () => {
+    getConfigStub.resolves({ name: "config", trafficFilter: { firebaseAuthRequired: false } });
+    await command.runner()("security.auth-only", "true", {
+      project: PROJECT_ID,
+      interactive: true,
+    });
+    expect(confirmStub).to.have.been.calledOnce;
+    expect(updateStub).to.have.been.calledWith(
+      PROJECT_ID,
+      { trafficFilter: { firebaseAuthRequired: true } },
+      ["trafficFilter.firebaseAuthRequired"],
+    );
+  });
+
+  it("does not prompt when auth-only is already true", async () => {
+    getConfigStub.resolves({ name: "config", trafficFilter: { firebaseAuthRequired: true } });
+    await command.runner()("security.auth-only", "true", {
+      project: PROJECT_ID,
+      interactive: true,
+    });
+    expect(confirmStub).to.not.have.been.called;
+    expect(updateStub).to.have.been.calledOnce;
+  });
+
+  it("does not prompt when relaxing auth-only to false", async () => {
+    await command.runner()("security.auth-only", "false", { project: PROJECT_ID });
+    expect(confirmStub).to.not.have.been.called;
+    expect(updateStub).to.have.been.calledWith(
+      PROJECT_ID,
+      { trafficFilter: { firebaseAuthRequired: false } },
+      ["trafficFilter.firebaseAuthRequired"],
+    );
+  });
+
+  it("propagates confirm() aborting in non-interactive mode without --force", async () => {
+    // confirm() throws in non-interactive mode when no --force is given; the command
+    // must surface that and not proceed to write.
+    getConfigStub.resolves({ name: "config", trafficFilter: { firebaseAuthRequired: false } });
+    confirmStub.rejects(new FirebaseError("cannot be answered in non-interactive mode"));
+    await expect(
+      command.runner()("security.auth-only", "true", { project: PROJECT_ID, nonInteractive: true }),
+    ).to.be.rejectedWith(FirebaseError, /non-interactive/);
+    expect(updateStub).to.not.have.been.called;
+  });
+
+  it("maps monitoring.state true to telemetryConfig.mode ALL", async () => {
+    await command.runner()("monitoring.state", "true", { project: PROJECT_ID });
+    expect(updateStub).to.have.been.calledWith(PROJECT_ID, { telemetryConfig: { mode: "ALL" } }, [
+      "telemetryConfig.mode",
+    ]);
+  });
+
+  it("maps a sample-rate percentage to a (0,1] sampling fraction", async () => {
+    await command.runner()("monitoring.sample-rate-percentage", "50", { project: PROJECT_ID });
+    expect(updateStub).to.have.been.calledWith(
+      PROJECT_ID,
+      { telemetryConfig: { samplingRate: 0.5 } },
+      ["telemetryConfig.samplingRate"],
+    );
+  });
+
+  it("rejects an out-of-range or non-integer sample rate", async () => {
+    for (const bad of ["0", "101", "1.5", "abc"]) {
+      await expect(
+        command.runner()("monitoring.sample-rate-percentage", bad, { project: PROJECT_ID }),
+      ).to.be.rejectedWith(FirebaseError, /integer in the range 1-100/);
+    }
+  });
+});

--- a/src/commands/ailogic-config-set.spec.ts
+++ b/src/commands/ailogic-config-set.spec.ts
@@ -106,6 +106,13 @@ describe("ailogic:config:set", () => {
     );
   });
 
+  it("accepts a case-insensitive boolean value", async () => {
+    await command.runner()("monitoring.state", "TRUE", { project: PROJECT_ID });
+    expect(updateStub).to.have.been.calledWith(PROJECT_ID, { telemetryConfig: { mode: "ALL" } }, [
+      "telemetryConfig.mode",
+    ]);
+  });
+
   it("maps monitoring.state true to telemetryConfig.mode ALL", async () => {
     await command.runner()("monitoring.state", "true", { project: PROJECT_ID });
     expect(updateStub).to.have.been.calledWith(PROJECT_ID, { telemetryConfig: { mode: "ALL" } }, [

--- a/src/commands/ailogic-config-set.spec.ts
+++ b/src/commands/ailogic-config-set.spec.ts
@@ -14,11 +14,12 @@ describe("ailogic:config:set", () => {
   let updateStub: sinon.SinonStub;
   let getConfigStub: sinon.SinonStub;
   let confirmStub: sinon.SinonStub;
+  let ensureStub: sinon.SinonStub;
 
   beforeEach(() => {
     (command as unknown as { befores: unknown[] }).befores = []; // bypass pre-action hooks
     sinon.stub(projectUtils, "needProjectId").returns(PROJECT_ID);
-    sinon.stub(ailogic, "ensureAILogicApiEnabled").resolves();
+    ensureStub = sinon.stub(ailogic, "ensureAILogicApiEnabled").resolves();
     sinon.stub(utils, "logSuccess");
     getConfigStub = sinon.stub(ailogic, "getConfig").resolves({ name: "config" });
     updateStub = sinon.stub(ailogic, "updateConfig").resolves({ name: "config" });
@@ -37,6 +38,13 @@ describe("ailogic:config:set", () => {
     await expect(
       command.runner()("security.auth-only", "yes", { project: PROJECT_ID }),
     ).to.be.rejectedWith(FirebaseError, /must be 'true' or 'false'/);
+  });
+
+  it("validates input before triggering the API-enablement flow (fail-fast)", async () => {
+    await expect(
+      command.runner()("monitoring.sample-rate-percentage", "500", { project: PROJECT_ID }),
+    ).to.be.rejectedWith(FirebaseError, /integer in the range 1-100/);
+    expect(ensureStub).to.not.have.been.called;
   });
 
   it("prompts when tightening auth-only from false to true, then updates", async () => {
@@ -84,9 +92,31 @@ describe("ailogic:config:set", () => {
     expect(updateStub).to.not.have.been.called;
   });
 
+  it("prompts when tightening template-only from false to true, then updates", async () => {
+    getConfigStub.resolves({ name: "config", trafficFilter: { templateOnly: false } });
+    await command.runner()("security.template-only", "true", {
+      project: PROJECT_ID,
+      interactive: true,
+    });
+    expect(confirmStub).to.have.been.calledOnce;
+    expect(updateStub).to.have.been.calledWith(
+      PROJECT_ID,
+      { trafficFilter: { templateOnly: true } },
+      ["trafficFilter.templateOnly"],
+    );
+  });
+
   it("maps monitoring.state true to telemetryConfig.mode ALL", async () => {
     await command.runner()("monitoring.state", "true", { project: PROJECT_ID });
     expect(updateStub).to.have.been.calledWith(PROJECT_ID, { telemetryConfig: { mode: "ALL" } }, [
+      "telemetryConfig.mode",
+    ]);
+  });
+
+  it("maps monitoring.state false to telemetryConfig.mode NONE without prompting", async () => {
+    await command.runner()("monitoring.state", "false", { project: PROJECT_ID });
+    expect(confirmStub).to.not.have.been.called;
+    expect(updateStub).to.have.been.calledWith(PROJECT_ID, { telemetryConfig: { mode: "NONE" } }, [
       "telemetryConfig.mode",
     ]);
   });

--- a/src/commands/ailogic-config-set.spec.ts
+++ b/src/commands/ailogic-config-set.spec.ts
@@ -148,6 +148,17 @@ describe("ailogic:config:set", () => {
     expect(updateStub).to.not.have.been.called;
   });
 
+  it("normalizes a zero-padded sample rate in the echoed value", async () => {
+    expect(
+      await command.runner()("monitoring.sample-rate-percentage", "007", { project: PROJECT_ID }),
+    ).to.deep.equal({ path: "monitoring.sample-rate-percentage", value: "7" });
+    expect(updateStub).to.have.been.calledWith(
+      PROJECT_ID,
+      { telemetryConfig: { samplingRate: 0.07 } },
+      ["telemetryConfig.samplingRate"],
+    );
+  });
+
   it("returns the normalized value for --json output", async () => {
     expect(
       await command.runner()("monitoring.state", "TRUE", { project: PROJECT_ID }),

--- a/src/commands/ailogic-config-set.spec.ts
+++ b/src/commands/ailogic-config-set.spec.ts
@@ -138,10 +138,19 @@ describe("ailogic:config:set", () => {
   });
 
   it("rejects an out-of-range or non-integer sample rate", async () => {
-    for (const bad of ["0", "101", "1.5", "abc"]) {
+    // "1e2", "0x32", and " 50 " all coerce to valid integers via Number(), so the
+    // strict decimal check must reject them too.
+    for (const bad of ["0", "101", "1.5", "abc", "1e2", "0x32", " 50 ", "50%"]) {
       await expect(
         command.runner()("monitoring.sample-rate-percentage", bad, { project: PROJECT_ID }),
       ).to.be.rejectedWith(FirebaseError, /integer in the range 1-100/);
     }
+    expect(updateStub).to.not.have.been.called;
+  });
+
+  it("returns the normalized value for --json output", async () => {
+    expect(
+      await command.runner()("monitoring.state", "TRUE", { project: PROJECT_ID }),
+    ).to.deep.equal({ path: "monitoring.state", value: "true" });
   });
 });

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -84,7 +84,8 @@ function buildUpdate(pathStr: string, value: string): ConfigUpdate {
       return {
         config: { telemetryConfig: { samplingRate: ailogic.percentToSamplingRate(Number(value)) } },
         updateMask: "telemetryConfig.samplingRate",
-        normalizedValue: value,
+        // Number() drops leading zeros so the echo matches what was stored ("007" -> "7").
+        normalizedValue: String(Number(value)),
       };
     }
     default:
@@ -97,7 +98,12 @@ function buildUpdate(pathStr: string, value: string): ConfigUpdate {
 export const command = new Command("ailogic:config:set <path> <value>")
   .description("set one configuration value")
   .option("-f, --force", "bypass confirmation prompt")
-  .before(requirePermissions, ["firebasevertexai.config.update", "firebasevertexai.config.get"])
+  .before(requirePermissions, [
+    "firebasevertexai.config.update",
+    "firebasevertexai.config.get",
+    // ensureAILogicApiEnabled reads API enablement state via Service Usage.
+    "serviceusage.services.get",
+  ])
   .action(async (pathStr: string, value: string, options: Options) => {
     const projectId = needProjectId(options);
 

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -25,6 +25,59 @@ function parseBool(pathStr: string, value: string): boolean {
   return value === "true";
 }
 
+// The parsed, validated change to apply: the partial Config, its updateMask, and
+// whether this is a security tightening (true) that requires confirmation.
+interface ConfigUpdate {
+  config: Partial<ailogic.Config>;
+  updateMask: string;
+  securityTightening: boolean;
+}
+
+/** Validates the path/value pair and builds the update, throwing on bad input. */
+function buildUpdate(pathStr: string, value: string): ConfigUpdate {
+  if (pathStr === "security.auth-only" || pathStr === "security.template-only") {
+    const boolVal = parseBool(pathStr, value);
+    const isAuthOnly = pathStr === "security.auth-only";
+    return {
+      config: {
+        trafficFilter: isAuthOnly ? { firebaseAuthRequired: boolVal } : { templateOnly: boolVal },
+      },
+      updateMask: isAuthOnly ? "trafficFilter.firebaseAuthRequired" : "trafficFilter.templateOnly",
+      securityTightening: boolVal,
+    };
+  }
+  if (pathStr === "monitoring.state") {
+    const boolVal = parseBool(pathStr, value);
+    return {
+      config: { telemetryConfig: { mode: boolVal ? "ALL" : "NONE" } },
+      updateMask: "telemetryConfig.mode",
+      securityTightening: false,
+    };
+  }
+  // monitoring.sample-rate-percentage
+  const numVal = Number(value);
+  if (!Number.isInteger(numVal) || numVal < 1 || numVal > 100) {
+    throw new FirebaseError(
+      `Value for ${clc.bold(pathStr)} must be an integer in the range 1-100.`,
+    );
+  }
+  // The API stores the sampling rate as a fraction in (0,1]; the CLI accepts 1-100 percent.
+  return {
+    config: { telemetryConfig: { samplingRate: numVal / 100 } },
+    updateMask: "telemetryConfig.samplingRate",
+    securityTightening: false,
+  };
+}
+
+/** Whether tightening `pathStr` to `true` changes it from a currently-false value. */
+function isTightening(pathStr: string, current: ailogic.Config): boolean {
+  const currentVal =
+    pathStr === "security.auth-only"
+      ? current.trafficFilter?.firebaseAuthRequired
+      : current.trafficFilter?.templateOnly;
+  return !(currentVal ?? false);
+}
+
 export const command = new Command("ailogic:config:set <path> <value>")
   .description("set one configuration value")
   .option("-f, --force", "bypass confirmation prompt")
@@ -32,74 +85,36 @@ export const command = new Command("ailogic:config:set <path> <value>")
   .action(async (pathStr: string, value: string, options: Options) => {
     const projectId = needProjectId(options);
 
-    // Validate the path up front so bad input fails fast, before the API-enablement flow.
+    // Validate the path and value up front so bad input fails fast, before the
+    // API-enablement flow.
     if (!WRITABLE_CONFIG_PATHS.includes(pathStr)) {
       throw new FirebaseError(
         `Unknown configuration path: ${pathStr}\n\nValid paths:\n\n` +
           WRITABLE_CONFIG_PATHS.map((p) => `  ${p}`).join("\n"),
       );
     }
+    const update = buildUpdate(pathStr, value);
 
     await ailogic.ensureAILogicApiEnabled(projectId, options);
 
-    if (pathStr === "security.auth-only" || pathStr === "security.template-only") {
-      const boolVal = parseBool(pathStr, value);
-      const isAuthOnly = pathStr === "security.auth-only";
-      const trafficFilter: ailogic.TrafficFilter = isAuthOnly
-        ? { firebaseAuthRequired: boolVal }
-        : { templateOnly: boolVal };
-      const mask = isAuthOnly ? "trafficFilter.firebaseAuthRequired" : "trafficFilter.templateOnly";
-
-      // Tightening security from false to true is client-breaking, so confirm first.
-      if (boolVal) {
-        const current = await ailogic.getConfig(projectId);
-        const currentVal =
-          (isAuthOnly
-            ? current.trafficFilter?.firebaseAuthRequired
-            : current.trafficFilter?.templateOnly) ?? false;
-        if (!currentVal) {
-          const rejectMsg = isAuthOnly
-            ? "reject requests from unauthenticated users"
-            : "reject requests not using templates";
-          // confirm() aborts in non-interactive mode unless --force is set.
-          const confirmed = await confirm({
-            message: `Enabling ${clc.bold(pathStr)} will ${rejectMsg}. Continue?`,
-            force: options.force,
-            nonInteractive: options.nonInteractive,
-          });
-          if (!confirmed) {
-            throw new FirebaseError("Command aborted.", { exit: 1 });
-          }
-        }
+    // Tightening a security setting from false to true is client-breaking, so confirm first.
+    if (update.securityTightening && isTightening(pathStr, await ailogic.getConfig(projectId))) {
+      const rejectMsg =
+        pathStr === "security.auth-only"
+          ? "reject requests from unauthenticated users"
+          : "reject requests not using templates";
+      // confirm() aborts in non-interactive mode unless --force is set.
+      const confirmed = await confirm({
+        message: `Enabling ${clc.bold(pathStr)} will ${rejectMsg}. Continue?`,
+        force: options.force,
+        nonInteractive: options.nonInteractive,
+      });
+      if (!confirmed) {
+        throw new FirebaseError("Command aborted.", { exit: 1 });
       }
-
-      await ailogic.updateConfig(projectId, { trafficFilter }, [mask]);
-      utils.logSuccess(`Updated security setting: ${clc.bold(pathStr)} = ${value}`);
-      return;
     }
 
-    if (pathStr === "monitoring.state") {
-      const boolVal = parseBool(pathStr, value);
-      await ailogic.updateConfig(
-        projectId,
-        { telemetryConfig: { mode: boolVal ? "ALL" : "NONE" } },
-        ["telemetryConfig.mode"],
-      );
-      utils.logSuccess(`Updated monitoring state: ${clc.bold(pathStr)} = ${value}`);
-      return;
-    }
-
-    // monitoring.sample-rate-percentage
-    const numVal = Number(value);
-    if (!Number.isInteger(numVal) || numVal < 1 || numVal > 100) {
-      throw new FirebaseError(
-        `Value for ${clc.bold(pathStr)} must be an integer in the range 1-100.`,
-      );
-    }
-    // The API stores the sampling rate as a fraction in (0,1]; the CLI accepts 1-100 percent.
-    const samplingRate = numVal / 100;
-    await ailogic.updateConfig(projectId, { telemetryConfig: { samplingRate } }, [
-      "telemetryConfig.samplingRate",
-    ]);
-    utils.logSuccess(`Updated monitoring sample rate: ${clc.bold(pathStr)} = ${value}%`);
+    await ailogic.updateConfig(projectId, update.config, [update.updateMask]);
+    utils.logSuccess(`Updated ${clc.bold(pathStr)} = ${value}`);
+    return { path: pathStr, value };
   });

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -1,0 +1,130 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import { confirm } from "../prompt";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:config:set <path> <value>")
+  .description("set one configuration value")
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requirePermissions, ["firebasevertexai.config.update", "firebasevertexai.config.get"])
+  .action(async (pathStr: string, value: string, options: Options) => {
+    const projectId = needProjectId(options);
+
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+
+    const validPaths = [
+      "security.auth-only",
+      "security.template-only",
+      "monitoring.state",
+      "monitoring.sample-rate-percentage",
+    ];
+
+    if (!validPaths.includes(pathStr)) {
+      throw new FirebaseError(
+        `Unknown configuration path: ${pathStr}\n\nValid paths:\n\n` +
+          validPaths.map((p) => `  ${p}`).join("\n"),
+      );
+    }
+
+    // Tightening check
+    if (pathStr === "security.auth-only" || pathStr === "security.template-only") {
+      if (value !== "true" && value !== "false") {
+        throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
+      }
+      const boolVal = value === "true";
+
+      if (boolVal) {
+        // Fetch current config to check if it's currently false
+        const currentConfig = await ailogic.getConfig(projectId);
+        const currentVal =
+          pathStr === "security.auth-only"
+            ? currentConfig.trafficFilter?.firebaseAuthRequired ?? false
+            : currentConfig.trafficFilter?.templateOnly ?? false;
+
+        if (!currentVal) {
+          const rejectMsg =
+            pathStr === "security.auth-only"
+              ? "reject requests from unauthenticated users"
+              : "reject requests not using templates";
+
+          if (options.nonInteractive && !options.force) {
+            throw new FirebaseError(
+              `Updating ${clc.bold(pathStr)} requires confirmation.\n\n` +
+                `To proceed in non-interactive mode, rerun with --force:\n\n` +
+                `  firebase ailogic:config:set ${pathStr} ${value} --force`,
+            );
+          }
+
+          const confirmed = await confirm({
+            message: `Enabling ${clc.bold(pathStr)} will ${rejectMsg}. Continue?`,
+            force: options.force,
+            nonInteractive: options.nonInteractive,
+          });
+
+          if (!confirmed) {
+            throw new FirebaseError("Command aborted.", { exit: 1 });
+          }
+        }
+      }
+
+      if (pathStr === "security.auth-only") {
+        await ailogic.updateConfig(
+          projectId,
+          {
+            trafficFilter: { firebaseAuthRequired: boolVal },
+          },
+          ["trafficFilter.firebaseAuthRequired"],
+        );
+      } else {
+        await ailogic.updateConfig(
+          projectId,
+          {
+            trafficFilter: { templateOnly: boolVal },
+          },
+          ["trafficFilter.templateOnly"],
+        );
+      }
+      logger.info(
+        clc.green(`Successfully updated security setting: ${clc.bold(pathStr)} = ${value}`),
+      );
+    } else if (pathStr === "monitoring.state") {
+      if (value !== "true" && value !== "false") {
+        throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
+      }
+      const boolVal = value === "true";
+      await ailogic.updateConfig(
+        projectId,
+        {
+          telemetryConfig: { mode: boolVal ? "ALL" : "NONE" },
+        },
+        ["telemetryConfig.mode"],
+      );
+      logger.info(
+        clc.green(`Successfully updated monitoring state: ${clc.bold(pathStr)} = ${value}`),
+      );
+    } else if (pathStr === "monitoring.sample-rate-percentage") {
+      const numVal = Number(value);
+      if (!Number.isInteger(numVal) || numVal < 1 || numVal > 100) {
+        throw new FirebaseError(
+          `Value for ${clc.bold(pathStr)} must be an integer in the range 1-100.`,
+        );
+      }
+      const samplingRate = numVal / 100;
+      await ailogic.updateConfig(
+        projectId,
+        {
+          telemetryConfig: { samplingRate },
+        },
+        ["telemetryConfig.samplingRate"],
+      );
+      logger.info(
+        clc.green(`Successfully updated monitoring sample rate: ${clc.bold(pathStr)} = ${value}%`),
+      );
+    }
+  });

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -9,14 +9,6 @@ import { confirm } from "../prompt";
 
 import { Options } from "../options";
 
-// Developer-facing config paths that `config:set` can write.
-const WRITABLE_CONFIG_PATHS = [
-  "security.auth-only",
-  "security.template-only",
-  "monitoring.state",
-  "monitoring.sample-rate-percentage",
-];
-
 /** Parses a "true"/"false" flag value (case-insensitive), throwing a FirebaseError otherwise. */
 function parseBool(pathStr: string, value: string): boolean {
   const normalized = value.toLowerCase();
@@ -26,57 +18,80 @@ function parseBool(pathStr: string, value: string): boolean {
   return normalized === "true";
 }
 
-// The parsed, validated change to apply: the partial Config, its updateMask, and
-// whether this is a security tightening (true) that requires confirmation.
+// The parsed, validated change to apply. `confirm` is present only when enabling
+// the setting is client-breaking and therefore needs approval before writing.
 interface ConfigUpdate {
   config: Partial<ailogic.Config>;
   updateMask: string;
-  securityTightening: boolean;
-}
-
-/** Validates the path/value pair and builds the update, throwing on bad input. */
-function buildUpdate(pathStr: string, value: string): ConfigUpdate {
-  if (pathStr === "security.auth-only" || pathStr === "security.template-only") {
-    const boolVal = parseBool(pathStr, value);
-    const isAuthOnly = pathStr === "security.auth-only";
-    return {
-      config: {
-        trafficFilter: isAuthOnly ? { firebaseAuthRequired: boolVal } : { templateOnly: boolVal },
-      },
-      updateMask: isAuthOnly ? "trafficFilter.firebaseAuthRequired" : "trafficFilter.templateOnly",
-      securityTightening: boolVal,
-    };
-  }
-  if (pathStr === "monitoring.state") {
-    const boolVal = parseBool(pathStr, value);
-    return {
-      config: { telemetryConfig: { mode: boolVal ? "ALL" : "NONE" } },
-      updateMask: "telemetryConfig.mode",
-      securityTightening: false,
-    };
-  }
-  // monitoring.sample-rate-percentage
-  const numVal = Number(value);
-  if (!Number.isInteger(numVal) || numVal < 1 || numVal > 100) {
-    throw new FirebaseError(
-      `Value for ${clc.bold(pathStr)} must be an integer in the range 1-100.`,
-    );
-  }
-  // The API stores the sampling rate as a fraction in (0,1]; the CLI accepts 1-100 percent.
-  return {
-    config: { telemetryConfig: { samplingRate: numVal / 100 } },
-    updateMask: "telemetryConfig.samplingRate",
-    securityTightening: false,
+  normalizedValue: string;
+  confirm?: {
+    message: string;
+    /** Whether the setting is already active, in which case no confirmation is needed. */
+    isAlreadyEnabled(current: ailogic.Config): boolean;
   };
 }
 
-/** Whether tightening `pathStr` to `true` changes it from a currently-false value. */
-function isTightening(pathStr: string, current: ailogic.Config): boolean {
-  const currentVal =
-    pathStr === "security.auth-only"
-      ? current.trafficFilter?.firebaseAuthRequired
-      : current.trafficFilter?.templateOnly;
-  return !(currentVal ?? false);
+/**
+ * Validates the path/value pair and builds the update, throwing on bad input.
+ * This is the single place that maps a CLI path to its resource field.
+ */
+function buildUpdate(pathStr: string, value: string): ConfigUpdate {
+  switch (pathStr) {
+    case "security.auth-only": {
+      const boolVal = parseBool(pathStr, value);
+      return {
+        config: { trafficFilter: { firebaseAuthRequired: boolVal } },
+        updateMask: "trafficFilter.firebaseAuthRequired",
+        normalizedValue: String(boolVal),
+        confirm: boolVal
+          ? {
+              message: `Enabling ${clc.bold(pathStr)} will reject requests from unauthenticated users. Continue?`,
+              isAlreadyEnabled: (current) => current.trafficFilter?.firebaseAuthRequired ?? false,
+            }
+          : undefined,
+      };
+    }
+    case "security.template-only": {
+      const boolVal = parseBool(pathStr, value);
+      return {
+        config: { trafficFilter: { templateOnly: boolVal } },
+        updateMask: "trafficFilter.templateOnly",
+        normalizedValue: String(boolVal),
+        confirm: boolVal
+          ? {
+              message: `Enabling ${clc.bold(pathStr)} will reject requests not using templates. Continue?`,
+              isAlreadyEnabled: (current) => current.trafficFilter?.templateOnly ?? false,
+            }
+          : undefined,
+      };
+    }
+    case "monitoring.state": {
+      const boolVal = parseBool(pathStr, value);
+      return {
+        config: { telemetryConfig: { mode: boolVal ? "ALL" : "NONE" } },
+        updateMask: "telemetryConfig.mode",
+        normalizedValue: String(boolVal),
+      };
+    }
+    case "monitoring.sample-rate-percentage": {
+      // Require a plain decimal integer; Number() alone would also accept
+      // hex ("0x32"), scientific notation ("1e2"), and decimals ("50.0").
+      if (!/^\d+$/.test(value) || Number(value) < 1 || Number(value) > 100) {
+        throw new FirebaseError(
+          `Value for ${clc.bold(pathStr)} must be an integer in the range 1-100.`,
+        );
+      }
+      return {
+        config: { telemetryConfig: { samplingRate: ailogic.percentToSamplingRate(Number(value)) } },
+        updateMask: "telemetryConfig.samplingRate",
+        normalizedValue: value,
+      };
+    }
+    default:
+      // Unreachable behind assertKnownConfigPath; kept exhaustive so a newly added
+      // writable path cannot silently fall into the wrong branch.
+      throw new FirebaseError(`Unknown configuration path: ${pathStr}`);
+  }
 }
 
 export const command = new Command("ailogic:config:set <path> <value>")
@@ -88,25 +103,16 @@ export const command = new Command("ailogic:config:set <path> <value>")
 
     // Validate the path and value up front so bad input fails fast, before the
     // API-enablement flow.
-    if (!WRITABLE_CONFIG_PATHS.includes(pathStr)) {
-      throw new FirebaseError(
-        `Unknown configuration path: ${pathStr}\n\nValid paths:\n\n` +
-          WRITABLE_CONFIG_PATHS.map((p) => `  ${p}`).join("\n"),
-      );
-    }
+    ailogic.assertKnownConfigPath(pathStr, ailogic.WRITABLE_CONFIG_PATHS);
     const update = buildUpdate(pathStr, value);
 
     await ailogic.ensureAILogicApiEnabled(projectId, options);
 
-    // Tightening a security setting from false to true is client-breaking, so confirm first.
-    if (update.securityTightening && isTightening(pathStr, await ailogic.getConfig(projectId))) {
-      const rejectMsg =
-        pathStr === "security.auth-only"
-          ? "reject requests from unauthenticated users"
-          : "reject requests not using templates";
+    // Tightening a security setting from off to on is client-breaking, so confirm first.
+    if (update.confirm && !update.confirm.isAlreadyEnabled(await ailogic.getConfig(projectId))) {
       // confirm() aborts in non-interactive mode unless --force is set.
       const confirmed = await confirm({
-        message: `Enabling ${clc.bold(pathStr)} will ${rejectMsg}. Continue?`,
+        message: update.confirm.message,
         force: options.force,
         nonInteractive: options.nonInteractive,
       });
@@ -116,6 +122,6 @@ export const command = new Command("ailogic:config:set <path> <value>")
     }
 
     await ailogic.updateConfig(projectId, update.config, [update.updateMask]);
-    utils.logSuccess(`Updated ${clc.bold(pathStr)} = ${value}`);
-    return { path: pathStr, value };
+    utils.logSuccess(`Updated ${clc.bold(pathStr)} = ${update.normalizedValue}`);
+    return { path: pathStr, value: update.normalizedValue };
   });

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -17,12 +17,13 @@ const WRITABLE_CONFIG_PATHS = [
   "monitoring.sample-rate-percentage",
 ];
 
-/** Parses a "true"/"false" flag value, throwing a FirebaseError otherwise. */
+/** Parses a "true"/"false" flag value (case-insensitive), throwing a FirebaseError otherwise. */
 function parseBool(pathStr: string, value: string): boolean {
-  if (value !== "true" && value !== "false") {
+  const normalized = value.toLowerCase();
+  if (normalized !== "true" && normalized !== "false") {
     throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
   }
-  return value === "true";
+  return normalized === "true";
 }
 
 // The parsed, validated change to apply: the partial Config, its updateMask, and

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -3,11 +3,27 @@ import { requirePermissions } from "../requirePermissions";
 import { needProjectId } from "../projectUtils";
 import * as ailogic from "../gcp/ailogic";
 import * as clc from "colorette";
-import { logger } from "../logger";
+import * as utils from "../utils";
 import { FirebaseError } from "../error";
 import { confirm } from "../prompt";
 
 import { Options } from "../options";
+
+// Developer-facing config paths that `config:set` can write.
+const WRITABLE_CONFIG_PATHS = [
+  "security.auth-only",
+  "security.template-only",
+  "monitoring.state",
+  "monitoring.sample-rate-percentage",
+];
+
+/** Parses a "true"/"false" flag value, throwing a FirebaseError otherwise. */
+function parseBool(pathStr: string, value: string): boolean {
+  if (value !== "true" && value !== "false") {
+    throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
+  }
+  return value === "true";
+}
 
 export const command = new Command("ailogic:config:set <path> <value>")
   .description("set one configuration value")
@@ -16,115 +32,74 @@ export const command = new Command("ailogic:config:set <path> <value>")
   .action(async (pathStr: string, value: string, options: Options) => {
     const projectId = needProjectId(options);
 
-    await ailogic.ensureAILogicApiEnabled(projectId, options);
-
-    const validPaths = [
-      "security.auth-only",
-      "security.template-only",
-      "monitoring.state",
-      "monitoring.sample-rate-percentage",
-    ];
-
-    if (!validPaths.includes(pathStr)) {
+    // Validate the path up front so bad input fails fast, before the API-enablement flow.
+    if (!WRITABLE_CONFIG_PATHS.includes(pathStr)) {
       throw new FirebaseError(
         `Unknown configuration path: ${pathStr}\n\nValid paths:\n\n` +
-          validPaths.map((p) => `  ${p}`).join("\n"),
+          WRITABLE_CONFIG_PATHS.map((p) => `  ${p}`).join("\n"),
       );
     }
 
-    // Tightening check
+    await ailogic.ensureAILogicApiEnabled(projectId, options);
+
     if (pathStr === "security.auth-only" || pathStr === "security.template-only") {
-      if (value !== "true" && value !== "false") {
-        throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
-      }
-      const boolVal = value === "true";
+      const boolVal = parseBool(pathStr, value);
+      const isAuthOnly = pathStr === "security.auth-only";
+      const trafficFilter: ailogic.TrafficFilter = isAuthOnly
+        ? { firebaseAuthRequired: boolVal }
+        : { templateOnly: boolVal };
+      const mask = isAuthOnly ? "trafficFilter.firebaseAuthRequired" : "trafficFilter.templateOnly";
 
+      // Tightening security from false to true is client-breaking, so confirm first.
       if (boolVal) {
-        // Fetch current config to check if it's currently false
-        const currentConfig = await ailogic.getConfig(projectId);
+        const current = await ailogic.getConfig(projectId);
         const currentVal =
-          pathStr === "security.auth-only"
-            ? currentConfig.trafficFilter?.firebaseAuthRequired ?? false
-            : currentConfig.trafficFilter?.templateOnly ?? false;
-
+          (isAuthOnly
+            ? current.trafficFilter?.firebaseAuthRequired
+            : current.trafficFilter?.templateOnly) ?? false;
         if (!currentVal) {
-          const rejectMsg =
-            pathStr === "security.auth-only"
-              ? "reject requests from unauthenticated users"
-              : "reject requests not using templates";
-
-          if (options.nonInteractive && !options.force) {
-            throw new FirebaseError(
-              `Updating ${clc.bold(pathStr)} requires confirmation.\n\n` +
-                `To proceed in non-interactive mode, rerun with --force:\n\n` +
-                `  firebase ailogic:config:set ${pathStr} ${value} --force`,
-            );
-          }
-
+          const rejectMsg = isAuthOnly
+            ? "reject requests from unauthenticated users"
+            : "reject requests not using templates";
+          // confirm() aborts in non-interactive mode unless --force is set.
           const confirmed = await confirm({
             message: `Enabling ${clc.bold(pathStr)} will ${rejectMsg}. Continue?`,
             force: options.force,
             nonInteractive: options.nonInteractive,
           });
-
           if (!confirmed) {
             throw new FirebaseError("Command aborted.", { exit: 1 });
           }
         }
       }
 
-      if (pathStr === "security.auth-only") {
-        await ailogic.updateConfig(
-          projectId,
-          {
-            trafficFilter: { firebaseAuthRequired: boolVal },
-          },
-          ["trafficFilter.firebaseAuthRequired"],
-        );
-      } else {
-        await ailogic.updateConfig(
-          projectId,
-          {
-            trafficFilter: { templateOnly: boolVal },
-          },
-          ["trafficFilter.templateOnly"],
-        );
-      }
-      logger.info(
-        clc.green(`Successfully updated security setting: ${clc.bold(pathStr)} = ${value}`),
-      );
-    } else if (pathStr === "monitoring.state") {
-      if (value !== "true" && value !== "false") {
-        throw new FirebaseError(`Value for ${clc.bold(pathStr)} must be 'true' or 'false'.`);
-      }
-      const boolVal = value === "true";
+      await ailogic.updateConfig(projectId, { trafficFilter }, [mask]);
+      utils.logSuccess(`Updated security setting: ${clc.bold(pathStr)} = ${value}`);
+      return;
+    }
+
+    if (pathStr === "monitoring.state") {
+      const boolVal = parseBool(pathStr, value);
       await ailogic.updateConfig(
         projectId,
-        {
-          telemetryConfig: { mode: boolVal ? "ALL" : "NONE" },
-        },
+        { telemetryConfig: { mode: boolVal ? "ALL" : "NONE" } },
         ["telemetryConfig.mode"],
       );
-      logger.info(
-        clc.green(`Successfully updated monitoring state: ${clc.bold(pathStr)} = ${value}`),
-      );
-    } else if (pathStr === "monitoring.sample-rate-percentage") {
-      const numVal = Number(value);
-      if (!Number.isInteger(numVal) || numVal < 1 || numVal > 100) {
-        throw new FirebaseError(
-          `Value for ${clc.bold(pathStr)} must be an integer in the range 1-100.`,
-        );
-      }
-      const samplingRate = numVal / 100;
-      await ailogic.updateConfig(
-        projectId,
-        {
-          telemetryConfig: { samplingRate },
-        },
-        ["telemetryConfig.samplingRate"],
-      );
-      logger.info(
-        clc.green(`Successfully updated monitoring sample rate: ${clc.bold(pathStr)} = ${value}%`),
+      utils.logSuccess(`Updated monitoring state: ${clc.bold(pathStr)} = ${value}`);
+      return;
+    }
+
+    // monitoring.sample-rate-percentage
+    const numVal = Number(value);
+    if (!Number.isInteger(numVal) || numVal < 1 || numVal > 100) {
+      throw new FirebaseError(
+        `Value for ${clc.bold(pathStr)} must be an integer in the range 1-100.`,
       );
     }
+    // The API stores the sampling rate as a fraction in (0,1]; the CLI accepts 1-100 percent.
+    const samplingRate = numVal / 100;
+    await ailogic.updateConfig(projectId, { telemetryConfig: { samplingRate } }, [
+      "telemetryConfig.samplingRate",
+    ]);
+    utils.logSuccess(`Updated monitoring sample rate: ${clc.bold(pathStr)} = ${value}%`);
   });

--- a/src/commands/ailogic-config-set.ts
+++ b/src/commands/ailogic-config-set.ts
@@ -82,7 +82,8 @@ function buildUpdate(pathStr: string, value: string): ConfigUpdate {
         );
       }
       return {
-        config: { telemetryConfig: { samplingRate: ailogic.percentToSamplingRate(Number(value)) } },
+        // The API stores samplingRate as a fraction in (0,1].
+        config: { telemetryConfig: { samplingRate: Number(value) / 100 } },
         updateMask: "telemetryConfig.samplingRate",
         // Number() drops leading zeros so the echo matches what was stored ("007" -> "7").
         normalizedValue: String(Number(value)),
@@ -97,6 +98,20 @@ function buildUpdate(pathStr: string, value: string): ConfigUpdate {
 
 export const command = new Command("ailogic:config:set <path> <value>")
   .description("set one configuration value")
+  .help(
+    `sets one AI Logic configuration value on the active project.
+
+Valid values for <path>, and the <value> each accepts:
+
+  security.auth-only                 true|false - only allow requests from authenticated users
+  security.template-only             true|false - only allow requests that use a server template
+  monitoring.state                   true|false - turn AI monitoring on or off
+  monitoring.sample-rate-percentage  1-100      - percentage of requests sampled for monitoring
+
+For example, to only allow requests from authenticated users:
+
+  firebase ailogic:config:set security.auth-only true`,
+  )
   .option("-f, --force", "bypass confirmation prompt")
   .before(requirePermissions, [
     "firebasevertexai.config.update",

--- a/src/commands/ailogic-providers-disable.ts
+++ b/src/commands/ailogic-providers-disable.ts
@@ -1,0 +1,40 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+import { confirm } from "../prompt";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:disable <providerType>")
+  .description("disable a Gemini API provider service")
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requirePermissions, ["serviceusage.services.disable", "firebasevertexai.config.update"])
+  .action(async (providerType: string, options: Options) => {
+    const projectId = needProjectId(options);
+    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
+      throw new FirebaseError(
+        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
+      );
+    }
+    if (options.nonInteractive && !options.force) {
+      throw new FirebaseError(
+        `Disabling provider ${clc.bold(providerType)} requires confirmation.\n\n` +
+          `To proceed in non-interactive mode, rerun with --force:\n\n` +
+          `  firebase ailogic:providers:disable ${providerType} --force`,
+      );
+    }
+    const confirmed = await confirm({
+      message: `You are about to disable ${clc.bold(providerType)}. This will stop running apps from invoking it. Are you sure?`,
+      force: options.force,
+      nonInteractive: options.nonInteractive,
+    });
+    if (!confirmed) {
+      throw new FirebaseError("Command aborted.", { exit: 1 });
+    }
+    await ailogic.disableProvider(projectId, providerType as ailogic.ProviderType);
+    logger.info(clc.green(`Successfully disabled provider: ${clc.bold(providerType)}`));
+  });

--- a/src/commands/ailogic-providers-disable.ts
+++ b/src/commands/ailogic-providers-disable.ts
@@ -15,26 +15,17 @@ export const command = new Command("ailogic:providers:disable <providerType>")
   .before(requirePermissions, ["serviceusage.services.disable", "firebasevertexai.config.update"])
   .action(async (providerType: string, options: Options) => {
     const projectId = needProjectId(options);
-    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
-      throw new FirebaseError(
-        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
-      );
-    }
-    if (options.nonInteractive && !options.force) {
-      throw new FirebaseError(
-        `Disabling provider ${clc.bold(providerType)} requires confirmation.\n\n` +
-          `To proceed in non-interactive mode, rerun with --force:\n\n` +
-          `  firebase ailogic:providers:disable ${providerType} --force`,
-      );
-    }
+    const provider = ailogic.parseProviderType(providerType);
+    // confirm() aborts (throws) in non-interactive mode unless --force is set, so a
+    // separate non-interactive guard is unnecessary here.
     const confirmed = await confirm({
-      message: `You are about to disable ${clc.bold(providerType)}. This will stop running apps from invoking it. Are you sure?`,
+      message: `You are about to disable ${clc.bold(provider)}. This will stop running apps from invoking it. Are you sure?`,
       force: options.force,
       nonInteractive: options.nonInteractive,
     });
     if (!confirmed) {
       throw new FirebaseError("Command aborted.", { exit: 1 });
     }
-    await ailogic.disableProvider(projectId, providerType as ailogic.ProviderType);
-    logger.info(clc.green(`Successfully disabled provider: ${clc.bold(providerType)}`));
+    await ailogic.disableProvider(projectId, provider);
+    logger.info(clc.green(`Successfully disabled provider: ${clc.bold(provider)}`));
   });

--- a/src/commands/ailogic-providers-disable.ts
+++ b/src/commands/ailogic-providers-disable.ts
@@ -11,6 +11,18 @@ import { Options } from "../options";
 
 export const command = new Command("ailogic:providers:disable <providerType>")
   .description("disable a Gemini API provider service")
+  .help(
+    `disables the Google Cloud API that backs a Gemini API provider. Running apps that use the provider will no longer be able to invoke it.
+
+Valid values for <providerType>:
+
+  gemini-developer-api       the Gemini Developer API
+  gemini-agent-platform-api  the Gemini API on the Agent Platform
+
+For example:
+
+  firebase ailogic:providers:disable gemini-developer-api`,
+  )
   .option("-f, --force", "bypass confirmation prompt")
   .before(requirePermissions, ["serviceusage.services.disable", "firebasevertexai.config.update"])
   .action(async (providerType: string, options: Options) => {

--- a/src/commands/ailogic-providers-enable.ts
+++ b/src/commands/ailogic-providers-enable.ts
@@ -1,0 +1,23 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import { FirebaseError } from "../error";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:enable <providerType>")
+  .description("enable a Gemini API provider service")
+  .before(requirePermissions, ["serviceusage.services.enable", "firebasevertexai.config.update"])
+  .action(async (providerType: string, options: Options) => {
+    const projectId = needProjectId(options);
+    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
+      throw new FirebaseError(
+        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
+      );
+    }
+    await ailogic.enableProvider(projectId, providerType as ailogic.ProviderType);
+    logger.info(clc.green(`Successfully enabled provider: ${clc.bold(providerType)}`));
+  });

--- a/src/commands/ailogic-providers-enable.ts
+++ b/src/commands/ailogic-providers-enable.ts
@@ -4,7 +4,6 @@ import { needProjectId } from "../projectUtils";
 import * as ailogic from "../gcp/ailogic";
 import * as clc from "colorette";
 import { logger } from "../logger";
-import { FirebaseError } from "../error";
 
 import { Options } from "../options";
 
@@ -13,11 +12,7 @@ export const command = new Command("ailogic:providers:enable <providerType>")
   .before(requirePermissions, ["serviceusage.services.enable", "firebasevertexai.config.update"])
   .action(async (providerType: string, options: Options) => {
     const projectId = needProjectId(options);
-    if (providerType !== "gemini-developer-api" && providerType !== "agent-platform-gemini-api") {
-      throw new FirebaseError(
-        `Invalid provider type: ${clc.bold(providerType)}. Must be 'gemini-developer-api' or 'agent-platform-gemini-api'.`,
-      );
-    }
-    await ailogic.enableProvider(projectId, providerType as ailogic.ProviderType);
-    logger.info(clc.green(`Successfully enabled provider: ${clc.bold(providerType)}`));
+    const provider = ailogic.parseProviderType(providerType);
+    await ailogic.enableProvider(projectId, provider);
+    logger.info(clc.green(`Successfully enabled provider: ${clc.bold(provider)}`));
   });

--- a/src/commands/ailogic-providers-enable.ts
+++ b/src/commands/ailogic-providers-enable.ts
@@ -9,6 +9,18 @@ import { Options } from "../options";
 
 export const command = new Command("ailogic:providers:enable <providerType>")
   .description("enable a Gemini API provider service")
+  .help(
+    `enables the Google Cloud APIs that back a Gemini API provider, along with the Firebase AI Logic API.
+
+Valid values for <providerType>:
+
+  gemini-developer-api       the Gemini Developer API
+  gemini-agent-platform-api  the Gemini API on the Agent Platform; requires the Blaze (pay-as-you-go) plan
+
+For example:
+
+  firebase ailogic:providers:enable gemini-developer-api`,
+  )
   .before(requirePermissions, ["serviceusage.services.enable", "firebasevertexai.config.update"])
   .action(async (providerType: string, options: Options) => {
     const projectId = needProjectId(options);

--- a/src/commands/ailogic-providers-list.ts
+++ b/src/commands/ailogic-providers-list.ts
@@ -1,0 +1,38 @@
+import { Command } from "../command";
+import { requirePermissions } from "../requirePermissions";
+import { needProjectId } from "../projectUtils";
+import * as ailogic from "../gcp/ailogic";
+import * as clc from "colorette";
+import { logger } from "../logger";
+import * as Table from "cli-table3";
+
+import { Options } from "../options";
+
+export const command = new Command("ailogic:providers:list")
+  .description("list which Gemini API providers are enabled")
+  .before(requirePermissions, ["serviceusage.services.get"])
+  .action(async (options: Options) => {
+    const projectId = needProjectId(options);
+    const enabledProviders = await ailogic.listProviders(projectId);
+
+    if (enabledProviders.length === 0) {
+      logger.info(clc.bold("No Gemini API providers are enabled."));
+      return enabledProviders;
+    }
+
+    const tableHead = ["Provider", "Status"];
+    const table = new Table({ head: tableHead, style: { head: ["green"] } });
+
+    // Show both possible providers, indicating if they are enabled or disabled
+    const allProviders: ailogic.ProviderType[] = [
+      "gemini-developer-api",
+      "agent-platform-gemini-api",
+    ];
+    for (const provider of allProviders) {
+      const isEnabled = enabledProviders.includes(provider);
+      table.push([clc.bold(provider), isEnabled ? clc.green("Enabled") : clc.red("Disabled")]);
+    }
+
+    logger.info(table.toString());
+    return enabledProviders;
+  });

--- a/src/commands/ailogic-providers-list.ts
+++ b/src/commands/ailogic-providers-list.ts
@@ -23,12 +23,8 @@ export const command = new Command("ailogic:providers:list")
     const tableHead = ["Provider", "Status"];
     const table = new Table({ head: tableHead, style: { head: ["green"] } });
 
-    // Show both possible providers, indicating if they are enabled or disabled
-    const allProviders: ailogic.ProviderType[] = [
-      "gemini-developer-api",
-      "agent-platform-gemini-api",
-    ];
-    for (const provider of allProviders) {
+    // Show every possible provider, indicating whether it is enabled or disabled.
+    for (const provider of ailogic.PROVIDER_TYPES) {
       const isEnabled = enabledProviders.includes(provider);
       table.push([clc.bold(provider), isEnabled ? clc.green("Enabled") : clc.red("Disabled")]);
     }

--- a/src/commands/help.spec.ts
+++ b/src/commands/help.spec.ts
@@ -1,0 +1,59 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import { command as helpCommand } from "./help";
+import { logger } from "../logger";
+
+describe("help command namespace listing", () => {
+  let loggerStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    loggerStub = sinon.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should show help for namespace subcommands", async () => {
+    const mockEnableCommand = {
+      name: () => "ailogic:providers:enable",
+      description: () => "enable a provider",
+      outputHelp: sinon.stub(),
+    };
+    const mockDisableCommand = {
+      name: () => "ailogic:providers:disable",
+      description: () => "disable a provider",
+      outputHelp: sinon.stub(),
+    };
+
+    const mockClient = {
+      cli: {
+        commands: [mockEnableCommand, mockDisableCommand],
+        outputHelp: sinon.stub(),
+      },
+      getCommand: sinon.stub().returns(undefined),
+      ailogic: {
+        providers: {},
+      },
+    };
+
+    // Run help command action with mock context
+    // `actionFn` is a private member of Command; cast through `unknown` to invoke it
+    // directly with a mocked command context. The target type is fully specified (no `any`).
+    const actionFn = (
+      helpCommand as unknown as {
+        actionFn: (this: { client: typeof mockClient }, commandName: string) => Promise<void>;
+      }
+    ).actionFn;
+    await actionFn.call({ client: mockClient }, "ailogic:providers");
+
+    // It should log the subcommands and descriptions
+    expect(loggerStub).to.have.been.called;
+    const allArgs = loggerStub.args.map((a) => a.join(" ")).join("\n");
+    expect(allArgs).to.include("Commands under ailogic:providers:");
+    expect(allArgs).to.include("ailogic:providers:enable");
+    expect(allArgs).to.include("enable a provider");
+    expect(allArgs).to.include("ailogic:providers:disable");
+    expect(allArgs).to.include("disable a provider");
+  });
+});

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -19,6 +19,9 @@ export const command = new Command("help [command]")
     }
 
     if (commandName) {
+      // Treat the argument as a command namespace (e.g. "ailogic:providers") and walk
+      // the nested client command tree segment by segment ("ailogic" -> "providers") to
+      // check whether it resolves to a group of subcommands rather than a leaf command.
       const keys = commandName.split(":");
       let current = client;
       let matched = true;
@@ -36,6 +39,8 @@ export const command = new Command("help [command]")
         }
       }
 
+      // If it resolved to a namespace, print every registered command under that prefix
+      // (e.g. `firebase help ailogic:providers` lists enable/disable/list).
       if (matched && current && typeof current === "object") {
         const prefix = commandName + ":";
         const subcmds = (client.cli.commands as CommanderCommand[]).filter((c) =>

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import * as clc from "colorette";
+import type { Command as CommanderCommand } from "commander";
 
 import { Command } from "../command";
 import { logger } from "../logger";
@@ -14,7 +15,46 @@ export const command = new Command("help [command]")
     const cmd = commandName ? client.getCommand(commandName) : undefined;
     if (cmd) {
       cmd.outputHelp();
-    } else if (commandName) {
+      return;
+    }
+
+    if (commandName) {
+      const keys = commandName.split(":");
+      let current = client;
+      let matched = true;
+      for (const key of keys) {
+        if (!current || typeof current !== "object") {
+          matched = false;
+          break;
+        }
+        const nextKey = Object.keys(current).find((k) => k.toLowerCase() === key.toLowerCase());
+        if (nextKey) {
+          current = current[nextKey];
+        } else {
+          matched = false;
+          break;
+        }
+      }
+
+      if (matched && current && typeof current === "object") {
+        const prefix = commandName + ":";
+        const subcmds = (client.cli.commands as CommanderCommand[]).filter((c) =>
+          c.name().startsWith(prefix),
+        );
+        if (subcmds.length > 0) {
+          logger.info();
+          logger.info(clc.bold(`Commands under ${clc.green(commandName)}:`));
+          logger.info();
+          for (const subcmd of subcmds) {
+            logger.info(`  ${clc.bold(subcmd.name().padEnd(45))} ${subcmd.description()}`);
+          }
+          logger.info();
+          return;
+        }
+      }
+    }
+
+    if (commandName) {
       logger.warn();
       utils.logWarning(
         clc.bold(commandName) + " is not a valid command. See below for valid commands",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -234,6 +234,10 @@ export function load(client: CLIClient): CLIClient {
     client.ailogic.providers.list = loadCommand("ailogic-providers-list");
   }
 
+  client.ailogic.config = {};
+  client.ailogic.config.get = loadCommand("ailogic-config-get");
+  client.ailogic.config.set = loadCommand("ailogic-config-set");
+
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");
   client.login.ci = loadCommand("login-ci");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -224,11 +224,15 @@ export function load(client: CLIClient): CLIClient {
       client.apphosting.rollouts.list = loadCommand("apphosting-rollouts-list");
     }
   }
-  client.ailogic = {};
-  client.ailogic.providers = {};
-  client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
-  client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
-  client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+  // Gated behind the `ailogic` experiment until the underlying API is API-council
+  // approved, since the surface may still change.
+  if (experiments.isEnabled("ailogic")) {
+    client.ailogic = {};
+    client.ailogic.providers = {};
+    client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
+    client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
+    client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+  }
 
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -232,11 +232,10 @@ export function load(client: CLIClient): CLIClient {
     client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
     client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
     client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+    client.ailogic.config = {};
+    client.ailogic.config.get = loadCommand("ailogic-config-get");
+    client.ailogic.config.set = loadCommand("ailogic-config-set");
   }
-
-  client.ailogic.config = {};
-  client.ailogic.config.get = loadCommand("ailogic-config-get");
-  client.ailogic.config.set = loadCommand("ailogic-config-set");
 
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -224,6 +224,12 @@ export function load(client: CLIClient): CLIClient {
       client.apphosting.rollouts.list = loadCommand("apphosting-rollouts-list");
     }
   }
+  client.ailogic = {};
+  client.ailogic.providers = {};
+  client.ailogic.providers.enable = loadCommand("ailogic-providers-enable");
+  client.ailogic.providers.disable = loadCommand("ailogic-providers-disable");
+  client.ailogic.providers.list = loadCommand("ailogic-providers-list");
+
   client.login = loadCommand("login");
   client.login.add = loadCommand("login-add");
   client.login.ci = loadCommand("login-ci");

--- a/src/ensureApiEnabled.ts
+++ b/src/ensureApiEnabled.ts
@@ -239,3 +239,18 @@ function cacheEnabledAPI(projectId: string, apiName: string) {
   cache[projectId][apiName] = true;
   configstore.set(API_ENABLEMENT_CACHE_KEY, cache);
 }
+
+/**
+ * Removes a single API from the local "enabled" cache so the next check re-queries the server.
+ * Call this after enabling or disabling an API to keep the cache consistent with the server state.
+ */
+export function uncacheEnabledAPI(projectId: string, apiName: string): void {
+  const cache = (configstore.get(API_ENABLEMENT_CACHE_KEY) || {}) as Record<
+    string,
+    Record<string, true>
+  >;
+  if (cache[projectId]) {
+    delete cache[projectId][apiName];
+    configstore.set(API_ENABLEMENT_CACHE_KEY, cache);
+  }
+}

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -136,6 +136,14 @@ export const ALL_EXPERIMENTS = experiments({
       "without a notice.",
   },
 
+  ailogic: {
+    shortDescription: "Manage Firebase AI Logic from the CLI.",
+    fullDescription:
+      "Enables the `firebase ailogic` command surface for managing Firebase AI Logic, " +
+      "starting with the Gemini API providers. These commands are in preview and may " +
+      "change until the underlying API is finalized.",
+  },
+
   apphosting: {
     shortDescription: "Allow CLI option for Frameworks",
     default: true,

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -3,7 +3,6 @@ import * as sinon from "sinon";
 import * as ailogic from "./ailogic";
 import * as ensureApiEnabled from "../ensureApiEnabled";
 import * as serviceUsage from "./serviceusage";
-import * as rules from "./rules";
 import * as cloudbilling from "./cloudbilling";
 import {
   AI_LOGIC_BEFORE_GENERATE_CONTENT,
@@ -342,74 +341,6 @@ describe("ailogic", () => {
     it("isProviderType narrows valid values only", () => {
       expect(ailogic.isProviderType("gemini-developer-api")).to.be.true;
       expect(ailogic.isProviderType("nope")).to.be.false;
-    });
-  });
-
-  describe("securityRules", () => {
-    let listReleasesStub: sinon.SinonStub;
-    let getLatestRulesetNameStub: sinon.SinonStub;
-    let getRulesetContentStub: sinon.SinonStub;
-    let createRulesetStub: sinon.SinonStub;
-    let updateOrCreateReleaseStub: sinon.SinonStub;
-
-    beforeEach(() => {
-      listReleasesStub = sinon.stub(rules, "listAllReleases");
-      getLatestRulesetNameStub = sinon.stub(rules, "getLatestRulesetName");
-      getRulesetContentStub = sinon.stub(rules, "getRulesetContent");
-      createRulesetStub = sinon.stub(rules, "createRuleset");
-      updateOrCreateReleaseStub = sinon.stub(rules, "updateOrCreateRelease");
-    });
-
-    afterEach(() => {
-      listReleasesStub.restore();
-      getLatestRulesetNameStub.restore();
-      getRulesetContentStub.restore();
-      createRulesetStub.restore();
-      updateOrCreateReleaseStub.restore();
-    });
-
-    it("should get rules and parse authOnly and templateOnly", async () => {
-      listReleasesStub.resolves([]);
-      getLatestRulesetNameStub.resolves("ruleset-name");
-      getRulesetContentStub.resolves([
-        {
-          name: "vertexai.rules",
-          content: `rules_version = '2';
-service firebase.vertexai {
-  match /projects/{project}/locations/{location} {
-    match /templates/{template} {
-      allow read: if request.auth != null;
-    }
-    match /models/{model} {
-      allow read: if false;
-    }
-  }
-}`,
-        },
-      ]);
-
-      const config = await ailogic.getSecurityRules("my-project");
-
-      expect(config).to.deep.equal({ authOnly: true, templateOnly: true });
-    });
-
-    it("should deploy rules with generateRulesContent", async () => {
-      createRulesetStub.resolves("new-ruleset");
-      updateOrCreateReleaseStub.resolves("release-name");
-
-      await ailogic.updateSecurityRules("my-project", true, false);
-
-      expect(createRulesetStub).to.have.been.calledWith("my-project", [
-        {
-          name: "vertexai.rules",
-          content: ailogic.generateRulesContent(true, false),
-        },
-      ]);
-      expect(updateOrCreateReleaseStub).to.have.been.calledWith(
-        "my-project",
-        "new-ruleset",
-        "firebase.vertexai",
-      );
     });
   });
 });

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -1,11 +1,15 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 import * as ailogic from "./ailogic";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as serviceUsage from "./serviceusage";
+import * as cloudbilling from "./cloudbilling";
 import {
   AI_LOGIC_BEFORE_GENERATE_CONTENT,
   AI_LOGIC_AFTER_GENERATE_CONTENT,
   AILogicEndpoint,
 } from "../deploy/functions/services/ailogic";
+import { FirebaseError } from "../error";
 
 describe("ailogic", () => {
   const mockEndpointBase = {
@@ -140,6 +144,122 @@ describe("ailogic", () => {
           },
         },
       );
+    });
+  });
+
+  describe("providers", () => {
+    let ensureStub: sinon.SinonStub;
+    let disableStub: sinon.SinonStub;
+    let uncacheStub: sinon.SinonStub;
+    let checkStub: sinon.SinonStub;
+    let billingStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      ensureStub = sinon.stub(ensureApiEnabled, "ensure");
+      disableStub = sinon.stub(serviceUsage, "disableServiceAndPoll");
+      uncacheStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
+      checkStub = sinon.stub(ensureApiEnabled, "check");
+      billingStub = sinon.stub(cloudbilling, "checkBillingEnabled");
+    });
+
+    afterEach(() => {
+      ensureStub.restore();
+      disableStub.restore();
+      uncacheStub.restore();
+      checkStub.restore();
+      billingStub.restore();
+    });
+
+    it("should enable gemini-developer-api", async () => {
+      ensureStub.resolves();
+
+      await ailogic.enableProvider("my-project", "gemini-developer-api");
+
+      expect(ensureStub).to.have.been.calledTwice;
+      expect(ensureStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+    });
+
+    it("should enable agent-platform-gemini-api if billing is enabled", async () => {
+      ensureStub.resolves();
+      billingStub.resolves(true);
+
+      await ailogic.enableProvider("my-project", "agent-platform-gemini-api");
+
+      expect(ensureStub).to.have.been.calledTwice;
+      expect(ensureStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "aiplatform.googleapis.com",
+        "ailogic",
+      );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+    });
+
+    it("should reject enabling agent-platform-gemini-api if billing is disabled", async () => {
+      ensureStub.resolves();
+      billingStub.resolves(false);
+
+      await expect(
+        ailogic.enableProvider("my-project", "agent-platform-gemini-api"),
+      ).to.be.rejectedWith(FirebaseError, /must be on the Blaze/);
+
+      expect(ensureStub).to.not.have.been.called;
+    });
+
+    it("should disable gemini-developer-api and disable proxy if agent-platform-gemini-api is also disabled", async () => {
+      disableStub.resolves();
+      checkStub.resolves(false); // agent-platform-gemini-api is disabled
+
+      await ailogic.disableProvider("my-project", "gemini-developer-api");
+
+      expect(disableStub).to.have.been.calledTwice;
+      expect(disableStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(disableStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "firebasevertexai.googleapis.com",
+        "ailogic",
+      );
+      expect(uncacheStub).to.have.been.calledTwice;
+    });
+
+    it("should disable gemini-developer-api but NOT disable proxy if agent-platform-gemini-api is enabled", async () => {
+      disableStub.resolves();
+      checkStub.resolves(true); // agent-platform-gemini-api is enabled
+
+      await ailogic.disableProvider("my-project", "gemini-developer-api");
+
+      expect(disableStub).to.have.been.calledOnce;
+      expect(disableStub.firstCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
+      expect(uncacheStub).to.have.been.calledOnce;
+    });
+
+    it("should list enabled providers", async () => {
+      checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
+      checkStub.onSecondCall().resolves(true); // agent-platform-gemini-api API is enabled
+
+      const enabled = await ailogic.listProviders("my-project");
+
+      expect(enabled).to.deep.equal(["gemini-developer-api", "agent-platform-gemini-api"]);
     });
   });
 });

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -3,6 +3,7 @@ import * as sinon from "sinon";
 import * as ailogic from "./ailogic";
 import * as ensureApiEnabled from "../ensureApiEnabled";
 import * as serviceUsage from "./serviceusage";
+import * as rules from "./rules";
 import * as cloudbilling from "./cloudbilling";
 import {
   AI_LOGIC_BEFORE_GENERATE_CONTENT,
@@ -147,6 +148,69 @@ describe("ailogic", () => {
     });
   });
 
+  describe("getConfig", () => {
+    let getStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      getStub = sinon.stub(ailogic.client, "get");
+    });
+
+    afterEach(() => {
+      getStub.restore();
+    });
+
+    it("should fetch config", async () => {
+      const mockConfig: ailogic.Config = {
+        name: "projects/my-project/locations/global/config",
+        generativeLanguageConfig: { apiKey: "key" },
+      };
+      getStub.resolves({ body: mockConfig });
+
+      const config = await ailogic.getConfig("my-project");
+
+      expect(getStub).to.have.been.calledWithMatch("projects/my-project/locations/global/config");
+      expect(config).to.deep.equal(mockConfig);
+    });
+  });
+
+  describe("updateConfig", () => {
+    let patchStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      patchStub = sinon.stub(ailogic.client, "patch");
+    });
+
+    afterEach(() => {
+      patchStub.restore();
+    });
+
+    it("should update config", async () => {
+      const patchConfig: Partial<ailogic.Config> = {
+        generativeLanguageConfig: { apiKey: "new-key" },
+      };
+      const mockConfig: ailogic.Config = {
+        name: "projects/my-project/locations/global/config",
+        generativeLanguageConfig: { apiKey: "new-key" },
+      };
+      patchStub.resolves({ body: mockConfig });
+
+      const config = await ailogic.updateConfig("my-project", patchConfig, [
+        "generativeLanguageConfig",
+      ]);
+
+      expect(patchStub).to.have.been.calledWithMatch(
+        "projects/my-project/locations/global/config",
+        patchConfig,
+        {
+          queryParams: {
+            updateMask: "generativeLanguageConfig",
+          },
+        },
+      );
+      expect(config).to.deep.equal(mockConfig);
+    });
+  });
+
   describe("providers", () => {
     let ensureStub: sinon.SinonStub;
     let disableStub: sinon.SinonStub;
@@ -278,6 +342,74 @@ describe("ailogic", () => {
     it("isProviderType narrows valid values only", () => {
       expect(ailogic.isProviderType("gemini-developer-api")).to.be.true;
       expect(ailogic.isProviderType("nope")).to.be.false;
+    });
+  });
+
+  describe("securityRules", () => {
+    let listReleasesStub: sinon.SinonStub;
+    let getLatestRulesetNameStub: sinon.SinonStub;
+    let getRulesetContentStub: sinon.SinonStub;
+    let createRulesetStub: sinon.SinonStub;
+    let updateOrCreateReleaseStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      listReleasesStub = sinon.stub(rules, "listAllReleases");
+      getLatestRulesetNameStub = sinon.stub(rules, "getLatestRulesetName");
+      getRulesetContentStub = sinon.stub(rules, "getRulesetContent");
+      createRulesetStub = sinon.stub(rules, "createRuleset");
+      updateOrCreateReleaseStub = sinon.stub(rules, "updateOrCreateRelease");
+    });
+
+    afterEach(() => {
+      listReleasesStub.restore();
+      getLatestRulesetNameStub.restore();
+      getRulesetContentStub.restore();
+      createRulesetStub.restore();
+      updateOrCreateReleaseStub.restore();
+    });
+
+    it("should get rules and parse authOnly and templateOnly", async () => {
+      listReleasesStub.resolves([]);
+      getLatestRulesetNameStub.resolves("ruleset-name");
+      getRulesetContentStub.resolves([
+        {
+          name: "vertexai.rules",
+          content: `rules_version = '2';
+service firebase.vertexai {
+  match /projects/{project}/locations/{location} {
+    match /templates/{template} {
+      allow read: if request.auth != null;
+    }
+    match /models/{model} {
+      allow read: if false;
+    }
+  }
+}`,
+        },
+      ]);
+
+      const config = await ailogic.getSecurityRules("my-project");
+
+      expect(config).to.deep.equal({ authOnly: true, templateOnly: true });
+    });
+
+    it("should deploy rules with generateRulesContent", async () => {
+      createRulesetStub.resolves("new-ruleset");
+      updateOrCreateReleaseStub.resolves("release-name");
+
+      await ailogic.updateSecurityRules("my-project", true, false);
+
+      expect(createRulesetStub).to.have.been.calledWith("my-project", [
+        {
+          name: "vertexai.rules",
+          content: ailogic.generateRulesContent(true, false),
+        },
+      ]);
+      expect(updateOrCreateReleaseStub).to.have.been.calledWith(
+        "my-project",
+        "new-ruleset",
+        "firebase.vertexai",
+      );
     });
   });
 });

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -286,6 +286,8 @@ describe("ailogic", () => {
 
       await ailogic.disableProvider("my-project", "gemini-developer-api");
 
+      // The cross-check must consult the OTHER provider's API.
+      expect(checkStub).to.have.been.calledWith("my-project", "aiplatform.googleapis.com");
       expect(disableStub).to.have.been.calledTwice;
       expect(disableStub.firstCall).to.have.been.calledWith(
         "my-project",
@@ -320,6 +322,16 @@ describe("ailogic", () => {
       const enabled = await ailogic.listProviders("my-project");
 
       expect(enabled).to.deep.equal(["gemini-developer-api", "gemini-agent-platform-api"]);
+    });
+
+    it("should map each provider to its own API enablement state", async () => {
+      // Pin per-API results so a swapped destructure/check cannot pass.
+      checkStub.withArgs("my-project", "generativelanguage.googleapis.com").resolves(true);
+      checkStub.withArgs("my-project", "aiplatform.googleapis.com").resolves(false);
+
+      const enabled = await ailogic.listProviders("my-project");
+
+      expect(enabled).to.deep.equal(["gemini-developer-api"]);
     });
   });
 

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -150,14 +150,14 @@ describe("ailogic", () => {
   describe("providers", () => {
     let ensureStub: sinon.SinonStub;
     let disableStub: sinon.SinonStub;
-    let uncacheStub: sinon.SinonStub;
     let checkStub: sinon.SinonStub;
     let billingStub: sinon.SinonStub;
 
     beforeEach(() => {
       ensureStub = sinon.stub(ensureApiEnabled, "ensure");
+      // disableServiceAndPoll now owns cache invalidation, so it is stubbed here and
+      // that behavior is verified in serviceusage.spec.ts.
       disableStub = sinon.stub(serviceUsage, "disableServiceAndPoll");
-      uncacheStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
       checkStub = sinon.stub(ensureApiEnabled, "check");
       billingStub = sinon.stub(cloudbilling, "checkBillingEnabled");
     });
@@ -165,7 +165,6 @@ describe("ailogic", () => {
     afterEach(() => {
       ensureStub.restore();
       disableStub.restore();
-      uncacheStub.restore();
       checkStub.restore();
       billingStub.restore();
     });
@@ -188,11 +187,11 @@ describe("ailogic", () => {
       );
     });
 
-    it("should enable agent-platform-gemini-api if billing is enabled", async () => {
+    it("should enable gemini-agent-platform-api if billing is enabled", async () => {
       ensureStub.resolves();
       billingStub.resolves(true);
 
-      await ailogic.enableProvider("my-project", "agent-platform-gemini-api");
+      await ailogic.enableProvider("my-project", "gemini-agent-platform-api");
 
       expect(ensureStub).to.have.been.calledTwice;
       expect(ensureStub.firstCall).to.have.been.calledWith(
@@ -207,20 +206,20 @@ describe("ailogic", () => {
       );
     });
 
-    it("should reject enabling agent-platform-gemini-api if billing is disabled", async () => {
+    it("should reject enabling gemini-agent-platform-api if billing is disabled", async () => {
       ensureStub.resolves();
       billingStub.resolves(false);
 
       await expect(
-        ailogic.enableProvider("my-project", "agent-platform-gemini-api"),
+        ailogic.enableProvider("my-project", "gemini-agent-platform-api"),
       ).to.be.rejectedWith(FirebaseError, /must be on the Blaze/);
 
       expect(ensureStub).to.not.have.been.called;
     });
 
-    it("should disable gemini-developer-api and disable proxy if agent-platform-gemini-api is also disabled", async () => {
+    it("should disable gemini-developer-api and disable proxy if gemini-agent-platform-api is also disabled", async () => {
       disableStub.resolves();
-      checkStub.resolves(false); // agent-platform-gemini-api is disabled
+      checkStub.resolves(false); // gemini-agent-platform-api is disabled
 
       await ailogic.disableProvider("my-project", "gemini-developer-api");
 
@@ -235,12 +234,11 @@ describe("ailogic", () => {
         "firebasevertexai.googleapis.com",
         "ailogic",
       );
-      expect(uncacheStub).to.have.been.calledTwice;
     });
 
-    it("should disable gemini-developer-api but NOT disable proxy if agent-platform-gemini-api is enabled", async () => {
+    it("should disable gemini-developer-api but NOT disable proxy if gemini-agent-platform-api is enabled", async () => {
       disableStub.resolves();
-      checkStub.resolves(true); // agent-platform-gemini-api is enabled
+      checkStub.resolves(true); // gemini-agent-platform-api is enabled
 
       await ailogic.disableProvider("my-project", "gemini-developer-api");
 
@@ -250,16 +248,36 @@ describe("ailogic", () => {
         "generativelanguage.googleapis.com",
         "ailogic",
       );
-      expect(uncacheStub).to.have.been.calledOnce;
     });
 
     it("should list enabled providers", async () => {
       checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
-      checkStub.onSecondCall().resolves(true); // agent-platform-gemini-api API is enabled
+      checkStub.onSecondCall().resolves(true); // gemini-agent-platform-api API is enabled
 
       const enabled = await ailogic.listProviders("my-project");
 
-      expect(enabled).to.deep.equal(["gemini-developer-api", "agent-platform-gemini-api"]);
+      expect(enabled).to.deep.equal(["gemini-developer-api", "gemini-agent-platform-api"]);
+    });
+  });
+
+  describe("parseProviderType", () => {
+    it("returns the provider for a valid value", () => {
+      expect(ailogic.parseProviderType("gemini-developer-api")).to.equal("gemini-developer-api");
+      expect(ailogic.parseProviderType("gemini-agent-platform-api")).to.equal(
+        "gemini-agent-platform-api",
+      );
+    });
+
+    it("throws a FirebaseError listing the valid providers for an invalid value", () => {
+      expect(() => ailogic.parseProviderType("agent-platform-gemini-api")).to.throw(
+        FirebaseError,
+        /Invalid provider type/,
+      );
+    });
+
+    it("isProviderType narrows valid values only", () => {
+      expect(ailogic.isProviderType("gemini-developer-api")).to.be.true;
+      expect(ailogic.isProviderType("nope")).to.be.false;
     });
   });
 });

--- a/src/gcp/ailogic.spec.ts
+++ b/src/gcp/ailogic.spec.ts
@@ -169,25 +169,27 @@ describe("ailogic", () => {
       billingStub.restore();
     });
 
-    it("should enable gemini-developer-api", async () => {
+    it("should enable gemini-developer-api, enabling the AI Logic API first", async () => {
       ensureStub.resolves();
 
       await ailogic.enableProvider("my-project", "gemini-developer-api");
 
       expect(ensureStub).to.have.been.calledTwice;
+      // The AI Logic API must be enabled before the provider API so a partial
+      // failure cannot leave a provider on while AI Logic is off.
       expect(ensureStub.firstCall).to.have.been.calledWith(
-        "my-project",
-        "generativelanguage.googleapis.com",
-        "ailogic",
-      );
-      expect(ensureStub.secondCall).to.have.been.calledWith(
         "my-project",
         "firebasevertexai.googleapis.com",
         "ailogic",
       );
+      expect(ensureStub.secondCall).to.have.been.calledWith(
+        "my-project",
+        "generativelanguage.googleapis.com",
+        "ailogic",
+      );
     });
 
-    it("should enable gemini-agent-platform-api if billing is enabled", async () => {
+    it("should enable gemini-agent-platform-api if billing is enabled, enabling the AI Logic API first", async () => {
       ensureStub.resolves();
       billingStub.resolves(true);
 
@@ -196,12 +198,12 @@ describe("ailogic", () => {
       expect(ensureStub).to.have.been.calledTwice;
       expect(ensureStub.firstCall).to.have.been.calledWith(
         "my-project",
-        "aiplatform.googleapis.com",
+        "firebasevertexai.googleapis.com",
         "ailogic",
       );
       expect(ensureStub.secondCall).to.have.been.calledWith(
         "my-project",
-        "firebasevertexai.googleapis.com",
+        "aiplatform.googleapis.com",
         "ailogic",
       );
     });
@@ -251,12 +253,31 @@ describe("ailogic", () => {
     });
 
     it("should list enabled providers", async () => {
-      checkStub.onFirstCall().resolves(true); // gemini-developer-api is enabled
-      checkStub.onSecondCall().resolves(true); // gemini-agent-platform-api API is enabled
+      checkStub
+        .withArgs("my-project", "firebasevertexai.googleapis.com", "ailogic", true)
+        .resolves(true);
+      checkStub
+        .withArgs("my-project", "generativelanguage.googleapis.com", "ailogic", true)
+        .resolves(true);
+      checkStub.withArgs("my-project", "aiplatform.googleapis.com", "ailogic", true).resolves(true);
 
       const enabled = await ailogic.listProviders("my-project");
 
       expect(enabled).to.deep.equal(["gemini-developer-api", "gemini-agent-platform-api"]);
+    });
+
+    it("should list no providers when the AI Logic API is disabled, even if provider APIs are enabled", async () => {
+      checkStub
+        .withArgs("my-project", "firebasevertexai.googleapis.com", "ailogic", true)
+        .resolves(false);
+      checkStub
+        .withArgs("my-project", "generativelanguage.googleapis.com", "ailogic", true)
+        .resolves(true);
+      checkStub.withArgs("my-project", "aiplatform.googleapis.com", "ailogic", true).resolves(true);
+
+      const enabled = await ailogic.listProviders("my-project");
+
+      expect(enabled).to.deep.equal([]);
     });
   });
 

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -378,24 +378,22 @@ export async function disableProvider(
  * Lists which Gemini API providers are enabled, derived from underlying API enablement state.
  */
 export async function listProviders(projectId: string): Promise<ProviderType[]> {
-  const enabled: ProviderType[] = [];
+  // The two enablement checks are independent, so run them in parallel to keep
+  // read commands (providers:list, config:get) responsive on a cold cache.
+  const [isDeveloperEnabled, isVertexEnabled] = await Promise.all([
+    ensureApiEnabled.check(
+      projectId,
+      "generativelanguage.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+      true,
+    ),
+    ensureApiEnabled.check(projectId, "aiplatform.googleapis.com", AILOGIC_LOGGING_PREFIX, true),
+  ]);
 
-  const isDeveloperEnabled = await ensureApiEnabled.check(
-    projectId,
-    "generativelanguage.googleapis.com",
-    AILOGIC_LOGGING_PREFIX,
-    true,
-  );
+  const enabled: ProviderType[] = [];
   if (isDeveloperEnabled) {
     enabled.push("gemini-developer-api");
   }
-
-  const isVertexEnabled = await ensureApiEnabled.check(
-    projectId,
-    "aiplatform.googleapis.com",
-    AILOGIC_LOGGING_PREFIX,
-    true,
-  );
   // aiplatform.googleapis.com cannot be enabled without billing (the Blaze plan),
   // so an enabled Vertex API already implies the agent-platform provider is available.
   if (isVertexEnabled) {

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -17,6 +17,12 @@ export const API_VERSION = "v1beta";
 /** Label used as the prefix for this module's user-facing progress logging. */
 export const AILOGIC_LOGGING_PREFIX = "ailogic";
 
+/**
+ * All AI Logic management resources live at the fixed `global` location; there is
+ * no per-region configuration surface for these commands.
+ */
+export const GLOBAL_LOCATION = "global";
+
 export const AI_LOGIC_BEFORE_GENERATE_CONTENT =
   "google.firebase.ailogic.v1.beforeGenerate" as const;
 export const AI_LOGIC_AFTER_GENERATE_CONTENT = "google.firebase.ailogic.v1.afterGenerate" as const;
@@ -262,7 +268,7 @@ export function parseProviderType(value: string): ProviderType {
  * Gets the AI Logic Config singleton.
  */
 export async function getConfig(projectId: string): Promise<Config> {
-  const name = `projects/${projectId}/locations/global/config`;
+  const name = `projects/${projectId}/locations/${GLOBAL_LOCATION}/config`;
   const res = await client.get<Config>(name);
   return res.body;
 }
@@ -275,7 +281,7 @@ export async function updateConfig(
   config: Partial<Config>,
   updateMask?: string[],
 ): Promise<Config> {
-  const name = `projects/${projectId}/locations/global/config`;
+  const name = `projects/${projectId}/locations/${GLOBAL_LOCATION}/config`;
   const queryParams: Record<string, string> = {};
   if (updateMask && updateMask.length > 0) {
     queryParams.updateMask = updateMask.join(",");
@@ -467,7 +473,12 @@ export async function updateSecurityRules(
  * Read-only commands use this to report state instead of forcing enablement.
  */
 export async function isAILogicApiEnabled(projectId: string): Promise<boolean> {
-  return ensureApiEnabled.check(projectId, "firebasevertexai.googleapis.com", "ailogic", true);
+  return ensureApiEnabled.check(
+    projectId,
+    "firebasevertexai.googleapis.com",
+    AILOGIC_LOGGING_PREFIX,
+    true,
+  );
 }
 
 /**

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -487,13 +487,15 @@ export async function ensureAILogicApiEnabled(
   const proceed = await confirm({
     message: "Would you like to enable it now?",
     default: true,
+    force: options.force,
   });
   if (!proceed) {
     throw new FirebaseError("Command aborted.", { exit: 1 });
   }
 
   for (;;) {
-    const provider = await select<ProviderType>({
+    // "cancel" gives the Spark-plan retry loop below an exit that is not Ctrl+C.
+    const provider = await select<ProviderType | "cancel">({
       message: "Which Gemini API provider do you want to enable?",
       choices: [
         { name: "gemini-developer-api", value: "gemini-developer-api" },
@@ -501,8 +503,12 @@ export async function ensureAILogicApiEnabled(
           name: "gemini-agent-platform-api (requires the Blaze plan)",
           value: "gemini-agent-platform-api",
         },
+        { name: "cancel", value: "cancel" },
       ],
     });
+    if (provider === "cancel") {
+      throw new FirebaseError("Command aborted.", { exit: 1 });
+    }
 
     if (provider === "gemini-agent-platform-api") {
       const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -13,6 +13,9 @@ import { confirm, select } from "../prompt";
 
 export const API_VERSION = "v1beta";
 
+/** Label used as the prefix for this module's user-facing progress logging. */
+export const AILOGIC_LOGGING_PREFIX = "ailogic";
+
 export const AI_LOGIC_BEFORE_GENERATE_CONTENT =
   "google.firebase.ailogic.v1.beforeGenerate" as const;
 export const AI_LOGIC_AFTER_GENERATE_CONTENT = "google.firebase.ailogic.v1.afterGenerate" as const;
@@ -212,17 +215,43 @@ export async function deleteBlockingFunction(endpoint: AILogicEndpoint): Promise
   await deleteTrigger(endpoint.project, location, triggerId, true);
 }
 
-export type ProviderType = "gemini-developer-api" | "agent-platform-gemini-api";
+export type ProviderType = "gemini-developer-api" | "gemini-agent-platform-api";
+
+export const PROVIDER_TYPES: ProviderType[] = ["gemini-developer-api", "gemini-agent-platform-api"];
+
+/** Whether the given string is a known Gemini API provider type. */
+export function isProviderType(value: string): value is ProviderType {
+  return PROVIDER_TYPES.some((p) => p === value);
+}
+
+/** Validates and narrows a string to a ProviderType, throwing a FirebaseError otherwise. */
+export function parseProviderType(value: string): ProviderType {
+  if (!isProviderType(value)) {
+    throw new FirebaseError(
+      `Invalid provider type: ${bold(value)}. Must be one of: ${PROVIDER_TYPES.map(
+        (p) => `'${p}'`,
+      ).join(", ")}.`,
+    );
+  }
+  return value;
+}
 
 /**
  * Enables a Gemini API provider service.
  */
 export async function enableProvider(projectId: string, providerType: ProviderType): Promise<void> {
-  const prefix = "ailogic";
   if (providerType === "gemini-developer-api") {
-    await ensureApiEnabled.ensure(projectId, "generativelanguage.googleapis.com", prefix);
-    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
-  } else if (providerType === "agent-platform-gemini-api") {
+    await ensureApiEnabled.ensure(
+      projectId,
+      "generativelanguage.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
+    await ensureApiEnabled.ensure(
+      projectId,
+      "firebasevertexai.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
+  } else if (providerType === "gemini-agent-platform-api") {
     const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
     if (!billingEnabled) {
       throw new FirebaseError(
@@ -231,77 +260,76 @@ export async function enableProvider(projectId: string, providerType: ProviderTy
         )} must be on the Blaze (pay-as-you-go) plan to enable the Agent Platform. To upgrade, visit the following URL:\n\nhttps://console.firebase.google.com/project/${projectId}/usage/details`,
       );
     }
-    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", prefix);
-    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
-  } else {
-    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", AILOGIC_LOGGING_PREFIX);
+    await ensureApiEnabled.ensure(
+      projectId,
+      "firebasevertexai.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
   }
 }
 
 /**
- * Disables a Gemini API provider service.
+ * Disables a Gemini API provider service. `disableServiceAndPoll` invalidates the
+ * enablement cache for each disabled service, so no explicit uncaching is needed here.
  */
 export async function disableProvider(
   projectId: string,
   providerType: ProviderType,
 ): Promise<void> {
-  const prefix = "ailogic";
   if (providerType === "gemini-developer-api") {
     await serviceUsage.disableServiceAndPoll(
       projectId,
       "generativelanguage.googleapis.com",
-      prefix,
+      AILOGIC_LOGGING_PREFIX,
     );
-    ensureApiEnabled.uncacheEnabledAPI(projectId, "generativelanguage.googleapis.com");
 
     const isVertexEnabled = await ensureApiEnabled.check(
       projectId,
       "aiplatform.googleapis.com",
-      prefix,
+      AILOGIC_LOGGING_PREFIX,
       true,
     );
     if (!isVertexEnabled) {
       await serviceUsage.disableServiceAndPoll(
         projectId,
         "firebasevertexai.googleapis.com",
-        prefix,
+        AILOGIC_LOGGING_PREFIX,
       );
-      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
     }
-  } else if (providerType === "agent-platform-gemini-api") {
-    await serviceUsage.disableServiceAndPoll(projectId, "aiplatform.googleapis.com", prefix);
-    ensureApiEnabled.uncacheEnabledAPI(projectId, "aiplatform.googleapis.com");
+  } else if (providerType === "gemini-agent-platform-api") {
+    await serviceUsage.disableServiceAndPoll(
+      projectId,
+      "aiplatform.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+    );
 
     const isDeveloperEnabled = await ensureApiEnabled.check(
       projectId,
       "generativelanguage.googleapis.com",
-      prefix,
+      AILOGIC_LOGGING_PREFIX,
       true,
     );
     if (!isDeveloperEnabled) {
       await serviceUsage.disableServiceAndPoll(
         projectId,
         "firebasevertexai.googleapis.com",
-        prefix,
+        AILOGIC_LOGGING_PREFIX,
       );
-      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
     }
-  } else {
-    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
   }
 }
 
 /**
- *
+ * Lists which Gemini API providers are enabled, derived from underlying API enablement state.
  */
 export async function listProviders(projectId: string): Promise<ProviderType[]> {
-  const prefix = "ailogic";
   const enabled: ProviderType[] = [];
 
   const isDeveloperEnabled = await ensureApiEnabled.check(
     projectId,
     "generativelanguage.googleapis.com",
-    prefix,
+    AILOGIC_LOGGING_PREFIX,
     true,
   );
   if (isDeveloperEnabled) {
@@ -311,13 +339,13 @@ export async function listProviders(projectId: string): Promise<ProviderType[]> 
   const isVertexEnabled = await ensureApiEnabled.check(
     projectId,
     "aiplatform.googleapis.com",
-    prefix,
+    AILOGIC_LOGGING_PREFIX,
     true,
   );
   // aiplatform.googleapis.com cannot be enabled without billing (the Blaze plan),
   // so an enabled Vertex API already implies the agent-platform provider is available.
   if (isVertexEnabled) {
-    enabled.push("agent-platform-gemini-api");
+    enabled.push("gemini-agent-platform-api");
   }
 
   return enabled;
@@ -335,7 +363,7 @@ export async function ensureAILogicApiEnabled(
   const isEnabled = await ensureApiEnabled.check(
     projectId,
     "firebasevertexai.googleapis.com",
-    "ailogic",
+    AILOGIC_LOGGING_PREFIX,
     true,
   );
   if (isEnabled) {
@@ -347,7 +375,7 @@ export async function ensureAILogicApiEnabled(
       `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.\n\n` +
         `Enable Firebase AI Logic with one of the Gemini API providers by running:\n\n` +
         `  firebase ailogic:providers:enable gemini-developer-api\n` +
-        `  firebase ailogic:providers:enable agent-platform-gemini-api\n\n` +
+        `  firebase ailogic:providers:enable gemini-agent-platform-api\n\n` +
         `Then run this command again.`,
     );
   }
@@ -381,17 +409,17 @@ export async function ensureAILogicApiEnabled(
       choices: [
         { name: "gemini-developer-api", value: "gemini-developer-api" },
         {
-          name: "agent-platform-gemini-api (requires the Blaze plan)",
-          value: "agent-platform-gemini-api",
+          name: "gemini-agent-platform-api (requires the Blaze plan)",
+          value: "gemini-agent-platform-api",
         },
       ],
     });
 
-    if (provider === "agent-platform-gemini-api") {
+    if (provider === "gemini-agent-platform-api") {
       const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
       if (!billingEnabled) {
         logger.info(
-          `\n${bold("Error:")} The agent-platform-gemini-api provider requires the pay-as-you-go (Blaze) plan.\n` +
+          `\n${bold("Error:")} The gemini-agent-platform-api provider requires the pay-as-you-go (Blaze) plan.\n` +
             `Project ${projectId} is on the Spark plan.\n\n` +
             `Upgrade your plan at:\n\n` +
             `  https://console.firebase.google.com/project/${projectId}/usage/details\n`,

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -2,7 +2,14 @@ import { Client } from "../apiv2";
 import { aiLogicProxyOrigin } from "../api";
 import { DeepOmit } from "../metaprogramming";
 import type { AILogicEndpoint } from "../deploy/functions/services/ailogic";
-import { getErrStatus } from "../error";
+import { FirebaseError, getErrStatus } from "../error";
+import * as ensureApiEnabled from "../ensureApiEnabled";
+import * as serviceUsage from "./serviceusage";
+import { bold } from "colorette";
+import * as cloudbilling from "./cloudbilling";
+import * as iam from "./iam";
+import { logger } from "../logger";
+import { confirm, select } from "../prompt";
 
 export const API_VERSION = "v1beta";
 
@@ -167,6 +174,9 @@ export async function listTriggers(
   return triggers;
 }
 
+/**
+ *
+ */
 export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise<Trigger> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
@@ -191,10 +201,209 @@ export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise
   }
 }
 
+/**
+ *
+ */
 export async function deleteBlockingFunction(endpoint: AILogicEndpoint): Promise<void> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
   const location = endpoint.blockingTrigger.options?.regionalWebhook ? endpoint.region : "global";
 
   await deleteTrigger(endpoint.project, location, triggerId, true);
+}
+
+export type ProviderType = "gemini-developer-api" | "agent-platform-gemini-api";
+
+/**
+ * Enables a Gemini API provider service.
+ */
+export async function enableProvider(projectId: string, providerType: ProviderType): Promise<void> {
+  const prefix = "ailogic";
+  if (providerType === "gemini-developer-api") {
+    await ensureApiEnabled.ensure(projectId, "generativelanguage.googleapis.com", prefix);
+    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
+  } else if (providerType === "agent-platform-gemini-api") {
+    const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
+    if (!billingEnabled) {
+      throw new FirebaseError(
+        `Your project ${bold(
+          projectId,
+        )} must be on the Blaze (pay-as-you-go) plan to enable the Agent Platform. To upgrade, visit the following URL:\n\nhttps://console.firebase.google.com/project/${projectId}/usage/details`,
+      );
+    }
+    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", prefix);
+    await ensureApiEnabled.ensure(projectId, "firebasevertexai.googleapis.com", prefix);
+  } else {
+    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+  }
+}
+
+/**
+ * Disables a Gemini API provider service.
+ */
+export async function disableProvider(
+  projectId: string,
+  providerType: ProviderType,
+): Promise<void> {
+  const prefix = "ailogic";
+  if (providerType === "gemini-developer-api") {
+    await serviceUsage.disableServiceAndPoll(
+      projectId,
+      "generativelanguage.googleapis.com",
+      prefix,
+    );
+    ensureApiEnabled.uncacheEnabledAPI(projectId, "generativelanguage.googleapis.com");
+
+    const isVertexEnabled = await ensureApiEnabled.check(
+      projectId,
+      "aiplatform.googleapis.com",
+      prefix,
+      true,
+    );
+    if (!isVertexEnabled) {
+      await serviceUsage.disableServiceAndPoll(
+        projectId,
+        "firebasevertexai.googleapis.com",
+        prefix,
+      );
+      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
+    }
+  } else if (providerType === "agent-platform-gemini-api") {
+    await serviceUsage.disableServiceAndPoll(projectId, "aiplatform.googleapis.com", prefix);
+    ensureApiEnabled.uncacheEnabledAPI(projectId, "aiplatform.googleapis.com");
+
+    const isDeveloperEnabled = await ensureApiEnabled.check(
+      projectId,
+      "generativelanguage.googleapis.com",
+      prefix,
+      true,
+    );
+    if (!isDeveloperEnabled) {
+      await serviceUsage.disableServiceAndPoll(
+        projectId,
+        "firebasevertexai.googleapis.com",
+        prefix,
+      );
+      ensureApiEnabled.uncacheEnabledAPI(projectId, "firebasevertexai.googleapis.com");
+    }
+  } else {
+    throw new FirebaseError(`Invalid provider type: ${providerType as string}`);
+  }
+}
+
+/**
+ *
+ */
+export async function listProviders(projectId: string): Promise<ProviderType[]> {
+  const prefix = "ailogic";
+  const enabled: ProviderType[] = [];
+
+  const isDeveloperEnabled = await ensureApiEnabled.check(
+    projectId,
+    "generativelanguage.googleapis.com",
+    prefix,
+    true,
+  );
+  if (isDeveloperEnabled) {
+    enabled.push("gemini-developer-api");
+  }
+
+  const isVertexEnabled = await ensureApiEnabled.check(
+    projectId,
+    "aiplatform.googleapis.com",
+    prefix,
+    true,
+  );
+  // aiplatform.googleapis.com cannot be enabled without billing (the Blaze plan),
+  // so an enabled Vertex API already implies the agent-platform provider is available.
+  if (isVertexEnabled) {
+    enabled.push("agent-platform-gemini-api");
+  }
+
+  return enabled;
+}
+
+/**
+ * Ensures that the Firebase AI Logic API is enabled. If not enabled:
+ * - In non-interactive mode: throws an error with instructions.
+ * - In interactive mode: prompts to enable, and guides the user to choose a provider to enable.
+ */
+export async function ensureAILogicApiEnabled(
+  projectId: string,
+  options: { nonInteractive?: boolean; force?: boolean },
+): Promise<void> {
+  const isEnabled = await ensureApiEnabled.check(
+    projectId,
+    "firebasevertexai.googleapis.com",
+    "ailogic",
+    true,
+  );
+  if (isEnabled) {
+    return;
+  }
+
+  if (options.nonInteractive) {
+    throw new FirebaseError(
+      `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.\n\n` +
+        `Enable Firebase AI Logic with one of the Gemini API providers by running:\n\n` +
+        `  firebase ailogic:providers:enable gemini-developer-api\n` +
+        `  firebase ailogic:providers:enable agent-platform-gemini-api\n\n` +
+        `Then run this command again.`,
+    );
+  }
+
+  // Verify the caller can actually enable the API before prompting, so we fail
+  // with a clear permission error up front instead of midway through the flow.
+  const { missing } = await iam.testIamPermissions(projectId, ["serviceusage.services.enable"]);
+  if (missing.length > 0) {
+    throw new FirebaseError(
+      `You do not have permission to enable the Firebase AI Logic API on project ${projectId}.\n\n` +
+        `Missing permission: ${missing.join(", ")}\n\n` +
+        `This permission is included in the Owner and Editor roles. Ask a project ` +
+        `administrator to enable the API or grant you the permission, then run this command again.`,
+    );
+  }
+
+  logger.info(
+    `The Firebase AI Logic API (firebasevertexai.googleapis.com) is not enabled on project ${projectId}.`,
+  );
+  const proceed = await confirm({
+    message: "Would you like to enable it now?",
+    default: true,
+  });
+  if (!proceed) {
+    throw new FirebaseError("Command aborted.", { exit: 1 });
+  }
+
+  for (;;) {
+    const provider = await select<ProviderType>({
+      message: "Which Gemini API provider do you want to enable?",
+      choices: [
+        { name: "gemini-developer-api", value: "gemini-developer-api" },
+        {
+          name: "agent-platform-gemini-api (requires the Blaze plan)",
+          value: "agent-platform-gemini-api",
+        },
+      ],
+    });
+
+    if (provider === "agent-platform-gemini-api") {
+      const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
+      if (!billingEnabled) {
+        logger.info(
+          `\n${bold("Error:")} The agent-platform-gemini-api provider requires the pay-as-you-go (Blaze) plan.\n` +
+            `Project ${projectId} is on the Spark plan.\n\n` +
+            `Upgrade your plan at:\n\n` +
+            `  https://console.firebase.google.com/project/${projectId}/usage/details\n`,
+        );
+        continue;
+      }
+    }
+
+    logger.info(`Enabling firebasevertexai.googleapis.com...`);
+    logger.info(`Enabling provider ${provider}...`);
+    await enableProvider(projectId, provider);
+    logger.info(bold(`Successfully enabled Firebase AI Logic with provider: ${provider}`));
+    break;
+  }
 }

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -5,6 +5,7 @@ import type { AILogicEndpoint } from "../deploy/functions/services/ailogic";
 import { FirebaseError, getErrStatus } from "../error";
 import * as ensureApiEnabled from "../ensureApiEnabled";
 import * as serviceUsage from "./serviceusage";
+import * as rules from "./rules";
 import { bold } from "colorette";
 import * as cloudbilling from "./cloudbilling";
 import * as iam from "./iam";
@@ -215,6 +216,27 @@ export async function deleteBlockingFunction(endpoint: AILogicEndpoint): Promise
   await deleteTrigger(endpoint.project, location, triggerId, true);
 }
 
+export interface GenerativeLanguageConfig {
+  apiKey?: string;
+}
+
+export interface TrafficFilter {
+  templateOnly?: boolean;
+  firebaseAuthRequired?: boolean;
+}
+
+export interface TelemetryConfig {
+  mode?: "MODE_UNSPECIFIED" | "NONE" | "ALL";
+  samplingRate?: number;
+}
+
+export interface Config {
+  name: string;
+  generativeLanguageConfig?: GenerativeLanguageConfig;
+  trafficFilter?: TrafficFilter;
+  telemetryConfig?: TelemetryConfig;
+}
+
 export type ProviderType = "gemini-developer-api" | "gemini-agent-platform-api";
 
 export const PROVIDER_TYPES: ProviderType[] = ["gemini-developer-api", "gemini-agent-platform-api"];
@@ -234,6 +256,32 @@ export function parseProviderType(value: string): ProviderType {
     );
   }
   return value;
+}
+
+/**
+ * Gets the AI Logic Config singleton.
+ */
+export async function getConfig(projectId: string): Promise<Config> {
+  const name = `projects/${projectId}/locations/global/config`;
+  const res = await client.get<Config>(name);
+  return res.body;
+}
+
+/**
+ * Updates the AI Logic Config singleton.
+ */
+export async function updateConfig(
+  projectId: string,
+  config: Partial<Config>,
+  updateMask?: string[],
+): Promise<Config> {
+  const name = `projects/${projectId}/locations/global/config`;
+  const queryParams: Record<string, string> = {};
+  if (updateMask && updateMask.length > 0) {
+    queryParams.updateMask = updateMask.join(",");
+  }
+  const res = await client.patch<Partial<Config>, Config>(name, config, { queryParams });
+  return res.body;
 }
 
 /**
@@ -349,6 +397,77 @@ export async function listProviders(projectId: string): Promise<ProviderType[]> 
   }
 
   return enabled;
+}
+
+/**
+ *
+ */
+export function generateRulesContent(authOnly: boolean, templateOnly: boolean): string {
+  const condition = authOnly ? "request.auth != null" : "true";
+
+  return `rules_version = '2';
+service firebase.vertexai {
+  match /projects/{project}/locations/{location} {
+    match /templates/{template} {
+      allow read: if ${condition};
+    }
+    match /models/{model} {
+      allow read: if ${templateOnly ? "false" : condition};
+    }
+  }
+}`;
+}
+
+export interface SecurityRulesConfig {
+  authOnly: boolean;
+  templateOnly: boolean;
+}
+
+/**
+ * Gets security rules settings by fetching and parsing the active release.
+ */
+export async function getSecurityRules(projectId: string): Promise<SecurityRulesConfig> {
+  const releases = await rules.listAllReleases(projectId);
+  const rulesetName = await rules.getLatestRulesetName(projectId, "firebase.vertexai", releases);
+  if (!rulesetName) {
+    return { authOnly: false, templateOnly: false };
+  }
+  const files = await rules.getRulesetContent(rulesetName);
+  const vertexFile = files.find((f) => f.name === "vertexai.rules");
+  if (!vertexFile) {
+    return { authOnly: false, templateOnly: false };
+  }
+  const content = vertexFile.content;
+  const authOnly = content.includes("request.auth != null");
+  const templateOnly = content.includes("allow read: if false");
+  return { authOnly, templateOnly };
+}
+
+/**
+ * Deploys new security rules.
+ */
+export async function updateSecurityRules(
+  projectId: string,
+  authOnly: boolean,
+  templateOnly: boolean,
+): Promise<void> {
+  const content = generateRulesContent(authOnly, templateOnly);
+  const files = [
+    {
+      name: "vertexai.rules",
+      content,
+    },
+  ];
+  const rulesetName = await rules.createRuleset(projectId, files);
+  await rules.updateOrCreateRelease(projectId, rulesetName, "firebase.vertexai");
+}
+
+/**
+ * Returns whether the Firebase AI Logic API is enabled on the project, without prompting to enable it.
+ * Read-only commands use this to report state instead of forcing enablement.
+ */
+export async function isAILogicApiEnabled(projectId: string): Promise<boolean> {
+  return ensureApiEnabled.check(projectId, "firebasevertexai.googleapis.com", "ailogic", true);
 }
 
 /**

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -5,7 +5,6 @@ import type { AILogicEndpoint } from "../deploy/functions/services/ailogic";
 import { FirebaseError, getErrStatus } from "../error";
 import * as ensureApiEnabled from "../ensureApiEnabled";
 import * as serviceUsage from "./serviceusage";
-import * as rules from "./rules";
 import { bold } from "colorette";
 import * as cloudbilling from "./cloudbilling";
 import * as iam from "./iam";
@@ -243,6 +242,37 @@ export interface Config {
   telemetryConfig?: TelemetryConfig;
 }
 
+// Developer-facing config paths that `ailogic:config:set` can write.
+export const WRITABLE_CONFIG_PATHS = [
+  "security.auth-only",
+  "security.template-only",
+  "monitoring.state",
+  "monitoring.sample-rate-percentage",
+];
+
+/** Throws a FirebaseError listing the valid paths when `path` is not one of them. */
+export function assertKnownConfigPath(path: string, validPaths: string[]): void {
+  if (!validPaths.includes(path)) {
+    throw new FirebaseError(
+      `Unknown configuration path: ${path}\n\nValid paths:\n\n` +
+        validPaths.map((p) => `  ${p}`).join("\n"),
+    );
+  }
+}
+
+/**
+ * Converts the API's telemetry sampling rate, a fraction in (0,1], to the
+ * integer percentage (1-100) the CLI exposes.
+ */
+export function samplingRateToPercent(samplingRate: number): number {
+  return Math.round(samplingRate * 100);
+}
+
+/** Converts a CLI integer percentage (1-100) to the API's (0,1] sampling-rate fraction. */
+export function percentToSamplingRate(percent: number): number {
+  return percent / 100;
+}
+
 export type ProviderType = "gemini-developer-api" | "gemini-agent-platform-api";
 
 export const PROVIDER_TYPES: ProviderType[] = ["gemini-developer-api", "gemini-agent-platform-api"];
@@ -404,69 +434,6 @@ export async function listProviders(projectId: string): Promise<ProviderType[]> 
 }
 
 /**
- *
- */
-export function generateRulesContent(authOnly: boolean, templateOnly: boolean): string {
-  const condition = authOnly ? "request.auth != null" : "true";
-
-  return `rules_version = '2';
-service firebase.vertexai {
-  match /projects/{project}/locations/{location} {
-    match /templates/{template} {
-      allow read: if ${condition};
-    }
-    match /models/{model} {
-      allow read: if ${templateOnly ? "false" : condition};
-    }
-  }
-}`;
-}
-
-export interface SecurityRulesConfig {
-  authOnly: boolean;
-  templateOnly: boolean;
-}
-
-/**
- * Gets security rules settings by fetching and parsing the active release.
- */
-export async function getSecurityRules(projectId: string): Promise<SecurityRulesConfig> {
-  const releases = await rules.listAllReleases(projectId);
-  const rulesetName = await rules.getLatestRulesetName(projectId, "firebase.vertexai", releases);
-  if (!rulesetName) {
-    return { authOnly: false, templateOnly: false };
-  }
-  const files = await rules.getRulesetContent(rulesetName);
-  const vertexFile = files.find((f) => f.name === "vertexai.rules");
-  if (!vertexFile) {
-    return { authOnly: false, templateOnly: false };
-  }
-  const content = vertexFile.content;
-  const authOnly = content.includes("request.auth != null");
-  const templateOnly = content.includes("allow read: if false");
-  return { authOnly, templateOnly };
-}
-
-/**
- * Deploys new security rules.
- */
-export async function updateSecurityRules(
-  projectId: string,
-  authOnly: boolean,
-  templateOnly: boolean,
-): Promise<void> {
-  const content = generateRulesContent(authOnly, templateOnly);
-  const files = [
-    {
-      name: "vertexai.rules",
-      content,
-    },
-  ];
-  const rulesetName = await rules.createRuleset(projectId, files);
-  await rules.updateOrCreateRelease(projectId, rulesetName, "firebase.vertexai");
-}
-
-/**
  * Returns whether the Firebase AI Logic API is enabled on the project, without prompting to enable it.
  * Read-only commands use this to report state instead of forcing enablement.
  */
@@ -488,13 +455,7 @@ export async function ensureAILogicApiEnabled(
   projectId: string,
   options: { nonInteractive?: boolean; force?: boolean },
 ): Promise<void> {
-  const isEnabled = await ensureApiEnabled.check(
-    projectId,
-    "firebasevertexai.googleapis.com",
-    AILOGIC_LOGGING_PREFIX,
-    true,
-  );
-  if (isEnabled) {
+  if (await isAILogicApiEnabled(projectId)) {
     return;
   }
 

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -240,18 +240,7 @@ export function parseProviderType(value: string): ProviderType {
  * Enables a Gemini API provider service.
  */
 export async function enableProvider(projectId: string, providerType: ProviderType): Promise<void> {
-  if (providerType === "gemini-developer-api") {
-    await ensureApiEnabled.ensure(
-      projectId,
-      "generativelanguage.googleapis.com",
-      AILOGIC_LOGGING_PREFIX,
-    );
-    await ensureApiEnabled.ensure(
-      projectId,
-      "firebasevertexai.googleapis.com",
-      AILOGIC_LOGGING_PREFIX,
-    );
-  } else if (providerType === "gemini-agent-platform-api") {
+  if (providerType === "gemini-agent-platform-api") {
     const billingEnabled = await cloudbilling.checkBillingEnabled(projectId);
     if (!billingEnabled) {
       throw new FirebaseError(
@@ -260,13 +249,21 @@ export async function enableProvider(projectId: string, providerType: ProviderTy
         )} must be on the Blaze (pay-as-you-go) plan to enable the Agent Platform. To upgrade, visit the following URL:\n\nhttps://console.firebase.google.com/project/${projectId}/usage/details`,
       );
     }
-    await ensureApiEnabled.ensure(projectId, "aiplatform.googleapis.com", AILOGIC_LOGGING_PREFIX);
-    await ensureApiEnabled.ensure(
-      projectId,
-      "firebasevertexai.googleapis.com",
-      AILOGIC_LOGGING_PREFIX,
-    );
   }
+
+  // Enable the AI Logic API first: a partial failure must not leave a provider's
+  // API enabled while the AI Logic API is off, a state where providers:list would
+  // report the provider as enabled but AI Logic itself is not usable.
+  await ensureApiEnabled.ensure(
+    projectId,
+    "firebasevertexai.googleapis.com",
+    AILOGIC_LOGGING_PREFIX,
+  );
+  const providerApi =
+    providerType === "gemini-developer-api"
+      ? "generativelanguage.googleapis.com"
+      : "aiplatform.googleapis.com";
+  await ensureApiEnabled.ensure(projectId, providerApi, AILOGIC_LOGGING_PREFIX);
 }
 
 /**
@@ -324,24 +321,36 @@ export async function disableProvider(
  * Lists which Gemini API providers are enabled, derived from underlying API enablement state.
  */
 export async function listProviders(projectId: string): Promise<ProviderType[]> {
-  const enabled: ProviderType[] = [];
+  // The three enablement checks are independent, so run them in parallel to keep
+  // read commands responsive on a cold cache.
+  const [isAILogicEnabled, isDeveloperEnabled, isVertexEnabled] = await Promise.all([
+    ensureApiEnabled.check(
+      projectId,
+      "firebasevertexai.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+      true,
+    ),
+    ensureApiEnabled.check(
+      projectId,
+      "generativelanguage.googleapis.com",
+      AILOGIC_LOGGING_PREFIX,
+      true,
+    ),
+    ensureApiEnabled.check(projectId, "aiplatform.googleapis.com", AILOGIC_LOGGING_PREFIX, true),
+  ]);
 
-  const isDeveloperEnabled = await ensureApiEnabled.check(
-    projectId,
-    "generativelanguage.googleapis.com",
-    AILOGIC_LOGGING_PREFIX,
-    true,
-  );
+  // A provider is only usable through AI Logic when the AI Logic API itself is
+  // enabled. Without this check, a project with (say) generativelanguage enabled
+  // outside the CLI would have its provider reported as enabled even though AI
+  // Logic is off.
+  if (!isAILogicEnabled) {
+    return [];
+  }
+
+  const enabled: ProviderType[] = [];
   if (isDeveloperEnabled) {
     enabled.push("gemini-developer-api");
   }
-
-  const isVertexEnabled = await ensureApiEnabled.check(
-    projectId,
-    "aiplatform.googleapis.com",
-    AILOGIC_LOGGING_PREFIX,
-    true,
-  );
   // aiplatform.googleapis.com cannot be enabled without billing (the Blaze plan),
   // so an enabled Vertex API already implies the agent-platform provider is available.
   if (isVertexEnabled) {

--- a/src/gcp/ailogic.ts
+++ b/src/gcp/ailogic.ts
@@ -183,9 +183,6 @@ export async function listTriggers(
   return triggers;
 }
 
-/**
- *
- */
 export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise<Trigger> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
@@ -210,9 +207,6 @@ export async function upsertBlockingFunction(endpoint: AILogicEndpoint): Promise
   }
 }
 
-/**
- *
- */
 export async function deleteBlockingFunction(endpoint: AILogicEndpoint): Promise<void> {
   const eventType = endpoint.blockingTrigger.eventType;
   const triggerId = AI_LOGIC_EVENTS_TO_TRIGGER[eventType];
@@ -258,19 +252,6 @@ export function assertKnownConfigPath(path: string, validPaths: string[]): void 
         validPaths.map((p) => `  ${p}`).join("\n"),
     );
   }
-}
-
-/**
- * Converts the API's telemetry sampling rate, a fraction in (0,1], to the
- * integer percentage (1-100) the CLI exposes.
- */
-export function samplingRateToPercent(samplingRate: number): number {
-  return Math.round(samplingRate * 100);
-}
-
-/** Converts a CLI integer percentage (1-100) to the API's (0,1] sampling-rate fraction. */
-export function percentToSamplingRate(percent: number): number {
-  return percent / 100;
 }
 
 export type ProviderType = "gemini-developer-api" | "gemini-agent-platform-api";

--- a/src/gcp/serviceusage.spec.ts
+++ b/src/gcp/serviceusage.spec.ts
@@ -28,4 +28,22 @@ describe("serviceusage", () => {
       expect(pollerStub).to.not.be.called;
     });
   });
+
+  describe("disableServiceAndPoll", () => {
+    it("does not poll if disableService responds with a completed operation", async () => {
+      postStub.onFirstCall().resolves({ body: { done: true } });
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(pollerStub).to.not.be.called;
+    });
+
+    it("polls if disableService responds with an uncompleted operation", async () => {
+      postStub.onFirstCall().resolves({ body: { done: false, name: "operation-name" } });
+      pollerStub.onFirstCall().resolves({});
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(pollerStub).to.have.been.calledOnce;
+      expect(pollerStub).to.have.been.calledWithMatch({
+        operationResourceName: "operation-name",
+      });
+    });
+  });
 });

--- a/src/gcp/serviceusage.spec.ts
+++ b/src/gcp/serviceusage.spec.ts
@@ -2,10 +2,12 @@ import { expect } from "chai";
 import * as sinon from "sinon";
 import * as serviceUsage from "./serviceusage";
 import * as poller from "../operation-poller";
+import * as ensureApiEnabled from "../ensureApiEnabled";
 
 describe("serviceusage", () => {
   let postStub: sinon.SinonStub;
   let pollerStub: sinon.SinonStub;
+  let uncacheStub: sinon.SinonStub;
 
   const projectNumber = "projectNumber";
   const service = "service";
@@ -14,11 +16,13 @@ describe("serviceusage", () => {
   beforeEach(() => {
     postStub = sinon.stub(serviceUsage.apiClient, "post").throws("unexpected post call");
     pollerStub = sinon.stub(poller, "pollOperation").throws("unexpected pollOperation call");
+    uncacheStub = sinon.stub(ensureApiEnabled, "uncacheEnabledAPI");
   });
 
   afterEach(() => {
     postStub.restore();
     pollerStub.restore();
+    uncacheStub.restore();
   });
 
   describe("generateServiceIdentityAndPoll", () => {
@@ -34,6 +38,12 @@ describe("serviceusage", () => {
       postStub.onFirstCall().resolves({ body: { done: true } });
       await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
       expect(pollerStub).to.not.be.called;
+    });
+
+    it("invalidates the enablement cache for the disabled service", async () => {
+      postStub.onFirstCall().resolves({ body: { done: true } });
+      await serviceUsage.disableServiceAndPoll(projectNumber, service, prefix);
+      expect(uncacheStub).to.have.been.calledOnceWith(projectNumber, service);
     });
 
     it("polls if disableService responds with an uncompleted operation", async () => {

--- a/src/gcp/serviceusage.ts
+++ b/src/gcp/serviceusage.ts
@@ -5,6 +5,7 @@ import { FirebaseError } from "../error";
 import * as utils from "../utils";
 import * as poller from "../operation-poller";
 import { LongRunningOperation } from "../operation-poller";
+import * as ensureApiEnabled from "../ensureApiEnabled";
 
 const API_VERSION = "v1beta1";
 const SERVICE_USAGE_ORIGIN = serviceUsageOrigin();
@@ -98,17 +99,18 @@ export async function disableService(
 export async function disableServiceAndPoll(
   projectId: string,
   service: string,
-  prefix: string,
+  loggingPrefix: string,
 ): Promise<void> {
-  utils.logLabeledBullet(prefix, `disabling service ${bold(service)}...`);
+  utils.logLabeledBullet(loggingPrefix, `disabling service ${bold(service)}...`);
   const op = await disableService(projectId, service);
-  if (op.done) {
-    return;
+  if (!op.done) {
+    await poller.pollOperation<void>({
+      ...serviceUsagePollerOptions,
+      operationResourceName: op.name,
+      headers: { "x-goog-user-project": `${projectId}` },
+    });
   }
-
-  await poller.pollOperation<void>({
-    ...serviceUsagePollerOptions,
-    operationResourceName: op.name,
-    headers: { "x-goog-user-project": `${projectId}` },
-  });
+  // The service is now disabled; invalidate the cached enablement status so that
+  // subsequent checks reflect reality without waiting for the cache to expire.
+  ensureApiEnabled.uncacheEnabledAPI(projectId, service);
 }

--- a/src/gcp/serviceusage.ts
+++ b/src/gcp/serviceusage.ts
@@ -70,3 +70,45 @@ export async function generateServiceIdentityAndPoll(
     headers: { "x-goog-user-project": `${projectNumber}` },
   });
 }
+
+/**
+ * Disables a service on the project.
+ */
+export async function disableService(
+  projectId: string,
+  service: string,
+): Promise<LongRunningOperation<unknown>> {
+  try {
+    const res = await apiClient.post<unknown, unknown>(
+      `projects/${projectId}/services/${service}:disable`,
+      /* body=*/ {},
+      { headers: { "x-goog-user-project": `${projectId}` } },
+    );
+    return res.body as LongRunningOperation<unknown>;
+  } catch (err: unknown) {
+    throw new FirebaseError(`Error disabling service ${service}.`, {
+      original: err as Error,
+    });
+  }
+}
+
+/**
+ * Calls disableService and polls till the operation is complete.
+ */
+export async function disableServiceAndPoll(
+  projectId: string,
+  service: string,
+  prefix: string,
+): Promise<void> {
+  utils.logLabeledBullet(prefix, `disabling service ${bold(service)}...`);
+  const op = await disableService(projectId, service);
+  if (op.done) {
+    return;
+  }
+
+  await poller.pollOperation<void>({
+    ...serviceUsagePollerOptions,
+    operationResourceName: op.name,
+    headers: { "x-goog-user-project": `${projectId}` },
+  });
+}


### PR DESCRIPTION
### Description

Adds the `firebase ailogic:config:*` commands to read and modify Firebase AI Logic configuration, gated behind the `ailogic` experiment (same as `ailogic:providers`).

- `ailogic:config:get [path]` reads the config. With no path it prints the whole resource; with a path it prints one value. Providers appear as read-only status derived from API enablement.
- `ailogic:config:set <path> <value>` writes one setting. Developer-facing paths map to the underlying resource fields:
  - `security.auth-only` -> `trafficFilter.firebaseAuthRequired`
  - `security.template-only` -> `trafficFilter.templateOnly`
  - `monitoring.state` -> `telemetryConfig.mode` (ALL/NONE)
  - `monitoring.sample-rate-percentage` -> `telemetryConfig.samplingRate` (an integer percent 1-100 exposed as the API's (0,1] fraction)

Tightening `security.auth-only` or `security.template-only` from false to true prompts for confirmation because existing clients start getting rejected; `confirm()` enforces `--force` in non-interactive mode. Input (path and value) is validated up front, before the API-enablement flow, so bad input fails fast.

**Depends on #10778** (`ailogic:providers`). This branch is rebased on top of that one, so until #10778 merges the diff here also shows the provider commits; once #10778 lands in `main` the diff narrows to the config-only changes automatically. Please review the `ailogic-config-*` and config-related `gcp/ailogic.ts` changes here; the provider files are the already-approved #10778 content.

### Scenarios Tested

- Unit tests: `ailogic-config-get.spec.ts`, `ailogic-config-set.spec.ts`, plus `getConfig`/`updateConfig` in `gcp/ailogic.spec.ts`. Covers unknown path, non-boolean and out-of-range values, false->true tightening confirmation, non-interactive-without-force, value/field mapping, nested-path reads, and fail-fast-before-enablement.
- `npm run build`, `npm run lint`, and `tsc --noEmit` are clean.
- Commands are hidden by default and appear under `FIREBASE_CLI_EXPERIMENTS=ailogic`.

### Sample Commands

```
firebase experiments:enable ailogic
firebase ailogic:config:get
firebase ailogic:config:get security.auth-only
firebase ailogic:config:set security.auth-only true
firebase ailogic:config:set monitoring.sample-rate-percentage 50
```
