### PR TITLE
fix: prevent gen1 node functions from deploying in kits

### DIFF
--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -714,6 +714,62 @@ describe("prepare", () => {
     });
   });
 
+  describe("checkKitForGen1", () => {
+    it("should do nothing for regular codebases with gen1 functions", () => {
+      const localCfg = { source: "src", codebase: "default" };
+      const wantBuild = build.of({
+        test: {
+          platform: "gcfv1",
+          entryPoint: "test",
+          project: "project",
+          runtime: latest("nodejs"),
+          httpsTrigger: {},
+        },
+      });
+
+      expect(() => prepare.checkKitForGen1(localCfg, wantBuild)).to.not.throw();
+    });
+
+    it("should do nothing for kit instances with only gen2 functions", () => {
+      const localCfg = { source: "src", kit: "my-kit", instances: { "my-kit-instance": "dir" } };
+      const wantBuild = build.of({
+        test: {
+          platform: "gcfv2",
+          entryPoint: "test",
+          project: "project",
+          runtime: latest("nodejs"),
+          httpsTrigger: {},
+        },
+      });
+
+      expect(() => prepare.checkKitForGen1(localCfg, wantBuild)).to.not.throw();
+    });
+
+    it("should throw a FirebaseError if a kit instance contains a gen1 function", () => {
+      const localCfg = { source: "src", kit: "my-kit", instances: { "my-kit-instance": "dir" } };
+      const wantBuild = build.of({
+        validFunc: {
+          platform: "gcfv2",
+          entryPoint: "validFunc",
+          project: "project",
+          runtime: latest("nodejs"),
+          httpsTrigger: {},
+        },
+        invalidFunc: {
+          platform: "gcfv1",
+          entryPoint: "invalidFunc",
+          project: "project",
+          runtime: latest("nodejs"),
+          httpsTrigger: {},
+        },
+      });
+
+      expect(() => prepare.checkKitForGen1(localCfg, wantBuild)).to.throw(
+        'Function kit "my-kit" contains gen1 functions, which are not supported in kits. Please remove this kit or upgrade these functions to gen2.',
+      );
+    });
+  });
+
   describe("inferDetailsFromExisting", () => {
     it("merges env vars if .env is not used", () => {
       const oldE = {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -49,6 +49,8 @@ import {
   shouldUseRuntimeConfig,
   isKitConfig,
   addKitPrefix,
+  ValidatedLocalSingle,
+  ValidatedKitSingle,
 } from "../../functions/projectConfig";
 import { AUTH_BLOCKING_EVENTS } from "../../functions/events/v1";
 import { generateServiceIdentity } from "../../gcp/serviceusage";
@@ -292,6 +294,9 @@ export async function prepare(
       isKitConfig(config) ? codebase : undefined,
     );
     const localCfg = requireLocal(config, "Remote sources are not supported.");
+
+    checkKitForGen1(localCfg, wantBuild);
+
     const userEnvOpt: functionsEnv.UserEnvsOpts = {
       functionsSource: options.config.path(localCfg.source),
       projectId: projectId,
@@ -1003,4 +1008,22 @@ export function partitionUserEnvs(allEnvs: Record<string, string>): {
     [{}, {}] as [Record<string, string>, Record<string, string>],
   );
   return { userEnvs: userEnvs, secretRefs: secretRefs };
+}
+
+/**
+ * Validates that a function kit codebase does not contain any gen1 functions.
+ * Throws a FirebaseError if a gen1 function is found.
+ */
+export function checkKitForGen1(
+  localCfg: ValidatedLocalSingle | ValidatedKitSingle,
+  wantBuild: build.Build,
+): void {
+  if (
+    isKitConfig(localCfg) &&
+    Object.values(wantBuild.endpoints).some((e) => e.platform === "gcfv1")
+  ) {
+    throw new FirebaseError(
+      `Function kit "${localCfg.kit}" contains gen1 functions, which are not supported in kits. Please remove this kit or upgrade these functions to gen2.`,
+    );
+  }
 }


### PR DESCRIPTION
### Description

We only support gen2 node functions in kits, so we want to fail as fast as possible if a user attempts to deploy one that contains gen1 functions.

This explicitly restricts kit codebase deployments to gen2 functions by introducing an early AST inspection step in `src/deploy/functions/prepare.ts`. If any gen1 functions are discovered within a kit prior to resolving the backend, a terminal `FirebaseError` is immediately thrown to safely halt the deployment.

### Scenarios Tested

- Regular codebases (`codebase: "default"`) containing gen1 endpoints pass successfully.
- Kit configured codebases containing exclusively gen2 endpoints pass successfully.
- Kit configured codebases containing a gen1 endpoint throw the specific `FirebaseError`.
- Automated test coverage added for all three evaluation scenarios in `prepare.spec.ts`.

### Sample Commands

`firebase deploy --only functions`

TAG=agy
CONV=fbade4e0-0d6f-426c-ae14-4f505375f008
