### PR TITLE
fix: make Data Connect emulator startup and configuration errors non-blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Gracefully handle Data Connect emulator startup failures and unconfigured services without blocking other emulators.
 - Added extensions replacement registry and scraper tool to track migrations for deprecated extensions ahead of the March 2027 decommission date.
 - [Added] Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.
 - Adds --immediate flag to ext:uninstall (#10921)

--- a/src/emulator/controller.spec.ts
+++ b/src/emulator/controller.spec.ts
@@ -103,5 +103,19 @@ describe("EmulatorController", () => {
       });
       expect(shouldStart(options, Emulators.FUNCTIONS)).to.be.false;
     });
+
+    it("should not start dataconnect emulator if there is no dataconnect service configured", () => {
+      const options = createMockOptions("dataconnect", {
+        dataconnect: undefined,
+      });
+      expect(shouldStart(options, Emulators.DATACONNECT)).to.be.false;
+    });
+
+    it("should start dataconnect emulator if dataconnect service is configured", () => {
+      const options = createMockOptions("dataconnect", {
+        dataconnect: [{ source: "dataconnect" }],
+      });
+      expect(shouldStart(options, Emulators.DATACONNECT)).to.be.true;
+    });
   });
 }).timeout(2000);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -200,6 +200,19 @@ export function shouldStart(options: Options, name: Emulators): boolean {
     return false;
   }
 
+  if (
+    name === Emulators.DATACONNECT &&
+    emulatorInTargets &&
+    !readFirebaseJson(options.config).length
+  ) {
+    EmulatorLogger.forEmulator(Emulators.DATACONNECT).logLabeled(
+      "ERROR",
+      "dataconnect",
+      `Failed to start Data Connect emulator: No valid Data Connect configuration detected in firebase.json. Run ${clc.bold("firebase init dataconnect")} to configure it.`,
+    );
+    return false;
+  }
+
   return emulatorInTargets;
 }
 
@@ -893,70 +906,90 @@ export async function startAll(
   }
 
   if (listenForEmulator.dataconnect) {
+    const dataconnectLogger = EmulatorLogger.forEmulator(Emulators.DATACONNECT);
     const config = readFirebaseJson(options.config);
     if (!config.length) {
-      throw new FirebaseError("No SQL Connect service found in firebase.json");
-    } else if (config.length > 1) {
-      logger.warn(
-        `TODO: Add support for multiple services in the SQL Connect emulator. Currently emulating first service ${config[0].source}`,
+      dataconnectLogger.logLabeled(
+        "ERROR",
+        "dataconnect",
+        `Failed to start Data Connect emulator: No valid Data Connect configuration detected in firebase.json. Run ${clc.bold("firebase init dataconnect")} to configure it.`,
       );
-    }
-
-    const args: DataConnectEmulatorArgs = {
-      listen: listenForEmulator.dataconnect,
-      projectId,
-      auto_download: true,
-      configDir: config[0].source,
-      config: options.config,
-      autoconnectToPostgres: true,
-      postgresListen: listenForEmulator["dataconnect.postgres"],
-      enable_output_generated_sdk: true, // TODO: source from arguments
-      enable_output_schema_extensions: true,
-      debug: options.debug,
-      account,
-    };
-
-    if (exportMetadata.dataconnect) {
-      utils.assertIsString(options.import);
-      const importDirAbsPath = path.resolve(options.import);
-      const exportMetadataFilePath = path.resolve(
-        importDirAbsPath,
-        exportMetadata.dataconnect.path,
-      );
-      const dataDirectory = options.config.get("emulators.dataconnect.dataDir");
-      if (exportMetadataFilePath && dataDirectory) {
-        EmulatorLogger.forEmulator(Emulators.DATACONNECT).logLabeled(
-          "WARN",
-          "dataconnect",
-          "'firebase.json#emulators.dataconnect.dataDir' is set and `--import` flag was passed. " +
-            "This will overwrite any data saved from previous runs.",
+    } else {
+      if (config.length > 1) {
+        logger.warn(
+          `TODO: Add support for multiple services in the SQL Connect emulator. Currently emulating first service ${config[0].source}`,
         );
-        if (
-          !options.nonInteractive &&
-          !(await confirm({
-            message: `Do you wish to continue and overwrite data in ${dataDirectory}?`,
-            default: false,
-          }))
-        ) {
-          await cleanShutdown();
-          throw new FirebaseError("Command aborted");
-        }
       }
 
-      EmulatorLogger.forEmulator(Emulators.DATACONNECT).logLabeled(
-        "BULLET",
-        "dataconnect",
-        `Importing data from ${exportMetadataFilePath}`,
-      );
-      args.importPath = exportMetadataFilePath;
-      void trackEmulator("emulator_import", {
-        initiated_by: "start",
-        emulator_name: Emulators.DATACONNECT,
-      });
-    }
+      const args: DataConnectEmulatorArgs = {
+        listen: listenForEmulator.dataconnect,
+        projectId,
+        auto_download: true,
+        configDir: config[0].source,
+        config: options.config,
+        autoconnectToPostgres: true,
+        postgresListen: listenForEmulator["dataconnect.postgres"],
+        enable_output_generated_sdk: true, // TODO: source from arguments
+        enable_output_schema_extensions: true,
+        debug: options.debug,
+        account,
+      };
 
-    const dataConnectEmulator = new DataConnectEmulator(args);
-    await startEmulator(dataConnectEmulator);
+      if (exportMetadata.dataconnect) {
+        utils.assertIsString(options.import);
+        const importDirAbsPath = path.resolve(options.import);
+        const exportMetadataFilePath = path.resolve(
+          importDirAbsPath,
+          exportMetadata.dataconnect.path,
+        );
+        const dataDirectory = options.config.get("emulators.dataconnect.dataDir");
+        if (exportMetadataFilePath && dataDirectory) {
+          dataconnectLogger.logLabeled(
+            "WARN",
+            "dataconnect",
+            "'firebase.json#emulators.dataconnect.dataDir' is set and `--import` flag was passed. " +
+              "This will overwrite any data saved from previous runs.",
+          );
+          if (
+            !options.nonInteractive &&
+            !(await confirm({
+              message: `Do you wish to continue and overwrite data in ${dataDirectory}?`,
+              default: false,
+            }))
+          ) {
+            await cleanShutdown();
+            throw new FirebaseError("Command aborted");
+          }
+        }
+
+        dataconnectLogger.logLabeled(
+          "BULLET",
+          "dataconnect",
+          `Importing data from ${exportMetadataFilePath}`,
+        );
+        args.importPath = exportMetadataFilePath;
+        void trackEmulator("emulator_import", {
+          initiated_by: "start",
+          emulator_name: Emulators.DATACONNECT,
+        });
+      }
+
+      try {
+        const dataConnectEmulator = new DataConnectEmulator(args);
+        await startEmulator(dataConnectEmulator);
+      } catch (err: unknown) {
+        try {
+          await EmulatorRegistry.stop(Emulators.DATACONNECT);
+        } catch {
+          // Ignore errors stopping failed instance
+        }
+        dataconnectLogger.logLabeled(
+          "ERROR",
+          "dataconnect",
+          `Failed to start Data Connect emulator: ${getErrMsg(err)}`,
+        );
+      }
+    }
   }
 
   if (listenForEmulator.storage) {


### PR DESCRIPTION
### Description
Prevent missing configurations and startup failures for the Data Connect emulator from crashing emulators:start and blocking the rest of the emulator suite:
- Gracefully skip Data Connect emulator with an error and remediation instructions (firebase init dataconnect) in shouldStart when no services are configured in firebase.json.
- Gracefully handle Data Connect emulator startup failure in startAll by cleaning up the failed instance and logging the error without crashing other emulators.

Fixes b/546204399

### Scenarios Tested
- Unit tests in controller.spec.ts for Data Connect shouldStart handling.

### Sample Commands
- firebase init emulators (select all emulators)
- firebase emulators:start