### PR TITLE
Stop checking TOS for ADC

### DIFF
--- a/src/requireTosAcceptance.spec.ts
+++ b/src/requireTosAcceptance.spec.ts
@@ -6,6 +6,7 @@ import { Options } from "./options";
 import { RC } from "./rc";
 import { expect } from "chai";
 import * as auth from "./auth";
+import * as defaultCredentials from "./defaultCredentials";
 
 const SAMPLE_OPTIONS: Options = {
   cwd: "/",
@@ -48,13 +49,19 @@ const SAMPLE_RESPONSE = {
 
 describe("requireTosAcceptance", () => {
   let loggedInStub: sinon.SinonStub;
+  let hasDefaultCredentialsStub: sinon.SinonStub;
+
   beforeEach(() => {
     nock.disableNetConnect();
     loggedInStub = sinon.stub(auth, "loggedIn");
+    hasDefaultCredentialsStub = sinon
+      .stub(defaultCredentials, "hasDefaultCredentials")
+      .resolves(false);
   });
   afterEach(() => {
     nock.enableNetConnect();
     loggedInStub.restore();
+    hasDefaultCredentialsStub.restore();
   });
 
   it("should resolve for accepted terms of service", async () => {
@@ -81,8 +88,17 @@ describe("requireTosAcceptance", () => {
     expect(nock.isDone()).to.be.true;
   });
 
-  it("should resolve to if not a human", async () => {
+  it("should resolve if not a human", async () => {
     loggedInStub.returns(false);
+
+    await requireTosAcceptance(APPHOSTING_TOS_ID)(SAMPLE_OPTIONS);
+
+    expect(nock.isDone()).to.be.true;
+  });
+
+  it("should resolve if using ADC", async () => {
+    loggedInStub.returns(true);
+    hasDefaultCredentialsStub.resolves(true);
 
     await requireTosAcceptance(APPHOSTING_TOS_ID)(SAMPLE_OPTIONS);
 

--- a/src/requireTosAcceptance.ts
+++ b/src/requireTosAcceptance.ts
@@ -35,6 +35,8 @@ export function requireTosAcceptance(tosId: TosId): (options: Options) => Promis
 async function requireTos(tosId: TosId): Promise<void> {
   // If they are not logged in, or they are using ADC, they either cannot make calls,
   // or are using a service account. Either way, no need to check TOS.
+  // TODO(joehanley): On the next major version, we should swap to prefer login creds over ADC. When we do so,
+  // we can remove `hasDefaultCredentials()` from this check.
   if (!loggedIn() || (await hasDefaultCredentials())) {
     return;
   }

--- a/src/requireTosAcceptance.ts
+++ b/src/requireTosAcceptance.ts
@@ -10,6 +10,7 @@ import {
 } from "./gcp/firedata";
 import { consoleOrigin } from "./api";
 import { loggedIn } from "./auth";
+import { hasDefaultCredentials } from "./defaultCredentials";
 
 const consoleLandingPage = new Map<TosId, string>([
   [APPHOSTING_TOS_ID, `${consoleOrigin()}/project/_/apphosting`],
@@ -32,9 +33,9 @@ export function requireTosAcceptance(tosId: TosId): (options: Options) => Promis
 }
 
 async function requireTos(tosId: TosId): Promise<void> {
-  // If they are not logged in, they either cannot make calls, or are using a service account.
-  // Either way, no need to check TOS.
-  if (!loggedIn()) {
+  // If they are not logged in, or they are using ADC, they either cannot make calls,
+  // or are using a service account. Either way, no need to check TOS.
+  if (!loggedIn() || (await hasDefaultCredentials())) {
     return;
   }
   const res = await getTosStatus();


### PR DESCRIPTION
### Description
Fixing an issue where we would attempt to check TOS using application default credentials, which always fails due to private API enablement issues.
