### PR TITLE
fix(functions): skip lifecycle hooks on partial (filtered) deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 - Fixed a bug where deploying functions with the `dartfunctions` experiment enabled could incorrectly prompt to delete existing GCF v2 functions.
 - Added `outputSchema` support for local MCP tools.
+- Skip functions lifecycle hooks during partial (filtered) deployments, and print instructions for running them manually.
 - Added `appcheck:providers:list`, `appcheck:providers:get` and `appcheck:providers:set` to configure App Check attestation providers for an app.
 - Added `appcheck:apps:list` to show every app with its configured App Check providers.
 - Added web app support for Crashlytics MCP tools and prompts.

--- a/src/deploy/functions/prompts.ts
+++ b/src/deploy/functions/prompts.ts
@@ -419,7 +419,7 @@ export async function promptForLifecycleEvent(
   choices.push({ name: "skip (default)", value: "skip" });
 
   const selection = await select<LifecycleEvent | "skip">({
-    message: `We cannot determine whether this deployment is a first deploy or a redeploy for codebase "${codebase}" because it is recovering from a previous partial failure.`,
+    message: `Cannot determine if this is a first deploy or a redeploy for codebase "${codebase}" because the last deployment was partial (either due to a failure or a filtered deploy).`,
     choices,
     default: "skip",
     nonInteractive: options?.nonInteractive,

--- a/src/deploy/functions/release/fabricator.spec.ts
+++ b/src/deploy/functions/release/fabricator.spec.ts
@@ -1606,7 +1606,10 @@ describe("Fabricator", () => {
       updateEndpoint.callsFake(fakeUpsert);
 
       await fab.applyPlan({
-        default: { regionalChangesets: { "us-central1": changes } },
+        default: {
+          plannedBackend: backend.of(ep1, ep2, ep3),
+          regionalChangesets: { "us-central1": changes },
+        },
       });
     });
 
@@ -1621,7 +1624,10 @@ describe("Fabricator", () => {
       };
 
       const summary = await fab.applyPlan({
-        default: { regionalChangesets: { "us-central1": changes } },
+        default: {
+          plannedBackend: backend.of(ep),
+          regionalChangesets: { "us-central1": changes },
+        },
       });
 
       const results = summary.results;
@@ -1677,7 +1683,10 @@ describe("Fabricator", () => {
     };
 
     const summary = await fab.applyPlan({
-      default: { regionalChangesets: { "us-central1": changes } },
+      default: {
+        plannedBackend: backend.of(createEP),
+        regionalChangesets: { "us-central1": changes },
+      },
     });
 
     const results = summary.results;
@@ -1707,7 +1716,10 @@ describe("Fabricator", () => {
     deleteEndpoint.resolves();
 
     const summary = await fab.applyPlan({
-      default: { regionalChangesets: { "us-central1": changes } },
+      default: {
+        plannedBackend: backend.of(createEP, updateEP, skipEP),
+        regionalChangesets: { "us-central1": changes },
+      },
     });
 
     const results = summary.results;
@@ -1728,6 +1740,7 @@ describe("Fabricator", () => {
       const ep2 = endpoint({ httpsTrigger: {} }, { region: "us-west1" });
       const plan: planner.DeploymentPlan = {
         default: {
+          plannedBackend: backend.of(ep1),
           regionalChangesets: {
             "us-central1": {
               endpointsToCreate: [ep1],
@@ -1761,6 +1774,7 @@ describe("Fabricator", () => {
       const ep2 = endpoint({ httpsTrigger: {} }, { region: "us-west1", id: "B" });
       const plan: planner.DeploymentPlan = {
         default: {
+          plannedBackend: backend.of(ep1),
           regionalChangesets: {
             "us-central1": {
               endpointsToCreate: [ep1],
@@ -1812,6 +1826,7 @@ describe("Fabricator", () => {
       const ep2 = endpoint({ httpsTrigger: {} }, { id: "B", region: "us-west1" });
       const plan: planner.DeploymentPlan = {
         default: {
+          plannedBackend: backend.of(ep1, ep2),
           regionalChangesets: {
             "us-central1": {
               endpointsToCreate: [ep1],
@@ -2050,6 +2065,7 @@ describe("Fabricator", () => {
 
     it("should create SA and grant roles in grantNewRoles", async () => {
       const plan: planner.CodebasePlan = {
+        plannedBackend: backend.empty(),
         regionalChangesets: {},
         serviceAccountToCreate: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
         managedServiceAccount: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
@@ -2074,6 +2090,7 @@ describe("Fabricator", () => {
 
     it("should remove roles or delete SA in removeOldRoles", async () => {
       const plan: planner.CodebasePlan = {
+        plannedBackend: backend.empty(),
         regionalChangesets: {},
         managedServiceAccount: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
         rolesToRemove: ["roles/oldRole"],
@@ -2090,6 +2107,7 @@ describe("Fabricator", () => {
 
     it("should delete SA if serviceAccountToDelete is set in removeOldRoles", async () => {
       const plan: planner.CodebasePlan = {
+        plannedBackend: backend.empty(),
         regionalChangesets: {},
         serviceAccountToDelete: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
       };
@@ -2106,6 +2124,7 @@ describe("Fabricator", () => {
       addServiceAccountRolesStub.rejects(new Error("Permission denied"));
 
       const plan: planner.CodebasePlan = {
+        plannedBackend: backend.empty(),
         regionalChangesets: {},
         serviceAccountToCreate: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
         managedServiceAccount: "firebase-fn-123@my-proj.iam.gserviceaccount.com",
@@ -2133,6 +2152,7 @@ describe("Fabricator", () => {
 
       const deploymentPlan: planner.DeploymentPlan = {
         default: {
+          plannedBackend: backend.of(endpoint),
           regionalChangesets: {
             "us-central1": {
               endpointsToCreate: [endpoint],
@@ -2188,6 +2208,7 @@ describe("Fabricator", () => {
 
       const deploymentPlan: planner.DeploymentPlan = {
         default: {
+          plannedBackend: backend.of(endpoint1, endpoint2),
           regionalChangesets: {
             "us-central1": {
               endpointsToCreate: [endpoint1, endpoint2],

--- a/src/deploy/functions/release/lifecycle.spec.ts
+++ b/src/deploy/functions/release/lifecycle.spec.ts
@@ -7,6 +7,7 @@ import {
   hasLifecycleHooks,
   isRecoveryDeployment,
 } from "./lifecycle";
+import * as planner from "./planner";
 import * as prompts from "../prompts";
 import * as cloudtasks from "../../../gcp/cloudtasks";
 import { logger } from "../../../logger";
@@ -356,6 +357,7 @@ describe("lifecycle", () => {
 
       const emptyPlan = {
         default: {
+          plannedBackend: wantBackend,
           regionalChangesets: {
             "default-us-east1-default": {
               endpointsToCreate: [],
@@ -375,6 +377,126 @@ describe("lifecycle", () => {
       );
       expect(executed).to.be.false;
       expect(enqueueStub).to.not.have.been.called;
+    });
+
+    it("skips hooks and warns when deployment is a partial filtered deploy (redeploy)", async () => {
+      const warningStub = sandbox.stub(utils, "logLabeledWarning");
+      const bulletStub = sandbox.stub(utils, "logLabeledBullet");
+
+      const fn1 = {
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+      };
+      const fn2 = {
+        id: "fn2",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn2",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+      };
+
+      const wantBackend = backend.of(fn1, fn2);
+      wantBackend.lifecycleHooks = {
+        afterRedeploy: {
+          task: {
+            function: "fn1",
+          },
+        },
+      };
+
+      const haveBackend = backend.of(fn1, fn2);
+
+      // Plan only targets fn1
+      const plan: planner.DeploymentPlan = {
+        "my-codebase": {
+          plannedBackend: backend.of(fn1),
+          regionalChangesets: {
+            "my-codebase-us-east1-default": {
+              endpointsToCreate: [],
+              endpointsToUpdate: [{ endpoint: fn1 }],
+              endpointsToDelete: [],
+              endpointsToSkip: [],
+            },
+          },
+        },
+      };
+
+      const executed = await executeLifecycleHooks(wantBackend, haveBackend, plan, "my-codebase");
+
+      expect(executed).to.be.false;
+      expect(warningStub).to.have.been.calledOnceWith(
+        "functions",
+        'Lifecycle hook "afterRedeploy" for codebase "my-codebase" was configured but not executed because this was a partial deployment (filtered).',
+      );
+      expect(bulletStub).to.have.been.calledOnceWith(
+        "functions",
+        "You can run the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterRedeploy my-codebase",
+      );
+    });
+
+    it("skips hooks and warns when deployment is a partial filtered deploy (first deploy)", async () => {
+      const warningStub = sandbox.stub(utils, "logLabeledWarning");
+      const bulletStub = sandbox.stub(utils, "logLabeledBullet");
+
+      const fn1 = {
+        id: "fn1",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn1",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+      };
+      const fn2 = {
+        id: "fn2",
+        project: "myProj",
+        region: "us-east1",
+        entryPoint: "fn2",
+        platform: "gcfv2" as const,
+        httpsTrigger: {},
+      };
+
+      const wantBackend = backend.of(fn1, fn2);
+      wantBackend.lifecycleHooks = {
+        afterFirstDeploy: {
+          task: {
+            function: "fn1",
+          },
+        },
+      };
+
+      const haveBackend = backend.empty();
+
+      // Plan only targets fn1
+      const plan: planner.DeploymentPlan = {
+        "my-codebase": {
+          plannedBackend: backend.of(fn1),
+          regionalChangesets: {
+            "my-codebase-us-east1-default": {
+              endpointsToCreate: [fn1],
+              endpointsToUpdate: [],
+              endpointsToDelete: [],
+              endpointsToSkip: [],
+            },
+          },
+        },
+      };
+
+      const executed = await executeLifecycleHooks(wantBackend, haveBackend, plan, "my-codebase");
+
+      expect(executed).to.be.false;
+      expect(warningStub).to.have.been.calledOnceWith(
+        "functions",
+        'Lifecycle hook "afterFirstDeploy" for codebase "my-codebase" was configured but not executed because this was a partial deployment (filtered).',
+      );
+      expect(bulletStub).to.have.been.calledOnceWith(
+        "functions",
+        "You can run the lifecycle hook in isolation by running: firebase functions:lifecycle:run afterFirstDeploy my-codebase",
+      );
     });
 
     it("logs a warning and suggest run command when task enqueue fails", async () => {

--- a/src/deploy/functions/release/lifecycle.ts
+++ b/src/deploy/functions/release/lifecycle.ts
@@ -31,9 +31,18 @@ export function hasLifecycleHooks(backendSpec: backend.Backend): boolean {
 }
 
 /**
- * Detects if this deployment is a redeploy of a partially successful but identical previous deployment.
- * This will be true only if the hashes for both backends are the same but the specified endpoints are different.
- * Note: If any code or comment modification was made between deploys, the hash will change, so this check won't detect it as an identical recovery deployment.
+ * Detects if the current deployment is recovering/completing a previous partial deployment
+ * of the same version, and is in a state where we cannot automatically determine the
+ * correct lifecycle event (prompting the user is required).
+ *
+ * This occurs when:
+ * 1. Some functions already match the target version hash (indicating a previous partial success).
+ * 2. Some functions in the target state are NOT active (missing or failed), meaning the codebase
+ *    has never been fully deployed at this version (or at all).
+ *
+ * We do NOT consider it a recovery deployment if all functions are already active (even if on
+ * older versions), because in that case we can safely infer that this is a redeployment
+ * and automatically run `afterRedeploy` once successful.
  */
 export function isRecoveryDeployment(
   wantBackend: backend.Backend,
@@ -49,16 +58,16 @@ export function isRecoveryDeployment(
     return false;
   }
 
-  // 1. We know a previous deploy was a partial success if haveBackend includes the same hash
-  // but wantBackend includes different functions.
+  // 1. Verify that at least one function in production already matches the target version hash.
+  // If none match, this is either a completely new deployment or a clean update, so it's not a recovery.
   const hasSameHash = haveEndpoints.some((ep) => ep.hash && wantHashes.has(ep.hash));
   if (!hasSameHash) {
     return false;
   }
 
-  // 2. If we have existing endpoints in haveBackend with matching hashes, but wantBackend contains net new functions,
-  // we know the current deployment is re-attempting a previous deployment with the same source code specification
-  // that failed to deploy all endpoints successfully.
+  // 2. Check if there are any target functions that are NOT currently active in production.
+  // If there are inactive/failed functions, the deployment is incomplete and ambiguous (could be
+  // recovering a first-time deploy), so we must prompt the user.
   const hasNetNewFunctions = wantEndpoints.some(
     (wantEp) =>
       !backend.findEndpoint(
@@ -84,6 +93,25 @@ export async function executeLifecycleHooks(
 ): Promise<boolean> {
   if (!hasLifecycleHooks(wantBackend)) {
     return false;
+  }
+
+  const codebasePlan = plan && codebase ? plan[codebase] : undefined;
+  if (codebasePlan && codebase) {
+    const allWantEndpoints = backend.allEndpoints(wantBackend);
+    const isFiltered = allWantEndpoints.some(backend.missingEndpoint(codebasePlan.plannedBackend));
+
+    if (isFiltered) {
+      const event = determineLifecycleEvent(haveBackend);
+      logLabeledWarning(
+        "functions",
+        `Lifecycle hook "${event}" for codebase "${codebase}" was configured but not executed because this was a partial deployment (filtered).`,
+      );
+      logLabeledBullet(
+        "functions",
+        `You can run the lifecycle hook in isolation by running: firebase functions:lifecycle:run ${event} ${codebase}`,
+      );
+      return false;
+    }
   }
 
   let event: backend.LifecycleEvent | undefined;

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -24,6 +24,7 @@ export interface Changeset {
 
 export interface BaseCodebasePlan {
   regionalChangesets: Record<string, Changeset>;
+  plannedBackend: backend.Backend;
 }
 
 export interface ActiveSecurityPlan {
@@ -230,6 +231,7 @@ export async function createDeploymentPlan(args: PlanArgs): Promise<CodebasePlan
     }
     return {
       regionalChangesets,
+      plannedBackend: wantBackend,
       rolesToAdd,
       rolesToRemove,
       serviceAccountToCreate,
@@ -238,6 +240,7 @@ export async function createDeploymentPlan(args: PlanArgs): Promise<CodebasePlan
   } else {
     return {
       regionalChangesets,
+      plannedBackend: wantBackend,
       serviceAccountToDelete,
     };
   }


### PR DESCRIPTION
### Description
Updates the deployment flow to skip executing lifecycle hooks (afterFirstDeploy, afterRedeploy) if the deployment is a partial deployment due to CLI filters (e.g. --only). If hooks are skipped, a warning is logged along with instructions on how to run them manually.

To support this, the CodebasePlan returned by the planner now includes the plannedBackend (the filtered target state). This allows downstream components like the lifecycle hook runner to easily determine if the deploy was partial by comparing the planned backend against the desired backend.

Here's a screenshot of the CLI output when skipping:

<img width="1205" height="99" alt="Screenshot 2026-08-09 at 2 22 31 PM" src="https://github.com/user-attachments/assets/728826fa-e5b1-412a-9b61-872701f8ab14" />

### Scenarios Tested
- Added unit tests
- Partial (filtered) deploy for a codebase with lifecycle events
- Full deploy for a codebase with lifecycle events
- Deploy of a codebase without lifecycle events.

### Sample Commands
npm run test
firebase deploy --only functions
firebase deploy --only functions:(single function in codebase with lifecycle events)

TAG=agy
CONV=ca939fe8-e463-44c5-b6ae-7a50e7b4599a