### PR TITLE
Use operation-specific wording in App Check debug token prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixed `appcheck:debugtokens:list` and `appcheck:debugtokens:delete` prompting "Select the app to register a debug token for" when asking which app to operate on.

--- a/src/appcheck/prompts.spec.ts
+++ b/src/appcheck/prompts.spec.ts
@@ -1,0 +1,100 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { getOrPromptAppId, getOrPromptProjectAndAppId } from "./prompts";
+import { AppCheckDebugOptions } from "./types";
+import * as apps from "../management/apps";
+import * as appUtils from "../appUtils";
+import * as projectUtils from "../projectUtils";
+import { FirebaseError } from "../error";
+
+describe("appcheck prompts", () => {
+  const projectId = "my-project";
+  const webApp = { appId: "1:1:web:aaa", platform: apps.AppPlatform.WEB } as apps.AppMetadata;
+  const otherApp = { appId: "1:1:web:bbb", platform: apps.AppPlatform.WEB } as apps.AppMetadata;
+
+  let sandbox: sinon.SinonSandbox;
+  let listFirebaseAppsStub: sinon.SinonStub;
+  let selectAppInteractivelyStub: sinon.SinonStub;
+  let detectAppsStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(projectUtils, "needProjectId").returns(projectId);
+    listFirebaseAppsStub = sandbox.stub(apps, "listFirebaseApps");
+    selectAppInteractivelyStub = sandbox.stub(apps, "selectAppInteractively");
+    detectAppsStub = sandbox.stub(appUtils, "detectApps").resolves([]);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("uses the app id from options without listing apps", async () => {
+    const result = await getOrPromptAppId({ app: webApp.appId } as AppCheckDebugOptions);
+
+    expect(result).to.deep.equal({ projectId, appId: webApp.appId });
+    expect(listFirebaseAppsStub.called).to.be.false;
+  });
+
+  it("throws when the project has no apps", async () => {
+    listFirebaseAppsStub.resolves([]);
+
+    await expect(getOrPromptAppId({} as AppCheckDebugOptions)).to.be.rejectedWith(
+      FirebaseError,
+      /no apps associated with project/,
+    );
+  });
+
+  it("selects the only app without prompting", async () => {
+    listFirebaseAppsStub.resolves([webApp]);
+
+    const result = await getOrPromptAppId({} as AppCheckDebugOptions);
+
+    expect(result).to.deep.equal({ projectId, appId: webApp.appId });
+    expect(selectAppInteractivelyStub.called).to.be.false;
+  });
+
+  it("throws for multiple apps in non-interactive mode", async () => {
+    listFirebaseAppsStub.resolves([webApp, otherApp]);
+
+    await expect(
+      getOrPromptAppId({ nonInteractive: true } as AppCheckDebugOptions),
+    ).to.be.rejectedWith(FirebaseError, /must specify an app id/);
+  });
+
+  it("narrows the choices to locally detected apps", async () => {
+    listFirebaseAppsStub.resolves([webApp, otherApp]);
+    detectAppsStub.resolves([{ appId: otherApp.appId }]);
+
+    const result = await getOrPromptAppId({} as AppCheckDebugOptions);
+
+    expect(result.appId).to.equal(otherApp.appId);
+    expect(selectAppInteractivelyStub.called).to.be.false;
+  });
+
+  it("prompts with the register wording by default", async () => {
+    listFirebaseAppsStub.resolves([webApp, otherApp]);
+    selectAppInteractivelyStub.resolves(webApp);
+
+    await getOrPromptAppId({} as AppCheckDebugOptions);
+
+    expect(selectAppInteractivelyStub.firstCall.args[2]).to.deep.equal({
+      message: "Select the app to register a debug token for:",
+    });
+  });
+
+  it("prompts with the caller supplied wording", async () => {
+    listFirebaseAppsStub.resolves([webApp, otherApp]);
+    selectAppInteractivelyStub.resolves(webApp);
+
+    await getOrPromptProjectAndAppId(
+      {} as AppCheckDebugOptions,
+      "Select the app to delete a debug token from:",
+    );
+
+    expect(selectAppInteractivelyStub.firstCall.args[2]).to.deep.equal({
+      message: "Select the app to delete a debug token from:",
+    });
+  });
+});

--- a/src/appcheck/prompts.ts
+++ b/src/appcheck/prompts.ts
@@ -9,9 +9,13 @@ import { AppCheckDebugOptions } from "./types";
 /**
  * Gets the appId from options or prompts the user to select an app if multiple exist.
  * Uses needProjectId(options) to retrieve the active or specified project ID.
+ * @param options the command options
+ * @param message the prompt shown when the user has to choose between apps.
+ * Defaults to the wording used when registering a debug token.
  */
 export async function getOrPromptAppId(
   options: AppCheckDebugOptions,
+  message = "Select the app to register a debug token for:",
 ): Promise<{ projectId: string; appId: string }> {
   const projectId = needProjectId(options);
 
@@ -43,7 +47,7 @@ export async function getOrPromptAppId(
   }
 
   const selectedApp = await selectAppInteractively(apps, AppPlatform.ANY, {
-    message: "Select the app to register a debug token for:",
+    message,
   });
 
   return { projectId, appId: selectedApp.appId };

--- a/src/commands/appcheck-debugtokens-delete.ts
+++ b/src/commands/appcheck-debugtokens-delete.ts
@@ -16,7 +16,10 @@ export const command = new Command("appcheck:debugtokens:delete <debugTokenId>")
   .option("--force", "attempt to delete debug token without prompting for confirmation")
   .before(requireAuth)
   .action(async (debugTokenId: string, options: AppCheckDebugOptions): Promise<void> => {
-    const { appId } = await getOrPromptProjectAndAppId(options);
+    const { appId } = await getOrPromptProjectAndAppId(
+      options,
+      "Select the app to delete a debug token from:",
+    );
     const projectNumber = await needProjectNumber(options);
 
     let debugTokenName = debugTokenId;

--- a/src/commands/appcheck-debugtokens-list.ts
+++ b/src/commands/appcheck-debugtokens-list.ts
@@ -30,7 +30,10 @@ export const command = new Command("appcheck:debugtokens:list")
   .option("--app <appId>", "the app id of your Firebase app")
   .before(requireAuth)
   .action(async (options: AppCheckDebugOptions): Promise<DebugToken[]> => {
-    const { appId } = await getOrPromptProjectAndAppId(options);
+    const { appId } = await getOrPromptProjectAndAppId(
+      options,
+      "Select the app to list debug tokens for:",
+    );
     const projectNumber = await needProjectNumber(options);
 
     const debugTokens = await promiseWithSpinner<DebugToken[]>(


### PR DESCRIPTION
## Description

`getOrPromptAppId` in `src/appcheck/prompts.ts` hardcodes the app-selection prompt:

```ts
const selectedApp = await selectAppInteractively(apps, AppPlatform.ANY, {
  message: "Select the app to register a debug token for:",
});
```

All three App Check debug token commands call it through the `getOrPromptProjectAndAppId` alias — `appcheck:debugtokens:create`, `appcheck:debugtokens:list` and `appcheck:debugtokens:delete`. So when a project has more than one app and the user has not passed `--app`, both of the non-create commands describe the wrong operation:

```
$ firebase appcheck:debugtokens:delete <id>
? Select the app to register a debug token for: (Use arrow keys)
```

That is worst in `delete`, where the prompt is the step that chooses *which app a token gets destroyed in*, and it tells the user it is about to register one.

## Fix

Give `getOrPromptAppId` an optional `message` parameter that defaults to the existing string, and have `list` and `delete` pass their own wording:

* `list` — "Select the app to list debug tokens for:"
* `delete` — "Select the app to delete a debug token from:"

`create` is untouched and its prompt is byte-identical, since it relies on the default.

## Testing

`src/appcheck/prompts.ts` had no spec, so this adds `src/appcheck/prompts.spec.ts` covering the helper's branches:

* uses `options.app` without listing apps
* throws when the project has no apps
* selects the only app without prompting
* throws for multiple apps in non-interactive mode
* narrows the choices to locally detected apps
* prompts with the register wording by default
* prompts with the caller supplied wording

```console
$ npx mocha "src/appcheck/*.spec.ts" "src/commands/appcheck-*.spec.ts"
19 passing
```

That is `12 passing` on an unmodified checkout, so all 7 additions are new coverage. Reverting only the three source files fails the regression test:

```
✖ prompts with the caller supplied wording
  AssertionError: expected { Object (message) } to deeply equal { Object (message) }
```

`npm run test:compile` is clean. `npx eslint` on the four changed files reports no findings other than the CRLF `prettier/prettier` noise my Windows checkout produces in every file (I fixed the one genuine `jsdoc/tag-lines` warning my new doc comment introduced).
