### PR TITLE
feat: add outputSchema support for local MCP tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Added `outputSchema` support for local MCP tools.
 - Added `appcheck:providers:list`, `appcheck:providers:get` and `appcheck:providers:set` to configure App Check attestation providers for an app.
 - Added `appcheck:apps:list` to show every app with its configured App Check providers.
 - Added web app support for Crashlytics MCP tools and prompts.

--- a/src/mcp/onemcp/onemcp_server.spec.ts
+++ b/src/mcp/onemcp/onemcp_server.spec.ts
@@ -33,6 +33,7 @@ describe("OneMcpServer", () => {
         name: "test_tool",
         description: "A test tool",
         inputSchema: { type: "object", properties: {} },
+        outputSchema: { type: "object", properties: { status: { type: "string" } } },
       };
       clientRequestStub.resolves({
         body: {
@@ -47,6 +48,7 @@ describe("OneMcpServer", () => {
       expect(tools).to.have.length(1);
       expect(tools[0].mcp.name).to.equal("auth_test_tool");
       expect(tools[0].mcp.description).to.equal(mockMcpTool.description);
+      expect(tools[0].mcp.outputSchema).to.deep.equal(mockMcpTool.outputSchema);
       expect(tools[0].mcp._meta).to.deep.equal({
         requiresAuth: false,
         requiresProject: true,

--- a/src/mcp/tool.spec.ts
+++ b/src/mcp/tool.spec.ts
@@ -33,12 +33,15 @@ describe("tool", () => {
         name: "test_tool",
         description: "A test tool",
         inputSchema: z.object({}),
+        outputSchema: z.object({ result: z.string() }),
       },
       testFn,
     );
 
     expect(testTool.mcp.name).to.equal("test_tool");
     expect(testTool.mcp.description).to.equal("A test tool");
+    expect(testTool.mcp.outputSchema).to.not.be.undefined;
+    expect(testTool.mcp.outputSchema.properties.result.type).to.equal("string");
     expect(testTool.fn).to.equal(testFn);
   });
 

--- a/src/mcp/tool.ts
+++ b/src/mcp/tool.ts
@@ -19,10 +19,7 @@ export type ServerToolMeta = {
   };
 };
 
-export interface ServerTool<
-  InputSchema extends ZodTypeAny = z.ZodAny,
-  OutputSchema extends ZodTypeAny = z.ZodAny,
-> {
+export interface ServerTool<InputSchema extends ZodTypeAny = z.ZodAny> {
   mcp: {
     name: string;
     description?: string;
@@ -53,12 +50,12 @@ export interface ServerTool<
 
 export function tool<InputSchema extends ZodTypeAny, OutputSchema extends ZodTypeAny = z.ZodAny>(
   feature: ServerFeature,
-  options: Omit<ServerTool<InputSchema, OutputSchema>["mcp"], "inputSchema" | "outputSchema"> & {
+  options: Omit<ServerTool<InputSchema>["mcp"], "inputSchema" | "outputSchema"> & {
     inputSchema: InputSchema;
     outputSchema?: OutputSchema;
     isAvailable?: (ctx: McpContext) => Promise<boolean>;
   },
-  fn: ServerTool<InputSchema, OutputSchema>["fn"],
+  fn: ServerTool<InputSchema>["fn"],
 ): ServerTool {
   const { isAvailable, ...mcpOptions } = options;
 

--- a/src/mcp/tool.ts
+++ b/src/mcp/tool.ts
@@ -19,11 +19,15 @@ export type ServerToolMeta = {
   };
 };
 
-export interface ServerTool<InputSchema extends ZodTypeAny = z.ZodAny> {
+export interface ServerTool<
+  InputSchema extends ZodTypeAny = z.ZodAny,
+  OutputSchema extends ZodTypeAny = z.ZodAny,
+> {
   mcp: {
     name: string;
     description?: string;
     inputSchema: any;
+    outputSchema?: any;
     annotations?: {
       title?: string;
 
@@ -47,13 +51,14 @@ export interface ServerTool<InputSchema extends ZodTypeAny = z.ZodAny> {
   isAvailable: (ctx: McpContext) => Promise<boolean>;
 }
 
-export function tool<InputSchema extends ZodTypeAny>(
+export function tool<InputSchema extends ZodTypeAny, OutputSchema extends ZodTypeAny = z.ZodAny>(
   feature: ServerFeature,
-  options: Omit<ServerTool<InputSchema>["mcp"], "inputSchema"> & {
+  options: Omit<ServerTool<InputSchema, OutputSchema>["mcp"], "inputSchema" | "outputSchema"> & {
     inputSchema: InputSchema;
+    outputSchema?: OutputSchema;
     isAvailable?: (ctx: McpContext) => Promise<boolean>;
   },
-  fn: ServerTool<InputSchema>["fn"],
+  fn: ServerTool<InputSchema, OutputSchema>["fn"],
 ): ServerTool {
   const { isAvailable, ...mcpOptions } = options;
 
@@ -63,6 +68,13 @@ export function tool<InputSchema extends ZodTypeAny>(
       inputSchema: cleanSchema(
         z.toJSONSchema(options.inputSchema, { target: "draft-7", io: "input" }),
       ),
+      ...(options.outputSchema
+        ? {
+            outputSchema: cleanSchema(
+              z.toJSONSchema(options.outputSchema, { target: "draft-7", io: "output" }),
+            ),
+          }
+        : {}),
     },
     fn,
     isAvailable: (ctx: McpContext) => {


### PR DESCRIPTION
### Description
Introduced the `outputSchema` property to the MCP `ServerTool` interface and the `tool()` builder function, enabling local tools to declare typed output schemas. Since the `@modelcontextprotocol/sdk` natively supports `outputSchema`, remote server schemas are automatically validated and forwarded.

### Scenarios Tested
- Verified that local tools constructed using `tool()` builder accept and compile with `outputSchema`.
- Verified that `outputSchema` gets processed and cleaned correctly in unit tests.
- Verified that `OneMcpServer.listTools()` successfully parses and retains the `outputSchema` returned by remote servers.

### Sample Commands
npx mocha src/mcp/tool.spec.ts src/mcp/onemcp/onemcp_server.spec.ts

