### PR TITLE
fix(extensions): skip extensions deploy when there is nothing to deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@
 - Added web app support for Crashlytics MCP tools and prompts.
 - Added support for forwarding custom HTTP headers (`Mcp-Param-*`) to remote MCP tools when defined in tool parameter input schemas (`x-mcp-header`), per [SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization).
 - Improved function parameter prompting clarity for multi-codebase deploys (#10897)
+- Fixed a bug where deploying functions from a codebase with no extensions still required the Cloud Billing API to be enabled. (#7584)

--- a/src/deploy/extensions/deploy.spec.ts
+++ b/src/deploy/extensions/deploy.spec.ts
@@ -11,6 +11,7 @@ describe("Extensions deploy", () => {
   let bulkCheckProductsProvisionedStub: sinon.SinonStub;
 
   const options: any = { nonInteractive: true, project: "test-project" };
+  const instance = (instanceId: string) => ({ instanceId, params: {}, systemParams: {} }) as any;
 
   beforeEach(() => {
     checkBillingEnabledStub = sinon.stub(cloudbilling, "checkBillingEnabled").resolves(true);
@@ -23,7 +24,7 @@ describe("Extensions deploy", () => {
     sinon.restore();
   });
 
-  it("should not check billing when there is nothing to deploy", async () => {
+  it("should do nothing when there is nothing to deploy", async () => {
     // A functions deploy for a codebase that declares no extensions reaches this
     // stage with an empty payload, and must not require the Cloud Billing API.
     await deploy({} as Context, options, {} as Payload);
@@ -32,7 +33,7 @@ describe("Extensions deploy", () => {
     expect(bulkCheckProductsProvisionedStub.called).to.be.false;
   });
 
-  it("should not check billing when the payload only has empty instance lists", async () => {
+  it("should do nothing when the payload only has empty instance lists", async () => {
     const payload: Payload = {
       instancesToCreate: [],
       instancesToUpdate: [],
@@ -43,26 +44,35 @@ describe("Extensions deploy", () => {
     await deploy({} as Context, options, payload);
 
     expect(checkBillingEnabledStub.called).to.be.false;
+    expect(bulkCheckProductsProvisionedStub.called).to.be.false;
   });
 
-  it("should not check billing for a delete-only deploy", async () => {
-    // Deleting an instance does not require the Blaze plan.
-    const payload: Payload = {
-      instancesToDelete: [{ instanceId: "doomed", params: {}, systemParams: {} } as any],
-    };
-
-    await deploy({} as Context, options, payload);
-
-    expect(checkBillingEnabledStub.called).to.be.false;
-  });
-
-  it("should check billing when there is an instance to create", async () => {
-    const payload: Payload = {
-      instancesToCreate: [{ instanceId: "new-instance", params: {}, systemParams: {} } as any],
-    };
+  it("should deploy normally when there is an instance to create", async () => {
+    const payload: Payload = { instancesToCreate: [instance("new-instance")] };
 
     await deploy({} as Context, options, payload);
 
     expect(checkBillingEnabledStub.calledWith("test-project")).to.be.true;
+    // Asserted so that widening the empty-payload guard above cannot silently turn
+    // a real deploy into a no-op.
+    expect(bulkCheckProductsProvisionedStub.called).to.be.true;
+  });
+
+  it("should not skip a delete-only deploy", async () => {
+    const payload: Payload = { instancesToDelete: [instance("doomed")] };
+
+    await deploy({} as Context, options, payload);
+
+    expect(checkBillingEnabledStub.called).to.be.true;
+    expect(bulkCheckProductsProvisionedStub.called).to.be.true;
+  });
+
+  it("should deploy normally when only configuring an instance", async () => {
+    const payload: Payload = { instancesToConfigure: [instance("existing")] };
+
+    await deploy({} as Context, options, payload);
+
+    expect(checkBillingEnabledStub.called).to.be.true;
+    expect(bulkCheckProductsProvisionedStub.called).to.be.true;
   });
 });

--- a/src/deploy/extensions/deploy.spec.ts
+++ b/src/deploy/extensions/deploy.spec.ts
@@ -1,0 +1,68 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { deploy } from "./deploy";
+import { Context, Payload } from "./args";
+import * as cloudbilling from "../../gcp/cloudbilling";
+import * as provisioningHelper from "../../extensions/provisioningHelper";
+
+describe("Extensions deploy", () => {
+  let checkBillingEnabledStub: sinon.SinonStub;
+  let bulkCheckProductsProvisionedStub: sinon.SinonStub;
+
+  const options: any = { nonInteractive: true, project: "test-project" };
+
+  beforeEach(() => {
+    checkBillingEnabledStub = sinon.stub(cloudbilling, "checkBillingEnabled").resolves(true);
+    bulkCheckProductsProvisionedStub = sinon
+      .stub(provisioningHelper, "bulkCheckProductsProvisioned")
+      .resolves();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it("should not check billing when there is nothing to deploy", async () => {
+    // A functions deploy for a codebase that declares no extensions reaches this
+    // stage with an empty payload, and must not require the Cloud Billing API.
+    await deploy({} as Context, options, {} as Payload);
+
+    expect(checkBillingEnabledStub.called).to.be.false;
+    expect(bulkCheckProductsProvisionedStub.called).to.be.false;
+  });
+
+  it("should not check billing when the payload only has empty instance lists", async () => {
+    const payload: Payload = {
+      instancesToCreate: [],
+      instancesToUpdate: [],
+      instancesToConfigure: [],
+      instancesToDelete: [],
+    };
+
+    await deploy({} as Context, options, payload);
+
+    expect(checkBillingEnabledStub.called).to.be.false;
+  });
+
+  it("should not check billing for a delete-only deploy", async () => {
+    // Deleting an instance does not require the Blaze plan.
+    const payload: Payload = {
+      instancesToDelete: [{ instanceId: "doomed", params: {}, systemParams: {} } as any],
+    };
+
+    await deploy({} as Context, options, payload);
+
+    expect(checkBillingEnabledStub.called).to.be.false;
+  });
+
+  it("should check billing when there is an instance to create", async () => {
+    const payload: Payload = {
+      instancesToCreate: [{ instanceId: "new-instance", params: {}, systemParams: {} } as any],
+    };
+
+    await deploy({} as Context, options, payload);
+
+    expect(checkBillingEnabledStub.calledWith("test-project")).to.be.true;
+  });
+});

--- a/src/deploy/extensions/deploy.ts
+++ b/src/deploy/extensions/deploy.ts
@@ -21,9 +21,10 @@ export async function deploy(context: Context, options: Options, payload: Payloa
   const instancesToConfigure = payload.instancesToConfigure ?? [];
   const instancesToDelete = payload.instancesToDelete ?? [];
 
-  // Nothing to do. `release` already guards this way; without the same guard here
-  // a functions deploy that declares no extensions still reaches the billing check
-  // below, because the SDK always emits an (empty) extensions record.
+  // Nothing to do. A functions deploy reaches this stage even when the codebase
+  // declares no extensions, since every codebase reports an extensions record and
+  // it is empty in that case. Without this guard such a deploy would go on to
+  // require the Cloud Billing API below.
   if (
     !instancesToCreate.length &&
     !instancesToUpdate.length &&
@@ -34,13 +35,8 @@ export async function deploy(context: Context, options: Options, payload: Payloa
   }
 
   const projectId = needProjectId(options);
-
-  // First, check that billing is enabled. Creating, updating or configuring an
-  // instance requires the Blaze plan; deleting one does not, so a delete-only
-  // deploy doesn't need the Cloud Billing API.
-  if (instancesToCreate.length || instancesToUpdate.length || instancesToConfigure.length) {
-    await checkBilling(projectId, options.nonInteractive);
-  }
+  // First, check that billing is enabled
+  await checkBilling(projectId, options.nonInteractive);
 
   // Then, check that required products are provisioned.
   await bulkCheckProductsProvisioned(projectId, [

--- a/src/deploy/extensions/deploy.ts
+++ b/src/deploy/extensions/deploy.ts
@@ -16,15 +16,37 @@ import { checkBilling } from "./validate";
  * @param payload The deploy payload
  */
 export async function deploy(context: Context, options: Options, payload: Payload): Promise<void> {
+  const instancesToCreate = payload.instancesToCreate ?? [];
+  const instancesToUpdate = payload.instancesToUpdate ?? [];
+  const instancesToConfigure = payload.instancesToConfigure ?? [];
+  const instancesToDelete = payload.instancesToDelete ?? [];
+
+  // Nothing to do. `release` already guards this way; without the same guard here
+  // a functions deploy that declares no extensions still reaches the billing check
+  // below, because the SDK always emits an (empty) extensions record.
+  if (
+    !instancesToCreate.length &&
+    !instancesToUpdate.length &&
+    !instancesToConfigure.length &&
+    !instancesToDelete.length
+  ) {
+    return;
+  }
+
   const projectId = needProjectId(options);
-  // First, check that billing is enabled
-  await checkBilling(projectId, options.nonInteractive);
+
+  // First, check that billing is enabled. Creating, updating or configuring an
+  // instance requires the Blaze plan; deleting one does not, so a delete-only
+  // deploy doesn't need the Cloud Billing API.
+  if (instancesToCreate.length || instancesToUpdate.length || instancesToConfigure.length) {
+    await checkBilling(projectId, options.nonInteractive);
+  }
 
   // Then, check that required products are provisioned.
   await bulkCheckProductsProvisioned(projectId, [
-    ...(payload.instancesToCreate ?? []),
-    ...(payload.instancesToUpdate ?? []),
-    ...(payload.instancesToConfigure ?? []),
+    ...instancesToCreate,
+    ...instancesToUpdate,
+    ...instancesToConfigure,
   ]);
 
   if (context.have) {
@@ -43,17 +65,17 @@ export async function deploy(context: Context, options: Options, payload: Payloa
   // Validate all creates, updates and configures.
   // Skip validating local extensions, since doing so requires us to create a new source.
   // No need to validate deletes.
-  for (const create of payload.instancesToCreate?.filter((i) => !!i.ref) ?? []) {
+  for (const create of instancesToCreate.filter((i) => !!i.ref)) {
     const task = tasks.createExtensionInstanceTask(projectId, create, /* validateOnly=*/ true);
     void validationQueue.run(task);
   }
 
-  for (const update of payload.instancesToUpdate?.filter((i) => !!i.ref) ?? []) {
+  for (const update of instancesToUpdate.filter((i) => !!i.ref)) {
     const task = tasks.updateExtensionInstanceTask(projectId, update, /* validateOnly=*/ true);
     void validationQueue.run(task);
   }
 
-  for (const configure of payload.instancesToConfigure?.filter((i) => !!i.ref) ?? []) {
+  for (const configure of instancesToConfigure.filter((i) => !!i.ref)) {
     const task = tasks.configureExtensionInstanceTask(
       projectId,
       configure,

--- a/src/deploy/extensions/prepare.spec.ts
+++ b/src/deploy/extensions/prepare.spec.ts
@@ -52,10 +52,23 @@ describe("Extensions prepare", () => {
       await expect(prepareDynamicExtensions(context, options, payload, builds)).to.not.be.rejected;
     });
 
-    it("should leave the payload untouched when nothing is defined and nothing exists", async () => {
-      // functions/prepare relies on this to tell "no extensions" apart from a real
-      // plan, so that the deploy and release stages are skipped entirely.
-      const context: Context = {};
+    it("should report no plan if the extensions API is down", async () => {
+      haveDynamicStub.rejects(new Error("Extensions API is having an outage"));
+
+      const options: any = {
+        config: {
+          src: { functions: { source: "functions" } },
+        },
+      };
+
+      const prepared = await prepareDynamicExtensions({}, options, {}, {});
+
+      expect(prepared).to.be.false;
+    });
+
+    it("should report no plan when nothing is defined and nothing exists", async () => {
+      // functions/prepare uses this to tell "no extensions" apart from a real plan,
+      // so that the deploy and release stages are skipped entirely.
       const payload: Payload = {};
       const options: any = {
         config: {
@@ -63,8 +76,9 @@ describe("Extensions prepare", () => {
         },
       };
 
-      await prepareDynamicExtensions(context, options, payload, {});
+      const prepared = await prepareDynamicExtensions({}, options, payload, {});
 
+      expect(prepared).to.be.false;
       expect(payload).to.deep.equal({});
     });
 
@@ -101,6 +115,45 @@ describe("Extensions prepare", () => {
 
       // Expect successful completion
       await expect(prepareDynamicExtensions(context, options, payload, builds)).to.not.be.rejected;
+
+      wantDynamicStub.restore();
+      v2apistub.restore();
+      tosStub.restore();
+    });
+
+    it("should report a plan when an existing instance needs deleting", async () => {
+      haveDynamicStub.resolves([
+        {
+          instanceId: "test-extension",
+          ref: { publisherId: "test", extensionId: "test", version: "0.1.0" },
+          params: {},
+          systemParams: {},
+          labels: { codebase: "default" },
+        },
+      ]);
+
+      const payload: Payload = {};
+      const options: any = {
+        config: {
+          get: () => [],
+          src: { functions: { source: "functions" } },
+        },
+        rc: { getEtags: () => [] },
+        dryRun: true,
+      };
+
+      const wantDynamicStub: sinon.SinonStub = sinon.stub(planner, "wantDynamic").resolves([]);
+      const v2apistub: sinon.SinonStub = sinon
+        .stub(v2FunctionHelper, "ensureNecessaryV2ApisAndRoles")
+        .resolves();
+      const tosStub: sinon.SinonStub = sinon
+        .stub(tos, "getAppDeveloperTOSStatus")
+        .resolves({ lastAcceptedVersion: "1.0.0" } as any);
+
+      const prepared = await prepareDynamicExtensions({}, options, payload, {});
+
+      expect(prepared).to.be.true;
+      expect(payload.instancesToDelete).to.have.length(1);
 
       wantDynamicStub.restore();
       v2apistub.restore();

--- a/src/deploy/extensions/prepare.spec.ts
+++ b/src/deploy/extensions/prepare.spec.ts
@@ -52,6 +52,22 @@ describe("Extensions prepare", () => {
       await expect(prepareDynamicExtensions(context, options, payload, builds)).to.not.be.rejected;
     });
 
+    it("should leave the payload untouched when nothing is defined and nothing exists", async () => {
+      // functions/prepare relies on this to tell "no extensions" apart from a real
+      // plan, so that the deploy and release stages are skipped entirely.
+      const context: Context = {};
+      const payload: Payload = {};
+      const options: any = {
+        config: {
+          src: { functions: { source: "functions" } },
+        },
+      };
+
+      await prepareDynamicExtensions(context, options, payload, {});
+
+      expect(payload).to.deep.equal({});
+    });
+
     it("should proceed normally if extensions API is healthy", async () => {
       haveDynamicStub.resolves([
         {

--- a/src/deploy/extensions/prepare.ts
+++ b/src/deploy/extensions/prepare.ts
@@ -161,13 +161,15 @@ async function prepareHelper(
  * @param options The prepare options
  * @param payload The prepare payload
  * @param builds firebase functions builds
+ * @return Whether a deployment plan was prepared. False means the context and
+ * payload were left untouched, so there is nothing for the caller to deploy.
  */
 export async function prepareDynamicExtensions(
   context: Context,
   options: DeployOptions,
   payload: Payload,
   builds: Record<string, Build>,
-): Promise<void> {
+): Promise<boolean> {
   const functionsConfig = normalizeAndValidate(options.config.src.functions);
   const filters = getEndpointFilters(options, functionsConfig);
   const extensions = extractExtensionsFromBuilds(builds, filters);
@@ -189,12 +191,12 @@ export async function prepareDynamicExtensions(
       "Failed to fetch the list of extensions. Assuming for now that there are no existing extensions. " +
         "If you are trying to install an extension through Firebase Functions this may fail later.",
     );
-    return;
+    return false;
   }
 
   if (Object.keys(extensions).length === 0 && haveExtensions.length === 0) {
     // Nothing defined, and nothing to delete
-    return;
+    return false;
   }
 
   const dynamicWant = await planner.wantDynamic({
@@ -203,14 +205,8 @@ export async function prepareDynamicExtensions(
     extensions,
   });
 
-  return prepareHelper(
-    context,
-    options,
-    payload,
-    dynamicWant,
-    haveExtensions,
-    true /* isDynamic */,
-  );
+  await prepareHelper(context, options, payload, dynamicWant, haveExtensions, true /* isDynamic */);
+  return true;
 }
 
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -278,11 +278,10 @@ export async function prepare(
   if (Object.values(wantBuilds).some((b) => b.extensions)) {
     const extContext: ExtContext = {};
     const extPayload: ExtPayload = {};
-    await prepareDynamicExtensions(extContext, options, extPayload, wantBuilds);
-    // prepareDynamicExtensions returns without touching the payload when there is
-    // nothing to deploy and nothing to delete. Only hand the extensions stages a
-    // plan when it actually made one, otherwise they run against an empty payload.
-    if (Object.keys(extPayload).length) {
+    // Every codebase reports an extensions record, empty when it declares none, so
+    // reaching here does not mean there is anything to deploy. Only hand the
+    // extensions stages a plan when one was actually prepared.
+    if (await prepareDynamicExtensions(extContext, options, extPayload, wantBuilds)) {
       context.extensions = extContext;
       payload.extensions = extPayload;
     }

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -279,8 +279,13 @@ export async function prepare(
     const extContext: ExtContext = {};
     const extPayload: ExtPayload = {};
     await prepareDynamicExtensions(extContext, options, extPayload, wantBuilds);
-    context.extensions = extContext;
-    payload.extensions = extPayload;
+    // prepareDynamicExtensions returns without touching the payload when there is
+    // nothing to deploy and nothing to delete. Only hand the extensions stages a
+    // plan when it actually made one, otherwise they run against an empty payload.
+    if (Object.keys(extPayload).length) {
+      context.extensions = extContext;
+      payload.extensions = extPayload;
+    }
   }
 
   // == Phase 2. Resolve build to backend.


### PR DESCRIPTION
Fixes #7584.

## Problem

`firebase deploy --only functions` on a codebase with no extensions still runs the extensions deploy stage, and the first thing that stage does is check the Cloud Billing API. Under Workload Identity or a service account that fails with a 403, since ADC carries no quota project and Cloud Billing usually is not enabled on the target project.

The chain:

1. The functions SDK always emits an `extensions` record in the manifest, `{}` when there are none.
2. `v1alpha1.ts` does `if (manifest.extensions)`, so an empty record still sets `build.extensions = {}`, which is truthy.
3. `functions/prepare.ts` therefore calls `prepareDynamicExtensions`, which returns early when nothing is declared and nothing exists remotely, but `prepare.ts` assigns `context.extensions` and `payload.extensions` anyway.
4. `functions/deploy.ts` gates on `payload.extensions && context.extensions`, and `{} && {}` is truthy, so extensions deploy runs against an empty plan and calls `checkBilling`.

`extensions/release.ts` already guards against an empty payload. `extensions/deploy.ts` does not, which is what lets this through.

## Fix

- `functions/prepare.ts`: only pass the extensions context and payload on when `prepareDynamicExtensions` reports that it built a plan. It now returns a boolean rather than leaving the caller to infer this from the payload contents.
- `extensions/deploy.ts`: return early when there is nothing to create, update, configure or delete, before the billing check. `release` has a similar guard, though it tests for the payload fields being absent rather than empty.

The Extensions API check and `firebaseextensions.instances.list` stay on the deploy path, since those are what detect extensions deleted from code, and they already fail soft. Worth noting that the Billing API is not needed for that detection: nothing in the prepare or list path calls Cloud Billing, so the empty-payload deploy stage was the only thing requiring it.

## Testing

New `extensions/deploy.spec.ts` covers empty payload, all-empty lists, create, delete-only and configure. The two no-op cases fail without this change. Cases that should proceed assert they reached `bulkCheckProductsProvisioned`, so widening the guard cannot silently turn a real deploy into a no-op. Added a case to `extensions/prepare.spec.ts` pinning the early-return contract that `functions/prepare` now depends on. Existing suites for `deploy/extensions` and `deploy/functions` pass (104 tests), `tsc --noEmit` and eslint are clean.