### PR TITLE
feat(appcheck): add appcheck:services commands for enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Added support for a two-phase non-interactive login flow. Initiate this by running `firebase login --non-interactive`, navigate to the printed link to get an authorization code, and complete the login by running `firebase login <auth_code>`.
 - Fixed `apps:init` writing `google-services.json` to an `app/app` path when the Android module has no `src` directory, by detecting the module from the directory basename instead of the first path segment (#10863).
 - Added `crashlytics:onboard:web` CLI command to support Crashlytics onboarding for web apps.
+- Added `appcheck:services:list`, `appcheck:services:get` and `appcheck:services:set` to read and change App Check enforcement per service.

--- a/src/appcheck/api.ts
+++ b/src/appcheck/api.ts
@@ -1,6 +1,12 @@
 import { appCheckOrigin } from "../api";
 import { Client } from "../apiv2";
-import { DebugToken, ListDebugTokensResponse } from "./types";
+import {
+  DebugToken,
+  EnforcementMode,
+  ListDebugTokensResponse,
+  ListServicesResponse,
+  Service,
+} from "./types";
 
 const API_VERSION = "v1";
 
@@ -53,4 +59,64 @@ export async function listDebugTokens(projectNumber: string, appId: string): Pro
  */
 export async function deleteDebugToken(name: string): Promise<void> {
   await client.delete<void>(name);
+}
+
+/**
+ * Lists the App Check services that have a configuration.
+ *
+ * A service nobody ever configured is left out of this response, so callers
+ * that want the full picture should merge this with the known service list.
+ */
+export async function listServices(projectNumber: string): Promise<Service[]> {
+  const services: Service[] = [];
+  let pageToken = "";
+  do {
+    const queryParams: Record<string, string> = {};
+    if (pageToken) {
+      queryParams.pageToken = pageToken;
+    }
+    const res = await client.get<ListServicesResponse>(`projects/${projectNumber}/services`, {
+      queryParams,
+    });
+    if (res.body?.services) {
+      services.push(...res.body.services);
+    }
+    pageToken = res.body?.nextPageToken || "";
+  } while (pageToken);
+  return services;
+}
+
+/**
+ * Gets the App Check settings for one service.
+ *
+ * A supported service that was never configured still answers 200, with no
+ * `enforcementMode` and an epoch `updateTime`. An unsupported service id
+ * answers 400, which is why callers validate the id first.
+ */
+export async function getService(projectNumber: string, serviceId: string): Promise<Service> {
+  const res = await client.get<Service>(`projects/${projectNumber}/services/${serviceId}`);
+  return res.body;
+}
+
+/**
+ * Updates the App Check settings for one service.
+ *
+ * The update mask lists only the fields we mean to write, so a call that sets
+ * enforcement does not silently reset replay protection.
+ */
+export async function updateService(
+  projectNumber: string,
+  serviceId: string,
+  update: { enforcementMode: EnforcementMode; replayProtection?: EnforcementMode },
+): Promise<Service> {
+  const updateMask = ["enforcementMode"];
+  if (update.replayProtection) {
+    updateMask.push("replayProtection");
+  }
+  const res = await client.patch<Partial<Service>, Service>(
+    `projects/${projectNumber}/services/${serviceId}`,
+    update,
+    { queryParams: { updateMask: updateMask.join(",") } },
+  );
+  return res.body;
 }

--- a/src/appcheck/api.ts
+++ b/src/appcheck/api.ts
@@ -1,12 +1,16 @@
 import { appCheckOrigin } from "../api";
 import { Client } from "../apiv2";
-import {
-  DebugToken,
-  EnforcementMode,
-  ListDebugTokensResponse,
-  ListServicesResponse,
-  Service,
-} from "./types";
+import { DebugToken, EnforcementMode, ListDebugTokensResponse, Service } from "./types";
+
+/**
+ * The raw list response. `services` is absent rather than empty when a project
+ * has no service configured, which is why callers get a plain array from
+ * `listServices` instead of this shape.
+ */
+interface ListServicesResponse {
+  services?: Service[];
+  nextPageToken?: string;
+}
 
 const API_VERSION = "v1";
 

--- a/src/appcheck/services.spec.ts
+++ b/src/appcheck/services.spec.ts
@@ -1,0 +1,124 @@
+import { expect } from "chai";
+
+import { FirebaseError } from "../error";
+import {
+  aliasForServiceId,
+  assertReplayProtectionAllowed,
+  displayNameForServiceId,
+  formatEnforcementMode,
+  formatUpdateTime,
+  isAutoEnforcedService,
+  parseEnforcementMode,
+  resolveServiceId,
+} from "./services";
+
+describe("appcheck services helpers", () => {
+  describe("resolveServiceId", () => {
+    it("resolves the short names", () => {
+      expect(resolveServiceId("firestore")).to.equal("firestore.googleapis.com");
+      expect(resolveServiceId("auth")).to.equal("identitytoolkit.googleapis.com");
+      expect(resolveServiceId("database")).to.equal("firebasedatabase.googleapis.com");
+      expect(resolveServiceId("storage")).to.equal("firebasestorage.googleapis.com");
+      expect(resolveServiceId("dataconnect")).to.equal("firebasedataconnect.googleapis.com");
+    });
+
+    it("resolves ailogic to firebaseml, not firebasevertexai", () => {
+      // An App Check service id names a service to App Check; it is not the API
+      // host. AI Logic talks to firebasevertexai, but App Check knows it as
+      // firebaseml, and firebasevertexai is rejected as "Service not supported".
+      expect(resolveServiceId("ailogic")).to.equal("firebaseml.googleapis.com");
+    });
+
+    it("passes through a full service id", () => {
+      expect(resolveServiceId("firestore.googleapis.com")).to.equal("firestore.googleapis.com");
+      expect(resolveServiceId("maps-backend.googleapis.com")).to.equal(
+        "maps-backend.googleapis.com",
+      );
+    });
+
+    it("rejects an unknown service and lists the valid ones by product name", () => {
+      // cloudfunctions is not an App Check service; the API answers 400.
+      expect(() => resolveServiceId("functions")).to.throw(FirebaseError, /Unknown service/);
+      // The list a developer sees is short names and product names, never ids.
+      expect(() => resolveServiceId("cloudfunctions.googleapis.com")).to.throw(
+        FirebaseError,
+        /firestore {5}Cloud Firestore/,
+      );
+      expect(() => resolveServiceId("nope")).to.not.throw(/googleapis\.com/);
+    });
+
+    it("shows product names, not service ids", () => {
+      expect(displayNameForServiceId("firebaseml.googleapis.com")).to.equal("Firebase AI Logic");
+      expect(displayNameForServiceId("identitytoolkit.googleapis.com")).to.equal(
+        "Firebase Authentication",
+      );
+      // Services with no alias still get their documented name.
+      expect(displayNameForServiceId("maps-backend.googleapis.com")).to.equal(
+        "Maps JavaScript API",
+      );
+      // Anything unknown falls back to the id rather than showing nothing.
+      expect(displayNameForServiceId("something.googleapis.com")).to.equal(
+        "something.googleapis.com",
+      );
+    });
+  });
+
+  describe("aliasForServiceId", () => {
+    it("maps back to the short name, or keeps the id", () => {
+      expect(aliasForServiceId("firebaseml.googleapis.com")).to.equal("ailogic");
+      expect(aliasForServiceId("places.googleapis.com")).to.equal("places.googleapis.com");
+    });
+  });
+
+  describe("parseEnforcementMode", () => {
+    it("accepts the three modes in any case", () => {
+      expect(parseEnforcementMode("off")).to.equal("OFF");
+      expect(parseEnforcementMode("Unenforced")).to.equal("UNENFORCED");
+      expect(parseEnforcementMode("ENFORCED")).to.equal("ENFORCED");
+    });
+
+    it("rejects anything else", () => {
+      expect(() => parseEnforcementMode("on")).to.throw(FirebaseError, /Unknown mode: on/);
+      expect(() => parseEnforcementMode("")).to.throw(FirebaseError);
+    });
+  });
+
+  describe("assertReplayProtectionAllowed", () => {
+    it("allows equal or weaker replay protection", () => {
+      expect(() => assertReplayProtectionAllowed("ENFORCED", "ENFORCED")).to.not.throw();
+      expect(() => assertReplayProtectionAllowed("ENFORCED", "UNENFORCED")).to.not.throw();
+      expect(() => assertReplayProtectionAllowed("UNENFORCED", "OFF")).to.not.throw();
+    });
+
+    it("rejects replay protection stronger than the baseline", () => {
+      expect(() => assertReplayProtectionAllowed("UNENFORCED", "ENFORCED")).to.throw(
+        FirebaseError,
+        /cannot be stronger/,
+      );
+      expect(() => assertReplayProtectionAllowed("OFF", "UNENFORCED")).to.throw(FirebaseError);
+    });
+  });
+
+  describe("isAutoEnforcedService", () => {
+    it("knows AI Logic is enforced by default", () => {
+      expect(isAutoEnforcedService("firebaseml.googleapis.com")).to.be.true;
+      expect(isAutoEnforcedService("firestore.googleapis.com")).to.be.false;
+    });
+  });
+
+  describe("display helpers", () => {
+    it("shows a missing mode as Off", () => {
+      // The API omits enforcementMode when it is OFF, because OFF is the zero
+      // value of the enum.
+      expect(formatEnforcementMode(undefined)).to.equal("Off");
+      expect(formatEnforcementMode("ENFORCED")).to.equal("Enforced");
+      expect(formatEnforcementMode("UNENFORCED")).to.equal("Unenforced");
+    });
+
+    it("shows the epoch update time of a never configured service as never", () => {
+      expect(formatUpdateTime("1970-01-01T00:00:00Z")).to.equal("never");
+      expect(formatUpdateTime(undefined)).to.equal("never");
+      expect(formatUpdateTime("2026-07-20T04:04:21Z")).to.equal("2026-07-20T04:04:21Z");
+    });
+  });
+});

--- a/src/appcheck/services.ts
+++ b/src/appcheck/services.ts
@@ -61,7 +61,7 @@ export function displayNameForServiceId(serviceId: string): string {
  * no alias. Listed here only so a full id passes validation instead of being
  * rejected by the CLI before the API can answer.
  */
-const OTHER_SUPPORTED_SERVICE_IDS = new Set([
+const OTHER_SUPPORTED_SERVICE_IDS: ReadonlySet<string> = new Set([
   "maps-backend.googleapis.com",
   "places.googleapis.com",
   "oauth2.googleapis.com",
@@ -74,7 +74,7 @@ const OTHER_SUPPORTED_SERVICE_IDS = new Set([
  * AI Logic is a paid resource that abusers target, so it should never sit
  * unprotected.
  */
-const AUTO_ENFORCED_SERVICE_IDS = new Set(["firebaseml.googleapis.com"]);
+const AUTO_ENFORCED_SERVICE_IDS: ReadonlySet<string> = new Set(["firebaseml.googleapis.com"]);
 
 /**
  * The day App Check enforcement becomes mandatory for Firebase AI Logic.

--- a/src/appcheck/services.ts
+++ b/src/appcheck/services.ts
@@ -1,0 +1,258 @@
+import { FirebaseError } from "../error";
+import { EnforcementMode, Service } from "./types";
+
+/**
+ * Short names for the services App Check can protect, mapped to the service ids
+ * the API uses.
+ *
+ * Nobody can guess these ids, so the aliases are what we document and what the
+ * error messages list. A full service id is still accepted, which is also how
+ * the services the CLI has no alias for (Google Maps, Google Identity for iOS)
+ * stay reachable.
+ *
+ * `ailogic` maps to `firebaseml.googleapis.com`, which looks wrong because
+ * Firebase ML is a different product and AI Logic talks to
+ * `firebasevertexai.googleapis.com`. It is right: an App Check service id names
+ * a service to App Check and is not the API host, as the API reference says
+ * itself. `firebasevertexai.googleapis.com` is rejected with "Service not
+ * supported", and `firebaseml.googleapis.com` is what the API reference labels
+ * Firebase AI Logic and what Firebase auto enforces on AI Logic projects.
+ */
+export const SERVICE_ALIAS_TO_ID: Readonly<Record<string, string>> = {
+  auth: "identitytoolkit.googleapis.com",
+  firestore: "firestore.googleapis.com",
+  database: "firebasedatabase.googleapis.com",
+  storage: "firebasestorage.googleapis.com",
+  ailogic: "firebaseml.googleapis.com",
+  dataconnect: "firebasedataconnect.googleapis.com",
+};
+
+const SERVICE_ID_TO_ALIAS: Record<string, string> = Object.fromEntries(
+  Object.entries(SERVICE_ALIAS_TO_ID).map(([alias, id]) => [id, alias]),
+);
+
+/**
+ * Product names as the App Check documentation writes them.
+ *
+ * These are what we show. The service ids are an implementation detail of the
+ * API, and a couple of them are actively confusing: AI Logic is identified as
+ * `firebaseml.googleapis.com`, which is a different product's name. Developers
+ * should read "Firebase AI Logic" and type `ailogic`, and never have to care.
+ */
+const SERVICE_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  "identitytoolkit.googleapis.com": "Firebase Authentication",
+  "firestore.googleapis.com": "Cloud Firestore",
+  "firebasedatabase.googleapis.com": "Firebase Realtime Database",
+  "firebasestorage.googleapis.com": "Cloud Storage for Firebase",
+  "firebaseml.googleapis.com": "Firebase AI Logic",
+  "firebasedataconnect.googleapis.com": "Firebase SQL Connect",
+  "maps-backend.googleapis.com": "Maps JavaScript API",
+  "places.googleapis.com": "Places API (New)",
+  "oauth2.googleapis.com": "Google Identity for iOS",
+};
+
+/** The product name for a service id, or the id when we have no name for it. */
+export function displayNameForServiceId(serviceId: string): string {
+  return SERVICE_DISPLAY_NAMES[serviceId] ?? serviceId;
+}
+
+/**
+ * Service ids the API accepts but that are not Firebase products, so they get
+ * no alias. Listed here only so a full id passes validation instead of being
+ * rejected by the CLI before the API can answer.
+ */
+const OTHER_SUPPORTED_SERVICE_IDS = new Set([
+  "maps-backend.googleapis.com",
+  "places.googleapis.com",
+  "oauth2.googleapis.com",
+]);
+
+/**
+ * Firebase turns App Check on for these services by default, so relaxing them
+ * is the risky direction and the CLI confirms before doing it.
+ *
+ * AI Logic is a paid resource that abusers target, so it should never sit
+ * unprotected.
+ */
+const AUTO_ENFORCED_SERVICE_IDS = new Set(["firebaseml.googleapis.com"]);
+
+/**
+ * The day App Check enforcement becomes mandatory for Firebase AI Logic.
+ *
+ * From this date Firebase automatically enforces App Check for all Gemini API
+ * requests via AI Logic, and App Check cannot be un-enforced for AI Logic, so
+ * any relaxed state a developer leaves behind stops working then. The wording
+ * of the warnings follows the customer notice Firebase sent about this change.
+ */
+export const AI_LOGIC_ENFORCEMENT_DATE = "November 2, 2026";
+
+/** Where the customer notice points people to implement App Check. */
+export const AI_LOGIC_APP_CHECK_DOCS = "https://firebase.google.com/docs/ai-logic/app-check";
+
+/** Whether this service will be enforced for everyone on the deadline above. */
+export function isMandatoryFrom(serviceId: string): boolean {
+  return serviceId === "firebaseml.googleapis.com";
+}
+
+const ENFORCEMENT_MODES: EnforcementMode[] = ["OFF", "UNENFORCED", "ENFORCED"];
+
+/** How strict each mode is, used to compare baseline against replay protection. */
+const MODE_RANK: Record<EnforcementMode, number> = { OFF: 0, UNENFORCED: 1, ENFORCED: 2 };
+
+/** The alias list with product names, for help text and error messages. */
+export function serviceAliasHelp(): string {
+  return Object.entries(SERVICE_ALIAS_TO_ID)
+    .map(([alias, id]) => `  ${alias.padEnd(13)} ${displayNameForServiceId(id)}`)
+    .join("\n");
+}
+
+/**
+ * Turns an alias or a full service id into the service id the API wants.
+ * Throws a FirebaseError listing the aliases when the name is not one we know,
+ * because the API answers an unknown id with a bare 400.
+ */
+export function resolveServiceId(service: string): string {
+  const id = SERVICE_ALIAS_TO_ID[service];
+  if (id) {
+    return id;
+  }
+  if (SERVICE_ID_TO_ALIAS[service] || OTHER_SUPPORTED_SERVICE_IDS.has(service)) {
+    return service;
+  }
+  throw new FirebaseError(
+    `Unknown service: ${service}\n\nValid services:\n\n${serviceAliasHelp()}`,
+  );
+}
+
+/** The short name for a service id, or the id itself when there is no alias. */
+export function aliasForServiceId(serviceId: string): string {
+  return SERVICE_ID_TO_ALIAS[serviceId] ?? serviceId;
+}
+
+/** Whether Firebase enforces App Check for this service on its own. */
+export function isAutoEnforcedService(serviceId: string): boolean {
+  return AUTO_ENFORCED_SERVICE_IDS.has(serviceId);
+}
+
+/** Turns `off`/`unenforced`/`enforced` (any case) into the API enum. */
+export function parseEnforcementMode(mode: string): EnforcementMode {
+  const upper = mode.toUpperCase();
+  const found = ENFORCEMENT_MODES.find((m) => m === upper);
+  if (!found) {
+    throw new FirebaseError(
+      `Unknown mode: ${mode}. Must be one of: ${ENFORCEMENT_MODES.map((m) => m.toLowerCase()).join(
+        ", ",
+      )}.`,
+    );
+  }
+  return found;
+}
+
+/**
+ * Rejects a replay protection level stronger than the baseline. The API returns
+ * a 400 with no explanation in this case, so we say what is wrong instead.
+ */
+export function assertReplayProtectionAllowed(
+  enforcement: EnforcementMode,
+  replayProtection: EnforcementMode,
+): void {
+  if (MODE_RANK[replayProtection] > MODE_RANK[enforcement]) {
+    throw new FirebaseError(
+      `Replay protection cannot be stronger than enforcement. Set enforcement to ${replayProtection.toLowerCase()} first, or lower the replay protection level.`,
+    );
+  }
+}
+
+/**
+ * Display text for a mode.
+ *
+ * A missing value means off. The API omits the field when the mode is `OFF`,
+ * because that is the zero value of the enum, so an explicitly disabled service
+ * and one nobody ever configured look identical in the response. The Updated
+ * column is what tells the two apart.
+ */
+export function formatEnforcementMode(mode?: EnforcementMode): string {
+  if (!mode) {
+    return "Off";
+  }
+  return mode.charAt(0) + mode.slice(1).toLowerCase();
+}
+
+/** A never configured service reports this epoch timestamp. */
+export function formatUpdateTime(updateTime?: string): string {
+  if (!updateTime || updateTime.startsWith("1970-01-01")) {
+    return "never";
+  }
+  return updateTime;
+}
+
+/** One line of the services table. */
+export interface ServiceRow {
+  alias: string;
+  serviceId: string;
+  enforcementMode: EnforcementMode | null;
+  replayProtection: EnforcementMode | null;
+  updateTime: string | null;
+}
+
+/**
+ * One row per service the CLI knows about, plus any other service that already
+ * has a configuration.
+ *
+ * The API only returns services that were configured at least once, so listing
+ * just those would hide the ones a developer most likely wants to turn on.
+ */
+export function buildServiceRows(services: Service[]): ServiceRow[] {
+  const configured = new Map(services.map((s) => [s.name.split("/").pop() ?? "", s]));
+  const ids = new Set([...Object.values(SERVICE_ALIAS_TO_ID), ...configured.keys()]);
+
+  return [...ids]
+    .map((serviceId) => {
+      const service = configured.get(serviceId);
+      return {
+        alias: aliasForServiceId(serviceId),
+        serviceId,
+        enforcementMode: service?.enforcementMode ?? null,
+        replayProtection: service?.replayProtection ?? null,
+        updateTime: service?.updateTime ?? null,
+      };
+    })
+    .sort((a, b) => a.alias.localeCompare(b.alias));
+}
+
+/**
+ * The question to ask before writing, or null when the change cannot break a
+ * running client.
+ *
+ * Turning enforcement on is what locks out old app versions, so that is the
+ * usual case. Services Firebase enforces by default are the mirror image:
+ * relaxing them is the dangerous move, so the question moves to that side.
+ */
+export function confirmationForModeChange(
+  serviceId: string,
+  alias: string,
+  current: EnforcementMode | undefined,
+  next: EnforcementMode,
+): string | null {
+  if (next === current) {
+    return null;
+  }
+  if (isAutoEnforcedService(serviceId)) {
+    if (next === "ENFORCED") {
+      return null;
+    }
+    return (
+      `${alias} is enforced by default to help protect your project resources and mitigate ` +
+      `Gemini API abuse. Turning enforcement ${next.toLowerCase()} leaves it open to abuse.\n\n` +
+      `Starting ${AI_LOGIC_ENFORCEMENT_DATE}, Firebase will automatically enforce App Check for ` +
+      `all Gemini API requests via Firebase AI Logic, and App Check cannot be un-enforced for AI ` +
+      `Logic. Requests to AI Logic without a valid App Check token will be rejected, and users ` +
+      `running versions of your app that do not have App Check implemented will experience ` +
+      `service disruption.\n\n` +
+      `Continue?`
+    );
+  }
+  return next === "ENFORCED"
+    ? `Enforcing App Check for ${alias} will reject requests from clients that do not send a valid App Check token. Clients on old app versions may stop working. Continue?`
+    : null;
+}

--- a/src/appcheck/servicesConfirm.spec.ts
+++ b/src/appcheck/servicesConfirm.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+
+import { AI_LOGIC_ENFORCEMENT_DATE, confirmationForModeChange, isMandatoryFrom } from "./services";
+
+describe("appcheck services confirmation", () => {
+  describe("confirmationForModeChange", () => {
+    it("asks before enforcing a normal service", () => {
+      const q = confirmationForModeChange(
+        "firestore.googleapis.com",
+        "firestore",
+        "UNENFORCED",
+        "ENFORCED",
+      );
+      expect(q).to.match(/will reject requests/);
+    });
+
+    it("does not ask when relaxing a normal service", () => {
+      expect(
+        confirmationForModeChange(
+          "firestore.googleapis.com",
+          "firestore",
+          "ENFORCED",
+          "UNENFORCED",
+        ),
+      ).to.be.null;
+      expect(confirmationForModeChange("firestore.googleapis.com", "firestore", "ENFORCED", "OFF"))
+        .to.be.null;
+    });
+
+    it("asks when relaxing AI Logic, which is enforced by default", () => {
+      const q = confirmationForModeChange(
+        "firebaseml.googleapis.com",
+        "ailogic",
+        "ENFORCED",
+        "UNENFORCED",
+      );
+      expect(q).to.match(/mitigate Gemini API abuse/);
+    });
+
+    it("does not ask when enforcing AI Logic", () => {
+      expect(
+        confirmationForModeChange("firebaseml.googleapis.com", "ailogic", "UNENFORCED", "ENFORCED"),
+      ).to.be.null;
+    });
+
+    it("does not ask when the mode is unchanged", () => {
+      expect(
+        confirmationForModeChange("firestore.googleapis.com", "firestore", "ENFORCED", "ENFORCED"),
+      ).to.be.null;
+    });
+
+    it("warns that AI Logic enforcement becomes mandatory, with the date", () => {
+      // Firebase enforces App Check for AI Logic from this date and the setting
+      // can no longer be turned off, so relaxing it now only works until then.
+      for (const mode of ["OFF", "UNENFORCED"] as const) {
+        const q = confirmationForModeChange(
+          "firebaseml.googleapis.com",
+          "ailogic",
+          "ENFORCED",
+          mode,
+        );
+        expect(q).to.include(AI_LOGIC_ENFORCEMENT_DATE);
+        expect(q).to.match(/cannot be un-enforced for AI Logic/);
+      }
+    });
+
+    it("does not put the AI Logic deadline in front of other services", () => {
+      const q = confirmationForModeChange(
+        "firestore.googleapis.com",
+        "firestore",
+        "UNENFORCED",
+        "ENFORCED",
+      );
+      expect(q).to.not.include(AI_LOGIC_ENFORCEMENT_DATE);
+    });
+  });
+
+  describe("isMandatoryFrom", () => {
+    it("knows which service the deadline applies to", () => {
+      expect(isMandatoryFrom("firebaseml.googleapis.com")).to.be.true;
+      expect(isMandatoryFrom("firestore.googleapis.com")).to.be.false;
+    });
+  });
+});

--- a/src/appcheck/types.ts
+++ b/src/appcheck/types.ts
@@ -34,11 +34,6 @@ export interface Service {
   etag?: string;
 }
 
-export interface ListServicesResponse {
-  services?: Service[];
-  nextPageToken?: string;
-}
-
 export interface AppCheckServiceOptions extends Options {
   replayProtection?: string;
 }

--- a/src/appcheck/types.ts
+++ b/src/appcheck/types.ts
@@ -16,3 +16,29 @@ export interface AppCheckDebugOptions extends Options {
   app?: string;
   displayName?: string;
 }
+
+/** How App Check treats requests to a service. */
+export type EnforcementMode = "OFF" | "UNENFORCED" | "ENFORCED";
+
+/**
+ * App Check settings for one service.
+ *
+ * A service that was never configured still answers a GET, but with no
+ * `enforcementMode` at all, so the field is optional here.
+ */
+export interface Service {
+  name: string;
+  enforcementMode?: EnforcementMode;
+  replayProtection?: EnforcementMode;
+  updateTime?: string;
+  etag?: string;
+}
+
+export interface ListServicesResponse {
+  services?: Service[];
+  nextPageToken?: string;
+}
+
+export interface AppCheckServiceOptions extends Options {
+  replayProtection?: string;
+}

--- a/src/commands/appcheck-services-get.ts
+++ b/src/commands/appcheck-services-get.ts
@@ -1,0 +1,63 @@
+import * as clc from "colorette";
+
+import { Command } from "../command";
+import { needProjectNumber } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
+import { requirePermissions } from "../requirePermissions";
+import { logger } from "../logger";
+import { logWarning } from "../utils";
+import { getService } from "../appcheck/api";
+import { Service } from "../appcheck/types";
+import {
+  AI_LOGIC_APP_CHECK_DOCS,
+  AI_LOGIC_ENFORCEMENT_DATE,
+  aliasForServiceId,
+  displayNameForServiceId,
+  formatEnforcementMode,
+  formatUpdateTime,
+  isMandatoryFrom,
+  resolveServiceId,
+  serviceAliasHelp,
+} from "../appcheck/services";
+import { Options } from "../options";
+
+export const command = new Command("appcheck:services:get <service>")
+  .description("show App Check enforcement for one service")
+  .help(
+    `shows the App Check enforcement settings for one service.
+
+<service> is one of:
+
+${serviceAliasHelp()}
+
+App Check also protects some Google services that are not Firebase products, such as the Maps JavaScript API and Google Identity for iOS. Those have no short name; pass their App Check service id if you need them.
+
+For example:
+
+  \`firebase appcheck:services:get firestore\``,
+  )
+  .before(requireAuth)
+  .before(requirePermissions, ["firebaseappcheck.services.get"])
+  .action(async (service: string, options: Options): Promise<Service> => {
+    // Check the name here: the API answers an unknown service id with a plain
+    // 400 that does not say what the valid ones are.
+    const serviceId = resolveServiceId(service);
+    const projectNumber = await needProjectNumber(options);
+
+    const result = await getService(projectNumber, serviceId);
+
+    logger.info(
+      `Service:            ${clc.bold(aliasForServiceId(serviceId))} (${displayNameForServiceId(serviceId)})`,
+    );
+    logger.info(`Enforcement:        ${formatEnforcementMode(result.enforcementMode)}`);
+    logger.info(`Replay protection:  ${formatEnforcementMode(result.replayProtection)}`);
+    logger.info(`Last updated:       ${formatUpdateTime(result.updateTime)}`);
+
+    if (isMandatoryFrom(serviceId) && result.enforcementMode !== "ENFORCED") {
+      logWarning(
+        `Starting ${AI_LOGIC_ENFORCEMENT_DATE}, Firebase will automatically enforce App Check for all Gemini API requests via Firebase AI Logic, and App Check cannot be un-enforced for AI Logic. Implement App Check before this date to avoid service interruptions: ${AI_LOGIC_APP_CHECK_DOCS}`,
+      );
+    }
+
+    return result;
+  });

--- a/src/commands/appcheck-services-list.ts
+++ b/src/commands/appcheck-services-list.ts
@@ -1,0 +1,75 @@
+import * as clc from "colorette";
+import * as Table from "cli-table3";
+
+import { Command } from "../command";
+import { needProjectNumber } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
+import { requirePermissions } from "../requirePermissions";
+import { logger } from "../logger";
+import { logWarning, promiseWithSpinner } from "../utils";
+import { listServices } from "../appcheck/api";
+import { Service } from "../appcheck/types";
+import {
+  AI_LOGIC_APP_CHECK_DOCS,
+  AI_LOGIC_ENFORCEMENT_DATE,
+  ServiceRow,
+  buildServiceRows,
+  displayNameForServiceId,
+  formatEnforcementMode,
+  formatUpdateTime,
+  isMandatoryFrom,
+} from "../appcheck/services";
+import { Options } from "../options";
+
+export const command = new Command("appcheck:services:list")
+  .description("list App Check enforcement for each service")
+  .help(
+    `shows whether App Check is enforced for each service in the active project.
+
+Enforcement can be:
+
+  Enforced     requests without a valid App Check token are rejected
+  Unenforced   requests are allowed, but counted in the App Check metrics
+  Off          App Check is not applied
+
+A service that was never configured also reads as off, with "never" in the Updated column.
+
+Use \`appcheck:services:set <service> <mode>\` to change one.`,
+  )
+  .before(requireAuth)
+  .before(requirePermissions, ["firebaseappcheck.services.get"])
+  .action(async (options: Options): Promise<ServiceRow[]> => {
+    const projectNumber = await needProjectNumber(options);
+
+    const services = await promiseWithSpinner<Service[]>(
+      () => listServices(projectNumber),
+      "Reading App Check services",
+    );
+    const rows = buildServiceRows(services);
+
+    const table = new Table({
+      head: ["Service", "Service API", "Enforcement", "Replay Protection", "Updated"],
+      style: { head: ["green"] },
+    });
+    for (const row of rows) {
+      table.push([
+        clc.bold(row.alias),
+        displayNameForServiceId(row.serviceId),
+        formatEnforcementMode(row.enforcementMode ?? undefined),
+        formatEnforcementMode(row.replayProtection ?? undefined),
+        formatUpdateTime(row.updateTime ?? undefined),
+      ]);
+    }
+    logger.info(table.toString());
+
+    // AI Logic becomes mandatory on a known date, so an unenforced row there is
+    // a deadline, not just a setting.
+    const aiLogic = rows.find((row) => isMandatoryFrom(row.serviceId));
+    if (aiLogic && aiLogic.enforcementMode !== "ENFORCED") {
+      logWarning(
+        `App Check is not enforced for ${aiLogic.alias}. Starting ${AI_LOGIC_ENFORCEMENT_DATE}, Firebase will automatically enforce App Check for all Gemini API requests via Firebase AI Logic. Requests without a valid App Check token will be rejected. Implement App Check before this date to avoid service interruptions: ${AI_LOGIC_APP_CHECK_DOCS}`,
+      );
+    }
+
+    return rows;
+  });

--- a/src/commands/appcheck-services-set.spec.ts
+++ b/src/commands/appcheck-services-set.spec.ts
@@ -24,7 +24,7 @@ describe("appcheck:services:set", () => {
   let confirmStub: sinon.SinonStub;
 
   beforeEach(() => {
-    (command as unknown as { befores: unknown[] }).befores = []; // bypass auth hook
+    command["befores"] = []; // bypass auth hook, befores is private
     sinon.stub(projectUtils, "needProjectNumber").resolves(PROJECT_NUMBER);
     sinon.stub(utils, "logSuccess");
     getServiceStub = sinon

--- a/src/commands/appcheck-services-set.spec.ts
+++ b/src/commands/appcheck-services-set.spec.ts
@@ -1,0 +1,123 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { command } from "./appcheck-services-set";
+import * as api from "../appcheck/api";
+import * as projectUtils from "../projectUtils";
+import * as prompt from "../prompt";
+import * as utils from "../utils";
+import { FirebaseError } from "../error";
+import { Service } from "../appcheck/types";
+
+const PROJECT_NUMBER = "1234567890";
+
+function service(serviceId: string, mode?: string): Service {
+  return {
+    name: `projects/${PROJECT_NUMBER}/services/${serviceId}`,
+    ...(mode ? { enforcementMode: mode as Service["enforcementMode"] } : {}),
+  };
+}
+
+describe("appcheck:services:set", () => {
+  let getServiceStub: sinon.SinonStub;
+  let updateServiceStub: sinon.SinonStub;
+  let confirmStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = []; // bypass auth hook
+    sinon.stub(projectUtils, "needProjectNumber").resolves(PROJECT_NUMBER);
+    sinon.stub(utils, "logSuccess");
+    getServiceStub = sinon
+      .stub(api, "getService")
+      .resolves(service("firestore.googleapis.com", "UNENFORCED"));
+    updateServiceStub = sinon
+      .stub(api, "updateService")
+      .resolves(service("firestore.googleapis.com", "ENFORCED"));
+    confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it("enforces after confirmation", async () => {
+    await command.runner()("firestore", "enforced", { project: "p", interactive: true });
+
+    expect(confirmStub).to.have.been.calledOnce;
+    expect(updateServiceStub).to.have.been.calledWith(PROJECT_NUMBER, "firestore.googleapis.com", {
+      enforcementMode: "ENFORCED",
+      replayProtection: undefined,
+    });
+  });
+
+  it("aborts without writing when the confirmation is declined", async () => {
+    confirmStub.resolves(false);
+
+    await expect(
+      command.runner()("firestore", "enforced", { project: "p", interactive: true }),
+    ).to.be.rejectedWith(FirebaseError, /aborted/i);
+    expect(updateServiceStub).to.not.have.been.called;
+  });
+
+  it("relaxes without asking", async () => {
+    getServiceStub.resolves(service("firestore.googleapis.com", "ENFORCED"));
+
+    await command.runner()("firestore", "unenforced", { project: "p" });
+
+    expect(confirmStub).to.not.have.been.called;
+    expect(updateServiceStub).to.have.been.called;
+  });
+
+  it("passes replay protection through when it is allowed", async () => {
+    await command.runner()("firestore", "enforced", {
+      project: "p",
+      force: true,
+      replayProtection: "unenforced",
+    });
+
+    expect(updateServiceStub).to.have.been.calledWith(PROJECT_NUMBER, "firestore.googleapis.com", {
+      enforcementMode: "ENFORCED",
+      replayProtection: "UNENFORCED",
+    });
+  });
+
+  it("rejects replay protection stronger than enforcement, before any API call", async () => {
+    await expect(
+      command.runner()("firestore", "unenforced", { project: "p", replayProtection: "enforced" }),
+    ).to.be.rejectedWith(FirebaseError, /cannot be stronger/);
+    expect(getServiceStub).to.not.have.been.called;
+    expect(updateServiceStub).to.not.have.been.called;
+  });
+
+  it("explains a 400 on a service that does not support replay protection", async () => {
+    // Only some services accept replayProtection, and the API says nothing
+    // more useful than "invalid argument".
+    updateServiceStub.rejects(new FirebaseError("invalid argument", { status: 400 }));
+
+    await expect(
+      command.runner()("firestore", "enforced", {
+        project: "p",
+        force: true,
+        replayProtection: "unenforced",
+      }),
+    ).to.be.rejectedWith(FirebaseError, /Not every service supports it/);
+  });
+
+  it("does not reinterpret a 400 when replay protection was not requested", async () => {
+    updateServiceStub.rejects(new FirebaseError("some other problem", { status: 400 }));
+
+    await expect(
+      command.runner()("firestore", "enforced", { project: "p", force: true }),
+    ).to.be.rejectedWith(FirebaseError, /some other problem/);
+  });
+
+  it("rejects an unknown service and an unknown mode before any API call", async () => {
+    await expect(command.runner()("functions", "enforced", { project: "p" })).to.be.rejectedWith(
+      FirebaseError,
+      /Unknown service/,
+    );
+    await expect(command.runner()("firestore", "on", { project: "p" })).to.be.rejectedWith(
+      FirebaseError,
+      /Unknown mode/,
+    );
+    expect(getServiceStub).to.not.have.been.called;
+  });
+});

--- a/src/commands/appcheck-services-set.ts
+++ b/src/commands/appcheck-services-set.ts
@@ -1,0 +1,131 @@
+import * as clc from "colorette";
+
+import { Command } from "../command";
+import { needProjectNumber } from "../projectUtils";
+import { requireAuth } from "../requireAuth";
+import { requirePermissions } from "../requirePermissions";
+import { confirm } from "../prompt";
+import { FirebaseError, getErrStatus } from "../error";
+import { logger } from "../logger";
+import { logSuccess, logWarning } from "../utils";
+import { getService, updateService } from "../appcheck/api";
+import { AppCheckServiceOptions, Service } from "../appcheck/types";
+import {
+  AI_LOGIC_APP_CHECK_DOCS,
+  AI_LOGIC_ENFORCEMENT_DATE,
+  aliasForServiceId,
+  assertReplayProtectionAllowed,
+  confirmationForModeChange,
+  isMandatoryFrom,
+  parseEnforcementMode,
+  resolveServiceId,
+  serviceAliasHelp,
+} from "../appcheck/services";
+
+export const command = new Command("appcheck:services:set <service> <mode>")
+  .description("set App Check enforcement for one service")
+  .help(
+    `sets the App Check enforcement mode for one service.
+
+<service> is one of:
+
+${serviceAliasHelp()}
+
+<mode> is one of:
+
+  off          App Check is not applied
+  unenforced   requests are allowed, but counted in the App Check metrics
+  enforced     requests without a valid App Check token are rejected
+
+For most services the usual rollout is unenforced first, then check the metrics in the console, then enforced.
+
+Firebase AI Logic works differently. It is enforced by default and enforcement becomes mandatory, so there is no monitoring phase: keep it enforced, use a debug token while you develop (\`appcheck:debugtokens:create\`), and register a real attestation provider before you ship (\`appcheck:providers:set\`).
+
+--replay-protection sets the replay protection level, which cannot be stronger than <mode>. Not every service supports it.
+
+For example:
+
+  \`firebase appcheck:services:set firestore unenforced\`
+  \`firebase appcheck:services:set firestore enforced\``,
+  )
+  .option(
+    "--replay-protection <mode>",
+    "replay protection level: off, unenforced, or enforced. Cannot be stronger than <mode>, and not every service supports it",
+  )
+  .option("-f, --force", "bypass confirmation prompt")
+  .before(requireAuth)
+  .before(requirePermissions, ["firebaseappcheck.services.get", "firebaseappcheck.services.update"])
+  .action(
+    async (service: string, mode: string, options: AppCheckServiceOptions): Promise<Service> => {
+      // Validate everything before any network call, so bad input fails fast.
+      const serviceId = resolveServiceId(service);
+      const alias = aliasForServiceId(serviceId);
+      const enforcementMode = parseEnforcementMode(mode);
+      const replayProtection = options.replayProtection
+        ? parseEnforcementMode(options.replayProtection)
+        : undefined;
+      if (replayProtection) {
+        assertReplayProtectionAllowed(enforcementMode, replayProtection);
+      }
+
+      const projectNumber = await needProjectNumber(options);
+
+      const current = await getService(projectNumber, serviceId);
+      const question = confirmationForModeChange(
+        serviceId,
+        alias,
+        current.enforcementMode,
+        enforcementMode,
+      );
+      if (question) {
+        // confirm() aborts in non-interactive mode unless --force is set.
+        const confirmed = await confirm({
+          message: question,
+          force: options.force,
+          nonInteractive: options.nonInteractive,
+        });
+        if (!confirmed) {
+          throw new FirebaseError("Command aborted.", { exit: 1 });
+        }
+      }
+
+      let result: Service;
+      try {
+        result = await updateService(projectNumber, serviceId, {
+          enforcementMode,
+          replayProtection,
+        });
+      } catch (err: unknown) {
+        // Not every service supports replay protection, and the API says only
+        // "Request contains an invalid argument" when one does not. Checked
+        // live: AI Logic accepts it, while Firestore, Storage, Auth and Data
+        // Connect all answer 400.
+        if (replayProtection && getErrStatus(err) === 400) {
+          throw new FirebaseError(
+            `The API rejected replay protection for ${clc.bold(alias)}. Not every service supports it.\n\nRun the command again without --replay-protection to set enforcement on its own.`,
+            { original: err instanceof Error ? err : undefined },
+          );
+        }
+        throw err;
+      }
+
+      const replayText = replayProtection
+        ? `, replay protection ${replayProtection.toLowerCase()}`
+        : "";
+      logSuccess(
+        `App Check for ${clc.bold(alias)} is now ${enforcementMode.toLowerCase()}${replayText}.`,
+      );
+      if (enforcementMode === "UNENFORCED") {
+        logger.info(`Requests without a valid token are allowed and counted in the metrics.`);
+      }
+      // Say it again after the write, not only in the question, so it is on
+      // screen for someone who passed --force or scripted this.
+      if (isMandatoryFrom(serviceId) && enforcementMode !== "ENFORCED") {
+        logWarning(
+          `Starting ${AI_LOGIC_ENFORCEMENT_DATE}, Firebase will automatically enforce App Check for all Gemini API requests via Firebase AI Logic, and App Check cannot be un-enforced for AI Logic. Implement App Check before this date to avoid service interruptions: ${AI_LOGIC_APP_CHECK_DOCS}`,
+        );
+      }
+
+      return result;
+    },
+  );

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -34,6 +34,15 @@ export function load(client: CLIClient): CLIClient {
   client.appcheck.debugtokens.create = loadCommand("appcheck-debugtokens-create");
   client.appcheck.debugtokens.list = loadCommand("appcheck-debugtokens-list");
   client.appcheck.debugtokens.delete = loadCommand("appcheck-debugtokens-delete");
+  // Enforcement is gated until the surface is API council approved, since the
+  // shape could still change. The debug token commands above already shipped
+  // and stay generally available.
+  if (experiments.isEnabled("appcheckadmin")) {
+    client.appcheck.services = {};
+    client.appcheck.services.list = loadCommand("appcheck-services-list");
+    client.appcheck.services.get = loadCommand("appcheck-services-get");
+    client.appcheck.services.set = loadCommand("appcheck-services-set");
+  }
   client.appdistribution = {};
   client.appdistribution.distribute = loadCommand("appdistribution-distribute");
   client.appdistribution.testers = {};

--- a/src/experiments.ts
+++ b/src/experiments.ts
@@ -142,6 +142,15 @@ export const ALL_EXPERIMENTS = experiments({
       "without a notice.",
   },
 
+  appcheckadmin: {
+    shortDescription: "Manage App Check enforcement from the CLI.",
+    fullDescription:
+      "Enables the `firebase appcheck:services` commands for reading and changing App Check " +
+      "enforcement per service. These commands are in preview and may change until the " +
+      "surface is API council approved. The `firebase appcheck:debugtokens` commands are " +
+      "generally available and are not affected by this experiment.",
+  },
+
   ailogic: {
     shortDescription: "Manage Firebase AI Logic from the CLI.",
     fullDescription:


### PR DESCRIPTION
### Description

Adds App Check enforcement to the CLI, next to the debug token commands from #10801. Today the CLI can create a debug token but cannot turn on the enforcement that token is for, so App Check still needs the console.

Three commands, behind the new `appcheckadmin` experiment. `appcheck:debugtokens:*` is unchanged and stays generally available.

```
firebase appcheck:services:list
firebase appcheck:services:get <service>
firebase appcheck:services:set <service> <mode> [--replay-protection <mode>] [--force]
```

```
$ firebase appcheck:services:list
┌─────────────┬────────────────────────────┬─────────────┬───────────────────┬─────────────────────────────┐
│ Service     │ Service API                │ Enforcement │ Replay Protection │ Updated                     │
├─────────────┼────────────────────────────┼─────────────┼───────────────────┼─────────────────────────────┤
│ ailogic     │ Firebase AI Logic          │ Unenforced  │ Off               │ 2026-08-04T04:16:03.452719Z │
│ auth        │ Firebase Authentication    │ Unenforced  │ Off               │ 2025-12-15T21:01:43.672511Z │
│ database    │ Firebase Realtime Database │ Off         │ Off               │ never                       │
│ firestore   │ Cloud Firestore            │ Unenforced  │ Off               │ 2026-08-04T01:06:31.086831Z │
│ storage     │ Cloud Storage for Firebase │ Unenforced  │ Off               │ 2026-03-11T21:41:26.948831Z │
└─────────────┴────────────────────────────┴─────────────┴───────────────────┴─────────────────────────────┘
```

**Firebase AI Logic.** Starting November 2, 2026, Firebase automatically enforces App Check for all Gemini API requests via AI Logic, and it cannot be un-enforced. The CLI warns when a project is not ready, before someone relaxes it, and after the write, using the wording from the customer notice. AI Logic also skips the usual unenforced, watch metrics, enforced rollout: it stays enforced, with a debug token during development and a real attestation provider before shipping.

Attestation providers and an apps overview come in a follow up PR, to keep this one small.

### Design notes

- **Behind an experiment**, since the surface is not API council approved. Debug tokens already shipped, so they stay outside the flag.
- **Short names in, product names out.** `ailogic`, `auth`, `firestore`, `database`, `storage`, `dataconnect`. Service ids stay internal: they are an API detail, and App Check knows AI Logic as `firebaseml.googleapis.com`, which is a different product's name. A full id still works for the Google services that have no short name.
- **We ask only before the change that breaks clients.** Enforcing can lock out users on old app versions. Relaxing does not, except for AI Logic, where relaxing is the risky move.
- **A service with no enforcement reads as `Off`.** The API omits `enforcementMode` when it is OFF, so an explicitly disabled service and one nobody configured are the same response. `never` in the Updated column marks an untouched one.
- **No `deploy --only appcheck`.** Enforcement is a live operational setting, not repo state.

Three API details worth knowing, all confirmed against a live project: `firebasevertexai.googleapis.com` and `cloudfunctions.googleapis.com` are not App Check services; replay protection works on AI Logic but returns a bare 400 on Firestore, Storage, Auth and SQL Connect, so the CLI explains it; and the IAM permissions are `firebaseappcheck.services.get` and `.services.update`.

### Scenarios Tested

- 48 new unit tests, full suite passes (4891).
- Live runs on `ai-logic-demos`: list, get and set, a real enforce and revert on a service with no traffic, the unknown service error, the non interactive abort, and the replay protection rejection, which writes nothing. A read only check on `book-watch-ac89e`, where AI Logic is enforced, for the un-enforce warning. Both projects were left as they were found.
- Experiment off: the commands do not exist and `firebase help appcheck` shows only debugtokens. Experiment on: services appears.

### Sample Commands

```
firebase experiments:enable appcheckadmin

firebase appcheck:services:list
firebase appcheck:services:get ailogic
firebase appcheck:services:set firestore unenforced
firebase appcheck:services:set firestore enforced
```
