### PR TITLE
test(functions): failing repro tests for declarative security managed SA bugs

### DIFF
--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1200,12 +1200,15 @@ describe("prepare", () => {
 
   describe("discoverSecurityDetails", () => {
     let testIamPermissionsStub: sinon.SinonStub;
+    let generateManagedSANameStub: sinon.SinonStub;
 
     beforeEach(() => {
       testIamPermissionsStub = sinon
         .stub(iam, "testIamPermissions")
         .resolves({ passed: true } as any);
-      sinon.stub(iam, "generateManagedServiceAccountName").resolves("firebase-fn-123");
+      generateManagedSANameStub = sinon
+        .stub(iam, "generateManagedServiceAccountName")
+        .resolves("firebase-fn-123");
       sinon.stub(resourcemanager, "getServiceAccountRoles").resolves([]);
     });
 
@@ -1227,6 +1230,44 @@ describe("prepare", () => {
       expect(result.newEtag).to.be.a("string");
       expect(e.serviceAccount).to.equal("firebase-fn-123@project.iam.gserviceaccount.com");
       expect(e.labels?.["firebase-declarative-security-etag"]).to.equal(result.newEtag);
+    });
+
+    it("reuses an existing managed service account in the project when no deployed functions reference it (BUG: currently generates a new one)", async () => {
+      // Scenario: a previous deploy created the managed SA and granted it roles, but
+      // function creation failed, so `have` is empty. The project still contains
+      // the managed SA, discoverable via IAM lookup.
+      const preexistingSA = "firebase-fn-1234567890@project.iam.gserviceaccount.com";
+      const getServiceAccountStub = sinon.stub(iam, "getServiceAccount").resolves({
+        name: `projects/project/serviceAccounts/${preexistingSA}`,
+        projectId: "project",
+        uniqueId: "12345",
+        email: preexistingSA,
+        displayName: "Firebase Functions managed service account",
+        etag: "etag",
+        description: "",
+        oauth2ClientId: "",
+        disabled: false,
+      });
+
+      const e: backend.Endpoint = {
+        ...ENDPOINT,
+      };
+      const want = backend.of(e);
+      want.requiredRoles = ["roles/viewer"];
+      const have = backend.empty();
+
+      const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+
+      // Desired behavior: reuse the SA that already exists in the project instead
+      // of generating a brand new random name (which orphans the previous SA and
+      // its project-level role grants on every failed deploy).
+      expect(
+        getServiceAccountStub.called || !generateManagedSANameStub.called,
+        "expected discoverSecurityDetails to look up existing managed service accounts " +
+          "in the project instead of unconditionally generating a new random SA name",
+      ).to.be.true;
+      expect(result.managedSA).to.equal(preexistingSA);
+      expect(e.serviceAccount).to.equal(preexistingSA);
     });
 
     it("should reset endpoints to default service account when unenrolling (opting out)", async () => {

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -670,6 +670,31 @@ describe("Fabricator", () => {
       expect(gcfv2.deleteFunction).to.have.been.called;
     });
 
+    it("retries function creation when a freshly created service account has not yet propagated (BUG: currently fails immediately)", async () => {
+      // GCF returns HTTP 404 when the deploy references a service account that
+      // was created moments ago and has not propagated through IAM yet.
+      const saNotFoundErr = new Error(
+        "Service account projects/-/serviceAccounts/firebase-fn-123@test-project.iam.gserviceaccount.com was not found. Please verify that the caller has iam.serviceAccounts.actAs permission on the service account.",
+      );
+      (saNotFoundErr as any).status = 404;
+      gcfv2.createFunction.onFirstCall().rejects(saNotFoundErr);
+      gcfv2.createFunction.resolves({ name: "op", done: false });
+      poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
+      run.setInvokerCreate.resolves();
+
+      // Use the same executor type as a real deploy (release/index.ts) so that
+      // retry-code based mitigations are exercised too, with fast backoff.
+      const queueFab = new fabricator.Fabricator({
+        ...ctorArgs,
+        functionExecutor: new executor.QueueExecutor({ retries: 3, backoff: 1, maxBackoff: 10 }),
+      });
+
+      const ep = endpoint({ httpsTrigger: {} }, { platform: "gcfv2" });
+      await queueFab.createV2Function(ep, new scraper.SourceTokenScraper());
+
+      expect(gcfv2.createFunction).to.have.been.calledTwice;
+    });
+
     it("throws on set invoker failure", async () => {
       gcfv2.createFunction.resolves({ name: "op", done: false });
       poller.pollOperation.resolves({ serviceConfig: { service: "service" } });
@@ -2069,6 +2094,26 @@ describe("Fabricator", () => {
         ["roles/viewer"],
         true,
       );
+    });
+
+    it("waits for a newly created service account to be visible before returning from grantNewRoles (BUG: no propagation check)", async () => {
+      // IAM service account creation is eventually consistent. grantNewRoles
+      // should poll getServiceAccount until the new SA is visible before the
+      // deploy proceeds to create functions that actAs it.
+      const getServiceAccountStub = sinon.stub(iam, "getServiceAccount").resolves({
+        name: "projects/test-project/serviceAccounts/firebase-fn-123@my-proj.iam.gserviceaccount.com",
+        email: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+      } as any);
+      const plan: planner.CodebasePlan = {
+        regionalChangesets: {},
+        serviceAccountToCreate: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+        managedServiceAccount: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+      };
+
+      await fab.grantNewRoles(plan, "default");
+
+      expect(createServiceAccountStub).to.have.been.called;
+      expect(getServiceAccountStub).to.have.been.called;
     });
 
     it("should remove roles or delete SA in removeOldRoles", async () => {


### PR DESCRIPTION
Repro tests for two bugs in the declarative security (`requireRoles`) managed service account flow, found while migrating storage-resize-images. Draft on purpose: the three new tests fail until the bugs are fixed, and are written against the desired behavior so a fix can land on top of them.

**1. Fresh SA propagation race**

First deploy with `requireRoles` creates the managed SA, grants roles, then immediately creates functions. IAM SA creation is eventually consistent, so GCF rejects the brand new SA with `404 ... was not found ... iam.serviceAccounts.actAs`. Nothing mitigates this today: `grantNewRoles` never polls for visibility (`src/deploy/functions/release/fabricator.ts:98-118`), and the 404 is never retried (`DEFAULT_RETRY_CODES = [429, 409, 503]` in `executor.ts:22`; `createV2Function`'s catch only special-cases Cloud Run RESOURCE_EXHAUSTED, `fabricator.ts:557-571`).

Tests: `fabricator.spec.ts` "retries function creation when a freshly created service account has not yet propagated" (uses a real `QueueExecutor` so either a retry-code or fabricator-level fix satisfies it) and "waits for a newly created service account to be visible before returning from grantNewRoles".

**2. Failed first deploy orphans the SA, every retry mints a new one**

The managed SA is only rediscovered via `serviceAccount` on already-deployed endpoints (`src/deploy/functions/prepare.ts:84-92`). If function creation fails after SA creation (bug 1 reproduces this reliably), the next deploy finds no `existingManagedSA` and unconditionally generates a fresh random `firebase-fn-<10digits>` name (`prepare.ts:141-145`, `src/gcp/iam.ts:307-330`). Each retry leaves another orphaned SA holding project-level role grants (Storage Admin, roles/aiplatform.user in our repro), with no cleanup path.

Test: `prepare.spec.ts` "reuses an existing managed service account in the project when no deployed functions reference it".

Issues with full repro output: #10859 (propagation race), #10860 (SA orphaning).
