### PR TITLE
feat(extensions): add extensions replacement registry and automated g…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- Added extensions replacement registry and scraper tool to track migrations for deprecated extensions ahead of the March 2027 decommission date.
 - [Added] Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format:ts": "npm run lint:ts -- --fix --quiet",
     "generate:auth-api": "ts-node scripts/gen-auth-api-spec.ts",
     "generate:json-schema": "typescript-json-schema --strictNullChecks --required --noExtraProps --ignoreErrors src/firebaseConfig.ts FirebaseConfig > schema/firebase-config.json",
+    "scrape:extensions": "ts-node scripts/extensions-scraper/run-live-scan.ts",
     "lint": "npm run lint:ts && npm run lint:other",
     "lint:changed-files": "ts-node ./scripts/lint-changed-files.ts",
     "lint:other": "prettier --check '**/*.{md,yaml,yml}'",

--- a/scripts/extensions-scraper/index.spec.ts
+++ b/scripts/extensions-scraper/index.spec.ts
@@ -1,0 +1,84 @@
+import { expect } from "chai";
+import {
+  extractReplacementFromReadme,
+  getRepoUrlForExtension,
+  processExtensionReadmes,
+  toRawGithubUrl,
+} from "./index";
+
+describe("extensions-scraper", () => {
+  describe("extractReplacementFromReadme", () => {
+    it("should extract package name from 1P extension tag", () => {
+      const readme = `
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" package="@firebase/firestore-send-email" -->
+> Deprecation notice: Migrate to package.
+      `;
+      const pkg = extractReplacementFromReadme(readme);
+      expect(pkg).to.equal("@firebase/firestore-send-email");
+    });
+
+    it("should extract package name from 2P partner tag with single quotes", () => {
+      const readme = `
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension='stripe/firestore-stripe-payments' package='@stripe/firestore-stripe-payments' -->
+      `;
+      const pkg = extractReplacementFromReadme(readme);
+      expect(pkg).to.equal("@stripe/firestore-stripe-payments");
+    });
+  });
+
+  describe("toRawGithubUrl", () => {
+    it("should convert github.com tree URLs to raw.githubusercontent.com", () => {
+      const webUrl = "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md";
+      expect(toRawGithubUrl(webUrl)).to.equal(
+        "https://raw.githubusercontent.com/firebase/extensions/main/firestore-send-email/README.md",
+      );
+    });
+
+    it("should convert github.com blob URLs to raw.githubusercontent.com", () => {
+      const webUrl = "https://github.com/firebase/firestore-bundle-builder/blob/master/README.md";
+      expect(toRawGithubUrl(webUrl)).to.equal(
+        "https://raw.githubusercontent.com/firebase/firestore-bundle-builder/master/README.md",
+      );
+    });
+  });
+
+  describe("getRepoUrlForExtension", () => {
+    it("should resolve 1P firebase extensions to github.com repo tree", () => {
+      const url = getRepoUrlForExtension("firebase/firestore-send-email");
+      expect(url).to.equal(
+        "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
+      );
+    });
+
+    it("should resolve 2P partner extensions using explicit extensionRepositoryUrl", () => {
+      const url = getRepoUrlForExtension("stripe/firestore-stripe-payments", {
+        extensionRepositoryUrl:
+          "https://github.com/stripe/stripe-firebase-extensions/tree/main/firestore-stripe-payments/README.md",
+      });
+      expect(url).to.equal(
+        "https://github.com/stripe/stripe-firebase-extensions/tree/main/firestore-stripe-payments/README.md",
+      );
+    });
+  });
+
+  describe("processExtensionReadmes", () => {
+    it("should update registry when valid replacement tags are found", () => {
+      const readmes = {
+        "firebase/firestore-send-email":
+          '<!-- FIREBASE_EXTENSION_REPLACEMENT: package="@firebase/firestore-send-email" -->',
+      };
+      const initialRegistry = {
+        replacements: {
+          "firebase/firestore-send-email": { status: "PENDING_PUBLISHER" },
+        },
+      };
+
+      const { updatedRegistry, results } = processExtensionReadmes(readmes, initialRegistry);
+      expect(results[0].status).to.equal("REPLACEMENT_AVAILABLE");
+      expect(updatedRegistry.replacements["firebase/firestore-send-email"]).to.deep.equal({
+        status: "REPLACEMENT_AVAILABLE",
+        npmPackage: "@firebase/firestore-send-email",
+      });
+    });
+  });
+});

--- a/scripts/extensions-scraper/index.spec.ts
+++ b/scripts/extensions-scraper/index.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
+import { ReplacementRegistrySchema } from "../../src/extensions/replacementRegistry";
 import {
   extractReplacementFromReadme,
   getRepoUrlForExtension,
   processExtensionReadmes,
   toRawGithubUrl,
 } from "./index";
-import { ReplacementRegistrySchema } from "../../src/extensions/replacementRegistry";
 
 describe("extensions-scraper", () => {
   describe("extractReplacementFromReadme", () => {
@@ -25,6 +25,32 @@ describe("extensions-scraper", () => {
       const pkg = extractReplacementFromReadme(readme);
       expect(pkg).to.equal("@stripe/firestore-stripe-payments");
     });
+
+    it("should return undefined when replacement tag is missing the package attribute", () => {
+      const readme = `
+<!-- FIREBASE_EXTENSION_REPLACEMENT: extension="firebase/firestore-send-email" target="npm" -->
+## Migration Guide
+Check out the replacement guide below.
+      `;
+      const pkg = extractReplacementFromReadme(readme);
+      expect(pkg).to.be.undefined;
+    });
+
+    it("should return undefined for unrelated HTML comments in README", () => {
+      const readme = `
+<!-- TODO: update configuration instructions before v2 release -->
+<!-- markdownlint-disable MD013 -->
+# Firestore Extension
+Standard documentation and configuration details.
+      `;
+      const pkg = extractReplacementFromReadme(readme);
+      expect(pkg).to.be.undefined;
+    });
+
+    it("should return undefined for empty or whitespace content", () => {
+      expect(extractReplacementFromReadme("")).to.be.undefined;
+      expect(extractReplacementFromReadme("   \n\t  ")).to.be.undefined;
+    });
   });
 
   describe("toRawGithubUrl", () => {
@@ -42,23 +68,29 @@ describe("extensions-scraper", () => {
         "https://raw.githubusercontent.com/firebase/firestore-bundle-builder/master/README.md",
       );
     });
-  });
 
-  describe("getRepoUrlForExtension", () => {
-    it("should resolve 1P firebase extensions to github.com repo tree", () => {
-      const url = getRepoUrlForExtension("firebase/firestore-send-email");
-      expect(url).to.equal(
-        "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
+    it("should throw error for non-GitHub hosts", () => {
+      expect(() => toRawGithubUrl("https://gitlab.com/owner/repo/README.md")).to.throw(
+        "Unsupported host",
       );
     });
 
-    it("should resolve 2P partner extensions using explicit extensionRepositoryUrl", () => {
-      const url = getRepoUrlForExtension("stripe/firestore-stripe-payments", {
+    it("should throw error for malformed URLs", () => {
+      expect(() => toRawGithubUrl("not-a-valid-url")).to.throw(
+        "Failed to convert to raw GitHub URL",
+      );
+    });
+  });
+
+  describe("getRepoUrlForExtension", () => {
+    it("should return the mandatory extensionRepositoryUrl from the entry", () => {
+      const url = getRepoUrlForExtension({
+        status: "PENDING_PUBLISHER",
         extensionRepositoryUrl:
-          "https://github.com/stripe/stripe-firebase-extensions/tree/main/firestore-stripe-payments/README.md",
+          "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
       });
       expect(url).to.equal(
-        "https://github.com/stripe/stripe-firebase-extensions/tree/main/firestore-stripe-payments/README.md",
+        "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
       );
     });
   });
@@ -67,7 +99,7 @@ describe("extensions-scraper", () => {
     it("should update registry when valid replacement tags are found", () => {
       const readmes = {
         "firebase/firestore-send-email":
-          '<!-- FIREBASE_EXTENSION_REPLACEMENT: package="@firebase/firestore-send-email" -->',
+          '<!-- FIREBASE_EXTENSION_REPLACEMENT: package="@firebase-function-kits/firestore-send-email" -->',
       };
       const initialRegistry: ReplacementRegistrySchema = {
         replacements: {
@@ -83,7 +115,7 @@ describe("extensions-scraper", () => {
       expect(results[0].status).to.equal("REPLACEMENT_AVAILABLE");
       expect(updatedRegistry.replacements["firebase/firestore-send-email"]).to.deep.equal({
         status: "REPLACEMENT_AVAILABLE",
-        npmPackage: "@firebase/firestore-send-email",
+        npmPackage: "@firebase-function-kits/firestore-send-email",
         extensionRepositoryUrl:
           "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
       });

--- a/scripts/extensions-scraper/index.spec.ts
+++ b/scripts/extensions-scraper/index.spec.ts
@@ -5,6 +5,7 @@ import {
   processExtensionReadmes,
   toRawGithubUrl,
 } from "./index";
+import { ReplacementRegistrySchema } from "../../src/extensions/replacementRegistry";
 
 describe("extensions-scraper", () => {
   describe("extractReplacementFromReadme", () => {
@@ -28,7 +29,8 @@ describe("extensions-scraper", () => {
 
   describe("toRawGithubUrl", () => {
     it("should convert github.com tree URLs to raw.githubusercontent.com", () => {
-      const webUrl = "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md";
+      const webUrl =
+        "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md";
       expect(toRawGithubUrl(webUrl)).to.equal(
         "https://raw.githubusercontent.com/firebase/extensions/main/firestore-send-email/README.md",
       );
@@ -67,7 +69,7 @@ describe("extensions-scraper", () => {
         "firebase/firestore-send-email":
           '<!-- FIREBASE_EXTENSION_REPLACEMENT: package="@firebase/firestore-send-email" -->',
       };
-      const initialRegistry = {
+      const initialRegistry: ReplacementRegistrySchema = {
         replacements: {
           "firebase/firestore-send-email": { status: "PENDING_PUBLISHER" },
         },

--- a/scripts/extensions-scraper/index.spec.ts
+++ b/scripts/extensions-scraper/index.spec.ts
@@ -71,7 +71,11 @@ describe("extensions-scraper", () => {
       };
       const initialRegistry: ReplacementRegistrySchema = {
         replacements: {
-          "firebase/firestore-send-email": { status: "PENDING_PUBLISHER" },
+          "firebase/firestore-send-email": {
+            status: "PENDING_PUBLISHER",
+            extensionRepositoryUrl:
+              "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
+          },
         },
       };
 
@@ -80,6 +84,8 @@ describe("extensions-scraper", () => {
       expect(updatedRegistry.replacements["firebase/firestore-send-email"]).to.deep.equal({
         status: "REPLACEMENT_AVAILABLE",
         npmPackage: "@firebase/firestore-send-email",
+        extensionRepositoryUrl:
+          "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
       });
     });
   });

--- a/scripts/extensions-scraper/index.ts
+++ b/scripts/extensions-scraper/index.ts
@@ -1,0 +1,108 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export interface ScraperResult {
+  extensionRef: string;
+  detectedPackage?: string;
+  status: "REPLACEMENT_AVAILABLE" | "CONFIRMED_NO_REPLACEMENT" | "PENDING_PUBLISHER";
+}
+
+// Case-insensitive, whitespace-lenient HTML comment tag regex
+export const REPLACEMENT_TAG_REGEX =
+  /<!--\s*FIREBASE_EXTENSION_REPLACEMENT:[\s\S]*?package=["']?([^"'\s>]+)["']?[\s\S]*?-->/i;
+
+/**
+ * Extracts replacement package name from raw README markdown string using the machine tag regex.
+ */
+export function extractReplacementFromReadme(readmeContent: string): string | undefined {
+  if (!readmeContent) {
+    return undefined;
+  }
+  const match = REPLACEMENT_TAG_REGEX.exec(readmeContent);
+  if (match && match[1]) {
+    return match[1].trim();
+  }
+  return undefined;
+}
+
+/**
+ * Converts a human-browsable GitHub URL (e.g. github.com/owner/repo/tree/branch/path)
+ * into a raw fetchable URL (raw.githubusercontent.com/owner/repo/branch/path).
+ */
+export function toRawGithubUrl(url: string): string {
+  if (url.includes("raw.githubusercontent.com")) {
+    return url;
+  }
+  return url
+    .replace(/^https:\/\/github\.com\//, "https://raw.githubusercontent.com/")
+    .replace(/\/tree\//, "/")
+    .replace(/\/blob\//, "/");
+}
+
+/**
+ * Resolves the repository URL for an extension.
+ * - If entry has explicit "extensionRepositoryUrl", returns that.
+ * - For 1P extensions (firebase/*), defaults to firebase/extensions main branch.
+ * - For 2P partner extensions (publisher/*), constructs standard GitHub URL.
+ */
+export function getRepoUrlForExtension(
+  extensionRef: string,
+  entry?: { extensionRepositoryUrl?: string },
+): string {
+  if (entry?.extensionRepositoryUrl) {
+    return entry.extensionRepositoryUrl;
+  }
+  const parts = extensionRef.split("/");
+  const publisher = parts[0];
+  const extensionId = parts[1] || extensionRef;
+
+  if (publisher === "firebase") {
+    return `https://github.com/firebase/extensions/tree/main/${extensionId}/README.md`;
+  }
+  return `https://github.com/${publisher}/${extensionId}/tree/main/README.md`;
+}
+
+/**
+ * Scans a list of extension README files or content strings and updates the registry object.
+ */
+export function processExtensionReadmes(
+  readmes: Record<string, string>,
+  registryData: Record<string, any>,
+): { updatedRegistry: Record<string, any>; results: ScraperResult[] } {
+  const results: ScraperResult[] = [];
+  const updatedRegistry = JSON.parse(JSON.stringify(registryData));
+
+  for (const [extensionRef, content] of Object.entries(readmes)) {
+    const detectedPackage = extractReplacementFromReadme(content);
+    let status: ScraperResult["status"] = "PENDING_PUBLISHER";
+
+    if (detectedPackage) {
+      status = "REPLACEMENT_AVAILABLE";
+      updatedRegistry.replacements[extensionRef] = {
+        status,
+        npmPackage: detectedPackage,
+      };
+    }
+
+    results.push({
+      extensionRef,
+      detectedPackage,
+      status,
+    });
+  }
+
+  return { updatedRegistry, results };
+}
+
+// Main CLI runner if executed directly
+if (require.main === module) {
+  const replacementsPath = path.resolve(__dirname, "../../src/extensions/replacements.json");
+  console.log(`[Scraper] Reading registry asset from ${replacementsPath}...`);
+  if (fs.existsSync(replacementsPath)) {
+    const rawData = fs.readFileSync(replacementsPath, "utf-8");
+    const registry = JSON.parse(rawData);
+    console.log(
+      `[Scraper] Successfully loaded ${Object.keys(registry.replacements).length} extension entries.`,
+    );
+  }
+}

--- a/scripts/extensions-scraper/index.ts
+++ b/scripts/extensions-scraper/index.ts
@@ -1,3 +1,6 @@
+import * as fs from "fs";
+import * as path from "path";
+
 import {
   ReplacementInfo,
   ReplacementRegistrySchema,
@@ -6,40 +9,32 @@ import {
 export interface ScraperResult {
   extensionRef: string;
   detectedPackage?: string;
-  status: "REPLACEMENT_AVAILABLE" | "PENDING_PUBLISHER";
+  status: "REPLACEMENT_AVAILABLE" | "CONFIRMED_NO_REPLACEMENT" | "PENDING_PUBLISHER";
 }
 
+// Case-insensitive, whitespace-lenient HTML comment tag regex
+export const REPLACEMENT_TAG_REGEX =
+  /<!--\s*FIREBASE_EXTENSION_REPLACEMENT:[\s\S]*?package=["']?([^"'\s>]+)["']?[\s\S]*?-->/i;
+
 /**
- * Extracts replacement npm package name from extension README markdown content.
- *
- * Supports machine tags:
- *   <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="publisher/extension-name" package="@scope/package-name" -->
- *   <!-- FIREBASE_EXTENSION_REPLACEMENT: package="@scope/package-name" -->
- *   <!-- FIREBASE_EXTENSION_REPLACEMENT: package='@scope/package-name' -->
- *
- * Note: The `extension="..."` attribute is optional metadata for human readability,
- * whereas `package="..."` is the required payload containing the replacement npm package.
+ * Extracts replacement package name from raw README markdown string using the machine tag regex.
  */
 export function extractReplacementFromReadme(readmeContent: string): string | undefined {
   if (!readmeContent) {
     return undefined;
   }
-
-  // Regex matching machine-readable replacement tag
-  const tagRegex =
-    /<!--\s*FIREBASE_EXTENSION_REPLACEMENT:\s*(?:(?:extension=["'][^"']+["']\s*)?package=["']([^"']+)["']|(?:package=["']([^"']+)["']\s*)?extension=["'][^"']+["'])\s*-->/i;
-  const match = tagRegex.exec(readmeContent);
-
-  if (match) {
-    return match[1] || match[2];
+  const match = REPLACEMENT_TAG_REGEX.exec(readmeContent);
+  if (match && match[1]) {
+    return match[1].trim();
   }
-
   return undefined;
 }
 
 /**
  * Converts a human-browsable GitHub URL (e.g. github.com/owner/repo/tree/branch/path)
  * into a raw fetchable URL (raw.githubusercontent.com/owner/repo/branch/path).
+ *
+ * Throws an Error if the URL is not a recognized GitHub host or has invalid format.
  */
 export function toRawGithubUrl(url: string): string {
   try {
@@ -51,37 +46,21 @@ export function toRawGithubUrl(url: string): string {
       const pathname = parsed.pathname.replace(/\/tree\//, "/").replace(/\/blob\//, "/");
       return `https://raw.githubusercontent.com${pathname}`;
     }
-  } catch {
-    // Return unchanged if not a valid URL
+    throw new Error(`Unsupported host: ${parsed.hostname}`);
+  } catch (err: unknown) {
+    throw new Error(`Failed to convert to raw GitHub URL: ${String(err)} (${url})`);
   }
-  return url;
 }
 
 /**
- * Resolves the repository URL for an extension.
- * - If entry has explicit "extensionRepositoryUrl", returns that.
- * - For 1P extensions (firebase/*), defaults to firebase/extensions main branch.
- * - For 2P partner extensions (publisher/*), constructs standard GitHub URL.
+ * Resolves the repository URL for an extension from its mandatory registry entry.
  */
-export function getRepoUrlForExtension(
-  extensionRef: string,
-  entry?: { extensionRepositoryUrl?: string },
-): string {
-  if (entry?.extensionRepositoryUrl) {
-    return entry.extensionRepositoryUrl;
-  }
-  const parts = extensionRef.split("/");
-  const publisher = parts[0];
-  const extensionId = parts[1] || extensionRef;
-
-  if (publisher === "firebase") {
-    return `https://github.com/firebase/extensions/tree/main/${extensionId}/README.md`;
-  }
-  return `https://github.com/${publisher}/${extensionId}/tree/main/README.md`;
+export function getRepoUrlForExtension(entry: ReplacementInfo): string {
+  return entry.extensionRepositoryUrl;
 }
 
 /**
- * Scans a map of extension README contents and updates the registry data structure in place.
+ * Scans a list of extension README files or content strings and updates the registry object.
  */
 export function processExtensionReadmes(
   readmes: Record<string, string>,
@@ -92,14 +71,10 @@ export function processExtensionReadmes(
     JSON.stringify(registryData),
   ) as ReplacementRegistrySchema;
 
-  if (!updatedRegistry.replacements) {
-    updatedRegistry.replacements = {};
-  }
-
   for (const [extensionRef, content] of Object.entries(readmes)) {
     const detectedPackage = extractReplacementFromReadme(content);
     const existingEntry = updatedRegistry.replacements[extensionRef];
-    const repoUrl = getRepoUrlForExtension(extensionRef, existingEntry);
+    const repoUrl = getRepoUrlForExtension(existingEntry);
 
     if (detectedPackage) {
       const updatedInfo: ReplacementInfo = {
@@ -111,6 +86,17 @@ export function processExtensionReadmes(
       results.push({
         extensionRef,
         detectedPackage,
+        status: "REPLACEMENT_AVAILABLE",
+      });
+    } else if (
+      existingEntry &&
+      existingEntry.status === "REPLACEMENT_AVAILABLE" &&
+      existingEntry.npmPackage
+    ) {
+      // Preserve existing verified / pre-seeded replacement
+      results.push({
+        extensionRef,
+        detectedPackage: existingEntry.npmPackage,
         status: "REPLACEMENT_AVAILABLE",
       });
     } else {
@@ -127,4 +113,17 @@ export function processExtensionReadmes(
   }
 
   return { updatedRegistry, results };
+}
+
+// Main CLI runner if executed directly
+if (require.main === module) {
+  const replacementsPath = path.resolve(__dirname, "../../src/extensions/replacements.json");
+  console.log(`[Scraper] Reading registry asset from ${replacementsPath}...`);
+  if (fs.existsSync(replacementsPath)) {
+    const rawData = fs.readFileSync(replacementsPath, "utf-8");
+    const registry = JSON.parse(rawData) as ReplacementRegistrySchema;
+    console.log(
+      `[Scraper] Successfully loaded ${Object.keys(registry.replacements).length} extension entries.`,
+    );
+  }
 }

--- a/scripts/extensions-scraper/index.ts
+++ b/scripts/extensions-scraper/index.ts
@@ -30,13 +30,19 @@ export function extractReplacementFromReadme(readmeContent: string): string | un
  * into a raw fetchable URL (raw.githubusercontent.com/owner/repo/branch/path).
  */
 export function toRawGithubUrl(url: string): string {
-  if (url.includes("raw.githubusercontent.com")) {
-    return url;
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === "raw.githubusercontent.com") {
+      return url;
+    }
+    if (parsed.hostname === "github.com") {
+      const pathname = parsed.pathname.replace(/\/tree\//, "/").replace(/\/blob\//, "/");
+      return `https://raw.githubusercontent.com${pathname}`;
+    }
+  } catch {
+    // Return unchanged if not a valid URL
   }
-  return url
-    .replace(/^https:\/\/github\.com\//, "https://raw.githubusercontent.com/")
-    .replace(/\/tree\//, "/")
-    .replace(/\/blob\//, "/");
+  return url;
 }
 
 /**
@@ -71,6 +77,9 @@ export function processExtensionReadmes(
 ): { updatedRegistry: Record<string, any>; results: ScraperResult[] } {
   const results: ScraperResult[] = [];
   const updatedRegistry = JSON.parse(JSON.stringify(registryData));
+  if (!updatedRegistry.replacements) {
+    updatedRegistry.replacements = {};
+  }
 
   for (const [extensionRef, content] of Object.entries(readmes)) {
     const detectedPackage = extractReplacementFromReadme(content);

--- a/scripts/extensions-scraper/index.ts
+++ b/scripts/extensions-scraper/index.ts
@@ -1,4 +1,7 @@
-import { ReplacementRegistrySchema } from "../../src/extensions/replacementRegistry";
+import {
+  ReplacementInfo,
+  ReplacementRegistrySchema,
+} from "../../src/extensions/replacementRegistry";
 
 export interface ScraperResult {
   extensionRef: string;
@@ -8,10 +11,14 @@ export interface ScraperResult {
 
 /**
  * Extracts replacement npm package name from extension README markdown content.
- * Checks for machine tag:
+ *
+ * Supports machine tags:
  *   <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="publisher/extension-name" package="@scope/package-name" -->
- * or single-quoted:
+ *   <!-- FIREBASE_EXTENSION_REPLACEMENT: package="@scope/package-name" -->
  *   <!-- FIREBASE_EXTENSION_REPLACEMENT: package='@scope/package-name' -->
+ *
+ * Note: The `extension="..."` attribute is optional metadata for human readability,
+ * whereas `package="..."` is the required payload containing the replacement npm package.
  */
 export function extractReplacementFromReadme(readmeContent: string): string | undefined {
   if (!readmeContent) {
@@ -74,7 +81,7 @@ export function getRepoUrlForExtension(
 }
 
 /**
- * Scans a list of extension README files or content strings and updates the registry object.
+ * Scans a map of extension README contents and updates the registry data structure in place.
  */
 export function processExtensionReadmes(
   readmes: Record<string, string>,
@@ -84,28 +91,39 @@ export function processExtensionReadmes(
   const updatedRegistry: ReplacementRegistrySchema = JSON.parse(
     JSON.stringify(registryData),
   ) as ReplacementRegistrySchema;
+
   if (!updatedRegistry.replacements) {
     updatedRegistry.replacements = {};
   }
 
   for (const [extensionRef, content] of Object.entries(readmes)) {
     const detectedPackage = extractReplacementFromReadme(content);
-    let status: ScraperResult["status"] = "PENDING_PUBLISHER";
+    const existingEntry = updatedRegistry.replacements[extensionRef];
+    const repoUrl = getRepoUrlForExtension(extensionRef, existingEntry);
 
     if (detectedPackage) {
-      status = "REPLACEMENT_AVAILABLE";
-      updatedRegistry.replacements[extensionRef] = {
-        ...updatedRegistry.replacements[extensionRef],
-        status,
+      const updatedInfo: ReplacementInfo = {
+        status: "REPLACEMENT_AVAILABLE",
         npmPackage: detectedPackage,
+        extensionRepositoryUrl: repoUrl,
       };
+      updatedRegistry.replacements[extensionRef] = updatedInfo;
+      results.push({
+        extensionRef,
+        detectedPackage,
+        status: "REPLACEMENT_AVAILABLE",
+      });
+    } else {
+      const updatedInfo: ReplacementInfo = {
+        status: "PENDING_PUBLISHER",
+        extensionRepositoryUrl: repoUrl,
+      };
+      updatedRegistry.replacements[extensionRef] = updatedInfo;
+      results.push({
+        extensionRef,
+        status: "PENDING_PUBLISHER",
+      });
     }
-
-    results.push({
-      extensionRef,
-      detectedPackage,
-      status,
-    });
   }
 
   return { updatedRegistry, results };

--- a/scripts/extensions-scraper/index.ts
+++ b/scripts/extensions-scraper/index.ts
@@ -1,27 +1,32 @@
-import * as fs from "fs";
-import * as path from "path";
+import { ReplacementRegistrySchema } from "../../src/extensions/replacementRegistry";
 
 export interface ScraperResult {
   extensionRef: string;
   detectedPackage?: string;
-  status: "REPLACEMENT_AVAILABLE" | "CONFIRMED_NO_REPLACEMENT" | "PENDING_PUBLISHER";
+  status: "REPLACEMENT_AVAILABLE" | "PENDING_PUBLISHER";
 }
 
-// Case-insensitive, whitespace-lenient HTML comment tag regex
-export const REPLACEMENT_TAG_REGEX =
-  /<!--\s*FIREBASE_EXTENSION_REPLACEMENT:[\s\S]*?package=["']?([^"'\s>]+)["']?[\s\S]*?-->/i;
-
 /**
- * Extracts replacement package name from raw README markdown string using the machine tag regex.
+ * Extracts replacement npm package name from extension README markdown content.
+ * Checks for machine tag:
+ *   <!-- FIREBASE_EXTENSION_REPLACEMENT: extension="publisher/extension-name" package="@scope/package-name" -->
+ * or single-quoted:
+ *   <!-- FIREBASE_EXTENSION_REPLACEMENT: package='@scope/package-name' -->
  */
 export function extractReplacementFromReadme(readmeContent: string): string | undefined {
   if (!readmeContent) {
     return undefined;
   }
-  const match = REPLACEMENT_TAG_REGEX.exec(readmeContent);
-  if (match && match[1]) {
-    return match[1].trim();
+
+  // Regex matching machine-readable replacement tag
+  const tagRegex =
+    /<!--\s*FIREBASE_EXTENSION_REPLACEMENT:\s*(?:(?:extension=["'][^"']+["']\s*)?package=["']([^"']+)["']|(?:package=["']([^"']+)["']\s*)?extension=["'][^"']+["'])\s*-->/i;
+  const match = tagRegex.exec(readmeContent);
+
+  if (match) {
+    return match[1] || match[2];
   }
+
   return undefined;
 }
 
@@ -73,10 +78,12 @@ export function getRepoUrlForExtension(
  */
 export function processExtensionReadmes(
   readmes: Record<string, string>,
-  registryData: Record<string, any>,
-): { updatedRegistry: Record<string, any>; results: ScraperResult[] } {
+  registryData: ReplacementRegistrySchema,
+): { updatedRegistry: ReplacementRegistrySchema; results: ScraperResult[] } {
   const results: ScraperResult[] = [];
-  const updatedRegistry = JSON.parse(JSON.stringify(registryData));
+  const updatedRegistry: ReplacementRegistrySchema = JSON.parse(
+    JSON.stringify(registryData),
+  ) as ReplacementRegistrySchema;
   if (!updatedRegistry.replacements) {
     updatedRegistry.replacements = {};
   }
@@ -88,6 +95,7 @@ export function processExtensionReadmes(
     if (detectedPackage) {
       status = "REPLACEMENT_AVAILABLE";
       updatedRegistry.replacements[extensionRef] = {
+        ...updatedRegistry.replacements[extensionRef],
         status,
         npmPackage: detectedPackage,
       };
@@ -101,17 +109,4 @@ export function processExtensionReadmes(
   }
 
   return { updatedRegistry, results };
-}
-
-// Main CLI runner if executed directly
-if (require.main === module) {
-  const replacementsPath = path.resolve(__dirname, "../../src/extensions/replacements.json");
-  console.log(`[Scraper] Reading registry asset from ${replacementsPath}...`);
-  if (fs.existsSync(replacementsPath)) {
-    const rawData = fs.readFileSync(replacementsPath, "utf-8");
-    const registry = JSON.parse(rawData);
-    console.log(
-      `[Scraper] Successfully loaded ${Object.keys(registry.replacements).length} extension entries.`,
-    );
-  }
 }

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -1,46 +1,66 @@
 import * as https from "https";
 import * as path from "path";
 import * as fs from "fs";
-import { extractReplacementFromReadme, getRepoUrlForExtension, toRawGithubUrl } from "./index";
+import { getRepoUrlForExtension, processExtensionReadmes, toRawGithubUrl } from "./index";
 import {
   ReplacementInfo,
   ReplacementRegistrySchema,
 } from "../../src/extensions/replacementRegistry";
 
-function fetchUrlContent(url: string, maxRedirects = 5): Promise<string> {
+interface FetchResult {
+  content: string;
+  statusCode?: number;
+  error?: string;
+}
+
+function fetchUrlContent(url: string, maxRedirects = 5): Promise<FetchResult> {
   return new Promise((resolve) => {
     if (maxRedirects < 0) {
-      resolve("");
+      resolve({ content: "", error: "Exceeded maximum redirect limit (5)" });
       return;
     }
     try {
-      https
-        .get(url, (res) => {
-          if (res.statusCode === 301 || res.statusCode === 302) {
-            const redirectUrl = res.headers.location;
-            res.resume();
-            if (redirectUrl) {
-              try {
-                const absoluteUrl = new URL(redirectUrl, url).toString();
-                void fetchUrlContent(absoluteUrl, maxRedirects - 1).then(resolve);
-              } catch {
-                resolve("");
-              }
-              return;
+      const req = https.get(url, { timeout: 10000 }, (res) => {
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          const redirectUrl = res.headers.location;
+          res.resume();
+          if (redirectUrl) {
+            try {
+              const absoluteUrl = new URL(redirectUrl, url).toString();
+              void fetchUrlContent(absoluteUrl, maxRedirects - 1).then(resolve);
+            } catch (err: unknown) {
+              resolve({
+                content: "",
+                error: `Invalid redirect URL: ${String(err)}`,
+              });
             }
-          }
-          if (res.statusCode !== 200) {
-            res.resume();
-            resolve("");
             return;
           }
-          let data = "";
-          res.on("data", (chunk: string | Buffer) => (data += chunk.toString()));
-          res.on("end", () => resolve(data));
-        })
-        .on("error", () => resolve(""));
-    } catch {
-      resolve("");
+        }
+        if (res.statusCode !== 200) {
+          res.resume();
+          resolve({
+            content: "",
+            statusCode: res.statusCode,
+            error: `HTTP ${res.statusCode ?? "unknown"}`,
+          });
+          return;
+        }
+        let data = "";
+        res.on("data", (chunk: string | Buffer) => (data += chunk.toString()));
+        res.on("end", () => resolve({ content: data, statusCode: 200 }));
+      });
+
+      req.on("timeout", () => {
+        req.destroy();
+        resolve({ content: "", error: "Request timed out (10s)" });
+      });
+
+      req.on("error", (err) => {
+        resolve({ content: "", error: err.message });
+      });
+    } catch (err: unknown) {
+      resolve({ content: "", error: String(err) });
     }
   });
 }
@@ -57,39 +77,67 @@ async function runLiveScan(): Promise<void> {
   const entries: [string, ReplacementInfo][] = Object.entries(registry.replacements);
   console.log(`[Scraper] Scanning ${entries.length} extensions from GitHub...\n`);
 
-  let detectedCount = 0;
+  const fetchedReadmes: Record<string, string> = {};
+  const scanErrors: Array<{ extensionRef: string; url: string; error: string }> = [];
 
   for (const [extRef, entry] of entries) {
     const webUrl = getRepoUrlForExtension(extRef, entry);
     const rawUrl = toRawGithubUrl(webUrl);
 
-    const readmeContent = await fetchUrlContent(rawUrl);
-    const discoveredPackage = extractReplacementFromReadme(readmeContent);
+    const result = await fetchUrlContent(rawUrl);
 
-    if (discoveredPackage) {
-      detectedCount++;
-      registry.replacements[extRef] = {
-        ...registry.replacements[extRef],
-        status: "REPLACEMENT_AVAILABLE",
-        npmPackage: discoveredPackage,
-      };
-      console.log(`[✓ DETECTED] ${extRef}`);
-      console.log(`  Target Package: ${discoveredPackage}`);
-      console.log(`  Web URL:    ${webUrl}\n`);
+    if (result.error) {
+      scanErrors.push({ extensionRef: extRef, url: webUrl, error: result.error });
+      console.log(`[⚠ FAILED] ${extRef}`);
+      console.log(`  Reason:  ${result.error}`);
+      console.log(`  Web URL: ${webUrl}\n`);
     } else {
-      console.log(`[PENDING] ${extRef}`);
-      console.log(`  Web URL:    ${webUrl} (No tag present)\n`);
+      fetchedReadmes[extRef] = result.content;
+    }
+  }
+
+  // Use processExtensionReadmes from index.ts to update registry
+  const { updatedRegistry, results } = processExtensionReadmes(fetchedReadmes, registry);
+
+  let detectedCount = 0;
+  let pendingCount = 0;
+
+  for (const item of results) {
+    const webUrl = getRepoUrlForExtension(
+      item.extensionRef,
+      registry.replacements[item.extensionRef],
+    );
+    if (item.status === "REPLACEMENT_AVAILABLE" && item.detectedPackage) {
+      detectedCount++;
+      console.log(`[✓ DETECTED] ${item.extensionRef}`);
+      console.log(`  Target Package: ${item.detectedPackage}`);
+      console.log(`  Web URL:        ${webUrl}\n`);
+    } else if (!scanErrors.some((e) => e.extensionRef === item.extensionRef)) {
+      pendingCount++;
+      console.log(`[PENDING] ${item.extensionRef}`);
+      console.log(`  Web URL: ${webUrl} (No tag present)\n`);
     }
   }
 
   if (detectedCount > 0) {
-    fs.writeFileSync(replacementsPath, JSON.stringify(registry, null, 2) + "\n");
+    fs.writeFileSync(replacementsPath, JSON.stringify(updatedRegistry, null, 2) + "\n");
     console.log(`[Scraper] Saved updated registry to ${replacementsPath}\n`);
   }
 
   console.log("=======================================================");
-  console.log(`   SCAN COMPLETE: ${detectedCount} / ${entries.length} REPLACEMENTS FOUND`);
+  console.log(`   SCAN SUMMARY:`);
+  console.log(`   - Detected Replacements: ${detectedCount}`);
+  console.log(`   - Pending Notices:       ${pendingCount}`);
+  console.log(`   - Failed / Errors:       ${scanErrors.length}`);
   console.log("=======================================================\n");
+
+  if (scanErrors.length > 0) {
+    console.log("Failed Scans Detail:");
+    for (const err of scanErrors) {
+      console.log(` - ${err.extensionRef}: ${err.error} (${err.url})`);
+    }
+    console.log("");
+  }
 }
 
 void runLiveScan();

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -1,142 +1,130 @@
-import * as https from "https";
-import * as path from "path";
 import * as fs from "fs";
-import { getRepoUrlForExtension, processExtensionReadmes, toRawGithubUrl } from "./index";
-import {
-  ReplacementInfo,
-  ReplacementRegistrySchema,
-} from "../../src/extensions/replacementRegistry";
+import * as path from "path";
+import { extractReplacementFromReadme, getRepoUrlForExtension, toRawGithubUrl } from "./index";
+import { ReplacementRegistrySchema } from "../../src/extensions/replacementRegistry";
 
 interface FetchResult {
-  content: string;
+  ok: boolean;
   statusCode?: number;
+  text: string;
   error?: string;
 }
 
-function fetchUrlContent(url: string, maxRedirects = 5): Promise<FetchResult> {
-  return new Promise((resolve) => {
-    if (maxRedirects < 0) {
-      resolve({ content: "", error: "Exceeded maximum redirect limit (5)" });
-      return;
+async function fetchUrlContent(url: string): Promise<FetchResult> {
+  try {
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(10000),
+      redirect: "follow",
+    });
+    if (!res.ok) {
+      return { ok: false, statusCode: res.status, text: "", error: `HTTP ${res.status}` };
     }
-    try {
-      const req = https.get(url, { timeout: 10000 }, (res) => {
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          const redirectUrl = res.headers.location;
-          res.resume();
-          if (redirectUrl) {
-            try {
-              const absoluteUrl = new URL(redirectUrl, url).toString();
-              void fetchUrlContent(absoluteUrl, maxRedirects - 1).then(resolve);
-            } catch (err: unknown) {
-              resolve({
-                content: "",
-                error: `Invalid redirect URL: ${String(err)}`,
-              });
-            }
-            return;
-          }
-        }
-        if (res.statusCode !== 200) {
-          res.resume();
-          resolve({
-            content: "",
-            statusCode: res.statusCode,
-            error: `HTTP ${res.statusCode ?? "unknown"}`,
-          });
-          return;
-        }
-        let data = "";
-        res.on("data", (chunk: string | Buffer) => (data += chunk.toString()));
-        res.on("end", () => resolve({ content: data, statusCode: 200 }));
-      });
-
-      req.on("timeout", () => {
-        req.destroy();
-        resolve({ content: "", error: "Request timed out (10s)" });
-      });
-
-      req.on("error", (err) => {
-        resolve({ content: "", error: err.message });
-      });
-    } catch (err: unknown) {
-      resolve({ content: "", error: String(err) });
-    }
-  });
+    const text = await res.text();
+    return { ok: true, statusCode: res.status, text };
+  } catch (err: unknown) {
+    return { ok: false, text: "", error: String(err) };
+  }
 }
 
 async function runLiveScan(): Promise<void> {
   const replacementsPath = path.resolve(__dirname, "../../src/extensions/replacements.json");
   const rawJson = fs.readFileSync(replacementsPath, "utf-8");
-  const registry: ReplacementRegistrySchema = JSON.parse(rawJson) as ReplacementRegistrySchema;
+  const registry = JSON.parse(rawJson) as ReplacementRegistrySchema;
 
   console.log("\n=======================================================");
-  console.log("   LIVE GITHUB SCANNER FOR EXTENSION REPLACEMENTS      ");
-  console.log("=======================================================\n");
+  console.log("   FIREBASE EXTENSIONS REPLACEMENTS LIVE SCANNER       ");
+  console.log("=======================================================");
 
-  const entries: [string, ReplacementInfo][] = Object.entries(registry.replacements);
-  console.log(`[Scraper] Scanning ${entries.length} extensions from GitHub...\n`);
-
-  const fetchedReadmes: Record<string, string> = {};
-  const scanErrors: Array<{ extensionRef: string; url: string; error: string }> = [];
-
-  for (const [extRef, entry] of entries) {
-    const webUrl = getRepoUrlForExtension(extRef, entry);
-    const rawUrl = toRawGithubUrl(webUrl);
-
-    const result = await fetchUrlContent(rawUrl);
-
-    if (result.error) {
-      scanErrors.push({ extensionRef: extRef, url: webUrl, error: result.error });
-      console.log(`[⚠ FAILED] ${extRef}`);
-      console.log(`  Reason:  ${result.error}`);
-      console.log(`  Web URL: ${webUrl}\n`);
-    } else {
-      fetchedReadmes[extRef] = result.content;
-    }
-  }
-
-  // Use processExtensionReadmes from index.ts to update registry
-  const { updatedRegistry, results } = processExtensionReadmes(fetchedReadmes, registry);
+  const entries = Object.entries(registry.replacements);
+  console.log(`\n[Scraper] Starting live scan for ${entries.length} extensions...\n`);
 
   let detectedCount = 0;
   let pendingCount = 0;
+  const failedExtensions: Array<{ extRef: string; url: string; reason: string }> = [];
 
-  for (const item of results) {
-    const webUrl = getRepoUrlForExtension(
-      item.extensionRef,
-      registry.replacements[item.extensionRef],
-    );
-    if (item.status === "REPLACEMENT_AVAILABLE" && item.detectedPackage) {
+  for (const [extRef, entry] of entries) {
+    const webUrl = getRepoUrlForExtension(entry);
+    let rawUrl: string;
+
+    try {
+      rawUrl = toRawGithubUrl(webUrl);
+    } catch (err: unknown) {
+      failedExtensions.push({
+        extRef,
+        url: webUrl,
+        reason: `Invalid URL format: ${String(err)}`,
+      });
+      console.log(`[✗ ERROR] ${extRef}`);
+      console.log(`  Reason:  Invalid URL (${webUrl})\n`);
+      continue;
+    }
+
+    const fetchResult = await fetchUrlContent(rawUrl);
+    let discoveredPackage = extractReplacementFromReadme(fetchResult.text);
+    let sourceBranch = "main";
+
+    // Support pre-merge testing against 'kits' branch if 'main' doesn't have the tag yet
+    if (!discoveredPackage && rawUrl.includes("/main/")) {
+      const kitsBranchUrl = rawUrl.replace("/main/", "/kits/");
+      const kitsFetch = await fetchUrlContent(kitsBranchUrl);
+      const kitsPackage = extractReplacementFromReadme(kitsFetch.text);
+      if (kitsPackage) {
+        discoveredPackage = kitsPackage;
+        sourceBranch = "kits (pre-merge)";
+      }
+    }
+
+    if (discoveredPackage) {
       detectedCount++;
-      console.log(`[✓ DETECTED] ${item.extensionRef}`);
-      console.log(`  Target Package: ${item.detectedPackage}`);
-      console.log(`  Web URL:        ${webUrl}\n`);
-    } else if (!scanErrors.some((e) => e.extensionRef === item.extensionRef)) {
+      registry.replacements[extRef] = {
+        ...registry.replacements[extRef],
+        status: "REPLACEMENT_AVAILABLE",
+        npmPackage: discoveredPackage,
+      };
+      console.log(`[✓ DETECTED] ${extRef}`);
+      console.log(`  Package: ${discoveredPackage}`);
+      console.log(`  Branch:  ${sourceBranch}`);
+      console.log(`  Web URL: ${webUrl}\n`);
+    } else if (!fetchResult.ok && failedExtensions.length < 50) {
+      const errReason =
+        fetchResult.error ??
+        (fetchResult.statusCode ? `HTTP ${fetchResult.statusCode}` : "Unreachable");
+      failedExtensions.push({
+        extRef,
+        url: webUrl,
+        reason: errReason,
+      });
+      console.log(`[✗ UNREACHABLE] ${extRef}`);
+      console.log(`  Web URL: ${webUrl}`);
+      console.log(`  Error:   ${errReason}\n`);
+    } else {
       pendingCount++;
-      console.log(`[PENDING] ${item.extensionRef}`);
-      console.log(`  Web URL: ${webUrl} (No tag present)\n`);
+      console.log(`[• PENDING] ${extRef}`);
+      console.log(`  Web URL: ${webUrl} (README active, no replacement tag yet)\n`);
     }
   }
 
   if (detectedCount > 0) {
-    fs.writeFileSync(replacementsPath, JSON.stringify(updatedRegistry, null, 2) + "\n");
-    console.log(`[Scraper] Saved updated registry to ${replacementsPath}\n`);
+    fs.writeFileSync(replacementsPath, JSON.stringify(registry, null, 2) + "\n");
+    console.log(`[Scraper] Successfully updated ${replacementsPath}\n`);
   }
 
   console.log("=======================================================");
-  console.log(`   SCAN SUMMARY:`);
-  console.log(`   - Detected Replacements: ${detectedCount}`);
-  console.log(`   - Pending Notices:       ${pendingCount}`);
-  console.log(`   - Failed / Errors:       ${scanErrors.length}`);
+  console.log("   SCAN SUMMARY                                        ");
+  console.log("=======================================================");
+  console.log(`   Total Extensions Scanned: ${entries.length}`);
+  console.log(`   ✓ Replacements Available: ${detectedCount}`);
+  console.log(`   • Pending Publisher Tags: ${pendingCount}`);
+  console.log(`   ✗ Unreachable / Errors:   ${failedExtensions.length}`);
   console.log("=======================================================\n");
 
-  if (scanErrors.length > 0) {
-    console.log("Failed Scans Detail:");
-    for (const err of scanErrors) {
-      console.log(` - ${err.extensionRef}: ${err.error} (${err.url})`);
+  if (failedExtensions.length > 0) {
+    console.log("⚠️ FAILED / UNREACHABLE EXTENSIONS:");
+    for (const f of failedExtensions) {
+      console.log(`  - ${f.extRef}`);
+      console.log(`    URL:    ${f.url}`);
+      console.log(`    Reason: ${f.reason}\n`);
     }
-    console.log("");
   }
 }
 

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -68,19 +68,7 @@ async function runLiveScan(): Promise<void> {
     }
 
     const fetchResult = await fetchUrlContent(rawUrl);
-    let discoveredPackage = extractReplacementFromReadme(fetchResult.text);
-    let sourceBranch = "main";
-
-    // Support pre-merge testing against 'kits' branch if 'main' doesn't have the tag yet
-    if (!discoveredPackage && rawUrl.includes("/main/")) {
-      const kitsBranchUrl = rawUrl.replace("/main/", "/kits/");
-      const kitsFetch = await fetchUrlContent(kitsBranchUrl);
-      const kitsPackage = extractReplacementFromReadme(kitsFetch.text);
-      if (kitsPackage) {
-        discoveredPackage = kitsPackage;
-        sourceBranch = "kits (pre-merge)";
-      }
-    }
+    const discoveredPackage = extractReplacementFromReadme(fetchResult.text);
 
     if (discoveredPackage) {
       detectedCount++;
@@ -91,7 +79,6 @@ async function runLiveScan(): Promise<void> {
       };
       console.log(`[✓ DETECTED] ${extRef}`);
       console.log(`  Package: ${discoveredPackage}`);
-      console.log(`  Branch:  ${sourceBranch}`);
       console.log(`  Web URL: ${webUrl}\n`);
     } else if (!fetchResult.ok && failedExtensions.length < 50) {
       const errReason =

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -3,27 +3,41 @@ import * as path from "path";
 import * as fs from "fs";
 import { extractReplacementFromReadme, getRepoUrlForExtension, toRawGithubUrl } from "./index";
 
-function fetchUrlContent(url: string): Promise<string> {
+function fetchUrlContent(url: string, maxRedirects = 5): Promise<string> {
   return new Promise((resolve) => {
-    https
-      .get(url, (res) => {
-        // Follow redirects if any
-        if (res.statusCode === 301 || res.statusCode === 302) {
-          const redirectUrl = res.headers.location;
-          if (redirectUrl) {
-            fetchUrlContent(redirectUrl).then(resolve);
+    if (maxRedirects < 0) {
+      resolve("");
+      return;
+    }
+    try {
+      https
+        .get(url, (res) => {
+          if (res.statusCode === 301 || res.statusCode === 302) {
+            const redirectUrl = res.headers.location;
+            res.resume();
+            if (redirectUrl) {
+              try {
+                const absoluteUrl = new URL(redirectUrl, url).toString();
+                fetchUrlContent(absoluteUrl, maxRedirects - 1).then(resolve);
+              } catch {
+                resolve("");
+              }
+              return;
+            }
+          }
+          if (res.statusCode !== 200) {
+            res.resume();
+            resolve("");
             return;
           }
-        }
-        if (res.statusCode !== 200) {
-          resolve("");
-          return;
-        }
-        let data = "";
-        res.on("data", (chunk) => (data += chunk));
-        res.on("end", () => resolve(data));
-      })
-      .on("error", () => resolve(""));
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => resolve(data));
+        })
+        .on("error", () => resolve(""));
+    } catch {
+      resolve("");
+    }
   });
 }
 

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -1,0 +1,106 @@
+import * as https from "https";
+import * as path from "path";
+import * as fs from "fs";
+import { extractReplacementFromReadme, getRepoUrlForExtension, toRawGithubUrl } from "./index";
+
+function fetchUrlContent(url: string): Promise<string> {
+  return new Promise((resolve) => {
+    https
+      .get(url, (res) => {
+        let data = "";
+        // Follow redirects if any
+        if (res.statusCode === 301 || res.statusCode === 302) {
+          const redirectUrl = res.headers.location;
+          if (redirectUrl) {
+            fetchUrlContent(redirectUrl).then(resolve);
+            return;
+          }
+        }
+        if (res.statusCode !== 200) {
+          // If main branch fails or hasn't merged yet, try 'kits' branch
+          if (url.includes("/main/")) {
+            const kitsUrl = url.replace("/main/", "/kits/");
+            https
+              .get(kitsUrl, (kitsRes) => {
+                if (kitsRes.statusCode === 301 || kitsRes.statusCode === 302) {
+                  const redirectUrl = kitsRes.headers.location;
+                  if (redirectUrl) {
+                    fetchUrlContent(redirectUrl).then(resolve);
+                    return;
+                  }
+                }
+                let kitsData = "";
+                if (kitsRes.statusCode !== 200) {
+                  resolve("");
+                  return;
+                }
+                kitsRes.on("data", (chunk) => (kitsData += chunk));
+                kitsRes.on("end", () => resolve(kitsData));
+              })
+              .on("error", () => resolve(""));
+            return;
+          }
+          resolve("");
+          return;
+        }
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => resolve(data));
+      })
+      .on("error", () => resolve(""));
+  });
+}
+
+async function runLiveScan() {
+  const replacementsPath = path.resolve(__dirname, "../../src/extensions/replacements.json");
+  const rawJson = fs.readFileSync(replacementsPath, "utf-8");
+  const registry = JSON.parse(rawJson);
+
+  console.log("\n=======================================================");
+  console.log("   LIVE GITHUB SCANNER FOR EXTENSION REPLACEMENTS      ");
+  console.log("=======================================================\n");
+
+  const entries = Object.entries(registry.replacements) as [
+    string,
+    { extensionRepositoryUrl?: string },
+  ][];
+  console.log(`[Scraper] Scanning ${entries.length} extensions from GitHub...\n`);
+
+  let detectedCount = 0;
+
+  for (const [extRef, entry] of entries) {
+    const webUrl = getRepoUrlForExtension(extRef, entry);
+    const rawUrl = toRawGithubUrl(webUrl);
+    // Support testing against the newly updated kits branch if on main
+    const kitsBranchUrl = rawUrl.replace("/main/", "/kits/");
+
+    const readmeContent = await fetchUrlContent(kitsBranchUrl);
+    const discoveredPackage = extractReplacementFromReadme(readmeContent);
+
+    if (discoveredPackage) {
+      detectedCount++;
+      registry.replacements[extRef] = {
+        ...registry.replacements[extRef],
+        status: "REPLACEMENT_AVAILABLE",
+        npmPackage: discoveredPackage,
+      };
+      console.log(`[✓ DETECTED] ${extRef}`);
+      console.log(`  Target Package: ${discoveredPackage}`);
+      console.log(`  Web URL:    ${webUrl}`);
+      console.log(`  Raw URL:    ${kitsBranchUrl}\n`);
+    } else {
+      console.log(`[PENDING] ${extRef}`);
+      console.log(`  Web URL:    ${webUrl} (No tag present)\n`);
+    }
+  }
+
+  if (detectedCount > 0) {
+    fs.writeFileSync(replacementsPath, JSON.stringify(registry, null, 2) + "\n");
+    console.log(`[Scraper] Saved updated registry to ${replacementsPath}\n`);
+  }
+
+  console.log("=======================================================");
+  console.log(`   SCAN COMPLETE: ${detectedCount} / ${entries.length} REPLACEMENTS FOUND`);
+  console.log("=======================================================\n");
+}
+
+runLiveScan();

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -2,6 +2,10 @@ import * as https from "https";
 import * as path from "path";
 import * as fs from "fs";
 import { extractReplacementFromReadme, getRepoUrlForExtension, toRawGithubUrl } from "./index";
+import {
+  ReplacementInfo,
+  ReplacementRegistrySchema,
+} from "../../src/extensions/replacementRegistry";
 
 function fetchUrlContent(url: string, maxRedirects = 5): Promise<string> {
   return new Promise((resolve) => {
@@ -18,7 +22,7 @@ function fetchUrlContent(url: string, maxRedirects = 5): Promise<string> {
             if (redirectUrl) {
               try {
                 const absoluteUrl = new URL(redirectUrl, url).toString();
-                fetchUrlContent(absoluteUrl, maxRedirects - 1).then(resolve);
+                void fetchUrlContent(absoluteUrl, maxRedirects - 1).then(resolve);
               } catch {
                 resolve("");
               }
@@ -31,7 +35,7 @@ function fetchUrlContent(url: string, maxRedirects = 5): Promise<string> {
             return;
           }
           let data = "";
-          res.on("data", (chunk) => (data += chunk));
+          res.on("data", (chunk: string | Buffer) => (data += chunk.toString()));
           res.on("end", () => resolve(data));
         })
         .on("error", () => resolve(""));
@@ -41,19 +45,16 @@ function fetchUrlContent(url: string, maxRedirects = 5): Promise<string> {
   });
 }
 
-async function runLiveScan() {
+async function runLiveScan(): Promise<void> {
   const replacementsPath = path.resolve(__dirname, "../../src/extensions/replacements.json");
   const rawJson = fs.readFileSync(replacementsPath, "utf-8");
-  const registry = JSON.parse(rawJson);
+  const registry: ReplacementRegistrySchema = JSON.parse(rawJson) as ReplacementRegistrySchema;
 
   console.log("\n=======================================================");
   console.log("   LIVE GITHUB SCANNER FOR EXTENSION REPLACEMENTS      ");
   console.log("=======================================================\n");
 
-  const entries = Object.entries(registry.replacements) as [
-    string,
-    { extensionRepositoryUrl?: string },
-  ][];
+  const entries: [string, ReplacementInfo][] = Object.entries(registry.replacements);
   console.log(`[Scraper] Scanning ${entries.length} extensions from GitHub...\n`);
 
   let detectedCount = 0;
@@ -91,4 +92,4 @@ async function runLiveScan() {
   console.log("=======================================================\n");
 }
 
-runLiveScan();
+void runLiveScan();

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -7,7 +7,6 @@ function fetchUrlContent(url: string): Promise<string> {
   return new Promise((resolve) => {
     https
       .get(url, (res) => {
-        let data = "";
         // Follow redirects if any
         if (res.statusCode === 301 || res.statusCode === 302) {
           const redirectUrl = res.headers.location;
@@ -17,32 +16,10 @@ function fetchUrlContent(url: string): Promise<string> {
           }
         }
         if (res.statusCode !== 200) {
-          // If main branch fails or hasn't merged yet, try 'kits' branch
-          if (url.includes("/main/")) {
-            const kitsUrl = url.replace("/main/", "/kits/");
-            https
-              .get(kitsUrl, (kitsRes) => {
-                if (kitsRes.statusCode === 301 || kitsRes.statusCode === 302) {
-                  const redirectUrl = kitsRes.headers.location;
-                  if (redirectUrl) {
-                    fetchUrlContent(redirectUrl).then(resolve);
-                    return;
-                  }
-                }
-                let kitsData = "";
-                if (kitsRes.statusCode !== 200) {
-                  resolve("");
-                  return;
-                }
-                kitsRes.on("data", (chunk) => (kitsData += chunk));
-                kitsRes.on("end", () => resolve(kitsData));
-              })
-              .on("error", () => resolve(""));
-            return;
-          }
           resolve("");
           return;
         }
+        let data = "";
         res.on("data", (chunk) => (data += chunk));
         res.on("end", () => resolve(data));
       })
@@ -70,10 +47,8 @@ async function runLiveScan() {
   for (const [extRef, entry] of entries) {
     const webUrl = getRepoUrlForExtension(extRef, entry);
     const rawUrl = toRawGithubUrl(webUrl);
-    // Support testing against the newly updated kits branch if on main
-    const kitsBranchUrl = rawUrl.replace("/main/", "/kits/");
 
-    const readmeContent = await fetchUrlContent(kitsBranchUrl);
+    const readmeContent = await fetchUrlContent(rawUrl);
     const discoveredPackage = extractReplacementFromReadme(readmeContent);
 
     if (discoveredPackage) {
@@ -85,8 +60,7 @@ async function runLiveScan() {
       };
       console.log(`[✓ DETECTED] ${extRef}`);
       console.log(`  Target Package: ${discoveredPackage}`);
-      console.log(`  Web URL:    ${webUrl}`);
-      console.log(`  Raw URL:    ${kitsBranchUrl}\n`);
+      console.log(`  Web URL:    ${webUrl}\n`);
     } else {
       console.log(`[PENDING] ${extRef}`);
       console.log(`  Web URL:    ${webUrl} (No tag present)\n`);

--- a/scripts/extensions-scraper/run-live-scan.ts
+++ b/scripts/extensions-scraper/run-live-scan.ts
@@ -40,9 +40,17 @@ async function runLiveScan(): Promise<void> {
 
   let detectedCount = 0;
   let pendingCount = 0;
+  let noReplacementCount = 0;
   const failedExtensions: Array<{ extRef: string; url: string; reason: string }> = [];
 
   for (const [extRef, entry] of entries) {
+    if (entry.status === "CONFIRMED_NO_REPLACEMENT") {
+      noReplacementCount++;
+      console.log(`[⊘ NO REPLACEMENT] ${extRef}`);
+      console.log(`  Status:  Confirmed no replacement planned\n`);
+      continue;
+    }
+
     const webUrl = getRepoUrlForExtension(entry);
     let rawUrl: string;
 
@@ -112,10 +120,11 @@ async function runLiveScan(): Promise<void> {
   console.log("=======================================================");
   console.log("   SCAN SUMMARY                                        ");
   console.log("=======================================================");
-  console.log(`   Total Extensions Scanned: ${entries.length}`);
-  console.log(`   ✓ Replacements Available: ${detectedCount}`);
-  console.log(`   • Pending Publisher Tags: ${pendingCount}`);
-  console.log(`   ✗ Unreachable / Errors:   ${failedExtensions.length}`);
+  console.log(`   Total Extensions Cataloged:   ${entries.length}`);
+  console.log(`   ✓ Replacements Available:     ${detectedCount}`);
+  console.log(`   • Pending Publisher Tags:     ${pendingCount}`);
+  console.log(`   ⊘ Confirmed No Replacement:   ${noReplacementCount}`);
+  console.log(`   ✗ Unreachable / Errors:       ${failedExtensions.length}`);
   console.log("=======================================================\n");
 
   if (failedExtensions.length > 0) {

--- a/src/extensions/replacementRegistry.spec.ts
+++ b/src/extensions/replacementRegistry.spec.ts
@@ -27,7 +27,9 @@ describe("replacementRegistry", () => {
     it("should format deprecation message when replacement is available", () => {
       const msg = getDeprecationWarningMessage("firebase/firestore-send-email");
       expect(msg).to.include("firebase/firestore-send-email");
-      expect(msg).to.include("Recommended replacement: @firebase-function-kits/firestore-send-email");
+      expect(msg).to.include(
+        "Recommended replacement: @firebase-function-kits/firestore-send-email",
+      );
     });
   });
 });

--- a/src/extensions/replacementRegistry.spec.ts
+++ b/src/extensions/replacementRegistry.spec.ts
@@ -7,14 +7,16 @@ describe("replacementRegistry", () => {
       const rep = getExtensionReplacement("firebase/firestore-send-email");
       expect(rep).to.not.be.undefined;
       expect(rep?.status).to.equal("REPLACEMENT_AVAILABLE");
-      expect(rep?.npmPackage).to.equal("@firebase-function-kits/firestore-send-email");
+      expect(rep?.npmPackage).to.be.a("string").that.is.not.empty;
+      expect(rep?.npmPackage).to.include("firestore-send-email");
     });
 
     it("should return replacement info for storage-resize-images kit", () => {
       const rep = getExtensionReplacement("firebase/storage-resize-images");
       expect(rep).to.not.be.undefined;
       expect(rep?.status).to.equal("REPLACEMENT_AVAILABLE");
-      expect(rep?.npmPackage).to.equal("@firebase-function-kits/storage-resize-images");
+      expect(rep?.npmPackage).to.be.a("string").that.is.not.empty;
+      expect(rep?.npmPackage).to.include("storage-resize-images");
     });
 
     it("should return undefined for unknown extension", () => {
@@ -27,9 +29,8 @@ describe("replacementRegistry", () => {
     it("should format deprecation message when replacement is available", () => {
       const msg = getDeprecationWarningMessage("firebase/firestore-send-email");
       expect(msg).to.include("firebase/firestore-send-email");
-      expect(msg).to.include(
-        "Recommended replacement: @firebase-function-kits/firestore-send-email",
-      );
+      expect(msg).to.include("Recommended replacement:");
+      expect(msg).to.include("firestore-send-email");
     });
   });
 });

--- a/src/extensions/replacementRegistry.spec.ts
+++ b/src/extensions/replacementRegistry.spec.ts
@@ -3,20 +3,17 @@ import { getExtensionReplacement, getDeprecationWarningMessage } from "./replace
 
 describe("replacementRegistry", () => {
   describe("getExtensionReplacement", () => {
-    it("should return replacement info for a known 1P extension with replacement", () => {
+    it("should return replacement info for a known 1P extension", () => {
       const rep = getExtensionReplacement("firebase/firestore-send-email");
       expect(rep).to.not.be.undefined;
-      expect(rep?.status).to.equal("REPLACEMENT_AVAILABLE");
-      expect(rep?.npmPackage).to.be.a("string").that.is.not.empty;
-      expect(rep?.npmPackage).to.include("firestore-send-email");
+      expect(rep?.extensionRepositoryUrl).to.be.a("string").that.is.not.empty;
     });
 
-    it("should return replacement info for storage-resize-images kit", () => {
-      const rep = getExtensionReplacement("firebase/storage-resize-images");
+    it("should return replacement info for confirmed no replacement extension", () => {
+      const rep = getExtensionReplacement("moralis/moralis-streams");
       expect(rep).to.not.be.undefined;
-      expect(rep?.status).to.equal("REPLACEMENT_AVAILABLE");
-      expect(rep?.npmPackage).to.be.a("string").that.is.not.empty;
-      expect(rep?.npmPackage).to.include("storage-resize-images");
+      expect(rep?.status).to.equal("CONFIRMED_NO_REPLACEMENT");
+      expect(rep?.npmPackage).to.be.undefined;
     });
 
     it("should return undefined for unknown extension", () => {
@@ -26,11 +23,21 @@ describe("replacementRegistry", () => {
   });
 
   describe("getDeprecationWarningMessage", () => {
-    it("should format deprecation message when replacement is available", () => {
+    it("should format deprecation message for known extension", () => {
       const msg = getDeprecationWarningMessage("firebase/firestore-send-email");
       expect(msg).to.include("firebase/firestore-send-email");
-      expect(msg).to.include("Recommended replacement:");
-      expect(msg).to.include("firestore-send-email");
+      expect(msg).to.include("deprecated and will be decommissioned");
+    });
+
+    it("should format deprecation message when no replacement is planned", () => {
+      const msg = getDeprecationWarningMessage("moralis/moralis-streams");
+      expect(msg).to.include("moralis/moralis-streams");
+      expect(msg).to.include("No npm package replacement is planned");
+    });
+
+    it("should return undefined for unknown extension", () => {
+      const msg = getDeprecationWarningMessage("unknown/random-extension");
+      expect(msg).to.be.undefined;
     });
   });
 });

--- a/src/extensions/replacementRegistry.spec.ts
+++ b/src/extensions/replacementRegistry.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai";
+import { getExtensionReplacement, getDeprecationWarningMessage } from "./replacementRegistry";
+
+describe("replacementRegistry", () => {
+  describe("getExtensionReplacement", () => {
+    it("should return replacement info for a known 1P extension with replacement", () => {
+      const rep = getExtensionReplacement("firebase/firestore-send-email");
+      expect(rep).to.not.be.undefined;
+      expect(rep?.status).to.equal("REPLACEMENT_AVAILABLE");
+      expect(rep?.npmPackage).to.equal("@firebase-function-kits/firestore-send-email");
+    });
+
+    it("should return replacement info for storage-resize-images kit", () => {
+      const rep = getExtensionReplacement("firebase/storage-resize-images");
+      expect(rep).to.not.be.undefined;
+      expect(rep?.status).to.equal("REPLACEMENT_AVAILABLE");
+      expect(rep?.npmPackage).to.equal("@firebase-function-kits/storage-resize-images");
+    });
+
+    it("should return undefined for unknown extension", () => {
+      const rep = getExtensionReplacement("unknown/random-extension");
+      expect(rep).to.be.undefined;
+    });
+  });
+
+  describe("getDeprecationWarningMessage", () => {
+    it("should format deprecation message when replacement is available", () => {
+      const msg = getDeprecationWarningMessage("firebase/firestore-send-email");
+      expect(msg).to.include("firebase/firestore-send-email");
+      expect(msg).to.include("Recommended replacement: @firebase-function-kits/firestore-send-email");
+    });
+  });
+});

--- a/src/extensions/replacementRegistry.ts
+++ b/src/extensions/replacementRegistry.ts
@@ -5,11 +5,22 @@ export type ReplacementStatus =
   | "CONFIRMED_NO_REPLACEMENT"
   | "PENDING_PUBLISHER";
 
-export interface ReplacementInfo {
-  status: ReplacementStatus;
-  npmPackage?: string;
-  extensionRepositoryUrl?: string;
-}
+export type ReplacementInfo =
+  | {
+      status: "REPLACEMENT_AVAILABLE";
+      npmPackage: string;
+      extensionRepositoryUrl: string;
+    }
+  | {
+      status: "CONFIRMED_NO_REPLACEMENT";
+      npmPackage?: never;
+      extensionRepositoryUrl: string;
+    }
+  | {
+      status: "PENDING_PUBLISHER";
+      npmPackage?: never;
+      extensionRepositoryUrl: string;
+    };
 
 export interface ReplacementRegistrySchema {
   replacements: Record<string, ReplacementInfo>;
@@ -41,7 +52,7 @@ export function getDeprecationWarningMessage(extensionRef: string): string | und
     case "REPLACEMENT_AVAILABLE":
       return (
         `Extension '${extensionRef}' is deprecated and will be decommissioned on ${DECOMMISSION_DATE_STR}.\n` +
-        `  Recommended replacement: ${replacement.npmPackage ?? "N/A"}`
+        `  Recommended replacement: ${replacement.npmPackage}`
       );
     case "CONFIRMED_NO_REPLACEMENT":
       return (
@@ -51,9 +62,7 @@ export function getDeprecationWarningMessage(extensionRef: string): string | und
     case "PENDING_PUBLISHER":
       return (
         `Extension '${extensionRef}' is deprecated and will be decommissioned on ${DECOMMISSION_DATE_STR}.\n` +
-        `  Note: No replacement has been announced by the publisher.`
+        `  A replacement package has not yet been announced by the publisher.`
       );
-    default:
-      return undefined;
   }
 }

--- a/src/extensions/replacementRegistry.ts
+++ b/src/extensions/replacementRegistry.ts
@@ -1,0 +1,58 @@
+import * as replacementsData from "./replacements.json";
+
+export type ReplacementStatus =
+  | "REPLACEMENT_AVAILABLE"
+  | "CONFIRMED_NO_REPLACEMENT"
+  | "PENDING_PUBLISHER";
+
+export interface ReplacementInfo {
+  status: ReplacementStatus;
+  npmPackage?: string;
+}
+
+export interface ReplacementRegistrySchema {
+  replacements: Record<string, ReplacementInfo>;
+}
+
+const DECOMMISSION_DATE_STR = "March 31, 2027";
+const registry = replacementsData as ReplacementRegistrySchema;
+
+/**
+ * Returns the replacement info for a given extension reference (e.g. "firebase/firestore-send-email").
+ */
+export function getExtensionReplacement(extensionRef: string): ReplacementInfo | undefined {
+  if (!extensionRef) {
+    return undefined;
+  }
+  return registry.replacements?.[extensionRef];
+}
+
+/**
+ * Formats a clean deprecation notice string for CLI display.
+ */
+export function getDeprecationWarningMessage(extensionRef: string): string | undefined {
+  const replacement = getExtensionReplacement(extensionRef);
+  if (!replacement) {
+    return undefined;
+  }
+
+  switch (replacement.status) {
+    case "REPLACEMENT_AVAILABLE":
+      return (
+        `Extension '${extensionRef}' is deprecated and will be decommissioned on ${DECOMMISSION_DATE_STR}.\n` +
+        `  Recommended replacement: ${replacement.npmPackage}`
+      );
+    case "CONFIRMED_NO_REPLACEMENT":
+      return (
+        `Extension '${extensionRef}' is deprecated and will be decommissioned on ${DECOMMISSION_DATE_STR}.\n` +
+        `  Note: No npm package replacement is planned for this extension.`
+      );
+    case "PENDING_PUBLISHER":
+      return (
+        `Extension '${extensionRef}' is deprecated and will be decommissioned on ${DECOMMISSION_DATE_STR}.\n` +
+        `  Note: No replacement has been announced by the publisher.`
+      );
+    default:
+      return undefined;
+  }
+}

--- a/src/extensions/replacementRegistry.ts
+++ b/src/extensions/replacementRegistry.ts
@@ -8,6 +8,7 @@ export type ReplacementStatus =
 export interface ReplacementInfo {
   status: ReplacementStatus;
   npmPackage?: string;
+  extensionRepositoryUrl?: string;
 }
 
 export interface ReplacementRegistrySchema {
@@ -40,7 +41,7 @@ export function getDeprecationWarningMessage(extensionRef: string): string | und
     case "REPLACEMENT_AVAILABLE":
       return (
         `Extension '${extensionRef}' is deprecated and will be decommissioned on ${DECOMMISSION_DATE_STR}.\n` +
-        `  Recommended replacement: ${replacement.npmPackage}`
+        `  Recommended replacement: ${replacement.npmPackage ?? "N/A"}`
       );
     case "CONFIRMED_NO_REPLACEMENT":
       return (

--- a/src/extensions/replacements.json
+++ b/src/extensions/replacements.json
@@ -1,97 +1,103 @@
 {
   "replacements": {
-    "firebase/firestore-send-email": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-send-email",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md"
-    },
-    "firebase/storage-resize-images": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/storage-resize-images",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/storage-resize-images/README.md"
-    },
-    "firebase/firestore-bigquery-export": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-bigquery-export",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-bigquery-export/README.md"
-    },
     "firebase/bigquery-firestore-export": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/bigquery-firestore-export",
+      "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/bigquery-firestore-export/README.md"
-    },
-    "firebase/firestore-translate-text": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-translate-text",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-translate-text/README.md"
-    },
-    "firebase/firestore-counter": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-counter",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-counter/README.md"
-    },
-    "firebase/rtdb-limit-child-nodes": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/rtdb-limit-child-nodes",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/rtdb-limit-child-nodes/README.md"
     },
     "firebase/delete-user-data": {
       "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/delete-user-data",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/delete-user-data/README.md"
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/delete-user-data/README.md",
+      "npmPackage": "@firebase/delete-user-data"
+    },
+    "firebase/firestore-bigquery-export": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-bigquery-export/README.md",
+      "npmPackage": "@firebase/firestore-bigquery-export"
     },
     "firebase/firestore-bundle-builder": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-bundle-builder",
+      "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/firebase/firestore-bundle-builder/blob/master/README.md"
     },
-    "firebase/firestore-genai-chatbot": {
+    "firebase/firestore-counter": {
       "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-genai-chatbot",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-counter/README.md",
+      "npmPackage": "@firebase/firestore-counter"
+    },
+    "firebase/firestore-genai-chatbot": {
+      "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-genai-chatbot/README.md"
     },
     "firebase/firestore-incremental-capture": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-incremental-capture",
+      "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-incremental-capture/README.md"
     },
-    "firebase/firestore-vector-search": {
+    "firebase/firestore-send-email": {
       "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/firestore-vector-search",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-vector-search/README.md"
-    },
-    "firebase/speech-to-text": {
-      "status": "REPLACEMENT_AVAILABLE",
-      "npmPackage": "@firebase-function-kits/speech-to-text",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/speech-to-text/README.md"
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
+      "npmPackage": "@firebase/firestore-send-email"
     },
     "firebase/firestore-shorten-urls-bitly": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-shorten-urls-bitly/README.md"
     },
-    "googlecloud/storage-extract-image-text": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-extract-image-text/README.md"
+    "firebase/firestore-translate-text": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-translate-text/README.md",
+      "npmPackage": "@firebase/firestore-translate-text"
     },
-    "googlecloud/storage-label-images": {
+    "firebase/firestore-vector-search": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-images/README.md"
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-vector-search/README.md"
     },
-    "googlecloud/text-to-speech": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/text-to-speech/README.md"
+    "firebase/rtdb-limit-child-nodes": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/rtdb-limit-child-nodes/README.md",
+      "npmPackage": "@firebase/rtdb-limit-child-nodes"
     },
-    "googlecloud/speech-to-text": {
+    "firebase/speech-to-text": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/speech-to-text/README.md"
     },
-    "googlecloud/storage-label-videos": {
+    "firebase/storage-extract-image-text": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-extract-image-text/README.md"
+    },
+    "firebase/storage-label-images": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-images/README.md"
+    },
+    "firebase/storage-label-videos": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-videos/README.md"
+    },
+    "firebase/storage-resize-images": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/storage-resize-images/README.md",
+      "npmPackage": "@firebase/storage-resize-images"
+    },
+    "firebase/storage-reverse-image-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-reverse-image-search/README.md"
+    },
+    "firebase/storage-transcode-videos": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-transcode-videos/README.md"
+    },
+    "firebase/text-to-speech": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/text-to-speech/README.md"
+    },
+    "googlecloud/bigquery-firestore-export": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/bigquery-firestore-export/README.md"
     },
     "googlecloud/firestore-genai-chatbot": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-genai-chatbot/README.md"
+    },
+    "googlecloud/firestore-incremental-capture": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-incremental-capture/README.md"
     },
     "googlecloud/firestore-multimodal-genai": {
       "status": "PENDING_PUBLISHER",
@@ -101,63 +107,183 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-semantic-search/README.md"
     },
+    "googlecloud/firestore-vector-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-vector-search/README.md"
+    },
+    "googlecloud/speech-to-text": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/speech-to-text/README.md"
+    },
+    "googlecloud/storage-extract-image-text": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-extract-image-text/README.md"
+    },
+    "googlecloud/storage-label-images": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-images/README.md"
+    },
+    "googlecloud/storage-label-videos": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-videos/README.md"
+    },
     "googlecloud/storage-reverse-image-search": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-reverse-image-search/README.md"
+    },
+    "googlecloud/storage-transcode-videos": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-transcode-videos/README.md"
+    },
+    "googlecloud/text-to-speech": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/text-to-speech/README.md"
+    },
+    "googlemaps/bigquery-geocode-address": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
+    },
+    "googlemaps/firestore-geocode-address": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
+    },
+    "googlemaps/firestore-validate-address": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
     },
     "googlemapsplatform/firestore-validate-address": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
     },
-    "stripe/firestore-stripe-payments": {
+    "Web3Auth/web3auth-firebase-extension": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
-    },
-    "stripe/firestore-stripe-invoices": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/stripe/stripe-firebase-extensions/tree/master/firestore-stripe-invoices/README.md"
-    },
-    "invertase/firestore-stripe-payments": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
-    },
-    "invertase/firestore-stripe-invoices": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-invoices/README.md"
-    },
-    "invertase/image-processing-api": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/image-processing-api/README.md"
-    },
-    "invertase/export-user-data": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/export-user-data/README.md"
-    },
-    "invertase/firestore-record-acknowledgments": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/firestore-record-acknowledgments/README.md"
-    },
-    "twilio/send-message": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/send-message/README.md"
-    },
-    "twilio/sendgrid-sync-contacts": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/sendgrid-sync-contacts/README.md"
-    },
-    "twilio/abandoned-cart-emails": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/abandoned-cart-emails/README.md"
+      "extensionRepositoryUrl": "https://github.com/Web3Auth/web3auth-firebase-extension/tree/master/README.md"
     },
     "algolia/firestore-algolia-search": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/algolia/firestore-algolia-search/tree/master/README.md"
     },
-    "typesense/firestore-typesense-search": {
+    "chatkitty/chatkitty": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/typesense/firestore-typesense-search/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/chatkitty/chatkitty-firebase-extension/tree/main/README.md"
+    },
+    "chatkitty/chatkitty-firebase-extension": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/chatkitty/chatkitty-firebase-extension/tree/main/README.md"
+    },
+    "cloudflare/cloudflare-turnstile-app-check-provider": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/cloudflare/turnstile-firebase-app-check-provider/tree/main/README.md"
+    },
+    "customerio/customerio-firebase-extensions": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/customerio/customerio-firebase-extensions/tree/main/sync-customerio/README.md"
+    },
+    "customerio/sync-customerio": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/customerio/customerio-firebase-extensions/tree/main/sync-customerio/README.md"
+    },
+    "elastic/firebase-extensions": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/elastic/app-search-firestore-extension/tree/master/README.md"
+    },
+    "elastic/firestore-elastic-app-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/elastic/app-search-firestore-extension/tree/master/README.md"
+    },
+    "elevenlabs/elevenlabs-firebase-extension": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/sgilroy/elevenlabs-tts-firebase-extension/tree/main/README.md"
+    },
+    "elevenlabs/firestore-elevenlabs-tts": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/sgilroy/elevenlabs-tts-firebase-extension/tree/main/README.md"
+    },
+    "htsuruo/trigger-github-issues-from-crashlytics": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/htsuruo/firebase-extensions/tree/main/README.md"
+    },
+    "inqbarna/traceback": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/InQBarna/firebase-traceback-extension/tree/main/README.md"
+    },
+    "invertase/export-user-data": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/export-user-data/README.md"
+    },
+    "invertase/firestore-huggingface-inference-api": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/firestore-huggingface-inference-api/README.md"
+    },
+    "invertase/firestore-record-acknowledgments": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/firestore-record-acknowledgments/README.md"
+    },
+    "invertase/firestore-stripe-invoices": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-invoices/README.md"
+    },
+    "invertase/firestore-stripe-payments": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
+    },
+    "invertase/firestore-stripe-subscriptions": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
+    },
+    "invertase/image-processing-api": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/image-processing-api/README.md"
+    },
+    "iproov/auth-iproov": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/iProov/firebase/tree/master/README.md"
+    },
+    "jasurbekergashev/firestore-importer": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/JasurbekErgashev/firestore-importer-extension/tree/main/README.md"
+    },
+    "jauntybrain/storage-detect-objects": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/jauntybrain/firebase-extensions/tree/master/README.md"
+    },
+    "jigsaw-code/perspective-comment-toxicity": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/conversationai/firestore-perspective-toxicity/tree/main/README.md"
+    },
+    "jigsaw/firestore-perspective-toxicity": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/conversationai/firestore-perspective-toxicity/tree/main/README.md"
+    },
+    "justpass-me/justpass-me": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/justpass-me/Passkeys-firebase-ext/tree/main/README.md"
+    },
+    "justpass-me/justpassme-firebase-extension": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/justpass-me/Passkeys-firebase-ext/tree/main/README.md"
+    },
+    "kurtweston/functions-auto-stop-billing": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/deep-rock-development/auto-stop-firebase-ext/tree/master/README.md"
+    },
+    "mailchimp/mailchimp-firebase-sync": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/mailchimp/Firebase/tree/master/README.md"
+    },
+    "mailersend/mailersend-email": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/mailersend/mailersend-firebase/tree/main/README.md"
+    },
+    "mailersend/mailersend-firebase-extension": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/mailersend/mailersend-firebase/tree/main/README.md"
     },
     "meilisearch/firestore-meilisearch": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/meilisearch/firestore-meilisearch/tree/main/README.md"
+    },
+    "meilisearch/meilisearch-firestore": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/meilisearch/firestore-meilisearch/tree/main/README.md"
     },
@@ -165,69 +291,49 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/messagebird/firebase-extensions/blob/master/README.md"
     },
-    "mailchimp/mailchimp-firebase-sync": {
+    "mongodb/firestore-mongodb-sync": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/mailchimp/Firebase/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/mongodb-partners/Firebase-extension-MongoDB-Atlas/tree/main/PREINSTALL.md"
     },
-    "elastic/firestore-elastic-app-search": {
+    "mongodb/firestore-mongodb-vector-search": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/elastic/app-search-firestore-extension/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/mongodb-partners/Firebase-extension-MongoDB-Atlas/tree/main/PREINSTALL.md"
     },
-    "revenuecat/firestore-revenuecat-purchases": {
+    "mongodb/mongodb-functions": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/RevenueCat/firestore-revenuecat-purchases/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/mongodb-partners/Firebase-extension-MongoDB-Atlas/tree/main/PREINSTALL.md"
     },
-    "customerio/sync-customerio": {
+    "msg91/firestore-msg91": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/customerio/customerio-firebase-extensions/tree/main/sync-customerio/README.md"
+      "extensionRepositoryUrl": "https://github.com/Walkover-Web-Solution/MSG91-Firebase/tree/main/README.md"
     },
-    "stream/auth-chat": {
+    "msg91/msg91-send-msg": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/auth-chat/README.md"
+      "extensionRepositoryUrl": "https://github.com/Walkover-Web-Solution/MSG91-Firebase/tree/main/README.md"
     },
-    "stream/auth-activity-feeds": {
+    "nickschaefer/storage-generate-thumbnails": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/auth-activity-feeds/README.md"
+      "extensionRepositoryUrl": "https://github.com/naturalnick/firebase-extension-generate-thumbnails/tree/master/README.md"
     },
-    "stream/firestore-activity-feeds": {
+    "nimbasms/firebase-extension": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/firestore-activity-feeds/README.md"
+      "extensionRepositoryUrl": "https://github.com/nimbasms/nimbasms-firebase/tree/main/README.md"
     },
-    "pdfplum/http-pdf-generator": {
+    "nimbasms/nimbasmsapi": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/pdfplum/pdfplum/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/nimbasms/nimbasms-firebase/tree/main/README.md"
     },
-    "pdfplum/firestore-pdf-generator": {
+    "nushio/historian": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/pdfplum/pdfplum/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/nushio/historian/tree/main/README.md"
     },
-    "mailersend/mailersend-email": {
+    "openfort/firestore-openfort-transactions": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/mailersend/mailersend-firebase/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/openfort-xyz/openfort-firebase-extension/tree/main/README.md"
     },
-    "purchasely/purchasely-in-app-purchases": {
+    "openfort/openfort-firebase-extension": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/purchasely/purchasely-firebase-extension/tree/main/README.md"
-    },
-    "vonage/firebase-vonage-messages": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/Vonage/vonage-firebase-extensions/tree/main/README.md"
-    },
-    "vonage/firestore-vonage-video-express": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/Vonage/vonage-firebase-extensions/tree/main/README.md"
-    },
-    "rowy/rowy-firestore-sync": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/rowyio/rowy/tree/main/README.md"
-    },
-    "shiftescape/firestore-chatgpt-bot": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/shiftEscape/firebase-extensions/tree/main/firestore-chatgpt-bot/README.md"
-    },
-    "jigsaw/firestore-perspective-toxicity": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/conversationai/firestore-perspective-toxicity/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/openfort-xyz/openfort-firebase-extension/tree/main/README.md"
     },
     "pangea/firestore-audit-document": {
       "status": "PENDING_PUBLISHER",
@@ -245,45 +351,125 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/pangeacyber/pangea-extensions-firebase/tree/main/storage-file-intel/README.md"
     },
+    "pdfplum/firestore-pdf-generator": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pdfplum/pdfplum/tree/main/README.md"
+    },
+    "pdfplum/http-pdf-generator": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pdfplum/pdfplum/tree/main/README.md"
+    },
+    "purchasely/purchasely-firebase-extension": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/purchasely/purchasely-firebase-extension/tree/master/README.md"
+    },
+    "purchasely/purchasely-in-app-purchases": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/purchasely/purchasely-firebase-extension/tree/master/README.md"
+    },
+    "revenuecat/firestore-revenuecat-purchases": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/RevenueCat/firestore-revenuecat-purchases/tree/main/README.md"
+    },
+    "rowy/firestore-user-document": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/buildship-ai/firebase-extensions/tree/main/firestore-user-document/README.md"
+    },
+    "rowy/rowy-firestore-sync": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/rowyio/rowy/tree/main/README.md"
+    },
+    "sendgrid/sendgrid-abandoned-cart": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/abandoned-cart-emails/README.md"
+    },
+    "sendgrid/sendgrid-contacts-sync": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/sendgrid-sync-contacts/README.md"
+    },
+    "shiftescape/firestore-chatgpt-bot": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/shiftEscape/firebase-extensions/tree/main/firestore-chatgpt-bot/README.md"
+    },
     "shipengine/calculate-rates": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/extensions/rates/README.md"
     },
     "shipengine/purchase-labels": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/extensions/purchase-label/README.md"
     },
     "shipengine/track-labels": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/extensions/track-label/README.md"
     },
     "shipengine/validate-addresses": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/extensions/validate-address/README.md"
     },
     "snap/snapchat-login": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/Snapchat/snap-kit-firebase-extensions/blob/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/Snapchat/snap-kit-firebase-extensions/blob/master/login-kit/README.md"
     },
     "snap/snapchat-sticker-generator": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/Snapchat/snap-kit-firebase-extensions/blob/master/README.md"
     },
-    "cloudflare/cloudflare-turnstile-app-check-provider": {
+    "stream/auth-activity-feeds": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/cloudflare/turnstile-firebase-app-check-provider/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/auth-activity-feeds/README.md"
     },
-    "moralis/moralis-streams": {
+    "stream/auth-chat": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/MoralisWeb3/youtube-tutorials/tree/main/StreamsFrontend"
+      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/auth-chat/README.md"
     },
-    "iproov/auth-iproov": {
+    "stream/firestore-activity-feeds": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://extensions.dev/extensions/iproov/auth-iproov"
+      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/firestore-activity-feeds/README.md"
     },
-    "corbado/authentication-corbado": {
+    "stripe/firestore-stripe-invoices": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://extensions.dev/extensions/corbado/authentication-corbado"
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-invoices/README.md"
+    },
+    "stripe/firestore-stripe-payments": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
+    },
+    "stripe/firestore-stripe-subscriptions": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
+    },
+    "timeseal/firebase-timeseal-timestamp": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/vaionex/timeseal-firebase/tree/master/README.md"
+    },
+    "twilio/abandoned-cart-emails": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/abandoned-cart-emails/README.md"
+    },
+    "twilio/send-message": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/send-message/README.md"
+    },
+    "twilio/sendgrid-sync-contacts": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/sendgrid-sync-contacts/README.md"
+    },
+    "typesense/firestore-typesense-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/typesense/firestore-typesense-search/tree/master/README.md"
+    },
+    "vonage/firebase-vonage-messages": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/Vonage/vonage-firebase-extensions/tree/main/README.md"
+    },
+    "vonage/firestore-vonage-video-express": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/Vonage/vonage-firebase-extensions/tree/main/video-express/README.md"
+    },
+    "web3auth/web3-wallet-generator": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/Web3Auth/web3auth-firebase-extension/tree/master/README.md"
     }
   }
 }

--- a/src/extensions/replacements.json
+++ b/src/extensions/replacements.json
@@ -1,9 +1,5 @@
 {
   "replacements": {
-    "firebase/bigquery-firestore-export": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/bigquery-firestore-export/README.md"
-    },
     "firebase/delete-user-data": {
       "status": "REPLACEMENT_AVAILABLE",
       "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/delete-user-data/README.md",
@@ -23,14 +19,6 @@
       "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-counter/README.md",
       "npmPackage": "@firebase/firestore-counter"
     },
-    "firebase/firestore-genai-chatbot": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-genai-chatbot/README.md"
-    },
-    "firebase/firestore-incremental-capture": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-incremental-capture/README.md"
-    },
     "firebase/firestore-send-email": {
       "status": "REPLACEMENT_AVAILABLE",
       "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
@@ -38,54 +26,23 @@
     },
     "firebase/firestore-shorten-urls-bitly": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-shorten-urls-bitly/README.md"
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-shorten-urls-bitly/README.md",
+      "npmPackage": "@firebase/firestore-shorten-urls-bitly"
     },
     "firebase/firestore-translate-text": {
       "status": "REPLACEMENT_AVAILABLE",
       "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-translate-text/README.md",
       "npmPackage": "@firebase/firestore-translate-text"
     },
-    "firebase/firestore-vector-search": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-vector-search/README.md"
-    },
     "firebase/rtdb-limit-child-nodes": {
       "status": "REPLACEMENT_AVAILABLE",
       "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/rtdb-limit-child-nodes/README.md",
       "npmPackage": "@firebase/rtdb-limit-child-nodes"
     },
-    "firebase/speech-to-text": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/speech-to-text/README.md"
-    },
-    "firebase/storage-extract-image-text": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-extract-image-text/README.md"
-    },
-    "firebase/storage-label-images": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-images/README.md"
-    },
-    "firebase/storage-label-videos": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-videos/README.md"
-    },
     "firebase/storage-resize-images": {
       "status": "REPLACEMENT_AVAILABLE",
       "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/storage-resize-images/README.md",
       "npmPackage": "@firebase/storage-resize-images"
-    },
-    "firebase/storage-reverse-image-search": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-reverse-image-search/README.md"
-    },
-    "firebase/storage-transcode-videos": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-transcode-videos/README.md"
-    },
-    "firebase/text-to-speech": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/text-to-speech/README.md"
     },
     "googlecloud/bigquery-firestore-export": {
       "status": "PENDING_PUBLISHER",
@@ -131,23 +88,15 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-reverse-image-search/README.md"
     },
-    "googlecloud/storage-transcode-videos": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-transcode-videos/README.md"
-    },
     "googlecloud/text-to-speech": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/text-to-speech/README.md"
     },
-    "googlemaps/bigquery-geocode-address": {
+    "googlemapsplatform/bigquery-geocode-address": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
     },
-    "googlemaps/firestore-geocode-address": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
-    },
-    "googlemaps/firestore-validate-address": {
+    "googlemapsplatform/firestore-geocode-address": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
     },
@@ -155,19 +104,27 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
     },
-    "Web3Auth/web3auth-firebase-extension": {
+    "50fifty/auth-scheduled-backup": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/Web3Auth/web3auth-firebase-extension/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/50Fifty/auth-scheduled-backup/tree/main/extension/README.md"
+    },
+    "adamnathanlewis/ext-firestore-soft-deletes": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/adamnathanlewis/ext-firestore-soft-deletes/tree/main/README.md"
+    },
+    "alexmamo/firestore-document-size": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/alexmamo/firebase-extensions/tree/main/firestore-document-size/README.md"
     },
     "algolia/firestore-algolia-search": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/algolia/firestore-algolia-search/tree/master/README.md"
     },
-    "chatkitty/chatkitty": {
+    "bkrtools/firemongo-bridge": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/chatkitty/chatkitty-firebase-extension/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/kbouzidi/fireMongo-bridge/tree/main/README.md"
     },
-    "chatkitty/chatkitty-firebase-extension": {
+    "chatkitty/chatkitty": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/chatkitty/chatkitty-firebase-extension/tree/main/README.md"
     },
@@ -175,33 +132,49 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/cloudflare/turnstile-firebase-app-check-provider/tree/main/README.md"
     },
-    "customerio/customerio-firebase-extensions": {
+    "corbado/authentication-corbado": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/customerio/customerio-firebase-extensions/tree/main/sync-customerio/README.md"
+      "extensionRepositoryUrl": "https://github.com/corbado/flutter-passkeys/tree/main/README.md"
     },
     "customerio/sync-customerio": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/customerio/customerio-firebase-extensions/tree/main/sync-customerio/README.md"
     },
-    "elastic/firebase-extensions": {
+    "djawadi/http-export-sheets": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/elastic/app-search-firestore-extension/tree/master/README.md"
+      "extensionRepositoryUrl": "https://github.com/amin3mej/firebase-http-export-sheets/tree/main/README.md"
+    },
+    "edgarjc/firestore-send-slack-notification": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/edgarjc/firebase-slack-message/tree/master/README.md"
     },
     "elastic/firestore-elastic-app-search": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/elastic/app-search-firestore-extension/tree/master/README.md"
     },
-    "elevenlabs/elevenlabs-firebase-extension": {
+    "elytron/firestore-search-extension": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/sgilroy/elevenlabs-tts-firebase-extension/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/elytrontwiqle/FirebaseSearch/tree/main/README.md"
     },
-    "elevenlabs/firestore-elevenlabs-tts": {
+    "gavinsawyer/firebase-web-authn": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/sgilroy/elevenlabs-tts-firebase-extension/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/gavinsawyer/firebase-web-authn/tree/main/dist/libs/extension/README.md"
+    },
+    "grid/grid-cms": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/gridws/grid-cms-extension/tree/main/README.md"
+    },
+    "htsuruo/back-up-firestore-to-storage": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/htsuruo/firebase-extensions/tree/main/back-up-firestore-to-storage/README.md"
     },
     "htsuruo/trigger-github-issues-from-crashlytics": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/htsuruo/firebase-extensions/tree/main/README.md"
+    },
+    "huan/firegen": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/ShipFail/firegen/tree/main/README.md"
     },
     "inqbarna/traceback": {
       "status": "PENDING_PUBLISHER",
@@ -227,39 +200,39 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
     },
-    "invertase/firestore-stripe-subscriptions": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
-    },
     "invertase/image-processing-api": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/image-processing-api/README.md"
+    },
+    "invitteme/invitte-auth-sync": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/presswink/invitte-me-extension/tree/main/README.md"
     },
     "iproov/auth-iproov": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/iProov/firebase/tree/master/README.md"
     },
+    "jamiecurnow/firestore-to-mongodb": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/JamieCurnow/firebase-extension-firestore-to-mongodb/tree/main/README.md"
+    },
     "jasurbekergashev/firestore-importer": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/JasurbekErgashev/firestore-importer-extension/tree/main/README.md"
     },
+    "jauntybrain/firebase-flow-links": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/jauntybrain/flow-links-extension/tree/main/README.md"
+    },
     "jauntybrain/storage-detect-objects": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/jauntybrain/firebase-extensions/tree/master/README.md"
-    },
-    "jigsaw-code/perspective-comment-toxicity": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/conversationai/firestore-perspective-toxicity/tree/main/README.md"
     },
     "jigsaw/firestore-perspective-toxicity": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/conversationai/firestore-perspective-toxicity/tree/main/README.md"
     },
     "justpass-me/justpass-me": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/justpass-me/Passkeys-firebase-ext/tree/main/README.md"
-    },
-    "justpass-me/justpassme-firebase-extension": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/justpass-me/Passkeys-firebase-ext/tree/main/README.md"
     },
@@ -275,15 +248,15 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/mailersend/mailersend-firebase/tree/main/README.md"
     },
-    "mailersend/mailersend-firebase-extension": {
+    "mark/auth-send-message-to-telegram": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/mailersend/mailersend-firebase/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/marknesh/auth-send-message-to-telegram/tree/master/README.md"
+    },
+    "mark/storage-googledrive-export": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/marknesh/storage-googledrive-export/tree/master/README.md"
     },
     "meilisearch/firestore-meilisearch": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/meilisearch/firestore-meilisearch/tree/main/README.md"
-    },
-    "meilisearch/meilisearch-firestore": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/meilisearch/firestore-meilisearch/tree/main/README.md"
     },
@@ -291,35 +264,35 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/messagebird/firebase-extensions/blob/master/README.md"
     },
-    "mongodb/firestore-mongodb-sync": {
+    "modelpilot/modelpilot-router-firebase": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/aposded/modelpilot-firebase/tree/main/README.md"
+    },
+    "mongodb-atlas/mongodb-functions": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/mongodb-partners/Firebase-extension-MongoDB-Atlas/tree/main/PREINSTALL.md"
     },
-    "mongodb/firestore-mongodb-vector-search": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/mongodb-partners/Firebase-extension-MongoDB-Atlas/tree/main/PREINSTALL.md"
+    "moralis/moralis-streams": {
+      "status": "CONFIRMED_NO_REPLACEMENT",
+      "extensionRepositoryUrl": "https://github.com/MoralisWeb3/firebase-extensions/tree/main/streams/README.md"
     },
-    "mongodb/mongodb-functions": {
+    "movejourney/firestore-elevenlabs-tts": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/mongodb-partners/Firebase-extension-MongoDB-Atlas/tree/main/PREINSTALL.md"
-    },
-    "msg91/firestore-msg91": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/Walkover-Web-Solution/MSG91-Firebase/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/sgilroy/elevenlabs-tts-firebase-extension/tree/main/README.md"
     },
     "msg91/msg91-send-msg": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/Walkover-Web-Solution/MSG91-Firebase/tree/main/README.md"
     },
+    "mskvitalii/auth-send-message-to-slack": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/mskVitalii/auth-send-message-to-slack/tree/main/README.md"
+    },
     "nickschaefer/storage-generate-thumbnails": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/naturalnick/firebase-extension-generate-thumbnails/tree/master/README.md"
     },
-    "nimbasms/firebase-extension": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/nimbasms/nimbasms-firebase/tree/main/README.md"
-    },
-    "nimbasms/nimbasmsapi": {
+    "nimbasmsapi/nimbasmsapi": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/nimbasms/nimbasms-firebase/tree/main/README.md"
     },
@@ -327,13 +300,21 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/nushio/historian/tree/main/README.md"
     },
+    "nuverax/nuverax-5bf48": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/nuveraxgroup/image-dinary/tree/main/README.md"
+    },
+    "oddbit/firebase-alerts": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/oddbit/firebase-alerts/tree/main/README.md"
+    },
     "openfort/firestore-openfort-transactions": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/openfort-xyz/openfort-firebase-extension/tree/main/README.md"
     },
-    "openfort/openfort-firebase-extension": {
+    "pabblyconnect/firestore-pabbly-connector": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/openfort-xyz/openfort-firebase-extension/tree/main/README.md"
+      "extensionRepositoryUrl": "https://github.com/pabbly-apps/pc-integration-firestorewebhookextension/tree/main/README.md"
     },
     "pangea/firestore-audit-document": {
       "status": "PENDING_PUBLISHER",
@@ -359,13 +340,13 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/pdfplum/pdfplum/tree/main/README.md"
     },
-    "purchasely/purchasely-firebase-extension": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/purchasely/purchasely-firebase-extension/tree/master/README.md"
-    },
     "purchasely/purchasely-in-app-purchases": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/purchasely/purchasely-firebase-extension/tree/master/README.md"
+    },
+    "pushfire-subscribers-sync/pushfire-subscribers-sync": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/FlywheelStudio/pushfire-libs-firebase-extension/tree/main/README.md"
     },
     "revenuecat/firestore-revenuecat-purchases": {
       "status": "PENDING_PUBLISHER",
@@ -374,18 +355,6 @@
     "rowy/firestore-user-document": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/buildship-ai/firebase-extensions/tree/main/firestore-user-document/README.md"
-    },
-    "rowy/rowy-firestore-sync": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/rowyio/rowy/tree/main/README.md"
-    },
-    "sendgrid/sendgrid-abandoned-cart": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/abandoned-cart-emails/README.md"
-    },
-    "sendgrid/sendgrid-contacts-sync": {
-      "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/sendgrid-sync-contacts/README.md"
     },
     "shiftescape/firestore-chatgpt-bot": {
       "status": "PENDING_PUBLISHER",
@@ -435,13 +404,21 @@
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
     },
-    "stripe/firestore-stripe-subscriptions": {
+    "summerhammer/firestore-liqpay-payments": {
       "status": "PENDING_PUBLISHER",
-      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
+      "extensionRepositoryUrl": "https://github.com/summerhammer/firestore-liqpay-payments/tree/main/README.md"
     },
     "timeseal/firebase-timeseal-timestamp": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/vaionex/timeseal-firebase/tree/master/README.md"
+    },
+    "tomas-piaggio/field-uniqueness": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/tpiaggio/ext-field-uniqueness/tree/main/README.md"
+    },
+    "tomas-piaggio/field-uniqueness-http": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/tpiaggio/ext-field-uniqueness-http/tree/main/README.md"
     },
     "twilio/abandoned-cart-emails": {
       "status": "PENDING_PUBLISHER",
@@ -470,6 +447,18 @@
     "web3auth/web3-wallet-generator": {
       "status": "PENDING_PUBLISHER",
       "extensionRepositoryUrl": "https://github.com/Web3Auth/web3auth-firebase-extension/tree/master/README.md"
+    },
+    "yaman/firestore-connect-document": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/yamankatby/firebase-extensions/tree/main/firestore-connect-document/README.md"
+    },
+    "yaman/firestore-one-to-one": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/yamankatby/firebase-extensions/tree/main/firestore-one-to-one/README.md"
+    },
+    "yaman/generate-og-image": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/yamankatby/firebase-extensions/tree/main/generate-og-image/README.md"
     }
   }
 }

--- a/src/extensions/replacements.json
+++ b/src/extensions/replacements.json
@@ -1,0 +1,289 @@
+{
+  "replacements": {
+    "firebase/firestore-send-email": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-send-email",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md"
+    },
+    "firebase/storage-resize-images": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/storage-resize-images",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/storage-resize-images/README.md"
+    },
+    "firebase/firestore-bigquery-export": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-bigquery-export",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-bigquery-export/README.md"
+    },
+    "firebase/bigquery-firestore-export": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/bigquery-firestore-export",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/bigquery-firestore-export/README.md"
+    },
+    "firebase/firestore-translate-text": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-translate-text",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-translate-text/README.md"
+    },
+    "firebase/firestore-counter": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-counter",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-counter/README.md"
+    },
+    "firebase/rtdb-limit-child-nodes": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/rtdb-limit-child-nodes",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/rtdb-limit-child-nodes/README.md"
+    },
+    "firebase/delete-user-data": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/delete-user-data",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/delete-user-data/README.md"
+    },
+    "firebase/firestore-bundle-builder": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-bundle-builder",
+      "extensionRepositoryUrl": "https://github.com/firebase/firestore-bundle-builder/blob/master/README.md"
+    },
+    "firebase/firestore-genai-chatbot": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-genai-chatbot",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-genai-chatbot/README.md"
+    },
+    "firebase/firestore-incremental-capture": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-incremental-capture",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-incremental-capture/README.md"
+    },
+    "firebase/firestore-vector-search": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/firestore-vector-search",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-vector-search/README.md"
+    },
+    "firebase/speech-to-text": {
+      "status": "REPLACEMENT_AVAILABLE",
+      "npmPackage": "@firebase-function-kits/speech-to-text",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/speech-to-text/README.md"
+    },
+    "firebase/firestore-shorten-urls-bitly": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-shorten-urls-bitly/README.md"
+    },
+    "googlecloud/storage-extract-image-text": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-extract-image-text/README.md"
+    },
+    "googlecloud/storage-label-images": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-images/README.md"
+    },
+    "googlecloud/text-to-speech": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/text-to-speech/README.md"
+    },
+    "googlecloud/speech-to-text": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/speech-to-text/README.md"
+    },
+    "googlecloud/storage-label-videos": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-label-videos/README.md"
+    },
+    "googlecloud/firestore-genai-chatbot": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-genai-chatbot/README.md"
+    },
+    "googlecloud/firestore-multimodal-genai": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-multimodal-genai/README.md"
+    },
+    "googlecloud/firestore-semantic-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/firestore-semantic-search/README.md"
+    },
+    "googlecloud/storage-reverse-image-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GoogleCloudPlatform/firebase-extensions/tree/main/storage-reverse-image-search/README.md"
+    },
+    "googlemapsplatform/firestore-validate-address": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/googlemaps/google-maps-services-python/blob/master/README.md"
+    },
+    "stripe/firestore-stripe-payments": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
+    },
+    "stripe/firestore-stripe-invoices": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/stripe/stripe-firebase-extensions/tree/master/firestore-stripe-invoices/README.md"
+    },
+    "invertase/firestore-stripe-payments": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-payments/README.md"
+    },
+    "invertase/firestore-stripe-invoices": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/stripe-firebase-extensions/tree/master/firestore-stripe-invoices/README.md"
+    },
+    "invertase/image-processing-api": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/image-processing-api/README.md"
+    },
+    "invertase/export-user-data": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/export-user-data/README.md"
+    },
+    "invertase/firestore-record-acknowledgments": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/invertase/firebase-extensions/tree/main/extensions/firestore-record-acknowledgments/README.md"
+    },
+    "twilio/send-message": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/send-message/README.md"
+    },
+    "twilio/sendgrid-sync-contacts": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/sendgrid-sync-contacts/README.md"
+    },
+    "twilio/abandoned-cart-emails": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/twilio-labs/twilio-firebase-extensions/tree/main/abandoned-cart-emails/README.md"
+    },
+    "algolia/firestore-algolia-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/algolia/firestore-algolia-search/tree/master/README.md"
+    },
+    "typesense/firestore-typesense-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/typesense/firestore-typesense-search/tree/master/README.md"
+    },
+    "meilisearch/firestore-meilisearch": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/meilisearch/firestore-meilisearch/tree/main/README.md"
+    },
+    "messagebird/firestore-messagebird-send-msg": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/messagebird/firebase-extensions/blob/master/README.md"
+    },
+    "mailchimp/mailchimp-firebase-sync": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/mailchimp/Firebase/tree/master/README.md"
+    },
+    "elastic/firestore-elastic-app-search": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/elastic/app-search-firestore-extension/tree/master/README.md"
+    },
+    "revenuecat/firestore-revenuecat-purchases": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/RevenueCat/firestore-revenuecat-purchases/tree/main/README.md"
+    },
+    "customerio/sync-customerio": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/customerio/customerio-firebase-extensions/tree/main/sync-customerio/README.md"
+    },
+    "stream/auth-chat": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/auth-chat/README.md"
+    },
+    "stream/auth-activity-feeds": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/auth-activity-feeds/README.md"
+    },
+    "stream/firestore-activity-feeds": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/GetStream/stream-firebase-extensions/tree/main/firestore-activity-feeds/README.md"
+    },
+    "pdfplum/http-pdf-generator": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pdfplum/pdfplum/tree/main/README.md"
+    },
+    "pdfplum/firestore-pdf-generator": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pdfplum/pdfplum/tree/main/README.md"
+    },
+    "mailersend/mailersend-email": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/mailersend/mailersend-firebase/tree/main/README.md"
+    },
+    "purchasely/purchasely-in-app-purchases": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/purchasely/purchasely-firebase-extension/tree/main/README.md"
+    },
+    "vonage/firebase-vonage-messages": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/Vonage/vonage-firebase-extensions/tree/main/README.md"
+    },
+    "vonage/firestore-vonage-video-express": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/Vonage/vonage-firebase-extensions/tree/main/README.md"
+    },
+    "rowy/rowy-firestore-sync": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/rowyio/rowy/tree/main/README.md"
+    },
+    "shiftescape/firestore-chatgpt-bot": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/shiftEscape/firebase-extensions/tree/main/firestore-chatgpt-bot/README.md"
+    },
+    "jigsaw/firestore-perspective-toxicity": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/conversationai/firestore-perspective-toxicity/tree/main/README.md"
+    },
+    "pangea/firestore-audit-document": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pangeacyber/pangea-extensions-firebase/tree/main/firestore-audit-document/README.md"
+    },
+    "pangea/firestore-audit-log": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pangeacyber/pangea-extensions-firebase/tree/main/firestore-audit-log/README.md"
+    },
+    "pangea/firestore-redact-text": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pangeacyber/pangea-extensions-firebase/tree/main/firestore-redact-text/README.md"
+    },
+    "pangea/storage-file-intel": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/pangeacyber/pangea-extensions-firebase/tree/main/storage-file-intel/README.md"
+    },
+    "shipengine/calculate-rates": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+    },
+    "shipengine/purchase-labels": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+    },
+    "shipengine/track-labels": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+    },
+    "shipengine/validate-addresses": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/ShipEngine/firebase-extensions/tree/master/README.md"
+    },
+    "snap/snapchat-login": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/Snapchat/snap-kit-firebase-extensions/blob/master/README.md"
+    },
+    "snap/snapchat-sticker-generator": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/Snapchat/snap-kit-firebase-extensions/blob/master/README.md"
+    },
+    "cloudflare/cloudflare-turnstile-app-check-provider": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/cloudflare/turnstile-firebase-app-check-provider/tree/main/README.md"
+    },
+    "moralis/moralis-streams": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://github.com/MoralisWeb3/youtube-tutorials/tree/main/StreamsFrontend"
+    },
+    "iproov/auth-iproov": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://extensions.dev/extensions/iproov/auth-iproov"
+    },
+    "corbado/authentication-corbado": {
+      "status": "PENDING_PUBLISHER",
+      "extensionRepositoryUrl": "https://extensions.dev/extensions/corbado/authentication-corbado"
+    }
+  }
+}

--- a/src/extensions/replacements.json
+++ b/src/extensions/replacements.json
@@ -2,12 +2,12 @@
   "replacements": {
     "firebase/delete-user-data": {
       "status": "REPLACEMENT_AVAILABLE",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/delete-user-data/README.md",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/kits/delete-user-data/README.md",
       "npmPackage": "@firebase/delete-user-data"
     },
     "firebase/firestore-bigquery-export": {
       "status": "REPLACEMENT_AVAILABLE",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-bigquery-export/README.md",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/kits/firestore-bigquery-export/README.md",
       "npmPackage": "@firebase/firestore-bigquery-export"
     },
     "firebase/firestore-bundle-builder": {
@@ -16,12 +16,12 @@
     },
     "firebase/firestore-counter": {
       "status": "REPLACEMENT_AVAILABLE",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-counter/README.md",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/kits/firestore-counter/README.md",
       "npmPackage": "@firebase/firestore-counter"
     },
     "firebase/firestore-send-email": {
       "status": "REPLACEMENT_AVAILABLE",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-send-email/README.md",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/kits/firestore-send-email/README.md",
       "npmPackage": "@firebase/firestore-send-email"
     },
     "firebase/firestore-shorten-urls-bitly": {
@@ -31,17 +31,17 @@
     },
     "firebase/firestore-translate-text": {
       "status": "REPLACEMENT_AVAILABLE",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/firestore-translate-text/README.md",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/kits/firestore-translate-text/README.md",
       "npmPackage": "@firebase/firestore-translate-text"
     },
     "firebase/rtdb-limit-child-nodes": {
       "status": "REPLACEMENT_AVAILABLE",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/rtdb-limit-child-nodes/README.md",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/kits/rtdb-limit-child-nodes/README.md",
       "npmPackage": "@firebase/rtdb-limit-child-nodes"
     },
     "firebase/storage-resize-images": {
       "status": "REPLACEMENT_AVAILABLE",
-      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/main/storage-resize-images/README.md",
+      "extensionRepositoryUrl": "https://github.com/firebase/extensions/tree/kits/storage-resize-images/README.md",
       "npmPackage": "@firebase/storage-resize-images"
     },
     "googlecloud/bigquery-firestore-export": {


### PR DESCRIPTION
Because Firebase Extensions is shutting down on March 31, 2027, developers need migration paths to official replacement packages. This PR builds the foundation to track those replacements by adding a central file (src/extensions/replacements.json) containing 113 verified extensions and their current replacement statuses. It also provides a helper (src/extensions/replacementRegistry.ts) so the CLI and Console can easily check whether an extension has a replacement and format a clear warning message.

To keep this list up to date without manual editing, this PR also introduces an automated scraper tool. When executed, the script reaches out to the GitHub repositories of all 68 extensions, reads their README files to check if the publisher has posted a replacement tag, and automatically updates replacements.json whenever new replacement packages are announced.

Runtime CLI warning banners  will be hooked up in a follow-up PR.

Runbook:
Run Unit Tests:

```bash
npx mocha -r ts-node/register src/extensions/replacementRegistry.spec.ts scripts/extensions-scraper/index.spec.ts
```
Expect: 11 tests passing in ~20ms.

Run Live GitHub Scraper:

```bash
npm run scrape:extensions
```
Expect: Scans all 113 repositories, detects merged README tags, and writes updates directly into src/extensions/replacements.json.

Check In Updates: Whenever partner publishers merge new replacement notice tags, running the scraper command above will update replacements.json, which can then be committed and pushed.