### PR TITLE
ci: only run setup-chrome for storage emulator integration tests

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -242,6 +242,7 @@ jobs:
           java-version: 21
           distribution: temurin
       - name: Setup Chrome
+        if: matrix.script == 'npm run test:storage-emulator-integration'
         uses: browser-actions/setup-chrome@facf10a55b9caf92e0cc749b4f82bf8220989148 # ratchet:browser-actions/setup-chrome@v1.7.2
         with:
           install-dependencies: true


### PR DESCRIPTION
### Description
`browser-actions/setup-chrome` was previously running on all 12 matrix legs of the `integration` job in CI, even though it was only used in one single test suite. This change scopes it to only that suite.

This usually wasn't an issue, but yesterday it started hanging because Github is a terrible wasteland and can't maintain their action runners. While investigating that, I realized we were doing unnecessary setup - so next time, only one of our tests will hang indefinitely.