### PR TITLE
fix(emulator): display localhost in function initialization URLs (Fix issue 3728)

### DIFF
--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -8,6 +8,7 @@ import * as semver from "semver";
 import { URL } from "url";
 import { EventEmitter } from "events";
 
+import { formatFunctionUrlForDisplay } from "./functionsEmulatorUtils";
 import { Account } from "../types/auth";
 import { logger } from "../logger";
 import { trackEmulator } from "../track";
@@ -840,7 +841,7 @@ export class FunctionsEmulator implements EmulatorInstance {
         this.logger.logLabeled("BULLET", `functions[${definition.id}]`, msg);
       } else {
         const msg = url
-          ? `${clc.bold(triggerType)} function initialized (${url}).`
+          ? `${clc.bold(triggerType)} function initialized (${formatFunctionUrlForDisplay(url)}).`
           : `${clc.bold(triggerType)} function initialized.`;
         this.logger.logLabeled("SUCCESS", `functions[${definition.id}]`, msg);
       }

--- a/src/emulator/functionsEmulatorUtils.spec.ts
+++ b/src/emulator/functionsEmulatorUtils.spec.ts
@@ -6,6 +6,7 @@ import {
   compareVersionStrings,
   parseRuntimeVersion,
   isLocalHost,
+  formatFunctionUrlForDisplay,
 } from "./functionsEmulatorUtils";
 
 describe("FunctionsEmulatorUtils", () => {
@@ -182,5 +183,29 @@ describe("FunctionsEmulatorUtils", () => {
         expect(isLocalHost(t.href)).to.eq(t.expected);
       });
     }
+  });
+
+  describe("formatFunctionUrlForDisplay", () => {
+    it("should display localhost instead of the IPv4 wildcard address", () => {
+      const url = "http://0.0.0.0:5001/demo-project/us-central1/testFunction";
+
+      expect(formatFunctionUrlForDisplay(url)).to.equal(
+        "http://localhost:5001/demo-project/us-central1/testFunction",
+      );
+    });
+
+    it("should display localhost instead of the IPv4 loopback address", () => {
+      const url = "http://127.0.0.1:5001/demo-project/us-central1/testFunction";
+
+      expect(formatFunctionUrlForDisplay(url)).to.equal(
+        "http://localhost:5001/demo-project/us-central1/testFunction",
+      );
+    });
+
+    it("should preserve non-loopback hosts", () => {
+      const url = "http://192.168.1.10:5001/demo-project/us-central1/testFunction";
+
+      expect(formatFunctionUrlForDisplay(url)).to.equal(url);
+    });
   });
 });

--- a/src/emulator/functionsEmulatorUtils.ts
+++ b/src/emulator/functionsEmulatorUtils.ts
@@ -6,8 +6,20 @@
  * TODO(samstern): Audit dependencies of functionsEmulatorShared
  */
 
+import { URL } from "url";
+
 const wildcardRegex = new RegExp("{[^/{}]*}");
 const wildcardKeyRegex = new RegExp("^{(.+)}$");
+
+export function formatFunctionUrlForDisplay(url: string): string {
+  const parsedUrl = new URL(url);
+
+  if (parsedUrl.hostname === "0.0.0.0" || parsedUrl.hostname === "127.0.0.1") {
+    parsedUrl.hostname = "localhost";
+  }
+
+  return parsedUrl.toString();
+}
 
 export interface ModuleVersion {
   major: number;


### PR DESCRIPTION
### Description

Fixes #3728.

Function initialization messages can display local URLs using `0.0.0.0` or `127.0.0.1`, which is inconvenient because developers generally expect a browser-friendly `localhost` URL.

This change adds display-only URL formatting that replaces those local IPv4 addresses with `localhost`. Non-loopback hosts remain unchanged, and the emulator's internal binding and networking behavior are not affected.

Before:

```text
http://0.0.0.0:9002/...
http://127.0.0.1:9002/...
```

After:

```text
http://localhost:9002/...
```

### Scenarios Tested

- Confirmed that `0.0.0.0` is displayed as `localhost`.
- Confirmed that `127.0.0.1` is displayed as `localhost`.
- Confirmed that non-loopback hosts remain unchanged.
- Ran the complete related utility test file with all 28 tests passing.
- Ran the changed-file lint check with 0 errors.
- Built the complete Firebase Tools CLI successfully.
- Launched the Functions Emulator and confirmed that initialization URLs display `http://localhost:9002/...`.

#### Acceptance Criteria

- [x] Tests added for the new behavior
- [x] All directly related tests passing
- [x] Follows the project style requirements
- [x] No unrelated or breaking changes introduced
- [x] Documentation changes are not required

### Sample Commands

```bash
node lib/bin/firebase.js emulators:start \
  --config scripts/triggers-end-to-end-tests/firebase.json \
  --only functions:v1 \
  --project demo-test
```