### PR TITLE
feat(functions): Add kit migration template and support both net new install and migration case

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -294,6 +294,103 @@ describe("functions:kits:install", () => {
       ).to.be.rejectedWith(FirebaseError, /Invalid NPM package name/);
     });
 
+    it("should throw an error if --template has an invalid template name", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          npm_package: "@firebase-functions-kits/firestore-bigquery-export",
+          template: "invalid-template",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        "Invalid template 'invalid-template'. Template must be 'installation' or 'migration'.",
+      );
+    });
+
+    it("should use the migration template when --template migration is specified", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        template: "migration",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      const indexContent = writtenFiles[
+        "function-kits/firestore-bigquery-export/src/index.ts"
+      ] as string;
+      expect(indexContent).to.be.a("string");
+      expect(indexContent).to.include("EXT_MIGRATED_SYSTEM_MEMORY");
+      expect(indexContent).to.include(
+        'export * from "@firebase-functions-kits/firestore-bigquery-export";',
+      );
+      expect(indexContent).to.not.include("{{PACKAGE_NAME}}");
+    });
+
+    it("should use the installation template by default or when explicitly specified", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      await command.runner()({
+        npm_package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        template: "installation",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+      });
+
+      const indexContent = writtenFiles[
+        "function-kits/firestore-bigquery-export/src/index.ts"
+      ] as string;
+      expect(indexContent).to.be.a("string");
+      expect(indexContent).to.include("maxInstances: 10");
+      expect(indexContent).to.include(
+        'export * from "@firebase-functions-kits/firestore-bigquery-export";',
+      );
+      expect(indexContent).to.not.include("{{PACKAGE_NAME}}");
+    });
+
     it("should successfully install a first-party kit into firebase.json", async () => {
       const writtenFiles: Record<string, unknown> = {};
 

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -33,6 +33,11 @@ const INDEX_KIT_MIGRATION_TEMPLATE = readTemplateSync(
   "init/functions/typescript/index-kit-migration.ts",
 );
 
+const TEMPLATES = {
+  installation: INDEX_KIT_TEMPLATE,
+  migration: INDEX_KIT_MIGRATION_TEMPLATE,
+};
+
 const FUNCTION_KITS_DIR = "function-kits";
 
 export interface FunctionsKitsInstallOptions extends Options {
@@ -151,7 +156,7 @@ export const command = new Command("functions:kits:install")
     }
 
     const templateType = options.template || "installation";
-    if (templateType !== "installation" && templateType !== "migration") {
+    if (!(templateType in TEMPLATES)) {
       throw new FirebaseError(
         `Invalid template '${templateType}'. Template must be 'installation' or 'migration'.`,
       );

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -29,11 +29,15 @@ const PACKAGE_NO_LINTING_TEMPLATE = readTemplateSync(
 const TSCONFIG_TEMPLATE = readTemplateSync("init/functions/typescript/tsconfig.json");
 const GITIGNORE_TEMPLATE = readTemplateSync("init/functions/typescript/_gitignore");
 const INDEX_KIT_TEMPLATE = readTemplateSync("init/functions/typescript/index-kit.ts");
+const INDEX_KIT_MIGRATION_TEMPLATE = readTemplateSync(
+  "init/functions/typescript/index-kit-migration.ts",
+);
 
 const FUNCTION_KITS_DIR = "function-kits";
 
 export interface FunctionsKitsInstallOptions extends Options {
   npm_package?: string;
+  template?: string;
 }
 
 /**
@@ -134,11 +138,23 @@ export async function checkPackageHasShrinkwrap(rawPkgName: string): Promise<boo
 export const command = new Command("functions:kits:install")
   .description("install a function kit into your project")
   .option("--npm_package <package>", "NPM package name or specifier to install as a function kit")
+  .option(
+    "--template [installation|migration]",
+    "template to use for the kit index file",
+    "installation",
+  )
   .action(async (options: FunctionsKitsInstallOptions): Promise<void> => {
     experiments.assertEnabled("kits", "install a function kit");
 
     if (!options.config) {
       throw new FirebaseError("Not in a Firebase project directory (firebase.json not found).");
+    }
+
+    const templateType = options.template || "installation";
+    if (templateType !== "installation" && templateType !== "migration") {
+      throw new FirebaseError(
+        `Invalid template '${templateType}'. Template must be 'installation' or 'migration'.`,
+      );
     }
 
     const rawPkgName = options.npm_package;
@@ -330,7 +346,9 @@ export const command = new Command("functions:kits:install")
     const relIndexTsPath = path.join(sourcePath, "src", "index.ts");
     const absIndexTsPath = options.config.path(relIndexTsPath);
     if (!(await fs.pathExists(absIndexTsPath))) {
-      const indexContent = INDEX_KIT_TEMPLATE.replace("{{PACKAGE_NAME}}", packageName);
+      const template =
+        templateType === "migration" ? INDEX_KIT_MIGRATION_TEMPLATE : INDEX_KIT_TEMPLATE;
+      const indexContent = template.replace("{{PACKAGE_NAME}}", packageName);
       await options.config.askWriteProjectFile(relIndexTsPath, indexContent);
     }
 

--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -37,7 +37,7 @@ setGlobalOptions({
     : undefined,
   ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as IngressSetting) || undefined,
   labels: process.env.EXT_MIGRATED_SYSTEM_LABELS
-    ? JSON.parse(process.env.EXT_MIGRATED_SYSTEM_LABELS)
+    ? (JSON.parse(process.env.EXT_MIGRATED_SYSTEM_LABELS) as Record<string, string>)
     : undefined,
 });
 

--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -10,6 +10,7 @@
  */
 
 import { setGlobalOptions } from "firebase-functions";
+import { MemoryOption, VpcEgressSetting, IngressSetting } from "firebase-functions/v2/options";
 import * as params from "firebase-functions/params";
 
 export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
@@ -21,12 +22,12 @@ export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
 // https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.globaloptions
 setGlobalOptions({
   region: regionParam,
-  memory: (process.env.EXT_MIGRATED_SYSTEM_MEMORY as any) || undefined,
+  memory: (process.env.EXT_MIGRATED_SYSTEM_MEMORY as MemoryOption) || undefined,
   timeoutSeconds: process.env.EXT_MIGRATED_SYSTEM_TIMEOUTSECONDS
     ? Number(process.env.EXT_MIGRATED_SYSTEM_TIMEOUTSECONDS)
     : undefined,
   vpcConnectorEgressSettings:
-    (process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS as any) || undefined,
+    (process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS as VpcEgressSetting) || undefined,
   vpcConnector: process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOR || undefined,
   maxInstances: process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES
     ? Number(process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES)
@@ -34,7 +35,7 @@ setGlobalOptions({
   minInstances: process.env.EXT_MIGRATED_SYSTEM_MININSTANCES
     ? Number(process.env.EXT_MIGRATED_SYSTEM_MININSTANCES)
     : undefined,
-  ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as any) || undefined,
+  ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as IngressSetting) || undefined,
   labels: process.env.EXT_MIGRATED_SYSTEM_LABELS
     ? JSON.parse(process.env.EXT_MIGRATED_SYSTEM_LABELS)
     : undefined,

--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -1,0 +1,44 @@
+/**
+ * Export functions from a function kit.
+ * 
+ * This template is intended for users migrating from using a Firebase
+ * Extension to its equivalent function kit. It will set the global options for
+ * the function kit to equal what is configured for the Extension instance.
+ * Configuration from the Extension instance to migrate can be exported using
+ * the `firebase ext:export --mode functions --instance <ext-instance-id>`
+ * command.
+ */
+
+import { setGlobalOptions } from "firebase-functions";
+import * as params from "firebase-functions/params";
+
+export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
+  description: "Region where functions should be deployed.",
+});
+
+// This allows you to set default options that apply to all functions in this
+// kit. Learn more about these options and additional configurations at:
+// https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.globaloptions
+setGlobalOptions({
+  region: regionParam,
+  memory: (process.env.EXT_MIGRATED_SYSTEM_MEMORY as any) || undefined,
+  timeoutSeconds: process.env.EXT_MIGRATED_SYSTEM_TIMEOUTSECONDS
+    ? Number(process.env.EXT_MIGRATED_SYSTEM_TIMEOUTSECONDS)
+    : undefined,
+  vpcConnectorEgressSettings:
+    (process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS as any) || undefined,
+  vpcConnector: process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOR || undefined,
+  maxInstances: process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES
+    ? Number(process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES)
+    : undefined,
+  minInstances: process.env.EXT_MIGRATED_SYSTEM_MININSTANCES
+    ? Number(process.env.EXT_MIGRATED_SYSTEM_MININSTANCES)
+    : undefined,
+  ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as any) || undefined,
+  labels: process.env.EXT_MIGRATED_SYSTEM_LABELS
+    ? JSON.parse(process.env.EXT_MIGRATED_SYSTEM_LABELS)
+    : undefined,
+});
+
+// Exports the functions located in the kit.
+export * from "{{PACKAGE_NAME}}";

--- a/templates/init/functions/typescript/index-kit-migration.ts
+++ b/templates/init/functions/typescript/index-kit-migration.ts
@@ -11,10 +11,14 @@
 
 import { setGlobalOptions } from "firebase-functions";
 import { MemoryOption, VpcEgressSetting, IngressSetting } from "firebase-functions/v2/options";
-import * as params from "firebase-functions/params";
+import { defineString } from "firebase-functions/params";
 
-export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
-  description: "Region where functions should be deployed.",
+// This is how you create a "param". A param is a placeholder for a value
+// which is determined at install/deploy time. Use a param whenever you want
+// the value to differ. Learn more at
+// https://firebase.google.com/docs/functions/config-env#params
+export const regionParam = defineString("FUNCTION_DEFAULT_REGION", {
+  description: "Global default region where functions should be deployed. Can be overriden per-function.",
 });
 
 // This allows you to set default options that apply to all functions in this
@@ -22,20 +26,20 @@ export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
 // https://firebase.google.com/docs/reference/functions/2nd-gen/node/firebase-functions.globaloptions
 setGlobalOptions({
   region: regionParam,
-  memory: (process.env.EXT_MIGRATED_SYSTEM_MEMORY as MemoryOption) || undefined,
+  memory: (process.env.EXT_MIGRATED_SYSTEM_MEMORY as MemoryOption) ?? undefined,
   timeoutSeconds: process.env.EXT_MIGRATED_SYSTEM_TIMEOUTSECONDS
     ? Number(process.env.EXT_MIGRATED_SYSTEM_TIMEOUTSECONDS)
     : undefined,
   vpcConnectorEgressSettings:
-    (process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS as VpcEgressSetting) || undefined,
-  vpcConnector: process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOR || undefined,
+    (process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOREGRESSSETTINGS as VpcEgressSetting) ?? undefined,
+  vpcConnector: process.env.EXT_MIGRATED_SYSTEM_VPCCONNECTOR ?? undefined,
   maxInstances: process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES
     ? Number(process.env.EXT_MIGRATED_SYSTEM_MAXINSTANCES)
     : undefined,
   minInstances: process.env.EXT_MIGRATED_SYSTEM_MININSTANCES
     ? Number(process.env.EXT_MIGRATED_SYSTEM_MININSTANCES)
     : undefined,
-  ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as IngressSetting) || undefined,
+  ingressSettings: (process.env.EXT_MIGRATED_SYSTEM_INGRESSSETTINGS as IngressSetting) ?? undefined,
   labels: process.env.EXT_MIGRATED_SYSTEM_LABELS
     ? (JSON.parse(process.env.EXT_MIGRATED_SYSTEM_LABELS) as Record<string, string>)
     : undefined,

--- a/templates/init/functions/typescript/index-kit.ts
+++ b/templates/init/functions/typescript/index-kit.ts
@@ -31,4 +31,5 @@ setGlobalOptions({
   maxInstances: 10,
 });
 
+// Exports the functions located in the kit.
 export * from "{{PACKAGE_NAME}}";

--- a/templates/init/functions/typescript/index-kit.ts
+++ b/templates/init/functions/typescript/index-kit.ts
@@ -12,7 +12,7 @@ import * as params from "firebase-functions/params";
 // the value to differ. Learn more at
 // https://firebase.google.com/docs/functions/config-env#params
 export const regionParam = params.defineString("FUNCTION_DEFAULT_REGION", {
-  description: "Region where functions should be deployed.",
+  description: "Global default region where functions should be deployed. Can be overriden per-function.",
 });
 
 


### PR DESCRIPTION
### Description

This adds a new template (`index-kit-migration.ts`) to support the Extension -> kit migration case, where users will be leveraging exported environment variables from the `ext:export` command to set the global options in their kit instance. A new flag, `--template`, is added to the install command to configure which template to use. `installation` is the default using the standard `index-kit.ts` template, and `migration` will use the `index-kit-migration.ts` template.

### Scenarios Tested
 
* Installing a package with `--template migration` adds the right template and it compiles
* Installing a package without the template command works the same as before.

### Sample Commands

* `firebase functions:kits:install --project <project> --template migration`
* `firebase functions:kits:install --project <project>`
* `npm run build`