### PR TITLE
Fix `dataconnect_list_services` MCP tool

### DIFF
--- a/src/mcp/tools/dataconnect/list_services.ts
+++ b/src/mcp/tools/dataconnect/list_services.ts
@@ -57,7 +57,7 @@ export const list_services = tool(
           client.listSchemas(`projects/${projectId}/locations/-/services/-`),
           client.listConnectors(`projects/${projectId}/locations/-/services/-`),
         ]);
-        host.logger.debug(`${services}\n${schemas}\n${connectors}`);
+        host.logger.debug(JSON.stringify({ services, schemas, connectors }));
 
         for (const s of services) {
           const k = s.name.split("/").slice(2, 6).join("/");

--- a/src/mcp/tools/dataconnect/list_services.ts
+++ b/src/mcp/tools/dataconnect/list_services.ts
@@ -12,7 +12,6 @@ import {
   mainSchemaYaml,
 } from "../../../dataconnect/types";
 import { dump } from "js-yaml";
-import { logger } from "../../../logger";
 
 interface CombinedServiceInfo {
   local?: ServiceInfo;
@@ -40,7 +39,7 @@ export const list_services = tool(
       requiresAuth: false,
     },
   },
-  async (_, { projectId, config }) => {
+  async (_, { projectId, config, host }) => {
     const localServiceInfos = await loadAll(projectId, config);
     const serviceInfos = new Map<string, CombinedServiceInfo>();
 
@@ -58,7 +57,8 @@ export const list_services = tool(
           client.listSchemas(`projects/${projectId}/locations/-/services/-`),
           client.listConnectors(`projects/${projectId}/locations/-/services/-`),
         ]);
-        console.log(services, schemas, connectors);
+        host.logger.debug(`${services}\n${schemas}\n${connectors}`);
+
         for (const s of services) {
           const k = s.name.split("/").slice(2, 6).join("/");
           const st = serviceInfos.get(k) || {};
@@ -83,7 +83,7 @@ export const list_services = tool(
           serviceInfos.set(k, st);
         }
       } catch (e: any) {
-        logger.debug("cannot fetch dataconnect resources in the backend", e);
+        host.logger.debug(`cannot fetch dataconnect resources in the backend.\n${e}`);
       }
     }
 


### PR DESCRIPTION
### Description

Remove `console.log()` from this MCP tool per guidance from https://github.com/firebase/firebase-tools/blob/main/src/mcp/CONTRIBUTING.md

### Scenarios Tested

Install Firebase MCP and verified this tool working after patch

### Sample Commands

N/A
