### PR TITLE
fix(firedata): ignore quota project on getTosStatus to prevent 403

### DIFF
--- a/src/gcp/firedata.ts
+++ b/src/gcp/firedata.ts
@@ -29,7 +29,11 @@ export interface GetTosStatusResponse {
  * Fetches the Terms of Service status for the logged in user.
  */
 export async function getTosStatus(): Promise<GetTosStatusResponse> {
-  const res = await client.get<GetTosStatusResponse>("accessmanagement/tos:getStatus");
+  const res = await client.request<void, GetTosStatusResponse>({
+    method: "GET",
+    path: "accessmanagement/tos:getStatus",
+    ignoreQuotaProject: true,
+  });
   return res.body;
 }
 


### PR DESCRIPTION
Sets `ignoreQuotaProject` to true to prevent setting default `x-goog` quota headers that result in a 403 error for TosStatus checks. Fixes b/536740497(buganizer link).