### PR TITLE
avoid spreading readdirRecursive results to prevent call stack overflow

### DIFF
--- a/src/deploy/apphosting/util.ts
+++ b/src/deploy/apphosting/util.ts
@@ -48,7 +48,9 @@ export async function createLocalBuildTarArchive(
         ignoreStrings: ["firebase-debug.log", "firebase-debug.*.log"],
         supportGitIgnore: false,
       });
-      allFiles.push(...rdrFiles.map((rdrf) => path.relative(rootDir, rdrf.name)));
+      for (const rdrf of rdrFiles) {
+        allFiles.push(path.relative(rootDir, rdrf.name));
+      }
     } else {
       allFiles.push(path.relative(rootDir, absolutePath));
     }


### PR DESCRIPTION


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->
https://github.com/firebase/firebase-tools/issues/10956

The use of lambdas caused a call stack overflow when we had a lot of files

### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

TODO: Need to test with a giant app to reproduce the issue and fix it. 

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
