### PR TITLE
refactor: unify duplicate selectAppInteractively implementations

### DIFF
--- a/src/commands/apps-sdkconfig.ts
+++ b/src/commands/apps-sdkconfig.ts
@@ -7,10 +7,12 @@ import {
   AppConfigurationData,
   AppMetadata,
   AppPlatform,
+  checkForApps,
   getAppConfig,
   getAppConfigFile,
   getAppPlatform,
   listFirebaseApps,
+  selectAppInteractively,
 } from "../management/apps";
 import { needProjectId } from "../projectUtils";
 import { getOrPromptProject } from "../management/projects";
@@ -18,41 +20,10 @@ import { FirebaseError } from "../error";
 import { requireAuth } from "../requireAuth";
 import { logger } from "../logger";
 import { Options } from "../options";
-import { select, confirm } from "../prompt";
+import { confirm } from "../prompt";
 
-function checkForApps(apps: AppMetadata[], appPlatform: AppPlatform): void {
-  if (!apps.length) {
-    throw new FirebaseError(
-      `There are no ${appPlatform === AppPlatform.ANY ? "" : appPlatform + " "}apps ` +
-        "associated with this Firebase project",
-    );
-  }
-}
 export interface AppsSdkConfigOptions extends Options {
   out?: string | boolean;
-}
-async function selectAppInteractively(
-  apps: AppMetadata[],
-  appPlatform: AppPlatform,
-): Promise<AppMetadata> {
-  checkForApps(apps, appPlatform);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const choices = apps.map((app: any) => {
-    return {
-      name:
-        `${app.displayName || app.bundleId || app.packageName}` +
-        ` - ${app.appId} (${app.platform})`,
-      value: app,
-    };
-  });
-
-  return await select<AppMetadata>({
-    message:
-      `Select the ${appPlatform === AppPlatform.ANY ? "" : appPlatform + " "}` +
-      "app to get the configuration data:",
-    choices,
-  });
 }
 
 export const command = new Command("apps:sdkconfig [platform] [appId]")

--- a/src/init/features/ailogic/index.spec.ts
+++ b/src/init/features/ailogic/index.spec.ts
@@ -71,7 +71,8 @@ describe("init ailogic", () => {
       listFirebaseAppsStub.resolves([]); // No apps
 
       await expect(init.askQuestions(mockSetup)).to.be.rejectedWith(
-        "No Firebase apps found in this project. Please create an app first using the Firebase Console or 'firebase apps:create'.",
+        "There are no apps associated with this Firebase project.\n" +
+          "You can create an app for this project with 'firebase apps:create'",
       );
 
       sinon.assert.calledWith(listFirebaseAppsStub, "test-project", AppPlatform.ANY);

--- a/src/init/features/ailogic/index.ts
+++ b/src/init/features/ailogic/index.ts
@@ -1,8 +1,7 @@
-import { select } from "../../../prompt";
 import { Setup } from "../..";
 import { FirebaseError } from "../../../error";
 import { AppInfo, getConfigFileName, parseAppId } from "./utils";
-import { listFirebaseApps, AppMetadata, AppPlatform } from "../../../management/apps";
+import { listFirebaseApps, AppPlatform, selectAppInteractively } from "../../../management/apps";
 import { provisionFirebaseApp } from "../../../management/provisioning/provision";
 import {
   ProvisionAppOptions,
@@ -12,41 +11,6 @@ import {
 export interface AiLogicInfo {
   appId: string;
   displayName?: string;
-}
-
-function checkForApps(apps: AppMetadata[]): void {
-  if (!apps.length) {
-    throw new FirebaseError(
-      "No Firebase apps found in this project. Please create an app first using the Firebase Console or 'firebase apps:create'.",
-      { exit: 1 },
-    );
-  }
-}
-
-async function selectAppInteractively(apps: AppMetadata[]): Promise<AppMetadata> {
-  checkForApps(apps);
-
-  const choices = apps.map((app) => {
-    let displayText = app.displayName || app.appId;
-
-    if (!app.displayName) {
-      if (app.platform === AppPlatform.IOS && "bundleId" in app) {
-        displayText = app.bundleId as string;
-      } else if (app.platform === AppPlatform.ANDROID && "packageName" in app) {
-        displayText = app.packageName as string;
-      }
-    }
-
-    return {
-      name: `${displayText} - ${app.appId} (${app.platform})`,
-      value: app,
-    };
-  });
-
-  return await select<AppMetadata>({
-    message: "Select the Firebase app to enable AI Logic for:",
-    choices,
-  });
 }
 
 /**
@@ -61,7 +25,9 @@ export async function askQuestions(setup: Setup): Promise<void> {
   }
 
   const apps = await listFirebaseApps(setup.projectId, AppPlatform.ANY);
-  const selectedApp = await selectAppInteractively(apps);
+  const selectedApp = await selectAppInteractively(apps, AppPlatform.ANY, {
+    message: "Select the Firebase app to enable AI Logic for:",
+  });
 
   // Set up the feature info
   if (!setup.featureInfo) {

--- a/src/management/apps.spec.ts
+++ b/src/management/apps.spec.ts
@@ -24,6 +24,7 @@ import {
   findIntelligentPathForAndroid,
   findIntelligentPathForIOS,
   getPlatform,
+  selectAppInteractively,
 } from "./apps";
 import * as pollUtils from "../operation-poller";
 import { FirebaseError } from "../error";
@@ -832,6 +833,63 @@ describe("App management", () => {
     }
     afterEach(() => {
       mockfs.restore();
+    });
+  });
+
+  describe("selectAppInteractively", () => {
+    it("should throw a FirebaseError when apps array is empty", async () => {
+      await expect(selectAppInteractively([], AppPlatform.ANY)).to.be.rejectedWith(
+        FirebaseError,
+        /There are no apps associated with this Firebase project/,
+      );
+    });
+
+    it("should format the select prompt options and return the selected app", async () => {
+      const promptSelectStub = sandbox.stub(prompt, "select");
+      const mockApps = [
+        {
+          appId: "appId1",
+          displayName: "App 1",
+          platform: AppPlatform.IOS,
+          bundleId: "com.example.app1",
+        } as unknown as IosAppMetadata,
+        {
+          appId: "appId2",
+          platform: AppPlatform.ANDROID,
+          packageName: "com.example.app2",
+        } as unknown as AndroidAppMetadata,
+      ];
+      promptSelectStub.resolves(mockApps[1]);
+
+      const selectedApp = await selectAppInteractively(mockApps, AppPlatform.ANY);
+
+      expect(selectedApp).to.deep.equal(mockApps[1]);
+      expect(promptSelectStub.calledOnce).to.be.true;
+      const callArgs = promptSelectStub.getCall(0).args[0];
+      expect(callArgs.message).to.equal("Select the app to get the configuration data:");
+      expect(callArgs.choices).to.deep.equal([
+        { name: "App 1 - appId1 (IOS)", value: mockApps[0] },
+        { name: "com.example.app2 - appId2 (ANDROID)", value: mockApps[1] },
+      ]);
+    });
+
+    it("should support a custom prompt message", async () => {
+      const promptSelectStub = sandbox.stub(prompt, "select");
+      const mockApps = [
+        {
+          appId: "appId1",
+          displayName: "App 1",
+          platform: AppPlatform.IOS,
+        } as unknown as IosAppMetadata,
+      ];
+      promptSelectStub.resolves(mockApps[0]);
+
+      await selectAppInteractively(mockApps, AppPlatform.ANY, {
+        message: "Choose custom app:",
+      });
+
+      expect(promptSelectStub.calledOnce).to.be.true;
+      expect(promptSelectStub.getCall(0).args[0].message).to.equal("Choose custom app:");
     });
   });
 });

--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -43,6 +43,9 @@ interface CreateWebAppOptions extends CreateFirebaseAppOptions {
   displayName: string;
 }
 
+/**
+ *
+ */
 export async function getPlatform(appDir: string, config: Config) {
   // Detect what platform based on current user
   let targetPlatforms = await getPlatformsFromFolder(appDir);
@@ -164,6 +167,9 @@ async function initiateWebAppCreation(options: CreateWebAppOptions): Promise<Web
   }
 }
 export type SdkInitOptions = CreateIosAppOptions | CreateAndroidAppOptions | CreateWebAppOptions;
+/**
+ *
+ */
 export async function sdkInit(appPlatform: AppPlatform, options: SdkInitOptions) {
   let appData;
   switch (appPlatform) {
@@ -181,6 +187,9 @@ export async function sdkInit(appPlatform: AppPlatform, options: SdkInitOptions)
   }
   return appData;
 }
+/**
+ *
+ */
 export async function getSdkOutputPath(
   appDir: string,
   platform: AppPlatform,
@@ -198,6 +207,9 @@ export async function getSdkOutputPath(
   }
   throw new FirebaseError("Platform " + platform.toString() + " is not supported yet.");
 }
+/**
+ *
+ */
 export function checkForApps(apps: AppMetadata[], appPlatform: AppPlatform): void {
   if (!apps.length) {
     throw new FirebaseError(
@@ -207,30 +219,49 @@ export function checkForApps(apps: AppMetadata[], appPlatform: AppPlatform): voi
     );
   }
 }
-async function selectAppInteractively(
+/**
+ * Interactively prompts the user to select a Firebase App from a list.
+ */
+export async function selectAppInteractively(
   apps: AppMetadata[],
-  appPlatform: AppPlatform,
+  appPlatform: AppPlatform = AppPlatform.ANY,
+  options?: {
+    message?: string;
+  },
 ): Promise<AppMetadata> {
   checkForApps(apps, appPlatform);
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const choices = apps.map((app: any) => {
+  const choices = apps.map((app) => {
+    let displayText = app.displayName || app.appId;
+
+    if (!app.displayName) {
+      if (app.platform === AppPlatform.IOS && "bundleId" in app) {
+        displayText = (app as IosAppMetadata).bundleId;
+      } else if (app.platform === AppPlatform.ANDROID && "packageName" in app) {
+        displayText = (app as AndroidAppMetadata).packageName;
+      }
+    }
+
     return {
-      name:
-        `${app.displayName || app.bundleId || app.packageName}` +
-        ` - ${app.appId} (${app.platform})`,
+      name: `${displayText} - ${app.appId} (${app.platform})`,
       value: app,
     };
   });
 
-  return await select({
-    message:
-      `Select the ${appPlatform === AppPlatform.ANY ? "" : appPlatform + " "}` +
-      "app to get the configuration data:",
+  const message =
+    options?.message ??
+    `Select the ${appPlatform === AppPlatform.ANY ? "" : appPlatform + " "}` +
+      "app to get the configuration data:";
+
+  return await select<AppMetadata>({
+    message,
     choices,
   });
 }
 
+/**
+ *
+ */
 export async function getSdkConfig(
   options: Options,
   appPlatform: AppPlatform,
@@ -597,6 +628,9 @@ export function getAppConfigFile(config: AppConfig, platform: AppPlatform): AppC
 
 export type AppConfig = MobileConfig | WebConfig;
 
+/**
+ *
+ */
 export async function writeConfigToFile(
   filename: string,
   nonInteractive: boolean,
@@ -741,6 +775,9 @@ export async function deleteAppAndroidSha(
   }
 }
 
+/**
+ *
+ */
 export async function findIntelligentPathForIOS(appDir: string, options: AppsInitOptions) {
   const currentFiles: fs.Dirent[] = await fs.readdir(appDir, { withFileTypes: true });
   for (let i = 0; i < currentFiles.length; i++) {
@@ -771,6 +808,9 @@ export async function findIntelligentPathForIOS(appDir: string, options: AppsIni
   return outputPath;
 }
 
+/**
+ *
+ */
 export async function findIntelligentPathForAndroid(appDir: string, options: AppsInitOptions) {
   /**
    * android/build.gradle // if it's this, choose app

--- a/src/management/apps.ts
+++ b/src/management/apps.ts
@@ -43,9 +43,6 @@ interface CreateWebAppOptions extends CreateFirebaseAppOptions {
   displayName: string;
 }
 
-/**
- *
- */
 export async function getPlatform(appDir: string, config: Config) {
   // Detect what platform based on current user
   let targetPlatforms = await getPlatformsFromFolder(appDir);
@@ -167,9 +164,6 @@ async function initiateWebAppCreation(options: CreateWebAppOptions): Promise<Web
   }
 }
 export type SdkInitOptions = CreateIosAppOptions | CreateAndroidAppOptions | CreateWebAppOptions;
-/**
- *
- */
 export async function sdkInit(appPlatform: AppPlatform, options: SdkInitOptions) {
   let appData;
   switch (appPlatform) {
@@ -187,9 +181,6 @@ export async function sdkInit(appPlatform: AppPlatform, options: SdkInitOptions)
   }
   return appData;
 }
-/**
- *
- */
 export async function getSdkOutputPath(
   appDir: string,
   platform: AppPlatform,
@@ -207,9 +198,6 @@ export async function getSdkOutputPath(
   }
   throw new FirebaseError("Platform " + platform.toString() + " is not supported yet.");
 }
-/**
- *
- */
 export function checkForApps(apps: AppMetadata[], appPlatform: AppPlatform): void {
   if (!apps.length) {
     throw new FirebaseError(
@@ -259,9 +247,6 @@ export async function selectAppInteractively(
   });
 }
 
-/**
- *
- */
 export async function getSdkConfig(
   options: Options,
   appPlatform: AppPlatform,
@@ -628,9 +613,6 @@ export function getAppConfigFile(config: AppConfig, platform: AppPlatform): AppC
 
 export type AppConfig = MobileConfig | WebConfig;
 
-/**
- *
- */
 export async function writeConfigToFile(
   filename: string,
   nonInteractive: boolean,
@@ -775,9 +757,6 @@ export async function deleteAppAndroidSha(
   }
 }
 
-/**
- *
- */
 export async function findIntelligentPathForIOS(appDir: string, options: AppsInitOptions) {
   const currentFiles: fs.Dirent[] = await fs.readdir(appDir, { withFileTypes: true });
   for (let i = 0; i < currentFiles.length; i++) {
@@ -808,9 +787,6 @@ export async function findIntelligentPathForIOS(appDir: string, options: AppsIni
   return outputPath;
 }
 
-/**
- *
- */
 export async function findIntelligentPathForAndroid(appDir: string, options: AppsInitOptions) {
   /**
    * android/build.gradle // if it's this, choose app


### PR DESCRIPTION
### Description
Consolidates the three duplicate implementations of `selectAppInteractively` found in `src/commands/apps-sdkconfig.ts`, `src/init/features/ailogic/index.ts`, and `src/management/apps.ts` into a single, public, type-safe implementation exported from `src/management/apps.ts`.

Key Changes:
- Replaced the private implementations in `src/commands/apps-sdkconfig.ts` and `src/init/features/ailogic/index.ts` with the exported function from `src/management/apps.ts`.
- Removed unused imports and duplicate helper functions like `checkForApps`.
- Added unit tests for `selectAppInteractively` covering empty checks, choice formatting, and custom message options.
- Adjusted unit tests in `src/init/features/ailogic/index.spec.ts` to expect the new general project app check error message.

### Scenarios Tested
- Ran mocha tests on app management (`src/management/apps.spec.ts`) and AI logic (`src/init/features/ailogic/index.spec.ts`).
- Ran complete CLI fast test suite with 4685 unit tests.
- Linted modified files to ensure strict TypeScript checks and formatting guidelines.

### Sample Commands
`npx mocha src/management/apps.spec.ts`
`npx mocha src/init/features/ailogic/index.spec.ts`
