### PR TITLE
Add a step to the crashlytics:web:onboard command to grant read acces…

### DIFF
--- a/src/crashlytics/onboarding.spec.ts
+++ b/src/crashlytics/onboarding.spec.ts
@@ -12,6 +12,7 @@ import { FirebaseError } from "../error";
 describe("onboarding", () => {
   let ensureStub: sinon.SinonStub;
   let bucketStub: sinon.SinonStub;
+  let grantViewAccessStub: sinon.SinonStub;
   let sinkStub: sinon.SinonStub;
   let configStub: sinon.SinonStub;
   let checkBillingStub: sinon.SinonStub;
@@ -30,6 +31,11 @@ describe("onboarding", () => {
     bucketStub = sinon.stub(cloudlogging, "createOrUpdateLogBucket").resolves({
       name: "projects/test-project/locations/global/buckets/firebase-telemetry",
       analyticsEnabled: true,
+    });
+    grantViewAccessStub = sinon.stub(cloudlogging, "grantLogViewAccess").resolves({
+      bindings: [{ role: "roles/logging.viewAccessor", members: ["projectViewer:test-project"] }],
+      etag: "etag",
+      version: 3,
     });
     sinkStub = sinon.stub(cloudlogging, "createOrUpdateLogSink").resolves({
       name: "firebase-telemetry-routing",
@@ -59,6 +65,14 @@ describe("onboarding", () => {
       "firebase-telemetry",
       "global",
       true,
+    );
+    expect(grantViewAccessStub).to.have.been.calledWith(
+      "test-project",
+      "firebase-telemetry",
+      "_AllLogs",
+      ["projectViewer:test-project", "projectEditor:test-project"],
+      "roles/logging.viewAccessor",
+      "global",
     );
     expect(sinkStub).to.have.been.calledOnce;
     expect(configStub).to.have.been.calledWith(

--- a/src/crashlytics/onboarding.ts
+++ b/src/crashlytics/onboarding.ts
@@ -4,6 +4,7 @@ import { checkBillingEnabled, enableBilling } from "../gcp/cloudbilling";
 import {
   createOrUpdateLogBucket,
   createOrUpdateLogSink,
+  grantLogViewAccess,
   LogBucket,
   LogSink,
 } from "../gcp/cloudlogging";
@@ -13,6 +14,8 @@ import { logLabeledBullet, logLabeledSuccess } from "../utils";
 export const CRASHLYTICS_TELEMETRY_BUCKET_ID = "firebase-telemetry";
 export const CRASHLYTICS_TELEMETRY_SINK_ID = "firebase-telemetry-routing";
 export const CRASHLYTICS_TELEMETRY_RESOURCE_TYPE = "firebasetelemetry.googleapis.com/App";
+export const CRASHLYTICS_TELEMETRY_VIEW_ID = "_AllLogs";
+export const CRASHLYTICS_TELEMETRY_VIEW_ACCESSOR_ROLE = "roles/logging.viewAccessor";
 
 export interface OnboardWebResult {
   bucket: LogBucket;
@@ -22,7 +25,8 @@ export interface OnboardWebResult {
 
 /**
  * Onboards a Firebase Web App to Crashlytics by enabling required APIs,
- * setting up Cloud Logging bucket and sink routing, and creating a Telemetry Config.
+ * setting up Cloud Logging bucket and sink routing, granting view accessor permissions,
+ * and creating a Telemetry Config.
  */
 export async function onboardCrashlyticsWeb(
   projectId: string,
@@ -57,6 +61,20 @@ export async function onboardCrashlyticsWeb(
     true,
   );
   logLabeledSuccess("crashlytics", "Cloud Logging bucket configured.");
+
+  logLabeledBullet(
+    "crashlytics",
+    `Granting view accessor permission on bucket '${CRASHLYTICS_TELEMETRY_BUCKET_ID}' to project viewers and editors...`,
+  );
+  await grantLogViewAccess(
+    projectId,
+    CRASHLYTICS_TELEMETRY_BUCKET_ID,
+    CRASHLYTICS_TELEMETRY_VIEW_ID,
+    [`projectViewer:${projectId}`, `projectEditor:${projectId}`],
+    CRASHLYTICS_TELEMETRY_VIEW_ACCESSOR_ROLE,
+    "global",
+  );
+  logLabeledSuccess("crashlytics", "Cloud Logging view permissions configured.");
 
   const destination = `logging.googleapis.com/projects/${projectId}/locations/global/buckets/${CRASHLYTICS_TELEMETRY_BUCKET_ID}`;
   const filter = `resource.type="${CRASHLYTICS_TELEMETRY_RESOURCE_TYPE}"`;

--- a/src/gcp/cloudlogging.spec.ts
+++ b/src/gcp/cloudlogging.spec.ts
@@ -193,12 +193,17 @@ describe("cloudlogging", () => {
         )
         .reply(403, { error: "forbidden" });
 
-      await expect(
-        cloudlogging.getLogViewIamPolicy("project", "firebase-telemetry", "_AllLogs", "global"),
-      ).to.be.rejectedWith(
+      const promise = cloudlogging.getLogViewIamPolicy(
+        "project",
+        "firebase-telemetry",
+        "_AllLogs",
+        "global",
+      );
+      await expect(promise).to.be.rejectedWith(
         FirebaseError,
         "Failed to get IAM policy for log view _AllLogs on bucket firebase-telemetry (status 403):",
       );
+      await expect(promise).to.be.rejected.and.eventually.have.property("status", 403);
     });
   });
 
@@ -240,18 +245,18 @@ describe("cloudlogging", () => {
         )
         .reply(500, { error: "internal error" });
 
-      await expect(
-        cloudlogging.setLogViewIamPolicy(
-          "project",
-          "firebase-telemetry",
-          "_AllLogs",
-          policy,
-          "global",
-        ),
-      ).to.be.rejectedWith(
+      const promise = cloudlogging.setLogViewIamPolicy(
+        "project",
+        "firebase-telemetry",
+        "_AllLogs",
+        policy,
+        "global",
+      );
+      await expect(promise).to.be.rejectedWith(
         FirebaseError,
         "Failed to set IAM policy for log view _AllLogs on bucket firebase-telemetry (status 500):",
       );
+      await expect(promise).to.be.rejected.and.eventually.have.property("status", 500);
     });
   });
 

--- a/src/gcp/cloudlogging.spec.ts
+++ b/src/gcp/cloudlogging.spec.ts
@@ -167,4 +167,260 @@ describe("cloudlogging", () => {
       ).to.eventually.deep.equal(sink);
     });
   });
+
+  describe("getLogViewIamPolicy", () => {
+    it("should resolve with policy on success", async () => {
+      const policy = {
+        bindings: [{ role: "roles/logging.viewAccessor", members: ["projectViewer:project"] }],
+        etag: "etag123",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:getIamPolicy",
+        )
+        .reply(200, policy);
+
+      await expect(
+        cloudlogging.getLogViewIamPolicy("project", "firebase-telemetry", "_AllLogs", "global"),
+      ).to.eventually.deep.equal(policy);
+    });
+
+    it("should reject if API call fails", async () => {
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:getIamPolicy",
+        )
+        .reply(403, { error: "forbidden" });
+
+      await expect(
+        cloudlogging.getLogViewIamPolicy("project", "firebase-telemetry", "_AllLogs", "global"),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        "Failed to get IAM policy for log view _AllLogs on bucket firebase-telemetry (status 403):",
+      );
+    });
+  });
+
+  describe("setLogViewIamPolicy", () => {
+    it("should resolve with policy on success", async () => {
+      const policy = {
+        bindings: [{ role: "roles/logging.viewAccessor", members: ["projectViewer:project"] }],
+        etag: "etag123",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:setIamPolicy",
+          { policy },
+        )
+        .reply(200, policy);
+
+      await expect(
+        cloudlogging.setLogViewIamPolicy(
+          "project",
+          "firebase-telemetry",
+          "_AllLogs",
+          policy,
+          "global",
+        ),
+      ).to.eventually.deep.equal(policy);
+    });
+
+    it("should reject if API call fails", async () => {
+      const policy = {
+        bindings: [],
+        etag: "etag123",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:setIamPolicy",
+          { policy },
+        )
+        .reply(500, { error: "internal error" });
+
+      await expect(
+        cloudlogging.setLogViewIamPolicy(
+          "project",
+          "firebase-telemetry",
+          "_AllLogs",
+          policy,
+          "global",
+        ),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        "Failed to set IAM policy for log view _AllLogs on bucket firebase-telemetry (status 500):",
+      );
+    });
+  });
+
+  describe("grantLogViewAccess", () => {
+    it("should add binding when role does not exist in policy", async () => {
+      const existingPolicy = {
+        bindings: [{ role: "roles/logging.viewer", members: ["user:admin@example.com"] }],
+        etag: "etag123",
+        version: 3,
+      };
+      const updatedPolicy = {
+        bindings: [
+          { role: "roles/logging.viewer", members: ["user:admin@example.com"] },
+          { role: "roles/logging.viewAccessor", members: ["projectViewer:project"] },
+        ],
+        etag: "etag123",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:getIamPolicy",
+        )
+        .reply(200, existingPolicy);
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:setIamPolicy",
+          { policy: updatedPolicy },
+        )
+        .reply(200, updatedPolicy);
+
+      const result = await cloudlogging.grantLogViewAccess(
+        "project",
+        "firebase-telemetry",
+        "_AllLogs",
+        "projectViewer:project",
+        "roles/logging.viewAccessor",
+        "global",
+      );
+      expect(result).to.deep.equal(updatedPolicy);
+    });
+
+    it("should add member to existing role binding", async () => {
+      const existingPolicy = {
+        bindings: [{ role: "roles/logging.viewAccessor", members: ["user:existing@example.com"] }],
+        etag: "etag123",
+        version: 3,
+      };
+      const updatedPolicy = {
+        bindings: [
+          {
+            role: "roles/logging.viewAccessor",
+            members: ["user:existing@example.com", "projectViewer:project"],
+          },
+        ],
+        etag: "etag123",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:getIamPolicy",
+        )
+        .reply(200, existingPolicy);
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:setIamPolicy",
+          { policy: updatedPolicy },
+        )
+        .reply(200, updatedPolicy);
+
+      const result = await cloudlogging.grantLogViewAccess(
+        "project",
+        "firebase-telemetry",
+        "_AllLogs",
+        "projectViewer:project",
+        "roles/logging.viewAccessor",
+        "global",
+      );
+      expect(result).to.deep.equal(updatedPolicy);
+    });
+
+    it("should return existing policy without calling setIamPolicy if member already has role", async () => {
+      const existingPolicy = {
+        bindings: [{ role: "roles/logging.viewAccessor", members: ["projectViewer:project"] }],
+        etag: "etag123",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:getIamPolicy",
+        )
+        .reply(200, existingPolicy);
+
+      const result = await cloudlogging.grantLogViewAccess(
+        "project",
+        "firebase-telemetry",
+        "_AllLogs",
+        "projectViewer:project",
+        "roles/logging.viewAccessor",
+        "global",
+      );
+      expect(result).to.deep.equal(existingPolicy);
+    });
+
+    it("should create new policy if getLogViewIamPolicy returns 404", async () => {
+      const expectedPolicy = {
+        bindings: [{ role: "roles/logging.viewAccessor", members: ["projectViewer:project"] }],
+        etag: "",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:getIamPolicy",
+        )
+        .reply(404, { error: "not found" });
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:setIamPolicy",
+          { policy: expectedPolicy },
+        )
+        .reply(200, expectedPolicy);
+
+      const result = await cloudlogging.grantLogViewAccess(
+        "project",
+        "firebase-telemetry",
+        "_AllLogs",
+        "projectViewer:project",
+        "roles/logging.viewAccessor",
+        "global",
+      );
+      expect(result).to.deep.equal(expectedPolicy);
+    });
+
+    it("should add multiple members to the role binding", async () => {
+      const existingPolicy = {
+        bindings: [],
+        etag: "etag123",
+        version: 3,
+      };
+      const updatedPolicy = {
+        bindings: [
+          {
+            role: "roles/logging.viewAccessor",
+            members: ["projectViewer:project", "projectEditor:project", "projectOwner:project"],
+          },
+        ],
+        etag: "etag123",
+        version: 3,
+      };
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:getIamPolicy",
+        )
+        .reply(200, existingPolicy);
+      nock(cloudloggingOrigin())
+        .post(
+          "/v2/projects/project/locations/global/buckets/firebase-telemetry/views/_AllLogs:setIamPolicy",
+          { policy: updatedPolicy },
+        )
+        .reply(200, updatedPolicy);
+
+      const result = await cloudlogging.grantLogViewAccess(
+        "project",
+        "firebase-telemetry",
+        "_AllLogs",
+        ["projectViewer:project", "projectEditor:project", "projectOwner:project"],
+        "roles/logging.viewAccessor",
+        "global",
+      );
+      expect(result).to.deep.equal(updatedPolicy);
+    });
+  });
 });

--- a/src/gcp/cloudlogging.ts
+++ b/src/gcp/cloudlogging.ts
@@ -203,7 +203,7 @@ export async function getLogViewIamPolicy(
     const msg = err.message || JSON.stringify(err.body) || err;
     throw new FirebaseError(
       `Failed to get IAM policy for log view ${viewId} on bucket ${bucketId} (status ${err.status}): ${msg}`,
-      { original: err },
+      { original: err, status: err.status },
     );
   }
 }
@@ -228,7 +228,7 @@ export async function setLogViewIamPolicy(
     const msg = err.message || JSON.stringify(err.body) || err;
     throw new FirebaseError(
       `Failed to set IAM policy for log view ${viewId} on bucket ${bucketId} (status ${err.status}): ${msg}`,
-      { original: err },
+      { original: err, status: err.status },
     );
   }
 }

--- a/src/gcp/cloudlogging.ts
+++ b/src/gcp/cloudlogging.ts
@@ -1,6 +1,7 @@
 import { cloudloggingOrigin } from "../api";
 import { Client } from "../apiv2";
 import { FirebaseError } from "../error";
+import { Policy } from "./iam";
 
 const API_VERSION = "v2";
 
@@ -181,4 +182,106 @@ export async function createOrUpdateLogSink(
       { original: err },
     );
   }
+}
+
+/**
+ * Retrieves the IAM policy for a Cloud Logging Log View.
+ * Ref: https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.locations.buckets.views/getIamPolicy
+ */
+export async function getLogViewIamPolicy(
+  projectId: string,
+  bucketId: string,
+  viewId: string,
+  location = "global",
+): Promise<Policy> {
+  const client = new Client({ urlPrefix: cloudloggingOrigin(), apiVersion: API_VERSION });
+  const path = `/projects/${projectId}/locations/${location}/buckets/${bucketId}/views/${viewId}:getIamPolicy`;
+  try {
+    const res = await client.post<void, Policy>(path);
+    return res.body;
+  } catch (err: any) {
+    const msg = err.message || JSON.stringify(err.body) || err;
+    throw new FirebaseError(
+      `Failed to get IAM policy for log view ${viewId} on bucket ${bucketId} (status ${err.status}): ${msg}`,
+      { original: err },
+    );
+  }
+}
+
+/**
+ * Sets the IAM policy for a Cloud Logging Log View.
+ * Ref: https://cloud.google.com/logging/docs/reference/v2/rest/v2/projects.locations.buckets.views/setIamPolicy
+ */
+export async function setLogViewIamPolicy(
+  projectId: string,
+  bucketId: string,
+  viewId: string,
+  policy: Policy,
+  location = "global",
+): Promise<Policy> {
+  const client = new Client({ urlPrefix: cloudloggingOrigin(), apiVersion: API_VERSION });
+  const path = `/projects/${projectId}/locations/${location}/buckets/${bucketId}/views/${viewId}:setIamPolicy`;
+  try {
+    const res = await client.post<{ policy: Policy }, Policy>(path, { policy });
+    return res.body;
+  } catch (err: any) {
+    const msg = err.message || JSON.stringify(err.body) || err;
+    throw new FirebaseError(
+      `Failed to set IAM policy for log view ${viewId} on bucket ${bucketId} (status ${err.status}): ${msg}`,
+      { original: err },
+    );
+  }
+}
+
+/**
+ * Grants an IAM role to one or more members on a Cloud Logging Log View if not already present.
+ */
+export async function grantLogViewAccess(
+  projectId: string,
+  bucketId: string,
+  viewId: string,
+  members: string | string[],
+  role = "roles/logging.viewAccessor",
+  location = "global",
+): Promise<Policy> {
+  const memberList = Array.isArray(members) ? members : [members];
+  let policy: Policy;
+  try {
+    policy = await getLogViewIamPolicy(projectId, bucketId, viewId, location);
+  } catch (err: any) {
+    if (err?.original?.status === 404 || err?.status === 404) {
+      policy = {
+        bindings: [],
+        etag: "",
+        version: 3,
+      };
+    } else {
+      throw err;
+    }
+  }
+
+  policy.bindings = policy.bindings || [];
+  let existingBinding = policy.bindings.find((b) => b.role === role);
+
+  if (!existingBinding) {
+    existingBinding = {
+      role,
+      members: [],
+    };
+    policy.bindings.push(existingBinding);
+  }
+
+  let updated = false;
+  for (const m of memberList) {
+    if (!existingBinding.members.includes(m)) {
+      existingBinding.members.push(m);
+      updated = true;
+    }
+  }
+
+  if (!updated) {
+    return policy;
+  }
+
+  return await setLogViewIamPolicy(projectId, bucketId, viewId, policy, location);
 }


### PR DESCRIPTION
Add a step to the crashlytics:web:onboard command to grant read access to the newly created firebase-telemetry log bucket to project viewers and editors. They always have this access to the _Default bucket, but this needs to be done explicitly for custom buckets like this.