### PR TITLE
feat(functions): load .env files and pass to functions discovery in runtimeDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.
+- [Added] Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -22,6 +22,7 @@ import { Options } from "../../options";
 import { ValidatedConfig } from "../../functions/projectConfig";
 import { BEFORE_CREATE_EVENT, BEFORE_SIGN_IN_EVENT } from "../../functions/events/v1";
 import { latest } from "./runtimes/supported";
+import * as functionsEnv from "../../functions/env";
 
 describe("partition env helper", () => {
   it("splits a Record into two based on which keys begin with FIREBASE_SECRET_REF", () => {
@@ -195,6 +196,27 @@ describe("prepare", () => {
       } finally {
         experiments.setEnabled("kits", null);
       }
+    });
+
+    it("should load user envs and pass them to discoverBuild", async () => {
+      sandbox.stub(functionsEnv, "loadUserEnvs").returns({ MY_ENV_VAR: "my_val" });
+      const config: ValidatedConfig = [
+        { source: "source", codebase: "codebase", runtime: "nodejs22" },
+      ];
+      const options = {
+        config: {
+          path: (p: string) => p,
+        },
+        projectId: "project",
+      } as unknown as Options;
+      const firebaseConfig = { projectId: "project" };
+      const runtimeConfig = {};
+
+      await prepare.loadCodebases(config, options, firebaseConfig, runtimeConfig);
+
+      expect(discoverBuildStub.firstCall.args[1]).to.deep.include({
+        MY_ENV_VAR: "my_val",
+      });
     });
 
     it("should preserve runtime from codebase config", async () => {

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -804,6 +804,21 @@ export async function loadCodebases(
     logger.debug(`Building ${runtimeDelegate.language} source`);
     await runtimeDelegate.build();
 
+    const userEnvOpt: functionsEnv.UserEnvsOpts = {
+      functionsSource: sourceDir,
+      projectId: projectId,
+      projectAlias: options.projectAlias,
+      projectDir: options.config.projectDir,
+    };
+    if (isKitConfig(codebaseConfig) && codebase in codebaseConfig.instances) {
+      userEnvOpt.configDir = options.config.path(codebaseConfig.instances[codebase]);
+    } else {
+      proto.convertIfPresent(userEnvOpt, codebaseConfig, "configDir", (cd) =>
+        options.config.path(cd),
+      );
+    }
+    const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
+
     const firebaseEnvs = functionsEnv.loadFirebaseEnvs(
       firebaseConfig,
       projectId,
@@ -819,6 +834,7 @@ export async function loadCodebases(
       : { firebase: firebaseConfig };
 
     const discoveredBuild = await runtimeDelegate.discoverBuild(codebaseRuntimeConfig, {
+      ...userEnvs,
       ...firebaseEnvs,
       // Quota project is required when using GCP's Client-based APIs
       // Some GCP client SDKs, like Vertex AI, requires appropriate quota project setup

--- a/src/deploy/functions/prepare.ts
+++ b/src/deploy/functions/prepare.ts
@@ -1,7 +1,6 @@
 import * as clc from "colorette";
 
 import * as args from "./args";
-import * as proto from "../../gcp/proto";
 import * as backend from "./backend";
 import * as build from "./build";
 import * as experiments from "../../experiments";
@@ -49,6 +48,7 @@ import {
   shouldUseRuntimeConfig,
   isKitConfig,
   addKitPrefix,
+  resolveConfigDir,
   ValidatedLocalSingle,
   ValidatedKitSingle,
 } from "../../functions/projectConfig";
@@ -319,10 +319,9 @@ export async function prepare(
       projectAlias: options.projectAlias,
       projectDir: options.config.projectDir,
     };
-    if (isKitConfig(localCfg) && codebase in localCfg.instances) {
-      userEnvOpt.configDir = options.config.path(localCfg.instances[codebase]);
-    } else {
-      proto.convertIfPresent(userEnvOpt, localCfg, "configDir", (cd) => options.config.path(cd));
+    const configDir = resolveConfigDir(localCfg, codebase);
+    if (configDir) {
+      userEnvOpt.configDir = options.config.path(configDir);
     }
 
     const rawUserEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
@@ -810,12 +809,9 @@ export async function loadCodebases(
       projectAlias: options.projectAlias,
       projectDir: options.config.projectDir,
     };
-    if (isKitConfig(codebaseConfig) && codebase in codebaseConfig.instances) {
-      userEnvOpt.configDir = options.config.path(codebaseConfig.instances[codebase]);
-    } else {
-      proto.convertIfPresent(userEnvOpt, codebaseConfig, "configDir", (cd) =>
-        options.config.path(cd),
-      );
+    const configDir = resolveConfigDir(codebaseConfig, codebase);
+    if (configDir) {
+      userEnvOpt.configDir = options.config.path(configDir);
     }
     const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
 

--- a/src/deploy/functions/runtimes/dart/index.ts
+++ b/src/deploy/functions/runtimes/dart/index.ts
@@ -350,6 +350,8 @@ export class Delegate implements runtimes.RuntimeDelegate {
       const buildRunnerProcess = spawn(this.bin, ["run", "build_runner", "build"], {
         cwd: this.sourceDir,
         stdio: ["ignore", "pipe", "pipe"],
+        // TODO: Including process.env was a mistake; only known envs should be included after a breaking change.
+        env: { ...process.env, ...envs },
       });
 
       buildRunnerProcess.stdout?.on("data", (chunk: Buffer) => {

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -599,7 +599,6 @@ export class FunctionsEmulator implements EmulatorInstance {
       emulatableBackend.runtime = runtimeDelegate.runtime;
       emulatableBackend.bin = runtimeDelegate.bin;
 
-      // Don't include user envs when parsing triggers. Do include user envs when resolving parameter values
       const firebaseConfig = this.getFirebaseConfig();
       const environment = {
         ...this.getSystemEnvs(),
@@ -616,7 +615,10 @@ export class FunctionsEmulator implements EmulatorInstance {
         projectDir: this.args.projectDir,
       };
       const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
-      const discoveredBuild = await runtimeDelegate.discoverBuild(runtimeConfig, environment);
+      const discoveredBuild = await runtimeDelegate.discoverBuild(runtimeConfig, {
+        ...environment,
+        ...userEnvs,
+      });
       if (discoveredBuild.extensions && this.args.extensionsEmulator) {
         await this.args.extensionsEmulator.addDynamicExtensions(
           emulatableBackend.codebase,

--- a/src/emulator/functionsEmulator.ts
+++ b/src/emulator/functionsEmulator.ts
@@ -616,8 +616,8 @@ export class FunctionsEmulator implements EmulatorInstance {
       };
       const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
       const discoveredBuild = await runtimeDelegate.discoverBuild(runtimeConfig, {
-        ...environment,
         ...userEnvs,
+        ...environment,
       });
       if (discoveredBuild.extensions && this.args.extensionsEmulator) {
         await this.args.extensionsEmulator.addDynamicExtensions(

--- a/src/functions/iac/export.spec.ts
+++ b/src/functions/iac/export.spec.ts
@@ -25,6 +25,7 @@ describe("export", () => {
   beforeEach(() => {
     sinon.stub(functionsConfig, "getFirebaseConfig").resolves({ projectId: "my-project" });
     sinon.stub(functionsEnv, "loadFirebaseEnvs").returns({});
+    sinon.stub(functionsEnv, "loadUserEnvs").returns({ FOO: "bar" });
     sinon.stub(runtimes, "getRuntimeDelegate").resolves(mockDelegate);
     sinon.stub(supported, "guardVersionSupport");
     needProjectIdStub = sinon.stub(projectUtils, "needProjectId").returns("my-project");
@@ -55,6 +56,7 @@ describe("export", () => {
       expect(mockDelegate.validate.calledOnce).to.be.true;
       expect(mockDelegate.build.calledOnce).to.be.true;
       expect(mockDelegate.discoverBuild.calledOnce).to.be.true;
+      expect(mockDelegate.discoverBuild.firstCall.args[1]).to.deep.include({ FOO: "bar" });
       expect(result).to.deep.equal({
         "functions.yaml": yaml.dump(mockBuild),
       });

--- a/src/functions/iac/export.ts
+++ b/src/functions/iac/export.ts
@@ -43,10 +43,21 @@ export async function getInternalIac(
   logger.debug(`Building ${runtimeDelegate.language} source`);
   await runtimeDelegate.build();
 
+  const userEnvOpt: functionsEnv.UserEnvsOpts = {
+    functionsSource: options.config.path(codebase.source),
+    projectId,
+    projectAlias: options.projectAlias,
+    projectDir: options.config.projectDir,
+  };
+  const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
+
   logger.debug(`Discovering ${runtimeDelegate.language} source`);
   const build = await runtimeDelegate.discoverBuild(
     {}, // Assume empty runtimeConfig
-    firebaseEnvs,
+    {
+      ...userEnvs,
+      ...firebaseEnvs,
+    },
   );
 
   return {

--- a/src/functions/iac/export.ts
+++ b/src/functions/iac/export.ts
@@ -49,6 +49,10 @@ export async function getInternalIac(
     projectAlias: options.projectAlias,
     projectDir: options.config.projectDir,
   };
+  const configDir = projectConfig.resolveConfigDir(codebase, codebase.codebase);
+  if (configDir) {
+    userEnvOpt.configDir = options.config.path(configDir);
+  }
   const userEnvs = functionsEnv.loadUserEnvs(userEnvOpt);
 
   logger.debug(`Discovering ${runtimeDelegate.language} source`);


### PR DESCRIPTION
### Description
Updates functions discovery (runtimeDelegate.discoverBuild) across deployment (prepare.ts), emulator (functionsEmulator.ts), and IAC export (export.ts) to load existing .env files using functionsEnv.loadUserEnvs and pass the loaded environment variables to the discovery process. Also updates the Dart runtime delegate to include envs in spawn options when running build_runner.

### Scenarios Tested
- Verified loadCodebases loads .env variables and passes them to discoverBuild.
- Verified functionsEmulator passes loaded userEnvs to discoverBuild.
- Verified getInternalIac in export.ts loads .env variables and passes them to discoverBuild.
- Ran unit test suite: npx mocha src/deploy/functions/prepare.spec.ts src/emulator/functionsEmulator.spec.ts src/functions/env.spec.ts src/functions/iac/export.spec.ts src/deploy/functions/runtimes/dart/index.spec.ts.

### Sample Commands
- firebase deploy --only functions
- firebase emulators:start --only functions
