### PR TITLE
Handle 403 gracefully when provisioning default compute service account

### DIFF
--- a/src/apphosting/backend.spec.ts
+++ b/src/apphosting/backend.spec.ts
@@ -264,6 +264,31 @@ describe("apphosting setup functions", () => {
       expect(createServiceAccountStub).to.not.be.called;
       expect(addServiceAccountToRolesStub).to.not.be.called;
     });
+
+    it("should log a warning and continue if user lacks permission to create service account (403)", async () => {
+      testResourceIamPermissionsStub.resolves();
+      createServiceAccountStub.rejects(new FirebaseError("Permission denied", { status: 403 }));
+
+      await expect(ensureAppHostingComputeServiceAccount(projectId, serviceAccount)).to.be
+        .fulfilled;
+
+      expect(testResourceIamPermissionsStub).to.be.calledOnce;
+      expect(createServiceAccountStub).to.be.calledOnce;
+      expect(addServiceAccountToRolesStub).to.not.be.called;
+    });
+
+    it("should log a warning and continue if user lacks permission to set IAM roles (403)", async () => {
+      testResourceIamPermissionsStub.resolves();
+      createServiceAccountStub.resolves();
+      addServiceAccountToRolesStub.rejects(new FirebaseError("Permission denied", { status: 403 }));
+
+      await expect(ensureAppHostingComputeServiceAccount(projectId, serviceAccount)).to.be
+        .fulfilled;
+
+      expect(testResourceIamPermissionsStub).to.be.calledOnce;
+      expect(createServiceAccountStub).to.be.calledOnce;
+      expect(addServiceAccountToRolesStub).to.be.calledOnce;
+    });
   });
 
   describe("deleteBackendAndPoll", () => {

--- a/src/apphosting/backend.spec.ts
+++ b/src/apphosting/backend.spec.ts
@@ -268,13 +268,14 @@ describe("apphosting setup functions", () => {
     it("should log a warning and continue if user lacks permission to create service account (403)", async () => {
       testResourceIamPermissionsStub.resolves();
       createServiceAccountStub.rejects(new FirebaseError("Permission denied", { status: 403 }));
+      addServiceAccountToRolesStub.resolves();
 
       await expect(ensureAppHostingComputeServiceAccount(projectId, serviceAccount)).to.be
         .fulfilled;
 
       expect(testResourceIamPermissionsStub).to.be.calledOnce;
       expect(createServiceAccountStub).to.be.calledOnce;
-      expect(addServiceAccountToRolesStub).to.not.be.called;
+      expect(addServiceAccountToRolesStub).to.be.calledOnce;
     });
 
     it("should log a warning and continue if user lacks permission to set IAM roles (403)", async () => {

--- a/src/apphosting/backend.ts
+++ b/src/apphosting/backend.ts
@@ -424,7 +424,6 @@ async function provisionDefaultComputeServiceAccount(projectId: string): Promise
       logWarning(
         "Unable to verify or create default compute service account due to missing IAM permissions. Continuing deploy...",
       );
-      return;
     } else if (getErrStatus(err) !== 409) {
       // 409 Already Exists errors can safely be ignored.
       throw err;

--- a/src/apphosting/backend.ts
+++ b/src/apphosting/backend.ts
@@ -420,8 +420,13 @@ async function provisionDefaultComputeServiceAccount(projectId: string): Promise
       "Firebase App Hosting compute service account",
     );
   } catch (err: unknown) {
-    // 409 Already Exists errors can safely be ignored.
-    if (getErrStatus(err) !== 409) {
+    if (getErrStatus(err) === 403) {
+      logWarning(
+        "Unable to verify or create default compute service account due to missing IAM permissions. Continuing deploy...",
+      );
+      return;
+    } else if (getErrStatus(err) !== 409) {
+      // 409 Already Exists errors can safely be ignored.
       throw err;
     }
   }
@@ -441,6 +446,10 @@ async function provisionDefaultComputeServiceAccount(projectId: string): Promise
     if (getErrStatus(err) === 400) {
       logWarning(
         "Your App Hosting compute service account is still being provisioned in the background. If you encounter an error, please try again after a few moments.",
+      );
+    } else if (getErrStatus(err) === 403) {
+      logWarning(
+        "Unable to set IAM roles on default compute service account due to missing permissions. Continuing deploy...",
       );
     } else {
       throw err;


### PR DESCRIPTION


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
Fix for https://github.com/firebase/firebase-tools/issues/10956

If we hit "already exists" or "permission denied" erors when trying to add/update the service account, we continue anyway optimistically with the app deployment. 

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
