### PR TITLE
Initial commit for ext:migrate

### DIFF
--- a/src/commands/ext-migrate.ts
+++ b/src/commands/ext-migrate.ts
@@ -5,6 +5,7 @@ import { needProjectId } from "../projectUtils";
 import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
 import { requirePermissions } from "../requirePermissions";
 import { createMigrationPlan } from "../extensions/migrate";
+import { validateNpmPackageName } from "./functions-kits-install";
 import { logger } from "../logger";
 import { Options } from "../options";
 import { logLabeledBullet } from "../utils";
@@ -25,6 +26,9 @@ export const command = new Command("ext:migrate")
   .before(checkMinRequiredVersion, "extMinVersion")
   .action(async (options: ExtMigrateOptions) => {
     const projectId = needProjectId(options);
+    if (options.package) {
+      validateNpmPackageName(options.package);
+    }
     const plan = await createMigrationPlan(projectId, {
       package: options.package,
       extInstance: options.extInstance,

--- a/src/commands/ext-migrate.ts
+++ b/src/commands/ext-migrate.ts
@@ -1,10 +1,13 @@
+import * as clc from "colorette";
 import { checkMinRequiredVersion } from "../checkMinRequiredVersion";
 import { Command } from "../command";
 import { needProjectId } from "../projectUtils";
-import { ensureExtensionsApiEnabled } from "../extensions/extensionsHelper";
+import { ensureExtensionsApiEnabled, logPrefix } from "../extensions/extensionsHelper";
 import { requirePermissions } from "../requirePermissions";
-import { migrate } from "../extensions/migrate";
+import { createMigrationPlan } from "../extensions/migrate";
+import { logger } from "../logger";
 import { Options } from "../options";
+import { logLabeledBullet } from "../utils";
 
 export interface ExtMigrateOptions extends Options {
   package?: string;
@@ -22,10 +25,17 @@ export const command = new Command("ext:migrate")
   .before(checkMinRequiredVersion, "extMinVersion")
   .action(async (options: ExtMigrateOptions) => {
     const projectId = needProjectId(options);
-    return migrate(projectId, {
+    const plan = await createMigrationPlan(projectId, {
       package: options.package,
       extInstance: options.extInstance,
       extension: options.extension,
       nonInteractive: options.nonInteractive,
     });
+
+    logLabeledBullet(
+      logPrefix,
+      `Selected instance ${clc.bold(plan.instanceId)} (${plan.kitPackage}) for migration.`,
+    );
+    logger.info("TODO: Draw the rest of the owl");
+    return plan;
   });

--- a/src/commands/ext-migrate.ts
+++ b/src/commands/ext-migrate.ts
@@ -1,0 +1,31 @@
+import { checkMinRequiredVersion } from "../checkMinRequiredVersion";
+import { Command } from "../command";
+import { needProjectId } from "../projectUtils";
+import { ensureExtensionsApiEnabled } from "../extensions/extensionsHelper";
+import { requirePermissions } from "../requirePermissions";
+import { migrate } from "../extensions/migrate";
+import { Options } from "../options";
+
+export interface ExtMigrateOptions extends Options {
+  package?: string;
+  extInstance?: string;
+  extension?: string;
+}
+
+export const command = new Command("ext:migrate")
+  .description("migrate an extension instance to a function kit")
+  .option("-p, --package <package>", "optional kit package override to use")
+  .option("-i, --ext-instance <instanceId>", "extension instance ID to migrate")
+  .option("-e, --extension <extensionRef>", "extension reference or name to migrate")
+  .before(requirePermissions, ["firebaseextensions.instances.list"])
+  .before(ensureExtensionsApiEnabled)
+  .before(checkMinRequiredVersion, "extMinVersion")
+  .action(async (options: ExtMigrateOptions) => {
+    const projectId = needProjectId(options);
+    return migrate(projectId, {
+      package: options.package,
+      extInstance: options.extInstance,
+      extension: options.extension,
+      nonInteractive: options.nonInteractive,
+    });
+  });

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -133,6 +133,9 @@ export function load(client: CLIClient): CLIClient {
   client.ext.list = loadCommand("ext-list");
   client.ext.uninstall = loadCommand("ext-uninstall");
   client.ext.update = loadCommand("ext-update");
+  if (experiments.isEnabled("extMigrationFeatures")) {
+    client.ext.migrate = loadCommand("ext-migrate");
+  }
   client.ext.sdk = {};
   client.ext.sdk.install = loadCommand("ext-sdk-install");
   client.ext.dev = {};

--- a/src/extensions/migrate.spec.ts
+++ b/src/extensions/migrate.spec.ts
@@ -123,6 +123,11 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
     it("should return undefined for unknown extension ref", () => {
       expect(migrateModule.getKitPackage("custom/unknown")).to.be.undefined;
     });
+
+    it("should return undefined for a known extension ref with no replacement", () => {
+      expect(migrateModule.getKitPackage("moralis/moralis-streams")).to.be.undefined;
+      expect(migrateModule.getKitPackage("firebase/firestore-bundle-builder")).to.be.undefined;
+    });
   });
 
   describe("formatExtensionsTable", () => {

--- a/src/extensions/migrate.spec.ts
+++ b/src/extensions/migrate.spec.ts
@@ -113,10 +113,10 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
 
     it("should return mapped kit package for known extension ref", () => {
       expect(migrateModule.getKitPackage("firestore-send-email")).to.equal(
-        "@firebase/firestore-send-email",
+        "@firebase-function-kits/firestore-send-email",
       );
       expect(migrateModule.getKitPackage("firebase/firestore-send-email")).to.equal(
-        "@firebase/firestore-send-email",
+        "@firebase-function-kits/firestore-send-email",
       );
     });
 
@@ -137,7 +137,7 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
       expect(rows[0].extension).to.equal("firebase/firestore-send-email");
       expect(rows[0].publisher).to.equal("firebase");
       expect(rows[0].instances).to.deep.equal(["email-1", "email-2"]);
-      expect(rows[0].kitPackage).to.equal("@firebase/firestore-send-email");
+      expect(rows[0].kitPackage).to.equal("@firebase-function-kits/firestore-send-email");
     });
   });
 
@@ -146,7 +146,7 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
       const migratable = migrateModule.getMigratableInstances([mockInstance1, mockUnknownInstance]);
       expect(migratable).to.have.lengthOf(1);
       expect(migratable[0].instanceId).to.equal("email-1");
-      expect(migratable[0].kitPackage).to.equal("@firebase/firestore-send-email");
+      expect(migratable[0].kitPackage).to.equal("@firebase-function-kits/firestore-send-email");
     });
   });
 
@@ -209,7 +209,7 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
         instance: mockInstance1,
         instanceId: "email-1",
         extensionRef: "firebase/firestore-send-email",
-        kitPackage: "@firebase/firestore-send-email",
+        kitPackage: "@firebase-function-kits/firestore-send-email",
       });
     });
   });
@@ -283,7 +283,7 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
         instance: mockInstance1,
         instanceId: "email-1",
         extensionRef: "firebase/firestore-send-email",
-        kitPackage: "@firebase/firestore-send-email",
+        kitPackage: "@firebase-function-kits/firestore-send-email",
       });
     });
 
@@ -342,7 +342,7 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
         instance: mockInstance1,
         instanceId: "email-1",
         extensionRef: "firebase/firestore-send-email",
-        kitPackage: "@firebase/firestore-send-email",
+        kitPackage: "@firebase-function-kits/firestore-send-email",
       });
     });
   });

--- a/src/extensions/migrate.spec.ts
+++ b/src/extensions/migrate.spec.ts
@@ -3,12 +3,14 @@ import * as sinon from "sinon";
 
 import { FirebaseError } from "../error";
 import { logger } from "../logger";
+import * as prompt from "../prompt";
 import * as extensionsApi from "./extensionsApi";
 import * as migrateModule from "./migrate";
 import { ExtensionInstance } from "./types";
 
 describe("ext:migrate core logic (Unique Veneer)", () => {
   let sandbox: sinon.SinonSandbox;
+  let selectStub: sinon.SinonStub;
 
   const mockInstance1: ExtensionInstance = {
     name: "projects/test-project/instances/email-1",
@@ -97,6 +99,7 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     sandbox.stub(logger, "info");
+    selectStub = sandbox.stub(prompt, "select");
   });
 
   afterEach(() => {
@@ -142,47 +145,86 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
     });
   });
 
-  describe("migrate flow (no flags)", () => {
-    it("should notify when all extensions have already been migrated (0 instances)", async () => {
+  describe("promptInstanceSelection", () => {
+    it("should format choices and call prompt.select with correct values", async () => {
+      const migratable = migrateModule.getMigratableInstances([mockInstance1, mockInstance2]);
+      selectStub.resolves(migratable[1]);
+
+      const selected = await migrateModule.promptInstanceSelection(migratable);
+
+      expect(selected).to.equal(migratable[1]);
+      expect(selectStub).to.be.calledOnce;
+      const opts = selectStub.firstCall
+        .args[0] as prompt.SelectOptions<migrateModule.ExtensionMigrationPlan>;
+      const choices = opts.choices as prompt.Choice<migrateModule.ExtensionMigrationPlan>[];
+      expect(opts.message).to.equal("Which extension instance would you like to migrate?");
+      expect(choices).to.have.lengthOf(2);
+      expect(choices[0].name).to.equal("email-1 (firebase/firestore-send-email)");
+      expect(choices[0].value).to.equal(migratable[0]);
+      expect(choices[1].name).to.equal("email-2 (firebase/firestore-send-email)");
+      expect(choices[1].value).to.equal(migratable[1]);
+    });
+  });
+
+  describe("createMigrationPlan (no flags)", () => {
+    it("should throw error when all extensions have already been migrated (0 instances)", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([]);
 
-      await migrateModule.migrate("test-project", {});
-
-      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
-        .false;
+      await expect(migrateModule.createMigrationPlan("test-project", {})).to.be.rejectedWith(
+        FirebaseError,
+        /All extensions in project .* have already been migrated/,
+      );
     });
 
     it("should throw error if no installed extensions can be migrated", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
 
-      await expect(migrateModule.migrate("test-project", {})).to.be.rejectedWith(
+      await expect(migrateModule.createMigrationPlan("test-project", {})).to.be.rejectedWith(
         FirebaseError,
         /No remaining Extensions have an associated function kit/,
       );
     });
 
-    it("should prompt selection and output TODO when instances can be migrated", async () => {
+    it("should prompt selection and return plan when instances can be migrated", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1, mockInstance2]);
-      sandbox.stub(migrateModule, "promptInstanceSelection").resolves({
+      selectStub.callsFake(
+        async (opts: prompt.SelectOptions<migrateModule.ExtensionMigrationPlan>) => {
+          const choices = opts.choices as prompt.Choice<migrateModule.ExtensionMigrationPlan>[];
+          return choices[0].value;
+        },
+      );
+
+      const plan = await migrateModule.createMigrationPlan("test-project", {});
+
+      expect(selectStub).to.be.calledOnce;
+      const opts = selectStub.firstCall
+        .args[0] as prompt.SelectOptions<migrateModule.ExtensionMigrationPlan>;
+      expect(opts.choices).to.have.lengthOf(2);
+      expect(plan).to.deep.equal({
         instance: mockInstance1,
-        instanceId: "resize-1",
-        extensionRef: "firebase/storage-resize-images",
-        kitPackage: "@firebase-function-kits/storage-resize-images",
+        instanceId: "email-1",
+        extensionRef: "firebase/firestore-send-email",
+        kitPackage: "@firebase/firestore-send-email",
       });
-
-      await migrateModule.migrate("test-project", {});
-
-      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
-        .true;
     });
   });
 
-  describe("migrate flow (--extension flag)", () => {
+  describe("createMigrationPlan (--extension flag)", () => {
+    it("should throw error if specified extension is not installed", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
+
+      await expect(
+        migrateModule.createMigrationPlan("test-project", { extension: "non-existent-extension" }),
+      ).to.be.rejectedWith(FirebaseError, /Extension non-existent-extension is not installed/);
+    });
+
     it("should throw error if specified extension cannot be migrated", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
 
       await expect(
-        migrateModule.migrate("test-project", { extension: "my-publisher/unknown-extension" }),
+        migrateModule.createMigrationPlan("test-project", {
+          extension: "my-publisher/unknown-extension",
+        }),
       ).to.be.rejectedWith(
         FirebaseError,
         /This extension does not have an associated function kit/,
@@ -192,55 +234,64 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
     it("should allow migration when --package override is passed for extension with no counterpart", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
 
-      await migrateModule.migrate("test-project", {
+      const plan = await migrateModule.createMigrationPlan("test-project", {
         extension: "my-publisher/unknown-extension",
         package: "@custom/override-package",
       });
 
-      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
-        .true;
+      expect(plan).to.deep.equal({
+        instance: mockUnknownInstance,
+        instanceId: "custom-ext",
+        extensionRef: "my-publisher/unknown-extension",
+        kitPackage: "@custom/override-package",
+      });
     });
 
-    it("should throw error if specified extension is not installed", async () => {
+    it("should auto-select single matching instance and return plan", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
 
-      await expect(
-        migrateModule.migrate("test-project", { extension: "non-existent-extension" }),
-      ).to.be.rejectedWith(FirebaseError, /Extension non-existent-extension is not installed/);
-    });
+      const plan = await migrateModule.createMigrationPlan("test-project", {
+        extension: "firestore-send-email",
+      });
 
-    it("should auto-select single matching instance and output TODO", async () => {
-      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
-
-      await migrateModule.migrate("test-project", { extension: "firestore-send-email" });
-
-      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
-        .true;
-    });
-
-    it("should prompt selection when multiple instances exist for specified extension", async () => {
-      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1, mockInstance2]);
-      const promptStub = sandbox.stub(migrateModule, "promptInstanceSelection").resolves({
+      expect(plan).to.deep.equal({
         instance: mockInstance1,
         instanceId: "email-1",
         extensionRef: "firebase/firestore-send-email",
         kitPackage: "@firebase/firestore-send-email",
       });
+    });
 
-      await migrateModule.migrate("test-project", { extension: "firestore-send-email" });
+    it("should prompt selection when multiple instances exist for specified extension", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1, mockInstance2]);
+      selectStub.callsFake(
+        async (opts: prompt.SelectOptions<migrateModule.ExtensionMigrationPlan>) => {
+          const choices = opts.choices as prompt.Choice<migrateModule.ExtensionMigrationPlan>[];
+          return choices[1].value;
+        },
+      );
 
-      expect(promptStub.calledOnce).to.be.true;
-      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
-        .true;
+      const plan = await migrateModule.createMigrationPlan("test-project", {
+        extension: "firestore-send-email",
+      });
+
+      expect(selectStub).to.be.calledOnce;
+      const opts = selectStub.firstCall
+        .args[0] as prompt.SelectOptions<migrateModule.ExtensionMigrationPlan>;
+      const choices = opts.choices as prompt.Choice<migrateModule.ExtensionMigrationPlan>[];
+      expect(choices).to.have.lengthOf(2);
+      expect(choices[0].name).to.equal("email-1 (firebase/firestore-send-email)");
+      expect(choices[1].name).to.equal("email-2 (firebase/firestore-send-email)");
+      expect(plan?.instanceId).to.equal("email-2");
     });
   });
 
-  describe("migrate flow (--ext-instance flag)", () => {
+  describe("createMigrationPlan (--ext-instance flag)", () => {
     it("should throw error if specified instance is not found", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
 
       await expect(
-        migrateModule.migrate("test-project", { extInstance: "non-existent" }),
+        migrateModule.createMigrationPlan("test-project", { extInstance: "non-existent" }),
       ).to.be.rejectedWith(FirebaseError, /Extension instance non-existent was not found/);
     });
 
@@ -248,20 +299,26 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
 
       await expect(
-        migrateModule.migrate("test-project", { extInstance: "custom-ext" }),
+        migrateModule.createMigrationPlan("test-project", { extInstance: "custom-ext" }),
       ).to.be.rejectedWith(
         FirebaseError,
         /This extension does not have an associated function kit/,
       );
     });
 
-    it("should select specified instance and output TODO", async () => {
+    it("should select specified instance and return plan", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
 
-      await migrateModule.migrate("test-project", { extInstance: "email-1" });
+      const plan = await migrateModule.createMigrationPlan("test-project", {
+        extInstance: "email-1",
+      });
 
-      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
-        .true;
+      expect(plan).to.deep.equal({
+        instance: mockInstance1,
+        instanceId: "email-1",
+        extensionRef: "firebase/firestore-send-email",
+        kitPackage: "@firebase/firestore-send-email",
+      });
     });
   });
 });

--- a/src/extensions/migrate.spec.ts
+++ b/src/extensions/migrate.spec.ts
@@ -1,0 +1,255 @@
+import { expect } from "chai";
+import * as sinon from "sinon";
+
+import { FirebaseError } from "../error";
+import { logger } from "../logger";
+import * as extensionsApi from "./extensionsApi";
+import * as migrateModule from "./migrate";
+import { ExtensionInstance } from "./types";
+
+describe("ext:migrate core logic (Unique Veneer)", () => {
+  let sandbox: sinon.SinonSandbox;
+
+  const mockInstance1: ExtensionInstance = {
+    name: "projects/test-project/instances/email-1",
+    createTime: "2025-01-01T00:00:00Z",
+    updateTime: "2025-01-01T00:00:00Z",
+    state: "ACTIVE",
+    serviceAccountEmail: "sa@test.gserviceaccount.com",
+    config: {
+      name: "projects/test-project/instances/email-1/configurations/1",
+      createTime: "2025-01-01T00:00:00Z",
+      extensionRef: "firebase/firestore-send-email",
+      params: {},
+      systemParams: {},
+      source: {
+        state: "ACTIVE",
+        name: "sources/1",
+        packageUri: "https://gcs...",
+        hash: "abc",
+        spec: {
+          name: "firestore-send-email",
+          version: "0.1.18",
+          resources: [],
+          params: [],
+          systemParams: [],
+        },
+      },
+    },
+  };
+
+  const mockInstance2: ExtensionInstance = {
+    name: "projects/test-project/instances/email-2",
+    createTime: "2025-01-02T00:00:00Z",
+    updateTime: "2025-01-02T00:00:00Z",
+    state: "ACTIVE",
+    serviceAccountEmail: "sa@test.gserviceaccount.com",
+    config: {
+      name: "projects/test-project/instances/email-2/configurations/1",
+      createTime: "2025-01-02T00:00:00Z",
+      extensionRef: "firebase/firestore-send-email",
+      params: {},
+      systemParams: {},
+      source: {
+        state: "ACTIVE",
+        name: "sources/2",
+        packageUri: "https://gcs...",
+        hash: "def",
+        spec: {
+          name: "firestore-send-email",
+          version: "0.1.18",
+          resources: [],
+          params: [],
+          systemParams: [],
+        },
+      },
+    },
+  };
+
+  const mockUnknownInstance: ExtensionInstance = {
+    name: "projects/test-project/instances/custom-ext",
+    createTime: "2025-01-03T00:00:00Z",
+    updateTime: "2025-01-03T00:00:00Z",
+    state: "ACTIVE",
+    serviceAccountEmail: "sa@test.gserviceaccount.com",
+    config: {
+      name: "projects/test-project/instances/custom-ext/configurations/1",
+      createTime: "2025-01-03T00:00:00Z",
+      extensionRef: "my-publisher/unknown-extension",
+      params: {},
+      systemParams: {},
+      source: {
+        state: "ACTIVE",
+        name: "sources/3",
+        packageUri: "https://gcs...",
+        hash: "ghi",
+        spec: {
+          name: "unknown-extension",
+          version: "1.0.0",
+          resources: [],
+          params: [],
+          systemParams: [],
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(logger, "info");
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe("getKitPackage", () => {
+    it("should return package override if provided", () => {
+      expect(migrateModule.getKitPackage("any/ref", "@custom/kit")).to.equal("@custom/kit");
+    });
+
+    it("should return mapped kit package for known extension ref", () => {
+      expect(migrateModule.getKitPackage("firestore-send-email")).to.equal(
+        "@firebase/firestore-send-email",
+      );
+      expect(migrateModule.getKitPackage("firebase/firestore-send-email")).to.equal(
+        "@firebase/firestore-send-email",
+      );
+    });
+
+    it("should return undefined for unknown extension ref", () => {
+      expect(migrateModule.getKitPackage("custom/unknown")).to.be.undefined;
+    });
+  });
+
+  describe("formatExtensionsTable", () => {
+    it("should format table of installed extensions correctly", () => {
+      const { rows } = migrateModule.formatExtensionsTable([mockInstance1, mockInstance2]);
+      expect(rows).to.have.lengthOf(1);
+      expect(rows[0].extension).to.equal("firebase/firestore-send-email");
+      expect(rows[0].publisher).to.equal("firebase");
+      expect(rows[0].instances).to.deep.equal(["email-1", "email-2"]);
+      expect(rows[0].kitPackage).to.equal("@firebase/firestore-send-email");
+    });
+  });
+
+  describe("getMigratableInstances", () => {
+    it("should filter out instances without associated function kits", () => {
+      const migratable = migrateModule.getMigratableInstances([mockInstance1, mockUnknownInstance]);
+      expect(migratable).to.have.lengthOf(1);
+      expect(migratable[0].instanceId).to.equal("email-1");
+      expect(migratable[0].kitPackage).to.equal("@firebase/firestore-send-email");
+    });
+  });
+
+  describe("migrate flow (no flags)", () => {
+    it("should notify when all extensions have already been migrated (0 instances)", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([]);
+
+      await migrateModule.migrate("test-project", {});
+
+      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
+        .false;
+    });
+
+    it("should throw error if no installed extensions can be migrated", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
+
+      await expect(migrateModule.migrate("test-project", {})).to.be.rejectedWith(
+        FirebaseError,
+        /No remaining Extensions have an associated function kit/,
+      );
+    });
+
+    it("should prompt selection and output TODO when instances can be migrated", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1, mockInstance2]);
+      sandbox.stub(migrateModule, "promptInstanceSelection").resolves({
+        instance: mockInstance1,
+        instanceId: "resize-1",
+        extensionRef: "firebase/storage-resize-images",
+        kitPackage: "@firebase-function-kits/storage-resize-images",
+      });
+
+      await migrateModule.migrate("test-project", {});
+
+      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
+        .true;
+    });
+  });
+
+  describe("migrate flow (--extension flag)", () => {
+    it("should throw error if specified extension cannot be migrated", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
+
+      await expect(
+        migrateModule.migrate("test-project", { extension: "my-publisher/unknown-extension" }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /This extension does not have an associated function kit/,
+      );
+    });
+
+    it("should throw error if specified extension is not installed", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
+
+      await expect(
+        migrateModule.migrate("test-project", { extension: "firestore-send-email" }),
+      ).to.be.rejectedWith(FirebaseError, /Extension firestore-send-email is not installed/);
+    });
+
+    it("should auto-select single matching instance and output TODO", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
+
+      await migrateModule.migrate("test-project", { extension: "storage-resize-images" });
+
+      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
+        .true;
+    });
+
+    it("should prompt selection when multiple instances exist for specified extension", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1, mockInstance2]);
+      const promptStub = sandbox.stub(migrateModule, "promptInstanceSelection").resolves({
+        instance: mockInstance1,
+        instanceId: "resize-1",
+        extensionRef: "firebase/storage-resize-images",
+        kitPackage: "@firebase-function-kits/storage-resize-images",
+      });
+
+      await migrateModule.migrate("test-project", { extension: "storage-resize-images" });
+
+      expect(promptStub.calledOnce).to.be.true;
+      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
+        .true;
+    });
+  });
+
+  describe("migrate flow (--ext-instance flag)", () => {
+    it("should throw error if specified instance is not found", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
+
+      await expect(
+        migrateModule.migrate("test-project", { extInstance: "non-existent" }),
+      ).to.be.rejectedWith(FirebaseError, /Extension instance non-existent was not found/);
+    });
+
+    it("should throw error if specified instance cannot be migrated", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
+
+      await expect(
+        migrateModule.migrate("test-project", { extInstance: "custom-ext" }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /This extension does not have an associated function kit/,
+      );
+    });
+
+    it("should select specified instance and output TODO", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
+
+      await migrateModule.migrate("test-project", { extInstance: "resize-1" });
+
+      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
+        .true;
+    });
+  });
+});

--- a/src/extensions/migrate.spec.ts
+++ b/src/extensions/migrate.spec.ts
@@ -189,18 +189,30 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
       );
     });
 
+    it("should allow migration when --package override is passed for extension with no counterpart", async () => {
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
+
+      await migrateModule.migrate("test-project", {
+        extension: "my-publisher/unknown-extension",
+        package: "@custom/override-package",
+      });
+
+      expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
+        .true;
+    });
+
     it("should throw error if specified extension is not installed", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
 
       await expect(
-        migrateModule.migrate("test-project", { extension: "firestore-send-email" }),
-      ).to.be.rejectedWith(FirebaseError, /Extension firestore-send-email is not installed/);
+        migrateModule.migrate("test-project", { extension: "non-existent-extension" }),
+      ).to.be.rejectedWith(FirebaseError, /Extension non-existent-extension is not installed/);
     });
 
     it("should auto-select single matching instance and output TODO", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
 
-      await migrateModule.migrate("test-project", { extension: "storage-resize-images" });
+      await migrateModule.migrate("test-project", { extension: "firestore-send-email" });
 
       expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
         .true;
@@ -210,12 +222,12 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1, mockInstance2]);
       const promptStub = sandbox.stub(migrateModule, "promptInstanceSelection").resolves({
         instance: mockInstance1,
-        instanceId: "resize-1",
-        extensionRef: "firebase/storage-resize-images",
-        kitPackage: "@firebase-function-kits/storage-resize-images",
+        instanceId: "email-1",
+        extensionRef: "firebase/firestore-send-email",
+        kitPackage: "@firebase/firestore-send-email",
       });
 
-      await migrateModule.migrate("test-project", { extension: "storage-resize-images" });
+      await migrateModule.migrate("test-project", { extension: "firestore-send-email" });
 
       expect(promptStub.calledOnce).to.be.true;
       expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
@@ -246,7 +258,7 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
     it("should select specified instance and output TODO", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockInstance1]);
 
-      await migrateModule.migrate("test-project", { extInstance: "resize-1" });
+      await migrateModule.migrate("test-project", { extInstance: "email-1" });
 
       expect((logger.info as sinon.SinonSpy).calledWith("TODO: Draw the rest of the owl")).to.be
         .true;

--- a/src/extensions/migrate.spec.ts
+++ b/src/extensions/migrate.spec.ts
@@ -231,6 +231,26 @@ describe("ext:migrate core logic (Unique Veneer)", () => {
       );
     });
 
+    it("should throw error if third-party extension matching shortName has no kit package for its actual ref", async () => {
+      const mockThirdPartyInstance: ExtensionInstance = {
+        ...mockInstance1,
+        config: {
+          ...mockInstance1.config,
+          extensionRef: "otherpublisher/firestore-send-email",
+        },
+      };
+      sandbox.stub(extensionsApi, "listInstances").resolves([mockThirdPartyInstance]);
+
+      await expect(
+        migrateModule.createMigrationPlan("test-project", {
+          extension: "firestore-send-email",
+        }),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        /This extension does not have an associated function kit/,
+      );
+    });
+
     it("should allow migration when --package override is passed for extension with no counterpart", async () => {
       sandbox.stub(extensionsApi, "listInstances").resolves([mockUnknownInstance]);
 

--- a/src/extensions/migrate.ts
+++ b/src/extensions/migrate.ts
@@ -194,13 +194,6 @@ export async function migrate(projectId: string, options: MigrateOptions): Promi
 
     selectedInstanceInfo = await promptInstanceSelection(migratable, options.nonInteractive);
   } else if (options.extension) {
-    const kitPkg = getKitPackage(options.extension, options.package);
-    if (!kitPkg) {
-      throw new FirebaseError(
-        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
-      );
-    }
-
     const matchingInstances = instances.filter((inst) => {
       const ref = getExtensionRef(inst);
       return (
@@ -213,6 +206,13 @@ export async function migrate(projectId: string, options: MigrateOptions): Promi
     if (matchingInstances.length === 0) {
       throw new FirebaseError(
         `Extension ${options.extension} is not installed on project ${projectId}.`,
+      );
+    }
+
+    const kitPkg = getKitPackage(options.extension, options.package);
+    if (!kitPkg) {
+      throw new FirebaseError(
+        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
       );
     }
 

--- a/src/extensions/migrate.ts
+++ b/src/extensions/migrate.ts
@@ -24,12 +24,14 @@ export interface ExtensionTableRow {
   kitPackage: string;
 }
 
-export interface MigratableInstanceInfo {
+export interface ExtensionMigrationPlan {
   instance: ExtensionInstance;
   instanceId: string;
   extensionRef: string;
   kitPackage: string;
 }
+
+export type MigratableInstanceInfo = ExtensionMigrationPlan;
 
 interface ReplacementEntry {
   status?: string;
@@ -99,10 +101,12 @@ export function formatExtensionsTable(
     }
     const kitPkg = getKitPackage(ref, packageOverride) ?? "N/A";
 
-    if (!grouped.has(ref)) {
-      grouped.set(ref, { publisher, instances: [], kitPackage: kitPkg });
+    const groupEntry = grouped.get(ref);
+    if (!groupEntry) {
+      grouped.set(ref, { publisher, instances: [instanceId], kitPackage: kitPkg });
+    } else {
+      groupEntry.instances.push(instanceId);
     }
-    grouped.get(ref)!.instances.push(instanceId);
   });
 
   const rows: ExtensionTableRow[] = [];
@@ -165,41 +169,46 @@ export async function promptInstanceSelection(
 }
 
 /**
- * Unique veneer entrypoint for ext:migrate logic.
+ * Creates an extension migration plan for ext:migrate logic (Unique veneer).
  */
-export async function migrate(projectId: string, options: MigrateOptions): Promise<void> {
+export async function createMigrationPlan(
+  projectId: string,
+  options: MigrateOptions,
+): Promise<ExtensionMigrationPlan> {
   const instances = await listInstances(projectId);
 
-  let selectedInstanceInfo: MigratableInstanceInfo | undefined;
-
-  if (!options.extInstance && !options.extension) {
-    if (instances.length === 0) {
-      logLabeledBullet(
-        logPrefix,
-        `All extensions in project ${clc.bold(projectId)} have already been migrated.`,
-      );
-      return;
-    }
-
-    const { tableString } = formatExtensionsTable(instances, options.package);
-    logLabeledBullet(logPrefix, `list of extensions installed in ${clc.bold(projectId)}:`);
-    logger.info(tableString);
-
-    const migratable = getMigratableInstances(instances, options.package);
-    if (migratable.length === 0) {
+  if (options.extInstance) {
+    const foundInstance = instances.find((inst) => getInstanceId(inst) === options.extInstance);
+    if (!foundInstance) {
       throw new FirebaseError(
-        "No remaining Extensions have an associated function kit. Please reach out to the extension author to request one",
+        `Extension instance ${options.extInstance} was not found on project ${projectId}.`,
       );
     }
 
-    selectedInstanceInfo = await promptInstanceSelection(migratable, options.nonInteractive);
-  } else if (options.extension) {
+    const ref = getExtensionRef(foundInstance);
+    const kitPkg = getKitPackage(ref, options.package);
+    if (!kitPkg) {
+      throw new FirebaseError(
+        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
+      );
+    }
+
+    return {
+      instance: foundInstance,
+      instanceId: getInstanceId(foundInstance),
+      extensionRef: ref,
+      kitPackage: kitPkg,
+    };
+  }
+
+  if (options.extension) {
+    const targetExt = options.extension;
     const matchingInstances = instances.filter((inst) => {
       const ref = getExtensionRef(inst);
       return (
-        ref === options.extension ||
-        (ref.includes("/") && ref.split("/")[1] === options.extension) ||
-        (options.extension!.includes("/") && ref === options.extension!.split("/")[1])
+        ref === targetExt ||
+        (ref.includes("/") && ref.split("/")[1] === targetExt) ||
+        (targetExt.includes("/") && ref === targetExt.split("/")[1])
       );
     });
 
@@ -218,53 +227,39 @@ export async function migrate(projectId: string, options: MigrateOptions): Promi
 
     if (matchingInstances.length === 1) {
       const inst = matchingInstances[0];
-      selectedInstanceInfo = {
+      return {
         instance: inst,
         instanceId: getInstanceId(inst),
         extensionRef: getExtensionRef(inst),
         kitPackage: kitPkg,
       };
-    } else {
-      const migratableChoices = matchingInstances.map((inst) => ({
-        instance: inst,
-        instanceId: getInstanceId(inst),
-        extensionRef: getExtensionRef(inst),
-        kitPackage: kitPkg,
-      }));
-      selectedInstanceInfo = await promptInstanceSelection(
-        migratableChoices,
-        options.nonInteractive,
-      );
-    }
-  } else if (options.extInstance) {
-    const foundInstance = instances.find((inst) => getInstanceId(inst) === options.extInstance);
-    if (!foundInstance) {
-      throw new FirebaseError(
-        `Extension instance ${options.extInstance} was not found on project ${projectId}.`,
-      );
     }
 
-    const ref = getExtensionRef(foundInstance);
-    const kitPkg = getKitPackage(ref, options.package);
-    if (!kitPkg) {
-      throw new FirebaseError(
-        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
-      );
-    }
-
-    selectedInstanceInfo = {
-      instance: foundInstance,
-      instanceId: getInstanceId(foundInstance),
-      extensionRef: ref,
+    const migratableChoices = matchingInstances.map((inst) => ({
+      instance: inst,
+      instanceId: getInstanceId(inst),
+      extensionRef: getExtensionRef(inst),
       kitPackage: kitPkg,
-    };
+    }));
+    return promptInstanceSelection(migratableChoices, options.nonInteractive);
   }
 
-  if (selectedInstanceInfo) {
-    logLabeledBullet(
-      logPrefix,
-      `Selected instance ${clc.bold(selectedInstanceInfo.instanceId)} (${selectedInstanceInfo.kitPackage}) for migration.`,
+  if (instances.length === 0) {
+    throw new FirebaseError(
+      `All extensions in project ${clc.bold(projectId)} have already been migrated.`,
     );
-    logger.info("TODO: Draw the rest of the owl");
   }
+
+  const { tableString } = formatExtensionsTable(instances, options.package);
+  logLabeledBullet(logPrefix, `list of extensions installed in ${clc.bold(projectId)}:`);
+  logger.info(tableString);
+
+  const migratable = getMigratableInstances(instances, options.package);
+  if (migratable.length === 0) {
+    throw new FirebaseError(
+      "No remaining Extensions have an associated function kit. Please reach out to the extension author to request one",
+    );
+  }
+
+  return promptInstanceSelection(migratable, options.nonInteractive);
 }

--- a/src/extensions/migrate.ts
+++ b/src/extensions/migrate.ts
@@ -53,10 +53,6 @@ export function getKitPackage(extensionRef: string, packageOverride?: string): s
   if (!entry && !extensionRef.includes("/")) {
     entry = map[`firebase/${extensionRef}`];
   }
-  if (!entry && extensionRef.includes("/")) {
-    const shortName = extensionRef.split("/")[1];
-    entry = map[shortName];
-  }
 
   if (entry && entry.npmPackage && entry.status === "REPLACEMENT_AVAILABLE") {
     return entry.npmPackage;
@@ -188,8 +184,9 @@ export async function createMigrationPlan(
     const ref = getExtensionRef(foundInstance);
     const kitPkg = getKitPackage(ref, options.package);
     if (!kitPkg) {
+      // TODO: Consider including references to a skill once considered production ready.
       throw new FirebaseError(
-        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
+        "This extension does not have an associated function kit. You can create your own function kit by forking the extension.",
       );
     }
 
@@ -230,8 +227,9 @@ export async function createMigrationPlan(
       );
 
     if (matchingInstancesWithKit.length === 0) {
+      // TODO: Consider including references to a skill once considered production ready.
       throw new FirebaseError(
-        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
+        "This extension does not have an associated function kit. You can create your own function kit by forking the extension.",
       );
     }
 
@@ -266,8 +264,9 @@ export async function createMigrationPlan(
 
   const migratable = getMigratableInstances(instances, options.package);
   if (migratable.length === 0) {
+    // TODO: Consider including references to a skill once considered production ready.
     throw new FirebaseError(
-      "No remaining Extensions have an associated function kit. Please reach out to the extension author to request one",
+      "No remaining Extensions have an associated function kit. You can create your own function kit by forking the extension.",
     );
   }
 

--- a/src/extensions/migrate.ts
+++ b/src/extensions/migrate.ts
@@ -218,27 +218,37 @@ export async function createMigrationPlan(
       );
     }
 
-    const kitPkg = getKitPackage(options.extension, options.package);
-    if (!kitPkg) {
+    const matchingInstancesWithKit = matchingInstances
+      .map((inst) => {
+        const ref = getExtensionRef(inst);
+        const kitPkg = getKitPackage(ref, options.package);
+        return { inst, ref, kitPkg };
+      })
+      .filter(
+        (item): item is { inst: ExtensionInstance; ref: string; kitPkg: string } =>
+          item.kitPkg !== undefined,
+      );
+
+    if (matchingInstancesWithKit.length === 0) {
       throw new FirebaseError(
         "This extension does not have an associated function kit. Please reach out to the extension author to request one",
       );
     }
 
-    if (matchingInstances.length === 1) {
-      const inst = matchingInstances[0];
+    if (matchingInstancesWithKit.length === 1) {
+      const { inst, ref, kitPkg } = matchingInstancesWithKit[0];
       return {
         instance: inst,
         instanceId: getInstanceId(inst),
-        extensionRef: getExtensionRef(inst),
+        extensionRef: ref,
         kitPackage: kitPkg,
       };
     }
 
-    const migratableChoices = matchingInstances.map((inst) => ({
+    const migratableChoices = matchingInstancesWithKit.map(({ inst, ref, kitPkg }) => ({
       instance: inst,
       instanceId: getInstanceId(inst),
-      extensionRef: getExtensionRef(inst),
+      extensionRef: ref,
       kitPackage: kitPkg,
     }));
     return promptInstanceSelection(migratableChoices, options.nonInteractive);

--- a/src/extensions/migrate.ts
+++ b/src/extensions/migrate.ts
@@ -1,0 +1,270 @@
+import * as clc from "colorette";
+import * as Table from "cli-table3";
+
+import { FirebaseError } from "../error";
+import { logger } from "../logger";
+import { last, logLabeledBullet } from "../utils";
+import { logPrefix } from "./extensionsHelper";
+import { listInstances } from "./extensionsApi";
+import { ExtensionInstance } from "./types";
+import { select } from "../prompt";
+import * as replacements from "./replacements.json";
+
+export interface MigrateOptions {
+  package?: string;
+  extInstance?: string;
+  extension?: string;
+  nonInteractive?: boolean;
+}
+
+export interface ExtensionTableRow {
+  extension: string;
+  publisher: string;
+  instances: string[];
+  kitPackage: string;
+}
+
+export interface MigratableInstanceInfo {
+  instance: ExtensionInstance;
+  instanceId: string;
+  extensionRef: string;
+  kitPackage: string;
+}
+
+interface ReplacementEntry {
+  status?: string;
+  extensionRepositoryUrl?: string;
+  npmPackage?: string;
+}
+
+/**
+ * Returns the mapped kit package for an extension reference, or undefined if not found.
+ */
+export function getKitPackage(extensionRef: string, packageOverride?: string): string | undefined {
+  if (packageOverride) {
+    return packageOverride;
+  }
+  const data = replacements as { replacements?: Record<string, ReplacementEntry> };
+  const map = data.replacements || {};
+
+  let entry = map[extensionRef];
+  if (!entry && !extensionRef.includes("/")) {
+    entry = map[`firebase/${extensionRef}`];
+  }
+  if (!entry && extensionRef.includes("/")) {
+    const shortName = extensionRef.split("/")[1];
+    entry = map[shortName];
+  }
+
+  if (entry && entry.npmPackage && entry.status === "REPLACEMENT_AVAILABLE") {
+    return entry.npmPackage;
+  }
+  return undefined;
+}
+
+/**
+ * Extracts instance ID from full instance resource name or config.
+ */
+export function getInstanceId(instance: ExtensionInstance): string {
+  return last(instance.name.split("/")) ?? instance.name;
+}
+
+/**
+ * Extracts extension reference from instance config.
+ */
+export function getExtensionRef(instance: ExtensionInstance): string {
+  return instance.config.extensionRef || instance.config.source?.spec?.name || "";
+}
+
+/**
+ * Formats the table of installed extensions and their mapped kit packages.
+ */
+export function formatExtensionsTable(
+  instances: ExtensionInstance[],
+  packageOverride?: string,
+): { tableString: string; rows: ExtensionTableRow[] } {
+  const table = new Table({
+    head: ["Extension", "publisher", "Instances", "kit package"],
+    style: { head: ["yellow"] },
+  });
+
+  const grouped = new Map<string, { publisher: string; instances: string[]; kitPackage: string }>();
+
+  instances.forEach((instance) => {
+    const ref = getExtensionRef(instance);
+    const instanceId = getInstanceId(instance);
+    let publisher = "N/A";
+    if (ref.includes("/")) {
+      publisher = ref.split("/")[0];
+    }
+    const kitPkg = getKitPackage(ref, packageOverride) ?? "N/A";
+
+    if (!grouped.has(ref)) {
+      grouped.set(ref, { publisher, instances: [], kitPackage: kitPkg });
+    }
+    grouped.get(ref)!.instances.push(instanceId);
+  });
+
+  const rows: ExtensionTableRow[] = [];
+  grouped.forEach((data, ref) => {
+    table.push([ref, data.publisher, data.instances.join(", "), data.kitPackage]);
+    rows.push({
+      extension: ref,
+      publisher: data.publisher,
+      instances: data.instances,
+      kitPackage: data.kitPackage,
+    });
+  });
+
+  return { tableString: table.toString(), rows };
+}
+
+/**
+ * Returns list of instances that can be migrated (have a mapped kit package).
+ */
+export function getMigratableInstances(
+  instances: ExtensionInstance[],
+  packageOverride?: string,
+): MigratableInstanceInfo[] {
+  const result: MigratableInstanceInfo[] = [];
+  for (const instance of instances) {
+    const ref = getExtensionRef(instance);
+    const instanceId = getInstanceId(instance);
+    const kitPkg = getKitPackage(ref, packageOverride);
+    if (kitPkg) {
+      result.push({
+        instance,
+        instanceId,
+        extensionRef: ref,
+        kitPackage: kitPkg,
+      });
+    }
+  }
+  return result;
+}
+
+/**
+ * Helper to prompt instance selection dialog.
+ */
+export async function promptInstanceSelection(
+  migratableInstances: MigratableInstanceInfo[],
+  nonInteractive?: boolean,
+): Promise<MigratableInstanceInfo> {
+  const choices = migratableInstances.map((item) => ({
+    name: `${item.instanceId} (${item.extensionRef})`,
+    value: item,
+  }));
+
+  const selected = await select<MigratableInstanceInfo>({
+    message: "Which extension instance would you like to migrate?",
+    choices,
+    nonInteractive,
+  });
+
+  return selected;
+}
+
+/**
+ * Unique veneer entrypoint for ext:migrate logic.
+ */
+export async function migrate(projectId: string, options: MigrateOptions): Promise<void> {
+  const instances = await listInstances(projectId);
+
+  let selectedInstanceInfo: MigratableInstanceInfo | undefined;
+
+  if (!options.extInstance && !options.extension) {
+    if (instances.length === 0) {
+      logLabeledBullet(
+        logPrefix,
+        `All extensions in project ${clc.bold(projectId)} have already been migrated.`,
+      );
+      return;
+    }
+
+    const { tableString } = formatExtensionsTable(instances, options.package);
+    logLabeledBullet(logPrefix, `list of extensions installed in ${clc.bold(projectId)}:`);
+    logger.info(tableString);
+
+    const migratable = getMigratableInstances(instances, options.package);
+    if (migratable.length === 0) {
+      throw new FirebaseError(
+        "No remaining Extensions have an associated function kit. Please reach out to the extension author to request one",
+      );
+    }
+
+    selectedInstanceInfo = await promptInstanceSelection(migratable, options.nonInteractive);
+  } else if (options.extension) {
+    const kitPkg = getKitPackage(options.extension, options.package);
+    if (!kitPkg) {
+      throw new FirebaseError(
+        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
+      );
+    }
+
+    const matchingInstances = instances.filter((inst) => {
+      const ref = getExtensionRef(inst);
+      return (
+        ref === options.extension ||
+        (ref.includes("/") && ref.split("/")[1] === options.extension) ||
+        (options.extension!.includes("/") && ref === options.extension!.split("/")[1])
+      );
+    });
+
+    if (matchingInstances.length === 0) {
+      throw new FirebaseError(
+        `Extension ${options.extension} is not installed on project ${projectId}.`,
+      );
+    }
+
+    if (matchingInstances.length === 1) {
+      const inst = matchingInstances[0];
+      selectedInstanceInfo = {
+        instance: inst,
+        instanceId: getInstanceId(inst),
+        extensionRef: getExtensionRef(inst),
+        kitPackage: kitPkg,
+      };
+    } else {
+      const migratableChoices = matchingInstances.map((inst) => ({
+        instance: inst,
+        instanceId: getInstanceId(inst),
+        extensionRef: getExtensionRef(inst),
+        kitPackage: kitPkg,
+      }));
+      selectedInstanceInfo = await promptInstanceSelection(
+        migratableChoices,
+        options.nonInteractive,
+      );
+    }
+  } else if (options.extInstance) {
+    const foundInstance = instances.find((inst) => getInstanceId(inst) === options.extInstance);
+    if (!foundInstance) {
+      throw new FirebaseError(
+        `Extension instance ${options.extInstance} was not found on project ${projectId}.`,
+      );
+    }
+
+    const ref = getExtensionRef(foundInstance);
+    const kitPkg = getKitPackage(ref, options.package);
+    if (!kitPkg) {
+      throw new FirebaseError(
+        "This extension does not have an associated function kit. Please reach out to the extension author to request one",
+      );
+    }
+
+    selectedInstanceInfo = {
+      instance: foundInstance,
+      instanceId: getInstanceId(foundInstance),
+      extensionRef: ref,
+      kitPackage: kitPkg,
+    };
+  }
+
+  if (selectedInstanceInfo) {
+    logLabeledBullet(
+      logPrefix,
+      `Selected instance ${clc.bold(selectedInstanceInfo.instanceId)} (${selectedInstanceInfo.kitPackage}) for migration.`,
+    );
+    logger.info("TODO: Draw the rest of the owl");
+  }
+}


### PR DESCRIPTION
### Description

Adds a the start of ext:migrate, guarded by the extMigrationFeatures experiment.

This implements the top of the state diagram in the API proposal. After this code runs, the tool knows which extension instance to migrate.

### Scenarios Tested

Manually tested:
* no flags on a project with no extensions (correctly says all extensions have been migrated)
* no flags on a project exclusively with extensions that cannot be migrated (shows table, errors that none can be migrated)
* no flags on a project with extensions that can be migrated (shows table, presents selector only for migratable extensions)
* `--ext-instance <real instance>` (correctly chooses that instance to migrate)
* `--ext-instance <fake instance>` (errors that the instance cannot be found)
* `--extension <not in the project>` (errors that the extension is not installed)
* `--extension <has no counterpart>` (errors that there is no kit to migrate to, unless --package is passed)
* `--extension <has counterpart, one instance>` (selects the instance)
* `--extension <has counterpart, more than one instance>` (provides selector for the instance)

### Notes:

This does not fix that the replacements.json has the wrong package names (it was created before the package names were finalized in git)