### PR TITLE
fix: make App Hosting emulator startup and configuration errors non-blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Gracefully handle App Hosting emulator startup failures and auto-detect start commands from lockfiles without blocking other emulators.
 - Added extensions replacement registry and scraper tool to track migrations for deprecated extensions ahead of the March 2027 decommission date.
 - [Added] Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.
 - Adds --immediate flag to ext:uninstall (#10921)

--- a/src/emulator/controller.spec.ts
+++ b/src/emulator/controller.spec.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as sinon from "sinon";
 import { Emulators } from "./types";
 import { EmulatorRegistry } from "./registry";
 import { expect } from "chai";
@@ -10,6 +12,7 @@ function createMockOptions(
   configValues: { [key: string]: any },
 ): Options {
   const config = {
+    projectDir: ".",
     get: (key: string) => configValues[key],
     has: (key: string) => !!configValues[key],
     src: {
@@ -20,6 +23,7 @@ function createMockOptions(
   return {
     only,
     config,
+    cwd: process.cwd(),
     project: "test-project",
   } as any;
 }
@@ -102,6 +106,33 @@ describe("EmulatorController", () => {
         functions: {}, // Config is present, but no source
       });
       expect(shouldStart(options, Emulators.FUNCTIONS)).to.be.false;
+    });
+
+    it("should not start apphosting emulator if start command is not set and no lockfile exists", () => {
+      const options = createMockOptions("apphosting", {
+        apphosting: { rootDirectory: "./nonexistent-dir" },
+      });
+      expect(shouldStart(options, Emulators.APPHOSTING)).to.be.false;
+    });
+
+    it("should start apphosting emulator if startCommand is configured", () => {
+      const options = createMockOptions("apphosting", {
+        apphosting: { startCommand: "npm run dev" },
+      });
+      expect(shouldStart(options, Emulators.APPHOSTING)).to.be.true;
+    });
+
+    it("should start apphosting emulator if start command is not set but lockfile is present", () => {
+      const existsStub = sinon.stub(fs, "existsSync");
+      existsStub.withArgs(sinon.match(/package-lock\.json/)).returns(true);
+      try {
+        const options = createMockOptions("apphosting", {
+          apphosting: { rootDirectory: "./my-app" },
+        });
+        expect(shouldStart(options, Emulators.APPHOSTING)).to.be.true;
+      } finally {
+        existsStub.restore();
+      }
     });
   });
 }).timeout(2000);

--- a/src/emulator/controller.ts
+++ b/src/emulator/controller.ts
@@ -200,6 +200,36 @@ export function shouldStart(options: Options, name: Emulators): boolean {
     return false;
   }
 
+  if (name === Emulators.APPHOSTING && emulatorInTargets) {
+    const apphostingEmulatorConfig = options.config.src.emulators?.[Emulators.APPHOSTING];
+    const startCommand =
+      apphostingEmulatorConfig?.startCommand || apphostingEmulatorConfig?.startCommandOverride;
+    if (!startCommand) {
+      const rootDirectory = apphostingEmulatorConfig?.rootDirectory;
+      let backendRoot: string;
+      try {
+        backendRoot = resolveProjectPath(options, rootDirectory ?? "./");
+      } catch {
+        backendRoot = path.resolve(
+          options.config?.projectDir || options.cwd || process.cwd(),
+          rootDirectory ?? "./",
+        );
+      }
+      const hasLockfile =
+        fs.existsSync(path.join(backendRoot, "package-lock.json")) ||
+        fs.existsSync(path.join(backendRoot, "yarn.lock")) ||
+        fs.existsSync(path.join(backendRoot, "pnpm-lock.yaml"));
+      if (!hasLockfile) {
+        EmulatorLogger.forEmulator(Emulators.APPHOSTING).logLabeled(
+          "ERROR",
+          Emulators.APPHOSTING,
+          "Failed to start App Hosting emulator: Failed to auto-detect your project's start command. Consider manually setting the start command by setting `firebase.json#emulators.apphosting.startCommand`",
+        );
+        return false;
+      }
+    }
+  }
+
   return emulatorInTargets;
 }
 
@@ -1018,8 +1048,8 @@ export async function startAll(
     }
 
     const apphostingAddr = legacyGetFirstAddr(Emulators.APPHOSTING);
+    const apphostingLogger = EmulatorLogger.forEmulator(Emulators.APPHOSTING);
     if (apphostingEmulatorConfig?.startCommandOverride) {
-      const apphostingLogger = EmulatorLogger.forEmulator(Emulators.APPHOSTING);
       apphostingLogger.logLabeled(
         "WARN",
         Emulators.APPHOSTING,
@@ -1037,7 +1067,20 @@ export async function startAll(
       options,
     });
 
-    await startEmulator(apphostingEmulator);
+    try {
+      await startEmulator(apphostingEmulator);
+    } catch (err: unknown) {
+      try {
+        await EmulatorRegistry.stop(Emulators.APPHOSTING);
+      } catch {
+        // Ignore errors stopping failed instance
+      }
+      apphostingLogger.logLabeled(
+        "ERROR",
+        Emulators.APPHOSTING,
+        `Failed to start App Hosting emulator: ${getErrMsg(err)}`,
+      );
+    }
   }
 
   if (listenForEmulator.logging) {


### PR DESCRIPTION
### Description
Prevent missing configurations and startup failures for the App Hosting emulator from crashing emulators:start and blocking the rest of the emulator suite:
- Check for package manager lockfiles (package-lock.json, yarn.lock, pnpm-lock.yaml) in shouldStart when startCommand is unconfigured, skipping startup with an error log if none are found.
- Gracefully handle App Hosting emulator startup failure in startAll by cleaning up the failed instance and logging the error without crashing other emulators.

Fixes b/546204399

### Scenarios Tested
- Unit tests in controller.spec.ts for App Hosting shouldStart handling (missing lockfile, startCommand configured, and lockfile present).

### Sample Commands
- firebase init emulators (select all emulators)
- firebase emulators:start