### PR TITLE
Decode stream bodies once instead of per chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-﻿- Fixed `streamToString` corrupting multi-byte UTF-8 characters that span a stream chunk boundary.
+- Fixed `streamToString` corrupting multi-byte UTF-8 characters that span a stream chunk boundary.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+﻿- Fixed `streamToString` corrupting multi-byte UTF-8 characters that span a stream chunk boundary.

--- a/src/streamUtils.ts
+++ b/src/streamUtils.ts
@@ -25,11 +25,14 @@ export function streamToString(s?: NodeJS.ReadableStream | null): Promise<string
     return Promise.resolve("");
   }
   return new Promise((resolve, reject) => {
-    let b = "";
+    const chunks: Buffer[] = [];
     s.on("error", reject);
     s.on("data", (d: Buffer | string) => {
-      b += d.toString();
+      // Buffer the raw chunks and decode once at the end. Decoding each chunk
+      // on its own corrupts any multi-byte character that straddles a chunk
+      // boundary, turning it into replacement characters.
+      chunks.push(Buffer.isBuffer(d) ? d : Buffer.from(String(d), "utf8"));
     });
-    s.once("end", () => resolve(b));
+    s.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
   });
 }

--- a/src/streamUtils.ts
+++ b/src/streamUtils.ts
@@ -25,13 +25,13 @@ export function streamToString(s?: NodeJS.ReadableStream | null): Promise<string
     return Promise.resolve("");
   }
   return new Promise((resolve, reject) => {
-    const chunks: Buffer[] = [];
+    const chunks: Uint8Array[] = [];
     s.on("error", reject);
-    s.on("data", (d: Buffer | string) => {
+    s.on("data", (d: Buffer | string | Uint8Array) => {
       // Buffer the raw chunks and decode once at the end. Decoding each chunk
       // on its own corrupts any multi-byte character that straddles a chunk
       // boundary, turning it into replacement characters.
-      chunks.push(Buffer.isBuffer(d) ? d : Buffer.from(String(d), "utf8"));
+      chunks.push(d instanceof Uint8Array ? d : Buffer.from(String(d), "utf8"));
     });
     s.once("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
   });

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -308,6 +308,20 @@ describe("utils", () => {
 
       await expect(utils.streamToString(stream)).to.eventually.equal(text);
     });
+
+    it("should decode Uint8Array chunks", async () => {
+      // Object-mode streams, e.g. Readable.from(), hand back the chunks as they
+      // were supplied rather than coercing them to Buffer.
+      const text = "caf\u00e9 \u4e2d\u6587 \u{1F600}";
+      const buf = Buffer.from(text, "utf8");
+      const cut = buf.indexOf(Buffer.from("\u00e9", "utf8")) + 1;
+      const stream = Readable.from([
+        new Uint8Array(buf.subarray(0, cut)),
+        new Uint8Array(buf.subarray(cut)),
+      ]);
+
+      await expect(utils.streamToString(stream)).to.eventually.equal(text);
+    });
   });
 
   describe("allSettled", () => {

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -4,6 +4,7 @@ import * as sinon from "sinon";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
+import { Readable } from "stream";
 
 import * as utils from "./utils";
 import { FirebaseError } from "./error";
@@ -293,6 +294,19 @@ describe("utils", () => {
     it("should return empty string if stream is undefined or null", async () => {
       await expect(utils.streamToString(undefined)).to.eventually.equal("");
       await expect(utils.streamToString(null)).to.eventually.equal("");
+    });
+
+    it("should decode a multi-byte character split across chunks", async () => {
+      // "café 中文 😀" holds 2-, 3- and 4-byte UTF-8 characters.
+      const text = "caf\u00e9 \u4e2d\u6587 \u{1F600}";
+      const buf = Buffer.from(text, "utf8");
+      const cut = buf.indexOf(Buffer.from("\u00e9", "utf8")) + 1;
+      const stream = new Readable();
+      stream.push(buf.subarray(0, cut));
+      stream.push(buf.subarray(cut));
+      stream.push(null);
+
+      await expect(utils.streamToString(stream)).to.eventually.equal(text);
     });
   });
 


### PR DESCRIPTION
### Description

`streamToString` decodes each chunk on its own:

```ts
s.on("data", (d: Buffer | string) => {
  b += d.toString();
});
```

A UTF-8 character that straddles a chunk boundary is therefore split across two independent `toString()` calls, and each half decodes to replacement characters. Code points, so the difference is unambiguous:

| input | boundary falls inside | result |
| --- | --- | --- |
| `café` | `é` (2 bytes) | `U+FFFD U+FFFD` instead of `U+00E9` |
| `a中b` | `中` (3 bytes) | `U+FFFD U+FFFD U+FFFD` instead of `U+4E2D` |
| `hi😀there` | emoji (4 bytes) | `U+FFFD U+FFFD U+FFFD` instead of `U+1F600` |

Input that happens to be split on a character boundary, or that is pure ASCII, is unaffected — which is why the existing tests (`"hello world"`, `undefined`, `null`) pass.

This buffers the chunks and decodes once at the end.

### No known user-visible impact today

Worth being explicit, since it affects how you'd prioritise this. I could not reach the bug through a real command, and I looked:

- The `responseType: "json"` path calls `res.text()` → `streamToString`, but only when the undici branch is taken, which requires `compress: false`.
- Both callers that pass `compress: false` — `hosting/initMiddleware.ts` and `hosting/proxy.ts` — use `responseType: "stream"` and pipe the body, so they never call `text()`.
- The direct callers in `database-get.ts`, `downloadUtils.ts`, `profiler.ts` and `emulator/hubExport.ts` all read the body only behind `status >= 400`, and error bodies are normally small enough to arrive in one chunk.

So this is a latent bug in a shared helper (also re-exported from `utils.ts`) rather than something failing in the field. It would bite the first caller that reads a large non-ASCII body.

### Verification

Beyond the new unit test, I checked the behaviour against a real undici response: a local server that writes a body in two `write()` calls split inside `é`. undici delivered two data events (`[20, 15]`), and `streamToString` returned the corrupted string before this change and the correct one after.

Also covered, all passing: an empty stream, a single chunk, a stream with `setEncoding("utf8")` (so chunks arrive as strings), every byte pushed as its own chunk, and `error` events still rejecting. I ran the split-character case 20 times to confirm it isn't timing dependent.

`d instanceof Uint8Array ? d : Buffer.from(String(d), "utf8")` covers both `Buffer` (which extends `Uint8Array`) and raw `Uint8Array` chunks, and still stringifies anything else rather than throwing in `Buffer.concat`.

```console
$ npx mocha src/utils.spec.ts src/apiv2.spec.ts src/downloadUtils.spec.ts
111 passing, 1 failing
```

That one failure is pre-existing and unrelated — a timezone-dependent assertion (`expected '2020-02-23 00:05:45' to match /^2020-02-22 \d\d:35:45$/`); I'm on UTC+5:30. It fails identically on an unmodified checkout. With `src/streamUtils.ts` reverted the new test fails, so it does pin the fix.

`npm run test:compile` is clean, and `eslint` reports no errors on either changed file.

### Review follow-ups

Two commits on top of the original change:

- **`Uint8Array` chunks.** The review flagged that `Buffer.isBuffer()` is false for a plain `Uint8Array`, sending it down the `String(d)` path where it decodes to `"99,97,102,..."`. That's right, though it predates this PR — `d.toString()` on a `Uint8Array` produced the same comma-separated output before. Where it does and doesn't apply is worth being precise about: a non-object-mode stream converts `Uint8Array` to `Buffer` on `push()`, and so does `Readable.fromWeb()`, so ordinary byte streams were never affected. Object-mode streams like `Readable.from([...])` pass chunks through untouched, and those did corrupt. Now checks `instanceof Uint8Array`, which covers `Buffer` too, with a test built on `Readable.from()` that fails against the old check.
- **Changelog BOM.** My changelog line was written with a UTF-8 BOM. `prettier --check` accepts it either way and doesn't strip it, so it would have carried an invisible U+FEFF into the release notes. Removed.

Rechecked after both commits: `src/*.spec.ts` goes from 510 passing / 13 failing to 511 / 13 against the previous commit, the 13 being pre-existing Windows failures (symlink privileges, `unzip`, `.gitignore` handling) in unrelated files.
