### PR TITLE
refactor(functions): use labeled "function" logs for kits

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -31,6 +31,7 @@ describe("functions:kits:install", () => {
   let wrapSpawnStub: sinon.SinonStub;
   let spawnWithOutputStub: sinon.SinonStub;
   let loggerInfoStub: sinon.SinonStub;
+  let loggerWarnStub: sinon.SinonStub;
 
   beforeEach(() => {
     (command as unknown as { befores: unknown[] }).befores = [];
@@ -46,7 +47,7 @@ describe("functions:kits:install", () => {
     sinon.stub(fs, "writeJson").resolves();
     sinon.stub(fs, "writeFile").resolves();
     loggerInfoStub = sinon.stub(logger, "info");
-    sinon.stub(logger, "warn");
+    loggerWarnStub = sinon.stub(logger, "warn");
   });
 
   afterEach(() => {
@@ -436,6 +437,14 @@ describe("functions:kits:install", () => {
         ["run", "build"],
         "/abs/path",
       );
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/Running npm install\.\.\./),
+      );
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/Building TypeScript source\.\.\./),
+      );
     });
 
     it("should run npm install with --ignore-scripts for third-party kit", async () => {
@@ -451,6 +460,14 @@ describe("functions:kits:install", () => {
         "npm",
         ["run", "build"],
         "/abs/path",
+      );
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/Running npm install --ignore-scripts\.\.\./),
+      );
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/Building TypeScript source\.\.\./),
       );
     });
 
@@ -788,6 +805,11 @@ describe("functions:kits:install", () => {
           },
         ],
       });
+
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/Function kit firestore-bigquery-export successfully installed\./),
+      );
     });
 
     it("should prompt and allow custom kit ID and instance ID", async () => {
@@ -1038,6 +1060,10 @@ describe("functions:kits:install", () => {
         default: false,
         nonInteractive: true,
       });
+      expect(loggerWarnStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/does not have an npm-shrinkwrap\.json file/),
+      );
     });
 
     it("should prompt confirmation when a third-party kit has npm-shrinkwrap.json", async () => {
@@ -1064,6 +1090,10 @@ describe("functions:kits:install", () => {
         default: false,
         nonInteractive: true,
       });
+      expect(loggerWarnStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/is a third-party kit/),
+      );
     });
 
     it("should prompt confirmation when a third-party kit lacks npm-shrinkwrap.json", async () => {
@@ -1091,6 +1121,14 @@ describe("functions:kits:install", () => {
         default: false,
         nonInteractive: true,
       });
+      expect(loggerWarnStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/is a third-party kit/),
+      );
+      expect(loggerWarnStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(/does not have an npm-shrinkwrap\.json file/),
+      );
     });
 
     it("should cancel installation if user declines confirmation for first-party kit without shrinkwrap", async () => {

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -7,7 +7,7 @@ import { Command } from "../command";
 import { FirebaseError, getErrMsg } from "../error";
 import { KitFunctionConfig, FunctionsConfig } from "../firebaseConfig";
 import { getProjectId } from "../projectUtils";
-import { logLabeledBullet, logLabeledSuccess } from "../utils";
+import { logLabeledBullet, logLabeledSuccess, logLabeledWarning } from "../utils";
 
 import {
   isKitConfig,
@@ -306,19 +306,17 @@ export async function promptSecurityConfirmation(
 ): Promise<boolean> {
   const isThirdParty = isThirdPartyPackage(packageName);
   if (isThirdParty) {
-    logger.warn(
-      clc.yellow(
-        `Warning: Package ${clc.bold(packageName)} is a third-party kit (outside the @firebase-functions-kits scope).`,
-      ),
+    logLabeledWarning(
+      "functions",
+      `Package ${clc.bold(packageName)} is a third-party kit (outside the @firebase-functions-kits scope).`,
     );
   }
 
   const hasShrinkwrap = await self.checkPackageHasShrinkwrap(rawPkgName);
   if (!hasShrinkwrap) {
-    logger.warn(
-      clc.yellow(
-        `Warning: Package ${clc.bold(packageName)} does not have an npm-shrinkwrap.json file. npm-shrinkwrap guarantees that you deploy the same version of dependencies that the publisher tested against. Since this kit does not have an npm-shrinkwrap, it is possible that deploys or updates may introduce bugs or vulnerabilities in newer dependency versions that the publisher did not test against.`,
-      ),
+    logLabeledWarning(
+      "functions",
+      `Package ${clc.bold(packageName)} does not have an npm-shrinkwrap.json file. npm-shrinkwrap guarantees that you deploy the same version of dependencies that the publisher tested against. Since this kit does not have an npm-shrinkwrap, it is possible that deploys or updates may introduce bugs or vulnerabilities in newer dependency versions that the publisher did not test against.`,
     );
   }
 
@@ -560,14 +558,14 @@ export async function buildAndInstallKit(
   isThirdParty: boolean,
 ): Promise<void> {
   const installArgs = isThirdParty ? ["install", "--ignore-scripts"] : ["install"];
-  logger.info(clc.bold(`Running npm ${installArgs.join(" ")}...`));
+  logLabeledBullet("functions", `Running npm ${installArgs.join(" ")}...`);
   try {
     await wrapSpawn("npm", installArgs, absSourcePath);
   } catch (err: unknown) {
     throw new FirebaseError(`NPM install failed: ${getErrMsg(err)}`);
   }
 
-  logger.info(clc.bold("Building TypeScript source..."));
+  logLabeledBullet("functions", "Building TypeScript source...");
   try {
     await wrapSpawn("npm", ["run", "build"], absSourcePath);
   } catch (err: unknown) {
@@ -686,5 +684,5 @@ export const command = new Command("functions:kits:install")
 
     addKitToConfig(options.config, kitId, instanceId, packageName, sourcePath, configDirPath);
 
-    logger.info(clc.green(`✔ Function kit ${clc.bold(kitId)} successfully installed.`));
+    logLabeledSuccess("functions", `Function kit ${clc.bold(kitId)} successfully installed.`);
   });


### PR DESCRIPTION
### Description

Logs for kits should labeled with "functions" to follow CLI product conventions.