### PR TITLE
feat: inject FIREBASE_KIT_INSTANCE_ID environment variable for function kits

### DIFF
--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -149,6 +149,54 @@ describe("prepare", () => {
       }
     });
 
+    it("should provide FIREBASE_KIT_INSTANCE_ID to discovery envs only for kit instances", async () => {
+      experiments.setEnabled("kits", true);
+      try {
+        const config: ValidatedConfig = [
+          {
+            kit: "my-kit",
+            sourcePackage: { id: "@firebase-functions-kits/my-kit" },
+            source: "source",
+            instances: {
+              "inst-alpha": "config/inst-alpha",
+              "inst-beta": "config/inst-beta",
+            },
+            runtime: "nodejs22",
+          },
+          { source: "source-default", codebase: "default", runtime: "nodejs22" },
+        ];
+        const options = {
+          config: {
+            path: (p: string) => p,
+          },
+          projectId: "project",
+        } as unknown as Options;
+        const firebaseConfig = { projectId: "project" };
+        const runtimeConfig = {};
+
+        await prepare.loadCodebases(config, options, firebaseConfig, runtimeConfig);
+
+        expect(discoverBuildStub).to.have.been.calledThrice;
+
+        // Match discovery envs for the first kit instance
+        expect(discoverBuildStub.firstCall.args[1]).to.deep.include({
+          FIREBASE_KIT_INSTANCE_ID: "inst-alpha",
+        });
+
+        // Match discovery envs for the second kit instance
+        expect(discoverBuildStub.secondCall.args[1]).to.deep.include({
+          FIREBASE_KIT_INSTANCE_ID: "inst-beta",
+        });
+
+        // Match discovery envs for the default codebase (should NOT include FIREBASE_KIT_INSTANCE_ID)
+        expect(discoverBuildStub.thirdCall.args[1]).to.not.have.property(
+          "FIREBASE_KIT_INSTANCE_ID",
+        );
+      } finally {
+        experiments.setEnabled("kits", null);
+      }
+    });
+
     it("should preserve runtime from codebase config", async () => {
       const config: ValidatedConfig = [
         { source: "source", codebase: "codebase", runtime: "nodejs20" },

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -286,7 +286,11 @@ export async function prepare(
   const wantBackends: Record<string, backend.Backend> = {};
   for (const [codebase, wantBuild] of Object.entries(wantBuilds)) {
     const config = configForCodebase(context.config, codebase);
-    const firebaseEnvs = functionsEnv.loadFirebaseEnvs(firebaseConfig, projectId);
+    const firebaseEnvs = functionsEnv.loadFirebaseEnvs(
+      firebaseConfig,
+      projectId,
+      isKitConfig(config) ? codebase : undefined,
+    );
     const localCfg = requireLocal(config, "Remote sources are not supported.");
     const userEnvOpt: functionsEnv.UserEnvsOpts = {
       functionsSource: options.config.path(localCfg.source),
@@ -779,7 +783,11 @@ export async function loadCodebases(
     logger.debug(`Building ${runtimeDelegate.language} source`);
     await runtimeDelegate.build();
 
-    const firebaseEnvs = functionsEnv.loadFirebaseEnvs(firebaseConfig, projectId);
+    const firebaseEnvs = functionsEnv.loadFirebaseEnvs(
+      firebaseConfig,
+      projectId,
+      isKitConfig(codebaseConfig) ? codebase : undefined,
+    );
     logLabeledBullet(
       "functions",
       `Loading and analyzing source code for codebase ${codebase} to determine what to deploy`,

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -557,6 +557,7 @@ export async function startAll(
             configDir: path.join(projectDir, configDir),
             env: {
               ...options.extDevEnv,
+              FIREBASE_KIT_INSTANCE_ID: instanceId,
             },
             secretEnv: [],
             predefinedTriggers: options.extDevTriggers as ParsedTriggerDefinition[] | undefined,

--- a/src/functions/env.spec.ts
+++ b/src/functions/env.spec.ts
@@ -1000,4 +1000,23 @@ FOO=foo
       expect(logBulletStub.firstCall.args[0]).to.include(expectedPath);
     });
   });
+
+  describe("loadFirebaseEnvs", () => {
+    it("should return basic firebase envs when no kitInstanceId is provided", () => {
+      const result = env.loadFirebaseEnvs({ foo: "bar" }, "my-project");
+      expect(result).to.deep.equal({
+        FIREBASE_CONFIG: '{"foo":"bar"}',
+        GCLOUD_PROJECT: "my-project",
+      });
+    });
+
+    it("should return kit instance id when kitInstanceId is provided", () => {
+      const result = env.loadFirebaseEnvs({ foo: "bar" }, "my-project", "my-kit-instance");
+      expect(result).to.deep.equal({
+        FIREBASE_CONFIG: '{"foo":"bar"}',
+        GCLOUD_PROJECT: "my-project",
+        FIREBASE_KIT_INSTANCE_ID: "my-kit-instance",
+      });
+    });
+  });
 });

--- a/src/functions/env.ts
+++ b/src/functions/env.ts
@@ -431,11 +431,16 @@ export function loadUserEnvs(opts: UserEnvsOpts): Record<string, string> {
 export function loadFirebaseEnvs(
   firebaseConfig: Record<string, any>,
   projectId: string,
+  kitInstanceId?: string,
 ): Record<string, string> {
-  return {
+  const envs: Record<string, string> = {
     FIREBASE_CONFIG: JSON.stringify(firebaseConfig),
     GCLOUD_PROJECT: projectId,
   };
+  if (kitInstanceId) {
+    envs.FIREBASE_KIT_INSTANCE_ID = kitInstanceId;
+  }
+  return envs;
 }
 
 /**

--- a/src/serve/functions.ts
+++ b/src/serve/functions.ts
@@ -43,7 +43,7 @@ export class FunctionsServer {
             prefix: projectConfig.addKitPrefix(instanceId),
             configDir: path.join(options.config.projectDir, configDir),
             runtime: localCfg.runtime,
-            env: {},
+            env: { FIREBASE_KIT_INSTANCE_ID: instanceId },
             secretEnv: [],
           });
         }


### PR DESCRIPTION
### Description
This change ensures that when deploying or emulating functions that belong to a Kit codebase, an environment variable `FIREBASE_KIT_INSTANCE_ID` is automatically injected into the process containing exactly the kit instance string identifier.

This mirrors how variables like `FIREBASE_CONFIG` and `GCLOUD_PROJECT` are orchestrated through `loadFirebaseEnvs()` and prevents the developer from manually mapping these contexts. The variable remains omitted if the user is deploying a standard codebase.

### Scenarios Tested
- Deployed multiple kits which contain functions that log and return their instance ids showing correct behavior.
- Deployed a non-kit codebase with the kits experiment on and off
- Run all tests

### Sample Commands
- `npm run test`
- `firebase deploy --only functions`