### PR TITLE
fix: update typo for 1p kits to firebase-function-kits

### DIFF
--- a/schema/firebase-config.json
+++ b/schema/firebase-config.json
@@ -1018,7 +1018,7 @@
                     "description": "Package details when resolved from a package repository.",
                     "properties": {
                         "name": {
-                            "description": "Package name (e.g., \"@firebase-functions-kits/firestore-bigquery-export\")",
+                            "description": "Package name (e.g., \"@firebase-function-kits/firestore-bigquery-export\")",
                             "type": "string"
                         }
                     },

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -33,7 +33,7 @@ describe("functions:kits:install", () => {
 
       await expect(
         command.runner()({
-          package: "@firebase-functions-kits/firestore-bigquery-export",
+          package: "@firebase-function-kits/firestore-bigquery-export",
           cwd: "/mock/project",
           nonInteractive: true,
         }),
@@ -45,7 +45,7 @@ describe("functions:kits:install", () => {
     it("should throw an error if not in a Firebase project directory", async () => {
       await expect(
         command.runner()({
-          package: "@firebase-functions-kits/firestore-bigquery-export",
+          package: "@firebase-function-kits/firestore-bigquery-export",
           cwd: "/mock/project",
           nonInteractive: true,
         }),
@@ -87,7 +87,7 @@ describe("functions:kits:install", () => {
       };
 
       await command.runner()({
-        package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
         template: "migration",
         cwd: "/mock/project",
         config: mockConfig,
@@ -99,7 +99,7 @@ describe("functions:kits:install", () => {
 
       expect(installKitOrInstanceStub).to.have.been.calledOnceWith({
         config: mockConfig,
-        package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
         template: "migration",
         nonInteractive: true,
         project: "my-project",

--- a/src/deploy/functions/prepare.spec.ts
+++ b/src/deploy/functions/prepare.spec.ts
@@ -233,7 +233,7 @@ describe("prepare", () => {
         const config: ValidatedConfig = [
           {
             kit: "my-kit",
-            sourcePackage: { name: "@firebase-functions-kits/my-kit" },
+            sourcePackage: { name: "@firebase-function-kits/my-kit" },
             source: "source",
             instances: {
               "inst-alpha": "config/inst-alpha",
@@ -266,7 +266,7 @@ describe("prepare", () => {
         const config: ValidatedConfig = [
           {
             kit: "my-kit",
-            sourcePackage: { name: "@firebase-functions-kits/my-kit" },
+            sourcePackage: { name: "@firebase-function-kits/my-kit" },
             source: "source",
             instances: {
               "inst-alpha": "config/inst-alpha",

--- a/src/firebaseConfig.ts
+++ b/src/firebaseConfig.ts
@@ -198,7 +198,7 @@ type CodebaseFunctionConfigBase = FunctionConfigBase & {
 };
 
 export type KitSourcePackage = {
-  /** Package name (e.g., "@firebase-functions-kits/firestore-bigquery-export") */
+  /** Package name (e.g., "@firebase-function-kits/firestore-bigquery-export") */
   name: string;
 };
 

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -78,7 +78,7 @@ describe("functions/kits/install", () => {
 
     it("should accept valid scoped package names with exactly one slash", () => {
       expect(() =>
-        validateNpmPackageName("@firebase-functions-kits/firestore-bigquery-export"),
+        validateNpmPackageName("@firebase-function-kits/firestore-bigquery-export"),
       ).to.not.throw();
       expect(() => validateNpmPackageName("@invertase/example-kit")).to.not.throw();
     });
@@ -139,38 +139,38 @@ describe("functions/kits/install", () => {
   describe("parseNpmPackageSpecifier", () => {
     it("should parse scoped package with version", () => {
       const res = parseNpmPackageSpecifier(
-        "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        "@firebase-function-kits/firestore-bigquery-export@1.0.0",
       );
       expect(res).to.deep.equal({
-        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+        packageName: "@firebase-function-kits/firestore-bigquery-export",
         version: "1.0.0",
       });
     });
 
     it("should parse scoped package with release candidate version", () => {
       const res = parseNpmPackageSpecifier(
-        "@firebase-functions-kits/firestore-bigquery-export@1.0.0-rc.1",
+        "@firebase-function-kits/firestore-bigquery-export@1.0.0-rc.1",
       );
       expect(res).to.deep.equal({
-        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+        packageName: "@firebase-function-kits/firestore-bigquery-export",
         version: "1.0.0-rc.1",
       });
     });
 
     it("should parse scoped package with tag", () => {
       const res = parseNpmPackageSpecifier(
-        "@firebase-functions-kits/firestore-bigquery-export@latest",
+        "@firebase-function-kits/firestore-bigquery-export@latest",
       );
       expect(res).to.deep.equal({
-        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+        packageName: "@firebase-function-kits/firestore-bigquery-export",
         version: "latest",
       });
     });
 
     it("should parse scoped package without version", () => {
-      const res = parseNpmPackageSpecifier("@firebase-functions-kits/firestore-bigquery-export");
+      const res = parseNpmPackageSpecifier("@firebase-function-kits/firestore-bigquery-export");
       expect(res).to.deep.equal({
-        packageName: "@firebase-functions-kits/firestore-bigquery-export",
+        packageName: "@firebase-function-kits/firestore-bigquery-export",
       });
     });
 
@@ -201,7 +201,7 @@ describe("functions/kits/install", () => {
   describe("sanitizePackageNameToKitName", () => {
     it("should extract kit name from scoped package name", () => {
       expect(
-        sanitizePackageNameToKitName("@firebase-functions-kits/firestore-bigquery-export"),
+        sanitizePackageNameToKitName("@firebase-function-kits/firestore-bigquery-export"),
       ).to.equal("firestore-bigquery-export");
       expect(sanitizePackageNameToKitName("@foo/bar")).to.equal("bar");
     });
@@ -218,13 +218,13 @@ describe("functions/kits/install", () => {
   });
 
   describe("isThirdPartyPackage", () => {
-    it("should return false for packages under @firebase-functions-kits scope", () => {
-      expect(isThirdPartyPackage("@firebase-functions-kits/firestore-bigquery-export")).to.be.false;
+    it("should return false for packages under @firebase-function-kits scope", () => {
+      expect(isThirdPartyPackage("@firebase-function-kits/firestore-bigquery-export")).to.be.false;
     });
 
-    it("should return true for packages outside @firebase-functions-kits scope", () => {
+    it("should return true for packages outside @firebase-function-kits scope", () => {
       expect(isThirdPartyPackage("firebase-functions-kits")).to.be.true;
-      expect(isThirdPartyPackage("@firebase-functions-kits-fake/foo")).to.be.true;
+      expect(isThirdPartyPackage("@firebase-function-kits-fake/foo")).to.be.true;
       expect(isThirdPartyPackage("@other-scope/my-kit")).to.be.true;
       expect(isThirdPartyPackage("third-party-kit")).to.be.true;
     });
@@ -233,25 +233,25 @@ describe("functions/kits/install", () => {
   describe("checkPackageHasShrinkwrap", () => {
     it("should return true when npm pack output includes hasShrinkwrap", async () => {
       spawnWithOutputStub.resolves(JSON.stringify([{ hasShrinkwrap: true }]));
-      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      const res = await checkPackageHasShrinkwrap("@firebase-function-kits/my-kit");
       expect(res).to.be.true;
     });
 
     it("should return true when npm pack files list includes npm-shrinkwrap.json", async () => {
       spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "npm-shrinkwrap.json" }] }]));
-      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      const res = await checkPackageHasShrinkwrap("@firebase-function-kits/my-kit");
       expect(res).to.be.true;
     });
 
     it("should return false when npm-shrinkwrap.json is not in package", async () => {
       spawnWithOutputStub.resolves(JSON.stringify([{ files: [{ path: "package.json" }] }]));
-      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      const res = await checkPackageHasShrinkwrap("@firebase-function-kits/my-kit");
       expect(res).to.be.false;
     });
 
     it("should return false when npm pack fails", async () => {
       spawnWithOutputStub.rejects(new Error("npm pack error"));
-      const res = await checkPackageHasShrinkwrap("@firebase-functions-kits/my-kit");
+      const res = await checkPackageHasShrinkwrap("@firebase-function-kits/my-kit");
       expect(res).to.be.false;
     });
   });
@@ -772,8 +772,8 @@ describe("functions/kits/install", () => {
       const confirmStub = sinon.stub(prompt, "confirm");
 
       const res = await promptSecurityConfirmation(
-        "@firebase-functions-kits/my-kit",
-        "@firebase-functions-kits/my-kit",
+        "@firebase-function-kits/my-kit",
+        "@firebase-function-kits/my-kit",
       );
 
       expect(res).to.be.false;
@@ -785,14 +785,14 @@ describe("functions/kits/install", () => {
       const confirmStub = sinon.stub(prompt, "confirm").resolves(true);
 
       const res = await promptSecurityConfirmation(
-        "@firebase-functions-kits/my-kit",
-        "@firebase-functions-kits/my-kit",
+        "@firebase-function-kits/my-kit",
+        "@firebase-function-kits/my-kit",
       );
 
       expect(res).to.be.false;
       expect(confirmStub).to.have.been.calledOnceWith({
         message:
-          "Are you sure you want to install @firebase-functions-kits/my-kit without locked dependencies?",
+          "Are you sure you want to install @firebase-function-kits/my-kit without locked dependencies?",
         default: false,
         nonInteractive: undefined,
       });
@@ -829,8 +829,8 @@ describe("functions/kits/install", () => {
 
       await expect(
         promptSecurityConfirmation(
-          "@firebase-functions-kits/my-kit",
-          "@firebase-functions-kits/my-kit",
+          "@firebase-function-kits/my-kit",
+          "@firebase-function-kits/my-kit",
         ),
       ).to.be.rejectedWith(FirebaseError, "Installation cancelled.");
     });
@@ -894,12 +894,12 @@ describe("functions/kits/install", () => {
 
   describe("buildAndInstallKit", () => {
     it("should run npm install and npm run build without --ignore-scripts for first-party kit", async () => {
-      await buildAndInstallKit("/abs/path", "@firebase-functions-kits/my-kit", false);
+      await buildAndInstallKit("/abs/path", "@firebase-function-kits/my-kit", false);
 
       expect(wrapSpawnStub).to.have.been.calledTwice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
-        ["install", "@firebase-functions-kits/my-kit", "--save-prefix=^"],
+        ["install", "@firebase-function-kits/my-kit", "--save-prefix=^"],
         "/abs/path",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
@@ -1068,7 +1068,7 @@ describe("functions/kits/install", () => {
       const writtenFiles: Record<string, unknown> = {};
       const existingKit: ValidatedKitSingle = {
         kit: "firestore-bigquery-export",
-        sourcePackage: { name: "@firebase-functions-kits/firestore-bigquery-export" },
+        sourcePackage: { name: "@firebase-function-kits/firestore-bigquery-export" },
         source: "function-kits/firestore-bigquery-export/source",
         instances: {
           inst1: "function-kits/firestore-bigquery-export/config-inst1",
@@ -1117,7 +1117,7 @@ describe("functions/kits/install", () => {
     it("should configure env for existing instance when selected", async () => {
       const existingKit: ValidatedKitSingle = {
         kit: "firestore-bigquery-export",
-        sourcePackage: { name: "@firebase-functions-kits/firestore-bigquery-export" },
+        sourcePackage: { name: "@firebase-function-kits/firestore-bigquery-export" },
         source: "function-kits/firestore-bigquery-export/source",
         instances: {
           inst1: "function-kits/firestore-bigquery-export/config-inst1",
@@ -1197,7 +1197,7 @@ describe("functions/kits/install", () => {
       await expect(
         installKitOrInstance({
           config: mockConfig,
-          package: "@firebase-functions-kits/firestore-bigquery-export",
+          package: "@firebase-function-kits/firestore-bigquery-export",
           template: "invalid-template" as unknown as TemplateType,
         }),
       ).to.be.rejectedWith(
@@ -1223,7 +1223,7 @@ describe("functions/kits/install", () => {
 
       const res = await installKitOrInstance({
         config: mockConfig,
-        package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
         nonInteractive: true,
       });
 
@@ -1238,7 +1238,7 @@ describe("functions/kits/install", () => {
       expect(wrapSpawnStub).to.have.been.calledTwice;
       expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
         "npm",
-        ["install", "@firebase-functions-kits/firestore-bigquery-export@1.0.0", "--save-prefix=^"],
+        ["install", "@firebase-function-kits/firestore-bigquery-export@1.0.0", "--save-prefix=^"],
         "/mock/project/function-kits/firestore-bigquery-export/source",
       );
       expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
@@ -1252,7 +1252,7 @@ describe("functions/kits/install", () => {
           {
             kit: "firestore-bigquery-export",
             sourcePackage: {
-              name: "@firebase-functions-kits/firestore-bigquery-export",
+              name: "@firebase-function-kits/firestore-bigquery-export",
             },
             source: "function-kits/firestore-bigquery-export/source",
             instances: {
@@ -1282,7 +1282,7 @@ describe("functions/kits/install", () => {
 
       const res = await installKitOrInstance({
         config: mockConfig,
-        package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
         kitId: "custom-kit",
         instanceId: "custom-instance",
         nonInteractive: true,
@@ -1314,7 +1314,7 @@ describe("functions/kits/install", () => {
 
       await installKitOrInstance({
         config: mockConfig,
-        package: "@firebase-functions-kits/firestore-bigquery-export@1.0.0",
+        package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
         nonInteractive: true,
         seedEnv: {
           projectId: "target-proj",
@@ -1345,7 +1345,7 @@ describe("functions/kits/install", () => {
     it("should handle existing kit when package is already in firebase.json", async () => {
       const existingKit: ValidatedKitSingle = {
         kit: "firestore-bigquery-export",
-        sourcePackage: { name: "@firebase-functions-kits/firestore-bigquery-export" },
+        sourcePackage: { name: "@firebase-function-kits/firestore-bigquery-export" },
         source: "function-kits/firestore-bigquery-export/source",
         instances: {
           inst1: "function-kits/firestore-bigquery-export/config-inst1",
@@ -1361,7 +1361,7 @@ describe("functions/kits/install", () => {
 
       const res = await installKitOrInstance({
         config: mockConfig,
-        package: "@firebase-functions-kits/firestore-bigquery-export",
+        package: "@firebase-function-kits/firestore-bigquery-export",
         instanceId: "inst2",
         nonInteractive: true,
         project: "target-proj",

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -130,8 +130,8 @@ export function generateUniqueId(baseId: string, existingIds: Set<string>): stri
 
 /**
  * Parses an npm package specifier string into package name and version/tag.
- * e.g., "@firebase-functions-kits/firestore-bigquery-export@1.0.0" ->
- * { packageName: "@firebase-functions-kits/firestore-bigquery-export", version: "1.0.0" }
+ * e.g., "@firebase-function-kits/firestore-bigquery-export@1.0.0" ->
+ * { packageName: "@firebase-function-kits/firestore-bigquery-export", version: "1.0.0" }
  */
 export function parseNpmPackageSpecifier(rawPkg: string): {
   packageName: string;
@@ -163,7 +163,7 @@ export function validateNpmPackageName(packageName: string): void {
 
 /**
  * Sanitizes an npm package name into a valid kit identifier.
- * e.g., "@firebase-functions-kits/firestore-bigquery-export" -> "firestore-bigquery-export"
+ * e.g., "@firebase-function-kits/firestore-bigquery-export" -> "firestore-bigquery-export"
  */
 export function sanitizePackageNameToKitName(packageName: string): string {
   const parts = packageName.split("/");
@@ -173,10 +173,10 @@ export function sanitizePackageNameToKitName(packageName: string): string {
 }
 
 /**
- * Checks if a package name is third-party (outside the @firebase-functions-kits scope).
+ * Checks if a package name is third-party (outside the @firebase-function-kits scope).
  */
 export function isThirdPartyPackage(packageName: string): boolean {
-  return !packageName.startsWith("@firebase-functions-kits/");
+  return !packageName.startsWith("@firebase-function-kits/");
 }
 
 /**
@@ -380,7 +380,7 @@ export async function promptSecurityConfirmation(
   if (isThirdParty) {
     logLabeledWarning(
       "functions",
-      `Package ${clc.bold(packageName)} is a third-party kit (outside the @firebase-functions-kits scope).`,
+      `Package ${clc.bold(packageName)} is a third-party kit (outside the @firebase-function-kits scope).`,
     );
   }
 

--- a/src/functions/projectConfig.spec.ts
+++ b/src/functions/projectConfig.spec.ts
@@ -251,7 +251,7 @@ describe("projectConfig", () => {
       const VALID_KIT_CONFIG = {
         kit: "firestore-bigquery-export",
         sourcePackage: {
-          name: "@firebase-functions-kits/firestore-bigquery-export",
+          name: "@firebase-function-kits/firestore-bigquery-export",
         },
         instances: {
           "firestore-bigquery-export": "config/bq-instance-1",
@@ -631,7 +631,7 @@ describe("projectConfig", () => {
         const cfg = projectConfig.validate([
           {
             kit: "my-kit",
-            sourcePackage: { name: "@firebase-functions-kits/my-kit" },
+            sourcePackage: { name: "@firebase-function-kits/my-kit" },
             source: "kit-source",
             instances: {
               "inst-alpha": "config/inst-alpha",


### PR DESCRIPTION
### Description

We were declaring kits outside of firebase-functions-kits as 3P, instead of firebase-function-kits.

### Scenarios Tested

npm run test
