### PR TITLE
fix: bump ws dependency to ^8.21.1 (CVE-2026-48779)

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -76,7 +76,7 @@
         "update-notifier-cjs": "^5.1.6",
         "winston": "^3.0.0",
         "winston-transport": "^4.4.0",
-        "ws": "^7.5.10",
+        "ws": "^8.21.1",
         "yaml": "^2.8.3",
         "zod": "^4.0.0"
       },
@@ -131,7 +131,7 @@
         "@types/triple-beam": "^1.3.0",
         "@types/universal-analytics": "^0.4.5",
         "@types/update-notifier": "^5.1.0",
-        "@types/ws": "^7.2.3",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
         "@typescript-eslint/parser": "^5.9.0",
         "astro": "^2.2.3",
@@ -5489,9 +5489,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-VT/GK7nvDA7lfHy40G3LKM+ICqmdIsBLBHGXcWD97MtqQEjNMX+7Gudo8YGpaSlYdTX7IFThhCE8Jx09HegymQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -21633,15 +21633,15 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -25888,9 +25888,9 @@
       }
     },
     "@types/ws": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.3.tgz",
-      "integrity": "sha512-VT/GK7nvDA7lfHy40G3LKM+ICqmdIsBLBHGXcWD97MtqQEjNMX+7Gudo8YGpaSlYdTX7IFThhCE8Jx09HegymQ==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -37639,9 +37639,9 @@
       }
     },
     "ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "requires": {}
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -173,7 +173,7 @@
     "undici": "^6.19.0",
     "winston": "^3.0.0",
     "winston-transport": "^4.4.0",
-    "ws": "^7.5.10",
+    "ws": "^8.21.1",
     "yaml": "^2.8.3",
     "zod": "^4.0.0"
   },
@@ -225,7 +225,7 @@
     "@types/triple-beam": "^1.3.0",
     "@types/universal-analytics": "^0.4.5",
     "@types/update-notifier": "^5.1.0",
-    "@types/ws": "^7.2.3",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",
     "astro": "^2.2.3",

--- a/src/emulator/loggingEmulator.spec.ts
+++ b/src/emulator/loggingEmulator.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { LogEntry } from "winston";
+import * as WebSocket from "ws";
+import { LoggingEmulator } from "./loggingEmulator";
+import { logger } from "../logger";
+
+describe("LoggingEmulator", () => {
+  let emulator: LoggingEmulator;
+  let client: WebSocket | undefined;
+  const port = 4501;
+
+  afterEach(async () => {
+    if (client) {
+      client.close();
+      client = undefined;
+    }
+    if (emulator) {
+      await emulator.stop();
+    }
+  });
+
+  it("should start and broadcast log messages", async () => {
+    emulator = new LoggingEmulator({ port, host: "127.0.0.1" });
+    await emulator.start();
+
+    client = new WebSocket(`ws://127.0.0.1:${port}`);
+
+    const messagePromise = new Promise<LogEntry>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("Timeout waiting for message"));
+      }, 5000);
+
+      client!.on("message", (data) => {
+        clearTimeout(timeout);
+        try {
+          resolve(JSON.parse(data.toString()) as LogEntry);
+        } catch (e) {
+          reject(e);
+        }
+      });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+      client!.on("open", () => resolve());
+      client!.on("error", (err) => reject(err));
+    });
+
+    logger.info("Hello world from unit test!");
+
+    const receivedMessage = await messagePromise;
+    expect(receivedMessage.message).to.contain("Hello world from unit test!");
+  });
+});


### PR DESCRIPTION
### Description
Taking over #10817

Upgrades `ws` from `^7.5.10` to `^8.21.1` and `@types/ws` to `^8.18.1` to resolve security vulnerability CVE-2026-48779. Also regenerates the shrinkwrap file `npm-shrinkwrap.json` to lock the upgraded versions.
Verified that the breaking changes in `ws` version 8 do not break any functionality in `firebase-tools`:
- `WebSocketServer.prototype.close()` no longer closes existing connections automatically, but `LoggingEmulator` already manually terminates all active socket connections when stopped.
- Text messages and close reasons are no longer decoded to strings but passed as `Buffer`s; since the emulator does not listen to `'message'` events and the `'close'` listener does not read the close reason argument, this does not affect us.

### Scenarios Tested
- Added unit test `src/emulator/loggingEmulator.spec.ts` verifying that `LoggingEmulator` starts and broadcasts log messages correctly via WebSocket.
- Ran mocha test suite.

### Sample Commands
`npx mocha src/emulator/loggingEmulator.spec.ts`
