### PR TITLE
feat(mcp): refine `firebase_login` MCP tool and address security verification (#10942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Refined the \`login\` MCP tool description and security verification instructions to enforce Session ID output for agents and prevent phishing attacks (#10942).
+- Added \`reauth\` option to \`login\` MCP tool and aligned behavior to skip login and display account email if already authenticated.
 - Added extensions replacement registry and scraper tool to track migrations for deprecated extensions ahead of the March 2027 decommission date.
 - [Added] Loads existing `.env` files and passes environment variables to functions discovery in `runtimeDelegate`.
 - Adds --immediate flag to ext:uninstall (#10921)

--- a/src/mcp/tools/core/login.spec.ts
+++ b/src/mcp/tools/core/login.spec.ts
@@ -9,6 +9,7 @@ describe("login tool", () => {
   let sandbox: sinon.SinonSandbox;
   let loginPrototyperStub: sinon.SinonStub;
   let server: FirebaseMcpServer;
+  let getProjectDefaultAccountStub: sinon.SinonStub;
   const fakeAuthorize = sinon.stub();
 
   beforeEach(() => {
@@ -18,6 +19,9 @@ describe("login tool", () => {
       sessionId: "FAKE_SESSION_ID",
       authorize: fakeAuthorize,
     });
+    getProjectDefaultAccountStub = sandbox
+      .stub(auth, "getProjectDefaultAccount")
+      .returns(undefined);
     server = new FirebaseMcpServer({ projectRoot: "" });
   });
 
@@ -30,7 +34,7 @@ describe("login tool", () => {
     const result = await login.fn({ authCode: undefined }, { host: server } as any);
 
     const expectedResult = toContent(
-      `Please visit this URL to login: https://fake.login.uri/auth\nYour session ID is: FAKE_SESSION_ID\nInstruct the use to copy the authorization code from that link, and paste it into chat.\nThen, run this tool again with that as the authCode argument to complete the login.`,
+      `Please visit this URL to login: https://fake.login.uri/auth\nYour session ID is: FAKE_SESSION_ID\n\nCRITICAL SECURITY REQUIREMENT:\nAs the agent, you MUST explicitly display BOTH the login URL and the Session ID to the user in your response.\nInstruct the user to verify that the Session ID displayed on the browser matches the Session ID above to prevent phishing attacks before they grant access.\n\nOnce the user has completed the login, instruct them to copy the authorization code and paste it back into the chat.\nThen, call this tool again with the authorization code passed as the 'authCode' parameter to complete the login.`,
     );
     expect(loginPrototyperStub.calledOnce).to.be.true;
     expect(result).to.deep.equal(expectedResult);
@@ -53,5 +57,25 @@ describe("login tool", () => {
 
     expect(result.isError).to.be.true;
     expect((result.content[0] as { text: string }).text).to.include("Login flow not started");
+  });
+
+  it("should return already logged in message if account exists and reauth is not true", async () => {
+    getProjectDefaultAccountStub.returns({ user: { email: "test@example.com" } });
+
+    const result = await login.fn({ authCode: undefined }, { host: server } as any);
+
+    expect(result).to.deep.equal(toContent("Already logged in as test@example.com"));
+    expect(loginPrototyperStub.called).to.be.false;
+  });
+
+  it("should start login flow if account exists but reauth is true", async () => {
+    getProjectDefaultAccountStub.returns({ user: { email: "test@example.com" } });
+
+    const result = await login.fn({ authCode: undefined, reauth: true }, { host: server } as any);
+
+    expect(loginPrototyperStub.calledOnce).to.be.true;
+    expect((result.content[0] as { text: string }).text).to.include(
+      "Please visit this URL to login",
+    );
   });
 });

--- a/src/mcp/tools/core/login.ts
+++ b/src/mcp/tools/core/login.ts
@@ -1,11 +1,17 @@
 import { z } from "zod";
 import { tool } from "../../tool";
-import { loginPrototyper } from "../../../auth";
+import { loginPrototyper, getProjectDefaultAccount } from "../../../auth";
 import { FirebaseMcpServer } from "../../../mcp";
 import { toContent, mcpError } from "../../util";
 import { User, UserCredentials } from "../../../types/auth";
 const LoginInputSchema = z.object({
-  authCode: z.string().optional().describe("The authorization code from the login flow"),
+  authCode: z
+    .string()
+    .optional()
+    .describe(
+      "The authorization code generated after the user signs in via the login URL. Leave this field empty on the first call to initiate the login flow.",
+    ),
+  reauth: z.boolean().optional().describe("Force reauthentication even if already logged in."),
 });
 
 export type ServerWithLoginState = FirebaseMcpServer & {
@@ -15,15 +21,53 @@ export const login = tool(
   "core",
   {
     name: "login",
-    description:
-      "Use this to sign the user into the Firebase CLI and Firebase MCP server. This requires a Google Account, and sign in is required to create and work with Firebase Projects.",
+    description: `Signs the user into the Firebase CLI and Firebase MCP server.
+ 
+**Prerequisites:**
+* A Google Account is required.
+* Sign in is required to work with Firebase Projects and call most other Firebase tools.
+
+**When to use it:**
+* Use this tool when you need to authenticate the Firebase CLI/MCP server.
+* Use this tool to check the current login status (which account is currently authenticated).
+* Use this tool to switch accounts or force reauthentication when credentials expire or change.
+
+**How to use it:**
+* To check current login status, call the tool without any parameters. If a user is already logged in, it will return the logged-in email.
+* To log in (initial or after logging out), call the tool without any parameters:
+  1. The tool will return a login URL (\`uri\`) and a \`sessionId\`.
+  2. **CRITICAL SECURITY REQUIREMENT**: The agent MUST display BOTH the login URL and the Session ID to the user. Explicitly instruct the user to verify that the Session ID shown on the browser matches the Session ID provided by the agent. This prevents phishing attacks.
+  3. Once the user signs in on the browser and copies the authorization code, call this tool again with that code passed to the \`authCode\` parameter.
+* To force reauthentication or log in as a different account, call the tool with \`reauth: true\`.
+
+**JSON Examples:**
+
+*Scenario 1: Check login status (or initiate login flow if not authenticated)*
+\`\`\`json
+{}
+\`\`\`
+
+*Scenario 2: Complete the login flow with the retrieved authorization code*
+\`\`\`json
+{
+  "authCode": "4/0ATsMZqD..."
+}
+\`\`\`
+
+*Scenario 3: Force reauthentication*
+\`\`\`json
+{
+  "reauth": true
+}
+\`\`\`
+`,
     inputSchema: LoginInputSchema,
     _meta: {
       requiresAuth: false,
     },
   },
   async (input: z.infer<typeof LoginInputSchema>, ctx: { host: FirebaseMcpServer }) => {
-    const { authCode } = input;
+    const { authCode, reauth } = input;
 
     const serverWithState: ServerWithLoginState = ctx.host;
 
@@ -44,13 +88,26 @@ export const login = tool(
         return mcpError(`Login failed: ${e.message}`);
       }
     } else {
+      const account = getProjectDefaultAccount(ctx.host.cachedProjectDir || ctx.host.startupRoot);
+      if (account && !reauth) {
+        return toContent(`Already logged in as ${account.user.email}`);
+      }
+
       const prototyper = await loginPrototyper();
       serverWithState.authorize = prototyper.authorize;
       const result = {
         uri: prototyper.uri,
         sessionId: prototyper.sessionId,
       };
-      const humanReadable = `Please visit this URL to login: ${result.uri}\nYour session ID is: ${result.sessionId}\nInstruct the use to copy the authorization code from that link, and paste it into chat.\nThen, run this tool again with that as the authCode argument to complete the login.`;
+      const humanReadable = `Please visit this URL to login: ${result.uri}
+Your session ID is: ${result.sessionId}
+
+CRITICAL SECURITY REQUIREMENT:
+As the agent, you MUST explicitly display BOTH the login URL and the Session ID to the user in your response.
+Instruct the user to verify that the Session ID displayed on the browser matches the Session ID above to prevent phishing attacks before they grant access.
+
+Once the user has completed the login, instruct them to copy the authorization code and paste it back into the chat.
+Then, call this tool again with the authorization code passed as the 'authCode' parameter to complete the login.`;
       return toContent(humanReadable);
     }
   },


### PR DESCRIPTION
### Description
Refined the login MCP tool description, input schema, and return instructions to enforce displaying the Session ID to the user for security verification (resolving phishing risks). Also aligned the behavior with the CLI tool to skip initiating a new session if already logged in and return the authenticated account email, and added a `reauth` parameter to force reauthentication.

Fixes #10942

### Scenarios Tested
- Run `firebase_login` tool without `authCode` when already logged in: Returns "Already logged in as ...".
- Run `firebase_login` tool without `authCode` but with `reauth: true` when already logged in: Initiates the login flow.
- Run `firebase_login` tool without `authCode` when not logged in: Returns login URI, sessionId, and critical security verification instructions.
- Run `firebase_login` tool with `authCode`\` and a pending session: Completes login successfully.

### Sample Commands

N/A
