### PR TITLE
fix(apphosting): increase default timeout for App Hosting operations to 60 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,3 @@
 - [Added] Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.
 - Adds --immediate flag to ext:uninstall (#10921)
 - [Fixed] Increases default polling timeout for App Hosting operations and rollouts to 60 minutes.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 - Added extensions replacement registry and scraper tool to track migrations for deprecated extensions ahead of the March 2027 decommission date.
 - [Added] Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.
 - Adds --immediate flag to ext:uninstall (#10921)
+- [Fixed] Increases default polling timeout for App Hosting operations and rollouts to 60 minutes.
+

--- a/src/apphosting/backend.ts
+++ b/src/apphosting/backend.ts
@@ -35,7 +35,7 @@ const DEFAULT_COMPUTE_SERVICE_ACCOUNT_NAME = "firebase-app-hosting-compute";
 const apphostingPollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
   apiOrigin: apphostingOrigin(),
   apiVersion: API_VERSION,
-  masterTimeout: 25 * 60 * 1_000,
+  masterTimeout: 60 * 60 * 1_000,
   maxBackoff: 10_000,
 };
 

--- a/src/apphosting/githubConnections.ts
+++ b/src/apphosting/githubConnections.ts
@@ -67,7 +67,7 @@ export function parseConnectionName(name: string): ConnectionNameParts | undefin
 const devConnectPollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
   apiOrigin: developerConnectOrigin(),
   apiVersion: "v1",
-  masterTimeout: 25 * 60 * 1_000,
+  masterTimeout: 60 * 60 * 1_000,
   maxBackoff: 10_000,
 };
 

--- a/src/apphosting/repo.ts
+++ b/src/apphosting/repo.ts
@@ -48,7 +48,7 @@ export function parseConnectionName(name: string): ConnectionNameParts | undefin
 const gcbPollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
   apiOrigin: cloudbuildOrigin(),
   apiVersion: "v2",
-  masterTimeout: 25 * 60 * 1_000,
+  masterTimeout: 60 * 60 * 1_000,
   maxBackoff: 10_000,
 };
 

--- a/src/apphosting/rollout.ts
+++ b/src/apphosting/rollout.ts
@@ -18,7 +18,7 @@ import { getBackend } from "./backend";
 const apphostingPollerOptions: Omit<poller.OperationPollerOptions, "operationResourceName"> = {
   apiOrigin: apphostingOrigin(),
   apiVersion: apphosting.API_VERSION,
-  masterTimeout: 25 * 60 * 1_000,
+  masterTimeout: 60 * 60 * 1_000,
   maxBackoff: 10_000,
 };
 

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -6,6 +6,7 @@ import { RC } from "../../rc";
 import { Context } from "./args";
 import release from "./release";
 import { expect } from "chai";
+import { FirebaseError } from "../../error";
 
 const BASE_OPTS = {
   cwd: "/",
@@ -47,10 +48,16 @@ describe("apphosting", () => {
             rootDir: "/",
             ignore: [],
           },
+          bar: {
+            backendId: "bar",
+            rootDir: "/",
+            ignore: [],
+          },
         },
-        backendLocations: { foo: "us-central1" },
+        backendLocations: { foo: "us-central1", bar: "us-central1" },
         backendStorageUris: {
           foo: "gs://firebaseapphosting-sources-us-central1/foo-1234.zip",
+          bar: "gs://firebaseapphosting-sources-us-central1/bar-1234.zip",
         },
         backendLocalBuilds: {},
       };
@@ -59,10 +66,22 @@ describe("apphosting", () => {
         .stub(rollout, "orchestrateRollout")
         .throws("Unexpected orchestrateRollout call");
 
-      orchestrateRolloutStub.onFirstCall().rejects();
+      orchestrateRolloutStub.onFirstCall().rejects(new Error("Build failed"));
       orchestrateRolloutStub.onSecondCall().resolves();
+      sinon.stub(backend, "getBackend").resolves({
+        name: "projects/my-project/locations/us-central1/backends/bar",
+        servingLocality: "GLOBAL_ACCESS",
+        labels: {},
+        createTime: "2023-01-01T00:00:00Z",
+        updateTime: "2023-01-01T00:00:00Z",
+        uri: "bar.apphosting.com",
+      });
 
-      await expect(release(context, opts)).to.eventually.not.rejected;
+      await expect(release(context, opts)).to.be.rejectedWith(
+        FirebaseError,
+        "One or more rollouts failed. Please review the errors above and try again.",
+      );
+      expect(orchestrateRolloutStub).to.have.been.calledTwice;
     });
 
     it("correctly passes buildInput for local builds", async () => {

--- a/src/deploy/apphosting/release.spec.ts
+++ b/src/deploy/apphosting/release.spec.ts
@@ -20,8 +20,6 @@ const BASE_OPTS = {
 };
 
 describe("apphosting", () => {
-  let orchestrateRolloutStub: sinon.SinonStub;
-
   afterEach(() => {
     sinon.verifyAndRestore();
   });
@@ -62,7 +60,7 @@ describe("apphosting", () => {
         backendLocalBuilds: {},
       };
 
-      orchestrateRolloutStub = sinon
+      const orchestrateRolloutStub = sinon
         .stub(rollout, "orchestrateRollout")
         .throws("Unexpected orchestrateRollout call");
 


### PR DESCRIPTION
### Description
Increases the default polling `masterTimeout` for App Hosting operations and rollouts from 25 minutes to 60 minutes.

App Hosting builds for large web applications (e.g. Next.js, Nuxt, Angular, large monorepos with static site generation) often exceed 25 minutes. Previously, the client-side poller timed out after 25 minutes (a limit originally inherited from Cloud Functions), causing the CLI to report failure and exit non-zero even though the backend Cloud Build job was still running and completed successfully shortly after.

Also fixes a flawed assertion in `src/deploy/apphosting/release.spec.ts` where `await expect(release(context, opts)).to.eventually.not.rejected` was a no-op in Chai-as-promised and only configured a single backend.

Fixes #10947

### Scenarios Tested
- Ran mocha unit tests across `src/apphosting/**/*.spec.ts` and `src/deploy/apphosting/**/*.spec.ts` (221 passing).
- Verified `npm run build` succeeds cleanly.
- Verified `src/deploy/apphosting/release.spec.ts` exercises multi-backend rollouts and asserts error propagation properly.

### Sample Commands
- `firebase deploy --only apphosting`
- `firebase apphosting:rollouts:create`