### PR TITLE
fix: support development version of functions SDK

### DIFF
--- a/src/deploy/functions/runtimes/node/index.ts
+++ b/src/deploy/functions/runtimes/node/index.ts
@@ -25,12 +25,6 @@ import * as versioning from "./versioning";
 
 import { fileExistsSync } from "../../../../fsutils";
 
-// The versions of the Firebase Functions SDK that added support for the container contract.
-const MIN_FUNCTIONS_SDK_VERSION = "3.20.0";
-
-// The version of the Firebase Functions SDK that added support for the extensions annotation in the container contract.
-const MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES = "5.1.0";
-
 /**
  *
  */
@@ -290,20 +284,24 @@ export class Delegate {
     config: backend.RuntimeConfigValues,
     env: backend.EnvironmentVariables,
   ): Promise<build.Build> {
-    if (semver.valid(this.sdkVersion)) {
-      if (semver.lt(this.sdkVersion, MIN_FUNCTIONS_SDK_VERSION)) {
+    if (this.sdkVersion === versioning.FUNCTIONS_SDK_DEV_VERSION) {
+      logger.debug("Skipping check for MIN_FUNCTIONS_SDK_VERSION for local development version.");
+    } else if (semver.valid(this.sdkVersion)) {
+      if (semver.lt(this.sdkVersion, versioning.MIN_FUNCTIONS_SDK_VERSION)) {
         throw new FirebaseError(
           `You are using an old version of firebase-functions SDK (${this.sdkVersion}). ` +
-            `Please update firebase-functions SDK to >=${MIN_FUNCTIONS_SDK_VERSION}`,
+            `Please update firebase-functions SDK to >=${versioning.MIN_FUNCTIONS_SDK_VERSION}`,
         );
       }
       // Perform a check for the minimum SDK version that added annotation support for the `Build.extensions` property
       // and log to the user explaining why they need to upgrade their version.
-      if (semver.lt(this.sdkVersion, MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES)) {
+      if (
+        semver.lt(this.sdkVersion, versioning.MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES)
+      ) {
         logLabeledBullet(
           "functions",
           `You are using a version of firebase-functions SDK (${this.sdkVersion}) that does not have support for the newest Firebase Extensions features. ` +
-            `Please update firebase-functions SDK to >=${MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES} to use them correctly`,
+            `Please update firebase-functions SDK to >=${versioning.MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES} to use them correctly`,
         );
       }
     } else {

--- a/src/deploy/functions/runtimes/node/versioning.spec.ts
+++ b/src/deploy/functions/runtimes/node/versioning.spec.ts
@@ -30,6 +30,12 @@ describe("checkFunctionsSDKVersion", () => {
     expect(warningSpy).not.called;
   });
 
+  it("Should not warn for the development SDK version", () => {
+    latestVersion.returns("3.20.0");
+    versioning.checkFunctionsSDKVersion(versioning.FUNCTIONS_SDK_DEV_VERSION);
+    expect(warningSpy).not.called;
+  });
+
   it("Should give an upgrade warning", () => {
     latestVersion.returns("5.0.1");
     versioning.checkFunctionsSDKVersion("5.0.0");

--- a/src/deploy/functions/runtimes/node/versioning.ts
+++ b/src/deploy/functions/runtimes/node/versioning.ts
@@ -14,7 +14,14 @@ interface NpmShowResult {
   };
 }
 
-const MIN_SDK_VERSION = "3.20.0";
+export const FUNCTIONS_SDK_DEV_VERSION = "0.0.0-development";
+
+// The versions of the Firebase Functions SDK that added support for the container contract.
+export const MIN_FUNCTIONS_SDK_VERSION = "3.20.0";
+
+// The version of the Firebase Functions SDK that added support for the extensions annotation in the container contract.
+export const MIN_FUNCTIONS_SDK_VERSION_FOR_EXTENSIONS_FEATURES = "5.1.0";
+
 const NPM_COMMAND_TIMEOUT_MILLIES = 10000;
 
 export const FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING =
@@ -27,7 +34,6 @@ export const FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING =
 
 /**
  * Exported for testing purposes only.
- *
  * @internal
  */
 export function findModuleVersion(name: string, resolvedPath: string): string | undefined {
@@ -110,8 +116,11 @@ export function getLatestSDKVersion(): string | undefined {
  * @param sourceDir the location of the customer's source code.
  */
 export function checkFunctionsSDKVersion(currentVersion: string): void {
+  if (currentVersion === FUNCTIONS_SDK_DEV_VERSION) {
+    return;
+  }
   try {
-    if (semver.lt(currentVersion, MIN_SDK_VERSION)) {
+    if (semver.lt(currentVersion, MIN_FUNCTIONS_SDK_VERSION)) {
       utils.logWarning(FUNCTIONS_SDK_VERSION_TOO_OLD_WARNING);
     }
 


### PR DESCRIPTION
### Description
This change ensures that when deploying a firebase-functions codebase that uses a locally checked-out repository branch of `firebase-functions` (which corresponds to version `"0.0.0-development"`), the CLI does not throw an error or warning about using an old version of the SDK.

Additionally, this deduplicates versioning constants such as `MIN_FUNCTIONS_SDK_VERSION` into a central modular location (`src/deploy/functions/runtimes/node/versioning.ts`), and adds tests to verify the version check logic gracefully ignores the development version.

### Scenarios Tested
- Added unit test in `versioning.spec.ts` for skipping warning on `0.0.0-development`.
- Fast tests (`npm run mocha:fast`) and lint tests (`npm run lint:changed-files`) pass successfully.

### Sample Commands
- `npm run test`
- `firebase deploy --only functions`

TAG=agy
CONV=a56547bb-2282-4d8e-b05e-03b7f555e277