### PR TITLE
feat(functions): Support local directory function kits

### DIFF
--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -93,6 +93,26 @@ describe("functions:kits:install", () => {
       );
     });
 
+    it("should throw an error if both --directory and --template are provided", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => `/mock/project/${p}`,
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          directory: "./my-kit",
+          template: "migration",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /Cannot specify --template with --directory\./);
+    });
+
     it("should delegate to installKitOrInstance with the provided --package options", async () => {
       const mockConfig = {
         projectDir: "/mock/project",

--- a/src/commands/functions-kits-install.spec.ts
+++ b/src/commands/functions-kits-install.spec.ts
@@ -52,7 +52,7 @@ describe("functions:kits:install", () => {
       ).to.be.rejectedWith(FirebaseError, /firebase.json not found/);
     });
 
-    it("should throw an error if --package is not provided", async () => {
+    it("should throw an error if neither --package nor --directory is provided", async () => {
       const mockConfig = {
         projectDir: "/mock/project",
         src: {
@@ -67,13 +67,33 @@ describe("functions:kits:install", () => {
           config: mockConfig,
           nonInteractive: true,
         }),
+      ).to.be.rejectedWith(FirebaseError, /Must specify either --package or --directory\./);
+    });
+
+    it("should throw an error if both --package and --directory are provided", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => `/mock/project/${p}`,
+      } as unknown as Config;
+
+      await expect(
+        command.runner()({
+          package: "@firebase-function-kits/firestore-bigquery-export",
+          directory: "./my-kit",
+          cwd: "/mock/project",
+          config: mockConfig,
+          nonInteractive: true,
+        }),
       ).to.be.rejectedWith(
         FirebaseError,
-        /Set the --package option to a valid NPM package and try again\./,
+        /Cannot specify both --package and --directory\. Please choose one\./,
       );
     });
 
-    it("should delegate to installKitOrInstance with the provided options", async () => {
+    it("should delegate to installKitOrInstance with the provided --package options", async () => {
       const mockConfig = {
         projectDir: "/mock/project",
         src: {
@@ -100,7 +120,43 @@ describe("functions:kits:install", () => {
       expect(installKitOrInstanceStub).to.have.been.calledOnceWith({
         config: mockConfig,
         package: "@firebase-function-kits/firestore-bigquery-export@1.0.0",
+        directory: undefined,
         template: "migration",
+        nonInteractive: true,
+        project: "my-project",
+        projectId: "my-project",
+        rc: mockRc,
+      });
+    });
+
+    it("should delegate to installKitOrInstance with the provided --directory options", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: {
+          functions: [],
+        },
+        path: (p: string) => `/mock/project/${p}`,
+      } as unknown as Config;
+
+      const mockRc = {
+        hasProjects: true,
+      };
+
+      await command.runner()({
+        directory: "./my-local-kit",
+        cwd: "/mock/project",
+        config: mockConfig,
+        nonInteractive: true,
+        project: "my-project",
+        projectId: "my-project",
+        rc: mockRc as unknown as RC,
+      });
+
+      expect(installKitOrInstanceStub).to.have.been.calledOnceWith({
+        config: mockConfig,
+        package: undefined,
+        directory: "./my-local-kit",
+        template: undefined,
         nonInteractive: true,
         project: "my-project",
         projectId: "my-project",

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -2,12 +2,7 @@ import { Command } from "../command";
 import { FirebaseError } from "../error";
 import * as experiments from "../experiments";
 import { Options } from "../options";
-import {
-  DEFAULT_TEMPLATE,
-  installKitOrInstance,
-  TEMPLATES,
-  TemplateType,
-} from "../functions/kits/install";
+import { installKitOrInstance, TEMPLATES, TemplateType } from "../functions/kits/install";
 
 export interface FunctionsKitsInstallOptions extends Options {
   package?: string;
@@ -23,9 +18,8 @@ export const command = new Command("functions:kits:install")
     "path to a local functions codebase directory to install as a function kit",
   )
   .option(
-    `--template [${Object.keys(TEMPLATES).join("|")}]`,
-    "template to use for the kit index file",
-    DEFAULT_TEMPLATE,
+    `--template <template>`,
+    `template to use for the kit index file (${Object.keys(TEMPLATES).join("|")})`,
   )
   .action(async (options: FunctionsKitsInstallOptions): Promise<void> => {
     experiments.assertEnabled("kits", "install a function kit");
@@ -40,12 +34,15 @@ export const command = new Command("functions:kits:install")
     if (!options.package && !options.directory) {
       throw new FirebaseError("Must specify either --package or --directory.");
     }
+    if (options.directory && options.template) {
+      throw new FirebaseError("Cannot specify --template with --directory.");
+    }
 
     await installKitOrInstance({
       config: options.config,
       package: options.package,
       directory: options.directory,
-      template: options.template as TemplateType,
+      template: options.template as TemplateType | undefined,
       nonInteractive: options.nonInteractive,
       project: options.project,
       projectId: options.projectId,

--- a/src/commands/functions-kits-install.ts
+++ b/src/commands/functions-kits-install.ts
@@ -11,12 +11,17 @@ import {
 
 export interface FunctionsKitsInstallOptions extends Options {
   package?: string;
+  directory?: string;
   template?: string;
 }
 
 export const command = new Command("functions:kits:install")
   .description("install a function kit into your project")
   .option("--package <package>", "NPM package name or specifier to install as a function kit")
+  .option(
+    "--directory <directory>",
+    "path to a local functions codebase directory to install as a function kit",
+  )
   .option(
     `--template [${Object.keys(TEMPLATES).join("|")}]`,
     "template to use for the kit index file",
@@ -29,14 +34,17 @@ export const command = new Command("functions:kits:install")
       throw new FirebaseError("Not in a Firebase project directory (firebase.json not found).");
     }
 
-    const rawPkgName = options.package;
-    if (!rawPkgName) {
-      throw new FirebaseError("Set the --package option to a valid NPM package and try again.");
+    if (options.package && options.directory) {
+      throw new FirebaseError("Cannot specify both --package and --directory. Please choose one.");
+    }
+    if (!options.package && !options.directory) {
+      throw new FirebaseError("Must specify either --package or --directory.");
     }
 
     await installKitOrInstance({
       config: options.config,
-      package: rawPkgName,
+      package: options.package,
+      directory: options.directory,
       template: options.template as TemplateType,
       nonInteractive: options.nonInteractive,
       project: options.project,

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -23,6 +23,11 @@ import {
   promptSecurityConfirmation,
   promptExistingInstanceForProject,
   buildAndInstallKit,
+  buildAndInstallDirectoryKit,
+  validateAndResolveDirectoryKit,
+  findExistingKit,
+  resolvePackageSource,
+  resolveDirectorySource,
   printKitFirstDeployReport,
   addKitInstanceOrConfigureProject,
   installKitOrInstance,
@@ -48,6 +53,7 @@ describe("functions/kits/install", () => {
   let seedKitInstanceEnvStub: sinon.SinonStub;
   let loggerInfoStub: sinon.SinonStub;
   let loggerWarnStub: sinon.SinonStub;
+  let statStub: sinon.SinonStub;
 
   beforeEach(() => {
     sinon.stub(experiments, "assertEnabled");
@@ -58,6 +64,7 @@ describe("functions/kits/install", () => {
       .resolves(JSON.stringify([{ hasShrinkwrap: true }]));
     sinon.stub(fs, "ensureDir").resolves();
     sinon.stub(fs, "pathExists").resolves(false);
+    statStub = sinon.stub(fs, "stat").resolves({ isDirectory: () => true } as fs.Stats);
     sinon.stub(fs, "readJson").resolves({});
     sinon.stub(fs, "writeJson").resolves();
     sinon.stub(fs, "writeFile").resolves();
@@ -439,6 +446,351 @@ describe("functions/kits/install", () => {
       const functions = (writtenFiles["firebase.json"] as { functions: unknown[] }).functions;
       expect(functions).to.have.length(2);
       expect(functions[0]).to.deep.equal(existingEntry);
+    });
+
+    it("should add directory kit without sourcePackage and with predeploy when hasBuildScript is true", () => {
+      const writtenFiles: Record<string, unknown> = {};
+      const mockConfig = {
+        src: {},
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+      } as unknown as Config;
+
+      addKitToConfig(
+        mockConfig,
+        "local-kit",
+        "inst1",
+        undefined,
+        "my-local-functions",
+        "function-kits/local-kit/config-inst1",
+        true,
+      );
+
+      expect(writtenFiles["firebase.json"]).to.deep.equal({
+        functions: [
+          {
+            kit: "local-kit",
+            source: "my-local-functions",
+            instances: {
+              inst1: "function-kits/local-kit/config-inst1",
+            },
+            predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+          },
+        ],
+      });
+    });
+
+    it("should add directory kit without predeploy when hasBuildScript is false", () => {
+      const writtenFiles: Record<string, unknown> = {};
+      const mockConfig = {
+        src: {},
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+      } as unknown as Config;
+
+      addKitToConfig(
+        mockConfig,
+        "local-kit",
+        "inst1",
+        undefined,
+        "my-local-functions",
+        "function-kits/local-kit/config-inst1",
+        false,
+      );
+
+      expect(writtenFiles["firebase.json"]).to.deep.equal({
+        functions: [
+          {
+            kit: "local-kit",
+            source: "my-local-functions",
+            instances: {
+              inst1: "function-kits/local-kit/config-inst1",
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe("validateAndResolveDirectoryKit", () => {
+    it("should throw if directory is outside of project directory", async () => {
+      await expect(
+        validateAndResolveDirectoryKit("/mock/project", "../outside-project"),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        "Directory '../outside-project' is outside of project directory. Function kit directory must be inside the project directory.",
+      );
+
+      await expect(
+        validateAndResolveDirectoryKit("/mock/project", "/other/path/outside"),
+      ).to.be.rejectedWith(
+        FirebaseError,
+        "Directory '/other/path/outside' is outside of project directory. Function kit directory must be inside the project directory.",
+      );
+    });
+
+    it("should throw if directory does not exist", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/nonexistent").resolves(false);
+
+      await expect(
+        validateAndResolveDirectoryKit("/mock/project", "nonexistent"),
+      ).to.be.rejectedWith(FirebaseError, "Directory 'nonexistent' does not exist.");
+    });
+
+    it("should throw if path is not a directory", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/file.txt").resolves(true);
+      statStub
+        .withArgs("/mock/project/file.txt")
+        .resolves({ isDirectory: () => false } as fs.Stats);
+
+      await expect(validateAndResolveDirectoryKit("/mock/project", "file.txt")).to.be.rejectedWith(
+        FirebaseError,
+        "Directory 'file.txt' is not a directory.",
+      );
+    });
+
+    it("should throw if directory does not contain a package.json", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-kit").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves(false);
+
+      await expect(validateAndResolveDirectoryKit("/mock/project", "my-kit")).to.be.rejectedWith(
+        FirebaseError,
+        "Directory 'my-kit' must contain a package.json file to be installed as a function kit.",
+      );
+    });
+
+    it("should throw if package.json cannot be parsed", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-kit").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves(true);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .rejects(new Error("Unexpected token"));
+
+      await expect(validateAndResolveDirectoryKit("/mock/project", "my-kit")).to.be.rejectedWith(
+        FirebaseError,
+        /Failed to parse package\.json in 'my-kit': Unexpected token/,
+      );
+    });
+
+    it("should return ValidatedDirectoryKit with hasBuildScript: true when build script exists", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-kit").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves(true);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves({
+          scripts: {
+            build: "tsc",
+          },
+        });
+
+      const res = await validateAndResolveDirectoryKit("/mock/project", "my-kit");
+      expect(res).to.deep.equal({
+        absDirectoryPath: "/mock/project/my-kit",
+        relSourcePath: "my-kit",
+        hasBuildScript: true,
+      });
+    });
+
+    it("should return ValidatedDirectoryKit with hasBuildScript: false when build script is absent", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-kit").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves(true);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves({
+          scripts: {
+            start: "node index.js",
+          },
+        });
+
+      const res = await validateAndResolveDirectoryKit("/mock/project", "my-kit");
+      expect(res).to.deep.equal({
+        absDirectoryPath: "/mock/project/my-kit",
+        relSourcePath: "my-kit",
+        hasBuildScript: false,
+      });
+    });
+
+    it("should handle current directory relative path", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project", "package.json"))
+        .resolves(true);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project", "package.json"))
+        .resolves({});
+
+      const res = await validateAndResolveDirectoryKit("/mock/project", ".");
+      expect(res).to.deep.equal({
+        absDirectoryPath: "/mock/project",
+        relSourcePath: ".",
+        hasBuildScript: false,
+      });
+    });
+  });
+
+  describe("buildAndInstallDirectoryKit", () => {
+    it("should run npm install and npm run build when hasBuildScript is true", async () => {
+      await buildAndInstallDirectoryKit("/mock/project/my-kit", true);
+
+      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install"],
+        "/mock/project/my-kit",
+      );
+      expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
+        "npm",
+        ["run", "build"],
+        "/mock/project/my-kit",
+      );
+    });
+
+    it("should run only npm install when hasBuildScript is false", async () => {
+      await buildAndInstallDirectoryKit("/mock/project/my-kit", false);
+
+      expect(wrapSpawnStub).to.have.been.calledOnce;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install"],
+        "/mock/project/my-kit",
+      );
+    });
+
+    it("should throw FirebaseError if npm install fails", async () => {
+      wrapSpawnStub.withArgs("npm", ["install"]).rejects(new Error("npm install error"));
+
+      await expect(buildAndInstallDirectoryKit("/mock/project/my-kit", true)).to.be.rejectedWith(
+        FirebaseError,
+        /NPM install failed: npm install error/,
+      );
+    });
+
+    it("should throw FirebaseError if typescript build fails", async () => {
+      wrapSpawnStub.withArgs("npm", ["run", "build"]).rejects(new Error("tsc error"));
+
+      await expect(buildAndInstallDirectoryKit("/mock/project/my-kit", true)).to.be.rejectedWith(
+        FirebaseError,
+        /TypeScript build failed: tsc error/,
+      );
+    });
+  });
+
+  describe("findExistingKit", () => {
+    const mockFunctions: ValidatedKitSingle[] = [
+      {
+        kit: "pkg-kit",
+        sourcePackage: { name: "@scope/my-pkg" },
+        source: "function-kits/pkg-kit/source",
+        instances: { inst1: "function-kits/pkg-kit/config-inst1" },
+      },
+      {
+        kit: "dir-kit",
+        source: "my-local-kit",
+        instances: { inst1: "function-kits/dir-kit/config-inst1" },
+      },
+    ];
+    const mockConfig = { projectDir: "/mock/project" } as Config;
+
+    it("should find existing kit by package name", () => {
+      const found = findExistingKit(mockFunctions, {
+        package: "@scope/my-pkg@1.0.0",
+        config: mockConfig,
+      });
+      expect(found).to.equal(mockFunctions[0]);
+    });
+
+    it("should find existing kit by local directory path", () => {
+      const found = findExistingKit(mockFunctions, {
+        directory: "my-local-kit",
+        config: mockConfig,
+      });
+      expect(found).to.equal(mockFunctions[1]);
+    });
+
+    it("should return undefined if kit is not found", () => {
+      const found = findExistingKit(mockFunctions, {
+        package: "other-pkg",
+        config: mockConfig,
+      });
+      expect(found).to.be.undefined;
+    });
+  });
+
+  describe("resolvePackageSource", () => {
+    it("should reject invalid template", async () => {
+      await expect(
+        resolvePackageSource({
+          config: { projectDir: "/mock/project" } as Config,
+          package: "my-pkg",
+          template: "invalid" as TemplateType,
+        }),
+      ).to.be.rejectedWith(FirebaseError, /Invalid template 'invalid'/);
+    });
+
+    it("should resolve valid package source", async () => {
+      wrapSpawnStub
+        .withArgs("npm", ["pack", "@firebase-function-kits/firestore-export", "--json"])
+        .resolves(
+          JSON.stringify([
+            {
+              name: "@firebase-function-kits/firestore-export",
+              hasShrinkwrap: true,
+            },
+          ]),
+        );
+
+      const source = await resolvePackageSource({
+        config: { projectDir: "/mock/project" } as Config,
+        package: "@firebase-function-kits/firestore-export",
+        template: "installation",
+        nonInteractive: true,
+      });
+
+      expect(source.defaultKitName).to.equal("@firebase-function-kits/firestore-export");
+      expect(source.sourcePackageName).to.equal("@firebase-function-kits/firestore-export");
+      expect(source.hasBuildScript).to.be.true;
+    });
+  });
+
+  describe("resolveDirectorySource", () => {
+    it("should throw if directory option is missing", async () => {
+      await expect(
+        resolveDirectorySource({
+          config: { projectDir: "/mock/project" } as Config,
+        }),
+      ).to.be.rejectedWith(FirebaseError, "Must specify --directory.");
+    });
+
+    it("should resolve valid directory source", async () => {
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-kit").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves(true);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-kit", "package.json"))
+        .resolves({ scripts: { build: "tsc" } });
+
+      const source = await resolveDirectorySource({
+        config: {
+          projectDir: "/mock/project",
+          path: (p: string) => path.join("/mock/project", p),
+        } as Config,
+        directory: "my-kit",
+      });
+
+      expect(source.defaultKitName).to.equal("my-kit");
+      expect(source.sourcePackageName).to.be.undefined;
+      expect(source.hasBuildScript).to.be.true;
     });
   });
 
@@ -1297,7 +1649,7 @@ describe("functions/kits/install", () => {
   });
 
   describe("installKitOrInstance", () => {
-    it("should throw an error if package is not provided", async () => {
+    it("should throw an error if neither package nor directory is provided", async () => {
       const mockConfig = {
         projectDir: "/mock/project",
         src: { functions: [] },
@@ -1307,11 +1659,26 @@ describe("functions/kits/install", () => {
       await expect(
         installKitOrInstance({
           config: mockConfig,
-          package: "",
+        }),
+      ).to.be.rejectedWith(FirebaseError, "Must specify either --package or --directory.");
+    });
+
+    it("should throw an error if both package and directory are provided", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+      } as unknown as Config;
+
+      await expect(
+        installKitOrInstance({
+          config: mockConfig,
+          package: "@firebase-function-kits/firestore-bigquery-export",
+          directory: "./my-kit",
         }),
       ).to.be.rejectedWith(
         FirebaseError,
-        /Set the --package option to a valid NPM package and try again\./,
+        "Cannot specify both --package and --directory. Please choose one.",
       );
     });
 
@@ -1349,7 +1716,7 @@ describe("functions/kits/install", () => {
       );
     });
 
-    it("should successfully install a first-party kit", async () => {
+    it("should successfully install a first-party package kit", async () => {
       const writtenFiles: Record<string, unknown> = {};
       const mockConfig = {
         projectDir: "/mock/project",
@@ -1408,7 +1775,7 @@ describe("functions/kits/install", () => {
       });
     });
 
-    it("should accept custom kitId and instanceId", async () => {
+    it("should accept custom kitId and instanceId for package kit", async () => {
       const writtenFiles: Record<string, unknown> = {};
       const mockConfig = {
         projectDir: "/mock/project",
@@ -1440,7 +1807,7 @@ describe("functions/kits/install", () => {
       });
     });
 
-    it("should seed environment variables when seedEnv is provided", async () => {
+    it("should seed environment variables when seedEnv is provided for package kit", async () => {
       const writtenFiles: Record<string, unknown> = {};
       const mockConfig = {
         projectDir: "/mock/project",
@@ -1512,6 +1879,273 @@ describe("functions/kits/install", () => {
 
       expect(res.action).to.equal("addedInstance");
       expect(res.kitId).to.equal("firestore-bigquery-export");
+      expect(res.instanceId).to.equal("inst2");
+    });
+
+    it("should successfully install a directory kit with build script", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-functions").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves(true);
+      (fs.stat as sinon.SinonStub)
+        .withArgs("/mock/project/my-functions")
+        .resolves({ isDirectory: () => true } as fs.Stats);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves({
+          scripts: {
+            build: "tsc",
+          },
+        });
+
+      const res = await installKitOrInstance({
+        config: mockConfig,
+        directory: "./my-functions",
+        nonInteractive: true,
+      });
+
+      expect(res).to.deep.equal({
+        action: "installedKit",
+        kitId: "my-functions",
+        instanceId: "my-functions",
+        sourcePath: "my-functions",
+        configDirPath: "function-kits/my-functions/config-my-functions",
+      });
+
+      expect(wrapSpawnStub).to.have.been.calledTwice;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install"],
+        "/mock/project/my-functions",
+      );
+      expect(wrapSpawnStub.secondCall).to.have.been.calledWith(
+        "npm",
+        ["run", "build"],
+        "/mock/project/my-functions",
+      );
+
+      expect(writtenFiles["firebase.json"]).to.deep.equal({
+        functions: [
+          {
+            kit: "my-functions",
+            source: "my-functions",
+            instances: {
+              "my-functions": "function-kits/my-functions/config-my-functions",
+            },
+            predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+          },
+        ],
+      });
+    });
+
+    it("should successfully install a directory kit without build script", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-functions").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves(true);
+      (fs.stat as sinon.SinonStub)
+        .withArgs("/mock/project/my-functions")
+        .resolves({ isDirectory: () => true } as fs.Stats);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves({
+          scripts: {
+            start: "node index.js",
+          },
+        });
+
+      const res = await installKitOrInstance({
+        config: mockConfig,
+        directory: "./my-functions",
+        nonInteractive: true,
+      });
+
+      expect(res).to.deep.equal({
+        action: "installedKit",
+        kitId: "my-functions",
+        instanceId: "my-functions",
+        sourcePath: "my-functions",
+        configDirPath: "function-kits/my-functions/config-my-functions",
+      });
+
+      expect(wrapSpawnStub).to.have.been.calledOnce;
+      expect(wrapSpawnStub.firstCall).to.have.been.calledWith(
+        "npm",
+        ["install"],
+        "/mock/project/my-functions",
+      );
+
+      expect(writtenFiles["firebase.json"]).to.deep.equal({
+        functions: [
+          {
+            kit: "my-functions",
+            source: "my-functions",
+            instances: {
+              "my-functions": "function-kits/my-functions/config-my-functions",
+            },
+          },
+        ],
+      });
+    });
+
+    it("should accept custom kitId and instanceId for directory kit", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-functions").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves(true);
+      (fs.stat as sinon.SinonStub)
+        .withArgs("/mock/project/my-functions")
+        .resolves({ isDirectory: () => true } as fs.Stats);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves({});
+
+      const res = await installKitOrInstance({
+        config: mockConfig,
+        directory: "./my-functions",
+        kitId: "custom-local-kit",
+        instanceId: "custom-local-instance",
+        nonInteractive: true,
+      });
+
+      expect(res).to.deep.equal({
+        action: "installedKit",
+        kitId: "custom-local-kit",
+        instanceId: "custom-local-instance",
+        sourcePath: "my-functions",
+        configDirPath: "function-kits/custom-local-kit/config-custom-local-instance",
+      });
+    });
+
+    it("should seed environment variables when seedEnv is provided for directory kit", async () => {
+      const writtenFiles: Record<string, unknown> = {};
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+        },
+        askWriteProjectFile: (file: string, content: unknown) => {
+          writtenFiles[file] = content;
+          return Promise.resolve();
+        },
+      } as unknown as Config;
+
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-functions").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves(true);
+      (fs.stat as sinon.SinonStub)
+        .withArgs("/mock/project/my-functions")
+        .resolves({ isDirectory: () => true } as fs.Stats);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves({});
+
+      await installKitOrInstance({
+        config: mockConfig,
+        directory: "./my-functions",
+        nonInteractive: true,
+        seedEnv: {
+          projectId: "target-proj",
+          envs: {
+            PARAM_ONE: "value1",
+          },
+        },
+      });
+
+      expect(seedKitInstanceEnvStub).to.have.been.calledOnceWith({
+        configDir: path.join("/mock/project", "function-kits/my-functions/config-my-functions"),
+        functionsSource: "/mock/project/my-functions",
+        projectDir: "/mock/project",
+        projectId: "target-proj",
+        projectAlias: undefined,
+        envs: {
+          PARAM_ONE: "value1",
+        },
+      });
+    });
+
+    it("should handle existing kit when directory is already in firebase.json", async () => {
+      const existingKit: ValidatedKitSingle = {
+        kit: "my-functions",
+        source: "my-functions",
+        instances: {
+          inst1: "function-kits/my-functions/config-inst1",
+        },
+      };
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [existingKit] },
+        path: (p: string) => path.join("/mock/project", p),
+        writeProjectFile: sinon.stub(),
+        askWriteProjectFile: sinon.stub().resolves(),
+      } as unknown as Config;
+
+      (fs.pathExists as sinon.SinonStub).withArgs("/mock/project/my-functions").resolves(true);
+      (fs.pathExists as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves(true);
+      (fs.stat as sinon.SinonStub)
+        .withArgs("/mock/project/my-functions")
+        .resolves({ isDirectory: () => true } as fs.Stats);
+      (fs.readJson as sinon.SinonStub)
+        .withArgs(path.join("/mock/project/my-functions", "package.json"))
+        .resolves({});
+
+      const res = await installKitOrInstance({
+        config: mockConfig,
+        directory: "./my-functions",
+        instanceId: "inst2",
+        nonInteractive: true,
+        project: "target-proj",
+      });
+
+      expect(res.action).to.equal("addedInstance");
+      expect(res.kitId).to.equal("my-functions");
       expect(res.instanceId).to.equal("inst2");
     });
   });

--- a/src/functions/kits/install.spec.ts
+++ b/src/functions/kits/install.spec.ts
@@ -358,14 +358,13 @@ describe("functions/kits/install", () => {
         },
       } as unknown as Config;
 
-      addKitToConfig(
-        mockConfig,
-        "new-kit",
-        "new-instance",
-        "@scope/pkg",
-        "function-kits/new-kit/source",
-        "function-kits/new-kit/config-new-instance",
-      );
+      addKitToConfig(mockConfig, {
+        kitId: "new-kit",
+        instanceId: "new-instance",
+        packageName: "@scope/pkg",
+        sourcePath: "function-kits/new-kit/source",
+        configDirPath: "function-kits/new-kit/config-new-instance",
+      });
 
       expect(writtenFiles["firebase.json"]).to.deep.equal({
         functions: [
@@ -397,14 +396,13 @@ describe("functions/kits/install", () => {
         },
       } as unknown as Config;
 
-      addKitToConfig(
-        mockConfig,
-        "new-kit",
-        "new-instance",
-        "@scope/pkg",
-        "function-kits/new-kit/source",
-        "function-kits/new-kit/config-new-instance",
-      );
+      addKitToConfig(mockConfig, {
+        kitId: "new-kit",
+        instanceId: "new-instance",
+        packageName: "@scope/pkg",
+        sourcePath: "function-kits/new-kit/source",
+        configDirPath: "function-kits/new-kit/config-new-instance",
+      });
 
       const functions = (writtenFiles["firebase.json"] as { functions: unknown[] }).functions;
       expect(functions).to.have.length(2);
@@ -434,14 +432,13 @@ describe("functions/kits/install", () => {
         },
       } as unknown as Config;
 
-      addKitToConfig(
-        mockConfig,
-        "new-kit",
-        "new-instance",
-        "@scope/pkg",
-        "function-kits/new-kit/source",
-        "function-kits/new-kit/config-new-instance",
-      );
+      addKitToConfig(mockConfig, {
+        kitId: "new-kit",
+        instanceId: "new-instance",
+        packageName: "@scope/pkg",
+        sourcePath: "function-kits/new-kit/source",
+        configDirPath: "function-kits/new-kit/config-new-instance",
+      });
 
       const functions = (writtenFiles["firebase.json"] as { functions: unknown[] }).functions;
       expect(functions).to.have.length(2);
@@ -457,15 +454,14 @@ describe("functions/kits/install", () => {
         },
       } as unknown as Config;
 
-      addKitToConfig(
-        mockConfig,
-        "local-kit",
-        "inst1",
-        undefined,
-        "my-local-functions",
-        "function-kits/local-kit/config-inst1",
-        true,
-      );
+      addKitToConfig(mockConfig, {
+        kitId: "local-kit",
+        instanceId: "inst1",
+        packageName: undefined,
+        sourcePath: "my-local-functions",
+        configDirPath: "function-kits/local-kit/config-inst1",
+        hasBuildScript: true,
+      });
 
       expect(writtenFiles["firebase.json"]).to.deep.equal({
         functions: [
@@ -490,15 +486,14 @@ describe("functions/kits/install", () => {
         },
       } as unknown as Config;
 
-      addKitToConfig(
-        mockConfig,
-        "local-kit",
-        "inst1",
-        undefined,
-        "my-local-functions",
-        "function-kits/local-kit/config-inst1",
-        false,
-      );
+      addKitToConfig(mockConfig, {
+        kitId: "local-kit",
+        instanceId: "inst1",
+        packageName: undefined,
+        sourcePath: "my-local-functions",
+        configDirPath: "function-kits/local-kit/config-inst1",
+        hasBuildScript: false,
+      });
 
       expect(writtenFiles["firebase.json"]).to.deep.equal({
         functions: [
@@ -1680,6 +1675,22 @@ describe("functions/kits/install", () => {
         FirebaseError,
         "Cannot specify both --package and --directory. Please choose one.",
       );
+    });
+
+    it("should throw an error if both directory and template are provided", async () => {
+      const mockConfig = {
+        projectDir: "/mock/project",
+        src: { functions: [] },
+        path: (p: string) => path.join("/mock/project", p),
+      } as unknown as Config;
+
+      await expect(
+        installKitOrInstance({
+          config: mockConfig,
+          directory: "./my-kit",
+          template: "migration",
+        }),
+      ).to.be.rejectedWith(FirebaseError, "Cannot specify --template with --directory.");
     });
 
     it("should throw an error if package has an invalid package name", async () => {

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -7,7 +7,7 @@ import { Config } from "../../config";
 import { FirebaseError, getErrMsg } from "../../error";
 import { KitFunctionConfig, FunctionsConfig } from "../../firebaseConfig";
 import { getProjectId } from "../../projectUtils";
-import { logLabeledBullet, logLabeledSuccess, logLabeledWarning } from "../../utils";
+import { logLabeledBullet, logLabeledSuccess, logLabeledWarning, resolveWithin } from "../../utils";
 import {
   addKitPrefix,
   isKitConfig,
@@ -74,9 +74,24 @@ export interface AddKitInstanceResult {
   absConfigDirPath: string;
 }
 
+export interface ValidatedDirectoryKit {
+  absDirectoryPath: string;
+  relSourcePath: string;
+  hasBuildScript: boolean;
+}
+
+export interface KitSource {
+  defaultKitName: string;
+  sourcePackageName?: string;
+  hasBuildScript: boolean;
+  setup: (kitId: string, instanceId: string) => Promise<ScaffoldedKitPaths>;
+  buildAndInstall: (absSourcePath: string) => Promise<void>;
+}
+
 export interface InstallKitOrInstanceOptions {
   config: Config;
-  package: string;
+  package?: string;
+  directory?: string;
   template?: TemplateType;
   kitId?: string;
   instanceId?: string;
@@ -330,7 +345,7 @@ export async function promptKitId(
   nonInteractive?: boolean,
   customKitId?: string,
 ): Promise<string> {
-  const baseKitId = sanitizePackageNameToKitName(packageName);
+  const baseKitId = sanitizePackageNameToKitName(packageName) || "kit";
   const defaultKitId = generateUniqueId(baseKitId, existingKitIds);
 
   if (customKitId) {
@@ -576,21 +591,20 @@ export function addKitToConfig(
   config: Config,
   kitId: string,
   instanceId: string,
-  packageName: string,
+  packageName: string | undefined,
   sourcePath: string,
   configDirPath: string,
+  hasBuildScript = true,
 ): void {
   const configSrc = config.src;
   const newKitConfig: KitFunctionConfig = {
     kit: kitId,
-    sourcePackage: {
-      name: packageName,
-    },
+    ...(packageName ? { sourcePackage: { name: packageName } } : {}),
     source: sourcePath,
     instances: {
       [instanceId]: configDirPath,
     },
-    predeploy: ['npm --prefix "$RESOURCE_DIR" run build'],
+    ...(hasBuildScript ? { predeploy: ['npm --prefix "$RESOURCE_DIR" run build'] } : {}),
   };
 
   const functionsRaw = configSrc.functions as KitFunctionConfig | KitFunctionConfig[] | undefined;
@@ -603,6 +617,82 @@ export function addKitToConfig(
   }
 
   config.writeProjectFile("firebase.json", configSrc);
+}
+
+/**
+ * Validates a local directory for use as a functions kit.
+ * Checks that the directory exists, is a directory, and contains a valid package.json.
+ */
+export async function validateAndResolveDirectoryKit(
+  projectDir: string,
+  rawDir: string,
+): Promise<ValidatedDirectoryKit> {
+  const absDirectoryPath = resolveWithin(
+    projectDir,
+    rawDir,
+    `Directory '${rawDir}' is outside of project directory. Function kit directory must be inside the project directory.`,
+  );
+
+  if (!(await fs.pathExists(absDirectoryPath))) {
+    throw new FirebaseError(`Directory '${rawDir}' does not exist.`);
+  }
+
+  const stat = await fs.stat(absDirectoryPath);
+  if (!stat.isDirectory()) {
+    throw new FirebaseError(`Directory '${rawDir}' is not a directory.`);
+  }
+
+  const packageJsonPath = path.join(absDirectoryPath, "package.json");
+  if (!(await fs.pathExists(packageJsonPath))) {
+    throw new FirebaseError(
+      `Directory '${rawDir}' must contain a package.json file to be installed as a function kit.`,
+    );
+  }
+
+  let packageJson: { scripts?: Record<string, string> } = {};
+  try {
+    packageJson = (await fs.readJson(packageJsonPath)) as typeof packageJson;
+  } catch (err: unknown) {
+    throw new FirebaseError(`Failed to parse package.json in '${rawDir}': ${getErrMsg(err)}`);
+  }
+
+  const hasBuildScript = Boolean(packageJson.scripts && packageJson.scripts.build);
+
+  let relSourcePath = path.relative(projectDir, absDirectoryPath);
+  if (!relSourcePath) {
+    relSourcePath = ".";
+  }
+  relSourcePath = relSourcePath.split(path.sep).join("/");
+
+  return {
+    absDirectoryPath,
+    relSourcePath,
+    hasBuildScript,
+  };
+}
+
+/**
+ * Installs dependencies and optionally compiles TypeScript source for a local directory kit.
+ */
+export async function buildAndInstallDirectoryKit(
+  absSourcePath: string,
+  hasBuildScript: boolean,
+): Promise<void> {
+  logLabeledBullet("functions", "Running npm install...");
+  try {
+    await wrapSpawn("npm", ["install"], absSourcePath);
+  } catch (err: unknown) {
+    throw new FirebaseError(`NPM install failed: ${getErrMsg(err)}`);
+  }
+
+  if (hasBuildScript) {
+    logLabeledBullet("functions", "Building TypeScript source...");
+    try {
+      await wrapSpawn("npm", ["run", "build"], absSourcePath);
+    } catch (err: unknown) {
+      throw new FirebaseError(`TypeScript build failed: ${getErrMsg(err)}`);
+    }
+  }
 }
 
 /**
@@ -902,12 +992,38 @@ export async function addKitInstanceOrConfigureProject(
 }
 
 /**
- * Orchestrates the complete kit installation flow.
- * Installs a brand new kit (if not present) or adds a new instance to an existing kit.
+ * Looks for an existing kit in the configuration matching either the npm package name or local directory source path.
  */
-export async function installKitOrInstance(
+export function findExistingKit(
+  existingFunctions: ValidatedSingle[],
+  options: { package?: string; directory?: string; config: Config },
+): ValidatedKitSingle | undefined {
+  if (options.package) {
+    const { packageName } = parseNpmPackageSpecifier(options.package);
+    return existingFunctions.find(
+      (c): c is ValidatedKitSingle => isKitConfig(c) && c.sourcePackage?.name === packageName,
+    );
+  }
+  if (options.directory) {
+    const absDir = path.isAbsolute(options.directory)
+      ? options.directory
+      : path.resolve(options.config.projectDir, options.directory);
+    return existingFunctions.find(
+      (c): c is ValidatedKitSingle =>
+        isKitConfig(c) &&
+        !c.sourcePackage &&
+        path.resolve(options.config.projectDir, c.source) === absDir,
+    );
+  }
+  return undefined;
+}
+
+/**
+ * Resolves and validates an npm package kit source.
+ */
+export async function resolvePackageSource(
   options: InstallKitOrInstanceOptions,
-): Promise<InstallKitOrInstanceResult> {
+): Promise<KitSource> {
   const templateType = options.template || DEFAULT_TEMPLATE;
   if (!(templateType in TEMPLATES)) {
     const validTemplates = Object.keys(TEMPLATES)
@@ -926,23 +1042,84 @@ export async function installKitOrInstance(
   const { packageName } = parseNpmPackageSpecifier(rawPkgName);
   validateNpmPackageName(packageName);
 
-  const existingFunctionsInfo = extractExistingFunctionsInfo(options.config.src.functions);
-  const existingKit = existingFunctionsInfo.existingFunctions.find(
-    (c): c is ValidatedKitSingle => isKitConfig(c) && c.sourcePackage?.name === packageName,
-  );
-
-  if (existingKit) {
-    return addKitInstanceOrConfigureProject(options, existingKit, existingFunctionsInfo);
-  }
-
   const isThirdParty = await promptSecurityConfirmation(
     rawPkgName,
     packageName,
     options.nonInteractive,
   );
 
+  return {
+    defaultKitName: packageName,
+    sourcePackageName: packageName,
+    hasBuildScript: true,
+    setup: (kitId: string, instanceId: string) =>
+      scaffoldKitFiles(options.config, kitId, instanceId, packageName, templateType),
+    buildAndInstall: (absSourcePath: string) =>
+      buildAndInstallKit(absSourcePath, rawPkgName, isThirdParty),
+  };
+}
+
+/**
+ * Resolves and validates a local directory kit source.
+ */
+export async function resolveDirectorySource(
+  options: InstallKitOrInstanceOptions,
+): Promise<KitSource> {
+  if (!options.directory) {
+    throw new FirebaseError("Must specify --directory.");
+  }
+
+  const { absDirectoryPath, relSourcePath, hasBuildScript } = await validateAndResolveDirectoryKit(
+    options.config.projectDir,
+    options.directory,
+  );
+
+  return {
+    defaultKitName: path.basename(absDirectoryPath),
+    sourcePackageName: undefined,
+    hasBuildScript,
+    setup: async (kitId: string, instanceId: string) => {
+      const configDirPath = path.join(FUNCTION_KITS_DIR, kitId, `config-${instanceId}`);
+      const absConfigDirPath = options.config.path(configDirPath);
+      await fs.ensureDir(absConfigDirPath);
+      return {
+        sourcePath: relSourcePath,
+        configDirPath,
+        absSourcePath: absDirectoryPath,
+        absConfigDirPath,
+      };
+    },
+    buildAndInstall: (absSourcePath: string) =>
+      buildAndInstallDirectoryKit(absSourcePath, hasBuildScript),
+  };
+}
+
+/**
+ * Orchestrates the complete kit installation flow.
+ * Installs a brand new kit (from package or directory) or adds a new instance to an existing kit.
+ */
+export async function installKitOrInstance(
+  options: InstallKitOrInstanceOptions,
+): Promise<InstallKitOrInstanceResult> {
+  if (options.package && options.directory) {
+    throw new FirebaseError("Cannot specify both --package and --directory. Please choose one.");
+  }
+  if (!options.package && !options.directory) {
+    throw new FirebaseError("Must specify either --package or --directory.");
+  }
+
+  const existingFunctionsInfo = extractExistingFunctionsInfo(options.config.src.functions);
+  const existingKit = findExistingKit(existingFunctionsInfo.existingFunctions, options);
+  if (existingKit) {
+    return addKitInstanceOrConfigureProject(options, existingKit, existingFunctionsInfo);
+  }
+
+  const source = options.directory
+    ? await resolveDirectorySource(options)
+    : await resolvePackageSource(options);
+
   const kitId = await promptKitId(
-    packageName,
+    source.defaultKitName,
     existingFunctionsInfo.existingKitIds,
     options.nonInteractive,
     options.kitId,
@@ -956,12 +1133,9 @@ export async function installKitOrInstance(
     options.instanceId,
   );
 
-  const { sourcePath, configDirPath, absSourcePath, absConfigDirPath } = await scaffoldKitFiles(
-    options.config,
+  const { sourcePath, configDirPath, absSourcePath, absConfigDirPath } = await source.setup(
     kitId,
     instanceId,
-    packageName,
-    templateType,
   );
 
   if (options.seedEnv?.envs && Object.keys(options.seedEnv.envs).length > 0) {
@@ -975,9 +1149,17 @@ export async function installKitOrInstance(
     });
   }
 
-  await buildAndInstallKit(absSourcePath, rawPkgName, isThirdParty);
+  await source.buildAndInstall(absSourcePath);
 
-  addKitToConfig(options.config, kitId, instanceId, packageName, sourcePath, configDirPath);
+  addKitToConfig(
+    options.config,
+    kitId,
+    instanceId,
+    source.sourcePackageName,
+    sourcePath,
+    configDirPath,
+    source.hasBuildScript,
+  );
 
   logLabeledSuccess("functions", `Function kit ${clc.bold(kitId)} successfully installed.`);
   await printKitFirstDeployReport(options, instanceId, absSourcePath);

--- a/src/functions/kits/install.ts
+++ b/src/functions/kits/install.ts
@@ -584,27 +584,30 @@ export async function buildAndInstallKit(
   }
 }
 
+export interface AddKitToConfigOptions {
+  kitId: string;
+  instanceId: string;
+  packageName?: string;
+  sourcePath: string;
+  configDirPath: string;
+  hasBuildScript?: boolean;
+}
+
 /**
  * Appends the newly configured kit into the firebase.json configuration and saves the file.
  */
-export function addKitToConfig(
-  config: Config,
-  kitId: string,
-  instanceId: string,
-  packageName: string | undefined,
-  sourcePath: string,
-  configDirPath: string,
-  hasBuildScript = true,
-): void {
+export function addKitToConfig(config: Config, options: AddKitToConfigOptions): void {
   const configSrc = config.src;
   const newKitConfig: KitFunctionConfig = {
-    kit: kitId,
-    ...(packageName ? { sourcePackage: { name: packageName } } : {}),
-    source: sourcePath,
+    kit: options.kitId,
+    ...(options.packageName ? { sourcePackage: { name: options.packageName } } : {}),
+    source: options.sourcePath,
     instances: {
-      [instanceId]: configDirPath,
+      [options.instanceId]: options.configDirPath,
     },
-    ...(hasBuildScript ? { predeploy: ['npm --prefix "$RESOURCE_DIR" run build'] } : {}),
+    ...(options.hasBuildScript ?? true
+      ? { predeploy: ['npm --prefix "$RESOURCE_DIR" run build'] }
+      : {}),
   };
 
   const functionsRaw = configSrc.functions as KitFunctionConfig | KitFunctionConfig[] | undefined;
@@ -762,14 +765,13 @@ export async function scaffoldKit(options: ScaffoldKitOptions): Promise<Scaffold
     });
   }
 
-  addKitToConfig(
-    options.config,
-    options.kitId,
-    options.instanceId,
-    options.packageName,
-    paths.sourcePath,
-    paths.configDirPath,
-  );
+  addKitToConfig(options.config, {
+    kitId: options.kitId,
+    instanceId: options.instanceId,
+    packageName: options.packageName,
+    sourcePath: paths.sourcePath,
+    configDirPath: paths.configDirPath,
+  });
 
   return paths;
 }
@@ -1107,6 +1109,9 @@ export async function installKitOrInstance(
   if (!options.package && !options.directory) {
     throw new FirebaseError("Must specify either --package or --directory.");
   }
+  if (options.directory && options.template) {
+    throw new FirebaseError("Cannot specify --template with --directory.");
+  }
 
   const existingFunctionsInfo = extractExistingFunctionsInfo(options.config.src.functions);
   const existingKit = findExistingKit(existingFunctionsInfo.existingFunctions, options);
@@ -1151,15 +1156,14 @@ export async function installKitOrInstance(
 
   await source.buildAndInstall(absSourcePath);
 
-  addKitToConfig(
-    options.config,
+  addKitToConfig(options.config, {
     kitId,
     instanceId,
-    source.sourcePackageName,
+    packageName: source.sourcePackageName,
     sourcePath,
     configDirPath,
-    source.hasBuildScript,
-  );
+    hasBuildScript: source.hasBuildScript,
+  });
 
   logLabeledSuccess("functions", `Function kit ${clc.bold(kitId)} successfully installed.`);
   await printKitFirstDeployReport(options, instanceId, absSourcePath);


### PR DESCRIPTION
### Description
Adds a `--directory <directory>` option to `firebase functions:kits:install` that allows developers to install and manage local Cloud Functions codebases as Function Kits without needing to publish them to npm.

Key highlights:
- **CLI Flag & Validation**:
  - Added `--directory <directory>` flag to `functions:kits:install` and enforced mutual exclusivity with `--package`.
  - Validates that the directory exists, is a valid directory, is contained within the Firebase project directory, and contains a valid `package.json`.
- **Configuration & Predeploy**:
  - Adds the kit configuration to `firebase.json` with `source` pointing directly to the relative directory path (and omitting `sourcePackage`).
  - Conditionally includes `"predeploy": ['npm --prefix "$RESOURCE_DIR" run build']` only when `scripts.build` exists in `package.json` (preventing errors on plain JavaScript codebases).
- **Multi-Instance Support**:
  - Supports installing multiple parameterized instances of a local kit or configuring environments for existing instances.
- **Refactoring**:
  - Extracted source resolution into a `KitSource` strategy pattern (`resolvePackageSource` and `resolveDirectorySource`) and decoupled existing kit detection into `findExistingKit`, keeping `installKitOrInstance` unified without duplicate pipeline logic.

### Scenarios Tested
- **Command Flag Validations**:
  - Calling `functions:kits:install` without `--package` or `--directory` throws a `FirebaseError`.
  - Providing both `--package` and `--directory` throws a mutual exclusivity `FirebaseError`.
  - Calling with `--directory` correctly delegates to `installKitOrInstance`.
- **Directory Validation (`validateAndResolveDirectoryKit`)**:
  - Fails when directory is outside the project root (e.g. `../outside-project`).
  - Fails when directory does not exist or is a regular file.
  - Fails when `package.json` is missing or contains invalid JSON.
  - Successfully detects `scripts.build` presence/absence and computes normalized relative paths.
- **Installation Flow (`installKitOrInstance`)**:
  - Installed a directory kit with a build script (verifying `npm install`, `npm run build`, and `predeploy` in `firebase.json`).
  - Installed a directory kit without a build script (verifying `npm install` runs and `predeploy` is omitted).
  - Adding a second instance to an existing directory kit in `firebase.json`.
  - Existing kit detection by matching resolved directory paths (`findExistingKit`).
- **NPM Package Kits**: Verified existing package installation flows remain fully functional with zero regressions.

### Sample Commands
```bash
# Install a local functions directory as a kit
firebase functions:kits:install --directory ./functions/my-custom-kit
```