### PR TITLE
feat(functions): add final report after kits:install

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -1565,18 +1565,13 @@ describe("functions:kits:install", () => {
         requiredAPIs: [
           { api: "firestore.googleapis.com", reason: "Firestore access" },
           { api: "bigquery.googleapis.com", reason: "BigQuery export" },
-          { api: "firestore.googleapis.com", reason: "Duplicate entry" },
         ],
         endpoints: {
           syncData: { entryPoint: "syncData" } as unknown as build.Endpoint,
           cleanUp: { entryPoint: "cleanUp" } as unknown as build.Endpoint,
         },
         params: [],
-        requiredRoles: [
-          "roles/datastore.user",
-          "roles/bigquery.dataEditor",
-          "roles/datastore.user",
-        ],
+        requiredRoles: ["roles/datastore.user", "roles/bigquery.dataEditor"],
       });
 
       await printKitFirstDeployReport(mockOptions, "my-inst", "/mock/source");
@@ -1601,8 +1596,8 @@ describe("functions:kits:install", () => {
         sinon.match(/functions:/),
         sinon.match(
           "At the first deploy, the following roles will be granted to the kit service account:\n" +
-            "- roles/bigquery.dataEditor\n" +
-            "- roles/datastore.user",
+            "- BigQuery Data Editor\n" +
+            "- Cloud Datastore User",
         ),
       );
     });

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -16,7 +16,11 @@ import {
   addKitToConfig,
   buildAndInstallKit,
   promptExistingInstanceForProject,
+  printKitFirstDeployReport,
+  FunctionsKitsInstallOptions,
 } from "./functions-kits-install";
+import * as kitsInstall from "./functions-kits-install";
+import * as build from "../deploy/functions/build";
 import * as experiments from "../experiments";
 import * as initSpawn from "../init/spawn";
 import { Config } from "../config";
@@ -1550,6 +1554,106 @@ describe("functions:kits:install", () => {
           sinon.match(/firebase deploy --only functions:inst-2 --project prod-project/),
         );
       });
+    });
+  });
+
+  describe("printKitFirstDeployReport", () => {
+    const mockOptions = {} as unknown as FunctionsKitsInstallOptions;
+
+    it("should print bulleted lists of functions, required APIs, and required roles", async () => {
+      sinon.stub(kitsInstall, "discoverKitBuild").resolves({
+        requiredAPIs: [
+          { api: "firestore.googleapis.com", reason: "Firestore access" },
+          { api: "bigquery.googleapis.com", reason: "BigQuery export" },
+          { api: "firestore.googleapis.com", reason: "Duplicate entry" },
+        ],
+        endpoints: {
+          syncData: { entryPoint: "syncData" } as unknown as build.Endpoint,
+          cleanUp: { entryPoint: "cleanUp" } as unknown as build.Endpoint,
+        },
+        params: [],
+        requiredRoles: [
+          "roles/datastore.user",
+          "roles/bigquery.dataEditor",
+          "roles/datastore.user",
+        ],
+      });
+
+      await printKitFirstDeployReport(mockOptions, "my-inst", "/mock/source");
+
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(
+          "At the first deploy, the following functions will be created in your project:\n" +
+            "- kit-my-inst-cleanUp\n" +
+            "- kit-my-inst-syncData",
+        ),
+      );
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(
+          "At the first deploy, the following APIs will be enabled in your project:\n" +
+            "- bigquery.googleapis.com\n" +
+            "- firestore.googleapis.com",
+        ),
+      );
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(
+          "At the first deploy, the following roles will be granted to the kit service account:\n" +
+            "- roles/bigquery.dataEditor\n" +
+            "- roles/datastore.user",
+        ),
+      );
+    });
+
+    it("should not print anything when there are no functions, APIs, or roles", async () => {
+      sinon.stub(kitsInstall, "discoverKitBuild").resolves({
+        requiredAPIs: [],
+        endpoints: {},
+        params: [],
+        requiredRoles: [],
+      });
+
+      await printKitFirstDeployReport(mockOptions, "my-inst", "/mock/source");
+
+      expect(loggerInfoStub).to.not.have.been.called;
+    });
+
+    it("should only print sections for non-empty lists", async () => {
+      sinon.stub(kitsInstall, "discoverKitBuild").resolves({
+        requiredAPIs: [],
+        endpoints: {
+          syncData: { entryPoint: "syncData" } as unknown as build.Endpoint,
+        },
+        params: [],
+        requiredRoles: [],
+      });
+
+      await printKitFirstDeployReport(mockOptions, "my-inst", "/mock/source");
+
+      expect(loggerInfoStub).to.have.been.calledWith(
+        sinon.match(/functions:/),
+        sinon.match(
+          "At the first deploy, the following functions will be created in your project:\n" +
+            "- kit-my-inst-syncData",
+        ),
+      );
+      expect(loggerInfoStub).to.not.have.been.calledWith(
+        sinon.match("At the first deploy, the following APIs will be enabled in your project"),
+      );
+      expect(loggerInfoStub).to.not.have.been.calledWith(
+        sinon.match(
+          "At the first deploy, the following roles will be granted to the kit service account",
+        ),
+      );
+    });
+
+    it("should handle discovery errors gracefully without throwing", async () => {
+      sinon.stub(kitsInstall, "discoverKitBuild").rejects(new Error("Discovery failed"));
+
+      await expect(printKitFirstDeployReport(mockOptions, "my-inst", "/mock/source")).to.not.be
+        .rejected;
     });
   });
 });

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -10,6 +10,7 @@ import { getProjectId } from "../projectUtils";
 import { logLabeledBullet, logLabeledSuccess, logLabeledWarning } from "../utils";
 
 import {
+  addKitPrefix,
   isKitConfig,
   normalizeAndValidate,
   validateKit,
@@ -24,6 +25,8 @@ import { confirm, input, select } from "../prompt";
 import { spawnWithOutput, wrapSpawn } from "../init/spawn";
 import { readTemplateSync } from "../templates";
 import * as supported from "../deploy/functions/runtimes/supported";
+import * as runtimes from "../deploy/functions/runtimes";
+import * as build from "../deploy/functions/build";
 import { hasProjectEnv } from "../functions/env";
 import * as self from "./functions-kits-install";
 import { Config } from "../config";
@@ -368,6 +371,11 @@ async function addInstanceToExistingKit(
     "functions",
     `Function kit instance ${clc.bold(instanceId)} successfully added to kit ${clc.bold(existingKit.kit)}.`,
   );
+  await self.printKitFirstDeployReport(
+    options,
+    instanceId,
+    options.config.path(existingKit.source),
+  );
 }
 
 /**
@@ -609,6 +617,64 @@ export function addKitToConfig(
   config.writeProjectFile("firebase.json", configSrc);
 }
 
+/**
+ * Discovers the build manifest from the compiled kit source directory.
+ */
+export async function discoverKitBuild(
+  options: FunctionsKitsInstallOptions,
+  absSourcePath: string,
+): Promise<build.Build> {
+  const projectId = getProjectId(options) || "";
+  const delegateContext: runtimes.DelegateContext = {
+    projectId,
+    sourceDir: absSourcePath,
+    projectDir: options.config?.projectDir || "",
+    runtime: supported.latest("nodejs"),
+  };
+  const runtimeDelegate = await runtimes.getRuntimeDelegate(delegateContext);
+  return runtimeDelegate.discoverBuild({}, {});
+}
+
+/**
+ * Discovers kit endpoints, required APIs, and required roles, and logs a formatted report.
+ */
+export async function printKitFirstDeployReport(
+  options: FunctionsKitsInstallOptions,
+  instanceId: string,
+  absSourcePath: string,
+): Promise<void> {
+  let discoveredBuild: build.Build;
+  try {
+    discoveredBuild = await self.discoverKitBuild(options, absSourcePath);
+  } catch (err: unknown) {
+    logger.debug(`Could not discover kit build for reporting: ${getErrMsg(err)}`);
+    return;
+  }
+
+  const prefix = addKitPrefix(instanceId);
+  build.applyPrefix(discoveredBuild, prefix);
+
+  const functions = Object.keys(discoveredBuild.endpoints).sort();
+  const apis = Array.from(new Set((discoveredBuild.requiredAPIs || []).map((a) => a.api))).sort();
+  const roles = Array.from(new Set(discoveredBuild.requiredRoles || [])).sort();
+
+  const printSection = (heading: string, items: string[]): void => {
+    if (items.length > 0) {
+      logLabeledBullet("functions", `${heading}\n` + items.map((item) => `- ${item}`).join("\n"));
+    }
+  };
+
+  printSection(
+    "At the first deploy, the following functions will be created in your project:",
+    functions,
+  );
+  printSection("At the first deploy, the following APIs will be enabled in your project:", apis);
+  printSection(
+    "At the first deploy, the following roles will be granted to the kit service account:",
+    roles,
+  );
+}
+
 export const command = new Command("functions:kits:install")
   .description("install a function kit into your project")
   .option("--npm_package <package>", "NPM package name or specifier to install as a function kit")
@@ -685,4 +751,5 @@ export const command = new Command("functions:kits:install")
     addKitToConfig(options.config, kitId, instanceId, packageName, sourcePath, configDirPath);
 
     logLabeledSuccess("functions", `Function kit ${clc.bold(kitId)} successfully installed.`);
+    await self.printKitFirstDeployReport(options, instanceId, absSourcePath);
   });

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -644,15 +644,14 @@ export async function printKitFirstDeployReport(
   absSourcePath: string,
 ): Promise<void> {
   let discoveredBuild: build.Build;
+  const prefix = addKitPrefix(instanceId);
   try {
     discoveredBuild = await self.discoverKitBuild(options, absSourcePath);
+    build.applyPrefix(discoveredBuild, prefix);
   } catch (err: unknown) {
     logger.debug(`Could not discover kit build for reporting: ${getErrMsg(err)}`);
     return;
   }
-
-  const prefix = addKitPrefix(instanceId);
-  build.applyPrefix(discoveredBuild, prefix);
 
   const functions = Object.keys(discoveredBuild.endpoints).sort();
   const apis = Array.from(new Set((discoveredBuild.requiredAPIs || []).map((a) => a.api))).sort();

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -27,6 +27,7 @@ import { readTemplateSync } from "../templates";
 import * as supported from "../deploy/functions/runtimes/supported";
 import * as runtimes from "../deploy/functions/runtimes";
 import * as build from "../deploy/functions/build";
+import * as iam from "../gcp/iam";
 import { hasProjectEnv } from "../functions/env";
 import * as self from "./functions-kits-install";
 import { Config } from "../config";
@@ -654,8 +655,9 @@ export async function printKitFirstDeployReport(
   }
 
   const functions = Object.keys(discoveredBuild.endpoints).sort();
-  const apis = Array.from(new Set((discoveredBuild.requiredAPIs || []).map((a) => a.api))).sort();
-  const roles = Array.from(new Set(discoveredBuild.requiredRoles || [])).sort();
+  const apis = (discoveredBuild.requiredAPIs || []).map((a) => a.api).sort();
+  const rawRoles = discoveredBuild.requiredRoles || [];
+  const roles = (await Promise.all(rawRoles.map((r) => iam.getRoleName(r)))).sort();
 
   const printSection = (heading: string, items: string[]): void => {
     if (items.length > 0) {


### PR DESCRIPTION
### Description

After a successful install, this will output a report to the terminal about the functions that would be created, the apis to be enabled, and the roles to be granted at the first deploy in the project. This mimics how this information is displayed to users of Extensions in the console.

### Scenarios Tested

* `firebase functions:kits:install --npm_package <package>` outputs the final report.