### PR TITLE
fix(mcp): resolve base options in deploy tool to preserve auth credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+- Fixed an issue where the `deploy` MCP tool failed with authentication errors during Data Connect deployment.
 - Refined the \`login\` MCP tool description and security verification instructions to enforce Session ID output for agents and prevent phishing attacks (#10942).
 - Added \`reauth\` option to \`login\` MCP tool and aligned behavior to skip login and display account email if already authenticated.
 - Updated Pub/Sub emulator to version 0.8.35.

--- a/src/mcp/tools/core/deploy.spec.ts
+++ b/src/mcp/tools/core/deploy.spec.ts
@@ -99,4 +99,32 @@ describe("deploy tool", () => {
 
     expect(updateJobSpy.calledWith(jobId, { status: "failed", error: "Deploy error" })).to.be.true;
   });
+
+  it("should not create a job if resolveOptions fails", async () => {
+    const createJobSpy = sandbox.spy(jobTracker, "createJob");
+    const rc = new RC(undefined, { projects: { default: "test-project" } });
+    const config = new Config({}, { cwd: "/test-dir" });
+    sandbox.stub(server, "resolveOptions").rejects(new Error("Config resolution error"));
+
+    const ctx: McpContext = {
+      projectId: "test-project",
+      host: server,
+      accountEmail: "test@example.com",
+      rc,
+      config,
+      firebaseCliCommand: "firebase",
+      isBillingEnabled: true,
+    };
+
+    let err: Error | undefined;
+    try {
+      await deploy.fn({ only: "hosting" }, ctx);
+    } catch (e: unknown) {
+      err = e instanceof Error ? e : new Error(String(e));
+    }
+
+    expect(err).to.exist;
+    expect(err?.message).to.equal("Config resolution error");
+    expect(createJobSpy.called).to.be.false;
+  });
 });

--- a/src/mcp/tools/core/deploy.spec.ts
+++ b/src/mcp/tools/core/deploy.spec.ts
@@ -1,0 +1,102 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+import { deploy } from "./deploy";
+import * as deployModule from "../../../deploy";
+import { jobTracker } from "../../util/jobs";
+import { FirebaseMcpServer } from "../../../mcp";
+import { McpContext } from "../../types";
+import { RC } from "../../../rc";
+import { Config } from "../../../config";
+
+describe("deploy tool", () => {
+  let sandbox: sinon.SinonSandbox;
+  let coreDeployStub: sinon.SinonStub;
+  let server: FirebaseMcpServer;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    coreDeployStub = sandbox.stub(deployModule, "deploy").resolves();
+    server = new FirebaseMcpServer({ projectRoot: "/test-dir" });
+    server.cachedProjectDir = "/test-dir";
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const mockContext = (baseOptions: Record<string, unknown> = {}): McpContext => {
+    const rc = new RC(undefined, { projects: { default: "test-project" } });
+    const config = new Config({}, { cwd: "/test-dir" });
+    sandbox.stub(server, "resolveOptions").resolves(baseOptions);
+
+    return {
+      projectId: "test-project",
+      host: server,
+      accountEmail: "test@example.com",
+      rc,
+      config,
+      firebaseCliCommand: "firebase",
+      isBillingEnabled: true,
+    };
+  };
+
+  it("should resolve base options and pass them to coreDeploy", async () => {
+    const fakeUser = { email: "test@example.com" };
+    const fakeTokens = { refresh_token: "fake_refresh_token" };
+    const ctx = mockContext({
+      user: fakeUser,
+      tokens: fakeTokens,
+      projectRoot: "/test-dir",
+      cwd: "/test-dir",
+    });
+
+    const result = await deploy.fn({ only: "dataconnect" }, ctx);
+
+    expect(result.structuredContent).to.have.property("jobId");
+    expect((result.structuredContent as { message: string }).message).to.equal(
+      "Deployment started",
+    );
+
+    // Wait for the background task to execute
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(coreDeployStub.calledOnce).to.be.true;
+    const [targets, options] = coreDeployStub.firstCall.args as [string[], Record<string, unknown>];
+    expect(targets).to.deep.equal(["dataconnect"]);
+    expect(options).to.include({
+      project: "test-project",
+      projectId: "test-project",
+      only: "dataconnect",
+      nonInteractive: true,
+      projectRoot: "/test-dir",
+      cwd: "/test-dir",
+    });
+    expect(options["user"]).to.deep.equal(fakeUser);
+    expect(options["tokens"]).to.deep.equal(fakeTokens);
+  });
+
+  it("should filter valid targets when only is provided", async () => {
+    const ctx = mockContext();
+
+    await deploy.fn({ only: "hosting,invalid_target,firestore" }, ctx);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(coreDeployStub.calledOnce).to.be.true;
+    const [targets] = coreDeployStub.firstCall.args as [string[]];
+    expect(targets).to.deep.equal(["hosting", "firestore"]);
+  });
+
+  it("should track job failure when coreDeploy fails", async () => {
+    coreDeployStub.rejects(new Error("Deploy error"));
+    const updateJobSpy = sandbox.spy(jobTracker, "updateJob");
+    const ctx = mockContext();
+
+    const result = await deploy.fn({ only: "hosting" }, ctx);
+    const jobId = (result.structuredContent as { jobId: string }).jobId;
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(updateJobSpy.calledWith(jobId, { status: "failed", error: "Deploy error" })).to.be.true;
+  });
+});

--- a/src/mcp/tools/core/deploy.ts
+++ b/src/mcp/tools/core/deploy.ts
@@ -54,7 +54,10 @@ export const deploy = tool(
     const jobId = Date.now().toString();
     jobTracker.createJob(jobId);
 
+    const baseOptions = await ctx.host.resolveOptions();
+
     const options = {
+      ...baseOptions,
       only: only || "",
       except: "",
       filteredTargets: targets,

--- a/src/mcp/tools/core/deploy.ts
+++ b/src/mcp/tools/core/deploy.ts
@@ -51,10 +51,10 @@ export const deploy = tool(
       targets = parts.filter((p) => validTargets.includes(p));
     }
 
+    const baseOptions = await ctx.host.resolveOptions();
+
     const jobId = Date.now().toString();
     jobTracker.createJob(jobId);
-
-    const baseOptions = await ctx.host.resolveOptions();
 
     const options = {
       ...baseOptions,


### PR DESCRIPTION
### Description
Fixes an issue where calling the `deploy` MCP tool failed with authentication errors (e.g., `FirebaseError: Failed to authenticate, have you run firebase login?`) when deploying services like Data Connect.

#### Cause
In `src/mcp/tools/core/deploy.ts`, the `options` object was constructed manually without inheriting base options from `ctx.host.resolveOptions()`. Consequently, `options.user` and `options.tokens` were undefined, which caused downstream operations (such as `getIAMUser(options)` during Data Connect schema migration) to fall back to Application Default Credentials (ADC) and fail if ADC was not configured.

#### Solution
- Call `await ctx.host.resolveOptions()` in the `deploy` MCP tool and spread `baseOptions` into the options passed to `coreDeploy`.
