### PR TITLE
fix(functions): separate kit source and instance config directories

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -689,7 +689,7 @@ describe("functions:kits:install", () => {
       });
 
       const indexContent = writtenFiles[
-        "function-kits/firestore-bigquery-export/src/index.ts"
+        "function-kits/firestore-bigquery-export/source/src/index.ts"
       ] as string;
       expect(indexContent).to.be.a("string");
       expect(indexContent).to.include("EXT_MIGRATED_SYSTEM_MEMORY");
@@ -726,7 +726,7 @@ describe("functions:kits:install", () => {
       });
 
       const indexContent = writtenFiles[
-        "function-kits/firestore-bigquery-export/src/index.ts"
+        "function-kits/firestore-bigquery-export/source/src/index.ts"
       ] as string;
       expect(indexContent).to.be.a("string");
       expect(indexContent).to.include("maxInstances: 10");
@@ -765,16 +765,16 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install"],
-        "/mock/project/function-kits/firestore-bigquery-export",
+        "/mock/project/function-kits/firestore-bigquery-export/source",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
         ["run", "build"],
-        "/mock/project/function-kits/firestore-bigquery-export",
+        "/mock/project/function-kits/firestore-bigquery-export/source",
       );
 
       const pkgJsonResult = writtenFiles[
-        "function-kits/firestore-bigquery-export/package.json"
+        "function-kits/firestore-bigquery-export/source/package.json"
       ] as { name?: string; dependencies?: Record<string, string> };
       expect(pkgJsonResult.name).to.equal("firestore-bigquery-export-wrapper");
       expect(pkgJsonResult.dependencies).to.have.property(
@@ -782,11 +782,11 @@ describe("functions:kits:install", () => {
         "1.0.0",
       );
 
-      expect(writtenFiles["function-kits/firestore-bigquery-export/src/index.ts"]).to.be.a(
+      expect(writtenFiles["function-kits/firestore-bigquery-export/source/src/index.ts"]).to.be.a(
         "string",
       );
       expect(
-        writtenFiles["function-kits/firestore-bigquery-export/src/index.ts"] as string,
+        writtenFiles["function-kits/firestore-bigquery-export/source/src/index.ts"] as string,
       ).to.include('export * from "@firebase-functions-kits/firestore-bigquery-export";');
 
       expect(writtenFiles["firebase.json"]).to.deep.equal({
@@ -796,7 +796,7 @@ describe("functions:kits:install", () => {
             sourcePackage: {
               name: "@firebase-functions-kits/firestore-bigquery-export",
             },
-            source: "function-kits/firestore-bigquery-export",
+            source: "function-kits/firestore-bigquery-export/source",
             instances: {
               "firestore-bigquery-export":
                 "function-kits/firestore-bigquery-export/config-firestore-bigquery-export",
@@ -808,7 +808,7 @@ describe("functions:kits:install", () => {
 
       expect(loggerInfoStub).to.have.been.calledWith(
         sinon.match(/functions:/),
-        sinon.match(/Function kit firestore-bigquery-export successfully installed\./),
+        sinon.match(/Function kit .*firestore-bigquery-export.* successfully installed\./),
       );
     });
 
@@ -844,7 +844,7 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install"],
-        "/mock/project/function-kits/my-custom-kit",
+        "/mock/project/function-kits/my-custom-kit/source",
       );
 
       expect(writtenFiles["firebase.json"]).to.deep.equal({
@@ -854,7 +854,7 @@ describe("functions:kits:install", () => {
             sourcePackage: {
               name: "@firebase-functions-kits/firestore-bigquery-export",
             },
-            source: "function-kits/my-custom-kit",
+            source: "function-kits/my-custom-kit/source",
             instances: {
               "my-instance": "function-kits/my-custom-kit/config-my-instance",
             },
@@ -886,12 +886,12 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
         ["install", "--ignore-scripts"],
-        "/mock/project/function-kits/custom-kit",
+        "/mock/project/function-kits/custom-kit/source",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
         ["run", "build"],
-        "/mock/project/function-kits/custom-kit",
+        "/mock/project/function-kits/custom-kit/source",
       );
     });
 

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -533,7 +533,7 @@ export async function scaffoldKitFiles(
   version?: string,
   templateType: TemplateType = DEFAULT_TEMPLATE,
 ): Promise<ScaffoldedKitPaths> {
-  const sourcePath = path.join(FUNCTION_KITS_DIR, kitId);
+  const sourcePath = path.join(FUNCTION_KITS_DIR, kitId, "source");
   const configDirPath = path.join(FUNCTION_KITS_DIR, kitId, `config-${instanceId}`);
 
   const absSourcePath = config.path(sourcePath);


### PR DESCRIPTION
### Description

Updates `functions:kits:install` to place kit source files into `function-kits/<kitId>/source` instead of `function-kits/<kitId>`. This ensures instance configuration directories (`function-kits/<kitId>/config-<instanceId>`) are siblings to the source directory rather than nested inside the kit source and build tree.

Also updates unit test log matching to properly handle ANSI color formatting codes across environments.

### Scenarios Tested

* `firebase functions:kits:install --npm_pacakge <package>` has "source" directory as a sibling to the config directories.
