### PR TITLE
Update Pub/Sub emulator to v0.8.35 to resolve CVE-2026-59921

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Updated Pub/Sub emulator to version 0.8.35.

--- a/src/emulator/downloadableEmulatorInfo.json
+++ b/src/emulator/downloadableEmulatorInfo.json
@@ -44,13 +44,13 @@
     }
   },
   "pubsub": {
-    "version": "0.8.34",
-    "expectedSize": 53008019,
-    "expectedChecksum": "3eb75c292dfa72d48a36428a49bac314",
-    "expectedChecksumSHA256": "062a71d30cbc0cc29de6e55f22ae9fc7eacb02c60272a2c4692826fdb83f0c25",
-    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.34.zip",
-    "downloadPathRelativeToCacheDir": "pubsub-emulator-0.8.34.zip",
-    "binaryPathRelativeToCacheDir": "pubsub-emulator-0.8.34/pubsub-emulator/bin/cloud-pubsub-emulator"
+    "version": "0.8.35",
+    "expectedSize": 53015972,
+    "expectedChecksum": "04cb782e3edf7a2b117990af8506453e",
+    "expectedChecksumSHA256": "b0f3b73a14b716ecf8925b7b8a0c8c858ffabddcf03df8b2b7fba682f48dc616",
+    "remoteUrl": "https://storage.googleapis.com/firebase-preview-drop/emulator/pubsub-emulator-0.8.35.zip",
+    "downloadPathRelativeToCacheDir": "pubsub-emulator-0.8.35.zip",
+    "binaryPathRelativeToCacheDir": "pubsub-emulator-0.8.35/pubsub-emulator/bin/cloud-pubsub-emulator"
   },
   "dataconnect": {
     "darwin": {


### PR DESCRIPTION
Updates the Pub/Sub emulator to version 0.8.35, which contains netty-codec-http version 4.1.136.Final, resolving CVE-2026-59921.