### PR TITLE
Add optional maxSizeBytes parameter to uploadObject and use for local builds

### DIFF
--- a/src/deploy/apphosting/deploy.spec.ts
+++ b/src/deploy/apphosting/deploy.spec.ts
@@ -13,6 +13,7 @@ import * as fs from "fs";
 import * as getProjectNumber from "../../getProjectNumber";
 import * as experiments from "../../experiments";
 import { FirebaseError } from "../../error";
+import { CLOUD_RUN_SIZE_LIMIT_BYTES } from "../../apphosting/constants";
 
 const BASE_OPTS = {
   cwd: "/",
@@ -201,6 +202,7 @@ describe("apphosting", () => {
         sinon.match.any,
         "firebaseapphosting-sources-000000000000-us-central1",
         gcs.ContentType.TAR,
+        CLOUD_RUN_SIZE_LIMIT_BYTES,
       );
     });
 
@@ -244,6 +246,7 @@ describe("apphosting", () => {
         sinon.match.any,
         "firebaseapphosting-sources-000000000000-us-central1",
         gcs.ContentType.TAR,
+        CLOUD_RUN_SIZE_LIMIT_BYTES,
       );
 
       expect(context.backendStorageUris["foo"]).to.equal(`gs://${bucketName}/foo-1234.zip`);

--- a/src/deploy/apphosting/deploy.ts
+++ b/src/deploy/apphosting/deploy.ts
@@ -10,6 +10,7 @@ import { Context } from "./args";
 import * as util from "./util";
 import * as experiments from "../../experiments";
 import { logger } from "../../logger";
+import { CLOUD_RUN_SIZE_LIMIT_BYTES } from "../../apphosting/constants";
 
 /**
  * Uploads App Hosting source code or local build output to Google Cloud Storage.
@@ -114,6 +115,7 @@ export default async function (context: Context, options: Options): Promise<void
           },
           bucketName,
           isLocalBuild ? gcs.ContentType.TAR : gcs.ContentType.ZIP,
+          isLocalBuild ? CLOUD_RUN_SIZE_LIMIT_BYTES : undefined,
         );
         logLabeledBullet("apphosting", `Uploaded at gs://${bucket}/${object}`);
         context.backendStorageUris[cfg.backendId] =

--- a/src/gcp/storage.spec.ts
+++ b/src/gcp/storage.spec.ts
@@ -1,9 +1,11 @@
 import { expect } from "chai";
 import * as sinon from "sinon";
+import { Readable } from "stream";
 
 import * as storage from "./storage";
 import * as utils from "../utils";
 import { FirebaseError } from "../error";
+import { Client } from "../apiv2";
 
 describe("storage", () => {
   describe("upsertBucket", () => {
@@ -231,6 +233,117 @@ describe("storage", () => {
 
       expect(logLabeledWarningStub).to.not.be.called;
       expect(createBucketStub).to.be.calledOnce;
+    });
+  });
+
+  describe("uploadObject", () => {
+    let clientRequestStub: sinon.SinonStub;
+
+    beforeEach(() => {
+      clientRequestStub = sinon.stub(Client.prototype, "request").resolves({
+        status: 200,
+        response: new Response(null, {
+          headers: new Headers({
+            "x-goog-generation": "123456789",
+          }),
+        }),
+        body: {},
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it("should use custom maxSizeBytes when provided", async () => {
+      const source = {
+        file: "/path/to/archive.tar.gz",
+        stream: new Readable({
+          read() {
+            this.push(null);
+          },
+        }),
+      };
+
+      const result = await storage.uploadObject(
+        source,
+        "my-bucket",
+        storage.ContentType.TAR,
+        262144000,
+      );
+
+      expect(result).to.deep.equal({
+        bucket: "my-bucket",
+        object: "archive.tar.gz",
+        generation: "123456789",
+      });
+      expect(clientRequestStub).to.be.calledOnceWith({
+        method: "PUT",
+        path: "/my-bucket/archive.tar.gz",
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "x-goog-content-length-range": "0,262144000",
+        },
+        body: source.stream,
+      });
+    });
+
+    it("should default to 123289600 when maxSizeBytes is not provided", async () => {
+      const source = {
+        file: "/path/to/source.zip",
+        stream: new Readable({
+          read() {
+            this.push(null);
+          },
+        }),
+      };
+
+      const result = await storage.uploadObject(source, "my-bucket", storage.ContentType.ZIP);
+
+      expect(result).to.deep.equal({
+        bucket: "my-bucket",
+        object: "source.zip",
+        generation: "123456789",
+      });
+      expect(clientRequestStub).to.be.calledOnceWith({
+        method: "PUT",
+        path: "/my-bucket/source.zip",
+        headers: {
+          "Content-Type": "application/zip",
+          "x-goog-content-length-range": "0,123289600",
+        },
+        body: source.stream,
+      });
+    });
+
+    it("should throw FirebaseError if TAR upload does not end with .tar.gz", async () => {
+      const source = {
+        file: "/path/to/archive.zip",
+        stream: new Readable({
+          read() {
+            this.push(null);
+          },
+        }),
+      };
+
+      await expect(
+        storage.uploadObject(source, "my-bucket", storage.ContentType.TAR),
+      ).to.be.rejectedWith(FirebaseError, "Expected a file name ending in .tar.gz");
+    });
+
+    it("should throw FirebaseError if ZIP upload does not end with .zip", async () => {
+      const source = {
+        file: "/path/to/archive.tar.gz",
+        stream: new Readable({
+          read() {
+            this.push(null);
+          },
+        }),
+      };
+
+      await expect(
+        storage.uploadObject(source, "my-bucket", storage.ContentType.ZIP),
+      ).to.be.rejectedWith(FirebaseError, "Expected a file name ending in .zip");
     });
   });
 });

--- a/src/gcp/storage.ts
+++ b/src/gcp/storage.ts
@@ -267,6 +267,7 @@ export async function uploadObject(
   /** Bucket to upload to. */
   bucketName: string,
   contentType?: ContentType,
+  maxSizeBytes?: number,
 ): Promise<{
   bucket: string;
   object: string;
@@ -286,13 +287,14 @@ export async function uploadObject(
 
   const localAPIClient = new Client({ urlPrefix: storageOrigin() });
   const location = `/${bucketName}/${path.basename(source.file)}`;
+  const rangeHeader = maxSizeBytes !== undefined ? `0,${maxSizeBytes}` : "0,123289600";
   const res = await localAPIClient.request({
     method: "PUT",
     path: location,
     headers: {
       "Content-Type":
         contentType === ContentType.TAR ? "application/octet-stream" : "application/zip",
-      "x-goog-content-length-range": "0,123289600",
+      "x-goog-content-length-range": rangeHeader,
     },
     body: source.stream,
   });


### PR DESCRIPTION

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change. Link to other relevant issues or pull requests. -->

https://github.com/firebase/firebase-tools/issues/10956


### Scenarios Tested

<!-- Write a list of all the user journeys and edge cases you've tested. Instructions for manual testing can be found at https://github.com/firebase/firebase-tools/blob/main/.github/CONTRIBUTING.md#development-setup -->

Verified the bug with a 249MiB app on main and verified that it worked correctly with this branch

### Sample Commands

<!-- Proposing a change to commands or flags? Provide examples of how they will be used. -->
