### PR TITLE
fix: prevent duplicate GCF v2 endpoints when loading Cloud Run services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed a bug where deploying functions with the `dartfunctions` experiment enabled could incorrectly prompt to delete existing GCF v2 functions.
 - Added `outputSchema` support for local MCP tools.
 - Added `appcheck:providers:list`, `appcheck:providers:get` and `appcheck:providers:set` to configure App Check attestation providers for an app.
 - Added `appcheck:apps:list` to show every app with its configured App Check providers.

--- a/src/deploy/functions/backend.spec.ts
+++ b/src/deploy/functions/backend.spec.ts
@@ -340,6 +340,7 @@ describe("Backend", () => {
           ingressSettings: "ALLOW_ALL" as const,
           timeoutSeconds: 60,
           serviceAccount: null,
+          runServiceId: "id",
         };
         delete wantEndpoint.state;
 
@@ -395,6 +396,7 @@ describe("Backend", () => {
           ingressSettings: "ALLOW_ALL" as const,
           timeoutSeconds: 60,
           serviceAccount: null,
+          runServiceId: "id",
         };
         delete wantEndpoint.state;
 

--- a/src/deploy/functions/backend.ts
+++ b/src/deploy/functions/backend.ts
@@ -645,6 +645,7 @@ async function loadExistingBackend(ctx: Context): Promise<Backend> {
  * @param ctx Context from the Command library, used for caching.
  * @param existingBackend The existing backend to load Cloud Run services into.
  * @param unreachableRegions Object to track unreachable regions.
+ * @param unreachableRegions.run Array of unreachable regions.
  * @param onlyMissing If true, only loads missing Cloud Run services.
  */
 async function loadCloudRunServices(
@@ -654,10 +655,29 @@ async function loadCloudRunServices(
   onlyMissing: boolean,
 ): Promise<void> {
   try {
+    const runServiceIdsByRegion: Record<string, Set<string>> = {};
+    for (const [region, endpoints] of Object.entries(existingBackend.endpoints)) {
+      const ids = Object.values(endpoints)
+        .map((e) => e.runServiceId)
+        .filter((id): id is string => !!id);
+      runServiceIdsByRegion[region] = new Set(ids);
+    }
+
     const runServices = await run.listServices(ctx.projectId);
     for (const service of runServices) {
       const endpoint = run.endpointFromService(service);
-      if (!onlyMissing || !existingBackend.endpoints[endpoint.region]?.[endpoint.id]) {
+
+      // We check both ID and runServiceId because:
+      // 1. GCF v1 functions don't have runServiceId, so we must match by ID (prevents overwrites).
+      // 2. GCF v2 functions (like kits) might have different IDs depending on the API source
+      //    (prefixed vs unprefixed), so we must match by their underlying Cloud Run service ID (prevents duplicates).
+      const hasMatchingId = !!existingBackend.endpoints[endpoint.region]?.[endpoint.id];
+      const hasMatchingServiceId = !!(
+        endpoint.runServiceId && runServiceIdsByRegion[endpoint.region]?.has(endpoint.runServiceId)
+      );
+      const alreadyLoaded = hasMatchingId || hasMatchingServiceId;
+
+      if (!onlyMissing || !alreadyLoaded) {
         existingBackend.endpoints[endpoint.region] =
           existingBackend.endpoints[endpoint.region] || {};
         existingBackend.endpoints[endpoint.region][endpoint.id] = endpoint;

--- a/src/gcp/runv2.spec.ts
+++ b/src/gcp/runv2.spec.ts
@@ -251,6 +251,7 @@ describe("runv2", () => {
         ingressSettings: "ALLOW_ALL",
         serviceAccount: null,
         timeoutSeconds: 60,
+        runServiceId: SERVICE_ID,
       };
 
       expect(runv2.endpointFromService(service)).to.deep.equal(expectedEndpoint);
@@ -306,6 +307,7 @@ describe("runv2", () => {
         ingressSettings: "ALLOW_ALL",
         serviceAccount: null,
         timeoutSeconds: 60,
+        runServiceId: SERVICE_ID,
       };
 
       expect(runv2.endpointFromService(service)).to.deep.equal(expectedEndpoint);
@@ -465,6 +467,7 @@ describe("runv2", () => {
         ingressSettings: "ALLOW_ALL",
         serviceAccount: null,
         timeoutSeconds: 60,
+        runServiceId: SERVICE_ID,
         // concurrency, minInstances, maxInstances will be undefined
       };
 

--- a/src/gcp/runv2.ts
+++ b/src/gcp/runv2.ts
@@ -618,6 +618,7 @@ export function endpointFromService(service: Omit<Service, ServiceOutputFields>)
       ? proto.secondsFromDuration(service.template.timeout)
       : 60,
     serviceAccount: service.template.serviceAccount || null,
+    runServiceId: svcId,
     ingressSettings: (service.annotations?.["run.googleapis.com/ingress"] === "internal"
       ? "ALLOW_INTERNAL_ONLY"
       : service.annotations?.["run.googleapis.com/ingress"] === "internal-and-cloud-load-balancing"


### PR DESCRIPTION
### Description
Fixes a bug where GCF v2 functions (such as kit functions) were loaded as duplicates in the existing backend state when the `dartfunctions` experiment was enabled.

The issue occurred because `loadCloudRunServices` swept all Cloud Run services (including GCF v2 services). Due to information loss in the Cloud Run v2 API list response (missing GCF annotations), the parser resolved GCF v2 services using their unprefixed/incorrect names, causing them to be added as duplicate endpoints.

To fix this, we implemented deduplication on load:
1. Expose the raw Cloud Run service ID in `endpoint.runServiceId` when parsing services in `src/gcp/runv2.ts`.
2. Update `loadCloudRunServices` in `src/deploy/functions/backend.ts` to check if the incoming service ID matches the `runServiceId` of any already loaded GCF v2 endpoint, and skip it if it matches.

#### Remaining Gap (functionsrunapionly)
Note that this load-side deduplication only works when the GCF API is called first (populating `existingBackend`). If the `functionsrunapionly` experiment is enabled, the GCF API is bypassed, and the parser will still resolve GCF v2 services with incorrect unprefixed names due to the missing annotations on Cloud Run.

To support kits in `functionsrunapionly` mode in the future, we will need to update the GCF v2 deploy path (`gcfV2.functionFromEndpoint` in `src/gcp/cloudfunctionsv2.ts`) to inject the `firebase-functions-metadata` annotation containing the prefixed ID during deployment, so that the Cloud Run parser can later resolve the correct prefixed name.

### Scenarios Tested
- Deploying kits (verified they no longer prompt for deletion of unprefixed functions).
- Deploying normal Node.js codebases.
- Deploying Dart (direct-to-run) codebases.
- Successfully ran all tests.

### Sample Commands
`firebase deploy --only functions`

TAG=agy
CONV=e21b1ae0-fa2f-4911-9df5-f5597f5c3c7e
