### PR TITLE
fix(functions): use dart build cli for Dart function bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Adds --immediate flag to ext:uninstall (#10921)
 - Updated dataconnect emulator version to v3.4.18.
 - Configured OneMCP server tools to require a Firebase project by default, with options to opt-out specific tools (such as Developer Knowledge document search).
-- Fixed a bug where deploying Dart functions with dependencies that use native build hooks (e.g. `sqlite3`) failed to compile.
+- Fixed a bug where deploying Dart functions with dependencies that use native build hooks (e.g. `sqlite3`) failed to compile. Note: Dart functions now require Dart SDK 3.13.0 or later.
 - Fixed a bug where deploying functions with the `dartfunctions` experiment enabled could incorrectly prompt to delete existing GCF v2 functions.
 - Added `outputSchema` support for local MCP tools.
 - Skip functions lifecycle hooks during partial (filtered) deployments, and print instructions for running them manually.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,13 @@
 - Load existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.
 - Adds --immediate flag to ext:uninstall (#10921)
 - Updated dataconnect emulator version to v3.4.18.
+- Configured OneMCP server tools to require a Firebase project by default, with options to opt-out specific tools (such as Developer Knowledge document search).
+- Fixed a bug where deploying Dart functions with dependencies that use native build hooks (e.g. `sqlite3`) failed to compile.
+- Fixed a bug where deploying functions with the `dartfunctions` experiment enabled could incorrectly prompt to delete existing GCF v2 functions.
+- Added `outputSchema` support for local MCP tools.
+- Skip functions lifecycle hooks during partial (filtered) deployments, and print instructions for running them manually.
+- Added `appcheck:providers:list`, `appcheck:providers:get` and `appcheck:providers:set` to configure App Check attestation providers for an app.
+- Added `appcheck:apps:list` to show every app with its configured App Check providers.
+- Added web app support for Crashlytics MCP tools and prompts.
+- Added support for forwarding custom HTTP headers (`Mcp-Param-*`) to remote MCP tools when defined in tool parameter input schemas (`x-mcp-header`), per [SEP-2243](https://modelcontextprotocol.io/seps/2243-http-standardization).
+- Improved function parameter prompting clarity for multi-codebase deploys (#10897)

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -36,6 +36,22 @@ describe("partition env helper", () => {
   });
 });
 
+describe("getExecutablePaths", () => {
+  it("returns the dart bundle executable path for a dart runtime", () => {
+    expect(prepare.getExecutablePaths(latest("dart"))).to.deep.equal([
+      "build/cli/linux_x64/bundle/bin/server",
+    ]);
+  });
+
+  it("returns no executable paths for a non-dart runtime", () => {
+    expect(prepare.getExecutablePaths(latest("nodejs"))).to.deep.equal([]);
+  });
+
+  it("returns no executable paths when the runtime is undefined", () => {
+    expect(prepare.getExecutablePaths(undefined)).to.deep.equal([]);
+  });
+});
+
 describe("prepare", () => {
   const ENDPOINT_BASE: Omit<backend.Endpoint, "httpsTrigger"> = {
     platform: "gcfv2",

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -52,6 +52,39 @@ describe("getExecutablePaths", () => {
   });
 });
 
+describe("stripStaleDartBuildIgnore", () => {
+  it("strips a stale 'build' entry from a dart codebase's ignore list", () => {
+    const localCfg = { source: "functions", ignore: [".dart_tool", "build"] };
+    expect(prepare.stripStaleDartBuildIgnore(latest("dart"), localCfg)).to.deep.equal({
+      source: "functions",
+      ignore: [".dart_tool"],
+    });
+  });
+
+  it("strips a stale 'build/' entry from a dart codebase's ignore list", () => {
+    const localCfg = { source: "functions", ignore: [".dart_tool", "build/"] };
+    expect(prepare.stripStaleDartBuildIgnore(latest("dart"), localCfg)).to.deep.equal({
+      source: "functions",
+      ignore: [".dart_tool"],
+    });
+  });
+
+  it("leaves a dart codebase's ignore list untouched when it has no stale 'build' entry", () => {
+    const localCfg = { source: "functions", ignore: [".dart_tool"] };
+    expect(prepare.stripStaleDartBuildIgnore(latest("dart"), localCfg)).to.deep.equal(localCfg);
+  });
+
+  it("leaves a non-dart codebase's ignore list untouched", () => {
+    const localCfg = { source: "functions", ignore: ["node_modules", "build"] };
+    expect(prepare.stripStaleDartBuildIgnore(latest("nodejs"), localCfg)).to.deep.equal(localCfg);
+  });
+
+  it("leaves a codebase with no ignore list untouched", () => {
+    const localCfg: { source: string; ignore?: string[] } = { source: "functions" };
+    expect(prepare.stripStaleDartBuildIgnore(latest("dart"), localCfg)).to.deep.equal(localCfg);
+  });
+});
+
 describe("prepare", () => {
   const ENDPOINT_BASE: Omit<backend.Endpoint, "httpsTrigger"> = {
     platform: "gcfv2",

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -32,6 +32,7 @@ import {
 } from "./functionsDeployHelper";
 import { logLabeledBullet, logLabeledWarning } from "../../utils";
 import { isDartEndpoint, classifyNonProductionEndpoints } from "./runtimes/dart/triggerSupport";
+import { DART_BUNDLE_EXECUTABLE_PATH } from "./runtimes/dart";
 import { getFunctionsConfig, prepareFunctionsUpload } from "./prepareFunctionsUpload";
 import { promptForFailurePolicies, promptForMinInstances } from "./prompts";
 import { needProjectId, needProjectNumber } from "../../projectUtils";
@@ -445,8 +446,7 @@ export async function prepare(
         ? "tar.gz"
         : "zip";
 
-      const isDart = supported.runtimeIsLanguage(wantBuilds[codebase].runtime, "dart");
-      const executablePaths = isDart ? ["build/cli/linux_x64/bundle/bin/server"] : [];
+      const executablePaths = getExecutablePaths(wantBuilds[codebase].runtime);
 
       const packagedSource = await prepareFunctionsUpload(
         options.config.projectDir,
@@ -868,6 +868,14 @@ function warnIfDartBackendHasUnsupportedTriggers(want: backend.Backend): void {
         "See https://github.com/firebase/firebase-functions-dart for current trigger support.",
     );
   }
+}
+
+/**
+ * Returns the executable paths to mark as executable when packaging a codebase's source,
+ * relative to the runtime in use.
+ */
+export function getExecutablePaths(runtime: supported.Runtime | undefined): string[] {
+  return supported.runtimeIsLanguage(runtime, "dart") ? [DART_BUNDLE_EXECUTABLE_PATH] : [];
 }
 
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -447,11 +447,12 @@ export async function prepare(
         : "zip";
 
       const executablePaths = getExecutablePaths(wantBuilds[codebase].runtime);
+      const uploadCfg = stripStaleDartBuildIgnore(wantBuilds[codebase].runtime, localCfg);
 
       const packagedSource = await prepareFunctionsUpload(
         options.config.projectDir,
         sourceDir,
-        localCfg,
+        uploadCfg,
         [...schPathSet],
         undefined,
         { exportType, executablePaths },
@@ -876,6 +877,31 @@ function warnIfDartBackendHasUnsupportedTriggers(want: backend.Backend): void {
  */
 export function getExecutablePaths(runtime: supported.Runtime | undefined): string[] {
   return supported.runtimeIsLanguage(runtime, "dart") ? [DART_BUNDLE_EXECUTABLE_PATH] : [];
+}
+
+/**
+ * Strips a stale "build" ignore entry from a Dart codebase's local config.
+ *
+ * Before the switch to `dart build cli`, `firebase init` seeded Dart codebases with
+ * `functions.ignore` including "build", which was harmless since the compiled executable
+ * lived at `bin/server`. The bundle now lives under `build/` (see
+ * DART_BUNDLE_EXECUTABLE_PATH), so honoring that stale entry for codebases configured
+ * before this fix would silently strip the executable from the deploy archive.
+ */
+export function stripStaleDartBuildIgnore<T extends { ignore?: string[] }>(
+  runtime: supported.Runtime | undefined,
+  localCfg: T,
+): T {
+  if (
+    !supported.runtimeIsLanguage(runtime, "dart") ||
+    !localCfg.ignore?.some((i) => i === "build" || i === "build/")
+  ) {
+    return localCfg;
+  }
+  return {
+    ...localCfg,
+    ignore: localCfg.ignore.filter((i) => i !== "build" && i !== "build/"),
+  };
 }
 
 /**

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -446,7 +446,7 @@ export async function prepare(
         : "zip";
 
       const isDart = supported.runtimeIsLanguage(wantBuilds[codebase].runtime, "dart");
-      const executablePaths = isDart ? ["bin/server"] : [];
+      const executablePaths = isDart ? ["build/cli/linux_x64/bundle/bin/server"] : [];
 
       const packagedSource = await prepareFunctionsUpload(
         options.config.projectDir,

--- a/src/deploy/functions/runtimes/dart/index.spec.ts
+++ b/src/deploy/functions/runtimes/dart/index.spec.ts
@@ -1,11 +1,105 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
-import { Delegate } from "./index";
+import * as childProcess from "child_process";
+import { EventEmitter } from "events";
+import { ChildProcess } from "child_process";
+import { Delegate, DART_ENTRY_POINT } from "./index";
 import * as discovery from "../discovery";
 import * as build from "../../build";
 import * as supported from "../supported";
+import { FirebaseError } from "../../../../error";
+import { EmulatorRegistry } from "../../../../emulator/registry";
+import { Emulators } from "../../../../emulator/types";
+
+function createFakeChildProcess(exitCode: number | null): ChildProcess {
+  const proc = new EventEmitter() as ChildProcess;
+  (proc as unknown as { stdout: EventEmitter }).stdout = new EventEmitter();
+  (proc as unknown as { stderr: EventEmitter }).stderr = new EventEmitter();
+  process.nextTick(() => proc.emit("exit", exitCode));
+  return proc;
+}
 
 describe("Dart Runtime Delegate", () => {
+  describe("validate", () => {
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should reject a Dart SDK older than the minimum required version", async () => {
+      sinon.stub(childProcess, "spawnSync").returns({
+        stdout: 'Dart SDK version: 3.9.0 (stable) (Thu Jan 1 2026) on "linux_x64"',
+        stderr: "",
+        status: 0,
+        signal: null,
+        pid: 1,
+        output: [],
+      } as unknown as ReturnType<typeof childProcess.spawnSync>);
+
+      const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
+
+      await expect(delegate.validate()).to.be.rejectedWith(
+        FirebaseError,
+        /Dart SDK version 3\.9\.0 is not supported.*requires Dart 3\.13\.0 or later/,
+      );
+    });
+  });
+
+  describe("build", () => {
+    let spawnStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      spawnStub = sinon.stub(childProcess, "spawn");
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should invoke `dart build cli` with the target/os/arch flags", async () => {
+      spawnStub.callsFake(() => createFakeChildProcess(0));
+
+      const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
+      await delegate.build();
+
+      expect(spawnStub.callCount).to.equal(2);
+      const [command, args] = spawnStub.secondCall.args as [string, string[]];
+      expect(command).to.equal("dart");
+      expect(args).to.deep.equal([
+        "build",
+        "cli",
+        "--target",
+        DART_ENTRY_POINT,
+        "--target-os",
+        "linux",
+        "--target-arch",
+        "x64",
+      ]);
+    });
+
+    it("should throw a FirebaseError with the dart build cli remediation command on failure", async () => {
+      spawnStub.onFirstCall().callsFake(() => createFakeChildProcess(0));
+      spawnStub.onSecondCall().callsFake(() => createFakeChildProcess(1));
+
+      const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
+
+      await expect(delegate.build()).to.be.rejectedWith(
+        FirebaseError,
+        /dart build cli --target bin\/server\.dart --target-os linux --target-arch x64/,
+      );
+    });
+
+    it("should skip `dart build cli` when the functions emulator is running", async () => {
+      spawnStub.callsFake(() => createFakeChildProcess(0));
+      sinon.stub(EmulatorRegistry, "isRunning").withArgs(Emulators.FUNCTIONS).returns(true);
+
+      const delegate = new Delegate("project", "sourceDir", supported.latest("dart"));
+      await delegate.build();
+
+      // Only build_runner should have been spawned; `dart build cli` is skipped.
+      expect(spawnStub.callCount).to.equal(1);
+    });
+  });
+
   describe("discoverBuild", () => {
     let detectFromYamlStub: sinon.SinonStub;
 

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -55,6 +55,9 @@ const MIN_DART_SDK_VERSION = "3.13.0";
 /** Default entry point for Dart functions projects. */
 export const DART_ENTRY_POINT = "bin/server.dart";
 
+/** Path to the executable produced by `dart build cli` for a linux-x64 target. */
+export const DART_BUNDLE_EXECUTABLE_PATH = "build/cli/linux_x64/bundle/bin/server";
+
 export class Delegate implements runtimes.RuntimeDelegate {
   public readonly language = "dart";
   public readonly bin = "dart";

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -200,53 +200,42 @@ export class Delegate implements runtimes.RuntimeDelegate {
       return;
     }
 
-    const binDir = path.join(this.sourceDir, "bin");
-    await fs.promises.mkdir(binDir, { recursive: true });
+    logLabeledBullet("functions", "building Dart linux-x64 bundle...");
 
-    logLabeledBullet("functions", "compiling Dart to linux-x64 executable...");
-
-    const compileProcess = spawn(
+    const buildProcess = spawn(
       this.bin,
-      [
-        "compile",
-        "exe",
-        this.entryPoint,
-        "-o",
-        "bin/server",
-        "--target-os=linux",
-        "--target-arch=x64",
-      ],
+      ["build", "cli", "--target", this.entryPoint, "--target-os", "linux", "--target-arch", "x64"],
       {
         cwd: this.sourceDir,
         stdio: ["ignore", "pipe", "pipe"],
       },
     );
 
-    compileProcess.stdout?.on("data", (chunk: Buffer) => {
-      logger.debug(`[dart compile] ${chunk.toString("utf8").trim()}`);
+    buildProcess.stdout?.on("data", (chunk: Buffer) => {
+      logger.debug(`[dart build cli] ${chunk.toString("utf8").trim()}`);
     });
-    compileProcess.stderr?.on("data", (chunk: Buffer) => {
-      logger.debug(`[dart compile] ${chunk.toString("utf8").trim()}`);
+    buildProcess.stderr?.on("data", (chunk: Buffer) => {
+      logger.debug(`[dart build cli] ${chunk.toString("utf8").trim()}`);
     });
 
     await new Promise<void>((resolve, reject) => {
-      compileProcess.on("exit", (code) => {
+      buildProcess.on("exit", (code) => {
         if (code === 0 || code === null) {
           resolve();
         } else {
           reject(
             new FirebaseError(
-              `Dart compilation failed with exit code ${code}. ` +
-                `Make sure your Dart project compiles successfully with: ` +
-                `dart compile exe ${this.entryPoint} --target-os=linux --target-arch=x64`,
+              `Dart build failed with exit code ${code}. ` +
+                `Make sure your Dart project builds successfully with: ` +
+                `dart build cli --target ${this.entryPoint} --target-os linux --target-arch x64`,
             ),
           );
         }
       });
-      compileProcess.on("error", reject);
+      buildProcess.on("error", reject);
     });
 
-    logLabeledBullet("functions", "Dart compilation complete.");
+    logLabeledBullet("functions", "Dart build complete.");
   }
 
   /**

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -47,9 +47,10 @@ export async function tryCreateDelegate(
 
 /**
  * Minimum Dart SDK version required.
- * Dart 3.8+ is needed for cross-compilation flags (--target-os, --target-arch).
+ * Dart 3.13+ is needed for `dart build cli` to support cross-compilation flags
+ * (--target-os, --target-arch).
  */
-const MIN_DART_SDK_VERSION = "3.9.0";
+const MIN_DART_SDK_VERSION = "3.13.0";
 
 /** Default entry point for Dart functions projects. */
 export const DART_ENTRY_POINT = "bin/server.dart";

--- a/src/init/features/functions/dart.ts
+++ b/src/init/features/functions/dart.ts
@@ -23,8 +23,9 @@ export async function setup(setup: any, config: Config): Promise<void> {
 
   // Write the latest supported runtime version to the config.
   config.set("functions.runtime", latest("dart"));
-  // Add dart specific ignores to config.
-  config.set("functions.ignore", [".dart_tool", "build"]);
+  // Add dart specific ignores to config. `build/` is intentionally not ignored:
+  // `dart build cli` writes the deployable bundle there (see DART_BUNDLE_EXECUTABLE_PATH).
+  config.set("functions.ignore", [".dart_tool"]);
 
   const install = await confirm({
     message: "Do you want to install dependencies now?",

--- a/templates/init/functions/dart/_gitignore
+++ b/templates/init/functions/dart/_gitignore
@@ -1,3 +1,3 @@
 .dart_tool/
-bin/server
+build/
 *.local


### PR DESCRIPTION
Closes https://github.com/firebase/firebase-tools/issues/10591

Following the release of Dart [3.13.0](https://github.com/dart-lang/sdk/commit/da6595cd6bb5d4c0a185d759a025e879ff06e631), we can now cross-compile with `dart build cli` (previously only `dart compile exe` supported `--target-os`/`--target-arch`), which unblocks using build hooks for Dart functions.

`dart compile exe` produces a single ahead-of-time compiled executable and skips Dart's native build hooks, so functions depending on packages with native assets don't build correctly. Switching to `dart build cli` runs those hooks and produces a proper bundle instead of a bare executable.

This updates the Dart runtime delegate to invoke `dart build cli` with the same target/os/arch flags, and updates `prepare.ts` to look for the resulting server executable at its new bundle path (`build/cli/linux_x64/bundle/bin/server`) instead of `bin/server`.

Related to https://github.com/firebase/firebase-functions-dart/issues/201