### PR TITLE
[FSQL] Prevent client socket errors from escalating to pglite server crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
 - Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.
+- Fixes Data Connect emulator crash when in-flight GraphQL requests are cancelled (#10821)

--- a/src/emulator/dataconnect/pgliteServer.ts
+++ b/src/emulator/dataconnect/pgliteServer.ts
@@ -79,8 +79,14 @@ export class PostgresServer {
       socket.on("end", () => {
         logger.debug("Postgres client disconnected");
       });
+      // Log and destroy individual client socket errors instead of escalating them
+      // to server-level errors.
       socket.on("error", (err) => {
-        server.emit("error", err);
+        logger.debug(
+          "Postgres client socket error (if this happened during request cancellation, it is expected and harmless):",
+          err,
+        );
+        socket.destroy();
       });
     });
     this.server = server;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the form below.

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. We've hooked up this repo with continuous integration to double check those things for you.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
This PR fixes Issue#10821


Cancelling an in-flight Data Connect request makes the Go backend Postgres driver send a CancelRequest frame on a new TCP connection. pg-gateway throws Unexpected initial message, which pgliteServer.ts currently re-emits as a server error—causing dataconnectEmulator.ts to call cleanShutdown() and stop all emulators.

This PR decouples client socket errors from server-level errors in pgliteServer.ts. Per-socket errors are now logged and destroyed so single connection drops don't crash the emulator stack. Real server errors (EADDRINUSE) are still handled normally.



### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->
* Sent CancelRequest packet to port while emulators were running; verified stack stayed alive and served subsequent GraphQL queries.
* Verified reproduction crash on npx firebase-tools@latest vs survival on local fix.
* Ran full emulator test suite and npm run lint:changed-files.

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
