### PR TITLE
inlined.sa propagation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,3 @@
 - Removed the warning that Dart functions may not yet be visible in the Firebase Console, since they are now shown.
 - Add the V1 environment variable FUNCTION_REGION to v2 functions (#10862)
 - Fixes service account propagation delays during Cloud Functions deploys and cleans up newly created service accounts on 100% deployment failure (#10871).
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,1 @@
 - Fixes service account propagation delays during Cloud Functions deploys and cleans up newly created service accounts on 100% deployment failure (#10871).
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - Add the V1 environment variable FUNCTION_REGION to v2 functions (#10862)
 - Fixes service account propagation delays during Cloud Functions deploys and cleans up newly created service accounts on 100% deployment failure (#10871).
 
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+- Update Firestore emulator to v1.22.0, adding support for DML
+- Add `appcheck:debugtokens:create`, `appcheck:debugtokens:list`, and `appcheck:debugtokens:delete` CLI commands for managing App Check debug tokens (#10801).
+- Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
+- Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
+- Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.
+- Fixes Data Connect emulator crash when in-flight GraphQL requests are cancelled (#10821)
+- Fixed a Cloud Storage emulator hang under concurrent requests, caused by the rules runtime's stdout being parsed per-chunk instead of per-line so batched responses were dropped (#6194, #6865).
+- Support for specifying that the input for a string or string[] param in Functions must be non-empty (#10678)
+- Removed the warning that Dart functions may not yet be visible in the Firebase Console, since they are now shown.
+- Add the V1 environment variable FUNCTION_REGION to v2 functions (#10862)
+- Fixes service account propagation delays during Cloud Functions deploys and cleans up newly created service accounts on 100% deployment failure (#10871).
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,2 @@
-- Update Firestore emulator to v1.22.0, adding support for DML
-- Add `appcheck:debugtokens:create`, `appcheck:debugtokens:list`, and `appcheck:debugtokens:delete` CLI commands for managing App Check debug tokens (#10801).
-- Add `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` HTTP headers to `OneMcpServer` requests per the MCP 0728 standard release candidate (https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate/ and https://modelcontextprotocol.io/seps/2243-http-standardization).
-- Fixes Storage Emulator to support JSON uploads larger than 100KB without hanging or throwing 413 error (#8355)
-- Add `extdeprecationwarnings` experiment to display phased deprecation notices and guidance across `ext:*` CLI commands.
-- Fixes Data Connect emulator crash when in-flight GraphQL requests are cancelled (#10821)
-- Fixed a Cloud Storage emulator hang under concurrent requests, caused by the rules runtime's stdout being parsed per-chunk instead of per-line so batched responses were dropped (#6194, #6865).
-- Support for specifying that the input for a string or string[] param in Functions must be non-empty (#10678)
-- Removed the warning that Dart functions may not yet be visible in the Firebase Console, since they are now shown.
-- Add the V1 environment variable FUNCTION_REGION to v2 functions (#10862)
 - Fixes service account propagation delays during Cloud Functions deploys and cleans up newly created service accounts on 100% deployment failure (#10871).
+

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,8 +30,7 @@ npm run format                   # Auto-fix formatting issues
 - **Throw `FirebaseError`** (`src/error.ts`) for expected, user-facing errors. If the error is due to a violation of a precondition (e.g. something
   that is null but should never be), specify a non-zero exit code.
 - **API calls must use `apiv2.ts`** for authenticated requests.
-- **Reduce nesting as much as possible** Code should avoid unnecessarily deep nesting or long periods of nesting. Handle edge cases early and exit
-  or fold them into the general case. Consider helper functions that can completely encapsulate branching, e.g. multiple ways a variable can be populated.
+- **Reduce nesting as much as possible:** Code should avoid unnecessarily deep nesting or long periods of nesting. Use early returns, `continue`, and `break` statements in functions and loops to handle edge cases early and keep main logic flat. Consider helper functions to encapsulate complex branching.
 
 ### TypeScript
 

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -83,6 +83,10 @@ export async function discoverSecurityDetails(
   newEtag?: string;
 }> {
   const requiredRoles = want.requiredRoles;
+  // Note: On partial first rollouts (where at least one function successfully deployed),
+  // haveBackend contains all active endpoints in GCP from list calls. firstHave.serviceAccount
+  // will identify existingManagedSA on subsequent deploys. On 100% deployment failures,
+  // fabricator cleans up the unreferenced service account so no orphaned SA remains.
   const firstHave = backend.allEndpoints(have)[0];
   let existingManagedSA: string | undefined;
   let haveRolesEtag: string | undefined;

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -46,15 +46,102 @@ describe("Executor", () => {
       await expect(exec.run(handler)).to.eventually.be.rejectedWith("Retryable");
     });
 
-    it("retries on custom specified retry codes", async () => {
+    it("retries on custom specified retry predicates", async () => {
       const handler = (): Promise<void> => {
         const err = new Error("Retryable");
         (err as any).code = 8;
         throw err;
       };
       await expect(
-        exec.run(handler, { retryCodes: [...executor.DEFAULT_RETRY_CODES, 8] }),
+        exec.run(handler, {
+          retryPredicates: [executor.isTransientError, executor.hasErrorCode(8)],
+        }),
       ).to.eventually.be.rejectedWith("Retryable");
+    });
+
+    it("retries on task-level retryPredicates", async () => {
+      let attempts = 0;
+      const handler = (): Promise<string> => {
+        attempts++;
+        if (attempts === 1) {
+          const err: any = new Error(
+            "Service account my-sa@project.iam.gserviceaccount.com does not exist",
+          );
+          err.status = 404;
+          return Promise.reject(err);
+        }
+        return Promise.resolve("success");
+      };
+
+      const result = await exec.run(handler, {
+        retryPredicates: [executor.isTransientError, executor.isServiceAccount404],
+      });
+      expect(result).to.equal("success");
+      expect(attempts).to.equal(2);
+    });
+
+    it("respects queue-level defaultRetryPredicates", async () => {
+      let attempts = 0;
+      const customExec = new executor.QueueExecutor({
+        retries: 5,
+        maxBackoff: 1,
+        backoff: 1,
+        defaultRetryPredicates: [executor.isServiceAccount404],
+      });
+
+      const handler = (): Promise<string> => {
+        attempts++;
+        if (attempts === 1) {
+          const err: any = new Error("Service account not found");
+          err.status = 404;
+          return Promise.reject(err);
+        }
+        return Promise.resolve("done");
+      };
+
+      const result = await customExec.run(handler);
+      expect(result).to.equal("done");
+      expect(attempts).to.equal(2);
+    });
+  });
+
+  describe("isServiceAccount404", () => {
+    it("matches 404 errors containing service account references", () => {
+      const err1: any = new Error("Service account proj@iam.gserviceaccount.com does not exist");
+      err1.status = 404;
+      expect(executor.isServiceAccount404(err1)).to.be.true;
+
+      const err2: any = new Error("Resource 'serviceaccount' not found");
+      err2.code = 404;
+      expect(executor.isServiceAccount404(err2)).to.be.true;
+
+      const err3: any = {
+        status: 404,
+        context: { body: { error: { message: "service account missing" } } },
+      };
+      expect(executor.isServiceAccount404(err3)).to.be.true;
+    });
+
+    it("does not match non-404 errors or non-service-account 404 errors", () => {
+      const err1: any = new Error("Service account missing");
+      err1.status = 500;
+      expect(executor.isServiceAccount404(err1)).to.be.false;
+
+      const err2: any = new Error("Function region us-central1 not found");
+      err2.status = 404;
+      expect(executor.isServiceAccount404(err2)).to.be.false;
+    });
+  });
+
+  describe("predicates", () => {
+    it("identifies transient errors correctly", () => {
+      expect(executor.isQuotaExhaustion({ status: 429 })).to.be.true;
+      expect(executor.isConflict({ status: 409 })).to.be.true;
+      expect(executor.isServiceUnavailable({ status: 503 })).to.be.true;
+      expect(executor.isTransientError({ status: 429 })).to.be.true;
+      expect(executor.isTransientError({ status: 409 })).to.be.true;
+      expect(executor.isTransientError({ status: 503 })).to.be.true;
+      expect(executor.isTransientError({ status: 500 })).to.be.false;
     });
   });
 });

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -133,7 +133,9 @@ describe("Executor", () => {
     });
 
     it("safely handles circular error objects without throwing", () => {
-      const circularErr: any = new Error("Service account proj@iam.gserviceaccount.com does not exist");
+      const circularErr: any = new Error(
+        "Service account proj@iam.gserviceaccount.com does not exist",
+      );
       circularErr.status = 404;
       circularErr.self = circularErr; // Circular reference
       expect(executor.isServiceAccount404(circularErr)).to.be.true;

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -132,6 +132,15 @@ describe("Executor", () => {
       expect(executor.isServiceAccount404(err2)).to.be.false;
     });
 
+    it("inspects all error message sources when err.message is generic", () => {
+      const genericErr: any = new Error("Generic Request Failed 404");
+      genericErr.status = 404;
+      genericErr.context = {
+        body: { error: { message: "Service account my-sa@project.iam.gserviceaccount.com missing" } },
+      };
+      expect(executor.isServiceAccount404(genericErr)).to.be.true;
+    });
+
     it("safely handles circular error objects without throwing", () => {
       const circularErr: any = new Error(
         "Service account proj@iam.gserviceaccount.com does not exist",

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -131,6 +131,13 @@ describe("Executor", () => {
       err2.status = 404;
       expect(executor.isServiceAccount404(err2)).to.be.false;
     });
+
+    it("safely handles circular error objects without throwing", () => {
+      const circularErr: any = new Error("Service account proj@iam.gserviceaccount.com does not exist");
+      circularErr.status = 404;
+      circularErr.self = circularErr; // Circular reference
+      expect(executor.isServiceAccount404(circularErr)).to.be.true;
+    });
   });
 
   describe("predicates", () => {

--- a/src/deploy/functions/release/executor.spec.ts
+++ b/src/deploy/functions/release/executor.spec.ts
@@ -136,7 +136,11 @@ describe("Executor", () => {
       const genericErr: any = new Error("Generic Request Failed 404");
       genericErr.status = 404;
       genericErr.context = {
-        body: { error: { message: "Service account my-sa@project.iam.gserviceaccount.com missing" } },
+        body: {
+          error: {
+            message: "Service account my-sa@project.iam.gserviceaccount.com missing",
+          },
+        },
       };
       expect(executor.isServiceAccount404(genericErr)).to.be.true;
     });

--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -38,12 +38,15 @@ export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
   }
   let message = "";
   try {
-    message = (
-      err?.message ||
-      err?.original?.message ||
-      err?.context?.body?.error?.message ||
-      String(err)
-    ).toLowerCase();
+    message = [
+      err?.message,
+      err?.original?.message,
+      err?.context?.body?.error?.message,
+      String(err),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
   } catch {
     message = String(err).toLowerCase();
   }

--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -8,20 +8,9 @@ export interface Executor {
   run<T>(func: () => Promise<T>, opts?: RunOptions): Promise<T>;
 }
 
-export interface RunOptions {
-  retryCodes?: number[];
-}
+export type RetryPredicate = (err: any) => boolean;
 
-interface Operation {
-  func: () => any;
-  retryCodes: number[];
-  result?: any;
-  error?: any;
-}
-
-export const DEFAULT_RETRY_CODES = [429, 409, 503];
-
-function parseErrorCode(err: any): number {
+export function parseErrorCode(err: any): number {
   return (
     err.status ||
     err.code ||
@@ -31,43 +20,92 @@ function parseErrorCode(err: any): number {
   );
 }
 
+export function hasErrorCode(...codes: number[]): RetryPredicate {
+  return (err: any): boolean => codes.includes(parseErrorCode(err));
+}
+
+export const isQuotaExhaustion: RetryPredicate = (err: any): boolean => parseErrorCode(err) === 429;
+export const isConflict: RetryPredicate = (err: any): boolean => parseErrorCode(err) === 409;
+export const isServiceUnavailable: RetryPredicate = (err: any): boolean =>
+  parseErrorCode(err) === 503;
+
+export const isTransientError: RetryPredicate = (err: any): boolean =>
+  isQuotaExhaustion(err) || isConflict(err) || isServiceUnavailable(err);
+
+export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
+  if (parseErrorCode(err) !== 404) {
+    return false;
+  }
+  const message = (
+    err.message ||
+    err.original?.message ||
+    err.context?.body?.error?.message ||
+    JSON.stringify(err)
+  ).toLowerCase();
+  return (
+    message.includes("serviceaccount") ||
+    message.includes("service account") ||
+    message.includes("gserviceaccount.com")
+  );
+};
+
+export const isCloudRunResourceExhausted: RetryPredicate = (err: any): boolean =>
+  parseErrorCode(err) === 8;
+
+export interface RunOptions {
+  retryPredicates?: RetryPredicate[];
+}
+
+interface Operation {
+  func: () => any;
+  retryPredicates: RetryPredicate[];
+  result?: any;
+  error?: any;
+}
+
 async function handler(op: Operation): Promise<void> {
   try {
     op.result = await op.func();
   } catch (err: any) {
     // Throw retry functions back to the queue where they will be retried
-    // with backoffs. To do this we cast a wide net for possible error codes.
-    // These can be either TOO MANY REQUESTS (429) errors or CONFLICT (409)
-    // errors. This can be a raw error with the correct HTTP code, a raw
-    // error with the HTTP code stashed where GCP puts it, or a FirebaseError
-    // wrapping either of the previous two cases.
-    const code = parseErrorCode(err);
-    if (op.retryCodes.includes(code)) {
+    // with backoffs.
+    const shouldRetry = op.retryPredicates.some((predicate) => predicate(err));
+    if (shouldRetry) {
       throw err;
     }
-    err.code = code;
+    err.code = parseErrorCode(err);
     op.error = err;
   }
   return;
 }
 
+export interface QueueExecutorOptions extends Omit<ThrottlerOptions<Operation, void>, "handler"> {
+  defaultRetryPredicates?: RetryPredicate[];
+}
+
 /**
  * A QueueExecutor implements the executor interface on top of a throttler queue.
- * Any 429 will be retried within the ThrottlerOptions parameters, but all
- * other errors are rethrown.
+ * Transient errors (429, 409, 503) will be retried within the ThrottlerOptions parameters by default,
+ * but all other errors are rethrown unless custom retryPredicates are supplied.
  */
 export class QueueExecutor implements Executor {
   private readonly queue: Queue<Operation, void>;
-  constructor(options: Omit<ThrottlerOptions<Operation, void>, "handler">) {
-    this.queue = new Queue({ ...options, handler });
+  private readonly defaultRetryPredicates: RetryPredicate[];
+
+  constructor(options: QueueExecutorOptions) {
+    const { defaultRetryPredicates, ...throttlerOptions } = options;
+    this.defaultRetryPredicates = defaultRetryPredicates || [isTransientError];
+    this.queue = new Queue({ ...throttlerOptions, handler });
   }
 
   async run<T>(func: () => Promise<T>, opts?: RunOptions): Promise<T> {
-    const retryCodes = opts?.retryCodes || DEFAULT_RETRY_CODES;
+    const retryPredicates: RetryPredicate[] = opts?.retryPredicates
+      ? [...opts.retryPredicates]
+      : [...this.defaultRetryPredicates];
 
     const op: Operation = {
       func,
-      retryCodes,
+      retryPredicates,
     };
     await this.queue.run(op);
     if (op.error) {
@@ -81,7 +119,7 @@ export class QueueExecutor implements Executor {
  * Inline executors run their functions right away.
  * Useful for testing.
  */
-export class InlineExecutor {
+export class InlineExecutor implements Executor {
   run<T>(func: () => Promise<T>): Promise<T> {
     return func();
   }

--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -50,8 +50,8 @@ export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
   return (
     message.includes("serviceaccount") ||
     message.includes("service account") ||
-    message.includes("iam.gserviceaccount.com") ||
-    message.includes("gserviceaccount.com")
+    /\b[a-z0-9._%+-]+@[a-z0-9.-]+\.gserviceaccount\.com\b/i.test(message) ||
+    /\bgserviceaccount\.com\b/i.test(message)
   );
 };
 

--- a/src/deploy/functions/release/executor.ts
+++ b/src/deploy/functions/release/executor.ts
@@ -36,15 +36,21 @@ export const isServiceAccount404: RetryPredicate = (err: any): boolean => {
   if (parseErrorCode(err) !== 404) {
     return false;
   }
-  const message = (
-    err.message ||
-    err.original?.message ||
-    err.context?.body?.error?.message ||
-    JSON.stringify(err)
-  ).toLowerCase();
+  let message = "";
+  try {
+    message = (
+      err?.message ||
+      err?.original?.message ||
+      err?.context?.body?.error?.message ||
+      String(err)
+    ).toLowerCase();
+  } catch {
+    message = String(err).toLowerCase();
+  }
   return (
     message.includes("serviceaccount") ||
     message.includes("service account") ||
+    message.includes("iam.gserviceaccount.com") ||
     message.includes("gserviceaccount.com")
   );
 };

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
 
+import { FirebaseError } from "../../../error";
 import * as fabricator from "./fabricator";
 import * as reporter from "./reporter";
 import * as executor from "./executor";
@@ -2096,6 +2097,119 @@ describe("Fabricator", () => {
       await fab.removeOldRoles(plan, "default");
 
       expect(deleteServiceAccountStub).to.have.been.calledWith(
+        "test-project",
+        "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+      );
+    });
+
+    it("should clean up newly created SA if role assignment fails in grantNewRoles", async () => {
+      addServiceAccountRolesStub.rejects(new Error("Permission denied"));
+
+      const plan: planner.CodebasePlan = {
+        regionalChangesets: {},
+        serviceAccountToCreate: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+        managedServiceAccount: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+        rolesToAdd: ["roles/viewer"],
+      };
+
+      await expect(fab.grantNewRoles(plan, "default")).to.be.rejectedWith(FirebaseError);
+      expect(deleteServiceAccountStub).to.have.been.calledWith(
+        "test-project",
+        "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+      );
+    });
+
+    it("should clean up newly created SA on 100% deployment failure", async () => {
+      const endpoint: backend.Endpoint = {
+        id: "fn1",
+        region: "us-central1",
+        project: "test-project",
+        platform: "gcfv1",
+        runtime: "nodejs18",
+        entryPoint: "fn1",
+        httpsTrigger: {},
+        codebase: "default",
+      };
+
+      const deploymentPlan: planner.DeploymentPlan = {
+        default: {
+          regionalChangesets: {
+            "us-central1": {
+              endpointsToCreate: [endpoint],
+              endpointsToUpdate: [],
+              endpointsToDelete: [],
+              endpointsToSkip: [],
+            },
+          },
+          serviceAccountToCreate: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+          managedServiceAccount: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+        },
+      };
+
+      // Stub applyUpserts to simulate a failed deployment for fn1
+      sinon.stub(fab, "applyUpserts").resolves([
+        {
+          endpoint,
+          durationMs: 100,
+          error: new Error("Deploy failed"),
+        },
+      ]);
+
+      const summary = await fab.applyPlan(deploymentPlan);
+
+      expect(summary.results.some((r) => r.error)).to.be.true;
+      expect(deleteServiceAccountStub).to.have.been.calledWith(
+        "test-project",
+        "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+      );
+    });
+
+    it("should NOT clean up SA on partial deployment success", async () => {
+      const endpoint1: backend.Endpoint = {
+        id: "fn1",
+        region: "us-central1",
+        project: "test-project",
+        platform: "gcfv1",
+        runtime: "nodejs18",
+        entryPoint: "fn1",
+        httpsTrigger: {},
+        codebase: "default",
+      };
+      const endpoint2: backend.Endpoint = {
+        id: "fn2",
+        region: "us-central1",
+        project: "test-project",
+        platform: "gcfv1",
+        runtime: "nodejs18",
+        entryPoint: "fn2",
+        httpsTrigger: {},
+        codebase: "default",
+      };
+
+      const deploymentPlan: planner.DeploymentPlan = {
+        default: {
+          regionalChangesets: {
+            "us-central1": {
+              endpointsToCreate: [endpoint1, endpoint2],
+              endpointsToUpdate: [],
+              endpointsToDelete: [],
+              endpointsToSkip: [],
+            },
+          },
+          serviceAccountToCreate: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+          managedServiceAccount: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
+        },
+      };
+
+      // Stub applyUpserts so endpoint1 succeeds and endpoint2 fails
+      sinon.stub(fab, "applyUpserts").resolves([
+        { endpoint: endpoint1, durationMs: 100 },
+        { endpoint: endpoint2, durationMs: 100, error: new Error("Deploy failed") },
+      ]);
+
+      await fab.applyPlan(deploymentPlan);
+
+      expect(deleteServiceAccountStub).to.not.have.been.calledWith(
         "test-project",
         "firebase-fn-123@my-proj.iam.gserviceaccount.com",
       );

--- a/src/deploy/functions/release/fabricator.ts
+++ b/src/deploy/functions/release/fabricator.ts
@@ -1,7 +1,13 @@
 import * as clc from "colorette";
 
-import { DEFAULT_RETRY_CODES, Executor } from "./executor";
+import {
+  Executor,
+  isCloudRunResourceExhausted,
+  isServiceAccount404,
+  isTransientError,
+} from "./executor";
 import { FirebaseError } from "../../../error";
+
 import { SourceTokenScraper } from "./sourceTokenScraper";
 import { Timer } from "./timer";
 import { assertExhaustive } from "../../../functional";
@@ -96,6 +102,7 @@ export class Fabricator {
   }
 
   async grantNewRoles(plan: planner.CodebasePlan, codebase: string): Promise<void> {
+    let createdSA = false;
     if (plan.serviceAccountToCreate) {
       utils.logLabeledBullet(
         "functions",
@@ -109,6 +116,7 @@ export class Fabricator {
           `Managed by Firebase CLI for codebase ${codebase}`,
           `Firebase Functions ${codebase}`,
         );
+        createdSA = true;
       } catch (e) {
         throw new FirebaseError(
           "Cannot enable declarative security because you do not have permissions necessary to create the service account. Please ask an IAM administrator to perform the next deploy.",
@@ -131,6 +139,16 @@ export class Fabricator {
           true, // skipAccountLookup
         );
       } catch (e) {
+        if (createdSA && plan.serviceAccountToCreate) {
+          try {
+            await iam.deleteServiceAccount(this.projectId, plan.serviceAccountToCreate);
+          } catch (cleanupErr) {
+            logger.debug(
+              "Failed to clean up newly created service account after role grant error",
+              cleanupErr,
+            );
+          }
+        }
         throw new FirebaseError(
           "The declarative security roles for this codebase have changed, but you do not have access to see what has changed. Please ask an IAM administrator to perform the next deploy.",
           { original: e as Error },
@@ -238,6 +256,8 @@ export class Fabricator {
       return acc;
     }, []);
 
+    await this.cleanupUnusedServiceAccounts(plan, summary.results);
+
     const hasFailures = summary.results.some((r) => r.error);
 
     if (hasFailures) {
@@ -282,6 +302,33 @@ export class Fabricator {
 
     summary.totalTime = timer.stop();
     return summary;
+  }
+
+  private async cleanupUnusedServiceAccounts(
+    plan: planner.DeploymentPlan,
+    results: reporter.DeployResult[],
+  ): Promise<void> {
+    for (const [codebase, codebasePlan] of Object.entries(plan)) {
+      if (!codebasePlan.serviceAccountToCreate) {
+        continue;
+      }
+      const codebaseSuccesses = results.filter((r) => r.endpoint.codebase === codebase && !r.error);
+      if (codebaseSuccesses.length > 0) {
+        continue;
+      }
+      utils.logLabeledWarning(
+        "functions",
+        `Cleaning up managed service account ${codebasePlan.serviceAccountToCreate} due to 100% deployment failure for codebase ${codebase}.`,
+      );
+      try {
+        await iam.deleteServiceAccount(this.projectId, codebasePlan.serviceAccountToCreate);
+      } catch (e) {
+        logger.debug(
+          `Failed to delete managed service account ${codebasePlan.serviceAccountToCreate} during failure cleanup`,
+          e,
+        );
+      }
+    }
   }
 
   async applyUpserts(
@@ -414,17 +461,20 @@ export class Fabricator {
       apiFunction.httpsTrigger.securityLevel = "SECURE_ALWAYS";
     }
     const resultFunction = await this.functionExecutor
-      .run(async () => {
-        // try to get the source token right before deploying
-        apiFunction.sourceToken = await scraper.getToken();
-        const op: { name: string } = await gcf.createFunction(apiFunction);
-        return poller.pollOperation<gcf.CloudFunction>({
-          ...gcfV1PollerOptions,
-          pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
-          operationResourceName: op.name,
-          onPoll: scraper.poller,
-        });
-      })
+      .run(
+        async () => {
+          // try to get the source token right before deploying
+          apiFunction.sourceToken = await scraper.getToken();
+          const op: { name: string } = await gcf.createFunction(apiFunction);
+          return poller.pollOperation<gcf.CloudFunction>({
+            ...gcfV1PollerOptions,
+            pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
+            operationResourceName: op.name,
+            onPoll: scraper.poller,
+          });
+        },
+        { retryPredicates: [isTransientError, isServiceAccount404] },
+      )
       .catch(rethrowAs<gcf.CloudFunction>(endpoint, "create"));
 
     endpoint.uri = resultFunction?.httpsTrigger?.url;
@@ -542,18 +592,21 @@ export class Fabricator {
     let resultFunction: gcfV2.OutputCloudFunction | null = null;
     while (!resultFunction) {
       resultFunction = await this.functionExecutor
-        .run(async () => {
-          if (experiments.isEnabled("functionsv2deployoptimizations")) {
-            apiFunction.buildConfig.sourceToken = await scraper.getToken();
-          }
-          const op: { name: string } = await gcfV2.createFunction(apiFunction);
-          return await poller.pollOperation<gcfV2.OutputCloudFunction>({
-            ...gcfV2PollerOptions,
-            pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
-            operationResourceName: op.name,
-            onPoll: scraper.poller,
-          });
-        })
+        .run(
+          async () => {
+            if (experiments.isEnabled("functionsv2deployoptimizations")) {
+              apiFunction.buildConfig.sourceToken = await scraper.getToken();
+            }
+            const op: { name: string } = await gcfV2.createFunction(apiFunction);
+            return await poller.pollOperation<gcfV2.OutputCloudFunction>({
+              ...gcfV2PollerOptions,
+              pollerName: `create-${endpoint.codebase}-${endpoint.region}-${endpoint.id}`,
+              operationResourceName: op.name,
+              onPoll: scraper.poller,
+            });
+          },
+          { retryPredicates: [isTransientError, isServiceAccount404] },
+        )
         .catch(async (err: any) => {
           // Abort waiting on source token so other concurrent calls don't get stuck
           scraper.abort();
@@ -703,7 +756,7 @@ export class Fabricator {
             onPoll: scraper.poller,
           });
         },
-        { retryCodes: [...DEFAULT_RETRY_CODES, CLOUD_RUN_RESOURCE_EXHAUSTED_CODE] },
+        { retryPredicates: [isTransientError, isCloudRunResourceExhausted, isServiceAccount404] },
       )
       .catch((err: any) => {
         scraper.abort();
@@ -781,7 +834,7 @@ export class Fabricator {
           };
           await poller.pollOperation<void>(pollerOptions);
         },
-        { retryCodes: [...DEFAULT_RETRY_CODES, CLOUD_RUN_RESOURCE_EXHAUSTED_CODE] },
+        { retryPredicates: [isTransientError, isCloudRunResourceExhausted, isServiceAccount404] },
       )
       .catch(rethrowAs(endpoint, "delete"));
   }
@@ -806,16 +859,19 @@ export class Fabricator {
     };
 
     await this.runFunctionExecutor
-      .run(async () => {
-        const op = await runV2.createService(
-          endpoint.project,
-          endpoint.region,
-          endpoint.id,
-          service,
-        );
-        endpoint.uri = op.uri;
-        endpoint.runServiceId = endpoint.id;
-      })
+      .run(
+        async () => {
+          const op = await runV2.createService(
+            endpoint.project,
+            endpoint.region,
+            endpoint.id,
+            service,
+          );
+          endpoint.uri = op.uri;
+          endpoint.runServiceId = endpoint.id;
+        },
+        { retryPredicates: [isTransientError, isServiceAccount404] },
+      )
       .catch(rethrowAs(endpoint, "create"));
 
     const serviceName = `projects/${endpoint.project}/locations/${endpoint.region}/services/${endpoint.runServiceId}`;


### PR DESCRIPTION
Fixes #10859 and #10860

To handle race conditions with SA propagation without polluting code everywhere, executor and throttler queue now accept retry predicates. Friendly predicate names are provided. I've opted to not have consts that are used repeatedly because isTransientError seems like a good thing to be able to read at the call site for what is retried.

To handle cleanup we've just extended the logic in fabricator.