### PR TITLE
fix: explicitly install packages with --save-prefix=^

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -432,10 +432,14 @@ describe("functions:kits:install", () => {
 
   describe("buildAndInstallKit", () => {
     it("should run npm install and npm run build without --ignore-scripts for first-party kit", async () => {
-      await buildAndInstallKit("/abs/path", false);
+      await buildAndInstallKit("/abs/path", "@firebase-functions-kits/my-kit", false);
 
       expect(wrapSpawnStub).to.have.been.calledTwice;
-      expect(wrapSpawnStub.firstCall).to.have.been.calledWith("npm", ["install"], "/abs/path");
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install", "@firebase-functions-kits/my-kit", "--save-prefix=^"],
+        "/abs/path",
+      );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
         "npm",
         ["run", "build"],
@@ -443,7 +447,7 @@ describe("functions:kits:install", () => {
       );
       expect(loggerInfoStub).to.have.been.calledWith(
         sinon.match(/functions:/),
-        sinon.match(/Running npm install\.\.\./),
+        sinon.match(/Running npm install @firebase-functions-kits\/my-kit --save-prefix=\^\.\.\./),
       );
       expect(loggerInfoStub).to.have.been.calledWith(
         sinon.match(/functions:/),
@@ -452,12 +456,12 @@ describe("functions:kits:install", () => {
     });
 
     it("should run npm install with --ignore-scripts for third-party kit", async () => {
-      await buildAndInstallKit("/abs/path", true);
+      await buildAndInstallKit("/abs/path", "third-party-kit", true);
 
       expect(wrapSpawnStub).to.have.been.calledTwice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
-        ["install", "--ignore-scripts"],
+        ["install", "third-party-kit", "--save-prefix=^", "--ignore-scripts"],
         "/abs/path",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
@@ -467,7 +471,7 @@ describe("functions:kits:install", () => {
       );
       expect(loggerInfoStub).to.have.been.calledWith(
         sinon.match(/functions:/),
-        sinon.match(/Running npm install --ignore-scripts\.\.\./),
+        sinon.match(/Running npm install third-party-kit --save-prefix=\^ --ignore-scripts\.\.\./),
       );
       expect(loggerInfoStub).to.have.been.calledWith(
         sinon.match(/functions:/),
@@ -478,7 +482,7 @@ describe("functions:kits:install", () => {
     it("should throw FirebaseError if npm install fails", async () => {
       wrapSpawnStub.onFirstCall().rejects(new Error("npm install error"));
 
-      await expect(buildAndInstallKit("/abs/path", false)).to.be.rejectedWith(
+      await expect(buildAndInstallKit("/abs/path", "my-kit", false)).to.be.rejectedWith(
         FirebaseError,
         /NPM install failed: npm install error/,
       );
@@ -488,7 +492,7 @@ describe("functions:kits:install", () => {
       wrapSpawnStub.onFirstCall().resolves();
       wrapSpawnStub.onSecondCall().rejects(new Error("tsc build error"));
 
-      await expect(buildAndInstallKit("/abs/path", false)).to.be.rejectedWith(
+      await expect(buildAndInstallKit("/abs/path", "my-kit", false)).to.be.rejectedWith(
         FirebaseError,
         /TypeScript build failed: tsc build error/,
       );
@@ -768,7 +772,7 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub).to.have.been.calledTwice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
-        ["install"],
+        ["install", "@firebase-functions-kits/firestore-bigquery-export@1.0.0", "--save-prefix=^"],
         "/mock/project/function-kits/firestore-bigquery-export/source",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
@@ -781,10 +785,6 @@ describe("functions:kits:install", () => {
         "function-kits/firestore-bigquery-export/source/package.json"
       ] as { name?: string; dependencies?: Record<string, string> };
       expect(pkgJsonResult.name).to.equal("firestore-bigquery-export-wrapper");
-      expect(pkgJsonResult.dependencies).to.have.property(
-        "@firebase-functions-kits/firestore-bigquery-export",
-        "1.0.0",
-      );
 
       expect(writtenFiles["function-kits/firestore-bigquery-export/source/src/index.ts"]).to.be.a(
         "string",
@@ -847,7 +847,7 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub).to.have.been.calledTwice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
-        ["install"],
+        ["install", "@firebase-functions-kits/firestore-bigquery-export@1.0.0", "--save-prefix=^"],
         "/mock/project/function-kits/my-custom-kit/source",
       );
 
@@ -889,7 +889,7 @@ describe("functions:kits:install", () => {
       expect(wrapSpawnStub).to.have.been.calledTwice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
-        ["install", "--ignore-scripts"],
+        ["install", "@third-party/custom-kit", "--save-prefix=^", "--ignore-scripts"],
         "/mock/project/function-kits/custom-kit/source",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -473,8 +473,6 @@ async function writeKitPackageJson(
   config: Config,
   sourcePath: string,
   kitId: string,
-  packageName: string,
-  version?: string,
 ): Promise<void> {
   const relPackageJsonPath = path.join(sourcePath, "package.json");
   const absPackageJsonPath = config.path(relPackageJsonPath);
@@ -505,10 +503,8 @@ async function writeKitPackageJson(
     }
   }
 
-  // Ensure the wrapper package has a unique name and depends on the specified kit package and version.
+  // Ensure the wrapper package has a unique name.
   pkgJson.name = `${kitId}-wrapper`;
-  pkgJson.dependencies = pkgJson.dependencies || {};
-  pkgJson.dependencies[packageName] = version || "latest";
 
   await config.askWriteProjectFile(relPackageJsonPath, pkgJson);
 }
@@ -539,7 +535,6 @@ export async function scaffoldKitFiles(
   kitId: string,
   instanceId: string,
   packageName: string,
-  version?: string,
   templateType: TemplateType = DEFAULT_TEMPLATE,
 ): Promise<ScaffoldedKitPaths> {
   const sourcePath = path.join(FUNCTION_KITS_DIR, kitId, "source");
@@ -551,7 +546,7 @@ export async function scaffoldKitFiles(
   await fs.ensureDir(absSourcePath);
   await fs.ensureDir(absConfigDirPath);
 
-  await writeKitPackageJson(config, sourcePath, kitId, packageName, version);
+  await writeKitPackageJson(config, sourcePath, kitId);
   await config.askWriteProjectFile(path.join(sourcePath, "tsconfig.json"), TSCONFIG_TEMPLATE);
   await config.askWriteProjectFile(path.join(sourcePath, ".gitignore"), GITIGNORE_TEMPLATE);
   await writeKitIndexTs(config, sourcePath, packageName, templateType);
@@ -564,9 +559,13 @@ export async function scaffoldKitFiles(
  */
 export async function buildAndInstallKit(
   absSourcePath: string,
+  rawPkgName: string,
   isThirdParty: boolean,
 ): Promise<void> {
-  const installArgs = isThirdParty ? ["install", "--ignore-scripts"] : ["install"];
+  const installArgs = ["install", rawPkgName, "--save-prefix=^"];
+  if (isThirdParty) {
+    installArgs.push("--ignore-scripts");
+  }
   logLabeledBullet("functions", `Running npm ${installArgs.join(" ")}...`);
   try {
     await wrapSpawn("npm", installArgs, absSourcePath);
@@ -706,7 +705,7 @@ export const command = new Command("functions:kits:install")
       throw new FirebaseError("Set the --package option to a valid NPM package and try again.");
     }
 
-    const { packageName, version } = parseNpmPackageSpecifier(rawPkgName);
+    const { packageName } = parseNpmPackageSpecifier(rawPkgName);
     validateNpmPackageName(packageName);
 
     const existingFunctionsInfo = extractExistingFunctionsInfo(options.config.src.functions);
@@ -743,11 +742,10 @@ export const command = new Command("functions:kits:install")
       kitId,
       instanceId,
       packageName,
-      version,
       templateType,
     );
 
-    await buildAndInstallKit(absSourcePath, isThirdParty);
+    await buildAndInstallKit(absSourcePath, rawPkgName, isThirdParty);
 
     addKitToConfig(options.config, kitId, instanceId, packageName, sourcePath, configDirPath);
 


### PR DESCRIPTION
### Description

This will make sure that npm packages we install for kits can accept any non-major version update.

### Scenarios Tested

* `firebase functions:kits:install --package <package>@0.1.0` installs and updates package.json with "^0.1.0" version.
* `firebase functions:kits:install --package <package>@latest` installs and updates package.json with "^0.1.0" version.