### PR TITLE
feat(functions): improve parameter prompting clarity for multi-codebase deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 - Added `appcheck:apps:list` to show every app with its configured App Check providers.
 - Added web app support for Crashlytics MCP tools and prompts.
 - Added support for forwarding custom HTTP headers (`Mcp-Param-*`) to remote MCP tools when defined in tool parameter input schemas (`x-mcp-header`), per [SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization).
+- Improved function parameter prompting clarity for multi-codebase deploys (#10897)

--- a/src/deploy/functions/build.ts
+++ b/src/deploy/functions/build.ts
@@ -339,6 +339,7 @@ interface ResolveBackendOpts {
   build: Build;
   firebaseConfig: FirebaseConfig;
   userEnvs: Record<string, string>;
+  codebase: string;
   nonInteractive?: boolean;
   isEmulator?: boolean;
   force?: boolean;
@@ -357,6 +358,7 @@ export async function resolveBackend(opts: ResolveBackendOpts): Promise<{
     opts.build.params,
     opts.firebaseConfig,
     envWithTypes(opts.build.params, opts.userEnvs),
+    opts.codebase,
     opts.nonInteractive,
     opts.force,
     opts.isEmulator,

--- a/src/deploy/functions/params.spec.ts
+++ b/src/deploy/functions/params.spec.ts
@@ -5,6 +5,8 @@ import * as prompt from "../../prompt";
 import * as params from "./params";
 import * as secretManager from "../../gcp/secretManager";
 import { FirebaseError } from "../../error";
+import * as utils from "../../utils";
+import { logger } from "../../logger";
 
 const expect = chai.expect;
 const fakeConfig = {
@@ -78,20 +80,27 @@ describe("CEL resolution", () => {
 
 describe("resolveParams", () => {
   let input: sinon.SinonStub;
+  let logBulletStub: sinon.SinonStub;
+
+  let loggerInfoStub: sinon.SinonStub;
 
   beforeEach(() => {
     input = sinon.stub(prompt, "input");
+    logBulletStub = sinon.stub(utils, "logBullet");
+    loggerInfoStub = sinon.stub(logger, "info");
   });
 
   afterEach(() => {
     input.restore();
+    logBulletStub.restore();
+    loggerInfoStub.restore();
   });
 
   it("always contains the precanned internal param values", async () => {
     const paramsToResolve: params.Param[] = [];
     const userEnv: Record<string, params.ParamValue> = {};
     expect(
-      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv)).paramValues,
+      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv, "default")).paramValues,
     ).to.deep.equal(expectedInternalParams);
   });
 
@@ -112,7 +121,7 @@ describe("resolveParams", () => {
       baz: new params.ParamValue("true", false, { string: false, number: false, boolean: true }),
     };
     expect(
-      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv)).paramValues,
+      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv, "default")).paramValues,
     ).to.deep.equal(
       Object.assign(
         {
@@ -139,7 +148,7 @@ describe("resolveParams", () => {
       }),
     };
     expect(
-      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv)).paramValues,
+      (await params.resolveParams(paramsToResolve, fakeConfig, userEnv, "default")).paramValues,
     ).to.deep.equal({
       DATABASE_URL: new params.ParamValue(fakeConfig.databaseURL, true, {
         string: true,
@@ -173,6 +182,7 @@ describe("resolveParams", () => {
           paramsToResolve,
           { locationId: "", projectId: "foo", storageBucket: "", databaseURL: "" },
           userEnv,
+          "default",
         )
       ).paramValues,
     ).to.deep.equal({
@@ -191,7 +201,9 @@ describe("resolveParams", () => {
       },
     ];
     input.resolves("bar");
-    expect((await params.resolveParams(paramsToResolve, fakeConfig, {})).paramValues).to.deep.equal(
+    expect(
+      (await params.resolveParams(paramsToResolve, fakeConfig, {}, "default")).paramValues,
+    ).to.deep.equal(
       Object.assign(
         {
           foo: new params.ParamValue("bar", false, { string: true }),
@@ -217,7 +229,7 @@ describe("resolveParams", () => {
       },
     ];
     input.resolves("baz");
-    await params.resolveParams(paramsToResolve, fakeConfig, {});
+    await params.resolveParams(paramsToResolve, fakeConfig, {}, "default");
     expect(input.getCall(1).args[0].default).to.eq("baz");
   });
 
@@ -237,7 +249,7 @@ describe("resolveParams", () => {
       },
     ];
     input.resolves("baz");
-    await params.resolveParams(paramsToResolve, fakeConfig, {});
+    await params.resolveParams(paramsToResolve, fakeConfig, {}, "default");
     expect(input.getCall(1).args[0].default).to.eq("baz/quox");
   });
 
@@ -263,7 +275,7 @@ describe("resolveParams", () => {
       },
     ];
     input.resolves("baz");
-    await params.resolveParams(paramsToResolve, fakeConfig, {});
+    await params.resolveParams(paramsToResolve, fakeConfig, {}, "default");
     expect(input.getCall(0).args[0].default).to.eq("https://foo.firebaseio.com/quox");
     expect(input.getCall(1).args[0].default).to.eq("projectID: foo");
     expect(input.getCall(2).args[0].default).to.eq(
@@ -281,7 +293,8 @@ describe("resolveParams", () => {
       },
     ];
     input.resolves("");
-    await expect(params.resolveParams(paramsToResolve, fakeConfig, {})).to.eventually.be.rejected;
+    await expect(params.resolveParams(paramsToResolve, fakeConfig, {}, "default")).to.eventually.be
+      .rejected;
   });
 
   it("errors when the default is a CEL expression that resolves to the wrong type", async () => {
@@ -300,7 +313,8 @@ describe("resolveParams", () => {
       },
     ];
     input.resolves("22");
-    await expect(params.resolveParams(paramsToResolve, fakeConfig, {})).to.eventually.be.rejected;
+    await expect(params.resolveParams(paramsToResolve, fakeConfig, {}, "default")).to.eventually.be
+      .rejected;
   });
 
   it("does not throw in non-interactive mode if secret exists in cloud", async () => {
@@ -310,7 +324,8 @@ describe("resolveParams", () => {
       secretVersion: { versionId: "1", state: "ENABLED", secret: {} as any },
     });
 
-    await expect(params.resolveParams(paramsToResolve, fakeConfig, {}, true)).to.be.fulfilled;
+    await expect(params.resolveParams(paramsToResolve, fakeConfig, {}, "default", true)).to.be
+      .fulfilled;
 
     getSecretMetadataStub.restore();
   });
@@ -321,10 +336,9 @@ describe("resolveParams", () => {
       secret: undefined,
     });
 
-    await expect(params.resolveParams(paramsToResolve, fakeConfig, {}, true)).to.be.rejectedWith(
-      FirebaseError,
-      /In non-interactive mode but have no value for the secret/,
-    );
+    await expect(
+      params.resolveParams(paramsToResolve, fakeConfig, {}, "default", true),
+    ).to.be.rejectedWith(FirebaseError, /In non-interactive mode but have no value for the secret/);
 
     getSecretMetadataStub.restore();
   });
@@ -333,9 +347,24 @@ describe("resolveParams", () => {
     const paramsToResolve: params.Param[] = [{ name: "MY_SECRET", type: "secret" }];
     const getSecretMetadataSpy = sinon.spy(secretManager, "getSecretMetadata");
 
-    await params.resolveParams(paramsToResolve, fakeConfig, {}, false, false, true);
+    await params.resolveParams(paramsToResolve, fakeConfig, {}, "default", false, false, true);
     expect(getSecretMetadataSpy.called).to.be.false;
 
     getSecretMetadataSpy.restore();
+  });
+
+  it("should print a header when prompting for a codebase", async () => {
+    const paramsToResolve: params.Param[] = [
+      {
+        name: "foo",
+        type: "string",
+        input: { text: {} },
+      },
+    ];
+    input.resolves("bar");
+    await params.resolveParams(paramsToResolve, fakeConfig, {}, "my-codebase");
+    expect(
+      loggerInfoStub.calledWith(sinon.match(/Prompting for parameters for codebase.*my-codebase/)),
+    ).to.be.true;
   });
 });

--- a/src/deploy/functions/params.ts
+++ b/src/deploy/functions/params.ts
@@ -1,3 +1,4 @@
+import * as clc from "colorette";
 import { logger } from "../../logger";
 import { FirebaseError } from "../../error";
 import { checkbox, input, password, select } from "../../prompt";
@@ -397,6 +398,7 @@ export async function resolveParams(
   params: Param[],
   firebaseConfig: FirebaseConfig,
   userEnvs: Record<string, ParamValue>,
+  codebase: string,
   nonInteractive?: boolean,
   force?: boolean,
   isEmulator = false,
@@ -433,6 +435,9 @@ export async function resolveParams(
         "To continue, either run `firebase deploy` with an interactive terminal, or add values to a dotenv file. " +
         "For information regarding how to use dotenv files, see https://firebase.google.com/docs/functions/config-env",
     );
+  }
+  if (needPrompt.length > 0) {
+    logger.info(`Prompting for parameters for codebase ${clc.bold(codebase)}:`);
   }
   for (const param of needPrompt) {
     const promptable = param as Exclude<Param, SecretParam>;

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -292,6 +292,7 @@ export async function prepare(
       functionsSource: options.config.path(localCfg.source),
       projectId: projectId,
       projectAlias: options.projectAlias,
+      projectDir: options.config.projectDir,
     };
     if (isKitConfig(localCfg) && codebase in localCfg.instances) {
       userEnvOpt.configDir = options.config.path(localCfg.instances[codebase]);
@@ -321,6 +322,7 @@ export async function prepare(
       build: wantBuild,
       firebaseConfig,
       userEnvs,
+      codebase,
       nonInteractive: options.nonInteractive,
       force: options.force,
       isEmulator: false,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -613,6 +613,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         projectAlias: this.args.projectAlias,
         isEmulator: true,
         configDir: emulatableBackend.configDir,
+        projectDir: this.args.projectDir,
       };
       const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
       const discoveredBuild = await runtimeDelegate.discoverBuild(runtimeConfig, environment);
@@ -628,6 +629,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         build: discoveredBuild,
         firebaseConfig: JSON.parse(firebaseConfig),
         userEnvs,
+        codebase: emulatableBackend.codebase,
         nonInteractive: false,
         isEmulator: true,
       });
@@ -1476,6 +1478,7 @@ export class FunctionsEmulator implements EmulatorInstance {
       projectId: this.args.projectId,
       projectAlias: this.args.projectAlias,
       isEmulator: true,
+      projectDir: this.args.projectDir,
     };
 
     if (functionsEnv.hasUserEnvs(projectInfo)) {

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -3,10 +3,12 @@ import * as path from "path";
 import * as os from "os";
 import { rmSync } from "node:fs";
 import { expect } from "chai";
+import * as sinon from "sinon";
 
 import * as env from "./env";
 import { FirebaseError } from "../error";
 import { ParamValue } from "../deploy/functions/params";
+import * as utils from "../utils";
 
 describe("functions/env", () => {
   describe("parse", () => {
@@ -304,27 +306,38 @@ FOO=foo
         fs.writeFileSync(path.join(sourceDir, filename), data);
       }
     };
+    let projectTmpdir: string;
     let tmpdir: string;
 
     beforeEach(() => {
-      tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "test"));
+      projectTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "project-test-"));
+      tmpdir = path.join(projectTmpdir, "functions");
+      fs.mkdirSync(tmpdir);
     });
 
     afterEach(() => {
-      rmSync(tmpdir, { recursive: true });
-      expect(() => {
-        fs.statSync(tmpdir);
-      }).to.throw();
+      rmSync(projectTmpdir, { recursive: true, force: true });
     });
 
     it("never affects the filesystem if the list of keys to write is empty", () => {
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        },
       );
       env.writeUserEnvs(
         {},
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+          isEmulator: true,
+        },
       );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
@@ -332,7 +345,10 @@ FOO=foo
     });
 
     it("touches .env.projectId if it doesn't already exist", () => {
-      env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir });
+      env.writeUserEnvs(
+        { FOO: "bar" },
+        { projectId: "project", projectDir: projectTmpdir, functionsSource: tmpdir },
+      );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(!!fs.statSync(path.join(tmpdir, ".env.project"))).to.be.true;
       expect(() => fs.statSync(path.join(tmpdir, ".env.local"))).to.throw;
@@ -341,7 +357,12 @@ FOO=foo
     it("touches .env.local if it doesn't already exist in emulator mode", () => {
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+        {
+          projectId: "project",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+          isEmulator: true,
+        },
       );
       expect(() => fs.statSync(path.join(tmpdir, ".env.alias"))).to.throw;
       expect(() => fs.statSync(path.join(tmpdir, ".env.project"))).to.throw;
@@ -353,7 +374,10 @@ FOO=foo
         [".env.project"]: "FOO=foo",
       });
       expect(() =>
-        env.writeUserEnvs({ FOO: "bar" }, { projectId: "project", functionsSource: tmpdir }),
+        env.writeUserEnvs(
+          { FOO: "bar" },
+          { projectId: "project", projectDir: projectTmpdir, functionsSource: tmpdir },
+        ),
       ).to.throw(FirebaseError);
     });
 
@@ -363,12 +387,18 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+        {
+          projectId: "project",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+          isEmulator: true,
+        },
       );
       expect(
         env.loadUserEnvs({
           projectId: "project",
           projectAlias: "alias",
+          projectDir: projectTmpdir,
           functionsSource: tmpdir,
           isEmulator: true,
         })["FOO"],
@@ -382,7 +412,12 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { FOO: "baz" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            projectDir: projectTmpdir,
+            functionsSource: tmpdir,
+          },
         ),
       ).to.throw(FirebaseError);
     });
@@ -393,12 +428,19 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "baz" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir, isEmulator: true },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+          isEmulator: true,
+        },
       );
       expect(
         env.loadUserEnvs({
           projectId: "project",
           projectAlias: "alias",
+          projectDir: projectTmpdir,
           functionsSource: tmpdir,
           isEmulator: true,
         })["FOO"],
@@ -412,7 +454,12 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { ASDF: "bar" },
-          { projectId: "project", functionsSource: tmpdir, isEmulator: true },
+          {
+            projectId: "project",
+            projectDir: projectTmpdir,
+            functionsSource: tmpdir,
+            isEmulator: true,
+          },
         ),
       ).to.throw(FirebaseError);
     });
@@ -421,19 +468,34 @@ FOO=foo
       expect(() =>
         env.writeUserEnvs(
           { lowercase: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            projectDir: projectTmpdir,
+            functionsSource: tmpdir,
+          },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { GCP_PROJECT: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            projectDir: projectTmpdir,
+            functionsSource: tmpdir,
+          },
         ),
       ).to.throw(env.KeyValidationError);
       expect(() =>
         env.writeUserEnvs(
           { FIREBASE_KEY: "bar" },
-          { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+          {
+            projectId: "project",
+            projectAlias: "alias",
+            projectDir: projectTmpdir,
+            functionsSource: tmpdir,
+          },
         ),
       ).to.throw(env.KeyValidationError);
     });
@@ -441,12 +503,20 @@ FOO=foo
     it("writes the specified key to a .env.projectId that it created", () => {
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
-          "FOO"
-        ],
+        env.loadUserEnvs({
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        })["FOO"],
       ).to.equal("bar");
     });
 
@@ -456,23 +526,37 @@ FOO=foo
       });
       env.writeUserEnvs(
         { FOO: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        },
       );
       expect(
-        env.loadUserEnvs({ projectId: "project", projectAlias: "alias", functionsSource: tmpdir })[
-          "FOO"
-        ],
+        env.loadUserEnvs({
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        })["FOO"],
       ).to.equal("bar");
     });
 
     it("writes multiple keys at once", () => {
       env.writeUserEnvs(
         { FOO: "foo", BAR: "bar" },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
         projectAlias: "alias",
+        projectDir: projectTmpdir,
         functionsSource: tmpdir,
       });
       expect(envs["FOO"]).to.equal("foo");
@@ -486,11 +570,17 @@ FOO=foo
           WITH_SLASHES: "\n\\\r\\\t\\\v",
           QUOTES: "'\"'",
         },
-        { projectId: "project", projectAlias: "alias", functionsSource: tmpdir },
+        {
+          projectId: "project",
+          projectAlias: "alias",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        },
       );
       const envs = env.loadUserEnvs({
         projectId: "project",
         projectAlias: "alias",
+        projectDir: projectTmpdir,
         functionsSource: tmpdir,
       });
       expect(envs["ESCAPES"]).to.equal("\n\r\t\v");
@@ -502,13 +592,18 @@ FOO=foo
       try {
         env.writeUserEnvs(
           { FOO: "bar", lowercase: "bar" },
-          { projectId: "project", functionsSource: tmpdir },
+          { projectId: "project", projectDir: projectTmpdir, functionsSource: tmpdir },
         );
       } catch (err: any) {
         // no-op
       }
-      expect(env.loadUserEnvs({ projectId: "project", functionsSource: tmpdir })["FOO"]).to.be
-        .undefined;
+      expect(
+        env.loadUserEnvs({
+          projectId: "project",
+          projectDir: projectTmpdir,
+          functionsSource: tmpdir,
+        })["FOO"],
+      ).to.be.undefined;
     });
   });
 
@@ -518,21 +613,23 @@ FOO=foo
         fs.writeFileSync(path.join(sourceDir, filename), data);
       }
     };
-    const projectInfo: Omit<env.UserEnvsOpts, "functionsSource"> = {
-      projectId: "my-project",
-      projectAlias: "dev",
-    };
+    let projectInfo: Omit<env.UserEnvsOpts, "functionsSource">;
+    let projectTmpdir: string;
     let tmpdir: string;
 
     beforeEach(() => {
-      tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "test"));
+      projectTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "project-test-"));
+      tmpdir = path.join(projectTmpdir, "functions");
+      fs.mkdirSync(tmpdir);
+      projectInfo = {
+        projectId: "my-project",
+        projectAlias: "dev",
+        projectDir: projectTmpdir,
+      };
     });
 
     afterEach(() => {
-      rmSync(tmpdir, { recursive: true });
-      expect(() => {
-        fs.statSync(tmpdir);
-      }).to.throw();
+      rmSync(projectTmpdir, { recursive: true, force: true });
     });
 
     it("loads nothing if .env files are missing", () => {
@@ -770,14 +867,17 @@ FOO=foo
   });
 
   describe("writeResolvedParams", () => {
+    let projectTmpdir: string;
     let tmpdir: string;
 
     beforeEach(() => {
-      tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "firebase-functions-test-"));
+      projectTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "project-test-"));
+      tmpdir = path.join(projectTmpdir, "functions");
+      fs.mkdirSync(tmpdir);
     });
 
     afterEach(() => {
-      rmSync(tmpdir, { recursive: true, force: true });
+      rmSync(projectTmpdir, { recursive: true, force: true });
     });
 
     it("should write only new, non-internal params", () => {
@@ -789,6 +889,7 @@ FOO=foo
       const userEnvs = { EXISTING_PARAM: "old_value" };
       const userEnvOpt = {
         projectId: "test-project",
+        projectDir: projectTmpdir,
         functionsSource: tmpdir,
       };
 
@@ -808,6 +909,7 @@ FOO=foo
       const userEnvs = { EXISTING_PARAM: "old_value" };
       const userEnvOpt = {
         projectId: "test-project",
+        projectDir: projectTmpdir,
         functionsSource: tmpdir,
       };
 
@@ -824,6 +926,7 @@ FOO=foo
       const userEnvs = {};
       const userEnvOpt = {
         projectId: "test-project",
+        projectDir: projectTmpdir,
         functionsSource: tmpdir,
         isEmulator: true,
       };
@@ -842,6 +945,7 @@ FOO=foo
       const userEnvs = {};
       const userEnvOpt = {
         projectId: "test-project",
+        projectDir: projectTmpdir,
         functionsSource: tmpdir,
       };
 
@@ -849,6 +953,51 @@ FOO=foo
 
       const writtenContent = fs.readFileSync(path.join(tmpdir, ".env.test-project"), "utf-8");
       expect(writtenContent).to.include('NEW_PARAM="value with\\nnewline"');
+    });
+  });
+
+  describe("relative path logging", () => {
+    let projectTmpdir: string;
+    let tmpdir: string;
+    let logBulletStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      projectTmpdir = fs.mkdtempSync(path.join(os.tmpdir(), "project-test-"));
+      tmpdir = path.join(projectTmpdir, "functions");
+      fs.mkdirSync(tmpdir);
+      logBulletStub = sinon.stub(utils, "logBullet");
+    });
+
+    afterEach(() => {
+      logBulletStub.restore();
+      rmSync(projectTmpdir, { recursive: true, force: true });
+    });
+
+    it("should print relative paths when loading envs", () => {
+      fs.writeFileSync(path.join(tmpdir, ".env"), "FOO=bar");
+
+      env.loadUserEnvs({
+        projectId: "project",
+        functionsSource: tmpdir,
+        projectDir: projectTmpdir,
+      });
+
+      const expectedPath = path.join("functions", ".env");
+      expect(logBulletStub.firstCall.args[0]).to.include(expectedPath);
+    });
+
+    it("should print relative paths when writing envs", () => {
+      env.writeUserEnvs(
+        { NEW_VAR: "value" },
+        {
+          projectId: "project",
+          functionsSource: tmpdir,
+          projectDir: projectTmpdir,
+        },
+      );
+
+      const expectedPath = path.join("functions", ".env.project");
+      expect(logBulletStub.firstCall.args[0]).to.include(expectedPath);
     });
   });
 });

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -258,6 +258,7 @@ export interface UserEnvsOpts {
   projectId: string;
   projectAlias?: string;
   isEmulator?: boolean;
+  projectDir: string;
 }
 
 /**
@@ -288,11 +289,13 @@ export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvs
     ? FUNCTIONS_EMULATOR_DOTENV
     : `.env.${envOpts.projectId}`;
   const targetEnvFileExists = allEnvFiles.includes(targetEnvFile);
+  const targetEnvFilePath = path.join(configDir, targetEnvFile);
+  const relativeTargetEnvFilePath = path.relative(envOpts.projectDir, targetEnvFilePath);
   if (!targetEnvFileExists) {
-    fs.writeFileSync(path.join(configDir, targetEnvFile), "", { flag: "wx" });
+    fs.writeFileSync(targetEnvFilePath, "", { flag: "wx" });
     logBullet(
       clc.yellow(clc.bold("functions: ")) +
-        `Created new local file ${targetEnvFile} to store param values. We suggest explicitly adding or excluding this file from version control.`,
+        `Created new local file ${relativeTargetEnvFilePath} to store param values. We suggest explicitly adding or excluding this file from version control.`,
     );
   }
 
@@ -308,7 +311,8 @@ export function writeUserEnvs(toWrite: Record<string, string>, envOpts: UserEnvs
 
   // Write all the keys in a single filesystem access
   logBullet(
-    clc.cyan(clc.bold("functions: ")) + `Writing new parameter values to disk: ${targetEnvFile}`,
+    clc.cyan(clc.bold("functions: ")) +
+      `Writing new parameter values to disk: ${relativeTargetEnvFilePath}`,
   );
   let lines = "";
   for (const k of Object.keys(toWrite)) {
@@ -405,8 +409,12 @@ export function loadUserEnvs(opts: UserEnvsOpts): Record<string, string> {
       });
     }
   }
+  const relativeEnvFiles = envFiles.map((f) =>
+    path.relative(opts.projectDir, path.join(configDir, f)),
+  );
   logBullet(
-    clc.cyan(clc.bold("functions: ")) + `Loaded environment variables from ${envFiles.join(", ")}.`,
+    clc.cyan(clc.bold("functions: ")) +
+      `Loaded environment variables from ${relativeEnvFiles.join(", ")}`,
   );
 
   return envs;


### PR DESCRIPTION


### Description
Improve parameter prompting clarity for multi-codebase deployments. When deploying functions with multiple codebases, it was previously unclear which codebase a parameter was being prompted for. This change:
- Prints a header before prompting for parameters for a codebase: "Prompting for parameters for codebase <codebase>:" (with bolded codebase name).
- Uses relative paths (from project root) for `.env` files in log messages (e.g. functions/.env.ajp-testing instead of /absolute/path/to/functions/.env.ajp-testing).
- Updates unit tests to verify the new logging format.

Before 

<img width="1230" height="207" alt="Screenshot 2026-08-06 at 10 45 43 AM" src="https://github.com/user-attachments/assets/54eb4ecc-5e1d-41b4-bd4f-af5d9fbd2304" />

After

<img width="1235" height="259" alt="Screenshot 2026-08-06 at 10 43 24 AM" src="https://github.com/user-attachments/assets/202d847c-6697-4958-a0c2-8fa6c25bd892" />



### Scenarios Tested
* Ran all tests (`npm run test`)
* Tested functions deployment in prod and emulator

### Sample Commands
* `firebase deploy --only functions`
* `firebase emulators:start`

TAG=agy
CONV=4eeb75b0-e6d0-4611-9e3a-9737a017a802
