### PR TITLE
fix: increment build number for preview releases

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -98,10 +98,18 @@ if [[ $VERSION == "preview" ]]; then
   npm version prerelease --preid=${sanitized_branch} --no-git-tag-version
   INITIAL_VERSION=$(jq -r ".version" package.json)
   PREFIX=${INITIAL_VERSION%.*}
-  COMMIT_SHA=$(git rev-parse --short=6 HEAD)
-  NEW_VERSION="${PREFIX}-${COMMIT_SHA}"
-  echo "Setting preview version to ${NEW_VERSION}..."
-  npm version "${NEW_VERSION}" --no-git-tag-version --allow-same-version
+  echo "Checking registry for existing preview versions with prefix ${PREFIX}..."
+  MATCHING_VERSIONS=$(npm view firebase-tools versions --registry https://wombat-dressing-room.appspot.com --json | jq -r 'if type == "array" then .[] else . end | select(startswith("'"$PREFIX"'."))' || true)
+  if [[ -n "$MATCHING_VERSIONS" ]]; then
+    MAX_SUFFIX=$(echo "$MATCHING_VERSIONS" | sed "s/^${PREFIX}\.//" | sort -n | tail -n 1)
+    NEXT_SUFFIX=$((MAX_SUFFIX + 1))
+    NEW_VERSION="${PREFIX}.${NEXT_SUFFIX}"
+    echo "Found existing preview versions. Bumping to ${NEW_VERSION}..."
+    npm version "${NEW_VERSION}" --no-git-tag-version --allow-same-version
+  else
+    NEW_VERSION=$INITIAL_VERSION
+    echo "No existing preview versions found. Using ${NEW_VERSION}."
+  fi
   echo "Made a preview version."
 else
   echo "Making a $VERSION version..."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -101,7 +101,8 @@ if [[ $VERSION == "preview" ]]; then
   echo "Checking registry for existing preview versions with prefix ${PREFIX}..."
   MATCHING_VERSIONS=$(npm view firebase-tools versions --registry https://wombat-dressing-room.appspot.com --json | jq -r 'if type == "array" then .[] else . end | select(startswith("'"$PREFIX"'."))' || true)
   if [[ -n "$MATCHING_VERSIONS" ]]; then
-    MAX_SUFFIX=$(echo "$MATCHING_VERSIONS" | sed "s/^${PREFIX}\.//" | sort -n | tail -n 1)
+    MAX_SUFFIX=$(echo "$MATCHING_VERSIONS" | sed 's/^.*\.//' | grep -E '^[0-9]+$' | sort -n | tail -n 1)
+    MAX_SUFFIX=${MAX_SUFFIX:-0}
     NEXT_SUFFIX=$((MAX_SUFFIX + 1))
     NEW_VERSION="${PREFIX}.${NEXT_SUFFIX}"
     echo "Found existing preview versions. Bumping to ${NEW_VERSION}..."

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -99,7 +99,7 @@ if [[ $VERSION == "preview" ]]; then
   INITIAL_VERSION=$(jq -r ".version" package.json)
   PREFIX=${INITIAL_VERSION%.*}
   echo "Checking registry for existing preview versions with prefix ${PREFIX}..."
-  MATCHING_VERSIONS=$(npm view firebase-tools versions --registry https://wombat-dressing-room.appspot.com --json | jq -r 'if type == "array" then .[] else . end | select(startswith("'"$PREFIX"'."))' || true)
+  MATCHING_VERSIONS=$(npm view firebase-tools versions --registry https://wombat-dressing-room.appspot.com --json | jq -r --arg prefix "$PREFIX" 'if type == "array" then .[] else . end | select(startswith($prefix + "."))' || true)
   if [[ -n "$MATCHING_VERSIONS" ]]; then
     MAX_SUFFIX=$(echo "$MATCHING_VERSIONS" | sed 's/^.*\.//' | grep -E '^[0-9]+$' | sort -n | tail -n 1)
     MAX_SUFFIX=${MAX_SUFFIX:-0}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -95,8 +95,13 @@ echo "Ran tests."
 if [[ $VERSION == "preview" ]]; then
   echo "Making a preview version..."
   sanitized_branch=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g')
-  npm version prerelease --preid=${sanitized_branch}
-  NEW_VERSION=$(jq -r ".version" package.json)
+  npm version prerelease --preid=${sanitized_branch} --no-git-tag-version
+  INITIAL_VERSION=$(jq -r ".version" package.json)
+  PREFIX=${INITIAL_VERSION%.*}
+  COMMIT_SHA=$(git rev-parse --short=6 HEAD)
+  NEW_VERSION="${PREFIX}-${COMMIT_SHA}"
+  echo "Setting preview version to ${NEW_VERSION}..."
+  npm version "${NEW_VERSION}" --no-git-tag-version --allow-same-version
   echo "Made a preview version."
 else
   echo "Making a $VERSION version..."


### PR DESCRIPTION
### Description
When running `./scripts/publish/run.sh preview <branch>` multiple times, the version generated by `npm version prerelease` was always `X.Y.Z-<branch>.0` because the temporary clone checked out by Cloud Build always has the base version in `package.json`, and the bumped version is not pushed back to the branch. Consequently, subsequent publishes of the preview package failed with a `403 Forbidden` error because overwriting an already published package version on the registry is not allowed.

This change updates `scripts/publish.sh` to check the registry for existing preview versions with the same prefix and increment the suffix dynamically.

### Scenarios Tested
- Verified version incrementing logic with a mock test script across multiple cases (empty registry, single version, multiple versions, string outputs).
- Verified `npm run lint:changed-files` passes.

### Sample Commands
`./scripts/publish/run.sh preview $BRANCH`

