### PR TITLE
refactor(kits): rename sourcePackage id to name

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -1018,7 +1018,7 @@
                     "description": "Package details when resolved from a package repository.",
                     "properties": {
                         "name": {
-                            "description": "Package identifier (e.g., \"@firebase-functions-kits/firestore-bigquery-export\")",
+                            "description": "Package name (e.g., \"@firebase-functions-kits/firestore-bigquery-export\")",
                             "type": "string"
                         }
                     },

--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -1017,13 +1017,13 @@
                     "additionalProperties": false,
                     "description": "Package details when resolved from a package repository.",
                     "properties": {
-                        "id": {
+                        "name": {
                             "description": "Package identifier (e.g., \"@firebase-functions-kits/firestore-bigquery-export\")",
                             "type": "string"
                         }
                     },
                     "required": [
-                        "id"
+                        "name"
                     ],
                     "type": "object"
                 }

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -352,7 +352,7 @@ describe("functions:kits:install", () => {
           {
             kit: "firestore-bigquery-export",
             sourcePackage: {
-              id: "@firebase-functions-kits/firestore-bigquery-export",
+              name: "@firebase-functions-kits/firestore-bigquery-export",
             },
             source: "function-kits/firestore-bigquery-export",
             instances: {
@@ -405,7 +405,7 @@ describe("functions:kits:install", () => {
           {
             kit: "my-custom-kit",
             sourcePackage: {
-              id: "@firebase-functions-kits/firestore-bigquery-export",
+              name: "@firebase-functions-kits/firestore-bigquery-export",
             },
             source: "function-kits/my-custom-kit",
             instances: {

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -352,7 +352,7 @@ export const command = new Command("functions:kits:install")
     const newKitConfig: KitFunctionConfig = {
       kit: kitId,
       sourcePackage: {
-        id: packageName,
+        name: packageName,
       },
       source: sourcePath,
       instances: {

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -155,7 +155,7 @@ describe("prepare", () => {
         const config: ValidatedConfig = [
           {
             kit: "my-kit",
-            sourcePackage: { id: "@firebase-functions-kits/my-kit" },
+            sourcePackage: { name: "@firebase-functions-kits/my-kit" },
             source: "source",
             instances: {
               "inst-alpha": "config/inst-alpha",

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -122,7 +122,7 @@ describe("prepare", () => {
         const config: ValidatedConfig = [
           {
             kit: "my-kit",
-            sourcePackage: { id: "@firebase-functions-kits/my-kit" },
+            sourcePackage: { name: "@firebase-functions-kits/my-kit" },
             source: "source",
             instances: {
               "inst-alpha": "config/inst-alpha",

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -198,7 +198,7 @@ type CodebaseFunctionConfigBase = FunctionConfigBase & {
 };
 
 export type KitSourcePackage = {
-  /** Package identifier (e.g., "@firebase-functions-kits/firestore-bigquery-export") */
+  /** Package name (e.g., "@firebase-functions-kits/firestore-bigquery-export") */
   name: string;
 };
 

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -199,7 +199,7 @@ type CodebaseFunctionConfigBase = FunctionConfigBase & {
 
 export type KitSourcePackage = {
   /** Package identifier (e.g., "@firebase-functions-kits/firestore-bigquery-export") */
-  id: string;
+  name: string;
 };
 
 export type KitFunctionConfig = FunctionConfigBase & {

--- a/src/functions/projectConfig.spec.ts
+++ b/src/functions/projectConfig.spec.ts
@@ -251,7 +251,7 @@ describe("projectConfig", () => {
       const VALID_KIT_CONFIG = {
         kit: "firestore-bigquery-export",
         sourcePackage: {
-          id: "@firebase-functions-kits/firestore-bigquery-export",
+          name: "@firebase-functions-kits/firestore-bigquery-export",
         },
         instances: {
           "firestore-bigquery-export": "config/bq-instance-1",
@@ -631,7 +631,7 @@ describe("projectConfig", () => {
         const cfg = projectConfig.validate([
           {
             kit: "my-kit",
-            sourcePackage: { id: "@firebase-functions-kits/my-kit" },
+            sourcePackage: { name: "@firebase-functions-kits/my-kit" },
             source: "kit-source",
             instances: {
               "inst-alpha": "config/inst-alpha",


### PR DESCRIPTION
### Description

Simply renames the `id` field in `sourcePackage` to `name` for function kits because it is the more common convention to describe the package name.

### Scenarios Tested

* Unit tests