### PR TITLE
feat: default OneMCP servers to require project, add project requirement opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Configured OneMCP server tools to require a Firebase project by default, with options to opt-out specific tools (such as developer knowledge document search).
+- Configured OneMCP server tools to require a Firebase project by default, with options to opt-out specific tools (such as Developer Knowledge document search).
 - Fixed a bug where deploying functions with the `dartfunctions` experiment enabled could incorrectly prompt to delete existing GCF v2 functions.
 - Added `outputSchema` support for local MCP tools.
 - Added `appcheck:providers:list`, `appcheck:providers:get` and `appcheck:providers:set` to configure App Check attestation providers for an app.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Configured OneMCP server tools to require a Firebase project by default, with options to opt-out specific tools (such as developer knowledge document search).
 - Fixed a bug where deploying functions with the `dartfunctions` experiment enabled could incorrectly prompt to delete existing GCF v2 functions.
 - Added `outputSchema` support for local MCP tools.
 - Added `appcheck:providers:list`, `appcheck:providers:get` and `appcheck:providers:set` to configure App Check attestation providers for an app.

--- a/src/mcp/onemcp/index.ts
+++ b/src/mcp/onemcp/index.ts
@@ -3,11 +3,17 @@ import { ServerFeature } from "../types";
 import { OneMcpServer } from "./onemcp_server";
 
 export const ONEMCP_SERVERS: Partial<Record<ServerFeature, OneMcpServer>> = {
-  developerknowledge: new OneMcpServer("developerknowledge", developerKnowledgeOrigin(), {
-    requiresAuth: true,
-  }),
+  developerknowledge: new OneMcpServer(
+    "developerknowledge",
+    developerKnowledgeOrigin(),
+    {
+      requiresAuth: true,
+    },
+    {
+      toolsToOptOutProjectRequirement: ["search_documents", "get_documents"],
+    },
+  ),
   firestore: new OneMcpServer("firestore", firestoreOrigin(), {
     requiresAuth: true,
-    requiresProject: true,
   }),
 };

--- a/src/mcp/onemcp/onemcp_server.spec.ts
+++ b/src/mcp/onemcp/onemcp_server.spec.ts
@@ -20,7 +20,7 @@ describe("OneMcpServer", () => {
     sandbox = sinon.createSandbox();
     clientRequestStub = sandbox.stub(Client.prototype, "request");
     ensureStub = sandbox.stub(ensureModule, "ensure").resolves();
-    server = new OneMcpServer(feature, serverUrl, { requiresAuth: false, requiresProject: true });
+    server = new OneMcpServer(feature, serverUrl, { requiresAuth: false });
   });
 
   afterEach(() => {
@@ -102,6 +102,53 @@ describe("OneMcpServer", () => {
 
       expect(tools).to.have.length(1);
       expect(tools[0].mcp.name).to.equal("auth_allowed_tool");
+    });
+
+    it("should set requiresProject to false if requiresProject is false in meta", async () => {
+      const serverWithoutProject = new OneMcpServer(feature, serverUrl, {
+        requiresAuth: false,
+        requiresProject: false,
+      });
+      clientRequestStub.resolves({
+        body: {
+          result: {
+            tools: [{ name: "test_tool", inputSchema: { type: "object" } }],
+          },
+        },
+      });
+
+      const tools = await serverWithoutProject.listTools();
+
+      expect(tools[0].mcp._meta?.requiresProject).to.be.false;
+    });
+
+    it("should set requiresProject to false for tools in toolsToOptOutProjectRequirement", async () => {
+      const serverWithOptOut = new OneMcpServer(
+        feature,
+        serverUrl,
+        { requiresAuth: false },
+        { toolsToOptOutProjectRequirement: ["opted_out_tool"] },
+      );
+      clientRequestStub.resolves({
+        body: {
+          result: {
+            tools: [
+              { name: "opted_out_tool", inputSchema: { type: "object" } },
+              { name: "normal_tool", inputSchema: { type: "object" } },
+            ],
+          },
+        },
+      });
+
+      const tools = await serverWithOptOut.listTools();
+
+      const optedOutTool = tools.find((t) => t.mcp.name === "auth_opted_out_tool");
+      const normalTool = tools.find((t) => t.mcp.name === "auth_normal_tool");
+
+      expect(optedOutTool).to.not.be.undefined;
+      expect(normalTool).to.not.be.undefined;
+      expect(optedOutTool!.mcp._meta?.requiresProject).to.be.false;
+      expect(normalTool!.mcp._meta?.requiresProject).to.be.true;
     });
   });
 
@@ -211,6 +258,42 @@ describe("OneMcpServer", () => {
         "MCP-Protocol-Version": LATEST_PROTOCOL_VERSION,
         "Mcp-Method": "tools/call",
         "Mcp-Name": "test_tool",
+      });
+      expect(ensureStub).to.not.have.been.called;
+    });
+
+    it("should call ensure and include project header when projectId is present, even if tool is opted out of project requirement", async () => {
+      const serverWithOptOut = new OneMcpServer(
+        feature,
+        serverUrl,
+        { requiresAuth: false },
+        { toolsToOptOutProjectRequirement: ["opted_out_tool"] },
+      );
+      const mockMcpTool = {
+        name: "opted_out_tool",
+        inputSchema: { type: "object", properties: {} },
+      };
+      clientRequestStub.onFirstCall().resolves({
+        body: { result: { tools: [mockMcpTool] } },
+      });
+
+      const tools = await serverWithOptOut.listTools();
+      const tool = tools[0];
+
+      clientRequestStub.onSecondCall().resolves({
+        body: { result: { content: [] } },
+      });
+
+      await tool.fn({ arg: "val" }, mockContext);
+
+      expect(ensureStub).to.have.been.calledOnceWith(
+        mockContext.projectId,
+        serverUrl,
+        feature,
+        true,
+      );
+      expect(clientRequestStub.secondCall.args[0].headers).to.deep.include({
+        "x-goog-user-project": "test-project",
       });
     });
 

--- a/src/mcp/onemcp/onemcp_server.ts
+++ b/src/mcp/onemcp/onemcp_server.ts
@@ -22,6 +22,11 @@ export interface OneMcpServerOptions {
    * and permitted in callTool().
    */
   allowedTools?: string[];
+  /**
+   * Optional list of tool names (original remote tool name or prefixed name)
+   * that should opt-out of the project requirement.
+   */
+  toolsToOptOutProjectRequirement?: string[];
 }
 
 /**
@@ -86,20 +91,33 @@ export class OneMcpServer {
         );
       });
 
-      return tools.map((mcpTool) => ({
-        mcp: {
-          ...mcpTool,
-          name: `${this.feature}_${mcpTool.name}`,
-          _meta: { ...this.meta, feature: this.feature },
-        },
-        fn: (
-          args: {
-            [x: string]: unknown;
+      const optOutSet = new Set(this.options.toolsToOptOutProjectRequirement || []);
+      return tools.map((mcpTool) => {
+        const isOptedOut =
+          this.meta.requiresProject === false ||
+          optOutSet.has(mcpTool.name) ||
+          optOutSet.has(`${this.feature}_${mcpTool.name}`);
+        const toolRequiresProject = !isOptedOut;
+
+        return {
+          mcp: {
+            ...mcpTool,
+            name: `${this.feature}_${mcpTool.name}`,
+            _meta: {
+              ...this.meta,
+              requiresProject: toolRequiresProject,
+              feature: this.feature,
+            },
           },
-          ctx: McpContext,
-        ) => this.callTool(mcpTool.name, mcpTool.inputSchema, args, ctx),
-        isAvailable: () => Promise.resolve(true),
-      }));
+          fn: (
+            args: {
+              [x: string]: unknown;
+            },
+            ctx: McpContext,
+          ) => this.callTool(mcpTool.name, mcpTool.inputSchema, args, ctx),
+          isAvailable: () => Promise.resolve(true),
+        };
+      });
     } catch (error) {
       throw new FirebaseError(
         "Failed to fetch remote tools for " + this.serverUrl + ": " + JSON.stringify(error),
@@ -143,7 +161,9 @@ export class OneMcpServer {
     }
 
     // TODO: Optimize this to not call ensure on every tool call.
-    await ensure(ctx.projectId, this.serverUrl, this.feature, /* silent=*/ true);
+    if (ctx.projectId) {
+      await ensure(ctx.projectId, this.serverUrl, this.feature, /* silent=*/ true);
+    }
     try {
       const res = await this.callClient.post<
         JSONRPCRequest & CallToolRequest,


### PR DESCRIPTION
### Description
- Set `requiresProject` to `true` by default for all OneMCP server tools.
- Introduced a new option `toolsToOptOutProjectRequirement` in `OneMcpServerOptions` to allow opting out specific tools (e.g. `search_documents`, `get_documents` for `developerknowledge`).
- Configured callTool to conditionally execute ensure API checking/enablement only when `ctx.projectId` is set.

### Scenarios Tested
- Added unit tests in `onemcp_server.spec.ts` covering defaulting `requiresProject`, opting out specific tools, and conditional execution of ensure based on presence of projectId.

### Sample Commands
- npx mocha src/mcp/onemcp/onemcp_server.spec.ts

