### PR TITLE
feat(functions): add functions:kits:install command

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -5,7 +5,8 @@ import * as fs from "fs-extra";
 
 import {
   command,
-  parsePackageSpecifier,
+  parseNpmPackageSpecifier,
+  validateNpmPackageName,
   sanitizePackageNameToKitName,
   isThirdPartyPackage,
   checkPackageHasShrinkwrap,
@@ -40,32 +41,107 @@ describe("functions:kits:install", () => {
     sinon.restore();
   });
 
-  describe("parsePackageSpecifier", () => {
+  describe("validateNpmPackageName", () => {
+    it("should accept valid unscoped package names", () => {
+      expect(() => validateNpmPackageName("my-kit")).to.not.throw();
+      expect(() => validateNpmPackageName("firestore-export")).to.not.throw();
+      expect(() => validateNpmPackageName("kit_123.v1")).to.not.throw();
+    });
+
+    it("should accept valid scoped package names with exactly one slash", () => {
+      expect(() =>
+        validateNpmPackageName("@firebase-functions-kits/firestore-bigquery-export"),
+      ).to.not.throw();
+      expect(() => validateNpmPackageName("@invertase/example-kit")).to.not.throw();
+    });
+
+    it("should reject package names with multiple slashes", () => {
+      expect(() => validateNpmPackageName("@scope/pkg/extra")).to.throw(
+        FirebaseError,
+        /Invalid NPM package name/,
+      );
+      expect(() => validateNpmPackageName("foo/bar/baz")).to.throw(
+        FirebaseError,
+        /Invalid NPM package name/,
+      );
+    });
+
+    it("should reject unscoped package names containing slashes", () => {
+      expect(() => validateNpmPackageName("foo/bar")).to.throw(
+        FirebaseError,
+        /Invalid NPM package name/,
+      );
+    });
+
+    it("should reject empty or malformed package names", () => {
+      expect(() => validateNpmPackageName("")).to.throw(FirebaseError, /Invalid NPM package name/);
+      expect(() => validateNpmPackageName("@scope")).to.throw(
+        FirebaseError,
+        /Invalid NPM package name/,
+      );
+      expect(() => validateNpmPackageName("a".repeat(215))).to.throw(
+        FirebaseError,
+        /Invalid NPM package name/,
+      );
+    });
+  });
+
+  describe("parseNpmPackageSpecifier", () => {
     it("should parse scoped package with version", () => {
-      const res = parsePackageSpecifier("@firebase-functions-kits/firestore-bigquery-export@1.0.0");
+      const res = parseNpmPackageSpecifier(
+        "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+      );
       expect(res).to.deep.equal({
         packageName: "@firebase-functions-kits/firestore-bigquery-export",
         version: "1.0.0",
       });
     });
 
+    it("should parse scoped package with release candidate version", () => {
+      const res = parseNpmPackageSpecifier(
+        "@firebase-functions-kits/firestore-bigquery-export@1.0.0-rc.1",
+      );
+      expect(res).to.deep.equal({
+        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+        version: "1.0.0-rc.1",
+      });
+    });
+
+    it("should parse scoped package with tag", () => {
+      const res = parseNpmPackageSpecifier(
+        "@firebase-functions-kits/firestore-bigquery-export@latest",
+      );
+      expect(res).to.deep.equal({
+        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+        version: "latest",
+      });
+    });
+
     it("should parse scoped package without version", () => {
-      const res = parsePackageSpecifier("@firebase-functions-kits/firestore-bigquery-export");
+      const res = parseNpmPackageSpecifier("@firebase-functions-kits/firestore-bigquery-export");
       expect(res).to.deep.equal({
         packageName: "@firebase-functions-kits/firestore-bigquery-export",
       });
     });
 
     it("should parse non-scoped package with version", () => {
-      const res = parsePackageSpecifier("my-kit@^2.0.0");
+      const res = parseNpmPackageSpecifier("my-kit@^2.0.0");
       expect(res).to.deep.equal({
         packageName: "my-kit",
         version: "^2.0.0",
       });
     });
 
+    it("should parse non-scoped package with tag", () => {
+      const res = parseNpmPackageSpecifier("my-kit@next");
+      expect(res).to.deep.equal({
+        packageName: "my-kit",
+        version: "next",
+      });
+    });
+
     it("should parse non-scoped package without version", () => {
-      const res = parsePackageSpecifier("my-kit");
+      const res = parseNpmPackageSpecifier("my-kit");
       expect(res).to.deep.equal({
         packageName: "my-kit",
       });
@@ -94,10 +170,12 @@ describe("functions:kits:install", () => {
   describe("isThirdPartyPackage", () => {
     it("should return false for packages under @firebase-functions-kits scope", () => {
       expect(isThirdPartyPackage("@firebase-functions-kits/firestore-bigquery-export")).to.be.false;
-      expect(isThirdPartyPackage("@firebase-functions-kits")).to.be.false;
     });
 
     it("should return true for packages outside @firebase-functions-kits scope", () => {
+      expect(isThirdPartyPackage("firebase-functions-kits")).to.be.true;
+      expect(isThirdPartyPackage("@firebase-function-kits-fake/foo")).to.be.true;
+      expect(isThirdPartyPackage("@firebase-functions-kits-fake/foo")).to.be.true;
       expect(isThirdPartyPackage("@other-scope/my-kit")).to.be.true;
       expect(isThirdPartyPackage("third-party-kit")).to.be.true;
     });
@@ -173,6 +251,25 @@ describe("functions:kits:install", () => {
         FirebaseError,
         /set the --npm_package option to a valid NPM package and try again\./,
       );
+    });
+
+    it("should throw an error if --npm_package has an invalid package name", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@scope/pkg/extra@1.0.0",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /Invalid NPM package name/);
     });
 
     it("should successfully install a first-party kit into firebase.json", async () => {
@@ -380,6 +477,85 @@ describe("functions:kits:install", () => {
           nonInteractive: true,
         }),
       ).to.be.rejectedWith(FirebaseError, /must be mutually exclusive/);
+    });
+
+    it("should reject instance ID that collides with another kit instance ID", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [
+            {
+              kit: "other-kit",
+              source: "function-kits/other-kit",
+              instances: {
+                "my-kit": "function-kits/other-kit/config-my-kit",
+              },
+            },
+          ],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@firebase-functions-kits/my-kit",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /functions kit instance ID must be unique across all kits, but 'my-kit' was used more than once/,
+      );
+    });
+
+    it("should prompt confirmation when a first-party kit lacks npm-shrinkwrap.json", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "package.json" }] }]));
+      const confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@firebase-functions-kits/my-kit",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      expect(confirmStub).to.have.been.calledOnceWith({
+        message:
+          "Are you sure you want to install @firebase-functions-kits/my-kit without locked dependencies?",
+        default: false,
+        nonInteractive: true,
+      });
+    });
+
+    it("should cancel installation if user declines confirmation for missing shrinkwrap", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "package.json" }] }]));
+      sinon.stub(prompt, "confirm").resolves(false);
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@firebase-functions-kits/my-kit",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, "Installation cancelled.");
     });
   });
 });

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -1,0 +1,330 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import * as path from "path";
+import * as fs from "fs-extra";
+
+import {
+  command,
+  parsePackageSpecifier,
+  sanitizePackageNameToKitName,
+  isThirdPartyPackage,
+  checkPackageHasShrinkwrap,
+} from "./functions-kits-install";
+import * as experiments from "../experiments";
+import * as initSpawn from "../init/spawn";
+import { Config } from "../config";
+import { FirebaseError } from "../error";
+
+describe("functions:kits:install", () => {
+  let assertEnabledStub: sinon.SinonStub;
+  let wrapSpawnStub: sinon.SinonStub;
+  let spawnWithOutputStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    (command as unknown as { befores: unknown[] }).befores = [];
+    sinon.stub(command, "prepare").resolves();
+    assertEnabledStub = sinon.stub(experiments, "assertEnabled");
+    wrapSpawnStub = sinon.stub(initSpawn, "wrapSpawn").resolves();
+    spawnWithOutputStub = sinon
+      .stub(initSpawn, "spawnWithOutput")
+      .resolves(JSON.stringify([{ hasShrinkwrap: true }]));
+    sinon.stub(fs, "ensureDir").resolves();
+    sinon.stub(fs, "pathExists").resolves(false);
+    sinon.stub(fs, "readJson").resolves({});
+    sinon.stub(fs, "writeJson").resolves();
+    sinon.stub(fs, "writeFile").resolves();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe("parsePackageSpecifier", () => {
+    it("should parse scoped package with version", () => {
+      const res = parsePackageSpecifier("@firebase-functions-kits/firestore-bigquery-export@1.0.0");
+      expect(res).to.deep.equal({
+        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+        version: "1.0.0",
+      });
+    });
+
+    it("should parse scoped package without version", () => {
+      const res = parsePackageSpecifier("@firebase-functions-kits/firestore-bigquery-export");
+      expect(res).to.deep.equal({
+        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+      });
+    });
+
+    it("should parse non-scoped package with version", () => {
+      const res = parsePackageSpecifier("my-kit@^2.0.0");
+      expect(res).to.deep.equal({
+        packageName: "my-kit",
+        version: "^2.0.0",
+      });
+    });
+
+    it("should parse non-scoped package without version", () => {
+      const res = parsePackageSpecifier("my-kit");
+      expect(res).to.deep.equal({
+        packageName: "my-kit",
+      });
+    });
+  });
+
+  describe("sanitizePackageNameToKitName", () => {
+    it("should extract kit name from scoped package name", () => {
+      expect(
+        sanitizePackageNameToKitName("@firebase-functions-kits/firestore-bigquery-export"),
+      ).to.equal("firestore-bigquery-export");
+      expect(sanitizePackageNameToKitName("@foo/bar")).to.equal("bar");
+    });
+
+    it("should sanitize non-scoped package name", () => {
+      expect(sanitizePackageNameToKitName("my-kit")).to.equal("my-kit");
+      expect(sanitizePackageNameToKitName("My_Kit!")).to.equal("my_kit");
+    });
+
+    it("should truncate long names to 40 characters", () => {
+      const longName = "@scope/" + "a".repeat(50);
+      expect(sanitizePackageNameToKitName(longName)).to.equal("a".repeat(40));
+    });
+  });
+
+  describe("isThirdPartyPackage", () => {
+    it("should return false for packages under @firebase-functions-kits scope", () => {
+      expect(isThirdPartyPackage("@firebase-functions-kits/firestore-bigquery-export")).to.be.false;
+      expect(isThirdPartyPackage("@firebase-functions-kits")).to.be.false;
+    });
+
+    it("should return true for packages outside @firebase-functions-kits scope", () => {
+      expect(isThirdPartyPackage("@other-scope/my-kit")).to.be.true;
+      expect(isThirdPartyPackage("third-party-kit")).to.be.true;
+    });
+  });
+
+  describe("checkPackageHasShrinkwrap", () => {
+    it("should return true when npm pack output includes hasShrinkwrap", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ hasShrinkwrap: true }]));
+      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      expect(res).to.be.true;
+    });
+
+    it("should return true when npm pack files list includes npm-shrinkwrap.json", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "npm-shrinkwrap.json" }] }]));
+      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      expect(res).to.be.true;
+    });
+
+    it("should return false when npm-shrinkwrap.json is not in package", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "package.json" }] }]));
+      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      expect(res).to.be.false;
+    });
+
+    it("should return false when npm pack fails", async () => {
+      spawnWithOutputStub.rejects(new Error("npm pack error"));
+      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      expect(res).to.be.false;
+    });
+  });
+
+  describe("command action", () => {
+    it("should assert that kits experiment is enabled", async () => {
+      assertEnabledStub.throws(new FirebaseError("kits experiment disabled"));
+
+      await expect(
+        command.runner()({
+          npm_package: "@firebase-functions-kits/firestore-bigquery-export",
+          cwd: "/mock/project",
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, "kits experiment disabled");
+
+      expect(assertEnabledStub).to.have.been.calledWith("kits", "install a function kit");
+    });
+
+    it("should throw an error if not in a Firebase project directory", async () => {
+      await expect(
+        command.runner()({
+          npm_package: "@firebase-functions-kits/firestore-bigquery-export",
+          cwd: "/mock/project",
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /firebase.json not found/);
+    });
+
+    it("should throw an error if --npm_package is not provided", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /set the --npm_package option to a valid NPM package and try again\./,
+      );
+    });
+
+    it("should successfully install a first-party kit into firebase.json", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install"],
+        "/mock/project/function-kits/firestore-bigquery-export/src",
+      );
+      expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
+        "npm",
+        ["run", "build"],
+        "/mock/project/function-kits/firestore-bigquery-export/src",
+      );
+
+      const pkgJsonResult = writtenFiles[
+        "function-kits/firestore-bigquery-export/src/package.json"
+      ] as { name?: string; dependencies?: Record<string, string> };
+      expect(pkgJsonResult.name).to.equal("firestore-bigquery-export-wrapper");
+      expect(pkgJsonResult.dependencies).to.have.property(
+        "@firebase-functions-kits/firestore-bigquery-export",
+        "1.0.0",
+      );
+
+      expect(writtenFiles["function-kits/firestore-bigquery-export/src/index.ts"]).to.be.a(
+        "string",
+      );
+      expect(
+        writtenFiles["function-kits/firestore-bigquery-export/src/index.ts"] as string,
+      ).to.include('export * from "@firebase-functions-kits/firestore-bigquery-export";');
+
+      expect(writtenFiles["firebase.json"]).to.deep.equal({
+        functions: [
+          {
+            kit: "firestore-bigquery-export",
+            sourcePackage: {
+              id: "@firebase-functions-kits/firestore-bigquery-export",
+            },
+            source: "function-kits/firestore-bigquery-export/src",
+            instances: {
+              "firestore-bigquery-export":
+                "function-kits/firestore-bigquery-export/config-firestore-bigquery-export",
+            },
+            predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+          },
+        ],
+      });
+    });
+
+    it("should run npm install with --ignore-scripts for third-party packages", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@third-party/custom-kit",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install", "--ignore-scripts"],
+        "/mock/project/function-kits/custom-kit/src",
+      );
+      expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
+        "npm",
+        ["run", "build"],
+        "/mock/project/function-kits/custom-kit/src",
+      );
+    });
+
+    it("should reject duplicate kit name in firebase.json", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [
+            {
+              kit: "firestore-bigquery-export",
+              source: "function-kits/firestore-bigquery-export",
+              instances: {
+                inst1: "function-kits/firestore-bigquery-export/config-inst1",
+              },
+            },
+          ],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@firebase-functions-kits/firestore-bigquery-export",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /functions.kit must be unique/);
+    });
+
+    it("should reject instance ID that collides with codebase name", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [
+            {
+              codebase: "my-kit",
+              source: "functions",
+            },
+          ],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@firebase-functions-kits/my-kit",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /must be mutually exclusive/);
+    });
+  });
+});

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -299,6 +299,8 @@ describe("functions:kits:install", () => {
     });
 
     it("should run npm install with --ignore-scripts for third-party packages", async () => {
+      sinon.stub(prompt, "confirm").resolves(true);
+
       const mockConfig = {
         projectDir: "/mock/project",
         src: { functions: [] },

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -203,16 +203,16 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install"],
-        "/mock/project/function-kits/firestore-bigquery-export/src",
+        "/mock/project/function-kits/firestore-bigquery-export",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
         ["run", "build"],
-        "/mock/project/function-kits/firestore-bigquery-export/src",
+        "/mock/project/function-kits/firestore-bigquery-export",
       );
 
       const pkgJsonResult = writtenFiles[
-        "function-kits/firestore-bigquery-export/src/package.json"
+        "function-kits/firestore-bigquery-export/package.json"
       ] as { name?: string; dependencies?: Record<string, string> };
       expect(pkgJsonResult.name).to.equal("firestore-bigquery-export-wrapper");
       expect(pkgJsonResult.dependencies).to.have.property(
@@ -234,7 +234,7 @@ describe("functions:kits:install", () => {
             sourcePackage: {
               id: "@firebase-functions-kits/firestore-bigquery-export",
             },
-            source: "function-kits/firestore-bigquery-export/src",
+            source: "function-kits/firestore-bigquery-export",
             instances: {
               "firestore-bigquery-export":
                 "function-kits/firestore-bigquery-export/config-firestore-bigquery-export",
@@ -265,12 +265,12 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install", "--ignore-scripts"],
-        "/mock/project/function-kits/custom-kit/src",
+        "/mock/project/function-kits/custom-kit",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
         ["run", "build"],
-        "/mock/project/function-kits/custom-kit/src",
+        "/mock/project/function-kits/custom-kit",
       );
     });
 

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -197,7 +197,6 @@ describe("functions:kits:install", () => {
 
     it("should return true for packages outside @firebase-functions-kits scope", () => {
       expect(isThirdPartyPackage("firebase-functions-kits")).to.be.true;
-      expect(isThirdPartyPackage("@firebase-function-kits-fake/foo")).to.be.true;
       expect(isThirdPartyPackage("@firebase-functions-kits-fake/foo")).to.be.true;
       expect(isThirdPartyPackage("@other-scope/my-kit")).to.be.true;
       expect(isThirdPartyPackage("third-party-kit")).to.be.true;
@@ -616,7 +615,60 @@ describe("functions:kits:install", () => {
       });
     });
 
-    it("should cancel installation if user declines confirmation for missing shrinkwrap", async () => {
+    it("should prompt confirmation when a third-party kit has npm-shrinkwrap.json", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ hasShrinkwrap: true }]));
+      const confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@third-party/custom-kit",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      expect(confirmStub).to.have.been.calledOnceWith({
+        message: "Are you sure you want to install the third-party kit @third-party/custom-kit?",
+        default: false,
+        nonInteractive: true,
+      });
+    });
+
+    it("should prompt confirmation when a third-party kit lacks npm-shrinkwrap.json", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "package.json" }] }]));
+      const confirmStub = sinon.stub(prompt, "confirm").resolves(true);
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@third-party/custom-kit",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      expect(confirmStub).to.have.been.calledOnceWith({
+        message:
+          "Are you sure you want to install the third-party kit @third-party/custom-kit without locked dependencies?",
+        default: false,
+        nonInteractive: true,
+      });
+    });
+
+    it("should cancel installation if user declines confirmation for first-party kit without shrinkwrap", async () => {
       spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "package.json" }] }]));
       sinon.stub(prompt, "confirm").resolves(false);
 
@@ -630,6 +682,48 @@ describe("functions:kits:install", () => {
       await expect(
         command.runner()({
           npm_package: "@firebase-functions-kits/my-kit",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, "Installation cancelled.");
+    });
+
+    it("should cancel installation if user declines confirmation for third-party kit with shrinkwrap", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ hasShrinkwrap: true }]));
+      sinon.stub(prompt, "confirm").resolves(false);
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@third-party/custom-kit",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, "Installation cancelled.");
+    });
+
+    it("should cancel installation if user declines confirmation for third-party kit without shrinkwrap", async () => {
+      spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "package.json" }] }]));
+      sinon.stub(prompt, "confirm").resolves(false);
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@third-party/custom-kit",
           cwd: "/mock/project",
           config: mockConfig,
           nonInteractive: true,

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -14,6 +14,7 @@ import * as experiments from "../experiments";
 import * as initSpawn from "../init/spawn";
 import { Config } from "../config";
 import { FirebaseError } from "../error";
+import * as prompt from "../prompt";
 
 describe("functions:kits:install", () => {
   let assertEnabledStub: sinon.SinonStub;
@@ -238,6 +239,58 @@ describe("functions:kits:install", () => {
             instances: {
               "firestore-bigquery-export":
                 "function-kits/firestore-bigquery-export/config-firestore-bigquery-export",
+            },
+            predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+          },
+        ],
+      });
+    });
+
+    it("should prompt and allow custom kit ID and instance ID", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      sinon
+        .stub(prompt, "input")
+        .onFirstCall()
+        .resolves("my-custom-kit")
+        .onSecondCall()
+        .resolves("my-instance");
+
+      await command.runner()({
+        npm_package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        cwd: "/mock/project",
+        config: mockConfig,
+      });
+
+      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install"],
+        "/mock/project/function-kits/my-custom-kit",
+      );
+
+      expect(writtenFiles["firebase.json"]).to.deep.equal({
+        functions: [
+          {
+            kit: "my-custom-kit",
+            sourcePackage: {
+              id: "@firebase-functions-kits/firestore-bigquery-export",
+            },
+            source: "function-kits/my-custom-kit",
+            instances: {
+              "my-instance": "function-kits/my-custom-kit/config-my-instance",
             },
             predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
           },

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -5,6 +5,7 @@ import * as fs from "fs-extra";
 
 import {
   command,
+  generateUniqueId,
   parseNpmPackageSpecifier,
   validateNpmPackageName,
   sanitizePackageNameToKitName,
@@ -83,6 +84,28 @@ describe("functions:kits:install", () => {
         FirebaseError,
         /Invalid NPM package name/,
       );
+    });
+  });
+
+  describe("generateUniqueId", () => {
+    it("should return base ID when it is not in existing IDs", () => {
+      const existing = new Set(["other-kit"]);
+      expect(generateUniqueId("my-kit", existing)).to.equal("my-kit");
+    });
+
+    it("should append random 4-character hex suffix when base ID collides", () => {
+      const existing = new Set(["my-kit"]);
+      const res = generateUniqueId("my-kit", existing);
+      expect(res).to.match(/^my-kit-[a-f0-9]{4}$/);
+      expect(existing.has(res)).to.be.false;
+    });
+
+    it("should truncate long base IDs to ensure total length <= 40", () => {
+      const longBase = "a".repeat(40);
+      const existing = new Set([longBase]);
+      const res = generateUniqueId(longBase, existing);
+      expect(res.length).to.be.at.most(40);
+      expect(res).to.match(/^a{35}-[a-f0-9]{4}$/);
     });
   });
 
@@ -426,7 +449,7 @@ describe("functions:kits:install", () => {
       );
     });
 
-    it("should reject duplicate kit name in firebase.json", async () => {
+    it("should reject duplicate kit name if entered interactively", async () => {
       const mockConfig = {
         projectDir: "/mock/project",
         src: {
@@ -442,44 +465,93 @@ describe("functions:kits:install", () => {
         },
         path: (p: string) => path.join("/mock/project", p),
         writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
       } as unknown as Config;
+
+      sinon.stub(prompt, "input").onFirstCall().resolves("firestore-bigquery-export");
 
       await expect(
         command.runner()({
           npm_package: "@firebase-functions-kits/firestore-bigquery-export",
           cwd: "/mock/project",
           config: mockConfig,
-          nonInteractive: true,
         }),
       ).to.be.rejectedWith(FirebaseError, /functions.kit must be unique/);
     });
 
-    it("should reject instance ID that collides with codebase name", async () => {
+    it("should auto-generate unique kit ID and instance ID in non-interactive mode on collision", async () => {
+      const writtenFiles: Record<string, unknown> = {};
       const mockConfig = {
         projectDir: "/mock/project",
         src: {
           functions: [
             {
-              codebase: "my-kit",
+              kit: "firestore-bigquery-export",
+              source: "function-kits/firestore-bigquery-export",
+              instances: {
+                inst1: "function-kits/firestore-bigquery-export/config-inst1",
+              },
+            },
+          ],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      const updatedFunctions = (
+        writtenFiles["firebase.json"] as { functions: Array<{ kit?: string }> }
+      ).functions;
+      expect(updatedFunctions).to.have.length(2);
+      const installedKit = updatedFunctions[1];
+      expect(installedKit.kit).to.match(/^firestore-bigquery-export-[a-f0-9]{4}$/);
+    });
+
+    it("should reject instance ID that collides with codebase name if entered interactively", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [
+            {
+              codebase: "my-custom-instance",
               source: "functions",
             },
           ],
         },
         path: (p: string) => path.join("/mock/project", p),
         writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
       } as unknown as Config;
+
+      sinon
+        .stub(prompt, "input")
+        .onFirstCall()
+        .resolves("my-kit")
+        .onSecondCall()
+        .resolves("my-custom-instance");
 
       await expect(
         command.runner()({
           npm_package: "@firebase-functions-kits/my-kit",
           cwd: "/mock/project",
           config: mockConfig,
-          nonInteractive: true,
         }),
       ).to.be.rejectedWith(FirebaseError, /must be mutually exclusive/);
     });
 
-    it("should reject instance ID that collides with another kit instance ID", async () => {
+    it("should reject instance ID that collides with another kit instance ID if entered interactively", async () => {
       const mockConfig = {
         projectDir: "/mock/project",
         src: {
@@ -488,25 +560,32 @@ describe("functions:kits:install", () => {
               kit: "other-kit",
               source: "function-kits/other-kit",
               instances: {
-                "my-kit": "function-kits/other-kit/config-my-kit",
+                "existing-instance": "function-kits/other-kit/config-existing-instance",
               },
             },
           ],
         },
         path: (p: string) => path.join("/mock/project", p),
         writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
       } as unknown as Config;
+
+      sinon
+        .stub(prompt, "input")
+        .onFirstCall()
+        .resolves("my-kit")
+        .onSecondCall()
+        .resolves("existing-instance");
 
       await expect(
         command.runner()({
           npm_package: "@firebase-functions-kits/my-kit",
           cwd: "/mock/project",
           config: mockConfig,
-          nonInteractive: true,
         }),
       ).to.be.rejectedWith(
         FirebaseError,
-        /functions kit instance ID must be unique across all kits, but 'my-kit' was used more than once/,
+        /functions kit instance ID must be unique across all kits, but 'existing-instance' was used more than once/,
       );
     });
 

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -29,16 +29,21 @@ const TSCONFIG_TEMPLATE = readTemplateSync("init/functions/typescript/tsconfig.j
 const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/typescript/_gitignore");
 const INDEX_KIT_TEMPLATE = readTemplateSync("init/functions/typescript/index-kit.ts");
 
+const FUNCTION_KITS_DIR = "function-kits";
+
 export interface FunctionsKitsInstallOptions extends Options {
   npm_package?: string;
 }
 
 /**
- * Parses a package specifier string into package name and version.
+ * Parses an npm package specifier string into package name and version/tag.
  * e.g., "@firebase-functions-kits/firestore-bigquery-export@1.0.0" ->
  * { packageName: "@firebase-functions-kits/firestore-bigquery-export", version: "1.0.0" }
  */
-export function parsePackageSpecifier(rawPkg: string): { packageName: string; version?: string } {
+export function parseNpmPackageSpecifier(rawPkg: string): {
+  packageName: string;
+  version?: string;
+} {
   const lastAt = rawPkg.lastIndexOf("@");
   if (lastAt > 0) {
     return {
@@ -50,16 +55,27 @@ export function parsePackageSpecifier(rawPkg: string): { packageName: string; ve
 }
 
 /**
+ * Validates that an npm package name adheres to npm naming conventions.
+ * - Unscoped: 'name' (no slashes)
+ * - Scoped: '@scope/name' (exactly one slash)
+ */
+export function validateNpmPackageName(packageName: string): void {
+  const npmPackageRegex = /^(?:@[a-z0-9_.-]+\/[a-z0-9_.-]+|[a-z0-9_.-]+)$/i;
+  if (!packageName || packageName.length > 214 || !npmPackageRegex.test(packageName)) {
+    throw new FirebaseError(
+      `Invalid NPM package name '${packageName}'. Package names must be valid npm package specifiers (e.g. 'my-kit' or '@scope/my-kit').`,
+    );
+  }
+}
+
+/**
  * Sanitizes an npm package name into a valid kit identifier.
  * e.g., "@firebase-functions-kits/firestore-bigquery-export" -> "firestore-bigquery-export"
  */
 export function sanitizePackageNameToKitName(packageName: string): string {
   const parts = packageName.split("/");
   const nameWithoutScope = parts[parts.length - 1] || packageName;
-  const sanitized = nameWithoutScope
-    .toLowerCase()
-    .replace(/^@/, "")
-    .replace(/[^a-z0-9_-]/g, "");
+  const sanitized = nameWithoutScope.toLowerCase().replace(/[^a-z0-9_-]/g, "");
   return (sanitized || "kit").slice(0, 40);
 }
 
@@ -67,10 +83,7 @@ export function sanitizePackageNameToKitName(packageName: string): string {
  * Checks if a package name is third-party (outside the @firebase-functions-kits scope).
  */
 export function isThirdPartyPackage(packageName: string): boolean {
-  return (
-    !packageName.startsWith("@firebase-functions-kits/") &&
-    packageName !== "@firebase-functions-kits"
-  );
+  return !packageName.startsWith("@firebase-functions-kits/");
 }
 
 /**
@@ -101,8 +114,8 @@ export async function checkPackageHasShrinkwrap(rawPkgName: string): Promise<boo
 }
 
 export const command = new Command("functions:kits:install")
-  .description("install a Cloud Function kit into your project")
-  .option("--npm_package <package>", "NPM package name or specifier for the function kit")
+  .description("install a function kit into your project")
+  .option("--npm_package <package>", "NPM package name or specifier to install as a function kit")
   .action(async (options: FunctionsKitsInstallOptions): Promise<void> => {
     experiments.assertEnabled("kits", "install a function kit");
 
@@ -115,7 +128,8 @@ export const command = new Command("functions:kits:install")
       throw new FirebaseError("set the --npm_package option to a valid NPM package and try again.");
     }
 
-    const { packageName, version } = parsePackageSpecifier(rawPkgName);
+    const { packageName, version } = parseNpmPackageSpecifier(rawPkgName);
+    validateNpmPackageName(packageName);
     const defaultKitId = sanitizePackageNameToKitName(packageName);
 
     const isThirdParty = isThirdPartyPackage(packageName);
@@ -125,16 +139,23 @@ export const command = new Command("functions:kits:install")
           `Warning: Package ${clc.bold(packageName)} is a third-party kit (outside the @firebase-functions-kits scope).`,
         ),
       );
-      const hasShrinkwrap = await self.checkPackageHasShrinkwrap(rawPkgName);
-      if (!hasShrinkwrap) {
-        logger.warn(
-          clc.yellow(
-            `Warning: Package ${clc.bold(packageName)} does not have an npm-shrinkwrap.json file. npm-shrinkwrap guarantees that you deploy the same version of dependencies that the publisher tested against. Since this kit does not have an npm-shrinkwrap, it is possible that deploys or updates may introduce bugs or vulnerabilities in newer dependency versions that the publisher did not test agianst.`,
-          ),
-        );
-      }
+    }
+
+    const hasShrinkwrap = await self.checkPackageHasShrinkwrap(rawPkgName);
+    if (!hasShrinkwrap) {
+      logger.warn(
+        clc.yellow(
+          `Warning: Package ${clc.bold(packageName)} does not have an npm-shrinkwrap.json file. npm-shrinkwrap guarantees that you deploy the same version of dependencies that the publisher tested against. Since this kit does not have an npm-shrinkwrap, it is possible that deploys or updates may introduce bugs or vulnerabilities in newer dependency versions that the publisher did not test against.`,
+        ),
+      );
+    }
+
+    if (isThirdParty || !hasShrinkwrap) {
+      const confirmMessage = isThirdParty
+        ? `Are you sure you want to install the third-party kit ${packageName}?`
+        : `Are you sure you want to install ${packageName} without locked dependencies?`;
       const confirmInstallation = await confirm({
-        message: `Are you sure you want to install the third-party kit ${packageName}?`,
+        message: confirmMessage,
         default: false,
         nonInteractive: options.nonInteractive,
       });
@@ -156,8 +177,8 @@ export const command = new Command("functions:kits:install")
       nonInteractive: options.nonInteractive,
     });
 
-    const sourcePath = path.join("function-kits", kitId);
-    const configDirPath = path.join("function-kits", kitId, `config-${instanceId}`);
+    const sourcePath = path.join(FUNCTION_KITS_DIR, kitId);
+    const configDirPath = path.join(FUNCTION_KITS_DIR, kitId, `config-${instanceId}`);
 
     let existingFunctions: ValidatedConfig | [] = [];
     const configFunctions = options.config.src.functions;
@@ -169,26 +190,26 @@ export const command = new Command("functions:kits:install")
       }
     }
 
-    for (const c of existingFunctions) {
-      if (isKitConfig(c) && c.kit === kitId) {
-        throw new FirebaseError(
-          `functions.kit must be unique but '${kitId}' was used more than once.`,
-        );
-      }
-    }
-
     const existingCodebases = new Set<string>();
     const existingInstanceIds = new Set<string>();
     for (const c of existingFunctions) {
-      if ("codebase" in c && c.codebase) {
+      if (isKitConfig(c)) {
+        if (c.kit === kitId) {
+          throw new FirebaseError(
+            `functions.kit must be unique but '${kitId}' was used more than once.`,
+          );
+        }
+        if (c.instances) {
+          for (const instId of Object.keys(c.instances)) {
+            existingInstanceIds.add(instId);
+          }
+        }
+      } else if (c.codebase) {
         existingCodebases.add(c.codebase);
-      }
-      if ("instances" in c && c.instances) {
-        validateKitInstances(c.instances, existingInstanceIds);
       }
     }
 
-    validateKitInstances({ [instanceId]: configDirPath }, existingInstanceIds);
+    validateKitInstances([instanceId], existingInstanceIds);
 
     if (existingCodebases.has(instanceId)) {
       throw new FirebaseError(
@@ -230,6 +251,7 @@ export const command = new Command("functions:kits:install")
       }
     }
 
+    // Ensure the wrapper package has a unique name and depends on the specified kit package and version.
     pkgJson.name = `${kitId}-wrapper`;
     pkgJson.dependencies = pkgJson.dependencies || {};
     pkgJson.dependencies[packageName] = version || "latest";

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -11,7 +11,7 @@ import {
   isKitConfig,
   normalizeAndValidate,
   validateKit,
-  validateKitInstances,
+  validateKitInstanceId,
   ValidatedConfig,
 } from "../functions/projectConfig";
 import * as experiments from "../experiments";
@@ -249,9 +249,12 @@ export const command = new Command("functions:kits:install")
       nonInteractive: options.nonInteractive,
       validate: (val: string) => {
         try {
-          validateKitInstances([val], existingInstanceIds);
+          validateKitInstanceId(val);
         } catch (err: unknown) {
           return getErrMsg(err);
+        }
+        if (existingInstanceIds.has(val)) {
+          return `functions kit instance ID must be unique across all kits, but '${val}' was used more than once.`;
         }
         if (existingCodebases.has(val)) {
           return `functions codebase name and kit instance ID must be mutually exclusive, but '${val}' was used as both a codebase name and a kit instance ID.`;
@@ -260,7 +263,12 @@ export const command = new Command("functions:kits:install")
       },
     });
 
-    validateKitInstances([instanceId], existingInstanceIds);
+    validateKitInstanceId(instanceId);
+    if (existingInstanceIds.has(instanceId)) {
+      throw new FirebaseError(
+        `functions kit instance ID must be unique across all kits, but '${instanceId}' was used more than once.`,
+      );
+    }
     if (existingCodebases.has(instanceId)) {
       throw new FirebaseError(
         `functions codebase name and kit instance ID must be mutually exclusive, but '${instanceId}' was used as both a codebase name and a kit instance ID.`,

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -1,4 +1,5 @@
 import * as clc from "colorette";
+import * as crypto from "crypto";
 import * as path from "path";
 import * as fs from "fs-extra";
 
@@ -33,6 +34,23 @@ const FUNCTION_KITS_DIR = "function-kits";
 
 export interface FunctionsKitsInstallOptions extends Options {
   npm_package?: string;
+}
+
+/**
+ * Generates a unique identifier by appending a random 4-character hex suffix if a collision exists.
+ * Ensures the candidate is truncated so the total length does not exceed 40 characters.
+ */
+export function generateUniqueId(baseId: string, existingIds: Set<string>): string {
+  if (!existingIds.has(baseId)) {
+    return baseId;
+  }
+  const prefix = baseId.slice(0, 35);
+  let candidate = "";
+  do {
+    const randomSuffix = crypto.randomBytes(2).toString("hex");
+    candidate = `${prefix}-${randomSuffix}`;
+  } while (existingIds.has(candidate));
+  return candidate;
 }
 
 /**
@@ -130,7 +148,6 @@ export const command = new Command("functions:kits:install")
 
     const { packageName, version } = parseNpmPackageSpecifier(rawPkgName);
     validateNpmPackageName(packageName);
-    const defaultKitId = sanitizePackageNameToKitName(packageName);
 
     const isThirdParty = isThirdPartyPackage(packageName);
     if (isThirdParty) {
@@ -164,22 +181,6 @@ export const command = new Command("functions:kits:install")
       }
     }
 
-    const kitId = await input({
-      message: "What would you like to name this kit?",
-      default: defaultKitId,
-      nonInteractive: options.nonInteractive,
-    });
-    validateKit(kitId);
-
-    const instanceId = await input({
-      message: "What would you like to name your first instance of this kit?",
-      default: kitId,
-      nonInteractive: options.nonInteractive,
-    });
-
-    const sourcePath = path.join(FUNCTION_KITS_DIR, kitId);
-    const configDirPath = path.join(FUNCTION_KITS_DIR, kitId, `config-${instanceId}`);
-
     let existingFunctions: ValidatedConfig | [] = [];
     const configFunctions = options.config.src.functions;
     if (configFunctions && (!Array.isArray(configFunctions) || configFunctions.length > 0)) {
@@ -190,14 +191,13 @@ export const command = new Command("functions:kits:install")
       }
     }
 
+    const existingKitIds = new Set<string>();
     const existingCodebases = new Set<string>();
     const existingInstanceIds = new Set<string>();
     for (const c of existingFunctions) {
       if (isKitConfig(c)) {
-        if (c.kit === kitId) {
-          throw new FirebaseError(
-            `functions.kit must be unique but '${kitId}' was used more than once.`,
-          );
+        if (c.kit) {
+          existingKitIds.add(c.kit);
         }
         if (c.instances) {
           for (const instId of Object.keys(c.instances)) {
@@ -209,13 +209,61 @@ export const command = new Command("functions:kits:install")
       }
     }
 
-    validateKitInstances([instanceId], existingInstanceIds);
+    const baseKitId = sanitizePackageNameToKitName(packageName);
+    const defaultKitId = generateUniqueId(baseKitId, existingKitIds);
 
+    const kitId = await input({
+      message: "What would you like to name this kit?",
+      default: defaultKitId,
+      nonInteractive: options.nonInteractive,
+      validate: (val: string) => {
+        try {
+          validateKit(val);
+        } catch (err: unknown) {
+          return getErrMsg(err);
+        }
+        if (existingKitIds.has(val)) {
+          return `functions.kit must be unique but '${val}' was used more than once.`;
+        }
+        return true;
+      },
+    });
+    validateKit(kitId);
+    if (existingKitIds.has(kitId)) {
+      throw new FirebaseError(
+        `functions.kit must be unique but '${kitId}' was used more than once.`,
+      );
+    }
+
+    const instanceCollisions = new Set([...existingInstanceIds, ...existingCodebases]);
+    const defaultInstanceId = generateUniqueId(kitId, instanceCollisions);
+
+    const instanceId = await input({
+      message: "What would you like to name your first instance of this kit?",
+      default: defaultInstanceId,
+      nonInteractive: options.nonInteractive,
+      validate: (val: string) => {
+        try {
+          validateKitInstances([val], existingInstanceIds);
+        } catch (err: unknown) {
+          return getErrMsg(err);
+        }
+        if (existingCodebases.has(val)) {
+          return `functions codebase name and kit instance ID must be mutually exclusive, but '${val}' was used as both a codebase name and a kit instance ID.`;
+        }
+        return true;
+      },
+    });
+
+    validateKitInstances([instanceId], existingInstanceIds);
     if (existingCodebases.has(instanceId)) {
       throw new FirebaseError(
         `functions codebase name and kit instance ID must be mutually exclusive, but '${instanceId}' was used as both a codebase name and a kit instance ID.`,
       );
     }
+
+    const sourcePath = path.join(FUNCTION_KITS_DIR, kitId);
+    const configDirPath = path.join(FUNCTION_KITS_DIR, kitId, `config-${instanceId}`);
 
     const absSourcePath = options.config.path(sourcePath);
     const absConfigDirPath = options.config.path(configDirPath);

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -94,7 +94,7 @@ export function sanitizePackageNameToKitName(packageName: string): string {
   const parts = packageName.split("/");
   const nameWithoutScope = parts[parts.length - 1] || packageName;
   const sanitized = nameWithoutScope.toLowerCase().replace(/[^a-z0-9_-]/g, "");
-  return (sanitized).slice(0, 40);
+  return sanitized.slice(0, 40);
 }
 
 /**

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -1,0 +1,285 @@
+import * as clc from "colorette";
+import * as path from "path";
+import * as fs from "fs-extra";
+
+import { Command } from "../command";
+import { FirebaseError, getErrMsg } from "../error";
+import { KitFunctionConfig } from "../firebaseConfig";
+
+import {
+  isKitConfig,
+  normalizeAndValidate,
+  validateKit,
+  validateKitInstances,
+  ValidatedConfig,
+} from "../functions/projectConfig";
+import * as experiments from "../experiments";
+import { logger } from "../logger";
+import { Options } from "../options";
+import { confirm, input } from "../prompt";
+import { spawnWithOutput, wrapSpawn } from "../init/spawn";
+import { readTemplateSync } from "../templates";
+import * as supported from "../deploy/functions/runtimes/supported";
+import * as self from "./functions-kits-install";
+
+const PACKAGE_NO_LINTING_TEMPLATE = readTemplateSync(
+  "init/functions/typescript/package.nolint.json",
+);
+const TSCONFIG_TEMPLATE = readTemplateSync("init/functions/typescript/tsconfig.json");
+const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/typescript/_gitignore");
+const INDEX_KIT_TEMPLATE = readTemplateSync("init/functions/typescript/index-kit.ts");
+
+export interface FunctionsKitsInstallOptions extends Options {
+  npm_package?: string;
+}
+
+/**
+ * Parses a package specifier string into package name and version.
+ * e.g., "@firebase-functions-kits/firestore-bigquery-export@1.0.0" ->
+ * { packageName: "@firebase-functions-kits/firestore-bigquery-export", version: "1.0.0" }
+ */
+export function parsePackageSpecifier(rawPkg: string): { packageName: string; version?: string } {
+  const lastAt = rawPkg.lastIndexOf("@");
+  if (lastAt > 0) {
+    return {
+      packageName: rawPkg.substring(0, lastAt),
+      version: rawPkg.substring(lastAt + 1),
+    };
+  }
+  return { packageName: rawPkg };
+}
+
+/**
+ * Sanitizes an npm package name into a valid kit identifier.
+ * e.g., "@firebase-functions-kits/firestore-bigquery-export" -> "firestore-bigquery-export"
+ */
+export function sanitizePackageNameToKitName(packageName: string): string {
+  const parts = packageName.split("/");
+  const nameWithoutScope = parts[parts.length - 1] || packageName;
+  const sanitized = nameWithoutScope
+    .toLowerCase()
+    .replace(/^@/, "")
+    .replace(/[^a-z0-9_-]/g, "");
+  return (sanitized || "kit").slice(0, 40);
+}
+
+/**
+ * Checks if a package name is third-party (outside the @firebase-functions-kits scope).
+ */
+export function isThirdPartyPackage(packageName: string): boolean {
+  return (
+    !packageName.startsWith("@firebase-functions-kits/") &&
+    packageName !== "@firebase-functions-kits"
+  );
+}
+
+/**
+ * Checks if an NPM package contains an npm-shrinkwrap.json file.
+ */
+export async function checkPackageHasShrinkwrap(rawPkgName: string): Promise<boolean> {
+  try {
+    const output = await spawnWithOutput("npm", ["pack", rawPkgName, "--dry-run", "--json"]);
+    const parsed = JSON.parse(output) as unknown;
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      const pkgInfo = parsed[0] as {
+        hasShrinkwrap?: boolean;
+        files?: Array<{ path?: string }>;
+      };
+      if (pkgInfo.hasShrinkwrap) {
+        return true;
+      }
+      if (Array.isArray(pkgInfo.files)) {
+        return pkgInfo.files.some(
+          (f) => f.path === "npm-shrinkwrap.json" || f.path === "npm-shrinkwrap.js",
+        );
+      }
+    }
+  } catch (err: unknown) {
+    logger.debug(`Failed to inspect package shrinkwrap for ${rawPkgName}: ${getErrMsg(err)}`);
+  }
+  return false;
+}
+
+export const command = new Command("functions:kits:install")
+  .description("install a Cloud Function kit into your project")
+  .option("--npm_package <package>", "NPM package name or specifier for the function kit")
+  .action(async (options: FunctionsKitsInstallOptions): Promise<void> => {
+    experiments.assertEnabled("kits", "install a function kit");
+
+    if (!options.config) {
+      throw new FirebaseError("Not in a Firebase project directory (firebase.json not found).");
+    }
+
+    const rawPkgName = options.npm_package;
+    if (!rawPkgName) {
+      throw new FirebaseError("set the --npm_package option to a valid NPM package and try again.");
+    }
+
+    const { packageName, version } = parsePackageSpecifier(rawPkgName);
+    const kitId = sanitizePackageNameToKitName(packageName);
+    validateKit(kitId);
+
+    const isThirdParty = isThirdPartyPackage(packageName);
+    if (isThirdParty) {
+      logger.warn(
+        clc.yellow(
+          `Warning: Package ${clc.bold(packageName)} is a third-party kit (outside the @firebase-functions-kits scope).`,
+        ),
+      );
+      const hasShrinkwrap = await self.checkPackageHasShrinkwrap(rawPkgName);
+      if (!hasShrinkwrap) {
+        logger.warn(
+          clc.yellow(
+            `Warning: Package ${clc.bold(packageName)} does not have an npm-shrinkwrap.json file. Dependencies are not locked and may present a security risk.`,
+          ),
+        );
+      }
+      const confirmInstallation = await confirm({
+        message: `Are you sure you want to install the third-party kit ${packageName}?`,
+        default: true,
+        nonInteractive: options.nonInteractive,
+      });
+      if (!confirmInstallation) {
+        throw new FirebaseError("Installation cancelled.");
+      }
+    }
+
+    const instanceId = await input({
+      message: "What would you like to name your first instance of this kit?",
+      default: kitId,
+      nonInteractive: options.nonInteractive,
+    });
+
+    const sourcePath = path.join("function-kits", kitId, "src");
+    const configDirPath = path.join("function-kits", kitId, `config-${instanceId}`);
+
+    let existingFunctions: ValidatedConfig | [] = [];
+    const configFunctions = options.config.src?.functions;
+    if (configFunctions && (!Array.isArray(configFunctions) || configFunctions.length > 0)) {
+      try {
+        existingFunctions = normalizeAndValidate(configFunctions);
+      } catch (err: unknown) {
+        throw new FirebaseError(`Invalid existing functions configuration: ${getErrMsg(err)}`);
+      }
+    }
+
+    for (const c of existingFunctions) {
+      if (isKitConfig(c) && c.kit === kitId) {
+        throw new FirebaseError(
+          `functions.kit must be unique but '${kitId}' was used more than once.`,
+        );
+      }
+    }
+
+    const existingCodebases = new Set<string>();
+    const existingInstanceIds = new Set<string>();
+    for (const c of existingFunctions) {
+      if ("codebase" in c && c.codebase) {
+        existingCodebases.add(c.codebase);
+      }
+      if ("instances" in c && c.instances) {
+        validateKitInstances(c.instances, existingInstanceIds);
+      }
+    }
+
+    validateKitInstances({ [instanceId]: configDirPath }, existingInstanceIds);
+
+    if (existingCodebases.has(instanceId)) {
+      throw new FirebaseError(
+        `functions codebase name and kit instance ID must be mutually exclusive, but '${instanceId}' was used as both a codebase name and a kit instance ID.`,
+      );
+    }
+
+    const absSourcePath = options.config.path(sourcePath);
+    const absConfigDirPath = options.config.path(configDirPath);
+
+    await fs.ensureDir(absSourcePath);
+    await fs.ensureDir(absConfigDirPath);
+
+    const relPackageJsonPath = path.join(sourcePath, "package.json");
+    const absPackageJsonPath = options.config.path(relPackageJsonPath);
+    let pkgJson: {
+      name?: string;
+      version?: string;
+      main?: string;
+      scripts?: Record<string, string>;
+      engines?: Record<string, string>;
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+      private?: boolean;
+    } = {};
+    if (await fs.pathExists(absPackageJsonPath)) {
+      try {
+        pkgJson = (await fs.readJson(absPackageJsonPath)) as typeof pkgJson;
+      } catch (err: unknown) {
+        logger.debug(`Failed to read existing package.json: ${getErrMsg(err)}`);
+      }
+    } else {
+      const latestNodeVersion = supported.latest("nodejs").replace("nodejs", "");
+      const subbedTemplate = PACKAGE_NO_LINTING_TEMPLATE.replace("{{RUNTIME}}", latestNodeVersion);
+      try {
+        pkgJson = JSON.parse(subbedTemplate) as typeof pkgJson;
+      } catch (err: unknown) {
+        logger.debug(`Failed to parse package.nolint.json template: ${getErrMsg(err)}`);
+      }
+    }
+
+    pkgJson.name = `${kitId}-wrapper`;
+    pkgJson.dependencies = pkgJson.dependencies || {};
+    pkgJson.dependencies[packageName] = version || "latest";
+
+    await options.config.askWriteProjectFile(relPackageJsonPath, pkgJson);
+    await options.config.askWriteProjectFile(
+      path.join(sourcePath, "tsconfig.json"),
+      TSCONFIG_TEMPLATE,
+    );
+    await options.config.askWriteProjectFile(
+      path.join(sourcePath, ".gitignore"),
+      GITIGNORE_TEMPLATE,
+    );
+
+    const relIndexTsPath = path.join(sourcePath, "index.ts");
+    const absIndexTsPath = options.config.path(relIndexTsPath);
+    if (!(await fs.pathExists(absIndexTsPath))) {
+      const indexContent = INDEX_KIT_TEMPLATE.replace("{{PACKAGE_NAME}}", packageName);
+      await options.config.askWriteProjectFile(relIndexTsPath, indexContent);
+    }
+
+    const installArgs = isThirdParty ? ["install", "--ignore-scripts"] : ["install"];
+    logger.info(clc.bold(`Running npm ${installArgs.join(" ")}...`));
+    try {
+      await wrapSpawn("npm", installArgs, absSourcePath);
+    } catch (err: unknown) {
+      throw new FirebaseError(`NPM install failed: ${getErrMsg(err)}`);
+    }
+
+    logger.info(clc.bold("Building TypeScript source..."));
+    try {
+      await wrapSpawn("npm", ["run", "build"], absSourcePath);
+    } catch (err: unknown) {
+      throw new FirebaseError(`TypeScript build failed: ${getErrMsg(err)}`);
+    }
+
+    const newKitConfig: KitFunctionConfig = {
+      kit: kitId,
+      sourcePackage: {
+        id: packageName,
+      },
+      source: sourcePath,
+      instances: {
+        [instanceId]: configDirPath,
+      },
+      predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+    };
+
+    if (!options.config.src.functions) {
+      options.config.src.functions = [newKitConfig];
+    } else if (Array.isArray(options.config.src.functions)) {
+      options.config.src.functions.push(newKitConfig);
+    } else {
+      options.config.src.functions = [options.config.src.functions, newKitConfig];
+    }
+
+    options.config.writeProjectFile("firebase.json", options.config.src);
+    logger.info(clc.green(`✔ Function kit ${clc.bold(kitId)} successfully installed.`));
+  });

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -116,8 +116,7 @@ export const command = new Command("functions:kits:install")
     }
 
     const { packageName, version } = parsePackageSpecifier(rawPkgName);
-    const kitId = sanitizePackageNameToKitName(packageName);
-    validateKit(kitId);
+    const defaultKitId = sanitizePackageNameToKitName(packageName);
 
     const isThirdParty = isThirdPartyPackage(packageName);
     if (isThirdParty) {
@@ -130,19 +129,26 @@ export const command = new Command("functions:kits:install")
       if (!hasShrinkwrap) {
         logger.warn(
           clc.yellow(
-            `Warning: Package ${clc.bold(packageName)} does not have an npm-shrinkwrap.json file. Dependencies are not locked and may present a security risk.`,
+            `Warning: Package ${clc.bold(packageName)} does not have an npm-shrinkwrap.json file. npm-shrinkwrap guarantees that you deploy the same version of dependencies that the publisher tested against. Since this kit does not have an npm-shrinkwrap, it is possible that deploys or updates may introduce bugs or vulnerabilities in newer dependency versions that the publisher did not test agianst.`,
           ),
         );
       }
       const confirmInstallation = await confirm({
         message: `Are you sure you want to install the third-party kit ${packageName}?`,
-        default: true,
+        default: false,
         nonInteractive: options.nonInteractive,
       });
       if (!confirmInstallation) {
         throw new FirebaseError("Installation cancelled.");
       }
     }
+
+    const kitId = await input({
+      message: "What would you like to name this kit?",
+      default: defaultKitId,
+      nonInteractive: options.nonInteractive,
+    });
+    validateKit(kitId);
 
     const instanceId = await input({
       message: "What would you like to name your first instance of this kit?",

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -94,7 +94,7 @@ export function sanitizePackageNameToKitName(packageName: string): string {
   const parts = packageName.split("/");
   const nameWithoutScope = parts[parts.length - 1] || packageName;
   const sanitized = nameWithoutScope.toLowerCase().replace(/[^a-z0-9_-]/g, "");
-  return (sanitized || "kit").slice(0, 40);
+  return (sanitized).slice(0, 40);
 }
 
 /**
@@ -168,9 +168,14 @@ export const command = new Command("functions:kits:install")
     }
 
     if (isThirdParty || !hasShrinkwrap) {
-      const confirmMessage = isThirdParty
-        ? `Are you sure you want to install the third-party kit ${packageName}?`
-        : `Are you sure you want to install ${packageName} without locked dependencies?`;
+      let confirmMessage: string;
+      if (isThirdParty && !hasShrinkwrap) {
+        confirmMessage = `Are you sure you want to install the third-party kit ${packageName} without locked dependencies?`;
+      } else if (isThirdParty) {
+        confirmMessage = `Are you sure you want to install the third-party kit ${packageName}?`;
+      } else {
+        confirmMessage = `Are you sure you want to install ${packageName} without locked dependencies?`;
+      }
       const confirmInstallation = await confirm({
         message: confirmMessage,
         default: false,
@@ -239,7 +244,7 @@ export const command = new Command("functions:kits:install")
     const defaultInstanceId = generateUniqueId(kitId, instanceCollisions);
 
     const instanceId = await input({
-      message: "What would you like to name your first instance of this kit?",
+      message: "What would you like to name this instance?",
       default: defaultInstanceId,
       nonInteractive: options.nonInteractive,
       validate: (val: string) => {

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -150,7 +150,7 @@ export const command = new Command("functions:kits:install")
       nonInteractive: options.nonInteractive,
     });
 
-    const sourcePath = path.join("function-kits", kitId, "src");
+    const sourcePath = path.join("function-kits", kitId);
     const configDirPath = path.join("function-kits", kitId, `config-${instanceId}`);
 
     let existingFunctions: ValidatedConfig | [] = [];
@@ -238,7 +238,7 @@ export const command = new Command("functions:kits:install")
       GITIGNORE_TEMPLATE,
     );
 
-    const relIndexTsPath = path.join(sourcePath, "index.ts");
+    const relIndexTsPath = path.join(sourcePath, "src", "index.ts");
     const absIndexTsPath = options.config.path(relIndexTsPath);
     if (!(await fs.pathExists(absIndexTsPath))) {
       const indexContent = INDEX_KIT_TEMPLATE.replace("{{PACKAGE_NAME}}", packageName);

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -154,7 +154,7 @@ export const command = new Command("functions:kits:install")
     const configDirPath = path.join("function-kits", kitId, `config-${instanceId}`);
 
     let existingFunctions: ValidatedConfig | [] = [];
-    const configFunctions = options.config.src?.functions;
+    const configFunctions = options.config.src.functions;
     if (configFunctions && (!Array.isArray(configFunctions) || configFunctions.length > 0)) {
       try {
         existingFunctions = normalizeAndValidate(configFunctions);
@@ -220,7 +220,7 @@ export const command = new Command("functions:kits:install")
       try {
         pkgJson = JSON.parse(subbedTemplate) as typeof pkgJson;
       } catch (err: unknown) {
-        logger.debug(`Failed to parse package.nolint.json template: ${getErrMsg(err)}`);
+        throw new FirebaseError("Failed to parse package.nolint.json template: " + getErrMsg(err));
       }
     }
 

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -198,6 +198,10 @@ export function load(client: CLIClient): CLIClient {
   client.functions.secrets.set = loadCommand("functions-secrets-set");
   client.functions.artifacts = {};
   client.functions.artifacts.setpolicy = loadCommand("functions-artifacts-setpolicy");
+  if (experiments.isEnabled("kits")) {
+    client.functions.kits = {};
+    client.functions.kits.install = loadCommand("functions-kits-install");
+  }
   client.help = loadCommand("help");
   client.hosting = {};
   client.hosting.channel = {};

--- a/src/functions/projectConfig.spec.ts
+++ b/src/functions/projectConfig.spec.ts
@@ -398,6 +398,13 @@ describe("projectConfig", () => {
         );
       });
 
+      it("fails validation if validateKitInstances is called standalone with duplicate instance IDs", () => {
+        expect(() => projectConfig.validateKitInstances(["inst1", "inst1"])).to.throw(
+          FirebaseError,
+          /functions kit instance ID must be unique across all kits, but 'inst1' was used more than once/,
+        );
+      });
+
       it("fails validation if instance ID starts with a dash", () => {
         const config = [
           {

--- a/src/functions/projectConfig.spec.ts
+++ b/src/functions/projectConfig.spec.ts
@@ -398,11 +398,30 @@ describe("projectConfig", () => {
         );
       });
 
-      it("fails validation if validateKitInstances is called standalone with duplicate instance IDs", () => {
-        expect(() => projectConfig.validateKitInstances(["inst1", "inst1"], new Set())).to.throw(
+      it("fails validation if validateKitInstanceId is called with invalid ID format", () => {
+        expect(() => projectConfig.validateKitInstanceId("Invalid_Instance!")).to.throw(
+          FirebaseError,
+          /Invalid kit instance ID/,
+        );
+        expect(() => projectConfig.validateKitInstanceId("-invalid")).to.throw(
+          FirebaseError,
+          /Invalid kit instance ID.*cannot start or end with a dash/,
+        );
+      });
+
+      it("fails validation if validateAndAddKitInstances is called with duplicate instance IDs", () => {
+        expect(() =>
+          projectConfig.validateAndAddKitInstances(["inst1", "inst1"], new Set()),
+        ).to.throw(
           FirebaseError,
           /functions kit instance ID must be unique across all kits, but 'inst1' was used more than once/,
         );
+      });
+
+      it("adds instance IDs to the provided set when validateAndAddKitInstances succeeds", () => {
+        const set = new Set(["existing-inst"]);
+        projectConfig.validateAndAddKitInstances(["inst1", "inst2"], set);
+        expect(Array.from(set)).to.deep.equal(["existing-inst", "inst1", "inst2"]);
       });
 
       it("fails validation if instance ID starts with a dash", () => {

--- a/src/functions/projectConfig.spec.ts
+++ b/src/functions/projectConfig.spec.ts
@@ -399,7 +399,7 @@ describe("projectConfig", () => {
       });
 
       it("fails validation if validateKitInstances is called standalone with duplicate instance IDs", () => {
-        expect(() => projectConfig.validateKitInstances(["inst1", "inst1"])).to.throw(
+        expect(() => projectConfig.validateKitInstances(["inst1", "inst1"], new Set())).to.throw(
           FirebaseError,
           /functions kit instance ID must be unique across all kits, but 'inst1' was used more than once/,
         );

--- a/src/functions/projectConfig.ts
+++ b/src/functions/projectConfig.ts
@@ -242,12 +242,13 @@ function assertUniqueSourcePrefixPair(config: ValidatedConfig): void {
 /**
  * Validate each instance ID format and ensure instance IDs are unique across all kit stanzas in the project.
  * @param instanceIds An iterable collection of instance IDs to validate.
- * @param existingInstanceIds A set of existing instance IDs in the project to check against for duplicates (defaults to a new Set).
+ * @param existingInstanceIds A set of existing instance IDs in the project to check against for duplicates.
  */
 export function validateKitInstances(
   instanceIds: Iterable<string>,
-  existingInstanceIds: Set<string> = new Set(),
+  existingInstanceIds: ReadonlySet<string>,
 ): void {
+  const seenInBatch = new Set<string>();
   for (const instanceId of instanceIds) {
     if (
       instanceId.length === 0 ||
@@ -259,12 +260,12 @@ export function validateKitInstances(
           "can contain only lowercase letters, numeric characters, underscores, and dashes, and cannot start or end with a dash.",
       );
     }
-    if (existingInstanceIds.has(instanceId)) {
+    if (seenInBatch.has(instanceId) || existingInstanceIds.has(instanceId)) {
       throw new FirebaseError(
         `functions kit instance ID must be unique across all kits, but '${instanceId}' was used more than once.`,
       );
     }
-    existingInstanceIds.add(instanceId);
+    seenInBatch.add(instanceId);
   }
 }
 
@@ -278,6 +279,9 @@ function assertUniqueKitInstancesAndCodebases(config: ValidatedConfig): void {
     }
     if ("instances" in c && c.instances) {
       validateKitInstances(Object.keys(c.instances), instanceIds);
+      for (const id of Object.keys(c.instances)) {
+        instanceIds.add(id);
+      }
     }
   }
 

--- a/src/functions/projectConfig.ts
+++ b/src/functions/projectConfig.ts
@@ -241,12 +241,14 @@ function assertUniqueSourcePrefixPair(config: ValidatedConfig): void {
 
 /**
  * Validate each instance ID format and ensure instance IDs are unique across all kit stanzas in the project.
+ * @param instanceIds An iterable collection of instance IDs to validate.
+ * @param existingInstanceIds A set of existing instance IDs in the project to check against for duplicates (defaults to a new Set).
  */
 export function validateKitInstances(
-  instances: Record<string, string>,
-  allProjectInstanceIds: Set<string>,
+  instanceIds: Iterable<string>,
+  existingInstanceIds: Set<string> = new Set(),
 ): void {
-  for (const instanceId of Object.keys(instances)) {
+  for (const instanceId of instanceIds) {
     if (
       instanceId.length === 0 ||
       instanceId.length > 40 ||
@@ -257,12 +259,12 @@ export function validateKitInstances(
           "can contain only lowercase letters, numeric characters, underscores, and dashes, and cannot start or end with a dash.",
       );
     }
-    if (allProjectInstanceIds.has(instanceId)) {
+    if (existingInstanceIds.has(instanceId)) {
       throw new FirebaseError(
         `functions kit instance ID must be unique across all kits, but '${instanceId}' was used more than once.`,
       );
     }
-    allProjectInstanceIds.add(instanceId);
+    existingInstanceIds.add(instanceId);
   }
 }
 
@@ -275,7 +277,7 @@ function assertUniqueKitInstancesAndCodebases(config: ValidatedConfig): void {
       codebases.add(c.codebase);
     }
     if ("instances" in c && c.instances) {
-      validateKitInstances(c.instances, instanceIds);
+      validateKitInstances(Object.keys(c.instances), instanceIds);
     }
   }
 

--- a/src/functions/projectConfig.ts
+++ b/src/functions/projectConfig.ts
@@ -240,32 +240,43 @@ function assertUniqueSourcePrefixPair(config: ValidatedConfig): void {
 }
 
 /**
- * Validate each instance ID format and ensure instance IDs are unique across all kit stanzas in the project.
- * @param instanceIds An iterable collection of instance IDs to validate.
- * @param existingInstanceIds A set of existing instance IDs in the project to check against for duplicates.
+ * Check that the kit instance ID is 40 characters or less and only contains allowed characters.
  */
-export function validateKitInstances(
+export function validateKitInstanceId(instanceId: string): void {
+  if (
+    instanceId.length === 0 ||
+    instanceId.length > 40 ||
+    !/^[a-z0-9_](?:[a-z0-9_-]*[a-z0-9_])?$/.test(instanceId)
+  ) {
+    throw new FirebaseError(
+      `Invalid kit instance ID '${instanceId}'. Instance ID must be 40 characters or less, ` +
+        "can contain only lowercase letters, numeric characters, underscores, and dashes, and cannot start or end with a dash.",
+    );
+  }
+}
+
+/**
+ * Validate each instance ID format and ensure instance IDs are unique across all kit stanzas in the project.
+ * Adds each validated instance ID to `allProjectInstanceIds`.
+ * @param instanceIds An iterable collection of instance IDs to validate.
+ * @param allProjectInstanceIds The set of all instance IDs across the project to check against and update.
+ */
+export function validateAndAddKitInstances(
   instanceIds: Iterable<string>,
-  existingInstanceIds: ReadonlySet<string>,
+  allProjectInstanceIds: Set<string>,
 ): void {
   const seenInBatch = new Set<string>();
   for (const instanceId of instanceIds) {
-    if (
-      instanceId.length === 0 ||
-      instanceId.length > 40 ||
-      !/^[a-z0-9_](?:[a-z0-9_-]*[a-z0-9_])?$/.test(instanceId)
-    ) {
-      throw new FirebaseError(
-        `Invalid kit instance ID '${instanceId}'. Instance ID must be 40 characters or less, ` +
-          "can contain only lowercase letters, numeric characters, underscores, and dashes, and cannot start or end with a dash.",
-      );
-    }
-    if (seenInBatch.has(instanceId) || existingInstanceIds.has(instanceId)) {
+    validateKitInstanceId(instanceId);
+    if (seenInBatch.has(instanceId) || allProjectInstanceIds.has(instanceId)) {
       throw new FirebaseError(
         `functions kit instance ID must be unique across all kits, but '${instanceId}' was used more than once.`,
       );
     }
     seenInBatch.add(instanceId);
+  }
+  for (const instanceId of seenInBatch) {
+    allProjectInstanceIds.add(instanceId);
   }
 }
 
@@ -278,10 +289,7 @@ function assertUniqueKitInstancesAndCodebases(config: ValidatedConfig): void {
       codebases.add(c.codebase);
     }
     if ("instances" in c && c.instances) {
-      validateKitInstances(Object.keys(c.instances), instanceIds);
-      for (const id of Object.keys(c.instances)) {
-        instanceIds.add(id);
-      }
+      validateAndAddKitInstances(Object.keys(c.instances), instanceIds);
     }
   }
 

--- a/templates/init/functions/typescript/index-kit.ts
+++ b/templates/init/functions/typescript/index-kit.ts
@@ -9,7 +9,7 @@ import {
   defineString,
 } from "firebase-functions/params";
 
-export const regionParam = defineString("FIREBASE_FUNCTION_KIT_REGION", {
+export const regionParam = defineString("FUNCTION_KIT_REGION", {
   description: "Region where functions should be deployed.",
 });
 

--- a/templates/init/functions/typescript/index-kit.ts
+++ b/templates/init/functions/typescript/index-kit.ts
@@ -1,80 +1,73 @@
 import { setGlobalOptions } from "firebase-functions";
-import {
-//   defineBoolean,
-//   defineFloat,
-//   defineInt,
-//   defineJson,
-//   defineList,
-//   defineSecret,
-  defineString,
-} from "firebase-functions/params";
+import * as params from "firebase-functions/params";
 
-export const regionParam = defineString("FUNCTION_KIT_REGION", {
+export const regionParam = params.defineString("FUNCTION_KIT_REGION", {
   description: "Region where functions should be deployed.",
 });
 
-// To configure more https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.globaloptions
-// and add them that way.
+// To require setting a global option for each instance of this kit, uncomment the option parameter
+// definition and the line configuring it below. Learn more about these options at:
+// https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.globaloptions
 
-// export const concurrencyParam = defineInt("FIREBASE_FUNCTION_KIT_CONCURRENCY", {
+// export const concurrencyParam = params.defineInt("FIREBASE_FUNCTION_KIT_CONCURRENCY", {
 //   description: "Number of concurrent requests a function instance can serve simultaneously.",
 // });
 
-// export const cpuParam = defineFloat("FIREBASE_FUNCTION_KIT_CPU", {
+// export const cpuParam = params.defineFloat("FIREBASE_FUNCTION_KIT_CPU", {
 //   description: "Fractional number of CPUs to allocate to a function.",
 // });
 
-// export const enforceAppCheckParam = defineBoolean("FIREBASE_FUNCTION_KIT_ENFORCE_APP_CHECK", {
+// export const enforceAppCheckParam = params.defineBoolean("FIREBASE_FUNCTION_KIT_ENFORCE_APP_CHECK", {
 //   description: "Controls whether Firebase App Check is enforced.",
 // });
 
-// export const ingressSettingsParam = defineString("FIREBASE_FUNCTION_KIT_INGRESS_SETTINGS", {
+// export const ingressSettingsParam = params.defineString("FIREBASE_FUNCTION_KIT_INGRESS_SETTINGS", {
 //   description: "Ingress settings to control network traffic sources (ALLOW_ALL, ALLOW_INTERNAL_ONLY, ALLOW_INTERNAL_AND_GCLB).",
 // });
 
-// export const invokerParam = defineString("FIREBASE_FUNCTION_KIT_INVOKER", {
+// export const invokerParam = params.defineString("FIREBASE_FUNCTION_KIT_INVOKER", {
 //   description: "Access control for HTTPS functions (e.g. 'public' or service account email).",
 // });
 
-// export const labelsParam = defineJson("FIREBASE_FUNCTION_KIT_LABELS", {
+// export const labelsParam = params.defineJson("FIREBASE_FUNCTION_KIT_LABELS", {
 //   description: "User-defined labels (JSON object) to set on the function.",
 // });
 
-// export const maxInstancesParam = defineInt("FIREBASE_FUNCTION_KIT_MAX_INSTANCES", {
+// export const maxInstancesParam = params.defineInt("FIREBASE_FUNCTION_KIT_MAX_INSTANCES", {
 //   description: "Maximum number of instances that can run in parallel.",
 // });
 
-// export const memoryParam = defineString("FIREBASE_FUNCTION_KIT_MEMORY", {
+// export const memoryParam = params.defineString("FIREBASE_FUNCTION_KIT_MEMORY", {
 //   description: "Amount of memory to allocate to the function (e.g. 256MiB, 512MiB, 1GiB, 2GiB).",
 // });
 
-// export const minInstancesParam = defineInt("FIREBASE_FUNCTION_KIT_MIN_INSTANCES", {
+// export const minInstancesParam = params.defineInt("FIREBASE_FUNCTION_KIT_MIN_INSTANCES", {
 //   description: "Minimum number of idle instances to keep running.",
 // });
 
-// export const omitParam = defineBoolean("FIREBASE_FUNCTION_KIT_OMIT", {
+// export const omitParam = params.defineBoolean("FIREBASE_FUNCTION_KIT_OMIT", {
 //   description: "If true, do not deploy or emulate these functions.",
 // });
 
-// export const preserveExternalChangesParam = defineBoolean("FIREBASE_FUNCTION_KIT_PRESERVE_EXTERNAL_CHANGES", {
+// export const preserveExternalChangesParam = params.defineBoolean("FIREBASE_FUNCTION_KIT_PRESERVE_EXTERNAL_CHANGES", {
 //   description: "If true, preserves configuration modified outside of function source code.",
 // });
 
-// export const secretParam = defineSecret("MY_SECRET");
+// export const secretParam = params.defineSecret("MY_SECRET");
 
-// export const serviceAccountParam = defineString("FIREBASE_FUNCTION_KIT_SERVICE_ACCOUNT", {
+// export const serviceAccountParam = params.defineString("FIREBASE_FUNCTION_KIT_SERVICE_ACCOUNT", {
 //   description: "Specific service account email for the function to run as.",
 // });
 
-// export const timeoutSecondsParam = defineInt("FIREBASE_FUNCTION_KIT_TIMEOUT_SECONDS", {
+// export const timeoutSecondsParam = params.defineInt("FIREBASE_FUNCTION_KIT_TIMEOUT_SECONDS", {
 //   description: "Timeout for the function in seconds (0 to 540 for event functions, up to 3600 for HTTPS).",
 // });
 
-// export const vpcConnectorParam = defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR", {
+// export const vpcConnectorParam = params.defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR", {
 //   description: "The VPC connector to connect the function to.",
 // });
 
-// export const vpcConnectorEgressSettingsParam = defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR_EGRESS_SETTINGS", {
+// export const vpcConnectorEgressSettingsParam = params.defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR_EGRESS_SETTINGS", {
 //   description: "Egress settings for VPC connector (PRIVATE_RANGES_ONLY or ALL_TRAFFIC).",
 // });
 

--- a/templates/init/functions/typescript/index-kit.ts
+++ b/templates/init/functions/typescript/index-kit.ts
@@ -1,0 +1,101 @@
+import { setGlobalOptions } from "firebase-functions";
+import {
+//   defineBoolean,
+//   defineFloat,
+//   defineInt,
+//   defineJson,
+//   defineList,
+//   defineSecret,
+  defineString,
+} from "firebase-functions/params";
+
+export const regionParam = defineString("FIREBASE_FUNCTION_KIT_REGION", {
+  description: "Region where functions should be deployed.",
+});
+
+// To configure more https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.globaloptions
+// and add them that way.
+
+// export const concurrencyParam = defineInt("FIREBASE_FUNCTION_KIT_CONCURRENCY", {
+//   description: "Number of concurrent requests a function instance can serve simultaneously.",
+// });
+
+// export const cpuParam = defineFloat("FIREBASE_FUNCTION_KIT_CPU", {
+//   description: "Fractional number of CPUs to allocate to a function.",
+// });
+
+// export const enforceAppCheckParam = defineBoolean("FIREBASE_FUNCTION_KIT_ENFORCE_APP_CHECK", {
+//   description: "Controls whether Firebase App Check is enforced.",
+// });
+
+// export const ingressSettingsParam = defineString("FIREBASE_FUNCTION_KIT_INGRESS_SETTINGS", {
+//   description: "Ingress settings to control network traffic sources (ALLOW_ALL, ALLOW_INTERNAL_ONLY, ALLOW_INTERNAL_AND_GCLB).",
+// });
+
+// export const invokerParam = defineString("FIREBASE_FUNCTION_KIT_INVOKER", {
+//   description: "Access control for HTTPS functions (e.g. 'public' or service account email).",
+// });
+
+// export const labelsParam = defineJson("FIREBASE_FUNCTION_KIT_LABELS", {
+//   description: "User-defined labels (JSON object) to set on the function.",
+// });
+
+// export const maxInstancesParam = defineInt("FIREBASE_FUNCTION_KIT_MAX_INSTANCES", {
+//   description: "Maximum number of instances that can run in parallel.",
+// });
+
+// export const memoryParam = defineString("FIREBASE_FUNCTION_KIT_MEMORY", {
+//   description: "Amount of memory to allocate to the function (e.g. 256MiB, 512MiB, 1GiB, 2GiB).",
+// });
+
+// export const minInstancesParam = defineInt("FIREBASE_FUNCTION_KIT_MIN_INSTANCES", {
+//   description: "Minimum number of idle instances to keep running.",
+// });
+
+// export const omitParam = defineBoolean("FIREBASE_FUNCTION_KIT_OMIT", {
+//   description: "If true, do not deploy or emulate these functions.",
+// });
+
+// export const preserveExternalChangesParam = defineBoolean("FIREBASE_FUNCTION_KIT_PRESERVE_EXTERNAL_CHANGES", {
+//   description: "If true, preserves configuration modified outside of function source code.",
+// });
+
+// export const secretParam = defineSecret("MY_SECRET");
+
+// export const serviceAccountParam = defineString("FIREBASE_FUNCTION_KIT_SERVICE_ACCOUNT", {
+//   description: "Specific service account email for the function to run as.",
+// });
+
+// export const timeoutSecondsParam = defineInt("FIREBASE_FUNCTION_KIT_TIMEOUT_SECONDS", {
+//   description: "Timeout for the function in seconds (0 to 540 for event functions, up to 3600 for HTTPS).",
+// });
+
+// export const vpcConnectorParam = defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR", {
+//   description: "The VPC connector to connect the function to.",
+// });
+
+// export const vpcConnectorEgressSettingsParam = defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR_EGRESS_SETTINGS", {
+//   description: "Egress settings for VPC connector (PRIVATE_RANGES_ONLY or ALL_TRAFFIC).",
+// });
+
+setGlobalOptions({
+  region: regionParam,
+  // concurrency: concurrencyParam,
+  // cpu: cpuParam,
+  // enforceAppCheck: enforceAppCheckParam,
+  // ingressSettings: ingressSettingsParam,
+  // invoker: invokerParam,
+  // labels: labelsParam,
+  // maxInstances: maxInstancesParam,
+  // memory: memoryParam,
+  // minInstances: minInstancesParam,
+  // omit: omitParam,
+  // preserveExternalChanges: preserveExternalChangesParam,
+  // secrets: [secretParam],
+  // serviceAccount: serviceAccountParam,
+  // timeoutSeconds: timeoutSecondsParam,
+  // vpcConnector: vpcConnectorParam,
+  // vpcConnectorEgressSettings: vpcConnectorEgressSettingsParam,
+});
+
+export * from "{{PACKAGE_NAME}}";

--- a/templates/init/functions/typescript/index-kit.ts
+++ b/templates/init/functions/typescript/index-kit.ts
@@ -1,94 +1,34 @@
+/**
+ *  This exports all functions in the kit so that the Firebase CLI can see it. The
+ *  kit may expose additional, optional features that you can configure after importing,
+ *  such as registering a callback. Check the kit's README for more information.
+ */
+
 import { setGlobalOptions } from "firebase-functions";
 import * as params from "firebase-functions/params";
 
-export const regionParam = params.defineString("FUNCTION_KIT_REGION", {
+// This is how you create a "param". A param is a placeholder for a value
+// which is determined at install/deploy time. Use a param whenever you want
+// the value to differ. Learn more at
+// https://firebase.google.com/docs/functions/config-env#params
+export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
   description: "Region where functions should be deployed.",
 });
 
-// To require setting a global option for each instance of this kit, uncomment the option parameter
-// definition and the line configuring it below. Learn more about these options at:
+
+// This allows you to set default options that apply to all functions in this
+// kit. Learn more about these options and additional configurations at:
 // https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.globaloptions
-
-// export const concurrencyParam = params.defineInt("FIREBASE_FUNCTION_KIT_CONCURRENCY", {
-//   description: "Number of concurrent requests a function instance can serve simultaneously.",
-// });
-
-// export const cpuParam = params.defineFloat("FIREBASE_FUNCTION_KIT_CPU", {
-//   description: "Fractional number of CPUs to allocate to a function.",
-// });
-
-// export const enforceAppCheckParam = params.defineBoolean("FIREBASE_FUNCTION_KIT_ENFORCE_APP_CHECK", {
-//   description: "Controls whether Firebase App Check is enforced.",
-// });
-
-// export const ingressSettingsParam = params.defineString("FIREBASE_FUNCTION_KIT_INGRESS_SETTINGS", {
-//   description: "Ingress settings to control network traffic sources (ALLOW_ALL, ALLOW_INTERNAL_ONLY, ALLOW_INTERNAL_AND_GCLB).",
-// });
-
-// export const invokerParam = params.defineString("FIREBASE_FUNCTION_KIT_INVOKER", {
-//   description: "Access control for HTTPS functions (e.g. 'public' or service account email).",
-// });
-
-// export const labelsParam = params.defineJson("FIREBASE_FUNCTION_KIT_LABELS", {
-//   description: "User-defined labels (JSON object) to set on the function.",
-// });
-
-// export const maxInstancesParam = params.defineInt("FIREBASE_FUNCTION_KIT_MAX_INSTANCES", {
-//   description: "Maximum number of instances that can run in parallel.",
-// });
-
-// export const memoryParam = params.defineString("FIREBASE_FUNCTION_KIT_MEMORY", {
-//   description: "Amount of memory to allocate to the function (e.g. 256MiB, 512MiB, 1GiB, 2GiB).",
-// });
-
-// export const minInstancesParam = params.defineInt("FIREBASE_FUNCTION_KIT_MIN_INSTANCES", {
-//   description: "Minimum number of idle instances to keep running.",
-// });
-
-// export const omitParam = params.defineBoolean("FIREBASE_FUNCTION_KIT_OMIT", {
-//   description: "If true, do not deploy or emulate these functions.",
-// });
-
-// export const preserveExternalChangesParam = params.defineBoolean("FIREBASE_FUNCTION_KIT_PRESERVE_EXTERNAL_CHANGES", {
-//   description: "If true, preserves configuration modified outside of function source code.",
-// });
-
-// export const secretParam = params.defineSecret("MY_SECRET");
-
-// export const serviceAccountParam = params.defineString("FIREBASE_FUNCTION_KIT_SERVICE_ACCOUNT", {
-//   description: "Specific service account email for the function to run as.",
-// });
-
-// export const timeoutSecondsParam = params.defineInt("FIREBASE_FUNCTION_KIT_TIMEOUT_SECONDS", {
-//   description: "Timeout for the function in seconds (0 to 540 for event functions, up to 3600 for HTTPS).",
-// });
-
-// export const vpcConnectorParam = params.defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR", {
-//   description: "The VPC connector to connect the function to.",
-// });
-
-// export const vpcConnectorEgressSettingsParam = params.defineString("FIREBASE_FUNCTION_KIT_VPC_CONNECTOR_EGRESS_SETTINGS", {
-//   description: "Egress settings for VPC connector (PRIVATE_RANGES_ONLY or ALL_TRAFFIC).",
-// });
-
 setGlobalOptions({
+  // If you pass a parameter, you will be prompted for new values on each instance.
   region: regionParam,
-  // concurrency: concurrencyParam,
-  // cpu: cpuParam,
-  // enforceAppCheck: enforceAppCheckParam,
-  // ingressSettings: ingressSettingsParam,
-  // invoker: invokerParam,
-  // labels: labelsParam,
-  // maxInstances: maxInstancesParam,
-  // memory: memoryParam,
-  // minInstances: minInstancesParam,
-  // omit: omitParam,
-  // preserveExternalChanges: preserveExternalChangesParam,
-  // secrets: [secretParam],
-  // serviceAccount: serviceAccountParam,
-  // timeoutSeconds: timeoutSecondsParam,
-  // vpcConnector: vpcConnectorParam,
-  // vpcConnectorEgressSettings: vpcConnectorEgressSettingsParam,
+  // If you want the same value for all instances across your kit, you can pass a
+  // normal value.
+  // For cost control, you can set the maximum number of containers that can be
+  // running at the same time. This helps mitigate the impact of unexpected
+  // traffic spikes by instead downgrading performance. This limit is a
+  // per-function limit.
+  maxInstances: 10,
 });
 
 export * from "{{PACKAGE_NAME}}";


### PR DESCRIPTION
### Description

Adds the `firebase functions:kits:install` command (gated behind the `kits` experiment) to allow developers to install and configure reusable Cloud Function kits in their Firebase projects.

Note: this is the first iteration of the command that just handles the first instance in a single project.

**Key Changes:**
- **Command Registration & Experiment Gating:** Registers `functions:kits:install` conditionally when the `kits` experiment is enabled.
- **Interactive & Flag Input:** Accepts a `--npm_package <package>` flag, and interactively prompts for the kit and initial instance ID.
- **Package Parsing & Validation:**
  - Parses scoped and unscoped package specifiers with optional versions/tags.
  - Sanitizes package names into valid kit identifiers.
  - Validates kit ID uniqueness and ensures instance IDs do not collide with existing codebase names or other kit instances in `firebase.json`.
- **Security & Third-Party Safeguards:**
  - Differentiates first-party (`@firebase-functions-kits/*`) and third-party packages.
  - Inspects packages for `npm-shrinkwrap.json` via `npm pack --dry-run --json` to warn users when dependencies are unlocked.
  - Prompts for explicit user confirmation before installing third-party kits.
  - Installs third-party packages with `--ignore-scripts` for safety.
- **Wrapper Project Scaffolding:**
  - Scaffolds a wrapper directory under `function-kits/<kit-id>/` containing `package.json`, `tsconfig.json`, `.gitignore`, and `src/index.ts` from templates.
  - Generates `index.ts` using `templates/init/functions/typescript/index-kit.ts`, re-exporting the kit package with customizable global function parameters.
  - Automatically runs `npm install` and `npm run build`.
- **Configuration Updates:** Adds the kit configuration block and instance mapping into `firebase.json`.
- **Testing:** Comprehensive unit test suite in `src/commands/functions-kits-install.spec.ts`.

### Scenarios Tested

- Experiment gating: Verified error is thrown when `kits` experiment is disabled.
- Precondition checks: Verified error when run outside a Firebase project directory (`firebase.json` missing).
- Package specifier parsing for scoped/unscoped packages with and without versions.
- Package name sanitization to valid kit identifiers (length truncation, character filtering).
- Third-party package detection and warnings for packages without `npm-shrinkwrap.json`.
- User confirmation flow cancellation / acceptance for third-party kits.
- Validated that third-party kits run `npm install --ignore-scripts`.
- Kit installation end-to-end scaffolding (`package.json`, `tsconfig.json`, `index.ts`, `firebase.json`).
- Conflict validations:
  - Duplicate `functions.kit` ID in `firebase.json`.
  - Collision between kit `instanceId` and existing function `codebase` name.

### Sample Commands

```bash
# Enable the kits experiment
firebase experiments:enable kits

# Install a package CLI
firebase functions:kits:install --npm_package @invertase/example-firebase-kit-hello-world@0.1.0
```