### PR TITLE
fix(functions): cleanup declarative security service account when codebase functions are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed an issue where managed service accounts for declarative security were not deleted when all functions in a codebase were deleted, or caused IAM permission errors on empty codebase deploys.
 - Configured OneMCP server tools to require a Firebase project by default, with options to opt-out specific tools (such as Developer Knowledge document search).
 - Fixed a bug where deploying functions with the `dartfunctions` experiment enabled could incorrectly prompt to delete existing GCF v2 functions.
 - Added `outputSchema` support for local MCP tools.

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -1402,6 +1402,37 @@ describe("prepare", () => {
       expect(e.labels?.["firebase-declarative-security-etag"]).to.be.undefined;
     });
 
+    it("should return existingManagedSA without checking permissions when wantBackend is empty", async () => {
+      testIamPermissionsStub.rejects(new Error("Should not be called"));
+      const want = backend.empty();
+      want.requiredRoles = ["roles/viewer"];
+      const have = backend.of({
+        ...ENDPOINT,
+        serviceAccount: "firebase-fn-123@project.iam.gserviceaccount.com",
+        labels: {
+          "firebase-declarative-security-etag": "salt-etag",
+        },
+      });
+
+      const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+
+      expect(result.existingManagedSA).to.equal("firebase-fn-123@project.iam.gserviceaccount.com");
+      expect(result.haveRolesEtag).to.equal("salt-etag");
+      expect(testIamPermissionsStub).to.not.have.been.called;
+    });
+
+    it("should return empty security object and not create SA when both want and have backends are empty", async () => {
+      testIamPermissionsStub.rejects(new Error("Should not be called"));
+      const want = backend.empty();
+      want.requiredRoles = ["roles/viewer"];
+      const have = backend.empty();
+
+      const result = await prepare.discoverSecurityDetails("default", want, have, "project");
+
+      expect(result).to.deep.equal({});
+      expect(testIamPermissionsStub).to.not.have.been.called;
+    });
+
     it("should keep explicit custom service accounts and not reset to default when unenrolling from declarative security", async () => {
       const eCustom: backend.Endpoint = {
         ...ENDPOINT,

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -65,11 +65,17 @@ import * as iam from "../../gcp/iam";
 import * as resourcemanager from "../../gcp/resourceManager";
 
 export const EVENTARC_SOURCE_ENV = "EVENTARC_CLOUD_EVENT_SOURCE";
+export const DECLARATIVE_SECURITY_ETAG_LABEL = "firebase-declarative-security-etag";
 
 /**
  * Discovers and coordinates declarative security details for a codebase.
- * Mutates want Backend to populate managed service account and etag labels.
- * Returns existing discovered roles, or undefined if no security changes needed.
+ * Mutates `want` Backend to populate managed service account and etag labels.
+ *
+ * Returns security metadata based on deployment state:
+ * - **Enrolling / Active**: Returns `{ haveRoles, haveRolesEtag, existingManagedSA, managedSA, newEtag }`.
+ * - **Unenrolling (Opting Out)**: Returns `{ existingManagedSA, haveRolesEtag }` so planner can schedule role revocation.
+ * - **Deleting All Functions**: Returns `{ existingManagedSA, ...(haveRolesEtag ? { haveRolesEtag } : {}) }` so planner can delete the SA.
+ * - **Inactive**: Returns `{}` when declarative security is not used in `want` or `have`.
  */
 export async function discoverSecurityDetails(
   codebase: string,
@@ -96,8 +102,8 @@ export async function discoverSecurityDetails(
     )?.serviceAccount ?? undefined;
   const haveRolesEtag = backend.findEndpoint(
     have,
-    (e) => !!e.labels?.["firebase-declarative-security-etag"],
-  )?.labels?.["firebase-declarative-security-etag"];
+    (e) => !!e.labels?.[DECLARATIVE_SECURITY_ETAG_LABEL],
+  )?.labels?.[DECLARATIVE_SECURITY_ETAG_LABEL];
 
   const isPartiallyFiltered = !!(
     filters &&
@@ -168,7 +174,7 @@ export async function discoverSecurityDetails(
   for (const endpoint of backend.allEndpoints(want)) {
     endpoint.serviceAccount = managedSA;
     endpoint.labels = endpoint.labels || {};
-    endpoint.labels["firebase-declarative-security-etag"] = newEtag;
+    endpoint.labels[DECLARATIVE_SECURITY_ETAG_LABEL] = newEtag;
   }
 
   if (haveRolesEtag && haveRolesEtag === newEtag) {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -89,10 +89,11 @@ export async function discoverSecurityDetails(
   // haveBackend contains all active endpoints in GCP from list calls. firstHave.serviceAccount
   // will identify existingManagedSA on subsequent deploys. On 100% deployment failures,
   // fabricator cleans up the unreferenced service account so no orphaned SA remains.
-  const existingManagedSA = backend.findEndpoint(
-    have,
-    (e) => typeof e.serviceAccount === "string" && e.serviceAccount.startsWith("firebase-fn-"),
-  )?.serviceAccount;
+  const existingManagedSA =
+    backend.findEndpoint(
+      have,
+      (e) => typeof e.serviceAccount === "string" && e.serviceAccount.startsWith("firebase-fn-"),
+    )?.serviceAccount ?? undefined;
   const haveRolesEtag = backend.findEndpoint(
     have,
     (e) => !!e.labels?.["firebase-declarative-security-etag"],

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -89,15 +89,14 @@ export async function discoverSecurityDetails(
   // haveBackend contains all active endpoints in GCP from list calls. firstHave.serviceAccount
   // will identify existingManagedSA on subsequent deploys. On 100% deployment failures,
   // fabricator cleans up the unreferenced service account so no orphaned SA remains.
-  const firstHave = backend.allEndpoints(have)[0];
-  let existingManagedSA: string | undefined;
-  let haveRolesEtag: string | undefined;
-  if (firstHave) {
-    haveRolesEtag = firstHave.labels?.["firebase-declarative-security-etag"];
-    existingManagedSA = firstHave.serviceAccount?.startsWith("firebase-fn-")
-      ? firstHave.serviceAccount
-      : undefined;
-  }
+  const existingManagedSA = backend.findEndpoint(
+    have,
+    (e) => typeof e.serviceAccount === "string" && e.serviceAccount.startsWith("firebase-fn-"),
+  )?.serviceAccount;
+  const haveRolesEtag = backend.findEndpoint(
+    have,
+    (e) => !!e.labels?.["firebase-declarative-security-etag"],
+  )?.labels?.["firebase-declarative-security-etag"];
 
   const isPartiallyFiltered = !!(
     filters &&
@@ -113,6 +112,16 @@ export async function discoverSecurityDetails(
       "To ensure a whole codebase is migrated cleanly, you may not deploy only part of a " +
         "codebase when opting into or out of declarative security (starting or no longer using `requireRoles`)",
     );
+  }
+
+  if (!backend.someEndpoint(want, () => true)) {
+    if (existingManagedSA) {
+      return {
+        existingManagedSA,
+        ...(haveRolesEtag ? { haveRolesEtag } : {}),
+      };
+    }
+    return {};
   }
 
   if (!requiredRoles && (!existingManagedSA || !haveRolesEtag)) {

--- a/src/deploy/functions/release/planner.spec.ts
+++ b/src/deploy/functions/release/planner.spec.ts
@@ -608,9 +608,9 @@ describe("planner", () => {
       );
     });
 
-    it("does not delete the service account when requiredRoles is defined but empty", async () => {
+    it("deletes the service account when requiredRoles is defined but all functions in codebase are deleted", async () => {
       const wantBackend = backend.empty();
-      wantBackend.requiredRoles = [];
+      wantBackend.requiredRoles = ["roles/datastore.user"];
       const haveBackend = backend.of(func("id", "region"));
 
       const plan = await planner.createDeploymentPlan({
@@ -622,6 +622,24 @@ describe("planner", () => {
         managedSA: "firebase-fn-123@my-project.iam.gserviceaccount.com",
       });
 
+      expect(plan.serviceAccountToDelete).to.equal(
+        "firebase-fn-123@my-project.iam.gserviceaccount.com",
+      );
+    });
+
+    it("does not create a service account when both wantBackend and haveBackend are empty even if requiredRoles is defined", async () => {
+      const wantBackend = backend.empty();
+      wantBackend.requiredRoles = ["roles/datastore.user"];
+      const haveBackend = backend.empty();
+
+      const plan = await planner.createDeploymentPlan({
+        wantBackend,
+        haveBackend,
+        codebase,
+        projectId: "my-project",
+      });
+
+      expect(plan.serviceAccountToCreate).to.be.undefined;
       expect(plan.serviceAccountToDelete).to.be.undefined;
     });
   });

--- a/src/deploy/functions/release/planner.ts
+++ b/src/deploy/functions/release/planner.ts
@@ -181,7 +181,9 @@ export async function createDeploymentPlan(args: PlanArgs): Promise<CodebasePlan
     !deleteAll
   );
 
-  if (requiredRoles) {
+  const hasWantEndpoints = backend.someEndpoint(wantBackend, () => true);
+
+  if (requiredRoles && hasWantEndpoints) {
     rolesToAdd = requiredRoles.filter((r) => !roles.includes(r));
     rolesToRemove = roles.filter((r) => !requiredRoles.includes(r));
     if (!existingManagedSA && managedSA) {
@@ -223,7 +225,7 @@ export async function createDeploymentPlan(args: PlanArgs): Promise<CodebasePlan
         "old default of 1. You can change this with the 'concurrency' option.",
     );
   }
-  if (requiredRoles) {
+  if (requiredRoles && hasWantEndpoints) {
     if (!managedSA) {
       throw new FirebaseError("managedServiceAccount is required when requiredRoles is defined.", {
         exit: 1,


### PR DESCRIPTION
Fixes an issue where deleting all functions in a codebase that uses declarative security (requireRoles) failed or left the managed service account (firebase-fn-...) orphaned in GCP IAM.

Specifically:
- In discoverSecurityDetails: When wantBackend has 0 endpoints, skip IAM permission checks, role queries, and managed SA generation. Return existing security metadata if an existing SA was deployed, or {} if both want and have backends are empty.
- In createDeploymentPlan: Require hasWantEndpoints to be true before treating declarative security as active. If wantBackend has 0 endpoints and haveBackend has an existing managed SA, set serviceAccountToDelete = existingManagedSA so the service account is cleanly deleted. If both wantBackend and haveBackend are empty, no service account is created or deleted.

- Deleting all functions from a codebase while keeping requireRoles in global options: verified that serviceAccountToDelete is set and the managed service account is deleted.
- Deploying an empty codebase with requireRoles specified (0 functions in want and have): verified that no service account is created and no IAM permission errors are thrown.
- Deploying functions with requireRoles: verified managed service account creation and role assignment works normally.
- Partial function deployments (--only functions:func1): verified managed service account is retained.

- npx mocha src/deploy/functions/release/planner.spec.ts src/deploy/functions/prepare.spec.ts
- firebase deploy --only functions
